### PR TITLE
Add sorting function to files list

### DIFF
--- a/Files UWP/Filesystem/ListedItem.cs
+++ b/Files UWP/Filesystem/ListedItem.cs
@@ -18,7 +18,7 @@ namespace Files.Filesystem
         public string DotFileExtension { get; set; }
         public string FilePath { get; set; }
         public string FileSize { get; set; }
-        public int RowIndex { get; set; }
+        public ulong FileSizeBytes { get; set; }
 
         public DateTimeOffset FileDateReal
         {

--- a/Files UWP/GenericFileBrowser.xaml
+++ b/Files UWP/GenericFileBrowser.xaml
@@ -154,11 +154,24 @@
     <Grid Background="Transparent" x:Name="RootGrid">
         <Grid.ContextFlyout>
             <MenuFlyout MenuFlyoutPresenterStyle="{StaticResource MenuFlyoutFluentThemeResources}">
+                <MenuFlyoutSubItem Text="Sort by" x:Name="SortByEmptySpace">
+                    <MenuFlyoutSubItem.Icon>
+                        <FontIcon Glyph="&#xE8CB;"/>
+                    </MenuFlyoutSubItem.Icon>
+                    <uilib:RadioMenuFlyoutItem Text="Name" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByName, Mode=TwoWay}"/>
+                    <uilib:RadioMenuFlyoutItem Text="Date modified" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByDate, Mode=TwoWay}"/>
+                    <uilib:RadioMenuFlyoutItem Text="Type" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByType, Mode=TwoWay}"/>
+                    <uilib:RadioMenuFlyoutItem Text="Size" GroupName="SortGroup" IsChecked="{x:Bind IsSortedBySize, Mode=TwoWay}"/>
+                    <MenuFlyoutSeparator/>
+                    <uilib:RadioMenuFlyoutItem Text="Ascending" GroupName="SortOrderGroup" IsChecked="{x:Bind IsSortedAscending, Mode=TwoWay}"/>
+                    <uilib:RadioMenuFlyoutItem Text="Descending" GroupName="SortOrderGroup" IsChecked="{x:Bind IsSortedDescending, Mode=TwoWay}"/>
+                </MenuFlyoutSubItem>
                 <MenuFlyoutItem Text="Refresh" x:Name="RefreshEmptySpace">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE72C;"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
+                <MenuFlyoutSeparator/>
                 <MenuFlyoutItem Text="Paste" x:Name="PasteEmptySpace" IsEnabled="{x:Bind Mode=TwoWay, Path=local:App.PS.isEnabled, UpdateSourceTrigger=PropertyChanged}">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE77F;"/>
@@ -199,7 +212,7 @@
         </Grid.ContextFlyout>
         <ProgressBar x:Name="progBar" Height="10" VerticalAlignment="Top" IsIndeterminate="True"/>
         <TextBlock Visibility="{x:Bind Mode=TwoWay, Path=TextState.isVisible, UpdateSourceTrigger=PropertyChanged}" x:Name="EmptyText" HorizontalAlignment="Center" Text="This folder is empty." TextWrapping="Wrap" VerticalAlignment="Top" Margin="0,125,0,0"/>
-        <controls:DataGrid ItemsSource="{x:Bind viewModelInstance.FilesAndFolders}" ScrollViewer.IsScrollInertiaEnabled="True"  ClipboardCopyMode="None" RowDetailsVisibilityMode="Collapsed" AllowDrop="True" Drop="AllView_DropAsync" DragLeave="AllView_DragLeave" DragStarting="AllView_DragStarting" SelectionChanged="AllView_SelectionChanged" Margin="24,24,0,0" Grid.Row="3" CellEditEnded="AllView_CellEditEnded" FocusVisualPrimaryThickness="0" SelectionMode="Extended" IsDoubleTapEnabled="True" x:FieldModifier="public" x:Name="AllView" AutoGenerateColumns="False" CanDrag="True" DragOver="AllView_DragOver" IsRightTapEnabled="True" CanUserReorderColumns="False" IsReadOnly="True" HorizontalAlignment="Left">
+        <controls:DataGrid ItemsSource="{x:Bind viewModelInstance.FilesAndFolders}" ScrollViewer.IsScrollInertiaEnabled="True"  ClipboardCopyMode="None" RowDetailsVisibilityMode="Collapsed" AllowDrop="True" Drop="AllView_DropAsync" DragLeave="AllView_DragLeave" DragStarting="AllView_DragStarting" SelectionChanged="AllView_SelectionChanged" Margin="24,24,0,0" Grid.Row="3" CellEditEnded="AllView_CellEditEnded" FocusVisualPrimaryThickness="0" SelectionMode="Extended" IsDoubleTapEnabled="True" x:FieldModifier="public" x:Name="AllView" AutoGenerateColumns="False" CanDrag="True" DragOver="AllView_DragOver" IsRightTapEnabled="True" CanUserReorderColumns="False" CanUserSortColumns="True" Sorting="AllView_Sorting" IsReadOnly="True" HorizontalAlignment="Left">
             <controls:DataGrid.Resources>
                 <SolidColorBrush x:Key="DataGridCellFocusVisualPrimaryBrush" Color="Transparent"/>
                 <SolidColorBrush x:Key="DataGridCellFocusVisualSecondaryBrush" Color="Transparent"/>
@@ -254,7 +267,6 @@
                                         <KeyboardAccelerator Modifiers="Control" Key="S"/>
                                     </MenuFlyoutItem.KeyboardAccelerators>
                                 </MenuFlyoutItem>
-
                                 <MenuFlyoutSeparator/>
                                 <MenuFlyoutItem Text="Delete" x:Name="DeleteItem" >
                                     <MenuFlyoutItem.Icon>
@@ -289,22 +301,17 @@
                                         <KeyboardAccelerator Modifiers="Control" Key="C"/>
                                     </MenuFlyoutItem.KeyboardAccelerators>
                                 </MenuFlyoutItem>
-
                                 <MenuFlyoutSeparator/>
                                 <MenuFlyoutItem Text="Pin to sidebar" x:Name="SidebarPinItem">
                                     <MenuFlyoutItem.Icon>
                                         <SymbolIcon Symbol="Pin"/>
                                     </MenuFlyoutItem.Icon>
-
                                 </MenuFlyoutItem>
-
                                 <MenuFlyoutItem Text="Properties" x:Name="PropertiesItem">
                                     <MenuFlyoutItem.Icon>
                                         <FontIcon Glyph="&#xE946;"/>
                                     </MenuFlyoutItem.Icon>
-
                                 </MenuFlyoutItem>
-
                             </MenuFlyout>
                         </Setter.Value>
                     </Setter>
@@ -320,7 +327,7 @@
             </controls:DataGrid.CellStyle>
 
             <controls:DataGrid.Columns>
-                <controls:DataGridTemplateColumn DisplayIndex="0" IsReadOnly="True">
+                <controls:DataGridTemplateColumn DisplayIndex="0" x:Name="iconColumn" IsReadOnly="True">
                     <controls:DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Grid x:Name="Icon" Margin="0, 0, 0, 0">
@@ -332,9 +339,9 @@
                         </DataTemplate>
                     </controls:DataGridTemplateColumn.CellTemplate>
                 </controls:DataGridTemplateColumn>
-                <controls:DataGridTextColumn DisplayIndex="1" IsReadOnly="True" Header="Name" Width="275" Binding="{Binding FileName}" Tag="Name"/>
-                <controls:DataGridTextColumn DisplayIndex="2" IsReadOnly="True" Header="Date modified" Width="Auto" Binding="{Binding FileDate}" Tag="Date"/>
-                <controls:DataGridTextColumn DisplayIndex="3" IsReadOnly="True" Header="Type" Width="150" Binding="{Binding FileType}" Tag="Type"/>
+                <controls:DataGridTextColumn DisplayIndex="1" x:Name="nameColumn" IsReadOnly="True" Header="Name" Width="275" Binding="{Binding FileName}" Tag="Name"/>
+                <controls:DataGridTextColumn DisplayIndex="2" x:Name="dateColumn" IsReadOnly="True" Header="Date modified" Width="Auto" Binding="{Binding FileDate}" Tag="Date"/>
+                <controls:DataGridTextColumn DisplayIndex="3" x:Name="typeColumn" IsReadOnly="True" Header="Type" Width="150" Binding="{Binding FileType}" Tag="Type"/>
                 <controls:DataGridTextColumn DisplayIndex="4" x:Name="sizeColumn" IsReadOnly="True" Header="Size" Width="Auto" MinWidth="100" Binding="{Binding FileSize}" Tag="Size"/>
             </controls:DataGrid.Columns>
         </controls:DataGrid>

--- a/Files UWP/Interacts/Interaction.cs
+++ b/Files UWP/Interacts/Interaction.cs
@@ -384,13 +384,8 @@ namespace Files.Interacts
                 var ObjectPressed = ((ReadOnlyObservableCollection<ListedItem>)dataGrid.ItemsSource)[RowPressed.GetIndex()];
                 // Check if RightTapped row is currently selected
                 var CurrentInstance = App.selectedTabInstance;
-                foreach (ListedItem listedItem in (CurrentInstance.accessibleContentFrame.Content as GenericFileBrowser).data.SelectedItems)
-                {
-                    if (RowPressed.GetIndex() == listedItem.RowIndex)
-                    {
-                        return;
-                    }
-                }
+                if ((CurrentInstance.accessibleContentFrame.Content as GenericFileBrowser).data.SelectedItems.Contains(ObjectPressed))
+                    return;
                 // The following code is only reachable when a user RightTapped an unselected row
                 dataGrid.SelectedItems.Clear();
                 dataGrid.SelectedItems.Add(ObjectPressed);
@@ -971,10 +966,15 @@ namespace Files.Interacts
 
                     foreach (ListedItem StorItem in (CurrentInstance.accessibleContentFrame.Content as GenericFileBrowser).data.SelectedItems)
                     {
-                        foreach (DataGridRow dataGridRow in dataGridRows)
+                        IEnumerator allItems = (CurrentInstance.accessibleContentFrame.Content as GenericFileBrowser).data.ItemsSource.GetEnumerator();
+                        int index = -1;
+                        while (allItems.MoveNext())
                         {
-                            if(dataGridRow.GetIndex() == StorItem.RowIndex)
+                            index++;
+                            var item = allItems.Current;
+                            if(item == StorItem)
                             {
+                                DataGridRow dataGridRow = dataGridRows[index];
                                 (CurrentInstance.accessibleContentFrame.Content as GenericFileBrowser).data.Columns[0].GetCellContent(dataGridRow).Opacity = 0.4;
                             }
                         }
@@ -1007,7 +1007,7 @@ namespace Files.Interacts
                     {
                         List<Grid> itemContentGrids = new List<Grid>();
                         FindChildren<Grid>(itemContentGrids, (CurrentInstance.accessibleContentFrame.Content as PhotoAlbum).gv.ContainerFromItem(gridViewItem.Content));
-                        var imageOfItem = itemContentGrids.Find(x => x.Tag.ToString() == "ItemImage");
+                        var imageOfItem = itemContentGrids.Find(x => x.Tag?.ToString() == "ItemImage");
                         if (imageOfItem.Opacity < 1)
                         {
                             imageOfItem.Opacity = 1;
@@ -1016,17 +1016,12 @@ namespace Files.Interacts
 
                     foreach (ListedItem StorItem in (tabInstance.accessibleContentFrame.Content as PhotoAlbum).gv.SelectedItems)
                     {
-                        foreach (GridViewItem itemToDimForCut in gridViewItems)
-                        {
-                            if ( (CurrentInstance.accessibleContentFrame.Content as PhotoAlbum).gv.Items.IndexOf(itemToDimForCut.Content) == StorItem.RowIndex)
-                            {
-                                List<Grid> itemContentGrids = new List<Grid>();
-                                FindChildren<Grid>(itemContentGrids, (CurrentInstance.accessibleContentFrame.Content as PhotoAlbum).gv.ContainerFromItem(itemToDimForCut.Content));
-                                var imageOfItem = itemContentGrids.Find(x => x.Tag.ToString() == "ItemImage");
-                                imageOfItem.Opacity = 0.4;
-                            }
-                        }
-
+                        GridViewItem itemToDimForCut = (GridViewItem) (tabInstance.accessibleContentFrame.Content as PhotoAlbum).gv.ContainerFromItem(StorItem);
+                        List<Grid> itemContentGrids = new List<Grid>();
+                        FindChildren<Grid>(itemContentGrids, (CurrentInstance.accessibleContentFrame.Content as PhotoAlbum).gv.ContainerFromItem(itemToDimForCut.Content));
+                        var imageOfItem = itemContentGrids.Find(x => x.Tag?.ToString() == "ItemImage");
+                        imageOfItem.Opacity = 0.4;
+                    
                         App.pathsToDeleteAfterPaste.Add(StorItem.FilePath);
                         if (StorItem.FileType != "Folder")
                         {

--- a/Files UWP/PhotoAlbum.xaml
+++ b/Files UWP/PhotoAlbum.xaml
@@ -388,6 +388,7 @@
                             <FontIcon Glyph="&#xE72C;"/>
                         </MenuFlyoutItem.Icon>
                     </MenuFlyoutItem>
+                    <MenuFlyoutSeparator/>
                     <MenuFlyoutItem Click="PasteGrid_Click" Text="Paste" IsEnabled="{x:Bind local:App.PS.isEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Name="PasteGrid">
                         <MenuFlyoutItem.Icon>
                             <FontIcon Glyph="&#xE77F;"/>
@@ -512,7 +513,7 @@
             </GridView.ItemContainerStyle>
             <GridView.ItemTemplate>
                 <DataTemplate x:DataType="local2:ListedItem">
-                    <Grid IsRightTapEnabled="True" RightTapped="StackPanel_RightTapped" Width="125" Height="125" Tag="{x:Bind RowIndex}" Padding="0" ToolTipService.ToolTip="{Binding FileName}" Background="Transparent" Margin="0, 0, 0, 0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                    <Grid IsRightTapEnabled="True" RightTapped="StackPanel_RightTapped" Width="125" Height="125" Padding="0" ToolTipService.ToolTip="{Binding FileName}" Background="Transparent" Margin="0, 0, 0, 0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="100"/>
                             <RowDefinition Height="25"/>

--- a/Files UWP/PhotoAlbum.xaml.cs
+++ b/Files UWP/PhotoAlbum.xaml.cs
@@ -256,12 +256,9 @@ namespace Files
         private void StackPanel_RightTapped(object sender, RightTappedRoutedEventArgs e)
         {
             var parentContainer = Interaction.FindParent<GridViewItem>(e.OriginalSource as DependencyObject);
-            foreach (ListedItem listedItem in FileList.SelectedItems)
+            if (FileList.SelectedItems.Contains(FileList.ItemFromContainer(parentContainer)))
             {
-                if (FileList.IndexFromContainer(parentContainer) == listedItem.RowIndex)
-                {
-                    return;
-                }
+                return;
             }
             // The following code is only reachable when a user RightTapped an unselected row
             FileList.SelectedItems.Clear();


### PR DESCRIPTION
**Files and folders can now be sorted** by clicking on
the column headers or by using the right-click context
menu. The sorting order mimics Windows Explorer,
by grouping the folders and files separately first, then
applying the relevant sort on the specified column,
then finally sorting by name.

Also:
- Improves right-click context menu action grouping
- Removes `RowIndex` from `ListedItem.cs` as it is not a reliable way to access items (indices change) after sorting is implemented
- Refactors code to work around the absence of `RowIndex`
- Other minor code refactoring

## Screenshots
![image](https://user-images.githubusercontent.com/8487294/67512843-456c5680-f6cc-11e9-8461-f7de5d0fbf38.png)
![image](https://user-images.githubusercontent.com/8487294/67512863-4f8e5500-f6cc-11e9-890d-94bce7cd7e46.png)
![image](https://user-images.githubusercontent.com/8487294/67512885-5a48ea00-f6cc-11e9-82c7-dc1a7ec2a963.png)

## Related Issues

Closes #178 

Possibly related: #20