### PR TITLE
[PROPOSAL] - Access android (MTP) devices

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1,10 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Files.Common
 {
     public static class Extensions
     {
+        public static IEnumerable<TSource> ExceptBy<TSource, TKey>(
+            this IEnumerable<TSource> source,
+            IEnumerable<TSource> other,
+            Func<TSource, TKey> keySelector)
+        {
+            var set = new HashSet<TKey>(other.Select(keySelector));
+            foreach (var item in source)
+                if (set.Add(keySelector(item)))
+                    yield return item;
+        }
+
         public static TOut Get<TOut, TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TOut defaultValue = default(TOut))
         {
             // If setting doesn't exist, create it.

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Vanara.Windows.Shell;
@@ -339,7 +340,7 @@ namespace FilesFullTrust
             }
         }
 
-        private static void HandleApplicationLaunch(string application, AppServiceRequestReceivedEventArgs args)
+        private static async void HandleApplicationLaunch(string application, AppServiceRequestReceivedEventArgs args)
         {
             var arguments = args.Request.Message.Get("Arguments", "");
             var workingDirectory = args.Request.Message.Get("WorkingDirectory", "");
@@ -395,43 +396,46 @@ namespace FilesFullTrust
                 {
                     try
                     {
-                        var split = application.Split(';').Where(x => !string.IsNullOrWhiteSpace(x));
-                        if (split.Count() == 1)
+                        await Win32API.StartSTATask(() =>
                         {
-                            Process.Start(application);
-                        }
-                        else
-                        {
-                            var groups = split.GroupBy(x => new
+                            var split = application.Split(';').Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => GetMtpPath(x));
+                            if (split.Count() == 1)
                             {
-                                Dir = Path.GetDirectoryName(x),
-                                Prog = Win32API.GetFileAssociation(x).Result ?? Path.GetExtension(x)
-                            });
-                            foreach (var group in groups)
+                                Process.Start(split.First());
+                            }
+                            else
                             {
-                                if (!group.Any()) continue;
-                                var files = group.Select(x => new ShellItem(x));
-                                using var sf = files.First().Parent;
-                                IContextMenu menu = null;
-                                try
+                                var groups = split.GroupBy(x => new {
+                                    Dir = Path.GetDirectoryName(x),
+                                    Prog = Win32API.GetFileAssociation(x).Result ?? Path.GetExtension(x)
+                                });
+                                foreach (var group in groups)
                                 {
-                                    menu = sf.GetChildrenUIObjects<IContextMenu>(null, files.ToArray());
-                                    menu.QueryContextMenu(Vanara.PInvoke.HMENU.NULL, 0, 0, 0, CMF.CMF_DEFAULTONLY);
-                                    var pici = new CMINVOKECOMMANDINFOEX();
-                                    pici.lpVerb = CMDSTR_OPEN;
-                                    pici.nShow = Vanara.PInvoke.ShowWindowCommand.SW_SHOW;
-                                    pici.cbSize = (uint)Marshal.SizeOf(pici);
-                                    menu.InvokeCommand(pici);
-                                }
-                                finally
-                                {
-                                    foreach (var elem in files)
-                                        elem.Dispose();
-                                    if (menu != null)
-                                        Marshal.ReleaseComObject(menu);
+                                    if (!group.Any()) continue;
+                                    var files = group.Select(x => new ShellItem(x));
+                                    using var sf = files.First().Parent;
+                                    Vanara.PInvoke.Shell32.IContextMenu menu = null;
+                                    try
+                                    {
+                                        menu = sf.GetChildrenUIObjects<Vanara.PInvoke.Shell32.IContextMenu>(null, files.ToArray());
+                                        menu.QueryContextMenu(Vanara.PInvoke.HMENU.NULL, 0, 0, 0, Vanara.PInvoke.Shell32.CMF.CMF_DEFAULTONLY);
+                                        var pici = new Vanara.PInvoke.Shell32.CMINVOKECOMMANDINFOEX();
+                                        pici.lpVerb = Vanara.PInvoke.Shell32.CMDSTR_OPEN;
+                                        pici.nShow = Vanara.PInvoke.ShowWindowCommand.SW_SHOW;
+                                        pici.cbSize = (uint)Marshal.SizeOf(pici);
+                                        menu.InvokeCommand(pici);
+                                    }
+                                    finally
+                                    {
+                                        foreach (var elem in files)
+                                            elem.Dispose();
+                                        if (menu != null)
+                                            Marshal.ReleaseComObject(menu);
+                                    }
                                 }
                             }
-                        }
+                            return true;
+                        });
                     }
                     catch (Win32Exception)
                     {
@@ -480,6 +484,19 @@ namespace FilesFullTrust
                 }
             }
             return false;
+        }
+
+        private static string GetMtpPath(string executable)
+        {
+            if (executable.StartsWith("\\\\?\\"))
+            {
+                using var computer = new ShellFolder(Vanara.PInvoke.Shell32.KNOWNFOLDERID.FOLDERID_ComputerFolder);
+                using var device = computer.FirstOrDefault(i => executable.Replace("\\\\?\\", "").StartsWith(i.Name));
+                var deviceId = device?.ParsingName;
+                var itemPath = Regex.Replace(executable, @"^\\\\\?\\[^\\]*\\?", "");
+                return deviceId != null ? Path.Combine(deviceId, itemPath) : executable;
+            }
+            return executable;
         }
 
         private static void Connection_ServiceClosed(AppServiceConnection sender, AppServiceClosedEventArgs args)

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -205,7 +205,7 @@ namespace Files
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
+        protected override async void OnNavigatedTo(NavigationEventArgs eventArgs)
         {
             base.OnNavigatedTo(eventArgs);
             // Add item jumping handler
@@ -221,7 +221,7 @@ namespace Files
             App.CurrentInstance.NavigationToolbar.CanRefresh = true;
             IsItemSelected = false;
             AssociatedViewModel.IsFolderEmptyTextDisplayed = false;
-            App.CurrentInstance.FilesystemViewModel.WorkingDirectory = parameters;
+            await App.CurrentInstance.FilesystemViewModel.SetWorkingDirectory(parameters);
 
             // pathRoot will be empty on recycle bin path
             string pathRoot = Path.GetPathRoot(App.CurrentInstance.FilesystemViewModel.WorkingDirectory);
@@ -234,8 +234,10 @@ namespace Files
                 App.CurrentInstance.NavigationToolbar.CanNavigateToParent = true;
             }
             App.CurrentInstance.InstanceViewModel.IsPageTypeNotHome = true; // show controls that were hidden on the home page
-            App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin =
-                !App.CurrentInstance.FilesystemViewModel.WorkingDirectory.StartsWith(AppSettings.RecycleBinPath);
+            App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin =
+                App.CurrentInstance.FilesystemViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath);
+            App.CurrentInstance.InstanceViewModel.IsPageTypeMtpDevice =
+                App.CurrentInstance.FilesystemViewModel.WorkingDirectory.StartsWith("\\\\?\\");
 
             App.CurrentInstance.FilesystemViewModel.RefreshItems();
 
@@ -317,6 +319,23 @@ namespace Files
                         await Interaction.InvokeWin32Component(commandToExecute.command, commandToExecute.arguments);
                     }
                 }
+            }
+        }
+
+        public void RightClickContextMenu_Opening(object sender, object e)
+        {
+            if (App.CurrentInstance.InstanceViewModel.IsPageTypeMtpDevice)
+            {
+                // MTP device
+                (this.FindName("OpenTerminal") as MenuFlyoutItemBase).IsEnabled = false;
+                UnloadMenuFlyoutItemByName("NewEmptySpace");
+                UnloadMenuFlyoutItemByName("NewEmptySpaceSeparator");
+            }
+            else
+            {
+                (this.FindName("OpenTerminal") as MenuFlyoutItemBase).IsEnabled = true;
+                (this.FindName("NewEmptySpace") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
+                (this.FindName("NewEmptySpaceSeparator") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
             }
         }
 
@@ -468,9 +487,9 @@ namespace Files
             foreach (ListedItem item in App.CurrentInstance.ContentPage.SelectedItems)
             {
                 if (item.PrimaryItemAttribute == StorageItemTypes.File)
-                    selectedStorageItems.Add(await StorageFile.GetFileFromPathAsync(item.ItemPath));
+                    selectedStorageItems.Add(await ItemViewModel.GetFileFromPathAsync(item.ItemPath));
                 else if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
-                    selectedStorageItems.Add(await StorageFolder.GetFolderFromPathAsync(item.ItemPath));
+                    selectedStorageItems.Add(await ItemViewModel.GetFolderFromPathAsync(item.ItemPath));
             }
 
             if (selectedStorageItems.Count == 0)

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -322,23 +322,6 @@ namespace Files
             }
         }
 
-        public void RightClickContextMenu_Opening(object sender, object e)
-        {
-            if (App.CurrentInstance.InstanceViewModel.IsPageTypeMtpDevice)
-            {
-                // MTP device
-                (this.FindName("OpenTerminal") as MenuFlyoutItemBase).IsEnabled = false;
-                UnloadMenuFlyoutItemByName("NewEmptySpace");
-                UnloadMenuFlyoutItemByName("NewEmptySpaceSeparator");
-            }
-            else
-            {
-                (this.FindName("OpenTerminal") as MenuFlyoutItemBase).IsEnabled = true;
-                (this.FindName("NewEmptySpace") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
-                (this.FindName("NewEmptySpaceSeparator") as MenuFlyoutItemBase).Visibility = Visibility.Visible;
-            }
-        }
-
         public void RightClickItemContextMenu_Opening(object sender, object e)
         {
             SetShellContextmenu();

--- a/Files/DataModels/SidebarPinnedModel.cs
+++ b/Files/DataModels/SidebarPinnedModel.cs
@@ -87,32 +87,14 @@ namespace Files.DataModels
             {
                 Debug.WriteLine(ex.Message);
             }
-            catch (ArgumentException ex)
+            catch (Exception ex) when (
+                ex is ArgumentException // Pinned item was invalid
+                || ex is FileNotFoundException // Pinned item was deleted
+                || ex is System.Runtime.InteropServices.COMException // Pinned item's drive was ejected
+                || (uint)ex.HResult == 0x800700A1) // The specified path is invalid (usually an mtp device was disconnected)
             {
                 Debug.WriteLine("Pinned item was invalid and will be removed from the file lines list soon: " + ex.Message);
                 RemoveItem(path);
-            }
-            catch (FileNotFoundException ex)
-            {
-                Debug.WriteLine("Pinned item was deleted and will be removed from the file lines list soon: " + ex.Message);
-                RemoveItem(path);
-            }
-            catch (System.Runtime.InteropServices.COMException ex)
-            {
-                Debug.WriteLine("Pinned item's drive was ejected and will be removed from the file lines list soon: " + ex.Message);
-                RemoveItem(path);
-            }
-            catch (Exception ex)
-            {
-                if ((uint)ex.HResult == 0x800700A1) // The specified path is invalid (usually an mtp device was disconnected)
-                {
-                    Debug.WriteLine("Pinned item was invalid and will be removed from the file lines list soon: " + ex.Message);
-                    RemoveItem(path);
-                }
-                else
-                {
-                    throw ex;
-                }
             }
         }
 

--- a/Files/Dialogs/AddItemDialog.xaml.cs
+++ b/Files/Dialogs/AddItemDialog.xaml.cs
@@ -53,7 +53,7 @@ namespace Files.Dialogs
             {
                 currentPath = TabInstance.FilesystemViewModel.WorkingDirectory;
             }
-            StorageFolder folderToCreateItem = await StorageFolder.GetFolderFromPathAsync(currentPath);
+            StorageFolder folderToCreateItem = await Filesystem.ItemViewModel.GetFolderFromPathAsync(currentPath);
             RenameDialog renameDialog = new RenameDialog();
 
             var renameResult = await renameDialog.ShowAsync();

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -162,6 +162,10 @@
     <Compile Include="Dialogs\ConfirmDeleteDialog.xaml.cs">
       <DependentUpon>ConfirmDeleteDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Filesystem\StorageFileHelpers\StorageFileExtensions.cs" />
+    <Compile Include="Filesystem\StorageFileHelpers\IStorageItemWithPath.cs" />
+    <Compile Include="Filesystem\StorageFileHelpers\StorageFileWithPath.cs" />
+    <Compile Include="Filesystem\StorageFileHelpers\StorageFolderWithPath.cs" />
     <Compile Include="Helpers\AcrylicTheme.cs" />
     <Compile Include="Helpers\DialogDisplayHelper.cs" />
     <Compile Include="Helpers\DispatcherHelper.cs" />

--- a/Files/Filesystem/DriveItem.cs
+++ b/Files/Filesystem/DriveItem.cs
@@ -12,6 +12,7 @@ namespace Files.Filesystem
         public string Glyph { get; set; }
         public string Text { get; set; }
         public string Path { get; set; }
+        public StorageFolder Root { get; set; }
         public NavigationControlItemType ItemType { get; set; } = NavigationControlItemType.Drive;
         public ByteSize MaxSpace { get; set; }
         public ByteSize FreeSpace { get; set; }
@@ -40,7 +41,8 @@ namespace Files.Filesystem
         {
             Text = root.DisplayName;
             Type = type;
-            Path = root.Path;
+            Path = string.IsNullOrEmpty(root.Path) ? $"\\\\?\\{root.Name}\\" : root.Path;
+            Root = root;
 
             var properties = Task.Run(async () =>
             {

--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -326,10 +326,11 @@ namespace Files.Filesystem
                     return new StorageFolderWithPath(matchingDrive, rootPath);
                 }
             }
-            else
-            {
-                return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(rootPath), rootPath);
-            }
+            // It's ok to return null here, on normal drives StorageFolder.GetFolderFromPathAsync works
+            //else
+            //{
+            //    return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(rootPath), rootPath);
+            //}
             return null;
         }
 

--- a/Files/Filesystem/StorageFileHelpers/IStorageItemWithPath.cs
+++ b/Files/Filesystem/StorageFileHelpers/IStorageItemWithPath.cs
@@ -1,0 +1,10 @@
+﻿using Windows.Storage;
+
+namespace Files.Filesystem
+{
+    public interface IStorageItemWithPath
+    {
+        public string Path { get; set; }
+        public IStorageItem Item { get; set; }
+    }
+}

--- a/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -1,0 +1,178 @@
+﻿using Files.Common;
+using Files.Filesystem;
+using Files.Helpers;
+using Files.Views.Pages;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.Storage;
+
+namespace Files.Filesystem
+{
+    public static class StorageFileExtensions
+    {
+        public static List<PathBoxItem> GetDirectoryPathComponents(string value)
+        {
+            List<string> pathComponents = new List<string>();
+            List<PathBoxItem> pathBoxItems = new List<PathBoxItem>();
+
+            // If path is a library, simplify it
+            // If path is found to not be a library
+            if (value.StartsWith("\\\\?\\"))
+            {
+                pathComponents = value.Replace("\\\\?\\", "").Split("\\", StringSplitOptions.RemoveEmptyEntries).ToList();
+            }
+            else
+            {
+                pathComponents = value.Split("\\", StringSplitOptions.RemoveEmptyEntries).ToList();
+            }
+
+            int index = 0;
+            foreach (string s in pathComponents)
+            {
+                string componentLabel = null;
+                string tag = "";
+                if (s.StartsWith(App.AppSettings.RecycleBinPath))
+                {
+                    // Handle the recycle bin: use the localized folder name
+                    PathBoxItem item = new PathBoxItem()
+                    {
+                        Title = ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin"),
+                        Path = tag,
+                    };
+                    App.CurrentInstance.NavigationToolbar.PathComponents.Add(item);
+                }
+                else if (s.Contains(":"))
+                {
+                    if (App.sideBarItems.FirstOrDefault(x => x.ItemType == NavigationControlItemType.Drive && x.Path.Contains(s, StringComparison.OrdinalIgnoreCase)) != null)
+                    {
+                        componentLabel = App.sideBarItems.FirstOrDefault(x => x.ItemType == NavigationControlItemType.Drive && x.Path.Contains(s, StringComparison.OrdinalIgnoreCase)).Text;
+                    }
+                    else
+                    {
+                        componentLabel = @"Drive (" + s + @"\)";
+                    }
+                    tag = s + @"\";
+
+                    PathBoxItem item = new PathBoxItem()
+                    {
+                        Title = componentLabel,
+                        Path = tag,
+                    };
+                    pathBoxItems.Add(item);
+                }
+                else
+                {
+                    componentLabel = s;
+                    foreach (string part in pathComponents.GetRange(0, index + 1))
+                    {
+                        tag = tag + part + @"\";
+                    }
+                    if (value.StartsWith("\\\\?\\"))
+                    {
+                        tag = "\\\\?\\" + tag;
+                    }
+                    else if (index == 0)
+                    {
+                        tag = "\\\\" + tag;
+                    }
+
+                    PathBoxItem item = new PathBoxItem()
+                    {
+                        Title = componentLabel,
+                        Path = tag,
+                    };
+                    pathBoxItems.Add(item);
+                }
+                index++;
+            }
+            return pathBoxItems;
+        }
+
+        public async static Task<StorageFolderWithPath> GetFolderWithPathFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
+        {
+            if (rootFolder != null)
+            {
+                var currComponents = GetDirectoryPathComponents(value);
+
+                if (rootFolder.Path == value)
+                {
+                    return rootFolder;
+                }
+                else if (parentFolder != null && value.IsSubPathOf(parentFolder.Path))
+                {
+                    var folder = parentFolder.Folder;
+                    var prevComponents = GetDirectoryPathComponents(parentFolder.Path);
+                    var path = parentFolder.Path;
+                    foreach (var component in currComponents.ExceptBy(prevComponents, c => c.Path))
+                    {
+                        folder = await folder.GetFolderAsync(component.Title);
+                        path = Path.Combine(path, folder.Name);
+                    }
+                    return new StorageFolderWithPath(folder, path);
+                }
+                else if (value.IsSubPathOf(rootFolder.Path))
+                {
+                    var folder = rootFolder.Folder;
+                    var path = rootFolder.Path;
+                    foreach (var component in currComponents.Skip(1))
+                    {
+                        folder = await folder.GetFolderAsync(component.Title);
+                        path = Path.Combine(path, folder.Name);
+                    }
+                    return new StorageFolderWithPath(folder, path);
+                }
+            }
+            return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(value));
+        }
+
+        public async static Task<StorageFolder> GetFolderFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
+        {
+            return (await GetFolderWithPathFromPathAsync(value, rootFolder, parentFolder)).Folder;
+        }
+
+        public async static Task<StorageFileWithPath> GetFileWithPathFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
+        {
+            if (rootFolder != null)
+            {
+                var currComponents = GetDirectoryPathComponents(value);
+
+                if (parentFolder != null && value.IsSubPathOf(parentFolder.Path))
+                {
+                    var folder = parentFolder.Folder;
+                    var prevComponents = GetDirectoryPathComponents(parentFolder.Path);
+                    var path = parentFolder.Path;
+                    foreach (var component in currComponents.ExceptBy(prevComponents, c => c.Path).SkipLast(1))
+                    {
+                        folder = await folder.GetFolderAsync(component.Title);
+                        path = Path.Combine(path, folder.Name);
+                    }
+                    var file = await folder.GetFileAsync(currComponents.Last().Title);
+                    path = Path.Combine(path, file.Name);
+                    return new StorageFileWithPath(file, path);
+                }
+                else if (value.IsSubPathOf(rootFolder.Path))
+                {
+                    var folder = rootFolder.Folder;
+                    var path = rootFolder.Path;
+                    foreach (var component in currComponents.Skip(1).SkipLast(1))
+                    {
+                        folder = await folder.GetFolderAsync(component.Title);
+                        path = Path.Combine(path, folder.Name);
+                    }
+                    var file = await folder.GetFileAsync(currComponents.Last().Title);
+                    path = Path.Combine(path, file.Name);
+                    return new StorageFileWithPath(file, path);
+                }
+            }
+            return new StorageFileWithPath(await StorageFile.GetFileFromPathAsync(value));
+        }
+
+        public async static Task<StorageFile> GetFileFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
+        {
+            return (await GetFileWithPathFromPathAsync(value, rootFolder, parentFolder)).File;
+        }
+    }
+}

--- a/Files/Filesystem/StorageFileHelpers/StorageFileWithPath.cs
+++ b/Files/Filesystem/StorageFileHelpers/StorageFileWithPath.cs
@@ -1,0 +1,33 @@
+﻿using Windows.Storage;
+
+namespace Files.Filesystem
+{
+    public class StorageFileWithPath : IStorageItemWithPath
+    {
+        public StorageFile File
+        {
+            get
+            {
+                return (StorageFile)Item;
+            }
+            set
+            {
+                Item = value;
+            }
+        }
+        public string Path { get; set; }
+        public IStorageItem Item { get; set; }
+
+        public StorageFileWithPath(StorageFile file)
+        {
+            File = file;
+            Path = File.Path;
+        }
+
+        public StorageFileWithPath(StorageFile file, string path)
+        {
+            File = file;
+            Path = path;
+        }
+    }
+}

--- a/Files/Filesystem/StorageFileHelpers/StorageFolderWithPath.cs
+++ b/Files/Filesystem/StorageFileHelpers/StorageFolderWithPath.cs
@@ -1,0 +1,33 @@
+﻿using Windows.Storage;
+
+namespace Files.Filesystem
+{
+    public class StorageFolderWithPath : IStorageItemWithPath
+    {
+        public StorageFolder Folder
+        {
+            get
+            {
+                return (StorageFolder)Item;
+            }
+            set
+            {
+                Item = value;
+            }
+        }
+        public string Path { get; set; }
+        public IStorageItem Item { get; set; }
+
+        public StorageFolderWithPath(StorageFolder folder)
+        {
+            Folder = folder;
+            Path = folder.Path;
+        }
+
+        public StorageFolderWithPath(StorageFolder folder, string path)
+        {
+            Folder = folder;
+            Path = path;
+        }
+    }
+}

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -68,7 +68,7 @@ namespace Files.Interacts
         public async void SetAsDesktopBackgroundItem_Click(object sender, RoutedEventArgs e)
         {
             // Get the path of the selected file
-            StorageFile sourceFile = await StorageFile.GetFileFromPathAsync(CurrentInstance.ContentPage.SelectedItem.ItemPath);
+            StorageFile sourceFile = await ItemViewModel.GetFileFromPathAsync(CurrentInstance.ContentPage.SelectedItem.ItemPath);
 
             // Get the app's local folder to use as the destination folder.
             StorageFolder localFolder = ApplicationData.Current.LocalFolder;
@@ -85,7 +85,7 @@ namespace Files.Interacts
         public async void SetAsLockscreenBackgroundItem_Click(object sender, RoutedEventArgs e)
         {
             // Get the path of the selected file
-            StorageFile sourceFile = await StorageFile.GetFileFromPathAsync(CurrentInstance.ContentPage.SelectedItem.ItemPath);
+            StorageFile sourceFile = await ItemViewModel.GetFileFromPathAsync(CurrentInstance.ContentPage.SelectedItem.ItemPath);
 
             // Get the app's local folder to use as the destination folder.
             StorageFolder localFolder = ApplicationData.Current.LocalFolder;
@@ -324,42 +324,44 @@ namespace Files.Interacts
                     var clickedOnItemPath = clickedOnItem.ItemPath;
                     if (clickedOnItem.PrimaryItemAttribute == StorageItemTypes.Folder)
                     {
-                        // Add location to MRU List
-                        mostRecentlyUsed.Add(await StorageFolder.GetFolderFromPathAsync(clickedOnItemPath));
+                        var childFolder = await ItemViewModel.GetFolderWithPathFromPathAsync(clickedOnItem.ItemPath);
 
-                        CurrentInstance.FilesystemViewModel.WorkingDirectory = clickedOnItemPath;
-                        CurrentInstance.NavigationToolbar.PathControlDisplayText = clickedOnItemPath;
+                        // Add location to MRU List
+                        mostRecentlyUsed.Add(childFolder.Folder, childFolder.Path);
+
+                        await App.CurrentInstance.FilesystemViewModel.SetWorkingDirectory(childFolder.Path);
+                        CurrentInstance.NavigationToolbar.PathControlDisplayText = childFolder.Path;
 
                         CurrentInstance.ContentPage.AssociatedViewModel.IsFolderEmptyTextDisplayed = false;
-                        CurrentInstance.ContentFrame.Navigate(sourcePageType, clickedOnItemPath, new SuppressNavigationTransitionInfo());
+                        CurrentInstance.ContentFrame.Navigate(sourcePageType, childFolder.Path, new SuppressNavigationTransitionInfo());
                     }
                     else
                     {
+                        var childFile = await ItemViewModel.GetFileWithPathFromPathAsync(clickedOnItem.ItemPath);
                         // Add location to MRU List
-                        mostRecentlyUsed.Add(await StorageFile.GetFileFromPathAsync(clickedOnItem.ItemPath));
+                        mostRecentlyUsed.Add(childFile.File, childFile.Path);
+
                         if (displayApplicationPicker)
                         {
-                            StorageFile file = await StorageFile.GetFileFromPathAsync(clickedOnItem.ItemPath);
                             var options = new LauncherOptions
                             {
                                 DisplayApplicationPicker = true
                             };
-                            await Launcher.LaunchFileAsync(file, options);
+                            await Launcher.LaunchFileAsync(childFile.File, options);
                         }
                         else
                         {
                             //try using launcher first
-
                             bool launchSuccess = false;
 
                             try
                             {
                                 StorageFileQueryResult fileQueryResult = null;
 
-                                StorageFile file = await StorageFile.GetFileFromPathAsync(clickedOnItem.ItemPath);
+                                var file = await ItemViewModel.GetFileFromPathAsync(clickedOnItem.ItemPath);
 
                                 //Get folder to create a file query (to pass to apps like Photos, Movies & TV..., needed to scroll through the folder like what Windows Explorer does)
-                                var currFolder = await StorageFolder.GetFolderFromPathAsync(Path.GetDirectoryName(clickedOnItem.ItemPath));
+                                StorageFolder currFolder = await ItemViewModel.GetFolderFromPathAsync(Path.GetDirectoryName(clickedOnItem.ItemPath));
 
                                 QueryOptions queryOptions = new QueryOptions(CommonFileQuery.DefaultQuery, null);
 
@@ -434,22 +436,20 @@ namespace Files.Interacts
                     }
                     foreach (ListedItem clickedOnItem in CurrentInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.File))
                     {
+                        var childFile = await ItemViewModel.GetFileWithPathFromPathAsync(clickedOnItem.ItemPath);
                         // Add location to MRU List
-                        mostRecentlyUsed.Add(await StorageFile.GetFileFromPathAsync(clickedOnItem.ItemPath));
-                    }
-                    if (displayApplicationPicker)
-                    {
-                        foreach (ListedItem clickedOnItem in CurrentInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.File))
+                        mostRecentlyUsed.Add(childFile.File, childFile.Path);
+
+                        if (displayApplicationPicker)
                         {
-                            StorageFile file = await StorageFile.GetFileFromPathAsync(clickedOnItem.ItemPath);
                             var options = new LauncherOptions
                             {
                                 DisplayApplicationPicker = true
                             };
-                            await Launcher.LaunchFileAsync(file, options);
+                            await Launcher.LaunchFileAsync(childFile.File, options);
                         }
                     }
-                    else
+                    if (!displayApplicationPicker)
                     {
                         var applicationPath = string.Join(";", CurrentInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.File).Select(x => x.ItemPath));
                         await InvokeWin32Component(applicationPath);
@@ -576,12 +576,12 @@ namespace Files.Interacts
             {
                 if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    var folderAsItem = await StorageFolder.GetFolderFromPathAsync(item.ItemPath);
+                    var folderAsItem = await ItemViewModel.GetFolderFromPathAsync(item.ItemPath);
                     items.Add(folderAsItem);
                 }
                 else
                 {
-                    var fileAsItem = await StorageFile.GetFileFromPathAsync(item.ItemPath);
+                    var fileAsItem = await ItemViewModel.GetFileFromPathAsync(item.ItemPath);
                     items.Add(fileAsItem);
                 }
             }
@@ -647,11 +647,11 @@ namespace Files.Interacts
                         {
                             if (storItem.PrimaryItemAttribute == StorageItemTypes.File)
                             {
-                                item = await StorageFile.GetFileFromPathAsync(storItem.ItemPath);
+                                item = await ItemViewModel.GetFileFromPathAsync(storItem.ItemPath);
                             }
                             else
                             {
-                                item = await StorageFolder.GetFolderFromPathAsync(storItem.ItemPath);
+                                item = await ItemViewModel.GetFolderFromPathAsync(storItem.ItemPath);
                             }
 
                             await item.DeleteAsync(App.InteractionViewModel.PermanentlyDelete);
@@ -661,11 +661,11 @@ namespace Files.Interacts
                             // try again
                             if (storItem.PrimaryItemAttribute == StorageItemTypes.File)
                             {
-                                item = await StorageFile.GetFileFromPathAsync(storItem.ItemPath);
+                                item = await ItemViewModel.GetFileFromPathAsync(storItem.ItemPath);
                             }
                             else
                             {
-                                item = await StorageFolder.GetFolderFromPathAsync(storItem.ItemPath);
+                                item = await ItemViewModel.GetFolderFromPathAsync(storItem.ItemPath);
                             }
 
                             await item.DeleteAsync(App.InteractionViewModel.PermanentlyDelete);
@@ -675,7 +675,7 @@ namespace Files.Interacts
                         {
                             // Recycle bin also stores a file starting with $I for each item
                             var iFilePath = Path.Combine(Path.GetDirectoryName(storItem.ItemPath), Path.GetFileName(storItem.ItemPath).Replace("$R", "$I"));
-                            await (await StorageFile.GetFileFromPathAsync(iFilePath)).DeleteAsync(StorageDeleteOption.PermanentDelete);
+                            await (await ItemViewModel.GetFileFromPathAsync(iFilePath)).DeleteAsync(StorageDeleteOption.PermanentDelete);
                         }
 
                         CurrentInstance.FilesystemViewModel.RemoveFileOrFolder(storItem);
@@ -768,12 +768,12 @@ namespace Files.Interacts
                 {
                     if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                     {
-                        var folder = await StorageFolder.GetFolderFromPathAsync(item.ItemPath);
+                        var folder = await ItemViewModel.GetFolderFromPathAsync(item.ItemPath);
                         await folder.RenameAsync(newName, NameCollisionOption.FailIfExists);
                     }
                     else
                     {
-                        var file = await StorageFile.GetFileFromPathAsync(item.ItemPath);
+                        var file = await ItemViewModel.GetFileFromPathAsync(item.ItemPath);
                         await file.RenameAsync(newName, NameCollisionOption.FailIfExists);
                     }
                 }
@@ -793,13 +793,13 @@ namespace Files.Interacts
                     {
                         if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                         {
-                            var folder = await StorageFolder.GetFolderFromPathAsync(item.ItemPath);
+                            var folder = await ItemViewModel.GetFolderFromPathAsync(item.ItemPath);
 
                             await folder.RenameAsync(newName, NameCollisionOption.GenerateUniqueName);
                         }
                         else
                         {
-                            var file = await StorageFile.GetFileFromPathAsync(item.ItemPath);
+                            var file = await ItemViewModel.GetFileFromPathAsync(item.ItemPath);
 
                             await file.RenameAsync(newName, NameCollisionOption.GenerateUniqueName);
                         }
@@ -808,13 +808,13 @@ namespace Files.Interacts
                     {
                         if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                         {
-                            var folder = await StorageFolder.GetFolderFromPathAsync(item.ItemPath);
+                            var folder = await ItemViewModel.GetFolderFromPathAsync(item.ItemPath);
 
                             await folder.RenameAsync(newName, NameCollisionOption.ReplaceExisting);
                         }
                         else
                         {
-                            var file = await StorageFile.GetFileFromPathAsync(item.ItemPath);
+                            var file = await ItemViewModel.GetFileFromPathAsync(item.ItemPath);
 
                             await file.RenameAsync(newName, NameCollisionOption.ReplaceExisting);
                         }
@@ -840,19 +840,20 @@ namespace Files.Interacts
                     {
                         if (listedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
                         {
-                            StorageFolder sourceFolder = await StorageFolder.GetFolderFromPathAsync(listedItem.ItemPath);
-                            await MoveDirectoryAsync(sourceFolder, Path.GetDirectoryName(listedItem.ItemOriginalPath), listedItem.ItemName);
+                            StorageFolder sourceFolder = await ItemViewModel.GetFolderFromPathAsync(listedItem.ItemPath);
+                            StorageFolder destFolder = await ItemViewModel.GetFolderFromPathAsync(Path.GetDirectoryName(listedItem.ItemOriginalPath));
+                            await MoveDirectoryAsync(sourceFolder, destFolder, listedItem.ItemName);
                             await sourceFolder.DeleteAsync(StorageDeleteOption.PermanentDelete);
                         }
                         else
                         {
-                            var file = await StorageFile.GetFileFromPathAsync(listedItem.ItemPath);
-                            var destinationFolder = await StorageFolder.GetFolderFromPathAsync(Path.GetDirectoryName(listedItem.ItemOriginalPath));
+                            var file = await ItemViewModel.GetFileFromPathAsync(listedItem.ItemPath);
+                            var destinationFolder = await ItemViewModel.GetFolderFromPathAsync(Path.GetDirectoryName(listedItem.ItemOriginalPath));
                             await file.MoveAsync(destinationFolder, Path.GetFileName(listedItem.ItemOriginalPath), NameCollisionOption.GenerateUniqueName);
                         }
                         // Recycle bin also stores a file starting with $I for each item
                         var iFilePath = Path.Combine(Path.GetDirectoryName(listedItem.ItemPath), Path.GetFileName(listedItem.ItemPath).Replace("$R", "$I"));
-                        await (await StorageFile.GetFileFromPathAsync(iFilePath)).DeleteAsync(StorageDeleteOption.PermanentDelete);
+                        await (await ItemViewModel.GetFileFromPathAsync(iFilePath)).DeleteAsync(StorageDeleteOption.PermanentDelete);
                     }
                     catch (UnauthorizedAccessException)
                     {
@@ -870,11 +871,10 @@ namespace Files.Interacts
             }
         }
 
-        public async Task<StorageFolder> MoveDirectoryAsync(StorageFolder SourceFolder, string DestinationPath, string sourceRootName)
+        public async Task<StorageFolder> MoveDirectoryAsync(StorageFolder SourceFolder, StorageFolder DestinationFolder, string sourceRootName)
         {
-            StorageFolder DestinationFolder = await StorageFolder.GetFolderFromPathAsync(DestinationPath);
             var createdRoot = await DestinationFolder.CreateFolderAsync(sourceRootName, CreationCollisionOption.FailIfExists);
-            DestinationFolder = await StorageFolder.GetFolderFromPathAsync(createdRoot.Path);
+            DestinationFolder = createdRoot;
 
             foreach (StorageFile fileInSourceDir in await SourceFolder.GetFilesAsync())
             {
@@ -882,7 +882,7 @@ namespace Files.Interacts
             }
             foreach (StorageFolder folderinSourceDir in await SourceFolder.GetFoldersAsync())
             {
-                await MoveDirectoryAsync(folderinSourceDir, DestinationFolder.Path, folderinSourceDir.Name);
+                await MoveDirectoryAsync(folderinSourceDir, DestinationFolder, folderinSourceDir.Name);
             }
             return createdRoot;
         }
@@ -909,12 +909,12 @@ namespace Files.Interacts
                     {
                         if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
                         {
-                            var item = await StorageFile.GetFileFromPathAsync(listedItem.ItemPath);
+                            var item = await ItemViewModel.GetFileFromPathAsync(listedItem.ItemPath);
                             items.Add(item);
                         }
                         else
                         {
-                            var item = await StorageFolder.GetFolderFromPathAsync(listedItem.ItemPath);
+                            var item = await ItemViewModel.GetFolderFromPathAsync(listedItem.ItemPath);
                             items.Add(item);
                         }
                     }
@@ -957,12 +957,12 @@ namespace Files.Interacts
                 {
                     if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
                     {
-                        var item = await StorageFile.GetFileFromPathAsync(listedItem.ItemPath);
+                        var item = await ItemViewModel.GetFileFromPathAsync(listedItem.ItemPath);
                         items.Add(item);
                     }
                     else
                     {
-                        var item = await StorageFolder.GetFolderFromPathAsync(listedItem.ItemPath);
+                        var item = await ItemViewModel.GetFolderFromPathAsync(listedItem.ItemPath);
                         items.Add(item);
                     }
                 }
@@ -1057,7 +1057,7 @@ namespace Files.Interacts
                 {
                     if (item.IsOfType(StorageItemTypes.Folder))
                     {
-                        if (destinationPath.IsSubPathOf(item.Path))
+                        if (!string.IsNullOrEmpty(item.Path) && destinationPath.IsSubPathOf(item.Path))
                         {
                             ImpossibleActionResponseTypes responseType = ImpossibleActionResponseTypes.Abort;
                             Binding themeBind = new Binding();
@@ -1088,7 +1088,11 @@ namespace Files.Interacts
                         {
                             try
                             {
-                                ClonedDirectoryOutput pastedOutput = await CloneDirectoryAsync(item.Path, destinationPath, item.Name, false, banner);
+                                ClonedDirectoryOutput pastedOutput = await CloneDirectoryAsync(
+                                    (StorageFolder)item,
+                                    await ItemViewModel.GetFolderFromPathAsync(destinationPath),
+                                    item.Name, false, banner);
+                                pastedSourceItems.Add(item);
                                 pastedItems.Add(pastedOutput.FolderOutput);
                                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
                                     new DispatchedHandler(() =>
@@ -1116,8 +1120,12 @@ namespace Files.Interacts
                         }
                         try
                         {
-                            StorageFile clipboardFile = await StorageFile.GetFileFromPathAsync(item.Path);
-                            StorageFile pastedFile = await clipboardFile.CopyAsync(await StorageFolder.GetFolderFromPathAsync(destinationPath), item.Name, NameCollisionOption.GenerateUniqueName);
+                            StorageFile clipboardFile = (StorageFile)item;
+                            StorageFile pastedFile = await clipboardFile.CopyAsync(
+                                await ItemViewModel.GetFolderFromPathAsync(destinationPath),
+                                item.Name,
+                                NameCollisionOption.GenerateUniqueName);
+                            pastedSourceItems.Add(item);
                             pastedItems.Add(pastedFile);
                         }
                         catch (FileNotFoundException)
@@ -1131,18 +1139,18 @@ namespace Files.Interacts
 
                 if (acceptedOperation == DataPackageOperation.Move)
                 {
-                    foreach (IStorageItem item in itemsToPaste)
+                    foreach (IStorageItem item in pastedSourceItems)
                     {
                         try
                         {
                             if (item.IsOfType(StorageItemTypes.File))
                             {
-                                StorageFile file = await StorageFile.GetFileFromPathAsync(item.Path);
+                                StorageFile file = (StorageFile)item;
                                 await file.DeleteAsync();
                             }
                             else if (item.IsOfType(StorageItemTypes.Folder))
                             {
-                                StorageFolder folder = await StorageFolder.GetFolderFromPathAsync(item.Path);
+                                StorageFolder folder = (StorageFolder)item;
                                 await folder.DeleteAsync();
                             }
                         }
@@ -1176,12 +1184,10 @@ namespace Files.Interacts
             public StatusBanner StatusBannerOutput { get; set; } = null;
         }
 
-        public async Task<ClonedDirectoryOutput> CloneDirectoryAsync(string SourcePath, string DestinationPath, string sourceRootName, bool suppressProgressFlyout, StatusBanner banner = null)
+        public async Task<ClonedDirectoryOutput> CloneDirectoryAsync(StorageFolder SourceFolder, StorageFolder DestinationFolder, string sourceRootName, bool suppressProgressFlyout, StatusBanner banner = null)
         {
-            StorageFolder SourceFolder = await StorageFolder.GetFolderFromPathAsync(SourcePath);
-            StorageFolder DestinationFolder = await StorageFolder.GetFolderFromPathAsync(DestinationPath);
             var createdRoot = await DestinationFolder.CreateFolderAsync(sourceRootName, CreationCollisionOption.GenerateUniqueName);
-            DestinationFolder = await StorageFolder.GetFolderFromPathAsync(createdRoot.Path);
+            DestinationFolder = createdRoot;
 
             foreach (StorageFile fileInSourceDir in await SourceFolder.GetFilesAsync())
             {
@@ -1229,7 +1235,7 @@ namespace Files.Interacts
                     }
                 }
 
-                var output = await CloneDirectoryAsync(folderinSourceDir.Path, DestinationFolder.Path, folderinSourceDir.Name, false, banner);
+                var output = await CloneDirectoryAsync(folderinSourceDir, DestinationFolder, folderinSourceDir.Name, false, banner);
                 banner = output.StatusBannerOutput;
             }
             if (!suppressProgressFlyout)
@@ -1268,7 +1274,7 @@ namespace Files.Interacts
         public async void ExtractItems_Click(object sender, RoutedEventArgs e)
         {
             var selectedIndex = CurrentInstance.ContentPage.GetSelectedIndex();
-            StorageFile selectedItem = await StorageFile.GetFileFromPathAsync(CurrentInstance.FilesystemViewModel.FilesAndFolders[selectedIndex].ItemPath);
+            StorageFile selectedItem = await ItemViewModel.GetFileFromPathAsync(CurrentInstance.FilesystemViewModel.FilesAndFolders[selectedIndex].ItemPath);
 
             StatusBanner banner = null;
             ExtractFilesDialog extractFilesDialog = new ExtractFilesDialog(CurrentInstance.FilesystemViewModel.WorkingDirectory);
@@ -1277,6 +1283,7 @@ namespace Files.Interacts
             {
                 var bufferItem = await selectedItem.CopyAsync(ApplicationData.Current.TemporaryFolder, selectedItem.DisplayName, NameCollisionOption.ReplaceExisting);
                 string destinationPath = ApplicationData.Current.LocalSettings.Values["Extract_Destination_Path"].ToString();
+                StorageFolder destinationFolder = await ItemViewModel.GetFolderFromPathAsync(destinationPath);
                 //ZipFile.ExtractToDirectory(selectedItem.Path, destinationPath, );
                 var destFolder_InBuffer = await ApplicationData.Current.TemporaryFolder.CreateFolderAsync(selectedItem.DisplayName + "_Extracted", CreationCollisionOption.ReplaceExisting);
                 using FileStream fs = new FileStream(bufferItem.Path, FileMode.Open);
@@ -1327,8 +1334,8 @@ namespace Files.Interacts
                         }
                     }
                 }));
-
-                await CloneDirectoryAsync(destFolder_InBuffer.Path, destinationPath, destFolder_InBuffer.Name, true)
+                
+                await CloneDirectoryAsync(destFolder_InBuffer, destinationFolder, destFolder_InBuffer.Name, true)
                     .ContinueWith(async (x) =>
                 {
                     await destFolder_InBuffer.DeleteAsync(StorageDeleteOption.PermanentDelete);
@@ -1388,7 +1395,7 @@ namespace Files.Interacts
         public async Task<string> GetHashForFile(ListedItem fileItem, string nameOfAlg, CancellationToken token, Microsoft.UI.Xaml.Controls.ProgressBar progress)
         {
             HashAlgorithmProvider algorithmProvider = HashAlgorithmProvider.OpenAlgorithm(nameOfAlg);
-            var itemFromPath = await StorageFile.GetFileFromPathAsync(fileItem.ItemPath);
+            var itemFromPath = await ItemViewModel.GetFileFromPathAsync(fileItem.ItemPath);
             var stream = await itemFromPath.OpenStreamForReadAsync();
             var inputStream = stream.AsInputStream();
             var str = inputStream.AsStreamForRead();

--- a/Files/Navigation/NavigationActions.cs
+++ b/Files/Navigation/NavigationActions.cs
@@ -33,7 +33,7 @@ namespace Files
             }
         }
 
-        public static void Forward_Click(object sender, RoutedEventArgs e)
+        public static async void Forward_Click(object sender, RoutedEventArgs e)
         {
             App.CurrentInstance.NavigationToolbar.CanGoForward = false;
             Frame instanceContentFrame = App.CurrentInstance.ContentFrame;
@@ -44,7 +44,7 @@ namespace Files
                 var incomingSourcePageType = instanceContentFrame.ForwardStack[instanceContentFrame.ForwardStack.Count - 1].SourcePageType;
                 var Parameter = instanceContentFrame.ForwardStack[instanceContentFrame.ForwardStack.Count - 1].Parameter;
                 SelectSidebarItemFromPath(incomingSourcePageType);
-                App.CurrentInstance.FilesystemViewModel.WorkingDirectory = Parameter.ToString();
+                await App.CurrentInstance.FilesystemViewModel.SetWorkingDirectory(Parameter.ToString());
                 instanceContentFrame.GoForward();
             }
         }

--- a/Files/UserControls/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/ModernNavigationToolbar.xaml
@@ -696,7 +696,7 @@
                 Background="Transparent"
                 CornerRadius="2"
                 FontFamily="Segoe MDL2 Assets"
-                IsEnabled="{x:Bind local1:App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}"
+                IsEnabled="{x:Bind local1:App.CurrentInstance.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
                 Style="{StaticResource ToolBarButtonStyle}"
                 ToolTipService.ToolTip="Create a new item (Ctrl + Shift + N)"
                 Visibility="Visible">
@@ -825,7 +825,7 @@
                             x:Uid="NavigationToolbarOpenInTerminal"
                             x:Load="{x:Bind local1:App.CurrentInstance.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
                             Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.OpenDirectoryInTerminal}"
-                            IsEnabled="{x:Bind local1:App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}"
+                            IsEnabled="{x:Bind local1:App.CurrentInstance.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
                             Text="Open in Terminal...">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon Glyph="&#xE756;" />

--- a/Files/UserControls/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/ModernNavigationToolbar.xaml
@@ -696,7 +696,7 @@
                 Background="Transparent"
                 CornerRadius="2"
                 FontFamily="Segoe MDL2 Assets"
-                IsEnabled="{x:Bind local1:App.CurrentInstance.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
+                IsEnabled="{x:Bind local1:App.CurrentInstance.InstanceViewModel.IsCreateButtonEnabledInPage, Mode=OneWay}"
                 Style="{StaticResource ToolBarButtonStyle}"
                 ToolTipService.ToolTip="Create a new item (Ctrl + Shift + N)"
                 Visibility="Visible">
@@ -717,6 +717,7 @@
                         <MenuFlyoutItem
                             x:Uid="ModernNavigationToolbaNewBitmapImage"
                             Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.NewBitmapImage_Click}"
+                            IsEnabled="{x:Bind local1:App.CurrentInstance.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
                             Text="Bitmap Image">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon Glyph="&#xEB9F;" />
@@ -725,6 +726,7 @@
                         <MenuFlyoutItem
                             x:Uid="ModernNavigationToolbaNewTextDocument"
                             Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.NewTextDocument_Click}"
+                            IsEnabled="{x:Bind local1:App.CurrentInstance.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
                             Text="Text Document">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon Glyph="&#xE8A5;" />
@@ -825,7 +827,7 @@
                             x:Uid="NavigationToolbarOpenInTerminal"
                             x:Load="{x:Bind local1:App.CurrentInstance.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
                             Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.OpenDirectoryInTerminal}"
-                            IsEnabled="{x:Bind local1:App.CurrentInstance.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
+                            IsEnabled="{x:Bind local1:App.CurrentInstance.InstanceViewModel.CanOpenTerminalInPage, Mode=OneWay}"
                             Text="Open in Terminal...">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon Glyph="&#xE756;" />

--- a/Files/UserControls/ModernNavigationToolbar.xaml.cs
+++ b/Files/UserControls/ModernNavigationToolbar.xaml.cs
@@ -211,7 +211,7 @@ namespace Files.UserControls
 
                 if (CurrentInput.Equals("Home", StringComparison.OrdinalIgnoreCase) || CurrentInput.Equals(ResourceController.GetTranslation("NewTab"), StringComparison.OrdinalIgnoreCase))
                 {
-                    App.CurrentInstance.FilesystemViewModel.WorkingDirectory = ResourceController.GetTranslation("NewTab");
+                    await App.CurrentInstance.FilesystemViewModel.SetWorkingDirectory(ResourceController.GetTranslation("NewTab"));
                     App.CurrentInstance.ContentFrame.Navigate(typeof(YourHome), ResourceController.GetTranslation("NewTab"), new SuppressNavigationTransitionInfo());
                 }
                 else
@@ -237,7 +237,8 @@ namespace Files.UserControls
 
                     try
                     {
-                        await StorageFolder.GetFolderFromPathAsync(CurrentInput);
+                        var item = await DrivesManager.GetRootFromPath(CurrentInput);
+                        await StorageFileExtensions.GetFolderFromPathAsync(CurrentInput, item);
 
                         App.CurrentInstance.ContentFrame.Navigate(AppSettings.GetLayoutType(), CurrentInput); // navigate to folder
                     }
@@ -245,7 +246,8 @@ namespace Files.UserControls
                     {
                         try
                         {
-                            await StorageFile.GetFileFromPathAsync(CurrentInput);
+                            var item = await DrivesManager.GetRootFromPath(CurrentInput);
+                            await StorageFileExtensions.GetFileFromPathAsync(CurrentInput, item);
                             await Interaction.InvokeWin32Component(CurrentInput);
                         }
                         catch (Exception ex) // Not a file or not accessible

--- a/Files/UserControls/YourHome.xaml.cs
+++ b/Files/UserControls/YourHome.xaml.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -44,7 +45,8 @@ namespace Files
         {
             base.OnNavigatedTo(eventArgs);
             App.CurrentInstance.InstanceViewModel.IsPageTypeNotHome = false;
-            App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin = true;
+            App.CurrentInstance.InstanceViewModel.IsPageTypeMtpDevice = false;
+            App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin = false;
             var parameters = eventArgs.Parameter.ToString();
             Locations.ItemLoader.itemsAdded.Clear();
             Locations.ItemLoader.DisplayItems();
@@ -74,14 +76,7 @@ namespace Files
 
         public async void PopulateRecentsList()
         {
-            var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
-            BitmapImage ItemImage;
-            string ItemPath;
-            string ItemName;
-            StorageItemTypes ItemType;
-            Visibility ItemFolderImgVis;
-            Visibility ItemEmptyImgVis;
-            Visibility ItemFileIconVis;
+            var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;            
             bool IsRecentsListEmpty = true;
             foreach (var entry in mostRecentlyUsed.Entries)
             {
@@ -111,29 +106,13 @@ namespace Files
                 try
                 {
                     IStorageItem item = await mostRecentlyUsed.GetItemAsync(mruToken);
-                    if (item.IsOfType(StorageItemTypes.File))
-                    {
-                        ItemName = item.Name;
-                        ItemPath = item.Path;
-                        ItemType = StorageItemTypes.File;
-                        ItemImage = new BitmapImage();
-                        StorageFile file = await StorageFile.GetFileFromPathAsync(ItemPath);
-                        var thumbnail = await file.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.SingleItem, 30, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale);
-                        if (thumbnail == null)
-                        {
-                            ItemEmptyImgVis = Visibility.Visible;
-                        }
-                        else
-                        {
-                            await ItemImage.SetSourceAsync(thumbnail.CloneStream());
-                            ItemEmptyImgVis = Visibility.Collapsed;
-                        }
-                        ItemFolderImgVis = Visibility.Collapsed;
-                        ItemFileIconVis = Visibility.Visible;
-                        recentItemsCollection.Add(new RecentItem() { RecentPath = ItemPath, Name = ItemName, Type = ItemType, FolderImg = ItemFolderImgVis, EmptyImgVis = ItemEmptyImgVis, FileImg = ItemImage, FileIconVis = ItemFileIconVis });
-                    }
+                    await AddItemToRecentList(item, entry);
                 }
                 catch (FileNotFoundException)
+                {
+                    mostRecentlyUsed.Remove(mruToken);
+                }
+                catch (ArgumentException)
                 {
                     mostRecentlyUsed.Remove(mruToken);
                 }
@@ -151,6 +130,46 @@ namespace Files
             if (recentItemsCollection.Count == 0)
             {
                 Empty.Visibility = Visibility.Visible;
+            }
+        }
+
+        private async Task AddItemToRecentList(IStorageItem item, Windows.Storage.AccessCache.AccessListEntry entry)
+        {
+            BitmapImage ItemImage;
+            string ItemPath;
+            string ItemName;
+            StorageItemTypes ItemType;
+            Visibility ItemFolderImgVis;
+            Visibility ItemEmptyImgVis;
+            Visibility ItemFileIconVis;            
+            if (item.IsOfType(StorageItemTypes.File))
+            {
+                using (var inputStream = await((StorageFile)item).OpenReadAsync())
+                using (var classicStream = inputStream.AsStreamForRead())
+                using (var streamReader = new StreamReader(classicStream))
+                {
+                    // Try to read the file to check if still exists
+                    streamReader.Peek();
+                }
+
+                ItemName = item.Name;
+                ItemPath = string.IsNullOrEmpty(item.Path) ? entry.Metadata : item.Path;
+                ItemType = StorageItemTypes.File;
+                ItemImage = new BitmapImage();
+                StorageFile file = (StorageFile)item;
+                var thumbnail = await file.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.SingleItem, 30, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale);
+                if (thumbnail == null)
+                {
+                    ItemEmptyImgVis = Visibility.Visible;
+                }
+                else
+                {
+                    await ItemImage.SetSourceAsync(thumbnail.CloneStream());
+                    ItemEmptyImgVis = Visibility.Collapsed;
+                }
+                ItemFolderImgVis = Visibility.Collapsed;
+                ItemFileIconVis = Visibility.Visible;
+                recentItemsCollection.Add(new RecentItem() { RecentPath = ItemPath, Name = ItemName, Type = ItemType, FolderImg = ItemFolderImgVis, EmptyImgVis = ItemEmptyImgVis, FileImg = ItemImage, FileIconVis = ItemFileIconVis });
             }
         }
 
@@ -213,7 +232,7 @@ namespace Files
                         foreach (var element in mru.Entries)
                         {
                             var f = await mru.GetItemAsync(element.Token);
-                            if (f.Path.Equals(vm.RecentPath))
+                            if (f.Path == vm.RecentPath || element.Metadata == vm.RecentPath)
                             {
                                 mru.Remove(element.Token);
                                 if (recentItemsCollection.Count == 0)

--- a/Files/View Models/CurrentInstanceViewModel.cs
+++ b/Files/View Models/CurrentInstanceViewModel.cs
@@ -12,7 +12,9 @@ namespace Files.View_Models
             set
             {
                 Set(ref _IsPageTypeNotHome, value);
+                RaisePropertyChanged("IsCreateButtonEnabledInPage");
                 RaisePropertyChanged("CanCreateFileInPage");
+                RaisePropertyChanged("CanOpenTerminalInPage");
             }
         }
 
@@ -24,7 +26,9 @@ namespace Files.View_Models
             set
             {
                 Set(ref _IsPageTypeMtpDevice, value);
+                RaisePropertyChanged("IsCreateButtonEnabledInPage");
                 RaisePropertyChanged("CanCreateFileInPage");
+                RaisePropertyChanged("CanOpenTerminalInPage");
             }
         }
 
@@ -36,11 +40,23 @@ namespace Files.View_Models
             set
             {
                 Set(ref _IsPageTypeRecycleBin, value);
+                RaisePropertyChanged("IsCreateButtonEnabledInPage");
                 RaisePropertyChanged("CanCreateFileInPage");
+                RaisePropertyChanged("CanOpenTerminalInPage");
             }
         }
 
+        public bool IsCreateButtonEnabledInPage
+        {
+            get => !_IsPageTypeRecycleBin && IsPageTypeNotHome;
+        }
+
         public bool CanCreateFileInPage
+        {
+            get => !_IsPageTypeMtpDevice && !_IsPageTypeRecycleBin && IsPageTypeNotHome;
+        }
+
+        public bool CanOpenTerminalInPage
         {
             get => !_IsPageTypeMtpDevice && !_IsPageTypeRecycleBin && IsPageTypeNotHome;
         }

--- a/Files/View Models/CurrentInstanceViewModel.cs
+++ b/Files/View Models/CurrentInstanceViewModel.cs
@@ -9,15 +9,40 @@ namespace Files.View_Models
         public bool IsPageTypeNotHome
         {
             get => _IsPageTypeNotHome;
-            set => Set(ref _IsPageTypeNotHome, value);
+            set
+            {
+                Set(ref _IsPageTypeNotHome, value);
+                RaisePropertyChanged("CanCreateFileInPage");
+            }
         }
 
-        private bool _IsPageTypeNotRecycleBin = false;
+        private bool _IsPageTypeMtpDevice = false;
 
-        public bool IsPageTypeNotRecycleBin
+        public bool IsPageTypeMtpDevice
         {
-            get => _IsPageTypeNotRecycleBin;
-            set => Set(ref _IsPageTypeNotRecycleBin, value);
+            get => _IsPageTypeMtpDevice;
+            set
+            {
+                Set(ref _IsPageTypeMtpDevice, value);
+                RaisePropertyChanged("CanCreateFileInPage");
+            }
+        }
+
+        private bool _IsPageTypeRecycleBin = false;
+
+        public bool IsPageTypeRecycleBin
+        {
+            get => _IsPageTypeRecycleBin;
+            set
+            {
+                Set(ref _IsPageTypeRecycleBin, value);
+                RaisePropertyChanged("CanCreateFileInPage");
+            }
+        }
+
+        public bool CanCreateFileInPage
+        {
+            get => !_IsPageTypeMtpDevice && !_IsPageTypeRecycleBin && IsPageTypeNotHome;
         }
     }
 }

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -857,6 +857,23 @@ namespace Files.Filesystem
                 }
             }
 
+            if (!enumFromStorageFolder)
+            {
+                FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
+                int additionalFlags = FIND_FIRST_EX_LARGE_FETCH;
+
+                IntPtr hFile = FindFirstFileExFromApp(path + "\\*.*", findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero,
+                                                      additionalFlags);
+                if (hFile.ToInt64() == -1)
+                {
+                    enumFromStorageFolder = true;
+                }
+                else
+                {
+                    FindClose(hFile);
+                }
+            }
+
             if (enumFromStorageFolder)
             {
                 Stopwatch stopwatch = new Stopwatch();

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -67,9 +67,13 @@ namespace Files.Filesystem
         public async Task SetWorkingDirectory(string value)
         {
             if (string.IsNullOrWhiteSpace(value))
+            {
                 return;
+            }
             if (WorkingDirectory == value)
+            {
                 return;
+            }
 
             INavigationControlItem item = null;
             List<INavigationControlItem> sidebarItems = App.sideBarItems.Where(x => !string.IsNullOrWhiteSpace(x.Path)).ToList();

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -26,9 +26,9 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media.Imaging;
+using FileAttributes = System.IO.FileAttributes;
 using static Files.Helpers.NativeDirectoryChangesHelper;
 using static Files.Helpers.NativeFindStorageItemHelper;
-using FileAttributes = System.IO.FileAttributes;
 
 namespace Files.Filesystem
 {
@@ -52,46 +52,89 @@ namespace Files.Filesystem
         private readonly DispatcherTimer jumpTimer = new DispatcherTimer();
         private SortOption _directorySortOption = SortOption.Name;
         private SortDirection _directorySortDirection = SortDirection.Ascending;
-        private string _WorkingDirectory;
 
+        private string _customPath;
         public string WorkingDirectory
         {
             get
             {
-                return _WorkingDirectory;
+                return _currentStorageFolder?.Path ?? _customPath;
             }
+        }
+        private StorageFolderWithPath _currentStorageFolder;
+        private StorageFolderWithPath _workingRoot;
 
-            set
+        public async Task SetWorkingDirectory(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return;
+            if (WorkingDirectory == value)
+                return;
+
+            INavigationControlItem item = null;
+            List<INavigationControlItem> sidebarItems = App.sideBarItems.Where(x => !string.IsNullOrWhiteSpace(x.Path)).ToList();
+
+            item = sidebarItems.FirstOrDefault(x => x.Path.Equals(value, StringComparison.OrdinalIgnoreCase));
+            if (item == null)
             {
-                if (!string.IsNullOrWhiteSpace(value))
-                {
-                    _WorkingDirectory = value;
-
-                    INavigationControlItem item = null;
-                    List<INavigationControlItem> sidebarItems = App.sideBarItems.Where(x => !string.IsNullOrWhiteSpace(x.Path)).ToList();
-
-                    item = sidebarItems.FirstOrDefault(x => x.Path.Equals(value, StringComparison.OrdinalIgnoreCase));
-                    if (item == null)
-                    {
-                        item = sidebarItems.FirstOrDefault(x => x.Path.Equals(value + "\\", StringComparison.OrdinalIgnoreCase));
-                    }
-                    if (item == null)
-                    {
-                        item = sidebarItems.FirstOrDefault(x => value.StartsWith(x.Path, StringComparison.OrdinalIgnoreCase));
-                    }
-                    if (item == null)
-                    {
-                        item = sidebarItems.FirstOrDefault(x => x.Path.Equals(Path.GetPathRoot(value), StringComparison.OrdinalIgnoreCase));
-                    }
-
-                    if (App.CurrentInstance.SidebarSelectedItem != item)
-                    {
-                        App.CurrentInstance.SidebarSelectedItem = item;
-                    }
-
-                    NotifyPropertyChanged("WorkingDirectory");
-                }
+                item = sidebarItems.FirstOrDefault(x => x.Path.Equals(value + "\\", StringComparison.OrdinalIgnoreCase));
             }
+            if (item == null)
+            {
+                item = sidebarItems.FirstOrDefault(x => value.StartsWith(x.Path, StringComparison.OrdinalIgnoreCase));
+            }
+            if (item == null)
+            {
+                item = sidebarItems.FirstOrDefault(x => x.Path.Equals(Path.GetPathRoot(value), StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (!Path.IsPathRooted(value))
+            {
+                _workingRoot = null;
+            }
+            else if (!Path.IsPathRooted(WorkingDirectory) || Path.GetPathRoot(WorkingDirectory) != Path.GetPathRoot(value))
+            {
+                _workingRoot = await DrivesManager.GetRootFromPath(value);
+            }
+
+            if (App.CurrentInstance.SidebarSelectedItem != item)
+            {
+                App.CurrentInstance.SidebarSelectedItem = item;
+            }
+
+            if (!Path.IsPathRooted(value))
+            {
+                _currentStorageFolder = null;
+                _customPath = value;
+            }
+            else
+            {
+                _currentStorageFolder = await StorageFileExtensions.GetFolderWithPathFromPathAsync(value, _workingRoot, _currentStorageFolder);
+                _customPath = null;
+            }
+
+            NotifyPropertyChanged("WorkingDirectory");
+        }
+
+        public static async Task<StorageFolder> GetFolderFromPathAsync(string value)
+        {
+            var instance = App.CurrentInstance.FilesystemViewModel;
+            return await StorageFileExtensions.GetFolderFromPathAsync(value, instance._workingRoot, instance._currentStorageFolder);
+        }
+        public static async Task<StorageFile> GetFileFromPathAsync(string value)
+        {
+            var instance = App.CurrentInstance.FilesystemViewModel;
+            return await StorageFileExtensions.GetFileFromPathAsync(value, instance._workingRoot, instance._currentStorageFolder);
+        }
+        public static async Task<StorageFolderWithPath> GetFolderWithPathFromPathAsync(string value)
+        {
+            var instance = App.CurrentInstance.FilesystemViewModel;
+            return await StorageFileExtensions.GetFolderWithPathFromPathAsync(value, instance._workingRoot, instance._currentStorageFolder);
+        }
+        public static async Task<StorageFileWithPath> GetFileWithPathFromPathAsync(string value)
+        {
+            var instance = App.CurrentInstance.FilesystemViewModel;
+            return await StorageFileExtensions.GetFileWithPathFromPathAsync(value, instance._workingRoot, instance._currentStorageFolder);
         }
 
         private bool _IsFolderEmptyTextDisplayed;
@@ -308,66 +351,9 @@ namespace Files.Filesystem
             {
                 Weight = FontWeights.SemiBold.Weight
             };
-            List<string> pathComponents = new List<string>();
-            // If path is a library, simplify it
-
-            // If path is found to not be a library
-            pathComponents = WorkingDirectory.Split("\\", StringSplitOptions.RemoveEmptyEntries).ToList();
-
-            int index = 0;
-            string tag = "";
-            foreach (string s in pathComponents)
+            foreach (var component in StorageFileExtensions.GetDirectoryPathComponents(WorkingDirectory))
             {
-                string componentLabel = null;
-                if (s.StartsWith(AppSettings.RecycleBinPath))
-                {
-                    // Handle the recycle bin: use the localized folder name
-                    PathBoxItem item = new PathBoxItem()
-                    {
-                        Title = ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin"),
-                        Path = tag,
-                    };
-                    App.CurrentInstance.NavigationToolbar.PathComponents.Add(item);
-                }
-                else if (s.Contains(":"))
-                {
-                    if (App.sideBarItems.FirstOrDefault(x => x.ItemType == NavigationControlItemType.Drive && x.Path.Contains(s, StringComparison.OrdinalIgnoreCase)) != null)
-                    {
-                        componentLabel = App.sideBarItems.FirstOrDefault(x => x.ItemType == NavigationControlItemType.Drive && x.Path.Contains(s, StringComparison.OrdinalIgnoreCase)).Text;
-                    }
-                    else
-                    {
-                        componentLabel = @"Drive (" + s + @"\)";
-                    }
-                    tag = s + @"\";
-
-                    PathBoxItem item = new PathBoxItem()
-                    {
-                        Title = componentLabel,
-                        Path = tag,
-                    };
-                    App.CurrentInstance.NavigationToolbar.PathComponents.Add(item);
-                }
-                else
-                {
-                    componentLabel = s;
-                    foreach (string part in pathComponents.GetRange(index, 1))
-                    {
-                        tag = tag + part + @"\";
-                    }
-                    if (index == 0)
-                    {
-                        tag = "\\\\" + tag;
-                    }
-
-                    PathBoxItem item = new PathBoxItem()
-                    {
-                        Title = componentLabel,
-                        Path = tag,
-                    };
-                    App.CurrentInstance.NavigationToolbar.PathComponents.Add(item);
-                }
-                index++;
+                App.CurrentInstance.NavigationToolbar.PathComponents.Add(component);
             }
         }
 
@@ -502,7 +488,7 @@ namespace Files.Filesystem
                     var matchingItem = _filesAndFolders.FirstOrDefault(x => x == item);
                     try
                     {
-                        var matchingStorageItem = await StorageFile.GetFileFromPathAsync(item.ItemPath);
+                        StorageFile matchingStorageItem = await StorageFileExtensions.GetFileFromPathAsync(item.ItemPath, _workingRoot);
                         if (matchingItem != null && matchingStorageItem != null)
                         {
                             matchingItem.FolderRelativeId = matchingStorageItem.FolderRelativeId;
@@ -530,7 +516,7 @@ namespace Files.Filesystem
                     var matchingItem = _filesAndFolders.FirstOrDefault(x => x == item);
                     try
                     {
-                        var matchingStorageItem = await StorageFolder.GetFolderFromPathAsync(item.ItemPath);
+                        StorageFolder matchingStorageItem = await StorageFileExtensions.GetFolderFromPathAsync(item.ItemPath, _workingRoot);
                         if (matchingItem != null && matchingStorageItem != null)
                         {
                             matchingItem.FolderRelativeId = matchingStorageItem.FolderRelativeId;
@@ -584,44 +570,47 @@ namespace Files.Filesystem
 
                 IsLoadingItems = true;
                 IsFolderEmptyTextDisplayed = false;
-                WorkingDirectory = path;
                 _filesAndFolders.Clear();
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
                 App.InteractionViewModel.IsContentLoadingIndicatorVisible = true;
 
-                switch (WorkingDirectory)
+                switch (path)
                 {
                     case "Desktop":
-                        WorkingDirectory = AppSettings.DesktopPath;
+                        await SetWorkingDirectory(App.AppSettings.DesktopPath);
                         break;
 
                     case "Downloads":
-                        WorkingDirectory = AppSettings.DownloadsPath;
+                        await SetWorkingDirectory(App.AppSettings.DownloadsPath);
                         break;
 
                     case "Documents":
-                        WorkingDirectory = AppSettings.DocumentsPath;
+                        await SetWorkingDirectory(App.AppSettings.DocumentsPath);
                         break;
 
                     case "Pictures":
-                        WorkingDirectory = AppSettings.PicturesPath;
+                        await SetWorkingDirectory(App.AppSettings.PicturesPath);
                         break;
 
                     case "Music":
-                        WorkingDirectory = AppSettings.MusicPath;
+                        await SetWorkingDirectory(App.AppSettings.MusicPath);
                         break;
 
                     case "Videos":
-                        WorkingDirectory = AppSettings.VideosPath;
+                        await SetWorkingDirectory(App.AppSettings.VideosPath);
                         break;
 
                     case "RecycleBin":
-                        WorkingDirectory = AppSettings.RecycleBinPath;
+                        await SetWorkingDirectory(App.AppSettings.RecycleBinPath);
                         break;
 
                     case "OneDrive":
-                        WorkingDirectory = AppSettings.OneDrivePath;
+                        await SetWorkingDirectory(App.AppSettings.OneDrivePath);
+                        break;
+
+                    default:
+                        await SetWorkingDirectory(path);
                         break;
                 }
 
@@ -657,7 +646,7 @@ namespace Files.Filesystem
 
                 OrderFiles();
                 stopwatch.Stop();
-                Debug.WriteLine("Loading of items in " + WorkingDirectory + " completed in " + stopwatch.ElapsedMilliseconds + " milliseconds.\n");
+                Debug.WriteLine($"Loading of items in {WorkingDirectory} completed in {stopwatch.ElapsedMilliseconds} milliseconds.\n");
                 App.CurrentInstance.NavigationToolbar.CanRefresh = true;
                 App.InteractionViewModel.IsContentLoadingIndicatorVisible = false;
                 IsLoadingItems = false;
@@ -788,48 +777,12 @@ namespace Files.Filesystem
 
         public async Task EnumerateItemsFromStandardFolder(string path)
         {
+            // Flag to use FindFirstFileExFromApp or StorageFolder enumeration
+            bool enumFromStorageFolder = false;
+
             try
             {
                 _rootFolder = await StorageFolder.GetFolderFromPathAsync(path);
-                CurrentFolder = new ListedItem(_rootFolder.FolderRelativeId)
-                {
-                    PrimaryItemAttribute = StorageItemTypes.Folder,
-                    ItemPropertiesInitialized = true,
-                    ItemName = _rootFolder.Name,
-                    ItemDateModifiedReal = (await _rootFolder.GetBasicPropertiesAsync()).DateModified,
-                    ItemType = _rootFolder.DisplayType,
-                    LoadFolderGlyph = true,
-                    FileImage = null,
-                    LoadFileIcon = false,
-                    ItemPath = _rootFolder.Path,
-                    LoadUnknownTypeGlyph = false,
-                    FileSize = null,
-                    FileSizeBytes = 0
-                };
-                if (await CheckBitlockerStatus(_rootFolder))
-                {
-                    var bitlockerDialog = new Dialogs.BitlockerDialog(Path.GetPathRoot(WorkingDirectory));
-                    var bitlockerResult = await bitlockerDialog.ShowAsync();
-                    if (bitlockerResult == ContentDialogResult.Primary)
-                    {
-                        var userInput = bitlockerDialog.storedPasswordInput;
-                        if (App.Connection != null)
-                        {
-                            var value = new ValueSet();
-                            value.Add("Arguments", "Bitlocker");
-                            value.Add("action", "Unlock");
-                            value.Add("drive", Path.GetPathRoot(WorkingDirectory));
-                            value.Add("password", userInput);
-                            await App.Connection.SendMessageAsync(value);
-
-                            if (await CheckBitlockerStatus(_rootFolder))
-                            {
-                                // Drive is still locked
-                                await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("BitlockerInvalidPwDialog/Title"), ResourceController.GetTranslation("BitlockerInvalidPwDialog/Text"));
-                            }
-                        }
-                    }
-                }
             }
             catch (UnauthorizedAccessException)
             {
@@ -846,53 +799,150 @@ namespace Files.Filesystem
             }
             catch (Exception e)
             {
-                await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("DriveUnpluggedDialog/Title"), e.Message);
-                IsLoadingItems = false;
-                return;
+                if (_workingRoot != null)
+                {
+                    _rootFolder = _currentStorageFolder.Folder;
+                    enumFromStorageFolder = true;
+                }
+                else
+                {
+                    await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("DriveUnpluggedDialog/Title"), e.Message);
+                    IsLoadingItems = false;
+                    return;
+                }
             }
 
-            FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
-            int additionalFlags = FIND_FIRST_EX_LARGE_FETCH;
-
-            IntPtr hFile = FindFirstFileExFromApp(path + "\\*.*", findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero,
-                                                  additionalFlags);
-
-            var count = 0;
-            if (hFile.ToInt64() != -1)
+            CurrentFolder = new ListedItem(_rootFolder.FolderRelativeId)
             {
-                do
+                PrimaryItemAttribute = StorageItemTypes.Folder,
+                ItemPropertiesInitialized = true,
+                ItemName = _rootFolder.Name,
+                ItemDateModifiedReal = (await _rootFolder.GetBasicPropertiesAsync()).DateModified,
+                ItemType = _rootFolder.DisplayType,
+                LoadFolderGlyph = true,
+                FileImage = null,
+                LoadFileIcon = false,
+                ItemPath = string.IsNullOrEmpty(_rootFolder.Path) ? _currentStorageFolder.Path : _rootFolder.Path,
+                LoadUnknownTypeGlyph = false,
+                FileSize = null,
+                FileSizeBytes = 0
+            };
+
+            if (await CheckBitlockerStatus(_rootFolder))
+            {
+                var bitlockerDialog = new Dialogs.BitlockerDialog(Path.GetPathRoot(WorkingDirectory));
+                var bitlockerResult = await bitlockerDialog.ShowAsync();
+                if (bitlockerResult == ContentDialogResult.Primary)
                 {
-                    if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) != FileAttributes.Hidden && ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) != FileAttributes.System)
+                    var userInput = bitlockerDialog.storedPasswordInput;
+                    if (App.Connection != null)
                     {
-                        if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
+                        var value = new ValueSet();
+                        value.Add("Arguments", "Bitlocker");
+                        value.Add("action", "Unlock");
+                        value.Add("drive", Path.GetPathRoot(WorkingDirectory));
+                        value.Add("password", userInput);
+                        await App.Connection.SendMessageAsync(value);
+
+                        if (await CheckBitlockerStatus(_rootFolder))
                         {
-                            if (!findData.cFileName.EndsWith(".lnk") && !findData.cFileName.EndsWith(".url"))
-                            {
-                                AddFile(findData, path);
-                                ++count;
-                            }
+                            // Drive is still locked
+                            await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("BitlockerInvalidPwDialog/Title"), ResourceController.GetTranslation("BitlockerInvalidPwDialog/Text"));
                         }
-                        else if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
+                    }
+                }
+            }
+
+            if (enumFromStorageFolder)
+            {
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+                uint count = 0;
+                while (true)
+                {
+                    IStorageItem item = null;
+                    try
+                    {
+                        var results = await _rootFolder.GetItemsAsync(count, 1);
+                        item = results?.FirstOrDefault();
+                        if (item == null) break;
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        ++count;
+                        continue;
+                    }
+                    if (item.IsOfType(StorageItemTypes.Folder))
+                    {
+                        await AddFolder(item as StorageFolder);
+                        ++count;
+                    }
+                    else
+                    {
+                        var file = item as StorageFile;
+                        if (!file.Name.EndsWith(".lnk") && !file.Name.EndsWith(".url"))
                         {
-                            if (findData.cFileName != "." && findData.cFileName != "..")
-                            {
-                                AddFolder(findData, path);
-                                ++count;
-                            }
+                            await AddFile(file, true);
                         }
+                        ++count;
                     }
                     if (_addFilesCTS.IsCancellationRequested)
                     {
                         break;
                     }
-
                     if (count % 64 == 0)
                     {
                         await CoreApplication.MainView.CoreWindow.Dispatcher.YieldAsync();
                     }
-                } while (FindNextFile(hFile, out findData));
+                }
+                stopwatch.Stop();
+                Debug.WriteLine($"Enumerating items in {WorkingDirectory} (device) completed in {stopwatch.ElapsedMilliseconds} milliseconds.\n");
+            }
+            else
+            {
+                FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
+                int additionalFlags = FIND_FIRST_EX_LARGE_FETCH;
 
-                FindClose(hFile);
+                IntPtr hFile = FindFirstFileExFromApp(path + "\\*.*", findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero,
+                                                      additionalFlags);
+
+                var count = 0;
+                if (hFile.ToInt64() != -1)
+                {
+                    do
+                    {
+                        if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) != FileAttributes.Hidden && ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) != FileAttributes.System)
+                        {
+                            if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
+                            {
+                                if (!findData.cFileName.EndsWith(".lnk") && !findData.cFileName.EndsWith(".url"))
+                                {
+                                    AddFile(findData, path);
+                                    ++count;
+                                }
+                            }
+                            else if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
+                            {
+                                if (findData.cFileName != "." && findData.cFileName != "..")
+                                {
+                                    AddFolder(findData, path);
+                                    ++count;
+                                }
+                            }
+                        }
+                        if (_addFilesCTS.IsCancellationRequested)
+                        {
+                            break;
+                        }
+
+                        if (count % 64 == 0)
+                        {
+                            await CoreApplication.MainView.CoreWindow.Dispatcher.YieldAsync();
+                        }
+                    } while (FindNextFile(hFile, out findData));
+
+                    FindClose(hFile);
+                }
             }
         }
 
@@ -911,66 +961,67 @@ namespace Files.Filesystem
             Debug.WriteLine("WatchForDirectoryChanges: {0}", path);
             hWatchDir = CreateFileFromApp(path, 1, 1 | 2 | 4,
                 IntPtr.Zero, 3, (uint)File_Attributes.BackupSemantics | (uint)File_Attributes.Overlapped, IntPtr.Zero);
+            if (hWatchDir.ToInt64() == -1) return;
 
             byte[] buff = new byte[4096];
 
             aWatcherAction = Windows.System.Threading.ThreadPool.RunAsync((x) =>
-             {
-                 var rand = Guid.NewGuid();
-                 buff = new byte[4096];
-                 int notifyFilters = FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_FILE_NAME;
+            {
+                var rand = Guid.NewGuid();
+                buff = new byte[4096];
+                int notifyFilters = FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_FILE_NAME;
 
-                 OVERLAPPED overlapped = new OVERLAPPED();
-                 overlapped.hEvent = CreateEvent(IntPtr.Zero, false, false, null);
-                 const uint INFINITE = 0xFFFFFFFF;
+                OVERLAPPED overlapped = new OVERLAPPED();
+                overlapped.hEvent = CreateEvent(IntPtr.Zero, false, false, null);
+                const uint INFINITE = 0xFFFFFFFF;
 
-                 while (x.Status != AsyncStatus.Canceled)
-                 {
-                     unsafe
-                     {
-                         fixed (byte* pBuff = buff)
-                         {
-                             ref var notifyInformation = ref Unsafe.As<byte, FILE_NOTIFY_INFORMATION>(ref buff[0]);
-                             if (x.Status != AsyncStatus.Canceled)
-                             {
-                                 NativeDirectoryChangesHelper.ReadDirectoryChangesW(hWatchDir, pBuff,
-                                 4096, false,
-                                 notifyFilters, null,
-                                 ref overlapped, null);
-                             }
-                             else
-                             {
-                                 break;
-                             }
+                while (x.Status != AsyncStatus.Canceled)
+                {
+                    unsafe
+                    {
+                        fixed (byte* pBuff = buff)
+                        {
+                            ref var notifyInformation = ref Unsafe.As<byte, FILE_NOTIFY_INFORMATION>(ref buff[0]);
+                            if (x.Status != AsyncStatus.Canceled)
+                            {
+                                NativeDirectoryChangesHelper.ReadDirectoryChangesW(hWatchDir, pBuff,
+                                4096, false,
+                                notifyFilters, null,
+                                ref overlapped, null);
+                            }
+                            else
+                            {
+                                break;
+                            }
 
-                             Debug.WriteLine("waiting: {0}", rand);
-                             if (x.Status == AsyncStatus.Canceled) { break; }
-                             var rc = WaitForSingleObjectEx(overlapped.hEvent, INFINITE, true);
-                             Debug.WriteLine("wait done: {0}", rand);
+                            Debug.WriteLine("waiting: {0}", rand);
+                            if (x.Status == AsyncStatus.Canceled) { break; }
+                            var rc = WaitForSingleObjectEx(overlapped.hEvent, INFINITE, true);
+                            Debug.WriteLine("wait done: {0}", rand);
 
-                             const uint FILE_ACTION_ADDED = 0x00000001;
-                             const uint FILE_ACTION_REMOVED = 0x00000002;
-                             const uint FILE_ACTION_MODIFIED = 0x00000003;
-                             const uint FILE_ACTION_RENAMED_OLD_NAME = 0x00000004;
-                             const uint FILE_ACTION_RENAMED_NEW_NAME = 0x00000005;
+                            const uint FILE_ACTION_ADDED = 0x00000001;
+                            const uint FILE_ACTION_REMOVED = 0x00000002;
+                            const uint FILE_ACTION_MODIFIED = 0x00000003;
+                            const uint FILE_ACTION_RENAMED_OLD_NAME = 0x00000004;
+                            const uint FILE_ACTION_RENAMED_NEW_NAME = 0x00000005;
 
-                             uint offset = 0;
-                             ref var notifyInfo = ref Unsafe.As<byte, FILE_NOTIFY_INFORMATION>(ref buff[offset]);
-                             if (x.Status == AsyncStatus.Canceled) { break; }
+                            uint offset = 0;
+                            ref var notifyInfo = ref Unsafe.As<byte, FILE_NOTIFY_INFORMATION>(ref buff[offset]);
+                            if (x.Status == AsyncStatus.Canceled) { break; }
 
-                             do
-                             {
-                                 notifyInfo = ref Unsafe.As<byte, FILE_NOTIFY_INFORMATION>(ref buff[offset]);
-                                 string FileName = null;
-                                 unsafe
-                                 {
-                                     fixed (char* name = notifyInfo.FileName)
-                                     {
-                                         FileName = Path.Combine(path, new string(name, 0, (int)notifyInfo.FileNameLength / 2));
-                                     }
-                                 }
+                            do
+                            {
+                                notifyInfo = ref Unsafe.As<byte, FILE_NOTIFY_INFORMATION>(ref buff[offset]);
+                                string FileName = null;
+                                unsafe
+                                {
+                                    fixed (char* name = notifyInfo.FileName)
+                                    {
+                                        FileName = Path.Combine(path, new string(name, 0, (int)notifyInfo.FileNameLength / 2));
+                                    }
+                                }
 
-                                 uint action = notifyInfo.Action;
+                                uint action = notifyInfo.Action;
 
                                  Debug.WriteLine("action: {0}", action);
                                  try
@@ -1011,17 +1062,18 @@ namespace Files.Filesystem
                                      // Prevent invalid operations
                                  }
 
-                                 offset += notifyInfo.NextEntryOffset;
-                             } while (notifyInfo.NextEntryOffset != 0 && x.Status != AsyncStatus.Canceled);
+                                offset += notifyInfo.NextEntryOffset;
 
-                             //ResetEvent(overlapped.hEvent);
-                             Debug.WriteLine("Task running...");
-                         }
-                     }
-                 }
-                 CloseHandle(overlapped.hEvent);
-                 Debug.WriteLine("aWatcherAction done: {0}", rand);
-             });
+                            } while (notifyInfo.NextEntryOffset != 0 && x.Status != AsyncStatus.Canceled);
+
+                            //ResetEvent(overlapped.hEvent);
+                            Debug.WriteLine("Task running...");
+                        }
+                    }
+                }
+                CloseHandle(overlapped.hEvent);
+                Debug.WriteLine("aWatcherAction done: {0}", rand);
+            });
 
             Debug.WriteLine("Task exiting...");
         }
@@ -1225,7 +1277,7 @@ namespace Files.Filesystem
             RapidAddItemsToCollectionAsync(path);
         }
 
-        private async Task AddFolder(StorageFolder folder)
+        public async Task AddFolder(StorageFolder folder)
         {
             var basicProperties = await folder.GetBasicPropertiesAsync();
 
@@ -1239,30 +1291,33 @@ namespace Files.Filesystem
 
                 _filesAndFolders.Add(new ListedItem(folder.FolderRelativeId)
                 {
-                    //FolderTooltipText = tooltipString,
+                    PrimaryItemAttribute = StorageItemTypes.Folder,
                     ItemName = folder.Name,
                     ItemDateModifiedReal = basicProperties.DateModified,
                     ItemType = folder.DisplayType,
                     LoadFolderGlyph = true,
                     FileImage = null,
                     LoadFileIcon = false,
-                    ItemPath = folder.Path,
+                    ItemPath = string.IsNullOrEmpty(folder.Path) ? Path.Combine(_currentStorageFolder.Path, folder.Name) : folder.Path,
                     LoadUnknownTypeGlyph = false,
                     FileSize = null,
-                    FileSizeBytes = 0
+                    FileSizeBytes = 0,
+                    //FolderTooltipText = tooltipString,
                 });
 
                 IsFolderEmptyTextDisplayed = false;
             }
         }
 
-        private async Task AddFile(StorageFile file)
+        public async Task AddFile(StorageFile file, bool suppressThumbnailLoading = false)
         {
             var basicProperties = await file.GetBasicPropertiesAsync();
 
-            var itemName = file.DisplayName;
+            // Display name does not include extension
+            var itemName = string.IsNullOrEmpty(file.DisplayName) || App.AppSettings.ShowFileExtensions ?
+                file.Name : file.DisplayName;
             var itemDate = basicProperties.DateModified;
-            var itemPath = file.Path;
+            var itemPath = string.IsNullOrEmpty(file.Path) ? Path.Combine(_currentStorageFolder.Path, file.Name) : file.Path;
             var itemSize = ByteSize.FromBytes(basicProperties.Size).ToBinaryString().ConvertSizeAbbreviation();
             var itemSizeBytes = basicProperties.Size;
             var itemType = file.DisplayType;
@@ -1277,7 +1332,8 @@ namespace Files.Filesystem
             {
                 try
                 {
-                    var itemThumbnailImg = await file.GetThumbnailAsync(ThumbnailMode.ListView, 40, ThumbnailOptions.UseCurrentScale);
+                    var itemThumbnailImg = suppressThumbnailLoading ? null :
+                        await file.GetThumbnailAsync(ThumbnailMode.ListView, 40, ThumbnailOptions.UseCurrentScale);
                     if (itemThumbnailImg != null)
                     {
                         itemEmptyImgVis = false;
@@ -1303,7 +1359,8 @@ namespace Files.Filesystem
             {
                 try
                 {
-                    var itemThumbnailImg = await file.GetThumbnailAsync(ThumbnailMode.ListView, 80, ThumbnailOptions.UseCurrentScale);
+                    var itemThumbnailImg = suppressThumbnailLoading ? null :
+                        await file.GetThumbnailAsync(ThumbnailMode.ListView, 80, ThumbnailOptions.UseCurrentScale);
                     if (itemThumbnailImg != null)
                     {
                         itemEmptyImgVis = false;
@@ -1331,6 +1388,7 @@ namespace Files.Filesystem
             }
             _filesAndFolders.Add(new ListedItem(file.FolderRelativeId)
             {
+                PrimaryItemAttribute = StorageItemTypes.File,
                 FileExtension = itemFileExtension,
                 LoadUnknownTypeGlyph = itemEmptyImgVis,
                 FileImage = icon,

--- a/Files/Views/InstanceTabsView.xaml.cs
+++ b/Files/Views/InstanceTabsView.xaml.cs
@@ -313,8 +313,9 @@ namespace Files
                     if (NormalizePath(currentPathForTabIcon) != NormalizePath("A:") && NormalizePath(currentPathForTabIcon) != NormalizePath("B:"))
                     {
                         var remDriveNames = (await KnownFolders.RemovableDevices.GetFoldersAsync()).Select(x => x.DisplayName);
+                        var matchingDriveName = remDriveNames.FirstOrDefault(x => NormalizePath(currentPathForTabIcon).Contains(x.ToUpperInvariant()));
 
-                        if (!remDriveNames.Contains(NormalizePath(currentPathForTabIcon)))
+                        if (matchingDriveName == null)
                         {
                             fontIconSource.Glyph = "\xEDA2";
                             tabLocationHeader = NormalizePath(currentPathForTabIcon);
@@ -322,7 +323,7 @@ namespace Files
                         else
                         {
                             fontIconSource.Glyph = "\xE88E";
-                            tabLocationHeader = (await KnownFolders.RemovableDevices.GetFolderAsync(currentPathForTabIcon)).DisplayName;
+                            tabLocationHeader = matchingDriveName;
                         }
                     }
                     else
@@ -482,15 +483,10 @@ namespace Files
                         {
                             App.CurrentInstance.InstanceViewModel.IsPageTypeNotHome = true;
                         }
-                        if ((tabView.SelectedItem as TabViewItem).Header.ToString() ==
-                            ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin"))
-                        {
-                            App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin = false;
-                        }
-                        else
-                        {
-                            App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin = true;
-                        }
+                        App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin =
+                            App.CurrentInstance?.FilesystemViewModel?.WorkingDirectory?.StartsWith(App.AppSettings.RecycleBinPath) ?? false;
+                        App.CurrentInstance.InstanceViewModel.IsPageTypeMtpDevice =
+                            App.CurrentInstance?.FilesystemViewModel?.WorkingDirectory?.StartsWith("\\\\?\\") ?? false;
                     }
 
                     App.InteractionViewModel.TabsLeftMargin = new Thickness(200, 0, 0, 0);

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -19,7 +19,7 @@
     mc:Ignorable="d">
 
     <local:BaseLayout.Resources>
-        <MenuFlyout x:Key="BaseLayoutContextFlyout">
+        <MenuFlyout x:Key="BaseLayoutContextFlyout" Opening="RightClickContextMenu_Opening">
             <MenuFlyoutSubItem
                 x:Name="SortByEmptySpace"
                 x:Uid="BaseLayoutContextFlyoutSortBy"
@@ -127,7 +127,8 @@
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>
-            <MenuFlyoutSeparator />
+            <MenuFlyoutSeparator
+                x:Name="NewEmptySpaceSeparator"/>
             <MenuFlyoutItem
                 x:Name="PinToSidebar"
                 x:Uid="BaseLayoutContextFlyoutPinDirectoryToSidebar"
@@ -450,13 +451,13 @@
                 Modifiers="Control" />
         </Grid.KeyboardAccelerators>
         <Interactivity:Interaction.Behaviors>
-            <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="False">
+            <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}" Value="True">
                 <Core:ChangePropertyAction
                     PropertyName="ContextFlyout"
                     TargetObject="{Binding ElementName=RootGrid}"
                     Value="{StaticResource BaseLayoutRecycleBinContextFlyout}" />
             </Core:DataTriggerBehavior>
-            <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="True">
+            <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}" Value="False">
                 <Core:ChangePropertyAction
                     PropertyName="ContextFlyout"
                     TargetObject="{Binding ElementName=RootGrid}"
@@ -553,13 +554,13 @@
                 </Style>
             </controls:DataGrid.ColumnHeaderStyle>
             <Interactivity:Interaction.Behaviors>
-                <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="False">
+                <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}" Value="True">
                     <Core:ChangePropertyAction
                         PropertyName="RowStyle"
                         TargetObject="{Binding ElementName=AllView}"
                         Value="{StaticResource DataGridRowRecycleBinContextFlyout}" />
                 </Core:DataTriggerBehavior>
-                <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="True">
+                <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}" Value="False">
                     <Core:ChangePropertyAction
                         PropertyName="RowStyle"
                         TargetObject="{Binding ElementName=AllView}"

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -19,7 +19,7 @@
     mc:Ignorable="d">
 
     <local:BaseLayout.Resources>
-        <MenuFlyout x:Key="BaseLayoutContextFlyout" Opening="RightClickContextMenu_Opening">
+        <MenuFlyout x:Key="BaseLayoutContextFlyout">
             <MenuFlyoutSubItem
                 x:Name="SortByEmptySpace"
                 x:Uid="BaseLayoutContextFlyoutSortBy"
@@ -84,7 +84,7 @@
                 x:Name="OpenTerminal"
                 x:Uid="BaseLayoutContextFlyoutOpenInTerminal"
                 Click="{x:Bind local:App.CurrentInstance.InteractionOperations.OpenDirectoryInTerminal}"
-                IsEnabled="True"
+                IsEnabled="{x:Bind local:App.CurrentInstance.InstanceViewModel.CanOpenTerminalInPage, Mode=OneWay}"
                 Text="Open in Terminal...">
                 <MenuFlyoutItem.Icon>
                     <FontIcon Glyph="&#xE756;" />
@@ -112,6 +112,7 @@
                     x:Name="NewBitmapImage"
                     x:Uid="BaseLayoutContextFlyoutNewBitmapImage"
                     Click="{x:Bind local:App.CurrentInstance.InteractionOperations.NewBitmapImage_Click}"
+                    IsEnabled="{x:Bind local:App.CurrentInstance.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
                     Text="Bitmap Image">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xEB9F;" />
@@ -121,14 +122,14 @@
                     x:Name="NewTextDocument"
                     x:Uid="BaseLayoutContextFlyoutNewTextDocument"
                     Click="{x:Bind local:App.CurrentInstance.InteractionOperations.NewTextDocument_Click}"
+                    IsEnabled="{x:Bind local:App.CurrentInstance.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
                     Text="Text Document">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE8A5;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>
-            <MenuFlyoutSeparator
-                x:Name="NewEmptySpaceSeparator"/>
+            <MenuFlyoutSeparator />
             <MenuFlyoutItem
                 x:Name="PinToSidebar"
                 x:Uid="BaseLayoutContextFlyoutPinDirectoryToSidebar"

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -435,9 +435,5 @@ namespace Files
             DataGridRow row = element as DataGridRow;
             return row.DataContext as ListedItem;
         }
-
-        private void RightClickContextMenu_Opening(object sender, object e)
-        {
-        }
     }
 }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -15,7 +15,7 @@
     PointerWheelChanged="BaseLayout_PointerWheelChanged"
     mc:Ignorable="d">
     <local:BaseLayout.Resources>
-        <MenuFlyout x:Key="BaseLayoutContextFlyout">
+        <MenuFlyout x:Key="BaseLayoutContextFlyout" Opening="RightClickContextMenu_Opening">
             <MenuFlyoutSubItem
                 x:Name="SortByEmptySpace"
                 x:Uid="BaseLayoutContextFlyoutSortBy"
@@ -123,7 +123,8 @@
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>
-            <MenuFlyoutSeparator />
+            <MenuFlyoutSeparator
+                x:Name="NewEmptySpaceSeparator"/>
             <MenuFlyoutItem
                 x:Name="PinToSidebar"
                 x:Uid="BaseLayoutContextFlyoutPinDirectoryToSidebar"
@@ -645,13 +646,13 @@
                 Modifiers="Control" />
         </Grid.KeyboardAccelerators>
         <Interactivity:Interaction.Behaviors>
-            <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="False">
+            <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}" Value="True">
                 <Core:ChangePropertyAction
                     PropertyName="ContextFlyout"
                     TargetObject="{Binding ElementName=RootGrid}"
                     Value="{StaticResource BaseLayoutRecycleBinContextFlyout}" />
             </Core:DataTriggerBehavior>
-            <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="True">
+            <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}" Value="False">
                 <Core:ChangePropertyAction
                     PropertyName="ContextFlyout"
                     TargetObject="{Binding ElementName=RootGrid}"
@@ -698,13 +699,13 @@
             SelectionChanged="FileList_SelectionChanged"
             SelectionMode="Extended">
             <Interactivity:Interaction.Behaviors>
-                <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="False">
+                <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}" Value="True">
                     <Core:ChangePropertyAction
                         PropertyName="ItemContainerStyle"
                         TargetObject="{Binding ElementName=FileList}"
                         Value="{StaticResource GridViewItemRecycleBinContextFlyout}" />
                 </Core:DataTriggerBehavior>
-                <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}" Value="True">
+                <Core:DataTriggerBehavior Binding="{x:Bind local:App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}" Value="False">
                     <Core:ChangePropertyAction
                         PropertyName="ItemContainerStyle"
                         TargetObject="{Binding ElementName=FileList}"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -15,7 +15,7 @@
     PointerWheelChanged="BaseLayout_PointerWheelChanged"
     mc:Ignorable="d">
     <local:BaseLayout.Resources>
-        <MenuFlyout x:Key="BaseLayoutContextFlyout" Opening="RightClickContextMenu_Opening">
+        <MenuFlyout x:Key="BaseLayoutContextFlyout">
             <MenuFlyoutSubItem
                 x:Name="SortByEmptySpace"
                 x:Uid="BaseLayoutContextFlyoutSortBy"
@@ -80,7 +80,7 @@
                 x:Name="OpenTerminal"
                 x:Uid="BaseLayoutContextFlyoutOpenInTerminal"
                 Click="{x:Bind local:App.CurrentInstance.InteractionOperations.OpenDirectoryInTerminal}"
-                IsEnabled="True"
+                IsEnabled="{x:Bind local:App.CurrentInstance.InstanceViewModel.CanOpenTerminalInPage, Mode=OneWay}"
                 Text="Open in Terminal...">
                 <MenuFlyoutItem.Icon>
                     <FontIcon Glyph="&#xE756;" />
@@ -108,6 +108,7 @@
                     x:Name="NewBitmapImage"
                     x:Uid="BaseLayoutContextFlyoutNewBitmapImage"
                     Click="{x:Bind local:App.CurrentInstance.InteractionOperations.NewBitmapImage_Click}"
+                    IsEnabled="{x:Bind local:App.CurrentInstance.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
                     Text="Bitmap Image">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xEB9F;" />
@@ -117,14 +118,14 @@
                     x:Name="NewTextDocument"
                     x:Uid="BaseLayoutContextFlyoutNewTextDocument"
                     Click="{x:Bind local:App.CurrentInstance.InteractionOperations.NewTextDocument_Click}"
+                    IsEnabled="{x:Bind local:App.CurrentInstance.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
                     Text="Text Document">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE8A5;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>
-            <MenuFlyoutSeparator
-                x:Name="NewEmptySpaceSeparator"/>
+            <MenuFlyoutSeparator />
             <MenuFlyoutItem
                 x:Name="PinToSidebar"
                 x:Uid="BaseLayoutContextFlyoutPinDirectoryToSidebar"

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -159,6 +159,11 @@ namespace Files.Views.Pages
                         NavigationPath = NavParams;
                         SidebarControl.SelectedSidebarItem = AppSettings.DrivesManager.Drives.First(x => x.Path.ToString().Equals($"{NavParams[0]}:\\", StringComparison.OrdinalIgnoreCase));
                     }
+                    else if(NavParams.StartsWith("\\\\?\\"))
+                    {
+                        NavigationPath = NavParams;
+                        SidebarControl.SelectedSidebarItem = App.AppSettings.DrivesManager.Drives.First(x => x.Path.ToString().Equals($"{System.IO.Path.GetPathRoot(NavParams)}", StringComparison.OrdinalIgnoreCase));
+                    }
                     else if (NavParams.StartsWith(AppSettings.RecycleBinPath))
                     {
                         NavigationPath = NavParams;


### PR DESCRIPTION
Might help fix #779

This PR contains a proposal of how MTP devices like android phones could be accessed by Files UWP.

What works:
* Navigation inside the MTP device
* Pasting/Deleting/Renaming inside the MTP device
* Creating new ~files~ folders inside the MTP device.
Files can only be copied to, explorer does the same
* Opening files inside the MTP device

@duke7553 what do you think?