### PR TITLE
feat: Uri activation with path

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -308,9 +308,14 @@ namespace Files
                 case ActivationKind.Protocol:
                     var eventArgs = args as ProtocolActivatedEventArgs;
 
-                    if (eventArgs.Uri.AbsoluteUri == "files-uwp:")
+                    if (eventArgs.Uri.Scheme == "files-uwp")
                     {
-                        rootFrame.Navigate(typeof(InstanceTabsView), null, new SuppressNavigationTransitionInfo());
+	                    var path = Uri.UnescapeDataString(eventArgs.Uri.AbsolutePath);
+	                    var actualPath = path.Replace('/', '\\');
+
+                        Logger.Info($"Activation: Protocol ({path};{actualPath})");
+
+                        rootFrame.Navigate(typeof(InstanceTabsView), actualPath, new SuppressNavigationTransitionInfo());
                     }
                     else
                     {

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -311,6 +311,8 @@ namespace Files
                     if (eventArgs.Uri.Scheme == "files-uwp")
                     {
 	                    var path = Uri.UnescapeDataString(eventArgs.Uri.AbsolutePath);
+
+                        // Convert forward slashes to backwards ones, because Windows.Storage-apis only accept backwards ones.
 	                    var actualPath = path.Replace('/', '\\');
 
                         Logger.Info($"Activation: Protocol ({path};{actualPath})");

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -309,11 +309,11 @@ namespace Files
                     var eventArgs = args as ProtocolActivatedEventArgs;
 
                     if (eventArgs.Uri.Scheme == "files-uwp")
-                    {
-	                    var path = Uri.UnescapeDataString(eventArgs.Uri.AbsolutePath);
+                    { 
+                        var path = Uri.UnescapeDataString(eventArgs.Uri.AbsolutePath);
 
                         // Convert forward slashes to backwards ones, because Windows.Storage-apis only accept backwards ones.
-	                    var actualPath = path.Replace('/', '\\');
+                        var actualPath = path.Replace('/', '\\');
 
                         Logger.Info($"Activation: Protocol ({path};{actualPath})");
 


### PR DESCRIPTION
allows to activate the app via uri and specify a path.

```
files-uwp:///C:/windows
```

1. The drive letter must be uppercase
2. forward slashes `/` must be used.