### PR TITLE
Replace hard-coded reference with environmental variable

### DIFF
--- a/ProcessLauncher/ProcessLauncher.csproj
+++ b/ProcessLauncher/ProcessLauncher.csproj
@@ -48,7 +48,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Windows">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.18362.0\Windows.winmd</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.18362.0\Windows.winmd</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
# Context
Currently the Reference to Windows.winmd is not set in a robust way.
#### `ProcessLauncher/ProcessLauncher.csproj`:
```csproj
<Reference Include="Windows">
      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.18362.0\Windows.winmd</HintPath>
</Reference>
```

The use of multiple `..\` chaining causes the project build to **fail** if the project directory was located on a deep folder in C:\, or on a different one from that in which the Windows SDK is located (most probably C:\).

Trying to build the project on D:\ causes the following errors:
![image](https://user-images.githubusercontent.com/8487294/67869962-24db4b00-fb69-11e9-8ce2-95e0cc7b8e36.png)
![image](https://user-images.githubusercontent.com/8487294/67870042-39b7de80-fb69-11e9-9b24-3cc319a47daf.png)

# Fix
Changing the reference to use the `$(MSBuildProgramFiles32)` environmental variable is a more reliable way to include the file.
```csproj
<Reference Include="Windows">
      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\UnionMetadata\10.0.18362.0\Windows.winmd</HintPath>
</Reference>
```

**After changing this line, the project was able to compile and run on my computer.**

# Related issues
Closes #252 