### PR TITLE
Add support for Recycle Bin

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Files.Common
 {
@@ -11,6 +12,21 @@ namespace Files.Common
                 dictionary[key] = (TValue)(object)defaultValue;
 
             return (TOut)(object)dictionary[key];
+        }
+
+        public static DateTime ToDateTime(this System.Runtime.InteropServices.ComTypes.FILETIME time)
+        {
+            ulong high = (ulong)time.dwHighDateTime;
+            uint low = (uint)time.dwLowDateTime;
+            long fileTime = (long)((high << 32) + low);
+            try
+            {
+                return DateTime.FromFileTimeUtc(fileTime);
+            }
+            catch
+            {
+                return DateTime.FromFileTimeUtc(0xFFFFFFFF);
+            }
         }
     }
 }

--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Files.Common
+{
+    public static class Extensions
+    {
+        public static TOut Get<TOut, TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TOut defaultValue = default(TOut))
+        {
+            // If setting doesn't exist, create it.
+            if (!dictionary.ContainsKey(key))
+                dictionary[key] = (TValue)(object)defaultValue;
+
+            return (TOut)(object)dictionary[key];
+        }
+    }
+}

--- a/Common/ShellFileItem.cs
+++ b/Common/ShellFileItem.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.Common
+{
+    public class ShellFileItem
+    {
+        public bool isFolder;
+        public string recyclePath;
+        public string fileName;
+        public string filePath;
+        public DateTime recycleDate;
+        public string fileSize;
+        public int fileSizeBytes;
+        public string fileType;
+
+        public ShellFileItem()
+        {
+
+        }
+
+        public ShellFileItem(bool isFolder, string recyclePath, string fileName, string filePath, DateTime recycleDate, string fileSize, int fileSizeBytes, string fileType)
+        {
+            this.isFolder = isFolder;
+            this.recyclePath = recyclePath;
+            this.fileName = fileName;
+            this.filePath = filePath;
+            this.recycleDate = recycleDate;
+            this.fileSize = fileSize;
+            this.fileSizeBytes = fileSizeBytes;
+            this.fileType = fileType;
+        }
+    }
+}

--- a/Common/ShellFileItem.cs
+++ b/Common/ShellFileItem.cs
@@ -15,7 +15,7 @@ namespace Files.Common
         public string FilePath;
         public DateTime RecycleDate;
         public string FileSize;
-        public long FileSizeBytes;
+        public ulong FileSizeBytes;
         public string FileType;
 
         public ShellFileItem()
@@ -23,7 +23,7 @@ namespace Files.Common
 
         }
 
-        public ShellFileItem(bool isFolder, string recyclePath, string fileName, string filePath, DateTime recycleDate, string fileSize, long fileSizeBytes, string fileType)
+        public ShellFileItem(bool isFolder, string recyclePath, string fileName, string filePath, DateTime recycleDate, string fileSize, ulong fileSizeBytes, string fileType)
         {
             this.IsFolder = isFolder;
             this.RecyclePath = recyclePath;

--- a/Common/ShellFileItem.cs
+++ b/Common/ShellFileItem.cs
@@ -9,30 +9,30 @@ namespace Files.Common
 {
     public class ShellFileItem
     {
-        public bool isFolder;
-        public string recyclePath;
-        public string fileName;
-        public string filePath;
-        public DateTime recycleDate;
-        public string fileSize;
-        public int fileSizeBytes;
-        public string fileType;
+        public bool IsFolder;
+        public string RecyclePath;
+        public string FileName;
+        public string FilePath;
+        public DateTime RecycleDate;
+        public string FileSize;
+        public long FileSizeBytes;
+        public string FileType;
 
         public ShellFileItem()
         {
 
         }
 
-        public ShellFileItem(bool isFolder, string recyclePath, string fileName, string filePath, DateTime recycleDate, string fileSize, int fileSizeBytes, string fileType)
+        public ShellFileItem(bool isFolder, string recyclePath, string fileName, string filePath, DateTime recycleDate, string fileSize, long fileSizeBytes, string fileType)
         {
-            this.isFolder = isFolder;
-            this.recyclePath = recyclePath;
-            this.fileName = fileName;
-            this.filePath = filePath;
-            this.recycleDate = recycleDate;
-            this.fileSize = fileSize;
-            this.fileSizeBytes = fileSizeBytes;
-            this.fileType = fileType;
+            this.IsFolder = isFolder;
+            this.RecyclePath = recyclePath;
+            this.FileName = fileName;
+            this.FilePath = filePath;
+            this.RecycleDate = recycleDate;
+            this.FileSize = fileSize;
+            this.FileSizeBytes = fileSizeBytes;
+            this.FileType = fileType;
         }
     }
 }

--- a/Files.Launcher/Files.Launcher.csproj
+++ b/Files.Launcher/Files.Launcher.csproj
@@ -26,6 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>8.0</LangVersion>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -107,6 +108,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <Content Include="NLog.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers">
@@ -119,6 +123,9 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
+    </PackageReference>
+    <PackageReference Include="NLog">
+      <Version>4.7.0</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.WindowsRuntime">
       <Version>4.6.0</Version>

--- a/Files.Launcher/Files.Launcher.csproj
+++ b/Files.Launcher/Files.Launcher.csproj
@@ -109,17 +109,6 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="Shell32">
-      <Guid>{50A7E9B0-70EF-11D1-B75A-00A0C90564FE}</Guid>
-      <VersionMajor>1</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers">
       <Version>3.3.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -136,6 +125,9 @@
     </PackageReference>
     <PackageReference Include="System.Runtime.WindowsRuntime.UI.Xaml">
       <Version>4.6.0</Version>
+    </PackageReference>
+    <PackageReference Include="Vanara.Windows.Shell">
+      <Version>3.2.7</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Files.Launcher/Files.Launcher.csproj
+++ b/Files.Launcher/Files.Launcher.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QuickLook.cs" />
+    <Compile Include="Win32API.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Files.Launcher/Files.Launcher.csproj
+++ b/Files.Launcher/Files.Launcher.csproj
@@ -6,8 +6,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{533F9E86-EE0A-4FCB-B70C-F29532C1B787}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <RootNamespace>ProcessLauncher</RootNamespace>
-    <AssemblyName>ProcessLauncher</AssemblyName>
+    <RootNamespace>FilesFullTrust</RootNamespace>
+    <AssemblyName>FilesFullTrust</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -107,6 +107,42 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="Shell32">
+      <Guid>{50A7E9B0-70EF-11D1-B75A-00A0C90564FE}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers">
+      <Version>3.3.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts">
+      <Version>10.0.19041.1</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.3</Version>
+    </PackageReference>
+    <PackageReference Include="System.Runtime.WindowsRuntime">
+      <Version>4.6.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Runtime.WindowsRuntime.UI.Xaml">
+      <Version>4.6.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj">
+      <Project>{0533133f-2559-4b53-a0fd-0970bc0e312e}</Project>
+      <Name>Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Files.Launcher/NLog.config
+++ b/Files.Launcher/NLog.config
@@ -3,7 +3,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <targets>
-        <target name="logfile" xsi:type="File" fileName="${var:LogPath}\debug.txt" concurrentWrites="true" 
+        <target name="logfile" xsi:type="File" fileName="${var:LogPath}\debug_fulltrust.txt" concurrentWrites="true" 
                 layout="${longdate}|${level:uppercase=true}|${logger}|${message}|${exception:format=tostring}"/>
         <target name="logconsole" xsi:type="Console" />
     </targets>

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -207,17 +207,18 @@ namespace FilesFullTrust
                             {
                                 try
                                 {
-                                    //folderItem.Properties.ReadOnly = true;
-                                    //folderItem.Properties.NoInheritedProperties = false;
+                                    folderItem.Properties.ReadOnly = true;
+                                    folderItem.Properties.NoInheritedProperties = false;
                                     string recyclePath = folderItem.FileSystemPath; // True path on disk
-                                    //string fileName = Path.GetFileName(folderItem.FileInfo.DisplayName); // Original file name
-                                    //string filePath = folderItem.FileInfo.DisplayName; // Original file path
-                                    //DateTime recycleDate = folderItem.FileInfo.CreationTime; // This is LocalTime
-                                    //string fileSize = folderItem.Properties.GetPropertyString(Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size);
-                                    //long fileSizeBytes = folderItem.IsFolder ? 0 : folderItem.FileInfo.Length;
-                                    //string fileType = folderItem.FileInfo.TypeName;
-                                    //bool isFolder = folderItem.FileInfo.Attributes.HasFlag(FileAttributes.Directory); //folderItem.IsFolder includes .zip
-                                    folderContentsList.Add(new ShellFileItem(folderItem.IsFolder && Path.GetExtension(folderItem.Name) != ".zip", recyclePath, Path.GetFileName(folderItem.Name), Path.GetDirectoryName(folderItem.Name), DateTime.Now, "0 Kb", 0, "Some stuff"));
+                                    string fileName = Path.GetFileName(folderItem.Name); // Original file name
+                                    string filePath = folderItem.Name; // Original file path + name
+                                    var dt = (System.Runtime.InteropServices.ComTypes.FILETIME)folderItem.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.DateCreated];
+                                    var recycleDate = dt.ToDateTime().ToLocalTime(); // This is LocalTime
+                                    string fileSize = folderItem.Properties.GetPropertyString(Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size);
+                                    ulong fileSizeBytes = folderItem.IsFolder ? 0 : (ulong)folderItem.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size];
+                                    string fileType = (string)folderItem.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.ItemTypeText];
+                                    bool isFolder = folderItem.IsFolder && Path.GetExtension(folderItem.Name) != ".zip";
+                                    folderContentsList.Add(new ShellFileItem(isFolder, recyclePath, fileName, filePath, recycleDate, fileSize, fileSizeBytes, fileType));
                                 }
                                 catch (System.IO.FileNotFoundException)
                                 {

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -198,34 +198,6 @@ namespace FilesFullTrust
                                 await args.Request.SendResponseAsync(responseQuery);
                             }
                         }
-                        else if (action == "Restore")
-                        {
-                            try
-                            {
-                                var sourceFilePath = (string)args.Request.Message["SourceFile"];
-                                using var sourceFile = new ShellItem(sourceFilePath);
-                                string originalFilePath = sourceFile.FileInfo.DisplayName;
-                                await System.Threading.Tasks.Task.Run(() =>
-                                {
-                                    if (sourceFile.FileInfo.Attributes.HasFlag(FileAttributes.Directory))
-                                    {
-                                        System.IO.Directory.Move(sourceFilePath, originalFilePath);
-                                    }
-                                    else
-                                    {
-                                        System.IO.File.Move(sourceFilePath, originalFilePath);
-                                    }
-                                    // Recycle bin also stores a file starting with $I for each item
-                                    var iFilePath = Path.Combine(Path.GetDirectoryName(sourceFilePath), Path.GetFileName(sourceFilePath).Replace("$R", "$I"));
-                                    System.IO.File.Delete(iFilePath);
-                                });
-                            }
-                            catch (System.IO.IOException ex)
-                            {
-                                // If destination file exists
-                                // TODO: display dialog to the user
-                            }
-                        }
                         else if (action == "Enumerate")
                         {
                             // Enumerate recyclebin contents and send response to UWP
@@ -239,7 +211,7 @@ namespace FilesFullTrust
                                     folderItem.Properties.NoInheritedProperties = false;
                                     string recyclePath = folderItem.FileSystemPath; // True path on disk
                                     string fileName = Path.GetFileName(folderItem.FileInfo.DisplayName); // Original file name
-                                    string filePath = Path.GetDirectoryName(folderItem.FileInfo.DisplayName); // Original file path
+                                    string filePath = folderItem.FileInfo.DisplayName; // Original file path
                                     DateTime recycleDate = folderItem.FileInfo.CreationTime; // This is LocalTime
                                     string fileSize = folderItem.Properties.GetPropertyString(Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size);
                                     long fileSizeBytes = folderItem.IsFolder ? 0 : folderItem.FileInfo.Length;

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -263,7 +263,7 @@ namespace FilesFullTrust
                 Process process = new Process();
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.FileName = executable;
-                // Show window is no arguments (opening terminal)
+                // Show window if arguments (opening terminal)
                 process.StartInfo.CreateNoWindow = string.IsNullOrEmpty(arguments);
                 process.StartInfo.Arguments = arguments;
                 process.Start();

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -215,7 +215,7 @@ namespace FilesFullTrust
                                     var dt = (System.Runtime.InteropServices.ComTypes.FILETIME)folderItem.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.DateCreated];
                                     var recycleDate = dt.ToDateTime().ToLocalTime(); // This is LocalTime
                                     string fileSize = folderItem.Properties.GetPropertyString(Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size);
-                                    ulong fileSizeBytes = folderItem.IsFolder ? 0 : (ulong)folderItem.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size];
+                                    ulong fileSizeBytes = (ulong)folderItem.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size];
                                     string fileType = (string)folderItem.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.ItemTypeText];
                                     bool isFolder = folderItem.IsFolder && Path.GetExtension(folderItem.Name) != ".zip";
                                     folderContentsList.Add(new ShellFileItem(isFolder, recyclePath, fileName, filePath, recycleDate, fileSize, fileSizeBytes, fileType));

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -207,17 +207,17 @@ namespace FilesFullTrust
                             {
                                 try
                                 {
-                                    folderItem.Properties.ReadOnly = true;
-                                    folderItem.Properties.NoInheritedProperties = false;
+                                    //folderItem.Properties.ReadOnly = true;
+                                    //folderItem.Properties.NoInheritedProperties = false;
                                     string recyclePath = folderItem.FileSystemPath; // True path on disk
-                                    string fileName = Path.GetFileName(folderItem.FileInfo.DisplayName); // Original file name
-                                    string filePath = folderItem.FileInfo.DisplayName; // Original file path
-                                    DateTime recycleDate = folderItem.FileInfo.CreationTime; // This is LocalTime
-                                    string fileSize = folderItem.Properties.GetPropertyString(Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size);
-                                    long fileSizeBytes = folderItem.IsFolder ? 0 : folderItem.FileInfo.Length;
-                                    string fileType = folderItem.FileInfo.TypeName;
-                                    bool isFolder = folderItem.FileInfo.Attributes.HasFlag(FileAttributes.Directory); //folderItem.IsFolder includes .zip
-                                    folderContentsList.Add(new ShellFileItem(isFolder, recyclePath, fileName, filePath, recycleDate, fileSize, fileSizeBytes, fileType));
+                                    //string fileName = Path.GetFileName(folderItem.FileInfo.DisplayName); // Original file name
+                                    //string filePath = folderItem.FileInfo.DisplayName; // Original file path
+                                    //DateTime recycleDate = folderItem.FileInfo.CreationTime; // This is LocalTime
+                                    //string fileSize = folderItem.Properties.GetPropertyString(Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size);
+                                    //long fileSizeBytes = folderItem.IsFolder ? 0 : folderItem.FileInfo.Length;
+                                    //string fileType = folderItem.FileInfo.TypeName;
+                                    //bool isFolder = folderItem.FileInfo.Attributes.HasFlag(FileAttributes.Directory); //folderItem.IsFolder includes .zip
+                                    folderContentsList.Add(new ShellFileItem(folderItem.IsFolder && Path.GetExtension(folderItem.Name) != ".zip", recyclePath, Path.GetFileName(folderItem.Name), Path.GetDirectoryName(folderItem.Name), DateTime.Now, "0 Kb", 0, "Some stuff"));
                                 }
                                 catch (System.IO.FileNotFoundException)
                                 {

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -263,7 +263,8 @@ namespace FilesFullTrust
                 Process process = new Process();
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.FileName = executable;
-                process.StartInfo.CreateNoWindow = true;
+                // Show window is no arguments (opening terminal)
+                process.StartInfo.CreateNoWindow = string.IsNullOrEmpty(arguments);
                 process.StartInfo.Arguments = arguments;
                 process.Start();
             }

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -199,6 +199,10 @@ namespace FilesFullTrust
                                 {
                                     // Happens if files are being deleted
                                 }
+                                finally
+                                {
+                                    folderItem?.Dispose();
+                                }
                             }
                             responseEnum.Add("Enumerate", Newtonsoft.Json.JsonConvert.SerializeObject(folderContentsList));
                             await args.Request.SendResponseAsync(responseEnum);

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -1,85 +1,282 @@
-﻿using System;
+﻿using Files.Common;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
-using System.IO.Pipes;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
-using Windows.Storage;
+using System.Threading;
+using Windows.ApplicationModel;
+using Windows.ApplicationModel.AppService;
+using Windows.Foundation.Collections;
 
-namespace ProcessLauncher
+namespace FilesFullTrust
 {
     internal class Program
     {
+        //Put all the variables required for the DLLImports here
+        enum RecycleFlags : uint { SHERB_NOCONFIRMATION = 0x00000001, SHERB_NOPROGRESSUI = 0x00000002, SHERB_NOSOUND = 0x00000004 }
+
+        [DllImport("Shell32.dll")]
+        static extern int SHEmptyRecycleBin
+              (IntPtr hwnd, string pszRootPath, RecycleFlags dwFlags);
+
+        [STAThread]
         private static void Main(string[] args)
         {
-            var localSettings = ApplicationData.Current.LocalSettings;
-            var arguments = (string)localSettings.Values["Arguments"];
-            if (!string.IsNullOrWhiteSpace(arguments))
-            {
-                if (arguments.Equals("StartupTasks"))
-                {
-                    // Check QuickLook Availability
-                    QuickLook.CheckQuickLookAvailability(localSettings);
-                }
-                else if (arguments.Equals("ToggleQuickLook"))
-                {
-                    var path = (string)localSettings.Values["path"];
-                    QuickLook.ToggleQuickLook(path);
-                }
-                else if (arguments.Equals("ShellCommand"))
-                {
-                    //Kill the process. This is a BRUTAL WAY to kill a process.
-                    var pid = (int)ApplicationData.Current.LocalSettings.Values["pid"];
-                    Process.GetProcessById(pid).Kill();
+            // Only one instance of the fulltrust process allowed
+            // This happens if multiple instances of the UWP app are launched
+            var mutex = new Mutex(true, "FilesUwpFullTrust", out bool isNew);
+            if (!isNew) return;
 
-                    Process process = new Process();
-                    process.StartInfo.UseShellExecute = true;
-                    process.StartInfo.FileName = "explorer.exe";
-                    process.StartInfo.CreateNoWindow = false;
-                    process.StartInfo.Arguments = (string)ApplicationData.Current.LocalSettings.Values["ShellCommand"];
-                    process.Start();
-                }
-                else
-                {
-                    var executable = (string)ApplicationData.Current.LocalSettings.Values["Application"];
-                    Process process = new Process();
-                    process.StartInfo.UseShellExecute = false;
-                    process.StartInfo.FileName = executable;
-                    process.StartInfo.CreateNoWindow = false;
-                    process.StartInfo.Arguments = arguments;
-                    process.Start();
-                }
-            }
-            else
+            Console.WriteLine("*****************************");
+            Console.WriteLine("**** Files UWP FullTrust ****");
+            Console.WriteLine("*****************************");
+
+            // Create shell COM object and get recycle bin folder
+            shell = new Shell32.Shell();
+            // Recycler = shell.NameSpace(ShellSpecialFolderConstants.ssfBITBUCKET);
+            Type shellAppType = Type.GetTypeFromProgID("Shell.Application");
+            Recycler = (Shell32.Folder)shellAppType.InvokeMember("NameSpace",
+                System.Reflection.BindingFlags.InvokeMethod, null, shell, new object[] { Shell32.ShellSpecialFolderConstants.ssfBITBUCKET });
+
+            // Save Localized recycle bin name
+            var localSettings = Windows.Storage.ApplicationData.Current.LocalSettings;
+            localSettings.Values["RecycleBin_Title"] = Recycler.Title;
+
+            //for (int i = 0; i < 0xFFFF; i++)
+            //{
+            //string detail = Recycler.GetDetailsOf(null, i);
+            //if (string.IsNullOrEmpty(detail)) break;
+            //Console.WriteLine("[{0}]: {1}",i,detail);
+            //}
+
+            watchers = new List<FileSystemWatcher>();
+
+            // Get user login SID
+            // Recycle bin path is fixed on NTFS drives: X:\$Recycle.Bin\SID
+            var sid = WindowsIdentity.GetCurrent().User;
+
+            foreach (var drive in DriveInfo.GetDrives())
             {
-                try
+                var recycle_path = Path.Combine(drive.Name, "$Recycle.Bin", sid.ToString());
+                if (!Directory.Exists(recycle_path)) continue;
+
+                // FileSystemWatcher does not work on shell folders
+                // Get here the disk path of recycle bin for each drive
+                var watcher = new FileSystemWatcher();
+                watcher.Path = recycle_path;
+                watcher.NotifyFilter = NotifyFilters.LastAccess
+                                    | NotifyFilters.LastWrite
+                                    | NotifyFilters.FileName
+                                    | NotifyFilters.DirectoryName;
+
+                // Watch all files
+                watcher.Filter = "*.*";
+
+                // Add event handlers.
+                //watcher.Changed += Watcher_Changed;
+                watcher.Created += Watcher_Changed;
+                watcher.Deleted += Watcher_Changed;
+                //watcher.Renamed += Watcher_Renamed;
+
+                // Begin watching.
+                watcher.EnableRaisingEvents = true;
+                watchers.Add(watcher);
+            }
+
+            // Connect to app service and wait until the connection gets closed
+            appServiceExit = new AutoResetEvent(false);
+            InitializeAppServiceConnection();
+            appServiceExit.WaitOne();
+
+            foreach (var watcher in watchers)
+                watcher.Dispose();
+            Marshal.FinalReleaseComObject(shell);
+        }
+
+        private static void Watcher_Renamed(object sender, RenamedEventArgs e)
+        {
+            Console.WriteLine($"File: {e.OldFullPath} renamed to {e.FullPath}");
+        }
+
+        private static async void Watcher_Changed(object sender, FileSystemEventArgs e)
+        {
+            Console.WriteLine($"File: {e.FullPath} {e.ChangeType}");
+            if (connection != null)
+            {
+                // Send message to UWP app to refresh items
+                await connection.SendMessageAsync(new ValueSet() { { "FileSystem", @"Shell:RecycleBinFolder" }, { "Path", e.FullPath }, { "Type", e.ChangeType.ToString() } });
+            }
+        }
+
+        private static AppServiceConnection connection;
+        private static AutoResetEvent appServiceExit;
+        private static Shell32.Shell shell;
+        private static Shell32.Folder Recycler;
+        private static List<FileSystemWatcher> watchers;
+
+        private static async void InitializeAppServiceConnection()
+        {
+            connection = new AppServiceConnection();
+            connection.AppServiceName = "FilesInteropService";
+            connection.PackageFamilyName = Package.Current.Id.FamilyName;
+            connection.RequestReceived += Connection_RequestReceived;
+            connection.ServiceClosed += Connection_ServiceClosed;
+
+            AppServiceConnectionStatus status = await connection.OpenAsync();
+            if (status != AppServiceConnectionStatus.Success)
+            {
+                // TODO: error handling
+                connection.Dispose();
+                connection = null;
+            }
+        }
+
+        private static async void Connection_RequestReceived(AppServiceConnection sender, AppServiceRequestReceivedEventArgs args)
+        {
+            // Get a deferral because we use an awaitable API below to respond to the message
+            // and we don't want this call to get cancelled while we are waiting.
+            var messageDeferral = args.GetDeferral();
+
+            if (args.Request.Message == null)
+            {
+                messageDeferral.Complete();
+                return;
+            }
+
+            try
+            {
+                if (args.Request.Message.ContainsKey("Arguments"))
                 {
-                    var executable = (string)ApplicationData.Current.LocalSettings.Values["Application"];
-                    Process process = new Process();
-                    process.StartInfo.UseShellExecute = false;
-                    process.StartInfo.FileName = executable;
-                    process.StartInfo.CreateNoWindow = true;
-                    process.Start();
+                    // This replaces launching the fulltrust process with arguments
+                    // Instead a single instance of the process is running
+                    // Requests from UWP app are sent via AppService connection
+                    var arguments = (string)args.Request.Message["Arguments"];
+                    var localSettings = Windows.Storage.ApplicationData.Current.LocalSettings;
+
+                    if (arguments.Equals("Terminate"))
+                    {
+                        // Exit fulltrust process (UWP is closed or suspended)
+                        appServiceExit.Set();
+                        messageDeferral.Complete();
+                    }
+                    else if (arguments.Equals("RecycleBin"))
+                    {
+                        var action = (string)args.Request.Message["action"];
+                        if (action.Equals("Empty"))
+                        {
+                            // Shell function to empty recyclebin
+                            SHEmptyRecycleBin(IntPtr.Zero, null, RecycleFlags.SHERB_NOCONFIRMATION | RecycleFlags.SHERB_NOPROGRESSUI);
+                        }
+                        else if (action.Equals("Enumerate"))
+                        {
+                            // Enumerate recyclebin contents and send response to UWP
+                            var response_enum = new ValueSet();
+                            Shell32.FolderItems items = Recycler.Items();
+                            var file_list = new List<ShellFileItem>();
+                            for (int i = 0; i < items.Count; i++)
+                            {
+                                Shell32.FolderItem FI = items.Item(i);
+                                string RecyclePath = FI.Path; // True path on disk
+                                string FileName = Recycler.GetDetailsOf(FI, 0); // Original file name
+                                string FilePath = Recycler.GetDetailsOf(FI, 1); // Original file path
+                                FileInfo fileInfo = new FileInfo(RecyclePath);
+                                DateTime RecycleDate = fileInfo.CreationTime; // Recycler.GetDetailsOf(FI, 2); Not easy to parse, depends on Locale
+                                string FileSize = Recycler.GetDetailsOf(FI, 3);
+                                int FileSizeBytes = FI.Size;
+                                string FileType = Recycler.GetDetailsOf(FI, 4);
+                                bool IsFolder = fileInfo.Attributes.HasFlag(FileAttributes.Directory); //FI.IsFolder includes .zip
+                                file_list.Add(new ShellFileItem(IsFolder, RecyclePath, FileName, FilePath, RecycleDate, FileSize, FileSizeBytes, FileType));
+                            }
+                            response_enum.Add("Enumerate", Newtonsoft.Json.JsonConvert.SerializeObject(file_list));
+                            await args.Request.SendResponseAsync(response_enum);
+                        }
+                    }
+                    else if (arguments.Equals("StartupTasks"))
+                    {
+                        // Check QuickLook Availability
+                        QuickLook.CheckQuickLookAvailability(localSettings);
+                    }
+                    else if (arguments.Equals("ToggleQuickLook"))
+                    {
+                        var path = (string)args.Request.Message["path"];
+                        QuickLook.ToggleQuickLook(path);
+                    }
+                    else if (arguments.Equals("ShellCommand"))
+                    {
+                        // Kill the process. This is a BRUTAL WAY to kill a process.
+                        var pid = (int)args.Request.Message["pid"];
+                        Process.GetProcessById(pid).Kill();
+
+                        Process process = new Process();
+                        process.StartInfo.UseShellExecute = true;
+                        process.StartInfo.FileName = "explorer.exe";
+                        process.StartInfo.CreateNoWindow = false;
+                        process.StartInfo.Arguments = (string)args.Request.Message["ShellCommand"];
+                        process.Start();
+                    }
+                    else if (args.Request.Message.ContainsKey("Application"))
+                    {
+                        var executable = (string)args.Request.Message["Application"];
+                        Process process = new Process();
+                        process.StartInfo.UseShellExecute = false;
+                        process.StartInfo.FileName = executable;
+                        process.StartInfo.CreateNoWindow = false;
+                        process.StartInfo.Arguments = arguments;
+                        process.Start();
+                    }
                 }
-                catch (Win32Exception)
+                else if (args.Request.Message.ContainsKey("Application"))
                 {
-                    var executable = (string)ApplicationData.Current.LocalSettings.Values["Application"];
-                    Process process = new Process();
-                    process.StartInfo.UseShellExecute = true;
-                    process.StartInfo.Verb = "runas";
-                    process.StartInfo.FileName = executable;
-                    process.StartInfo.CreateNoWindow = true;
                     try
                     {
+                        var executable = (string)args.Request.Message["Application"];
+                        Process process = new Process();
+                        process.StartInfo.UseShellExecute = false;
+                        process.StartInfo.FileName = executable;
+                        process.StartInfo.CreateNoWindow = true;
                         process.Start();
                     }
                     catch (Win32Exception)
                     {
-                        Process.Start(executable);
+                        var executable = (string)args.Request.Message["Application"];
+                        Process process = new Process();
+                        process.StartInfo.UseShellExecute = true;
+                        process.StartInfo.Verb = "runas";
+                        process.StartInfo.FileName = executable;
+                        process.StartInfo.CreateNoWindow = true;
+                        try
+                        {
+                            process.Start();
+                        }
+                        catch (Win32Exception)
+                        {
+                            try
+                            {
+                                Process.Start(executable);
+                            }
+                            catch (Win32Exception)
+                            {
+                                // Cannot open file (e.g DLL)
+                            }
+                        }
                     }
                 }
             }
+            finally
+            {
+                // Complete the deferral so that the platform knows that we're done responding to the app service call.
+                // Note for error handling: this must be called even if SendResponseAsync() throws an exception.
+                messageDeferral.Complete();
+            }
+        }
+
+        private static void Connection_ServiceClosed(AppServiceConnection sender, AppServiceClosedEventArgs args)
+        {
+            // Signal the event so the process can shut down
+            appServiceExit.Set();
         }
     }
 }

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -18,19 +18,6 @@ namespace FilesFullTrust
     {
         private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
-        // TODO: remove this when updated library is released
-        [DllImport("shell32.dll")]
-        static extern Vanara.PInvoke.HRESULT SHQueryRecycleBin(string pszRootPath, ref SHQUERYRBINFO pSHQueryRBInfo);
-
-        // TODO: remove this when updated library is released
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto, Pack = 4)]
-        struct SHQUERYRBINFO
-        {
-            public uint cbSize;
-            public long i64Size;
-            public long i64NumItems;
-        }
-
         [STAThread]
         private static void Main(string[] args)
         {
@@ -183,9 +170,9 @@ namespace FilesFullTrust
                         else if (action == "Query")
                         {
                             var responseQuery = new ValueSet();
-                            SHQUERYRBINFO queryBinInfo = new SHQUERYRBINFO();
-                            queryBinInfo.cbSize = (uint)Marshal.SizeOf(typeof(SHQUERYRBINFO));
-                            var res = SHQueryRecycleBin("", ref queryBinInfo);
+                            Win32API.SHQUERYRBINFO queryBinInfo = new Win32API.SHQUERYRBINFO();
+                            queryBinInfo.cbSize = (uint)Marshal.SizeOf(typeof(Win32API.SHQUERYRBINFO));
+                            var res = Win32API.SHQueryRecycleBin("", ref queryBinInfo);
                             // TODO: use this when updated library is released
                             //Vanara.PInvoke.Shell32.SHQUERYRBINFO queryBinInfo = new Vanara.PInvoke.Shell32.SHQUERYRBINFO();
                             //Vanara.PInvoke.Shell32.SHQueryRecycleBin(null, ref queryBinInfo);

--- a/Files.Launcher/Properties/AssemblyInfo.cs
+++ b/Files.Launcher/Properties/AssemblyInfo.cs
@@ -1,15 +1,14 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("ProcessLauncher")]
+[assembly: AssemblyTitle("FilesFullTrust")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("ProcessLauncher")]
+[assembly: AssemblyProduct("FilesFullTrust")]
 [assembly: AssemblyCopyright("Copyright ©  2019")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/Files.Launcher/QuickLook.cs
+++ b/Files.Launcher/QuickLook.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
-using System.Linq;
 using System.Security.Principal;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.Storage;
 
-namespace ProcessLauncher
+namespace FilesFullTrust
 {
     internal static class QuickLook
     {

--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Vanara.Windows.Shell;
+
+namespace FilesFullTrust
+{
+    internal class Win32API
+    {
+        // TODO: remove this when updated library is released
+        [DllImport("shell32.dll")]
+        public static extern Vanara.PInvoke.HRESULT SHQueryRecycleBin(string pszRootPath, ref SHQUERYRBINFO pSHQueryRBInfo);
+
+        // TODO: remove this when updated library is released
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto, Pack = 4)]
+        public struct SHQUERYRBINFO
+        {
+            public uint cbSize;
+            public long i64Size;
+            public long i64NumItems;
+        }
+
+        public enum PropertyReturnType
+        {
+            RAWVALUE,
+            DISPLAYVALUE
+        }
+
+        public static List<(Vanara.PInvoke.Ole32.PROPERTYKEY propertyKey, PropertyReturnType returnType)> RecyledFileProperties = 
+            new List<(Vanara.PInvoke.Ole32.PROPERTYKEY propertyKey, PropertyReturnType returnType)>
+        {
+            (Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size, PropertyReturnType.RAWVALUE),
+            (Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size, PropertyReturnType.DISPLAYVALUE),
+            (Vanara.PInvoke.Ole32.PROPERTYKEY.System.ItemTypeText, PropertyReturnType.RAWVALUE),
+            (PropertyStore.GetPropertyKeyFromName("System.Recycle.DateDeleted"), PropertyReturnType.RAWVALUE)
+        };
+
+        // A faster method of getting file shell properties (currently non used)
+        public static IList<object> GetFileProperties(ShellItem folderItem, List<(Vanara.PInvoke.Ole32.PROPERTYKEY propertyKey, PropertyReturnType returnType)> properties)
+        {
+            var propValueList = new List<object>(properties.Count);
+            var flags = Vanara.PInvoke.PropSys.GETPROPERTYSTOREFLAGS.GPS_DEFAULT | Vanara.PInvoke.PropSys.GETPROPERTYSTOREFLAGS.GPS_FASTPROPERTIESONLY;
+
+            Vanara.PInvoke.PropSys.IPropertyStore pStore = null;
+            try
+            {
+                pStore = ((Vanara.PInvoke.Shell32.IShellItem2)folderItem.IShellItem).GetPropertyStoreForKeys(properties.Select(p => p.propertyKey).ToArray(), (uint)properties.Count, flags, typeof(Vanara.PInvoke.PropSys.IPropertyStore).GUID);
+                foreach (var prop in properties)
+                {
+                    using var propVariant = new Vanara.PInvoke.Ole32.PROPVARIANT();
+                    pStore.GetValue(prop.propertyKey, propVariant);
+                    if (prop.returnType == PropertyReturnType.RAWVALUE)
+                    {
+                        propValueList.Add(propVariant.Value);
+                    }
+                    else if(prop.returnType == PropertyReturnType.DISPLAYVALUE)
+                    {
+                        using var pDesc = PropertyDescription.Create(prop.propertyKey);
+                        var pValue = pDesc?.FormatForDisplay(propVariant, Vanara.PInvoke.PropSys.PROPDESC_FORMAT_FLAGS.PDFF_DEFAULT);
+                        propValueList.Add(pValue);
+                    }
+                }
+            }
+            finally
+            {
+                Marshal.ReleaseComObject(pStore);
+            }
+
+            return propValueList;
+        }
+    }
+}

--- a/Files.Package/Package.appxmanifest
+++ b/Files.Package/Package.appxmanifest
@@ -1,5 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4" xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap uap5 mp rescap desktop4 desktop">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" 
+         xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"          
+         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" 
+         xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4" 
+         xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10" 
+         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" 
+         xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+         xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"
+         xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" 
+         IgnorableNamespaces="uap uap5 mp rescap desktop4 desktop">
 	<Identity Name="FilesUWPDev" Publisher="CN=53EC4384-7F5B-4CF6-8C23-513FFE9D1AB7" Version="0.9.0.0" />
 	<Properties>
 		<DisplayName>Files UWP - Dev</DisplayName>
@@ -26,11 +35,14 @@
 				<uap:SplashScreen Image="Assets\SplashScreen.png" uap5:Optional="true" />
 			</uap:VisualElements>
 			<Extensions>
-				<desktop:Extension Category="windows.fullTrustProcess" Executable="Files.Launcher\ProcessLauncher.exe">
+        <uap:Extension Category="windows.appService" EntryPoint="MessageRelay.StartupTask">
+          <uap3:AppService Name="FilesInteropService" uap4:SupportsMultipleInstances="false"/>
+        </uap:Extension>
+				<desktop:Extension Category="windows.fullTrustProcess" Executable="Files.Launcher\FilesFullTrust.exe">
 					<desktop:FullTrustProcess>
-						<desktop:ParameterGroup GroupId="DesktopAppExeGroup" Parameters="/DesktopApp"/>
+						<!--<desktop:ParameterGroup GroupId="DesktopAppExeGroup" Parameters="/DesktopApp"/>
 						<desktop:ParameterGroup GroupId="TerminalGroup" Parameters="/Terminal"/>
-						<desktop:ParameterGroup GroupId="UserFolderPathsGroup" Parameters="/DetectUserPaths"/>
+						<desktop:ParameterGroup GroupId="UserFolderPathsGroup" Parameters="/DetectUserPaths"/>-->
 					</desktop:FullTrustProcess>
 				</desktop:Extension>
 				<uap:Extension Category="windows.protocol">

--- a/Files.sln
+++ b/Files.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1145
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Files.Launcher", "Files.Launcher\Files.Launcher.csproj", "{533F9E86-EE0A-4FCB-B70C-F29532C1B787}"
 EndProject
@@ -9,18 +9,26 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Files", "Files\Files.csproj
 EndProject
 Project("{C7167F0D-BC9F-4E6E-AFE1-012C56B48DB5}") = "Files.Package", "Files.Package\Files.Package.wapproj", "{3B15596C-3DB9-4B58-B4C8-442D06A8C130}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Files.MessageRelay", "MessageRelay\Files.MessageRelay.csproj", "{7684E128-D854-4C00-B086-0DD7D52F6E54}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "Common\Common.csproj", "{0533133F-2559-4B53-A0FD-0970BC0E312E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
 		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|ARM = Release|ARM
 		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Debug|ARM.Build.0 = Debug|Any CPU
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Debug|ARM64.ActiveCfg = Debug|Any CPU
@@ -29,6 +37,8 @@ Global
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Debug|x64.Build.0 = Debug|Any CPU
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Debug|x86.Build.0 = Debug|Any CPU
+		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Release|Any CPU.Build.0 = Release|Any CPU
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Release|ARM.ActiveCfg = Release|Any CPU
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Release|ARM.Build.0 = Release|Any CPU
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Release|ARM64.ActiveCfg = Release|Any CPU
@@ -37,6 +47,7 @@ Global
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Release|x64.Build.0 = Release|Any CPU
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Release|x86.ActiveCfg = Release|x86
 		{533F9E86-EE0A-4FCB-B70C-F29532C1B787}.Release|x86.Build.0 = Release|x86
+		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Debug|ARM.ActiveCfg = Debug|ARM
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Debug|ARM.Build.0 = Debug|ARM
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -49,6 +60,7 @@ Global
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Debug|x86.ActiveCfg = Debug|x86
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Debug|x86.Build.0 = Debug|x86
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Debug|x86.Deploy.0 = Debug|x86
+		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Release|Any CPU.ActiveCfg = Release|x86
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Release|ARM.ActiveCfg = Release|ARM
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Release|ARM.Build.0 = Release|ARM
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Release|ARM.Deploy.0 = Release|ARM
@@ -61,6 +73,7 @@ Global
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Release|x86.ActiveCfg = Release|x86
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Release|x86.Build.0 = Release|x86
 		{64C30C4E-A69A-411C-9F78-776E7AAD583C}.Release|x86.Deploy.0 = Release|x86
+		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Debug|ARM.ActiveCfg = Debug|ARM
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Debug|ARM.Build.0 = Debug|ARM
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Debug|ARM.Deploy.0 = Debug|ARM
@@ -73,6 +86,7 @@ Global
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Debug|x86.ActiveCfg = Debug|x86
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Debug|x86.Build.0 = Debug|x86
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Debug|x86.Deploy.0 = Debug|x86
+		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Release|Any CPU.ActiveCfg = Release|x86
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Release|ARM.ActiveCfg = Release|ARM
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Release|ARM.Build.0 = Release|ARM
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Release|ARM.Deploy.0 = Release|ARM
@@ -85,6 +99,46 @@ Global
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Release|x86.ActiveCfg = Release|x86
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Release|x86.Build.0 = Release|x86
 		{3B15596C-3DB9-4B58-B4C8-442D06A8C130}.Release|x86.Deploy.0 = Release|x86
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Debug|ARM.ActiveCfg = Debug|ARM
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Debug|ARM.Build.0 = Debug|ARM
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Debug|ARM64.Build.0 = Debug|ARM64
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Debug|x64.ActiveCfg = Debug|x64
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Debug|x64.Build.0 = Debug|x64
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Debug|x86.ActiveCfg = Debug|x86
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Debug|x86.Build.0 = Debug|x86
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Release|ARM.ActiveCfg = Release|ARM
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Release|ARM.Build.0 = Release|ARM
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Release|ARM64.ActiveCfg = Release|ARM64
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Release|ARM64.Build.0 = Release|ARM64
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Release|x64.ActiveCfg = Release|x64
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Release|x64.Build.0 = Release|x64
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Release|x86.ActiveCfg = Release|x86
+		{7684E128-D854-4C00-B086-0DD7D52F6E54}.Release|x86.Build.0 = Release|x86
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Debug|ARM.Build.0 = Debug|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Debug|x64.Build.0 = Debug|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Debug|x86.Build.0 = Debug|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Release|ARM.ActiveCfg = Release|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Release|ARM.Build.0 = Release|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Release|ARM64.Build.0 = Release|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Release|x64.ActiveCfg = Release|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Release|x64.Build.0 = Release|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Release|x86.ActiveCfg = Release|Any CPU
+		{0533133F-2559-4B53-A0FD-0970BC0E312E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -193,7 +193,9 @@ namespace Files
                 if (App.CurrentInstance != null)
                 {
                     DataPackageView packageView = Clipboard.GetContent();
-                    if (packageView.Contains(StandardDataFormats.StorageItems) && App.CurrentInstance.CurrentPageType != typeof(YourHome))
+                    if (packageView.Contains(StandardDataFormats.StorageItems) 
+                        && App.CurrentInstance.CurrentPageType != typeof(YourHome)
+                        && !App.CurrentInstance.ViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
                     {
                         App.PS.IsEnabled = true;
                     }

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -13,12 +13,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
-using Windows.ApplicationModel.Core;
+using Windows.ApplicationModel.AppService;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
 using Windows.UI.Core;
@@ -66,7 +63,7 @@ namespace Files
         {
             InitializeComponent();
             Suspending += OnSuspending;
-
+            LeavingBackground += OnLeavingBackground;
             // Initialize NLog
             Windows.Storage.StorageFolder storageFolder = Windows.Storage.ApplicationData.Current.LocalFolder;
             NLog.LogManager.Configuration.Variables["LogPath"] = storageFolder.Path;
@@ -86,6 +83,69 @@ namespace Files
             AppSettings = new SettingsViewModel();
             InteractionViewModel = new InteractionViewModel();
             SelectedItemPropertiesViewModel = new SelectedItemPropertiesViewModel();
+        }
+
+        private void OnLeavingBackground(object sender, LeavingBackgroundEventArgs e)
+        {
+            // Need to reinitialize AppService when app is resuming
+            InitializeAppServiceConnection();
+        }
+
+        public static AppServiceConnection Connection;
+        public static Action AppServiceConnected;
+
+        private async void InitializeAppServiceConnection()
+        {
+            Connection = new AppServiceConnection();
+            Connection.AppServiceName = "FilesInteropService";
+            Connection.PackageFamilyName = Package.Current.Id.FamilyName;
+            Connection.RequestReceived += Connection_RequestReceived;
+            Connection.ServiceClosed += Connection_ServiceClosed;
+
+            AppServiceConnectionStatus status = await Connection.OpenAsync();
+            if (status != AppServiceConnectionStatus.Success)
+            {
+                // TODO: error handling
+                Connection.Dispose();
+                Connection = null;
+            }
+
+            // Launch fulltrust process
+            await FullTrustProcessLauncher.LaunchFullTrustProcessForCurrentAppAsync();
+
+            AppServiceConnected?.Invoke();
+        }
+
+        private void Connection_ServiceClosed(AppServiceConnection sender, AppServiceClosedEventArgs args)
+        {
+            Connection = null;
+        }
+
+        private async void Connection_RequestReceived(AppServiceConnection sender, AppServiceRequestReceivedEventArgs args)
+        {
+            // Get a deferral because we use an awaitable API below to respond to the message
+            // and we don't want this call to get cancelled while we are waiting.
+            var messageDeferral = args.GetDeferral();
+
+            // The fulltrust process signaled that something in the recycle bin folder has changed
+            if (args.Request.Message.ContainsKey("FileSystem"))
+            {
+                var path = (string)args.Request.Message["FileSystem"];
+                Debug.WriteLine("{0}: {1}", path, args.Request.Message["Type"]);
+                if (App.CurrentInstance.ViewModel.CurrentFolder?.ItemPath == path)
+                {
+                    // If we are currently displaying the reycle bin lets refresh the items
+                    await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
+                        async () =>
+                        {
+                            await App.CurrentInstance.ViewModel.RefreshItems();
+                        });
+                }
+            }
+
+            // Complete the deferral so that the platform knows that we're done responding to the app service call.
+            // Note for error handling: this must be called even if SendResponseAsync() throws an exception.
+            messageDeferral.Complete();
         }
 
         private void RegisterUncaughtExceptionLogger()
@@ -357,6 +417,11 @@ namespace Files
         {
             var deferral = e.SuspendingOperation.GetDeferral();
             //TODO: Save application state and stop any background activity
+            if (Connection != null)
+            {
+                Connection.Dispose();
+                Connection = null;
+            }
             AppSettings.Dispose();
             deferral.Complete();
         }

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -195,6 +195,23 @@ namespace Files
 
         public void RightClickContextMenu_Opening(object sender, object e)
         {
+            if (App.CurrentInstance.ViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
+            {
+                // In recycle bin many actions do not make sense (e.g. rename)
+                OpenRecycleBinRightClinkContextMenu();
+            }
+            else
+            {
+                OpenStandardRightClickContextMenu();
+            }
+        }
+
+        private void OpenStandardRightClickContextMenu()
+        {
+            // Remove recycle bin restore action and show separator
+            UnloadMenuFlyoutItemByName("RestoreItem");
+            (this.FindName("FileActionsSeparator") as MenuFlyoutSeparator).Visibility = Visibility.Visible;
+
             var selectedFileSystemItems = App.CurrentInstance.ContentPage.SelectedItems;
 
             // Find selected items that are not folders
@@ -255,6 +272,25 @@ namespace Files
 
             //check if the selected file is an image
             App.InteractionViewModel.CheckForImage();
+        }
+
+        private void OpenRecycleBinRightClinkContextMenu()
+        {
+            // Remove everything except "Delete", "Cut", "Properties"
+            UnloadMenuFlyoutItemByName("UnzipItem");
+            UnloadMenuFlyoutItemByName("OpenItem");
+            UnloadMenuFlyoutItemByName("OpenInNewTab");
+            UnloadMenuFlyoutItemByName("OpenInNewWindowItem");
+            UnloadMenuFlyoutItemByName("ShareItem");
+            UnloadMenuFlyoutItemByName("CopyItem");
+            UnloadMenuFlyoutItemByName("RenameItem");
+            UnloadMenuFlyoutItemByName("SidebarPinItem");
+            UnloadMenuFlyoutItemByName("QuickLook");
+
+            // Show "Restore" action and hide separator
+            // Restore is the first action of the list
+            (this.FindName("RestoreItem") as MenuFlyoutItem).Visibility = Visibility.Visible;
+            (this.FindName("FileActionsSeparator") as MenuFlyoutSeparator).Visibility = Visibility.Collapsed;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -190,15 +190,31 @@ namespace Files
         {
             var menuItem = this.FindName(nameToUnload) as DependencyObject;
             if (menuItem != null) // Prevent crash if the MenuFlyoutItem is missing
-                (menuItem as MenuFlyoutItem).Visibility = Visibility.Collapsed;
+                (menuItem as MenuFlyoutItemBase).Visibility = Visibility.Collapsed;
         }
 
         public void RightClickContextMenu_Opening(object sender, object e)
         {
             if (App.CurrentInstance.ViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
             {
+                (this.FindName("EmptyRecycleBin") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
+                (this.FindName("OpenTerminal") as MenuFlyoutItemBase).IsEnabled = false;
+                UnloadMenuFlyoutItemByName("NewEmptySpace");
+            }
+            else
+            {
+                UnloadMenuFlyoutItemByName("EmptyRecycleBin");
+                (this.FindName("OpenTerminal") as MenuFlyoutItemBase).IsEnabled = true;
+                (this.FindName("NewEmptySpace") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
+            }
+        }
+
+        public void RightClickItemContextMenu_Opening(object sender, object e)        
+        {
+            if (App.CurrentInstance.ViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
+            {
                 // In recycle bin many actions do not make sense (e.g. rename)
-                OpenRecycleBinRightClinkContextMenu();
+                OpenRecycleBinRightClickContextMenu();
             }
             else
             {
@@ -210,7 +226,7 @@ namespace Files
         {
             // Remove recycle bin restore action and show separator
             UnloadMenuFlyoutItemByName("RestoreItem");
-            (this.FindName("FileActionsSeparator") as MenuFlyoutSeparator).Visibility = Visibility.Visible;
+            (this.FindName("FileActionsSeparator") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
 
             var selectedFileSystemItems = App.CurrentInstance.ContentPage.SelectedItems;
 
@@ -230,12 +246,12 @@ namespace Files
                         if (selectedDataItem.FileExtension.Equals(".zip", StringComparison.OrdinalIgnoreCase))
                         {
                             UnloadMenuFlyoutItemByName("OpenItem");
-                            (this.FindName("UnzipItem") as MenuFlyoutItem).Visibility = Visibility.Visible;
+                            (this.FindName("UnzipItem") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
                             //this.FindName("UnzipItem");
                         }
                         else if (!selectedDataItem.FileExtension.Equals(".zip", StringComparison.OrdinalIgnoreCase))
                         {
-                            (this.FindName("OpenItem") as MenuFlyoutItem).Visibility = Visibility.Visible;
+                            (this.FindName("OpenItem") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
                             //this.FindName("OpenItem");
                             UnloadMenuFlyoutItemByName("UnzipItem");
                         }
@@ -252,9 +268,9 @@ namespace Files
                 UnloadMenuFlyoutItemByName("OpenItem");
                 if (selectedFileSystemItems.Count <= 5 && selectedFileSystemItems.Count > 0)
                 {
-                    (this.FindName("SidebarPinItem") as MenuFlyoutItem).Visibility = Visibility.Visible;
-                    (this.FindName("OpenInNewTab") as MenuFlyoutItem).Visibility = Visibility.Visible;
-                    (this.FindName("OpenInNewWindowItem") as MenuFlyoutItem).Visibility = Visibility.Visible;
+                    (this.FindName("SidebarPinItem") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
+                    (this.FindName("OpenInNewTab") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
+                    (this.FindName("OpenInNewWindowItem") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
                     //this.FindName("SidebarPinItem");
                     //this.FindName("OpenInNewTab");
                     //this.FindName("OpenInNewWindowItem");
@@ -262,7 +278,7 @@ namespace Files
                 }
                 else if (selectedFileSystemItems.Count > 5)
                 {
-                    (this.FindName("SidebarPinItem") as MenuFlyoutItem).Visibility = Visibility.Visible;
+                    (this.FindName("SidebarPinItem") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
                     //this.FindName("SidebarPinItem");
                     UnloadMenuFlyoutItemByName("OpenInNewTab");
                     UnloadMenuFlyoutItemByName("OpenInNewWindowItem");
@@ -274,7 +290,7 @@ namespace Files
             App.InteractionViewModel.CheckForImage();
         }
 
-        private void OpenRecycleBinRightClinkContextMenu()
+        private void OpenRecycleBinRightClickContextMenu()
         {
             // Remove everything except "Delete", "Cut", "Properties"
             UnloadMenuFlyoutItemByName("UnzipItem");
@@ -289,8 +305,11 @@ namespace Files
 
             // Show "Restore" action and hide separator
             // Restore is the first action of the list
-            (this.FindName("RestoreItem") as MenuFlyoutItem).Visibility = Visibility.Visible;
-            (this.FindName("FileActionsSeparator") as MenuFlyoutSeparator).Visibility = Visibility.Collapsed;
+            (this.FindName("RestoreItem") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
+            (this.FindName("FileActionsSeparator") as MenuFlyoutItemBase).Visibility = Visibility.Collapsed;
+
+            // Don't show image operations
+            App.InteractionViewModel.IsSelectedItemImage = false;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -167,6 +167,8 @@ namespace Files
                 App.CurrentInstance.NavigationToolbar.CanNavigateToParent = true;
             }
             App.InteractionViewModel.IsPageTypeNotHome = true; // show controls that were hidden on the home page
+            App.InteractionViewModel.IsPageTypeNotRecycleBin = 
+                !App.CurrentInstance.ViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath);
 
             await App.CurrentInstance.ViewModel.RefreshItems();
 

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -213,23 +213,6 @@ namespace Files
 
         public void RightClickItemContextMenu_Opening(object sender, object e)        
         {
-            if (App.CurrentInstance.ViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
-            {
-                // In recycle bin many actions do not make sense (e.g. rename)
-                OpenRecycleBinRightClickContextMenu();
-            }
-            else
-            {
-                OpenStandardRightClickContextMenu();
-            }
-        }
-
-        private void OpenStandardRightClickContextMenu()
-        {
-            // Remove recycle bin restore action and show separator
-            UnloadMenuFlyoutItemByName("RestoreItem");
-            (this.FindName("FileActionsSeparator") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
-
             var selectedFileSystemItems = App.CurrentInstance.ContentPage.SelectedItems;
 
             // Find selected items that are not folders
@@ -290,28 +273,6 @@ namespace Files
 
             //check if the selected file is an image
             App.InteractionViewModel.CheckForImage();
-        }
-
-        private void OpenRecycleBinRightClickContextMenu()
-        {
-            // Remove everything except "Delete", "Cut", "Properties"
-            UnloadMenuFlyoutItemByName("UnzipItem");
-            UnloadMenuFlyoutItemByName("OpenItem");
-            UnloadMenuFlyoutItemByName("OpenInNewTab");
-            UnloadMenuFlyoutItemByName("OpenInNewWindowItem");
-            UnloadMenuFlyoutItemByName("ShareItem");
-            UnloadMenuFlyoutItemByName("CopyItem");
-            UnloadMenuFlyoutItemByName("RenameItem");
-            UnloadMenuFlyoutItemByName("SidebarPinItem");
-            UnloadMenuFlyoutItemByName("QuickLook");
-
-            // Show "Restore" action and hide separator
-            // Restore is the first action of the list
-            (this.FindName("RestoreItem") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
-            (this.FindName("FileActionsSeparator") as MenuFlyoutItemBase).Visibility = Visibility.Collapsed;
-
-            // Don't show image operations
-            App.InteractionViewModel.IsSelectedItemImage = false;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -1,6 +1,5 @@
 using Files.Filesystem;
 using Files.Interacts;
-using Files.View_Models;
 using Files.Views.Pages;
 using System;
 using System.Collections.Generic;
@@ -157,7 +156,9 @@ namespace Files
             AssociatedViewModel.EmptyTextState.IsVisible = Visibility.Collapsed;
             App.CurrentInstance.ViewModel.WorkingDirectory = parameters;
 
-            if (App.CurrentInstance.ViewModel.WorkingDirectory == Path.GetPathRoot(App.CurrentInstance.ViewModel.WorkingDirectory))
+            // pathRoot will be empty on recycle bin path
+            string pathRoot = Path.GetPathRoot(App.CurrentInstance.ViewModel.WorkingDirectory);
+            if (string.IsNullOrEmpty(pathRoot) || App.CurrentInstance.ViewModel.WorkingDirectory == pathRoot)
             {
                 App.CurrentInstance.NavigationToolbar.CanNavigateToParent = false;
             }

--- a/Files/Dialogs/AddItemDialog.xaml.cs
+++ b/Files/Dialogs/AddItemDialog.xaml.cs
@@ -54,10 +54,6 @@ namespace Files.Dialogs
             {
                 currentPath = TabInstance.ViewModel.WorkingDirectory;
             }
-            if (currentPath.StartsWith(App.AppSettings.RecycleBinPath))
-            {
-                return; // Cannot create files in RecycleBin
-            }
             StorageFolder folderToCreateItem = await StorageFolder.GetFolderFromPathAsync(currentPath);
             RenameDialog renameDialog = new RenameDialog();
 

--- a/Files/Dialogs/AddItemDialog.xaml.cs
+++ b/Files/Dialogs/AddItemDialog.xaml.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using Windows.Storage;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace Files.Dialogs
@@ -54,6 +53,10 @@ namespace Files.Dialogs
             if (TabInstance.ContentPage != null)
             {
                 currentPath = TabInstance.ViewModel.WorkingDirectory;
+            }
+            if (currentPath.StartsWith(App.AppSettings.RecycleBinPath))
+            {
+                return; // Cannot create files in RecycleBin
             }
             StorageFolder folderToCreateItem = await StorageFolder.GetFolderFromPathAsync(currentPath);
             RenameDialog renameDialog = new RenameDialog();

--- a/Files/Dialogs/ConfirmDeleteDialog.xaml.cs
+++ b/Files/Dialogs/ConfirmDeleteDialog.xaml.cs
@@ -29,11 +29,15 @@ namespace Files.Dialogs
             Nothing
         }
 
-        public ConfirmDeleteDialog()
+        public ConfirmDeleteDialog(bool deleteFromRecycleBin = false)
         {
             this.InitializeComponent();
 
             this.Result = MyResult.Nothing; //clear the result in case the value is set from last time
+
+            // If deleting from recycle bin disable "permanently delete" option
+            this.chkPermanentlyDelete.IsEnabled = !deleteFromRecycleBin;
+            this.chkPermanentlyDelete.IsChecked = deleteFromRecycleBin;
         }
 
         private void btnDelete_Click(object sender, RoutedEventArgs e)

--- a/Files/Dialogs/ConfirmDeleteDialog.xaml.cs
+++ b/Files/Dialogs/ConfirmDeleteDialog.xaml.cs
@@ -36,8 +36,7 @@ namespace Files.Dialogs
             this.Result = MyResult.Nothing; //clear the result in case the value is set from last time
 
             // If deleting from recycle bin disable "permanently delete" option
-            this.chkPermanentlyDelete.IsEnabled = !deleteFromRecycleBin;
-            this.chkPermanentlyDelete.IsChecked = deleteFromRecycleBin;
+            this.chkPermanentlyDelete.IsEnabled = !deleteFromRecycleBin;            
         }
 
         private void btnDelete_Click(object sender, RoutedEventArgs e)

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -479,6 +479,11 @@
     <PackageReference Include="Microsoft.AppCenter.Crashes">
       <Version>3.1.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Net.Compilers">
+      <Version>3.3.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
     </PackageReference>
@@ -541,6 +546,16 @@
     <SDKReference Include="WindowsDesktop, Version=10.0.18362.0">
       <Name>Windows Desktop Extensions for the UWP</Name>
     </SDKReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj">
+      <Project>{0533133f-2559-4b53-a0fd-0970bc0e312e}</Project>
+      <Name>Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MessageRelay\Files.MessageRelay.csproj">
+      <Project>{7684e128-d854-4c00-b086-0dd7d52f6e54}</Project>
+      <Name>Files.MessageRelay</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -92,6 +92,8 @@ namespace Files.Filesystem
         public string ItemPath { get; set; }
         public string FileSize { get; set; }
         public ulong FileSizeBytes { get; set; }
+        // For recycle bin elements (path + name)
+        public string ItemOriginalPath { get; set; }
 
         public DateTimeOffset ItemDateModifiedReal
         {

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -653,7 +653,22 @@ namespace Files.Interacts
 
         public async void RestoreItem_Click(object sender, RoutedEventArgs e)
         {
-
+            if (App.CurrentInstance.ContentPage.IsItemSelected)
+            {
+                foreach (ListedItem listedItem in App.CurrentInstance.ContentPage.SelectedItems)
+                {
+                    // We could do this in UWP if ListedItem contained the original file path
+                    if (App.Connection != null)
+                    {
+                        var value = new ValueSet();
+                        value.Add("Arguments", "RecycleBin");
+                        value.Add("action", "Restore");
+                        value.Add("SourceFile", listedItem.ItemPath);
+                        // Send request to fulltrust process to restore the file
+                        await App.Connection.SendMessageAsync(value);
+                    }
+                }
+            }
         }
 
         public async void CutItem_Click(object sender, RoutedEventArgs e)

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -1,43 +1,40 @@
 using Files.Dialogs;
 using Files.Filesystem;
-using Microsoft.Toolkit.Uwp.UI.Controls;
+using Files.Helpers;
+using Files.Views.Pages;
+using GalaSoft.MvvmLight.Command;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Windows.ApplicationModel;
+using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.Foundation.Metadata;
+using Windows.Security.Cryptography;
+using Windows.Security.Cryptography.Core;
 using Windows.Storage;
+using Windows.Storage.Streams;
 using Windows.System;
+using Windows.System.UserProfile;
+using Windows.UI;
+using Windows.UI.Core;
 using Windows.UI.Popups;
+using Windows.UI.WindowManagement;
+using Windows.UI.WindowManagement.Preview;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
-using Windows.System.UserProfile;
 using static Files.Dialogs.ConfirmDeleteDialog;
-using Windows.ApplicationModel.Core;
-using Windows.UI.Core;
-using Files.Views.Pages;
-using Windows.Foundation.Metadata;
-using Windows.UI.WindowManagement;
-using Windows.UI.Xaml.Hosting;
-using Windows.UI.WindowManagement.Preview;
-using Windows.UI;
-using Windows.Security.Cryptography.Core;
-using Windows.Security.Cryptography;
-using Windows.Storage.Streams;
-using GalaSoft.MvvmLight.Command;
-using Files.Helpers;
-using Windows.UI.Xaml.Data;
-using Windows.Foundation.Collections;
 
 namespace Files.Interacts
 {
@@ -652,6 +649,11 @@ namespace Files.Interacts
 
             CurrentInstance.NavigationToolbar.CanGoForward = false;
             return true;
+        }
+
+        public async void RestoreItem_Click(object sender, RoutedEventArgs e)
+        {
+
         }
 
         public async void CutItem_Click(object sender, RoutedEventArgs e)

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -736,6 +736,18 @@ namespace Files.Interacts
             Abort
         }
 
+        public async void EmptyRecycleBin_ClickAsync(object sender, RoutedEventArgs e)
+        {
+            if (App.Connection != null)
+            {
+                var value = new ValueSet();
+                value.Add("Arguments", "RecycleBin");
+                value.Add("action", "Empty");
+                // Send request to fulltrust process to empty recyclebin
+                await App.Connection.SendMessageAsync(value);
+            }
+        }
+
         public async void PasteItem_ClickAsync(object sender, RoutedEventArgs e)
         {
             DataPackageView packageView = Clipboard.GetContent();

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -322,6 +322,12 @@ namespace Files.Interacts
 
         private async void OpenSelectedItems(bool displayApplicationPicker)
         {
+            if (CurrentInstance.ViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
+            {
+                // Do not open files and folders inside the recycle bin
+                return;
+            }
+
             try
             {
                 int selectedItemCount;

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -507,6 +507,8 @@ namespace Files.Interacts
         public async void DeleteItem_Click(object sender, RoutedEventArgs e)
         {
             var deleteFromRecycleBin = CurrentInstance.ViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath);
+            // Permanently delete if deleting from recycle bin
+            App.InteractionViewModel.PermanentlyDelete = deleteFromRecycleBin ? StorageDeleteOption.PermanentDelete : StorageDeleteOption.Default;
 
             if (App.AppSettings.ShowConfirmDeleteDialog == true) //check if the setting to show a confirmation dialog is on
             {

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -744,13 +744,6 @@ namespace Files.Interacts
 
         public async Task PasteItems(DataPackageView packageView, string destinationPath, DataPackageOperation acceptedOperation)
         {
-            if (destinationPath.StartsWith(App.AppSettings.RecycleBinPath))
-            {
-                // Cannot copy/paste to recycle bin
-                // TODO: do this the right way (customize contextmenu, ...)
-                return;
-            }
-
             itemsToPaste = await packageView.GetStorageItemsAsync();
             HashSet<IStorageItem> pastedItems = new HashSet<IStorageItem>();
             itemsPasted = 0;

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -703,10 +703,6 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="new">Empty recycle bin</target>
@@ -714,6 +710,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="new">Restore</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="new">Enable Recycle Bin support</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -694,7 +694,7 @@
         <trans-unit id="StatusBarControlSelectionOptions.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Selection options</source>
           <target state="new">Selection options</target>
-        </trans-unit>        
+        </trans-unit>
         <trans-unit id="PropertiesDialogReadOnly.Content" translate="yes" xml:space="preserve">
           <source>Read-only</source>
           <target state="new">Read-only</target>
@@ -706,6 +706,14 @@
         <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="new">Pin Recycle Bin to the sidebar</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="new">Empty recycle bin</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="new">Restore</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -694,7 +694,7 @@
         <trans-unit id="StatusBarControlSelectionOptions.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Selection options</source>
           <target state="new">Selection options</target>
-        </trans-unit>
+        </trans-unit>        
         <trans-unit id="PropertiesDialogReadOnly.Content" translate="yes" xml:space="preserve">
           <source>Read-only</source>
           <target state="new">Read-only</target>
@@ -702,6 +702,10 @@
         <trans-unit id="PropertiesDialogHidden.Content" translate="yes" xml:space="preserve">
           <source>Hidden</source>
           <target state="new">Hidden</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -702,10 +702,6 @@
           <source>Hidden</source>
           <target state="translated">Oculto</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="new">Empty recycle bin</target>
@@ -713,6 +709,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="new">Restore</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="new">Enable Recycle Bin support</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -693,7 +693,7 @@
         <trans-unit id="StatusBarControlSelectionOptions.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Selection options</source>
           <target state="translated">Opciones de selección</target>
-        </trans-unit>        
+        </trans-unit>
         <trans-unit id="PropertiesDialogReadOnly.Content" translate="yes" xml:space="preserve">
           <source>Read-only</source>
           <target state="translated">Solo lectura</target>
@@ -705,6 +705,14 @@
         <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="new">Pin Recycle Bin to the sidebar</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="new">Empty recycle bin</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="new">Restore</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -693,7 +693,7 @@
         <trans-unit id="StatusBarControlSelectionOptions.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Selection options</source>
           <target state="translated">Opciones de selección</target>
-        </trans-unit>
+        </trans-unit>        
         <trans-unit id="PropertiesDialogReadOnly.Content" translate="yes" xml:space="preserve">
           <source>Read-only</source>
           <target state="translated">Solo lectura</target>
@@ -701,6 +701,10 @@
         <trans-unit id="PropertiesDialogHidden.Content" translate="yes" xml:space="preserve">
           <source>Hidden</source>
           <target state="translated">Oculto</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -708,6 +708,14 @@
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="new">Empty recycle bin</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="new">Restore</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -695,7 +695,7 @@
         <trans-unit id="StatusBarControlSelectionOptions.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Selection options</source>
           <target state="new">Selection options</target>
-        </trans-unit>        
+        </trans-unit>
         <trans-unit id="PropertiesDialogReadOnly.Content" translate="yes" xml:space="preserve">
           <source>Read-only</source>
           <target state="new">Read-only</target>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -704,10 +704,6 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="new">Empty recycle bin</target>
@@ -715,6 +711,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="new">Restore</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="new">Enable Recycle Bin support</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -695,7 +695,7 @@
         <trans-unit id="StatusBarControlSelectionOptions.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Selection options</source>
           <target state="new">Selection options</target>
-        </trans-unit>
+        </trans-unit>        
         <trans-unit id="PropertiesDialogReadOnly.Content" translate="yes" xml:space="preserve">
           <source>Read-only</source>
           <target state="new">Read-only</target>
@@ -703,6 +703,10 @@
         <trans-unit id="PropertiesDialogHidden.Content" translate="yes" xml:space="preserve">
           <source>Hidden</source>
           <target state="new">Hidden</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -703,10 +703,6 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="translated">Fissa il cestino sulla barra laterale</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="translated">Svuota cestino</target>
@@ -714,6 +710,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="translated">Ripristina</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="translated">Abilita il supporto al Cestino</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -707,6 +707,14 @@
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="translated">Fissa il cestino sulla barra laterale</target>
         </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="translated">Svuota cestino</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="translated">Ripristina</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -8,7 +8,7 @@
       <group id="FILES/STRINGS/EN-US/RESOURCES.RESW" datatype="resx">
         <trans-unit id="ConfirmDeleteDialog.Title" translate="yes" xml:space="preserve">
           <source>Delete Item(s)</source>
-          <target state="translated">Elima gli elementi</target>
+          <target state="translated">Elimina gli elementi</target>
         </trans-unit>
         <trans-unit id="ConfirmDeleteDialogCancelButton.Content" translate="yes" xml:space="preserve">
           <source>Cancel</source>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -703,6 +703,10 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="translated">Fissa il cestino sulla barra laterale</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -704,6 +704,10 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="new">Pin Recycle Bin to the sidebar</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -708,6 +708,14 @@
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="new">Empty recycle bin</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="new">Restore</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -704,10 +704,6 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="new">Empty recycle bin</target>
@@ -715,6 +711,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="new">Restore</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="new">Enable Recycle Bin support</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -704,6 +704,10 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="new">Pin Recycle Bin to the sidebar</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -708,6 +708,14 @@
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="new">Empty recycle bin</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="new">Restore</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -704,10 +704,6 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="new">Empty recycle bin</target>
@@ -715,6 +711,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="new">Restore</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="new">Enable Recycle Bin support</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -702,10 +702,6 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="new">Empty recycle bin</target>
@@ -713,6 +709,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="new">Restore</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="new">Enable Recycle Bin support</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -702,6 +702,10 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="new">Pin Recycle Bin to the sidebar</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -706,6 +706,14 @@
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="new">Empty recycle bin</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="new">Restore</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -702,10 +702,6 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="new">Empty recycle bin</target>
@@ -713,6 +709,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="new">Restore</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="new">Enable Recycle Bin support</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -702,6 +702,10 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="new">Pin Recycle Bin to the sidebar</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -706,6 +706,14 @@
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="new">Empty recycle bin</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="new">Restore</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -704,6 +704,10 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="new">Pin Recycle Bin to the sidebar</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -708,6 +708,14 @@
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="new">Empty recycle bin</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="new">Restore</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -704,10 +704,6 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="new">Empty recycle bin</target>
@@ -715,6 +711,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="new">Restore</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="new">Enable Recycle Bin support</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -702,10 +702,6 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="new">Empty recycle bin</target>
@@ -713,6 +709,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="new">Restore</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="new">Enable Recycle Bin support</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -702,6 +702,10 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="new">Pin Recycle Bin to the sidebar</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -706,6 +706,14 @@
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="new">Empty recycle bin</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="new">Restore</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -704,6 +704,10 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
+        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Pin Recycle Bin to the sidebar</source>
+          <target state="new">Pin Recycle Bin to the sidebar</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -708,6 +708,14 @@
           <source>Pin Recycle Bin to the sidebar</source>
           <target state="new">Pin Recycle Bin to the sidebar</target>
         </trans-unit>
+        <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Empty recycle bin</source>
+          <target state="new">Empty recycle bin</target>
+        </trans-unit>
+        <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
+          <source>Restore</source>
+          <target state="new">Restore</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -704,10 +704,6 @@
           <source>Hidden</source>
           <target state="new">Hidden</target>
         </trans-unit>
-        <trans-unit id="SettingsPreferencesPinRecycleBin.Text" translate="yes" xml:space="preserve">
-          <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
           <target state="new">Empty recycle bin</target>
@@ -715,6 +711,10 @@
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>
           <target state="new">Restore</target>
+        </trans-unit>
+        <trans-unit id="SettingsExperimentalRecycleBin.Text" translate="yes" xml:space="preserve">
+          <source>Enable Recycle Bin support</source>
+          <target state="new">Enable Recycle Bin support</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/Program.cs
+++ b/Files/Program.cs
@@ -1,9 +1,7 @@
 ﻿using Files.CommandLine;
 using System;
-using System.Threading;
 using System.Threading.Tasks;
-using Windows.ApplicationModel;
-using Windows.Storage;
+using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
 
 namespace Files
@@ -43,10 +41,14 @@ namespace Files
         public static async Task OpenShellCommandInExplorer(string shellCommand, int pid)
         {
             System.Diagnostics.Debug.WriteLine("Launching shell command in FullTrustProcess");
-            ApplicationData.Current.LocalSettings.Values["ShellCommand"] = shellCommand;
-            ApplicationData.Current.LocalSettings.Values["Arguments"] = "ShellCommand";
-            ApplicationData.Current.LocalSettings.Values["pid"] = pid;
-            await FullTrustProcessLauncher.LaunchFullTrustProcessForCurrentAppAsync();
+            if (App.Connection != null)
+            {
+                var value = new ValueSet();
+                value.Add("ShellCommand", shellCommand);
+                value.Add("Arguments", "ShellCommand");
+                value.Add("pid", pid);
+                await App.Connection.SendMessageAsync(value);
+            }
         }
     }
 }

--- a/Files/Program.cs
+++ b/Files/Program.cs
@@ -1,7 +1,9 @@
 ﻿using Files.CommandLine;
 using System;
 using System.Threading.Tasks;
+using Windows.ApplicationModel;
 using Windows.Foundation.Collections;
+using Windows.Storage;
 using Windows.UI.Xaml;
 
 namespace Files
@@ -41,14 +43,10 @@ namespace Files
         public static async Task OpenShellCommandInExplorer(string shellCommand, int pid)
         {
             System.Diagnostics.Debug.WriteLine("Launching shell command in FullTrustProcess");
-            if (App.Connection != null)
-            {
-                var value = new ValueSet();
-                value.Add("ShellCommand", shellCommand);
-                value.Add("Arguments", "ShellCommand");
-                value.Add("pid", pid);
-                await App.Connection.SendMessageAsync(value);
-            }
+            ApplicationData.Current.LocalSettings.Values["ShellCommand"] = shellCommand;
+            ApplicationData.Current.LocalSettings.Values["Arguments"] = "ShellCommand";
+            ApplicationData.Current.LocalSettings.Values["pid"] = pid;
+            await FullTrustProcessLauncher.LaunchFullTrustProcessForCurrentAppAsync();
         }
     }
 }

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -357,6 +357,9 @@
   <data name="SettingsPreferencesPinOneDrive.Text" xml:space="preserve">
     <value>Pin OneDrive to the sidebar</value>
   </data>
+  <data name="SettingsPreferencesPinRecycleBin.Text" xml:space="preserve">
+    <value>Pin Recycle Bin to the sidebar</value>
+  </data>
   <data name="SettingsPreferencesShowConfirmDeleteDialog.Text" xml:space="preserve">
     <value>Show a confirmation dialog when deleting files or folders</value>
   </data>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -642,4 +642,10 @@
   <data name="PropertiesDialogHidden.Content" xml:space="preserve">
     <value>Hidden</value>
   </data>
+  <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
+    <value>Empty recycle bin</value>
+  </data>
+  <data name="BaseLayoutItemContextFlyoutRestore.Text" xml:space="preserve">
+    <value>Restore</value>
+  </data>
 </root>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -357,8 +357,8 @@
   <data name="SettingsPreferencesPinOneDrive.Text" xml:space="preserve">
     <value>Pin OneDrive to the sidebar</value>
   </data>
-  <data name="SettingsPreferencesPinRecycleBin.Text" xml:space="preserve">
-    <value>Pin Recycle Bin to the sidebar</value>
+  <data name="SettingsExperimentalRecycleBin.Text" xml:space="preserve">
+    <value>Enable Recycle Bin support</value>
   </data>
   <data name="SettingsPreferencesShowConfirmDeleteDialog.Text" xml:space="preserve">
     <value>Show a confirmation dialog when deleting files or folders</value>

--- a/Files/Strings/it-IT/Resources.resw
+++ b/Files/Strings/it-IT/Resources.resw
@@ -13,7 +13,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ConfirmDeleteDialog.Title" xml:space="preserve">
-    <value>Elima gli elementi</value>
+    <value>Elimina gli elementi</value>
   </data>
   <data name="ConfirmDeleteDialogCancelButton.Content" xml:space="preserve">
     <value>Annulla</value>

--- a/Files/Strings/it-IT/Resources.resw
+++ b/Files/Strings/it-IT/Resources.resw
@@ -522,4 +522,7 @@
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Vuoi eliminare questa cartella?</value>
   </data>
+  <data name="SettingsPreferencesPinRecycleBin.Text" xml:space="preserve">
+    <value>Fissa il cestino sulla barra laterale</value>
+  </data>
 </root>

--- a/Files/Strings/it-IT/Resources.resw
+++ b/Files/Strings/it-IT/Resources.resw
@@ -525,4 +525,10 @@
   <data name="SettingsPreferencesPinRecycleBin.Text" xml:space="preserve">
     <value>Fissa il cestino sulla barra laterale</value>
   </data>
+  <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
+    <value>Svuota cestino</value>
+  </data>
+  <data name="BaseLayoutItemContextFlyoutRestore.Text" xml:space="preserve">
+    <value>Ripristina</value>
+  </data>
 </root>

--- a/Files/Strings/it-IT/Resources.resw
+++ b/Files/Strings/it-IT/Resources.resw
@@ -522,13 +522,13 @@
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Vuoi eliminare questa cartella?</value>
   </data>
-  <data name="SettingsPreferencesPinRecycleBin.Text" xml:space="preserve">
-    <value>Fissa il cestino sulla barra laterale</value>
-  </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Svuota cestino</value>
   </data>
   <data name="BaseLayoutItemContextFlyoutRestore.Text" xml:space="preserve">
     <value>Ripristina</value>
+  </data>
+  <data name="SettingsExperimentalRecycleBin.Text" xml:space="preserve">
+    <value>Abilita il supporto al Cestino</value>
   </data>
 </root>

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
@@ -6,7 +6,8 @@
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:controlsprimitives="using:Microsoft.Toolkit.Uwp.UI.Controls.Primitives"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:Core="using:Microsoft.Xaml.Interactions.Core" 
     xmlns:local="using:Files"
     xmlns:local2="using:Files.Filesystem"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -222,18 +223,7 @@
                     <FontIcon Glyph="&#xE72D;" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
-            <MenuFlyoutSeparator 
-                x:Name="FileActionsSeparator"/>
-            <MenuFlyoutItem
-                x:Name="RestoreItem"
-                x:Uid="BaseLayoutItemContextFlyoutRestore"
-                x:Load="False"
-                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.RestoreItem_Click}"
-                Text="Restore">
-                <MenuFlyoutItem.Icon>
-                    <FontIcon Glyph="&#xE7A7;" />
-                </MenuFlyoutItem.Icon>
-            </MenuFlyoutItem>
+            <MenuFlyoutSeparator />
             <MenuFlyoutItem
                 x:Name="CutItem"
                 x:Uid="BaseLayoutItemContextFlyoutCut"
@@ -303,6 +293,54 @@
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
         </MenuFlyout>
+
+        <MenuFlyout x:Key="BaseLayoutRecycleBinItemContextFlyout">
+            <MenuFlyoutItem
+                x:Name="RestoreRecycleBinItem"
+                x:Uid="BaseLayoutItemContextFlyoutRestore"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.RestoreItem_Click}"
+                Text="Restore">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE7A7;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
+            <!--<MenuFlyoutItem
+                x:Name="CutRecycleBinItem"
+                x:Uid="BaseLayoutItemContextFlyoutCut"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.CutItem_Click}"
+                Text="Cut">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE8C6;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>-->
+            <MenuFlyoutSeparator />
+            <MenuFlyoutItem
+                x:Name="DeleteRecycleBinItem"
+                x:Uid="BaseLayoutItemContextFlyoutDelete"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.DeleteItem_Click}"
+                Text="Delete">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE74D;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
+            <MenuFlyoutSeparator />
+            <MenuFlyoutItem
+                x:Name="PropertiesRecycleBinItem"
+                x:Uid="BaseLayoutItemContextFlyoutProperties"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.ShowPropertiesButton_Click}"
+                Text="Properties">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE946;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
+        </MenuFlyout>
+
+        <Style x:Key="DataGridRowStandardContextFlyout" TargetType="controls:DataGridRow">
+            <Setter Property="ContextFlyout" Value="{StaticResource BaseLayoutItemContextFlyout}" />
+        </Style>
+        <Style x:Key="DataGridRowRecycleBinContextFlyout" TargetType="controls:DataGridRow">
+            <Setter Property="ContextFlyout" Value="{StaticResource BaseLayoutRecycleBinItemContextFlyout}" />
+        </Style>
     </local:BaseLayout.Resources>
 
     <Grid
@@ -391,11 +429,14 @@
                     <Setter Property="Background" Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
                 </Style>
             </controls:DataGrid.ColumnHeaderStyle>
-            <controls:DataGrid.RowStyle>
-                <Style TargetType="controls:DataGridRow">
-                    <Setter Property="ContextFlyout" Value="{StaticResource BaseLayoutItemContextFlyout}" />
-                </Style>
-            </controls:DataGrid.RowStyle>
+            <Interactivity:Interaction.Behaviors>
+                <Core:DataTriggerBehavior Binding="{x:Bind local:App.InteractionViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="False">
+                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=AllView}" PropertyName="RowStyle" Value="{StaticResource DataGridRowRecycleBinContextFlyout}" />
+                </Core:DataTriggerBehavior>
+                <Core:DataTriggerBehavior Binding="{x:Bind local:App.InteractionViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="True">
+                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=AllView}" PropertyName="RowStyle" Value="{StaticResource DataGridRowStandardContextFlyout}" />
+                </Core:DataTriggerBehavior>
+            </Interactivity:Interaction.Behaviors>
             <controls:DataGrid.CellStyle>
                 <Style TargetType="controls:DataGridCell">
                     <Setter Property="BorderThickness" Value="0" />

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
@@ -212,7 +212,18 @@
                     <FontIcon Glyph="&#xE72D;" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
-            <MenuFlyoutSeparator />
+            <MenuFlyoutSeparator 
+                x:Name="FileActionsSeparator"/>
+            <MenuFlyoutItem
+                x:Name="RestoreItem"
+                x:Uid="BaseLayoutItemContextFlyoutRestore"
+                x:Load="False"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.RestoreItem_Click}"
+                Text="Restore">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE7A7;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
             <MenuFlyoutItem
                 x:Name="CutItem"
                 x:Uid="BaseLayoutItemContextFlyoutCut"

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
@@ -18,7 +18,7 @@
     PointerWheelChanged="BaseLayout_PointerWheelChanged">
 
     <local:BaseLayout.Resources>
-        <MenuFlyout x:Key="BaseLayoutContextFlyout">
+        <MenuFlyout x:Key="BaseLayoutContextFlyout" Opening="RightClickContextMenu_Opening">
             <MenuFlyoutSubItem
                 x:Name="SortByEmptySpace"
                 x:Uid="BaseLayoutContextFlyoutSortBy"
@@ -126,6 +126,16 @@
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>
+            <MenuFlyoutItem
+                x:Name="EmptyRecycleBin"
+                x:Uid="BaseLayoutContextFlyoutEmptyRecycleBin"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.EmptyRecycleBin_ClickAsync}"
+                IsEnabled="True"
+                Text="Empty recycle bin">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE74D;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
             <MenuFlyoutSeparator />
             <MenuFlyoutItem
                 x:Name="PropertiesFolder"
@@ -138,7 +148,7 @@
             </MenuFlyoutItem>
         </MenuFlyout>
 
-        <MenuFlyout x:Key="BaseLayoutItemContextFlyout" Opening="RightClickContextMenu_Opening">
+        <MenuFlyout x:Key="BaseLayoutItemContextFlyout" Opening="RightClickItemContextMenu_Opening">
             <MenuFlyoutItem
                 x:Name="UnzipItem"
                 x:Uid="BaseLayoutItemContextFlyoutExtract"

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
@@ -245,6 +245,13 @@ namespace Files
 
         private void AllView_PreparingCellForEdit(object sender, DataGridPreparingCellForEditEventArgs e)
         {
+            if (App.CurrentInstance.ViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
+            {
+                // Do not rename files and folders inside the recycle bin
+                AllView.CancelEdit(); // cancel the edit operation
+                return;
+            }
+
             // Check if the double tap to rename files setting is off
             if (App.AppSettings.DoubleTapToRenameFiles == false)
             {

--- a/Files/UserControls/LayoutModes/GridViewBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GridViewBrowser.xaml
@@ -3,6 +3,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:Core="using:Microsoft.Xaml.Interactions.Core" 
     xmlns:local="using:Files"
     xmlns:local2="using:Files.Filesystem"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -217,18 +219,7 @@
                     <FontIcon Glyph="&#xE72D;" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
-            <MenuFlyoutSeparator 
-                x:Name="FileActionsSeparator"/>
-            <MenuFlyoutItem
-                x:Name="RestoreItem"
-                x:Uid="BaseLayoutItemContextFlyoutRestore"
-                x:Load="False"
-                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.RestoreItem_Click}"
-                Text="Restore">
-                <MenuFlyoutItem.Icon>
-                    <FontIcon Glyph="&#xE7A7;" />
-                </MenuFlyoutItem.Icon>
-            </MenuFlyoutItem>
+            <MenuFlyoutSeparator />
             <MenuFlyoutItem
                 x:Name="CutItem"
                 x:Uid="BaseLayoutItemContextFlyoutCut"
@@ -299,6 +290,47 @@
             </MenuFlyoutItem>
         </MenuFlyout>
 
+        <MenuFlyout x:Key="BaseLayoutRecycleBinItemContextFlyout">
+            <MenuFlyoutItem
+                x:Name="RestoreRecycleBinItem"
+                x:Uid="BaseLayoutItemContextFlyoutRestore"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.RestoreItem_Click}"
+                Text="Restore">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE7A7;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
+            <!--<MenuFlyoutItem
+                x:Name="CutRecycleBinItem"
+                x:Uid="BaseLayoutItemContextFlyoutCut"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.CutItem_Click}"
+                Text="Cut">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE8C6;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>-->
+            <MenuFlyoutSeparator />
+            <MenuFlyoutItem
+                x:Name="DeleteRecycleBinItem"
+                x:Uid="BaseLayoutItemContextFlyoutDelete"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.DeleteItem_Click}"
+                Text="Delete">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE74D;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
+            <MenuFlyoutSeparator />
+            <MenuFlyoutItem
+                x:Name="PropertiesRecycleBinItem"
+                x:Uid="BaseLayoutItemContextFlyoutProperties"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.ShowPropertiesButton_Click}"
+                Text="Properties">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE946;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
+        </MenuFlyout>
+        
         <DataTemplate x:Name="GridViewBrowserTemplate" x:DataType="local2:ListedItem">
             <Grid
                 Width="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}"
@@ -485,6 +517,12 @@
             </Grid>
         </DataTemplate>
 
+        <Style x:Key="GridViewItemStandardContextFlyout" TargetType="GridViewItem">
+            <Setter Property="ContextFlyout" Value="{StaticResource BaseLayoutItemContextFlyout}" />
+        </Style>
+        <Style x:Key="GridViewItemRecycleBinContextFlyout" TargetType="GridViewItem">
+            <Setter Property="ContextFlyout" Value="{StaticResource BaseLayoutRecycleBinItemContextFlyout}" />
+        </Style>
     </local:BaseLayout.Resources>
 
     <Grid
@@ -542,11 +580,14 @@
             PreviewKeyDown="FileList_PreviewKeyDown"
             SelectionChanged="FileList_SelectionChanged"
             SelectionMode="Extended">
-            <GridView.ItemContainerStyle>
-                <Style TargetType="GridViewItem">
-                    <Setter Property="ContextFlyout" Value="{StaticResource BaseLayoutItemContextFlyout}" />
-                </Style>
-            </GridView.ItemContainerStyle>
+            <Interactivity:Interaction.Behaviors>
+                <Core:DataTriggerBehavior Binding="{x:Bind local:App.InteractionViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="False">
+                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=FileList}" PropertyName="ItemContainerStyle" Value="{StaticResource DataGridRowRecycleBinContextFlyout}" />
+                </Core:DataTriggerBehavior>
+                <Core:DataTriggerBehavior Binding="{x:Bind local:App.InteractionViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="True">
+                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=FileList}" PropertyName="ItemContainerStyle" Value="{StaticResource DataGridRowStandardContextFlyout}" />
+                </Core:DataTriggerBehavior>
+            </Interactivity:Interaction.Behaviors>
         </GridView>
     </Grid>
 </local:BaseLayout>

--- a/Files/UserControls/LayoutModes/GridViewBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GridViewBrowser.xaml
@@ -582,10 +582,10 @@
             SelectionMode="Extended">
             <Interactivity:Interaction.Behaviors>
                 <Core:DataTriggerBehavior Binding="{x:Bind local:App.InteractionViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="False">
-                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=FileList}" PropertyName="ItemContainerStyle" Value="{StaticResource DataGridRowRecycleBinContextFlyout}" />
+                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=FileList}" PropertyName="ItemContainerStyle" Value="{StaticResource GridViewItemRecycleBinContextFlyout}" />
                 </Core:DataTriggerBehavior>
                 <Core:DataTriggerBehavior Binding="{x:Bind local:App.InteractionViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="True">
-                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=FileList}" PropertyName="ItemContainerStyle" Value="{StaticResource DataGridRowStandardContextFlyout}" />
+                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=FileList}" PropertyName="ItemContainerStyle" Value="{StaticResource GridViewItemStandardContextFlyout}" />
                 </Core:DataTriggerBehavior>
             </Interactivity:Interaction.Behaviors>
         </GridView>

--- a/Files/UserControls/LayoutModes/GridViewBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GridViewBrowser.xaml
@@ -207,7 +207,18 @@
                     <FontIcon Glyph="&#xE72D;" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
-            <MenuFlyoutSeparator />
+            <MenuFlyoutSeparator 
+                x:Name="FileActionsSeparator"/>
+            <MenuFlyoutItem
+                x:Name="RestoreItem"
+                x:Uid="BaseLayoutItemContextFlyoutRestore"
+                x:Load="False"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.RestoreItem_Click}"
+                Text="Restore">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE7A7;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
             <MenuFlyoutItem
                 x:Name="CutItem"
                 x:Uid="BaseLayoutItemContextFlyoutCut"

--- a/Files/UserControls/LayoutModes/GridViewBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GridViewBrowser.xaml
@@ -13,7 +13,7 @@
     PointerWheelChanged="BaseLayout_PointerWheelChanged"
     mc:Ignorable="d">
     <local:BaseLayout.Resources>
-        <MenuFlyout x:Key="BaseLayoutContextFlyout">
+        <MenuFlyout x:Key="BaseLayoutContextFlyout"  Opening="RightClickContextMenu_Opening">
             <MenuFlyoutSubItem
                 x:Name="SortByEmptySpace"
                 x:Uid="BaseLayoutContextFlyoutSortBy"
@@ -121,6 +121,16 @@
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>
+            <MenuFlyoutItem
+                x:Name="EmptyRecycleBin"
+                x:Uid="BaseLayoutContextFlyoutEmptyRecycleBin"
+                Click="{x:Bind local:App.CurrentInstance.InteractionOperations.EmptyRecycleBin_ClickAsync}"
+                IsEnabled="True"
+                Text="Empty recycle bin">
+                <MenuFlyoutItem.Icon>
+                    <FontIcon Glyph="&#xE74D;" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
             <MenuFlyoutSeparator />
             <MenuFlyoutItem
                 x:Name="PropertiesFolder"
@@ -133,7 +143,7 @@
             </MenuFlyoutItem>
         </MenuFlyout>
 
-        <MenuFlyout x:Key="BaseLayoutItemContextFlyout" Opening="RightClickContextMenu_Opening">
+        <MenuFlyout x:Key="BaseLayoutItemContextFlyout" Opening="RightClickItemContextMenu_Opening">
             <MenuFlyoutItem
                 x:Name="UnzipItem"
                 x:Uid="BaseLayoutItemContextFlyoutExtract"

--- a/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml
@@ -693,6 +693,7 @@
                 Margin="0,0,4,0"
                 HorizontalAlignment="Right"
                 x:Load="{x:Bind local1:App.InteractionViewModel.IsPageTypeNotHome, Mode=OneWay}"
+                IsEnabled="{x:Bind local1:App.InteractionViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}"
                 Background="Transparent"
                 CornerRadius="2"
                 FontFamily="Segoe MDL2 Assets"
@@ -807,6 +808,7 @@
                             x:Name="OpenInTerminalButton"
                             x:Uid="NavigationToolbarOpenInTerminal"
                             x:Load="{x:Bind local1:App.InteractionViewModel.IsPageTypeNotHome, Mode=OneWay}"
+                            IsEnabled="{x:Bind local1:App.InteractionViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}"
                             Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.OpenDirectoryInTerminal}"
                             Text="Open in Terminal..." />
                     </MenuFlyout>

--- a/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml.cs
+++ b/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml.cs
@@ -4,9 +4,8 @@ using Files.Views.Pages;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using Windows.ApplicationModel;
+using Windows.Foundation.Collections;
 using Windows.Storage;
 using Windows.System;
 using Windows.UI.Xaml;
@@ -255,11 +254,13 @@ namespace Files.UserControls
                             {
                                 if (item.Path.Equals(CurrentInput, StringComparison.OrdinalIgnoreCase) || item.Path.Equals(CurrentInput + ".exe", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    localSettings.Values["Application"] = item.Path;
-                                    localSettings.Values["Arguments"] = String.Format(item.arguments, App.CurrentInstance.ViewModel.WorkingDirectory);
-
-                                    await FullTrustProcessLauncher.LaunchFullTrustProcessForCurrentAppAsync();
-
+                                    if (App.Connection != null)
+                                    {
+                                        var value = new ValueSet();
+                                        value.Add("Application", item.Path);
+                                        value.Add("Arguments", String.Format(item.arguments, App.CurrentInstance.ViewModel.WorkingDirectory));
+                                        await App.Connection.SendMessageAsync(value);
+                                    }
                                     return;
                                 }
                             }

--- a/Files/UserControls/YourHome.xaml.cs
+++ b/Files/UserControls/YourHome.xaml.cs
@@ -49,6 +49,7 @@ namespace Files
         {
             base.OnNavigatedTo(eventArgs);
             App.InteractionViewModel.IsPageTypeNotHome = false;
+            App.InteractionViewModel.IsPageTypeNotRecycleBin = true;
             var parameters = eventArgs.Parameter.ToString();
             Locations.ItemLoader.itemsAdded.Clear();
             Locations.ItemLoader.DisplayItems();

--- a/Files/UserControls/YourHome.xaml.cs
+++ b/Files/UserControls/YourHome.xaml.cs
@@ -145,6 +145,11 @@ namespace Files
                 {
                     // Skip item until consent is provided
                 }
+                catch (COMException ex)
+                {
+                    mostRecentlyUsed.Remove(mruToken);
+                    System.Diagnostics.Debug.WriteLine(ex);
+                }
             }
 
             if (recentItemsCollection.Count == 0)
@@ -257,8 +262,12 @@ namespace Files
                     NavigationPath = App.AppSettings.MusicPath;
                     break;
 
-                case ("Videos"):
+                case "Videos":
                     NavigationPath = App.AppSettings.VideosPath;
+                    break;
+
+                case "RecycleBin":
+                    NavigationPath = App.AppSettings.RecycleBinPath;
                     break;
             }
 

--- a/Files/View Models/InteractionViewModel.cs
+++ b/Files/View Models/InteractionViewModel.cs
@@ -47,6 +47,14 @@ namespace Files.Controls
             set => Set(ref _IsPageTypeNotHome, value);
         }
 
+        private bool _IsPageTypeNotRecycleBin = false;
+
+        public bool IsPageTypeNotRecycleBin
+        {
+            get => _IsPageTypeNotRecycleBin;
+            set => Set(ref _IsPageTypeNotRecycleBin, value);
+        }
+
         public void CheckForImage()
         {
             //check if the selected item is an image file

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -398,11 +398,11 @@ namespace Files.Filesystem
                 _itemQueryResult.ContentsChanged -= FileContentsChanged;
             }
             watchedItemsOperation?.Cancel(); // Can be null
-            if (WorkingDirectory == null || !WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
+            App.CurrentInstance.NavigationToolbar.CanGoBack = true;
+            App.CurrentInstance.NavigationToolbar.CanGoForward = true;
+            if (!(WorkingDirectory?.StartsWith(App.AppSettings.RecycleBinPath) ?? false))
             {
                 // Can't go up from recycle bin
-                App.CurrentInstance.NavigationToolbar.CanGoBack = true;
-                App.CurrentInstance.NavigationToolbar.CanGoForward = true;
                 App.CurrentInstance.NavigationToolbar.CanNavigateToParent = true;
             }
         }

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -828,6 +828,7 @@ namespace Files.Filesystem
                                 FileImage = null,
                                 LoadFileIcon = false,
                                 ItemPath = item.RecyclePath, // this is the true path on disk so other stuff can work as is
+                                ItemOriginalPath = item.FilePath,
                                 LoadUnknownTypeGlyph = false,
                                 FileSize = item.FileSize,
                                 FileSizeBytes = (ulong)item.FileSizeBytes
@@ -861,6 +862,7 @@ namespace Files.Filesystem
                                 ItemDateModifiedReal = item.RecycleDate,
                                 ItemType = item.FileType,
                                 ItemPath = item.RecyclePath, // this is the true path on disk so other stuff can work as is
+                                ItemOriginalPath = item.FilePath,
                                 FileSize = item.FileSize,
                                 FileSizeBytes = (ulong)item.FileSizeBytes
                             });

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -25,7 +25,6 @@ using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Search;
 using Windows.UI.Core;
-using Windows.UI.Popups;
 using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -78,7 +77,7 @@ namespace Files.Filesystem
                     {
                         App.CurrentInstance.SidebarSelectedItem = item;
                     }
-                    
+
                     NotifyPropertyChanged("WorkingDirectory");
                 }
             }
@@ -399,10 +398,13 @@ namespace Files.Filesystem
                 _itemQueryResult.ContentsChanged -= FileContentsChanged;
             }
             watchedItemsOperation?.Cancel(); // Can be null
-            App.CurrentInstance.NavigationToolbar.CanGoBack = true;
-            App.CurrentInstance.NavigationToolbar.CanGoForward = true;
-            // Can't go up from recycle bin
-            App.CurrentInstance.NavigationToolbar.CanNavigateToParent = !path.StartsWith(App.AppSettings.RecycleBinPath);
+            if (WorkingDirectory == null || !WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
+            {
+                // Can't go up from recycle bin
+                App.CurrentInstance.NavigationToolbar.CanGoBack = true;
+                App.CurrentInstance.NavigationToolbar.CanGoForward = true;
+                App.CurrentInstance.NavigationToolbar.CanNavigateToParent = true;
+            }
         }
 
         public void OrderFiles()

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -813,8 +813,9 @@ namespace Files.Filesystem
                     && response.Message.ContainsKey("Enumerate"))
                 {
                     var folderContentsList = Newtonsoft.Json.JsonConvert.DeserializeObject<List<ShellFileItem>>((string)response.Message["Enumerate"]);
-                    foreach (var item in folderContentsList)
+                    for (int count = 0; count < folderContentsList.Count; count++)
                     {
+                        var item = folderContentsList[count];
                         if (item.IsFolder)
                         {
                             // Folder
@@ -866,6 +867,10 @@ namespace Files.Filesystem
                                 FileSize = item.FileSize,
                                 FileSizeBytes = (ulong)item.FileSizeBytes
                             });
+                        }
+                        if (count % 64 == 0)
+                        {
+                            await CoreApplication.MainView.CoreWindow.Dispatcher.YieldAsync();
                         }
                     }
                 }

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -831,8 +831,8 @@ namespace Files.Filesystem
                                 ItemPath = item.RecyclePath, // this is the true path on disk so other stuff can work as is
                                 ItemOriginalPath = item.FilePath,
                                 LoadUnknownTypeGlyph = false,
-                                FileSize = item.FileSize,
-                                FileSizeBytes = (ulong)item.FileSizeBytes
+                                FileSize = null,
+                                FileSizeBytes = 0
                                 //FolderTooltipText = tooltipString,
                             });
                         }

--- a/Files/Views/InstanceTabsView.xaml.cs
+++ b/Files/Views/InstanceTabsView.xaml.cs
@@ -2,12 +2,14 @@
 using Files.Views.Pages;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Windows.ApplicationModel.Core;
 using Windows.Storage;
+using Windows.System;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -130,6 +132,11 @@ namespace Files
                 {
                     tabLocationHeader = ResourceController.GetTranslation("SidebarVideos");
                     fontIconSource.Glyph = "\xE8B2";
+                }
+                else if (path.StartsWith(App.AppSettings.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    tabLocationHeader = "Recycle Bin";
+                    fontIconSource.Glyph = "\xE74D";
                 }
                 else if (App.AppSettings.OneDrivePath != null && path.StartsWith(App.AppSettings.OneDrivePath, StringComparison.OrdinalIgnoreCase))
                 {
@@ -260,6 +267,11 @@ namespace Files
             {
                 tabLocationHeader = ResourceController.GetTranslation("SidebarVideos");
                 fontIconSource.Glyph = "\xE8B2";
+            }
+            else if (currentPathForTabIcon.StartsWith(App.AppSettings.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
+            {
+                tabLocationHeader = "Recycle Bin";
+                fontIconSource.Glyph = "\xE74D";
             }
             else if (App.AppSettings.OneDrivePath != null && currentPathForTabIcon.StartsWith(App.AppSettings.OneDrivePath, StringComparison.OrdinalIgnoreCase))
             {

--- a/Files/Views/InstanceTabsView.xaml.cs
+++ b/Files/Views/InstanceTabsView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Files.Filesystem;
+﻿using Files.Common;
+using Files.Filesystem;
 using Files.Views.Pages;
 using Microsoft.UI.Xaml.Controls;
 using System;
@@ -135,7 +136,8 @@ namespace Files
                 }
                 else if (path.StartsWith(App.AppSettings.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
                 {
-                    tabLocationHeader = "Recycle Bin";
+                    var localSettings = ApplicationData.Current.LocalSettings;
+                    tabLocationHeader = localSettings.Values.Get("RecycleBin_Title", "Recycle Bin");
                     fontIconSource.Glyph = "\xE74D";
                 }
                 else if (App.AppSettings.OneDrivePath != null && path.StartsWith(App.AppSettings.OneDrivePath, StringComparison.OrdinalIgnoreCase))
@@ -270,7 +272,8 @@ namespace Files
             }
             else if (currentPathForTabIcon.StartsWith(App.AppSettings.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
             {
-                tabLocationHeader = "Recycle Bin";
+                var localSettings = ApplicationData.Current.LocalSettings;
+                tabLocationHeader = localSettings.Values.Get("RecycleBin_Title", "Recycle Bin");
                 fontIconSource.Glyph = "\xE74D";
             }
             else if (App.AppSettings.OneDrivePath != null && currentPathForTabIcon.StartsWith(App.AppSettings.OneDrivePath, StringComparison.OrdinalIgnoreCase))

--- a/Files/Views/InstanceTabsView.xaml.cs
+++ b/Files/Views/InstanceTabsView.xaml.cs
@@ -3,14 +3,12 @@ using Files.Filesystem;
 using Files.Views.Pages;
 using Microsoft.UI.Xaml.Controls;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Windows.ApplicationModel.Core;
 using Windows.Storage;
-using Windows.System;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -444,6 +442,15 @@ namespace Files
                     else
                     {
                         App.InteractionViewModel.IsPageTypeNotHome = true;
+                    }
+                    if ((tabView.SelectedItem as TabViewItem).Header.ToString() ==
+                        ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin"))
+                    {
+                        App.InteractionViewModel.IsPageTypeNotRecycleBin = false;
+                    }
+                    else
+                    {
+                        App.InteractionViewModel.IsPageTypeNotRecycleBin = true;
                     }
 
                     App.InteractionViewModel.TabsLeftMargin = new Thickness(200, 0, 0, 0);

--- a/Files/Views/Pages/ModernShellPage.xaml.cs
+++ b/Files/Views/Pages/ModernShellPage.xaml.cs
@@ -130,6 +130,11 @@ namespace Files.Views.Pages
                     SidebarControl.SelectedSidebarItem = App.sideBarItems.First(x => x.Path.Equals(App.AppSettings.VideosPath, StringComparison.OrdinalIgnoreCase));
                     break;
 
+                case "RecycleBin":
+                    NavigationPath = App.AppSettings.RecycleBinPath;
+                    SidebarControl.SelectedSidebarItem = App.sideBarItems.First(x => x.Path.Equals(App.AppSettings.RecycleBinPath, StringComparison.OrdinalIgnoreCase));
+                    break;
+
                 case "OneDrive":
                     NavigationPath = App.AppSettings.OneDrivePath;
                     SidebarControl.SelectedSidebarItem = App.sideBarItems.First(x => x.Path.Equals(App.AppSettings.OneDrivePath, StringComparison.OrdinalIgnoreCase));
@@ -140,6 +145,10 @@ namespace Files.Views.Pages
                     {
                         NavigationPath = NavParams;
                         SidebarControl.SelectedSidebarItem = App.AppSettings.DrivesManager.Drives.First(x => x.Path.ToString().Equals($"{NavParams[0]}:\\", StringComparison.OrdinalIgnoreCase));
+                    }
+                    else if (NavParams.StartsWith(App.AppSettings.RecycleBinPath))
+                    {
+                        NavigationPath = NavParams;
                     }
                     else
                     {

--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -80,7 +80,7 @@ namespace Files
 
                 if (selectedItem.PrimaryItemAttribute == StorageItemTypes.File)
                 {
-                    // get file MD5 hash
+                    // Get file MD5 hash
                     var hashAlgTypeName = HashAlgorithmNames.Md5;
                     ItemProperties.ItemMD5HashProgressVisibility = Visibility.Visible;
                     ItemProperties.ItemMD5Hash = await App.CurrentInstance.InteractionOperations.GetHashForFile(selectedItem, hashAlgTypeName);
@@ -96,7 +96,17 @@ namespace Files
             else
             {
                 var parentDirectory = App.CurrentInstance.ViewModel.CurrentFolder;
-                var parentDirectoryStorageItem = await StorageFolder.GetFolderFromPathAsync(parentDirectory.ItemPath);
+                if (parentDirectory.ItemPath.StartsWith(App.AppSettings.RecycleBinPath))
+                {
+                    // GetFolderFromPathAsync cannot access recyclebin folder
+                    // Currently a fake timestamp is used
+                    ItemProperties.ItemCreatedTimestamp = ListedItem.GetFriendlyDate(parentDirectory.ItemDateModifiedReal);
+                }
+                else
+                {
+                    var parentDirectoryStorageItem = await StorageFolder.GetFolderFromPathAsync(parentDirectory.ItemPath);
+                    ItemProperties.ItemCreatedTimestamp = ListedItem.GetFriendlyDate(parentDirectoryStorageItem.DateCreated);
+                }
                 ItemProperties.ItemName = parentDirectory.ItemName;
                 ItemProperties.ItemType = parentDirectory.ItemType;
                 ItemProperties.ItemPath = parentDirectory.ItemPath;
@@ -104,8 +114,7 @@ namespace Files
                 ItemProperties.LoadFileIcon = false;
                 ItemProperties.LoadFolderGlyph = true;
                 ItemProperties.LoadUnknownTypeGlyph = false;
-                ItemProperties.ItemModifiedTimestamp = parentDirectory.ItemDateModified;
-                ItemProperties.ItemCreatedTimestamp = ListedItem.GetFriendlyDate(parentDirectoryStorageItem.DateCreated);
+                ItemProperties.ItemModifiedTimestamp = parentDirectory.ItemDateModified;                
             }
         }
 

--- a/Files/Views/SettingsPages/Experimental.xaml
+++ b/Files/Views/SettingsPages/Experimental.xaml
@@ -36,8 +36,8 @@
                 
                 <Grid HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="200" />
-                        <ColumnDefinition Width="*" MaxWidth="420" />
+                        <ColumnDefinition Width="270" />
+                        <ColumnDefinition Width="*" MaxWidth="350" />
                         <ColumnDefinition Width="100" />
                     </Grid.ColumnDefinitions>
                     <Grid.ChildrenTransitions>
@@ -59,6 +59,35 @@
                         Width="40"
                         HorizontalAlignment="Right"
                         IsOn="{x:Bind local2:App.AppSettings.DoubleTapToRenameFiles, Mode=TwoWay}"
+                        OffContent=""
+                        OnContent="" />
+                </Grid>
+
+                <Grid HorizontalAlignment="Stretch">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="270" />
+                        <ColumnDefinition Width="*" MaxWidth="350" />
+                        <ColumnDefinition Width="100" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.ChildrenTransitions>
+                        <TransitionCollection>
+                            <RepositionThemeTransition />
+                        </TransitionCollection>
+                    </Grid.ChildrenTransitions>
+
+                    <TextBlock
+                        x:Uid="SettingsExperimentalRecycleBin"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        FontSize="16"
+                        Text="Enable Recycle Bin support"
+                        TextWrapping="Wrap" />
+
+                    <ToggleSwitch
+                        Grid.Column="2"
+                        Width="40"
+                        HorizontalAlignment="Right"
+                        IsOn="{x:Bind local2:App.AppSettings.PinRecycleBinToSideBar, Mode=TwoWay}"
                         OffContent=""
                         OnContent="" />
                 </Grid>

--- a/Files/Views/SettingsPages/Preferences.xaml
+++ b/Files/Views/SettingsPages/Preferences.xaml
@@ -60,7 +60,38 @@
                         OnContent=""
                         Toggled="OneDrivePin_Toggled" />
                 </Grid>
+                
+                <Grid HorizontalAlignment="Stretch">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="270" />
+                        <ColumnDefinition Width="*" MaxWidth="460" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.ChildrenTransitions>
+                        <TransitionCollection>
+                            <RepositionThemeTransition />
+                        </TransitionCollection>
+                    </Grid.ChildrenTransitions>
 
+                    <TextBlock
+                        x:Uid="SettingsPreferencesPinRecycleBin"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        FontSize="16"
+                        Text="Pin Recycle Bin to the sidebar"
+                        TextWrapping="Wrap" />
+
+                    <ToggleSwitch
+                        x:Name="RecycleBinPin"
+                        Grid.Column="2"
+                        Width="40"
+                        HorizontalAlignment="Right"
+                        IsEnabled="True"
+                        IsOn="{x:Bind local2:App.AppSettings.PinRecycleBinToSideBar, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        OffContent=""
+                        OnContent=""
+                        Toggled="RecycleBinPin_Toggled" />
+                </Grid>
+                
                 <Grid HorizontalAlignment="Stretch">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="270" />

--- a/Files/Views/SettingsPages/Preferences.xaml
+++ b/Files/Views/SettingsPages/Preferences.xaml
@@ -73,37 +73,6 @@
                     </Grid.ChildrenTransitions>
 
                     <TextBlock
-                        x:Uid="SettingsPreferencesPinRecycleBin"
-                        Grid.Column="0"
-                        VerticalAlignment="Center"
-                        FontSize="16"
-                        Text="Pin Recycle Bin to the sidebar"
-                        TextWrapping="Wrap" />
-
-                    <ToggleSwitch
-                        x:Name="RecycleBinPin"
-                        Grid.Column="2"
-                        Width="40"
-                        HorizontalAlignment="Right"
-                        IsEnabled="True"
-                        IsOn="{x:Bind local2:App.AppSettings.PinRecycleBinToSideBar, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                        OffContent=""
-                        OnContent=""
-                        Toggled="RecycleBinPin_Toggled" />
-                </Grid>
-                
-                <Grid HorizontalAlignment="Stretch">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="270" />
-                        <ColumnDefinition Width="*" MaxWidth="460" />
-                    </Grid.ColumnDefinitions>
-                    <Grid.ChildrenTransitions>
-                        <TransitionCollection>
-                            <RepositionThemeTransition />
-                        </TransitionCollection>
-                    </Grid.ChildrenTransitions>
-
-                    <TextBlock
                         x:Uid="SettingsPreferencesShowConfirmDeleteDialog"
                         Grid.Column="0"
                         VerticalAlignment="Center"

--- a/Files/Views/SettingsPages/Preferences.xaml.cs
+++ b/Files/Views/SettingsPages/Preferences.xaml.cs
@@ -69,12 +69,5 @@ namespace Files.SettingsPages
             App.AppSettings.PinOneDriveToSideBar = OneDrivePin.IsOn;
             OneDrivePin.IsEnabled = true;
         }
-
-        private void RecycleBinPin_Toggled(object sender, Windows.UI.Xaml.RoutedEventArgs e)
-        {
-            RecycleBinPin.IsEnabled = false;
-            App.AppSettings.PinRecycleBinToSideBar = RecycleBinPin.IsOn;
-            RecycleBinPin.IsEnabled = true;
-        }
     }
 }

--- a/Files/Views/SettingsPages/Preferences.xaml.cs
+++ b/Files/Views/SettingsPages/Preferences.xaml.cs
@@ -69,5 +69,12 @@ namespace Files.SettingsPages
             App.AppSettings.PinOneDriveToSideBar = OneDrivePin.IsOn;
             OneDrivePin.IsEnabled = true;
         }
+
+        private void RecycleBinPin_Toggled(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            RecycleBinPin.IsEnabled = false;
+            App.AppSettings.PinRecycleBinToSideBar = RecycleBinPin.IsOn;
+            RecycleBinPin.IsEnabled = true;
+        }
     }
 }

--- a/MessageRelay/Files.MessageRelay.csproj
+++ b/MessageRelay/Files.MessageRelay.csproj
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7684E128-D854-4C00-B086-0DD7D52F6E54}</ProjectGuid>
+    <OutputType>winmdobj</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MessageRelay</RootNamespace>
+    <AssemblyName>MessageRelay</AssemblyName>
+    <DefaultLanguage>it-IT</DefaultLanguage>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AllowCrossPlatformRetargeting>false</AllowCrossPlatformRetargeting>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+    <PlatformTarget>ARM64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+    <PlatformTarget>ARM64</PlatformTarget>
+    <OutputPath>bin\ARM64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="StartupTask.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>6.2.8</Version>
+    </PackageReference>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/MessageRelay/Files.MessageRelay.csproj
+++ b/MessageRelay/Files.MessageRelay.csproj
@@ -128,6 +128,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.8</Version>
     </PackageReference>
+    <PackageReference Include="NLog">
+      <Version>4.7.0</Version>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/MessageRelay/Properties/AssemblyInfo.cs
+++ b/MessageRelay/Properties/AssemblyInfo.cs
@@ -1,0 +1,28 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MessageRelay")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MessageRelay")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: ComVisible(false)]

--- a/MessageRelay/StartupTask.cs
+++ b/MessageRelay/StartupTask.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.AppService;
+using Windows.ApplicationModel.Background;
+using Windows.Foundation.Collections;
+
+namespace MessageRelay
+{
+    public sealed class StartupTask : IBackgroundTask
+    {
+        private Guid _thisConnectionGuid;
+        private BackgroundTaskDeferral _backgroundTaskDeferral;
+        private static readonly Dictionary<Guid, AppServiceConnection> Connections;
+
+        static StartupTask()
+        {
+            Connections = new Dictionary<Guid, AppServiceConnection>();
+        }
+
+        /// <summary>
+        /// When an AppServiceConnection of type 'FilesInteropService' (as
+        /// defined in Package.appxmanifest) is instantiated and OpenAsync() is called 
+        /// on it, then one of these StartupTask's in instantiated and Run() is called.
+        /// </summary>
+        /// <param name="taskInstance"></param>
+        public void Run(IBackgroundTaskInstance taskInstance)
+        {
+            try
+            {
+                // Get a service deferral so the service isn't terminated upon completion of Run()
+                _backgroundTaskDeferral = taskInstance.GetDeferral();
+                // Save a unique identifier for each connection
+                _thisConnectionGuid = Guid.NewGuid();
+                var triggerDetails = taskInstance.TriggerDetails as AppServiceTriggerDetails;
+                var connection = triggerDetails?.AppServiceConnection;
+                if (connection == null)
+                {
+                    System.Diagnostics.Debug.WriteLine("AppServiceConnection was null, ignorning this request");
+                    _backgroundTaskDeferral.Complete();
+                    return;
+                }
+                // Save the guid and connection in a *static* list of all connections
+                Connections.Add(_thisConnectionGuid, connection);
+                System.Diagnostics.Debug.WriteLine("Connection opened: " + _thisConnectionGuid);
+                taskInstance.Canceled += OnTaskCancelled;
+                // Listen for incoming app service requests
+                connection.RequestReceived += ConnectionRequestReceived;
+                connection.ServiceClosed += ConnectionOnServiceClosed;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Error in startup: " + ex);
+            }
+        }
+
+        /// <summary>
+        /// This happens when an app closes its connection normally.
+        /// </summary>
+        private async void OnTaskCancelled(IBackgroundTaskInstance sender, BackgroundTaskCancellationReason reason)
+        {
+            System.Diagnostics.Debug.WriteLine("MessageRelay was cancelled, removing " + _thisConnectionGuid + " from the list of active connections.");
+            RemoveConnection(_thisConnectionGuid);
+
+            if (Connections.Count == 1)
+            {
+                // Last open connection is the fulltrust process, lets close it
+                // This should be done better and handle fulltrust process crashes
+                var value = new ValueSet() { { "Arguments", "Terminate" } };
+                await SendMessage(Connections.Single(), value);
+            }
+
+            if (_backgroundTaskDeferral != null)
+            {
+                _backgroundTaskDeferral.Complete();
+                _backgroundTaskDeferral = null;
+            }
+        }
+
+        private void ConnectionOnServiceClosed(AppServiceConnection sender, AppServiceClosedEventArgs args)
+        {
+            // I don't think this ever happens
+            System.Diagnostics.Debug.WriteLine("Connection closed: " + _thisConnectionGuid);
+            RemoveConnection(_thisConnectionGuid);
+        }
+
+        private async void ConnectionRequestReceived(AppServiceConnection sender, AppServiceRequestReceivedEventArgs args)
+        {
+            // Take out a deferral since we use await
+            var appServiceDeferral = args.GetDeferral();
+            try
+            {
+                System.Diagnostics.Debug.WriteLine("Request initiated by " + _thisConnectionGuid);
+
+                // .ToList() required since connections may get removed during SendMessage()
+                var otherConnections = Connections
+                    .Where(i => i.Key != _thisConnectionGuid)
+                    .ToList();
+                foreach (var connection in otherConnections)
+                {
+                    // Relay request to all the other listeners
+                    // Break when a listener returns a response (message was handled)
+                    var returnData = await SendMessage(connection, args.Request.Message);
+                    if (returnData?.Message?.Any() ?? false)
+                    {
+                        await args.Request.SendResponseAsync(returnData?.Message);
+                        break;
+                    }
+                }
+            }
+            finally
+            {
+                appServiceDeferral.Complete();
+            }
+        }
+
+        private async Task<AppServiceResponse> SendMessage(KeyValuePair<Guid, AppServiceConnection> connection, ValueSet valueSet)
+        {
+            try
+            {
+                var result = await connection.Value.SendMessageAsync(valueSet);
+                if (result.Status == AppServiceResponseStatus.Success)
+                {
+                    System.Diagnostics.Debug.WriteLine("Successfully sent message to " + connection.Key + ". Result = " + result.Message);
+                    return result;
+                }
+                if (result.Status == AppServiceResponseStatus.Failure)
+                {
+                    // When an app with an open connection is terminated and it fails
+                    //      to dispose of its connection, the connection object remains
+                    //      in Connections.  When someone tries to send to it, it gets
+                    //      an AppServiceResponseStatus.Failure response
+                    System.Diagnostics.Debug.WriteLine("Error sending to " + connection.Key + ".  Removing it from the list of active connections.");
+                    RemoveConnection(connection.Key);
+                    return result;
+                }
+                System.Diagnostics.Debug.WriteLine("Error sending to " + connection.Key + " - " + result.Status);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Error SendMessage to " + connection.Key + ": " + ex);
+                return null;
+            }
+        }
+
+        private void RemoveConnection(Guid key)
+        {
+            var connection = Connections[key];
+            connection.Dispose();
+            connection = null;
+            Connections.Remove(key);
+        }
+    }
+}


### PR DESCRIPTION
Hello this pull request adds support for browsing the **Recycle Bin**!
"Support" here means that the recycle bin can be browsed just like any other folder in Files UWP, it's not just a "link" that opens the recycle bin in explorer.

![image](https://user-images.githubusercontent.com/9673091/82843494-91d77900-9edd-11ea-8699-1d43d4045238.png)

#### How it works
As I'm not aware of any way to properly access the recycle bin folder from the UWP app, I'm making use of Files UWP full trust process. The fulltrust process enumerates the contents of the recycle bin using the Shell32 api and send the results to the UWP app. Communication between the fulltrust process and the UWP app is done through AppService.

*NB: This requires to change the fulltrust process lifecyle*: instead of starting a new instance every time to handle the commands to open CMD, toggle QuickLook, etc., a single instance keeps running until the UWP app is closed or suspended.

#### What works
- New entry on the sidebar with localized name of the recycle bin
- Enumerating recycle bin elements
- Monitor filesystem changes and refresh items
- Showing the thumbnails for deleted files
- Properties dialog for deleted files
- Deleting files from the recycle bin

#### What's missing
- A button to empty recycle bin
- A customized context menu with the proper options (e.g "restore")

Let me know what you think of this, if you approve of the "architectural" changes I can keep working to complete what's missing.

