### PR TITLE
Add "newFile" option

### DIFF
--- a/Files/Dialogs/AddItemDialog.xaml.cs
+++ b/Files/Dialogs/AddItemDialog.xaml.cs
@@ -23,25 +23,25 @@ namespace Files.Dialogs
         public void AddItemsToList()
         {
             AddItemsList.Clear();
-            AddItemsList.Add(new AddListItem { Header = "Folder", SubHeader = "Creates an empty folder", Icon = "\xE838", IsItemEnabled = true });
-            AddItemsList.Add(new AddListItem { Header = "Text Document", SubHeader = "Creates a simple text file", Icon = "\xE8A5", IsItemEnabled = true });
-            AddItemsList.Add(new AddListItem { Header = "Bitmap Image", SubHeader = "Creates an empty bitmap image file", Icon = "\xEB9F", IsItemEnabled = true });
+            AddItemsList.Add(new AddListItem { Header = "Folder", SubHeader = "Creates an empty folder", Icon = "\xE838", IsItemEnabled = true, Type = AddItemType.Folder});
+            AddItemsList.Add(new AddListItem { Header = "Text Document", SubHeader = "Creates a simple text file", Icon = "\xE8A5", IsItemEnabled = true , Type = AddItemType.TextDocument});
+            AddItemsList.Add(new AddListItem { Header = "Bitmap Image", SubHeader = "Creates an empty bitmap image file", Icon = "\xEB9F", IsItemEnabled = true, Type = AddItemType.BitmapImage});
         }
 
         private void ListView_ItemClick(object sender, ItemClickEventArgs e)
         {
             App.AddItemDialogDisplay.Hide();
-            switch ((e.ClickedItem as AddListItem).Header)
+            switch ((e.ClickedItem as AddListItem).Type)
             {
-                case "Folder":
+                case AddItemType.Folder:
                     CreateFile(AddItemType.Folder);
                     break;
 
-                case "Text Document":
+                case AddItemType.TextDocument:
                     CreateFile(AddItemType.TextDocument);
                     break;
 
-                case "Bitmap Image":
+                case AddItemType.BitmapImage:
                     CreateFile(AddItemType.BitmapImage);
                     break;
             }
@@ -122,5 +122,6 @@ namespace Files.Dialogs
         public string SubHeader { get; set; }
         public string Icon { get; set; }
         public bool IsItemEnabled { get; set; }
+        public AddItemType Type { get; set; }
     }
 }

--- a/Files/Dialogs/AddItemDialog.xaml.cs
+++ b/Files/Dialogs/AddItemDialog.xaml.cs
@@ -26,7 +26,7 @@ namespace Files.Dialogs
             AddItemsList.Add(new AddListItem { Header = "Folder", SubHeader = "Creates an empty folder", Icon = "\xE838", IsItemEnabled = true, Type = AddItemType.Folder });
             AddItemsList.Add(new AddListItem { Header = "Text Document", SubHeader = "Creates a simple text file", Icon = "\xE8A5", IsItemEnabled = true , Type = AddItemType.TextDocument });
             AddItemsList.Add(new AddListItem { Header = "Bitmap Image", SubHeader = "Creates an empty bitmap image file", Icon = "\xEB9F", IsItemEnabled = true, Type = AddItemType.BitmapImage });
-            AddItemsList.Add(new AddListItem { Header = "File", SubHeader = "Create a file", Icon = "\xE8A5", IsItemEnabled = true, Type = AddItemType.File });
+            AddItemsList.Add(new AddListItem { Header = "File", SubHeader = "Create a file with file extension", Icon = "\xE8A5", IsItemEnabled = true, Type = AddItemType.File });
         }
 
         private void ListView_ItemClick(object sender, ItemClickEventArgs e)

--- a/Files/Dialogs/AddItemDialog.xaml.cs
+++ b/Files/Dialogs/AddItemDialog.xaml.cs
@@ -23,14 +23,15 @@ namespace Files.Dialogs
         public void AddItemsToList()
         {
             AddItemsList.Clear();
-            AddItemsList.Add(new AddListItem { Header = "Folder", SubHeader = "Creates an empty folder", Icon = "\xE838", IsItemEnabled = true, Type = AddItemType.Folder});
-            AddItemsList.Add(new AddListItem { Header = "Text Document", SubHeader = "Creates a simple text file", Icon = "\xE8A5", IsItemEnabled = true , Type = AddItemType.TextDocument});
-            AddItemsList.Add(new AddListItem { Header = "Bitmap Image", SubHeader = "Creates an empty bitmap image file", Icon = "\xEB9F", IsItemEnabled = true, Type = AddItemType.BitmapImage});
+            AddItemsList.Add(new AddListItem { Header = "Folder", SubHeader = "Creates an empty folder", Icon = "\xE838", IsItemEnabled = true, Type = AddItemType.Folder });
+            AddItemsList.Add(new AddListItem { Header = "Text Document", SubHeader = "Creates a simple text file", Icon = "\xE8A5", IsItemEnabled = true , Type = AddItemType.TextDocument });
+            AddItemsList.Add(new AddListItem { Header = "Bitmap Image", SubHeader = "Creates an empty bitmap image file", Icon = "\xEB9F", IsItemEnabled = true, Type = AddItemType.BitmapImage });
+            AddItemsList.Add(new AddListItem { Header = "File", SubHeader = "Create a file", Icon = "\xE8A5", IsItemEnabled = true, Type = AddItemType.File });
         }
 
         private void ListView_ItemClick(object sender, ItemClickEventArgs e)
         {
-            App.AddItemDialogDisplay.Hide();
+	        App.AddItemDialogDisplay.Hide();
             switch ((e.ClickedItem as AddListItem).Type)
             {
                 case AddItemType.Folder:
@@ -43,6 +44,9 @@ namespace Files.Dialogs
 
                 case AddItemType.BitmapImage:
                     CreateFile(AddItemType.BitmapImage);
+                    break;
+                case AddItemType.File:
+                    CreateFile(AddItemType.File);
                     break;
             }
         }
@@ -66,44 +70,64 @@ namespace Files.Dialogs
 
             var userInput = renameDialog.storedRenameInput;
 
-            if (fileType == AddItemType.Folder)
+            switch (fileType)
             {
-                StorageFolder folder;
-                if (!string.IsNullOrWhiteSpace(userInput))
-                {
-                    folder = await folderToCreateItem.CreateFolderAsync(userInput, CreationCollisionOption.GenerateUniqueName);
-                }
-                else
-                {
-                    folder = await folderToCreateItem.CreateFolderAsync(ResourceController.GetTranslation("NewFolder"), CreationCollisionOption.GenerateUniqueName);
-                }
-                TabInstance.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { PrimaryItemAttribute = StorageItemTypes.Folder, ItemName = folder.DisplayName, ItemDateModifiedReal = DateTimeOffset.Now, LoadUnknownTypeGlyph = false, LoadFolderGlyph = true, LoadFileIcon = false, ItemType = "Folder", FileImage = null, ItemPath = folder.Path });
-            }
-            else if (fileType == AddItemType.TextDocument)
-            {
-                StorageFile item;
-                if (!string.IsNullOrWhiteSpace(userInput))
-                {
-                    item = await folderToCreateItem.CreateFileAsync(userInput + ".txt", CreationCollisionOption.GenerateUniqueName);
-                }
-                else
-                {
-                    item = await folderToCreateItem.CreateFileAsync(ResourceController.GetTranslation("NewTextDocument") + ".txt", CreationCollisionOption.GenerateUniqueName);
-                }
-                TabInstance.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId) { PrimaryItemAttribute = StorageItemTypes.File, ItemName = item.DisplayName, ItemDateModifiedReal = DateTimeOffset.Now, LoadUnknownTypeGlyph = true, LoadFolderGlyph = false, LoadFileIcon = false, ItemType = item.DisplayType, FileImage = null, ItemPath = item.Path, FileExtension = item.FileType });
-            }
-            else if (fileType == AddItemType.BitmapImage)
-            {
-                StorageFile item;
-                if (!string.IsNullOrWhiteSpace(userInput))
-                {
-                    item = await folderToCreateItem.CreateFileAsync(userInput + ".bmp", CreationCollisionOption.GenerateUniqueName);
-                }
-                else
-                {
-                    item = await folderToCreateItem.CreateFileAsync(ResourceController.GetTranslation("NewBitmapImage") + ".bmp", CreationCollisionOption.GenerateUniqueName);
-                }
-                TabInstance.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId) { PrimaryItemAttribute = StorageItemTypes.File, ItemName = item.DisplayName, ItemDateModifiedReal = DateTimeOffset.Now, LoadUnknownTypeGlyph = true, LoadFolderGlyph = false, LoadFileIcon = false, ItemType = item.DisplayType, FileImage = null, ItemPath = item.Path, FileExtension = item.FileType });
+	            case AddItemType.Folder:
+	            {
+		            StorageFolder folder;
+		            if (!string.IsNullOrWhiteSpace(userInput))
+		            {
+			            folder = await folderToCreateItem.CreateFolderAsync(userInput, CreationCollisionOption.GenerateUniqueName);
+		            }
+		            else
+		            {
+			            folder = await folderToCreateItem.CreateFolderAsync(ResourceController.GetTranslation("NewFolder"), CreationCollisionOption.GenerateUniqueName);
+		            }
+		            TabInstance.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { PrimaryItemAttribute = StorageItemTypes.Folder, ItemName = folder.DisplayName, ItemDateModifiedReal = DateTimeOffset.Now, LoadUnknownTypeGlyph = false, LoadFolderGlyph = true, LoadFileIcon = false, ItemType = "Folder", FileImage = null, ItemPath = folder.Path });
+		            break;
+	            }
+	            case AddItemType.TextDocument:
+	            {
+		            StorageFile item;
+		            if (!string.IsNullOrWhiteSpace(userInput))
+		            {
+			            item = await folderToCreateItem.CreateFileAsync(userInput + ".txt", CreationCollisionOption.GenerateUniqueName);
+		            }
+		            else
+		            {
+			            item = await folderToCreateItem.CreateFileAsync(ResourceController.GetTranslation("NewTextDocument") + ".txt", CreationCollisionOption.GenerateUniqueName);
+		            }
+		            TabInstance.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId) { PrimaryItemAttribute = StorageItemTypes.File, ItemName = item.DisplayName, ItemDateModifiedReal = DateTimeOffset.Now, LoadUnknownTypeGlyph = true, LoadFolderGlyph = false, LoadFileIcon = false, ItemType = item.DisplayType, FileImage = null, ItemPath = item.Path, FileExtension = item.FileType });
+		            break;
+	            }
+	            case AddItemType.BitmapImage:
+	            {
+		            StorageFile item;
+		            if (!string.IsNullOrWhiteSpace(userInput))
+		            {
+			            item = await folderToCreateItem.CreateFileAsync(userInput + ".bmp", CreationCollisionOption.GenerateUniqueName);
+		            }
+		            else
+		            {
+			            item = await folderToCreateItem.CreateFileAsync(ResourceController.GetTranslation("NewBitmapImage") + ".bmp", CreationCollisionOption.GenerateUniqueName);
+		            }
+		            TabInstance.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId) { PrimaryItemAttribute = StorageItemTypes.File, ItemName = item.DisplayName, ItemDateModifiedReal = DateTimeOffset.Now, LoadUnknownTypeGlyph = true, LoadFolderGlyph = false, LoadFileIcon = false, ItemType = item.DisplayType, FileImage = null, ItemPath = item.Path, FileExtension = item.FileType });
+		            break;
+	            }
+	            case AddItemType.File:
+	            {
+		            StorageFile item;
+		            if (!string.IsNullOrWhiteSpace(userInput))
+		            {
+			            item = await folderToCreateItem.CreateFileAsync(userInput, CreationCollisionOption.GenerateUniqueName);
+		            }
+		            else
+		            {
+			            item = await folderToCreateItem.CreateFileAsync(ResourceController.GetTranslation("NewTextDocument"), CreationCollisionOption.GenerateUniqueName);
+		            }
+		            TabInstance.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId) { PrimaryItemAttribute = StorageItemTypes.File, ItemName = item.DisplayName, ItemDateModifiedReal = DateTimeOffset.Now, LoadUnknownTypeGlyph = true, LoadFolderGlyph = false, LoadFileIcon = false, ItemType = item.DisplayType, FileImage = null, ItemPath = item.Path, FileExtension = item.FileType });
+		            break;
+                    }
             }
         }
     }
@@ -113,7 +137,8 @@ namespace Files.Dialogs
         Folder = 0,
         TextDocument = 1,
         BitmapImage = 2,
-        CompressedArchive = 3
+        CompressedArchive = 3,
+        File = 4
     }
 
     public class AddListItem

--- a/Files/Dialogs/AddItemDialog.xaml.cs
+++ b/Files/Dialogs/AddItemDialog.xaml.cs
@@ -26,7 +26,7 @@ namespace Files.Dialogs
             AddItemsList.Add(new AddListItem { Header = "Folder", SubHeader = "Creates an empty folder", Icon = "\xE838", IsItemEnabled = true, Type = AddItemType.Folder });
             AddItemsList.Add(new AddListItem { Header = "Text Document", SubHeader = "Creates a simple text file", Icon = "\xE8A5", IsItemEnabled = true , Type = AddItemType.TextDocument });
             AddItemsList.Add(new AddListItem { Header = "Bitmap Image", SubHeader = "Creates an empty bitmap image file", Icon = "\xEB9F", IsItemEnabled = true, Type = AddItemType.BitmapImage });
-            AddItemsList.Add(new AddListItem { Header = "File", SubHeader = "Create a file with file extension", Icon = "\xE8A5", IsItemEnabled = true, Type = AddItemType.File });
+            AddItemsList.Add(new AddListItem { Header = "File", SubHeader = "Create a file with file extension", Icon = "\xE7C3", IsItemEnabled = true, Type = AddItemType.File });
         }
 
         private void ListView_ItemClick(object sender, ItemClickEventArgs e)

--- a/Files/Dialogs/AddItemDialog.xaml.cs
+++ b/Files/Dialogs/AddItemDialog.xaml.cs
@@ -30,7 +30,7 @@ namespace Files.Dialogs
         }
 
         private void ListView_ItemClick(object sender, ItemClickEventArgs e)
-        { 
+        {
             App.AddItemDialogDisplay.Hide();
 	        CreateFile(((AddListItem) e.ClickedItem).Type);
         }

--- a/Files/Dialogs/AddItemDialog.xaml.cs
+++ b/Files/Dialogs/AddItemDialog.xaml.cs
@@ -32,23 +32,7 @@ namespace Files.Dialogs
         private void ListView_ItemClick(object sender, ItemClickEventArgs e)
         {
 	        App.AddItemDialogDisplay.Hide();
-            switch ((e.ClickedItem as AddListItem).Type)
-            {
-                case AddItemType.Folder:
-                    CreateFile(AddItemType.Folder);
-                    break;
-
-                case AddItemType.TextDocument:
-                    CreateFile(AddItemType.TextDocument);
-                    break;
-
-                case AddItemType.BitmapImage:
-                    CreateFile(AddItemType.BitmapImage);
-                    break;
-                case AddItemType.File:
-                    CreateFile(AddItemType.File);
-                    break;
-            }
+	        CreateFile(((AddListItem) e.ClickedItem).Type);
         }
 
         public static async void CreateFile(AddItemType fileType)

--- a/Files/Dialogs/AddItemDialog.xaml.cs
+++ b/Files/Dialogs/AddItemDialog.xaml.cs
@@ -30,8 +30,8 @@ namespace Files.Dialogs
         }
 
         private void ListView_ItemClick(object sender, ItemClickEventArgs e)
-        {
-	        App.AddItemDialogDisplay.Hide();
+        { 
+            App.AddItemDialogDisplay.Hide();
 	        CreateFile(((AddListItem) e.ClickedItem).Type);
         }
 

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -871,6 +871,11 @@ namespace Files.Interacts
             AddItemDialog.CreateFile(AddItemType.BitmapImage);
         }
 
+        public void NewFile_Click(object sneder, RoutedEventArgs e)
+        {
+            AddItemDialog.CreateFile(AddItemType.File);
+        }
+
         public async void ExtractItems_Click(object sender, RoutedEventArgs e)
         {
             var selectedIndex = CurrentInstance.ContentPage.GetSelectedIndex();

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
@@ -131,7 +131,7 @@
                     Click="{x:Bind local:App.CurrentInstance.InteractionOperations.NewFile_Click}"
                     Text="File">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Glyph="&#xE8A5;" />
+                        <FontIcon Glyph="&#xE7C3;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
@@ -125,6 +125,15 @@
                         <FontIcon Glyph="&#xE8A5;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
+                <MenuFlyoutItem
+                    x:Name="NewFile"
+                    x:Uid="BaseLayoutContextFlyoutNewFile"
+                    Click="{x:Bind local:App.CurrentInstance.InteractionOperations.NewFile_Click}"
+                    Text="File">
+                    <MenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xE8A5;" />
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
             </MenuFlyoutSubItem>
             <MenuFlyoutSeparator />
             <MenuFlyoutItem

--- a/Files/UserControls/LayoutModes/GridViewBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GridViewBrowser.xaml
@@ -126,7 +126,7 @@
                     Click="{x:Bind local:App.CurrentInstance.InteractionOperations.NewFile_Click}"
                     Text="File">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Glyph="&#xE8A5;" />
+                        <FontIcon Glyph="&#xE7C3;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>

--- a/Files/UserControls/LayoutModes/GridViewBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GridViewBrowser.xaml
@@ -120,6 +120,15 @@
                         <FontIcon Glyph="&#xE8A5;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
+                <MenuFlyoutItem
+                    x:Name="NewFile"
+                    x:Uid="BaseLayoutContextFlyoutNewFile"
+                    Click="{x:Bind local:App.CurrentInstance.InteractionOperations.NewFile_Click}"
+                    Text="File">
+                    <MenuFlyoutItem.Icon>
+                        <FontIcon Glyph="&#xE8A5;" />
+                    </MenuFlyoutItem.Icon>
+                </MenuFlyoutItem>
             </MenuFlyoutSubItem>
             <MenuFlyoutSeparator />
             <MenuFlyoutItem

--- a/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml
@@ -729,6 +729,15 @@
                                 <FontIcon Glyph="&#xE8A5;" />
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            x:Name="NewFile"
+                            x:Uid="ModernNavigationToolbaNewFile"
+                            Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.NewFile_Click}"
+                            Text="File">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8A5;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
                     </MenuFlyout>
                 </Button.Flyout>
             </Button>

--- a/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml
@@ -735,7 +735,7 @@
                             Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.NewFile_Click}"
                             Text="File">
                             <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xE8A5;" />
+                                <FontIcon Glyph="&#xE7C3;" />
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
                     </MenuFlyout>


### PR DESCRIPTION
Adds a "newFile" option to the various "new"-menus (see #719).

![files_newDialog](https://user-images.githubusercontent.com/26199386/82897217-90e32d80-9f57-11ea-89bd-1cae0413ff23.png)

If you click the "file"-option the normal rename dialog opens.

![files_renameDialog](https://user-images.githubusercontent.com/26199386/82897247-9fc9e000-9f57-11ea-953a-b4fc751d7b3f.png)

and there you can specify the file with file extension (e.g. `test.md`).

To-Do
1. I added two new strings `x:Uid="ModernNavigationToolbaNewFile"` and `x:Uid="BaseLayoutContextFlyoutNewFile"` in xaml, but i don't know, if i have to add them to the `resources.resw` or ... (I'm not familiar with the translation tools)
2. I didn't changed the `renameDialog`, so it still shows the "Rename file without file extension". I wasn't sure, if it's better to create a new dialog for creating files or to alter the existing one.