### PR TITLE
Fixed grid view selection bugs

### DIFF
--- a/Files/UserControls/LayoutModes/PhotoAlbum.xaml.cs
+++ b/Files/UserControls/LayoutModes/PhotoAlbum.xaml.cs
@@ -32,20 +32,16 @@ namespace Files
 
         protected override void SetSelectedItemsOnUi(List<ListedItem> selectedItems)
         {
-            // To prevent program from crashing when the page is first loaded
-            if (selectedItems.Count > 0)
+            foreach (ListedItem listedItem in FileList.Items)
             {
-                foreach (ListedItem listedItem in FileList.Items)
-                {
-                    GridViewItem gridViewItem = FileList.ContainerFromItem(listedItem) as GridViewItem;
+                GridViewItem gridViewItem = FileList.ContainerFromItem(listedItem) as GridViewItem;
 
-                    if (gridViewItem != null)
-                    {
-                        List<Grid> grids = new List<Grid>();
-                        Interaction.FindChildren<Grid>(grids, gridViewItem);
-                        var rootItem = grids.Find(x => x.Tag?.ToString() == "ItemRoot");
-                        rootItem.CanDrag = selectedItems.Contains(listedItem);
-                    }
+                if (gridViewItem != null)
+                {
+                    List<Grid> grids = new List<Grid>();
+                    Interaction.FindChildren<Grid>(grids, gridViewItem);
+                    var rootItem = grids.Find(x => x.Tag?.ToString() == "ItemRoot");
+                    rootItem.CanDrag = selectedItems.Contains(listedItem);
                 }
             }
 
@@ -200,6 +196,8 @@ namespace Files
                     App.CurrentInstance.ViewModel.LoadExtendedItemProperties(sender.DataContext as ListedItem, 80);
                     (sender.DataContext as ListedItem).ItemPropertiesInitialized = true;
                 });
+
+                (sender as UIElement).CanDrag = FileList.SelectedItems.Contains(sender.DataContext as ListedItem); // Update CanDrag
             }
         }
 


### PR DESCRIPTION
Fixed selection bugs with the grid view layout (#660 and #678)

Removing the if statement in line 36
`if (selectedItems.Count > 0)`
fixes the deselect and then reselect bugs.
I have read the commented warning above the if, but I haven't been able to recreate any crashes or issues by removing it.

Line 200 
`(sender as UIElement).CanDrag = FileList.SelectedItems.Contains(sender.DataContext as ListedItem);`
fixes the issue whereby browsing up or down into a folder prevents the user from being able to select files.

Here's the result:
![Files-UWP-Dev-2020-05-15-15-16-40](https://user-images.githubusercontent.com/46000533/82054592-77242980-96bf-11ea-8d8e-1f0120a5481b.gif)
