### PR TITLE
CommandPrompt Activation

### DIFF
--- a/Files.Package/Package.appxmanifest
+++ b/Files.Package/Package.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap mp rescap desktop4 desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap uap5 mp rescap desktop4 desktop">
   <Identity Name="49306atecsolution.FilesUWP" Publisher="CN=53EC4384-7F5B-4CF6-8C23-513FFE9D1AB7" Version="0.7.0.0" />
   <Properties>
     <DisplayName>Files</DisplayName>
@@ -36,6 +36,14 @@
         <uap:Extension Category="windows.protocol">
           <uap:Protocol ReturnResults="none" Name="files-uwp"/>
         </uap:Extension>
+        <uap5:Extension
+          Category="windows.appExecutionAlias"
+          Executable="files.exe"
+          EntryPoint="files.App">
+          <uap5:AppExecutionAlias>
+            <uap5:ExecutionAlias Alias="files.exe"/>
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -33,6 +33,7 @@ using Microsoft.UI.Xaml.Controls;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.AppService;
 using Windows.ApplicationModel.AppExtensions;
+using Files.CommandLine;
 using Files.DataModels;
 using Newtonsoft.Json;
 
@@ -898,7 +899,39 @@ namespace Files
                     var cmdLineString = operation.Arguments;
                     var activationPath = operation.CurrentDirectoryPath;
 
-                    rootFrame.Navigate(typeof(InstanceTabsView), activationPath, new SuppressNavigationTransitionInfo());
+                    var parsedCommands = CommandLineParser.ParseUntrustedCommands(cmdLineString);
+
+                    if (parsedCommands != null && parsedCommands.Count > 0)
+                    {
+	                    foreach (var command in parsedCommands)
+	                    {
+		                    switch (command.Type)
+		                    {
+			                    case ParsedCommandType.OpenDirectory:
+                                    // TODO Open Directory
+
+                                    rootFrame.Navigate(typeof(InstanceTabsView), command.Payload, new SuppressNavigationTransitionInfo());
+
+                                    // Ensure the current window is active.
+                                    watcher = DeviceInformation.CreateWatcher(StorageDevice.GetDeviceSelector());
+                                    watcher.Added += DeviceAdded;
+                                    watcher.Removed += DeviceRemoved;
+                                    watcher.Updated += DeviceUpdated;
+                                    watcher.EnumerationCompleted += Watcher_EnumerationCompleted;
+                                    watcher.Start();
+                                    Task.Delay(5000);
+                                    Window.Current.Activate();
+                                    Window.Current.CoreWindow.KeyDown += CoreWindow_KeyDown;
+                                    Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += Dispatcher_AcceleratorKeyActivated;
+
+                                    
+                                    return;
+			                    case ParsedCommandType.Unkwon:
+				                    rootFrame.Navigate(typeof(InstanceTabsView), null, new SuppressNavigationTransitionInfo());
+                                    break;
+                            }
+	                    }
+                    }
 
                     /*
                     // Ensure the current window is active.

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -866,30 +866,51 @@ namespace Files
                 Window.Current.Content = rootFrame;
             }
 
-            if (args.Kind == ActivationKind.Protocol)
+            switch (args.Kind)
             {
-                var eventArgs = args as ProtocolActivatedEventArgs;
+                case ActivationKind.Protocol:
+                    var eventArgs = args as ProtocolActivatedEventArgs;
 
-                if (eventArgs.Uri.AbsoluteUri == "files-uwp:")
-                {
-                    rootFrame.Navigate(typeof(InstanceTabsView), null, new SuppressNavigationTransitionInfo());
-                }
-                else
-                {
-                    var trimmedPath = eventArgs.Uri.OriginalString.Split('=')[1];
-                    rootFrame.Navigate(typeof(InstanceTabsView), @trimmedPath, new SuppressNavigationTransitionInfo());
-                }
-                // Ensure the current window is active.
-                watcher = DeviceInformation.CreateWatcher(StorageDevice.GetDeviceSelector());
-                watcher.Added += DeviceAdded;
-                watcher.Removed += DeviceRemoved;
-                watcher.Updated += DeviceUpdated;
-                watcher.EnumerationCompleted += Watcher_EnumerationCompleted;
-                watcher.Start();
-                Window.Current.Activate();
-                Window.Current.CoreWindow.KeyDown += CoreWindow_KeyDown;
-                Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += Dispatcher_AcceleratorKeyActivated;
-                return;
+                    if (eventArgs.Uri.AbsoluteUri == "files-uwp:")
+                    {
+                        rootFrame.Navigate(typeof(InstanceTabsView), null, new SuppressNavigationTransitionInfo());
+                    }
+                    else
+                    {
+                        var trimmedPath = eventArgs.Uri.OriginalString.Split('=')[1];
+                        rootFrame.Navigate(typeof(InstanceTabsView), @trimmedPath, new SuppressNavigationTransitionInfo());
+                    }
+                    // Ensure the current window is active.
+                    watcher = DeviceInformation.CreateWatcher(StorageDevice.GetDeviceSelector());
+                    watcher.Added += DeviceAdded;
+                    watcher.Removed += DeviceRemoved;
+                    watcher.Updated += DeviceUpdated;
+                    watcher.EnumerationCompleted += Watcher_EnumerationCompleted;
+                    watcher.Start();
+                    Window.Current.Activate();
+                    Window.Current.CoreWindow.KeyDown += CoreWindow_KeyDown;
+                    Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += Dispatcher_AcceleratorKeyActivated;
+                    return;
+
+                case ActivationKind.CommandLineLaunch:
+                    var cmdLineArgs = args as CommandLineActivatedEventArgs;
+                    var operation = cmdLineArgs.Operation;
+                    var cmdLineString = operation.Arguments;
+                    var activationPath = operation.CurrentDirectoryPath;
+
+                    rootFrame.Navigate(typeof(InstanceTabsView), activationPath, new SuppressNavigationTransitionInfo());
+                    
+                    // Ensure the current window is active.
+                    watcher = DeviceInformation.CreateWatcher(StorageDevice.GetDeviceSelector());
+                    watcher.Added += DeviceAdded;
+                    watcher.Removed += DeviceRemoved;
+                    watcher.Updated += DeviceUpdated;
+                    watcher.EnumerationCompleted += Watcher_EnumerationCompleted;
+                    watcher.Start();
+                    Window.Current.Activate();
+                    Window.Current.CoreWindow.KeyDown += CoreWindow_KeyDown;
+                    Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += Dispatcher_AcceleratorKeyActivated;
+                    return;
             }
 
             rootFrame.Navigate(typeof(InstanceTabsView), null, new SuppressNavigationTransitionInfo());

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -899,7 +899,8 @@ namespace Files
                     var activationPath = operation.CurrentDirectoryPath;
 
                     rootFrame.Navigate(typeof(InstanceTabsView), activationPath, new SuppressNavigationTransitionInfo());
-                    
+
+                    /*
                     // Ensure the current window is active.
                     watcher = DeviceInformation.CreateWatcher(StorageDevice.GetDeviceSelector());
                     watcher.Added += DeviceAdded;
@@ -911,6 +912,8 @@ namespace Files
                     Window.Current.CoreWindow.KeyDown += CoreWindow_KeyDown;
                     Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += Dispatcher_AcceleratorKeyActivated;
                     return;
+                    */
+                    break;
             }
 
             rootFrame.Navigate(typeof(InstanceTabsView), null, new SuppressNavigationTransitionInfo());

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -932,20 +932,6 @@ namespace Files
                             }
 	                    }
                     }
-
-                    /*
-                    // Ensure the current window is active.
-                    watcher = DeviceInformation.CreateWatcher(StorageDevice.GetDeviceSelector());
-                    watcher.Added += DeviceAdded;
-                    watcher.Removed += DeviceRemoved;
-                    watcher.Updated += DeviceUpdated;
-                    watcher.EnumerationCompleted += Watcher_EnumerationCompleted;
-                    watcher.Start();
-                    Window.Current.Activate();
-                    Window.Current.CoreWindow.KeyDown += CoreWindow_KeyDown;
-                    Window.Current.CoreWindow.Dispatcher.AcceleratorKeyActivated += Dispatcher_AcceleratorKeyActivated;
-                    return;
-                    */
                     break;
             }
 

--- a/Files/CommandLine/CommandLineParser.cs
+++ b/Files/CommandLine/CommandLineParser.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.CommandLine
+{
+	class CommandLineParser
+	{
+		public static ParsedCommands ParseUntrustedCommands(string cmdLineString)
+		{
+			var commands = new ParsedCommands();
+
+			var parsedArgs = Parse(cmdLineString);
+
+			foreach (var kvp in parsedArgs)
+			{
+				Debug.WriteLine("arg {0} = {1}", kvp.Key, kvp.Value);
+				
+				var command = new ParsedCommand();
+
+				switch (kvp.Key)
+				{
+					case "-Directory":
+						command.Type = ParsedCommandType.OpenDirectory;
+						break;
+					default:
+						command.Type = ParsedCommandType.Unkwon;
+						break;
+				}
+
+				command.Payload = kvp.Value;
+				commands.Add(command);
+			}
+
+			return commands;
+		}
+
+		public static List<KeyValuePair<string, string>> Parse(string argString = null)
+		{
+			var parsedArgs = new List<KeyValuePair<string, string>>();
+
+			string[] args = argString.Split(" ");
+
+			if (args != null)
+			{
+				for (int i = 0; i < args.Length; i++)
+				{
+					if (args[i].StartsWith("-") || args[i].StartsWith("/"))
+					{
+						var data = ParseData(args, i);
+
+						if (data.Key != null)
+						{
+							for (int j = 0; j < parsedArgs.Count; j++)
+							{
+								if (parsedArgs[j].Key == data.Key)
+								{
+									parsedArgs.RemoveAt(j);
+								}
+							}
+
+							parsedArgs.Add(data);
+						}
+					}
+				}
+			}
+
+			return parsedArgs;
+		}
+
+		private static KeyValuePair<string, string> ParseData(string[] args, int index)
+		{
+			string key = null;
+			string val = null;
+			if (args[index].StartsWith("-") || args[index].StartsWith("/"))
+			{
+				if (args[index].Contains(":"))
+				{
+					string argument = args[index];
+					int endIndex = argument.IndexOf(':');
+					key = argument.Substring(1, endIndex - 1);   // trim the '/' and the ':'.
+					int valueStart = endIndex + 1;
+					val = valueStart < argument.Length ? argument.Substring(
+						valueStart, argument.Length - valueStart) : null;
+				}
+				else
+				{
+					key = args[index];
+					int argIndex = 1 + index;
+					if (argIndex < args.Length && !(args[argIndex].StartsWith("-") || args[argIndex].StartsWith("/")))
+					{
+						val = args[argIndex];
+					}
+					else
+					{
+						val = null;
+					}
+				}
+			}
+
+			return key != null ? new KeyValuePair<string, string>(key, val) : default(KeyValuePair<string, string>);
+		}
+	}
+}

--- a/Files/CommandLine/ParsedCommand.cs
+++ b/Files/CommandLine/ParsedCommand.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.CommandLine
+{
+	class ParsedCommand
+	{
+		public ParsedCommandType Type { get; set; }
+
+		public string Payload { get; set; }
+	}
+}

--- a/Files/CommandLine/ParsedCommandType.cs
+++ b/Files/CommandLine/ParsedCommandType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.CommandLine
+{
+	enum ParsedCommandType
+	{
+		Unkwon,
+		OpenDirectory,
+	}
+}

--- a/Files/CommandLine/ParsedCommands.cs
+++ b/Files/CommandLine/ParsedCommands.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.CommandLine
+{
+	class ParsedCommands : List<ParsedCommand>
+	{
+	}
+}

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -136,6 +136,10 @@
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="BaseLayout.cs" />
+    <Compile Include="CommandLine\CommandLineParser.cs" />
+    <Compile Include="CommandLine\ParsedCommand.cs" />
+    <Compile Include="CommandLine\ParsedCommands.cs" />
+    <Compile Include="CommandLine\ParsedCommandType.cs" />
     <Compile Include="Controls\FileViewControl.xaml.cs">
       <DependentUpon>FileViewControl.xaml</DependentUpon>
     </Compile>
@@ -404,6 +408,7 @@
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
# Description

I added the "AppExecutionAlias" `files.exe`, so the app can be launched from any command prompt.

In the folder `%localappdata%\Microsoft\WindowsApps` is now `files.exe` created, which helps #236.

I also did some testing with opening files in the current directory from the cmd, but there is currently a race condition between the app startup and the `PopulateDrivesListWithLocalDisks`-method, which does not populate the list fast enough. At a normal start from the cmdline, it always crashes, in the debugger with a breakpoint not. This only occurs if files wants to show the current directory.

# Questions

I would love some input on the cmdline-protocoll: Which commands, ...

PS:
The code as is does not support open in a directory, but works, in that it opens files. Don't know if you want to merge this as whole or as little parts.