### PR TITLE
Add support for Bitlocker

### DIFF
--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
@@ -140,15 +141,22 @@ namespace FilesFullTrust
 
         public static void UnlockBitlockerDrive(string drive, string password)
         {
-            Process process = new Process();
-            process.StartInfo.UseShellExecute = true;
-            process.StartInfo.Verb = "runas";
-            process.StartInfo.FileName = "powershell.exe";
-            process.StartInfo.CreateNoWindow = true;
-            process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            process.StartInfo.Arguments = $"-command \"$SecureString = ConvertTo-SecureString '{password}' -AsPlainText -Force; Unlock-BitLocker -MountPoint '{drive}' -Password $SecureString\"";
-            process.Start();
-            process.WaitForExit(30 * 1000);
+            try
+            {
+                Process process = new Process();
+                process.StartInfo.UseShellExecute = true;
+                process.StartInfo.Verb = "runas";
+                process.StartInfo.FileName = "powershell.exe";
+                process.StartInfo.CreateNoWindow = true;
+                process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                process.StartInfo.Arguments = $"-command \"$SecureString = ConvertTo-SecureString '{password}' -AsPlainText -Force; Unlock-BitLocker -MountPoint '{drive}' -Password $SecureString\"";
+                process.Start();
+                process.WaitForExit(30 * 1000);
+            }
+            catch (Win32Exception)
+            {
+                // If user cancels UAC
+            }
         }
     }
 }

--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -134,6 +136,19 @@ namespace FilesFullTrust
             {
                 Marshal.FreeHGlobal(argv);
             }
+        }
+
+        public static void UnlockBitlockerDrive(string drive, string password)
+        {
+            Process process = new Process();
+            process.StartInfo.UseShellExecute = true;
+            process.StartInfo.Verb = "runas";
+            process.StartInfo.FileName = "powershell.exe";
+            process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            process.StartInfo.Arguments = $"-command \"$SecureString = ConvertTo-SecureString '{password}' -AsPlainText -Force; Unlock-BitLocker -MountPoint '{drive}' -Password $SecureString\"";
+            process.Start();
+            process.WaitForExit(30 * 1000);
         }
     }
 }

--- a/Files/Dialogs/BitlockerDialog.xaml
+++ b/Files/Dialogs/BitlockerDialog.xaml
@@ -1,0 +1,33 @@
+﻿<ContentDialog
+    x:Class="Files.Dialogs.BitlockerDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local2="using:Files.Helpers"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    CornerRadius="4"
+    DefaultButton="Primary"
+    Title="Enter unlock password"
+    BorderThickness="0"
+    PrimaryButtonClick="NameDialog_PrimaryButtonClick"
+    x:Name="NameDialog"
+    PrimaryButtonText="Unlock"
+    SecondaryButtonText="Cancel"
+    x:Uid="BitlockerDialog"
+    RequestedTheme="{x:Bind local2:ThemeHelper.RootTheme}"
+    KeyDown="NameDialog_KeyDown">
+
+    <Grid MinWidth="300">
+        <StackPanel
+            Orientation="Vertical"
+            Spacing="4">
+            <TextBox 
+                x:Name="PasswordInput"
+                x:Uid="BitlockerDialogInputText"
+                PlaceholderText="Enter drive unlock password"
+                Height="35"
+                TextChanged="BitlockerInput_TextChanged" />
+        </StackPanel>
+    </Grid>
+</ContentDialog>

--- a/Files/Dialogs/BitlockerDialog.xaml
+++ b/Files/Dialogs/BitlockerDialog.xaml
@@ -8,26 +8,28 @@
     mc:Ignorable="d"
     CornerRadius="4"
     DefaultButton="Primary"
-    Title="Enter unlock password"
+    Title="Enter password to unlock the drive"
     BorderThickness="0"
-    PrimaryButtonClick="NameDialog_PrimaryButtonClick"
-    x:Name="NameDialog"
+    PrimaryButtonClick="BitlockerDialog_PrimaryButtonClick"
+    x:Name="BitlockerDriveDialog"
     PrimaryButtonText="Unlock"
     SecondaryButtonText="Cancel"
     x:Uid="BitlockerDialog"
     RequestedTheme="{x:Bind local2:ThemeHelper.RootTheme}"
-    KeyDown="NameDialog_KeyDown">
+    KeyDown="BitlockerDialog_KeyDown">
 
     <Grid MinWidth="300">
         <StackPanel
             Orientation="Vertical"
             Spacing="4">
-            <TextBox 
+            <PasswordBox 
                 x:Name="PasswordInput"
                 x:Uid="BitlockerDialogInputText"
-                PlaceholderText="Enter drive unlock password"
+                PlaceholderText="Password"
                 Height="35"
-                TextChanged="BitlockerInput_TextChanged" />
+                IsPasswordRevealButtonEnabled="True"
+                PasswordRevealMode="Peek"
+                PasswordChanged="BitlockerInput_TextChanged" />
         </StackPanel>
     </Grid>
 </ContentDialog>

--- a/Files/Dialogs/BitlockerDialog.xaml
+++ b/Files/Dialogs/BitlockerDialog.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     CornerRadius="4"
-    DefaultButton="Primary"
+    DefaultButton="None"
     Title="Enter password to unlock the drive"
     BorderThickness="0"
     PrimaryButtonClick="BitlockerDialog_PrimaryButtonClick"
@@ -15,9 +15,23 @@
     PrimaryButtonText="Unlock"
     SecondaryButtonText="Cancel"
     x:Uid="BitlockerDialog"
-    RequestedTheme="{x:Bind local2:ThemeHelper.RootTheme}"
-    KeyDown="BitlockerDialog_KeyDown">
+    RequestedTheme="{x:Bind local2:ThemeHelper.RootTheme}">
 
+    <ContentDialog.PrimaryButtonStyle>
+        <Style TargetType="Button" BasedOn="{StaticResource AccentButtonStyle}">
+            <Setter Property="ContentTemplate">
+                <Setter.Value>
+                    <DataTemplate x:DataType="Button">
+                        <StackPanel Spacing="5" Orientation="Horizontal">
+                            <FontIcon FontSize="14" Glyph="&#xEA18;" />
+                            <TextBlock Text="{Binding PrimaryButtonText, ElementName=BitlockerDriveDialog}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </ContentDialog.PrimaryButtonStyle>
+    
     <Grid MinWidth="300">
         <StackPanel
             Orientation="Vertical"

--- a/Files/Dialogs/BitlockerDialog.xaml.cs
+++ b/Files/Dialogs/BitlockerDialog.xaml.cs
@@ -7,28 +7,28 @@ namespace Files.Dialogs
 {
     public sealed partial class BitlockerDialog : ContentDialog
     {
-        public TextBox inputBox;
+        public PasswordBox inputBox;
         public string storedPasswordInput;
 
         public BitlockerDialog(string drive)
         {
             this.InitializeComponent();
             inputBox = PasswordInput;
+            IsPrimaryButtonEnabled = false;
         }
 
-        private void NameDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        private void BitlockerDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
         {
-            storedPasswordInput = inputBox.Text;
+            storedPasswordInput = inputBox.Password;
         }
 
-        private void BitlockerInput_TextChanged(object sender, TextChangedEventArgs e)
+        private void BitlockerInput_TextChanged(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            var textBox = sender as TextBox;
+            var textBox = sender as PasswordBox;
 
-            if (string.IsNullOrEmpty(textBox.Text))
+            if (string.IsNullOrEmpty(textBox.Password))
             {
                 IsPrimaryButtonEnabled = false;
-                return;
             }
             else
             {
@@ -36,7 +36,7 @@ namespace Files.Dialogs
             }
         }
 
-        private void NameDialog_KeyDown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
+        private void BitlockerDialog_KeyDown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
             if (e.Key.Equals(VirtualKey.Escape))
             {

--- a/Files/Dialogs/BitlockerDialog.xaml.cs
+++ b/Files/Dialogs/BitlockerDialog.xaml.cs
@@ -1,0 +1,47 @@
+﻿using Windows.System;
+using Windows.UI.Xaml.Controls;
+
+// The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Files.Dialogs
+{
+    public sealed partial class BitlockerDialog : ContentDialog
+    {
+        public TextBox inputBox;
+        public string storedPasswordInput;
+
+        public BitlockerDialog(string drive)
+        {
+            this.InitializeComponent();
+            inputBox = PasswordInput;
+        }
+
+        private void NameDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+            storedPasswordInput = inputBox.Text;
+        }
+
+        private void BitlockerInput_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            var textBox = sender as TextBox;
+
+            if (string.IsNullOrEmpty(textBox.Text))
+            {
+                IsPrimaryButtonEnabled = false;
+                return;
+            }
+            else
+            {
+                IsPrimaryButtonEnabled = true;
+            }
+        }
+
+        private void NameDialog_KeyDown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
+        {
+            if (e.Key.Equals(VirtualKey.Escape))
+            {
+                Hide();
+            }
+        }
+    }
+}

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -156,6 +156,9 @@
     <Compile Include="CommandLine\ParsedCommandType.cs" />
     <Compile Include="Converters\StorageDeleteOptionToBooleanConverter.cs" />
     <Compile Include="DataModels\SidebarPinnedModel.cs" />
+    <Compile Include="Dialogs\BitlockerDialog.xaml.cs">
+      <DependentUpon>BitlockerDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Dialogs\ConfirmDeleteDialog.xaml.cs">
       <DependentUpon>ConfirmDeleteDialog.xaml</DependentUpon>
     </Compile>
@@ -379,6 +382,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="Dialogs\BitlockerDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Dialogs\ConfirmDeleteDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -656,7 +656,7 @@ namespace Files.Interacts
             }
             catch (IOException)
             {
-                if (await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("FileInUseDeleteDialog.Title"), ResourceController.GetTranslation("FileInUseDeleteDialog.Text"), ResourceController.GetTranslation("FileInUseDeleteDialog.PrimaryButtonText"), ResourceController.GetTranslation("FileInUseDeleteDialog.SecondaryButtonText")))
+                if (await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("FileInUseDeleteDialog/Title"), ResourceController.GetTranslation("FileInUseDeleteDialog/Text"), ResourceController.GetTranslation("FileInUseDeleteDialog/PrimaryButtonText"), ResourceController.GetTranslation("FileInUseDeleteDialog/SecondaryButtonText")))
                 {
                     DeleteItem_Click(null, null);
                 }

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -656,7 +656,7 @@ namespace Files.Interacts
             }
             catch (IOException)
             {
-                if (await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("FileInUseDeleteDialog/Title"), ResourceController.GetTranslation("FileInUseDeleteDialog/Text"), ResourceController.GetTranslation("FileInUseDeleteDialog/PrimaryButtonText"), ResourceController.GetTranslation("FileInUseDeleteDialog/SecondaryButtonText")))
+                if (await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("FileInUseDeleteDialog.Title"), ResourceController.GetTranslation("FileInUseDeleteDialog.Text"), ResourceController.GetTranslation("FileInUseDeleteDialog.PrimaryButtonText"), ResourceController.GetTranslation("FileInUseDeleteDialog.SecondaryButtonText")))
                 {
                     DeleteItem_Click(null, null);
                 }

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -881,6 +881,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -874,12 +874,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -865,6 +865,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -886,8 +886,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -882,8 +882,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -875,8 +875,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -879,8 +879,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -858,6 +858,22 @@
           <source>Learn more about date formats</source>
           <target state="translated">Mas información acerca de formatos de fecha</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -867,12 +867,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -874,6 +874,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -877,6 +877,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -878,8 +878,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -882,8 +882,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -861,6 +861,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -870,12 +870,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -883,8 +883,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -875,12 +875,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -866,6 +866,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -887,8 +887,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -882,6 +882,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -876,8 +876,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -859,6 +859,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -880,8 +880,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -875,6 +875,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -868,12 +868,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -877,6 +877,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -878,8 +878,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -882,8 +882,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -861,6 +861,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -870,12 +870,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -877,6 +877,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -878,8 +878,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -882,8 +882,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -861,6 +861,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -870,12 +870,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -873,12 +873,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -880,6 +880,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="translated">Содержит:</target>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -864,6 +864,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="translated">Содержит:</target>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -885,8 +885,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -881,8 +881,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -873,12 +873,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -885,8 +885,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -864,6 +864,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -880,6 +880,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -881,8 +881,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -877,6 +877,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -878,8 +878,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -882,8 +882,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -861,6 +861,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -870,12 +870,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -873,12 +873,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -880,6 +880,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="translated">Містить:</target>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -885,8 +885,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -864,6 +864,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="translated">Містить:</target>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -881,8 +881,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -876,8 +876,8 @@
           <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
-          <source>Could not unlock the drive. Wrong password?</source>
-          <target state="new">Could not unlock the drive. Wrong password?</target>
+          <source>Please check the password and try again.</source>
+          <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
           <source>Bitlocker error</source>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -859,6 +859,22 @@
           <source>Learn more about date formats</source>
           <target state="new">Learn more about date formats</target>
         </trans-unit>
+        <trans-unit id="BitlockerDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
+          <source>Unlock</source>
+          <target state="new">Unlock</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="new">Cancel</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
+          <source>Enter unlock password</source>
+          <target state="new">Enter unlock password</target>
+        </trans-unit>
+        <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Enter drive unlock password</source>
+          <target state="new">Enter drive unlock password</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -880,8 +880,8 @@
           <target state="new">Please check the password and try again.</target>
         </trans-unit>
         <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
-          <source>Bitlocker error</source>
-          <target state="new">Bitlocker error</target>
+          <source>BitLocker error</source>
+          <target state="new">BitLocker error</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -875,6 +875,14 @@
           <source>Password</source>
           <target state="new">Password</target>
         </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Text" translate="yes" xml:space="preserve">
+          <source>Could not unlock the drive. Wrong password?</source>
+          <target state="new">Could not unlock the drive. Wrong password?</target>
+        </trans-unit>
+        <trans-unit id="BitlockerInvalidPwDialog.Title" translate="yes" xml:space="preserve">
+          <source>Bitlocker error</source>
+          <target state="new">Bitlocker error</target>
+        </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>
           <target state="new">Contains:</target>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -868,12 +868,12 @@
           <target state="new">Cancel</target>
         </trans-unit>
         <trans-unit id="BitlockerDialog.Title" translate="yes" xml:space="preserve">
-          <source>Enter unlock password</source>
-          <target state="new">Enter unlock password</target>
+          <source>Enter password to unlock the drive</source>
+          <target state="new">Enter password to unlock the drive</target>
         </trans-unit>
         <trans-unit id="BitlockerDialogInputText.PlaceholderText" translate="yes" xml:space="preserve">
-          <source>Enter drive unlock password</source>
-          <target state="new">Enter drive unlock password</target>
+          <source>Password</source>
+          <target state="new">Password</target>
         </trans-unit>
         <trans-unit id="PropertiesFilesAndFoldersCount.Text" translate="yes" xml:space="preserve">
           <source>Contains:</source>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -772,7 +772,7 @@
     <value>Please check the password and try again.</value>
   </data>
   <data name="BitlockerInvalidPwDialog.Title" xml:space="preserve">
-    <value>Bitlocker error</value>
+    <value>BitLocker error</value>
   </data>
   <data name="PropertiesFilesAndFoldersCount.Text" xml:space="preserve">
     <value>Contains:</value>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -768,6 +768,12 @@
   <data name="BitlockerDialogInputText.PlaceholderText" xml:space="preserve">
     <value>Password</value>
   </data>
+  <data name="BitlockerInvalidPwDialog.Text" xml:space="preserve">
+    <value>Could not unlock the drive. Wrong password?</value>
+  </data>
+  <data name="BitlockerInvalidPwDialog.Title" xml:space="preserve">
+    <value>Bitlocker error</value>
+  </data>
   <data name="PropertiesFilesAndFoldersCount.Text" xml:space="preserve">
     <value>Contains:</value>
   </data>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -769,7 +769,7 @@
     <value>Password</value>
   </data>
   <data name="BitlockerInvalidPwDialog.Text" xml:space="preserve">
-    <value>Could not unlock the drive. Wrong password?</value>
+    <value>Please check the password and try again.</value>
   </data>
   <data name="BitlockerInvalidPwDialog.Title" xml:space="preserve">
     <value>Bitlocker error</value>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -756,6 +756,18 @@
   <data name="SettingsAppearanceDateFormatsTip.ToolTipService.ToolTip" xml:space="preserve">
     <value>Learn more about date formats</value>
   </data>
+  <data name="BitlockerDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Unlock</value>
+  </data>
+  <data name="BitlockerDialog.SecondaryButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="BitlockerDialog.Title" xml:space="preserve">
+    <value>Enter unlock password</value>
+  </data>
+  <data name="BitlockerDialogInputText.PlaceholderText" xml:space="preserve">
+    <value>Enter drive unlock password</value>
+  </data>
   <data name="PropertiesFilesAndFoldersCount.Text" xml:space="preserve">
     <value>Contains:</value>
   </data>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -763,10 +763,10 @@
     <value>Cancel</value>
   </data>
   <data name="BitlockerDialog.Title" xml:space="preserve">
-    <value>Enter unlock password</value>
+    <value>Enter password to unlock the drive</value>
   </data>
   <data name="BitlockerDialogInputText.PlaceholderText" xml:space="preserve">
-    <value>Enter drive unlock password</value>
+    <value>Password</value>
   </data>
   <data name="PropertiesFilesAndFoldersCount.Text" xml:space="preserve">
     <value>Contains:</value>

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -805,6 +805,25 @@ namespace Files.Filesystem
                     FileSize = null,
                     FileSizeBytes = 0
                 };
+                if (await CheckBitlockerStatus(_rootFolder))
+                {
+                    var bitlockerDialog = new Dialogs.BitlockerDialog(Path.GetPathRoot(WorkingDirectory));
+                    var bitlockerResult = await bitlockerDialog.ShowAsync();
+                    if (bitlockerResult == ContentDialogResult.Primary)
+                    {
+                        var userInput = bitlockerDialog.storedPasswordInput;
+                        if (App.Connection != null)
+                        {
+                            var value = new ValueSet();
+                            value.Add("Arguments", "Bitlocker");
+                            value.Add("action", "Unlock");
+                            value.Add("drive", Path.GetPathRoot(WorkingDirectory));
+                            value.Add("password", userInput);
+                            // Send request to fulltrust process to enumerate recyclebin items
+                            var response = await App.Connection.SendMessageAsync(value);
+                        }
+                    }
+                }
             }
             catch (UnauthorizedAccessException)
             {
@@ -813,13 +832,13 @@ namespace Files.Filesystem
             }
             catch (FileNotFoundException)
             {
-                await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("FolderNotFoundDialog.Title"), ResourceController.GetTranslation("FolderNotFoundDialog.Text"));
+                await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("FolderNotFoundDialog/Title"), ResourceController.GetTranslation("FolderNotFoundDialog/Text"));
                 IsLoadingItems = false;
                 return;
             }
             catch (Exception e)
             {
-                await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("DriveUnpluggedDialog.Title"), e.Message);
+                await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("DriveUnpluggedDialog/Title"), e.Message);
                 IsLoadingItems = false;
                 return;
             }
@@ -867,6 +886,16 @@ namespace Files.Filesystem
 
                 FindClose(hFile);
             }
+        }
+
+        private async Task<bool> CheckBitlockerStatus(StorageFolder rootFolder)
+        {
+            if (Path.IsPathRooted(WorkingDirectory) && Path.GetPathRoot(WorkingDirectory) == WorkingDirectory)
+            {
+                IDictionary<string, object> extraProperties = await rootFolder.Properties.RetrievePropertiesAsync(new string[] { "System.Volume.BitLockerProtection" });
+                return (int?)extraProperties["System.Volume.BitLockerProtection"] == 6; // Drive is bitlocker protected and locked
+            }
+            return false;
         }
 
         private void WatchForDirectoryChanges(string path)

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -819,8 +819,13 @@ namespace Files.Filesystem
                             value.Add("action", "Unlock");
                             value.Add("drive", Path.GetPathRoot(WorkingDirectory));
                             value.Add("password", userInput);
-                            // Send request to fulltrust process to enumerate recyclebin items
-                            var response = await App.Connection.SendMessageAsync(value);
+                            await App.Connection.SendMessageAsync(value);
+
+                            if (await CheckBitlockerStatus(_rootFolder))
+                            {
+                                // Drive is still locked
+                                await DialogDisplayHelper.ShowDialog(ResourceController.GetTranslation("BitlockerInvalidPwDialog/Title"), ResourceController.GetTranslation("BitlockerInvalidPwDialog/Text"));
+                            }
                         }
                     }
                 }

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -398,7 +398,7 @@ namespace Files
                 if (App.CurrentInstance.CurrentPageType == typeof(GenericFileBrowser))
                 {
                     var focusedElement = FocusManager.GetFocusedElement(XamlRoot) as FrameworkElement;
-                    if (focusedElement is TextBox)
+                    if (focusedElement is TextBox || focusedElement is PasswordBox)
                     {
                         return;
                     }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -300,7 +300,7 @@ namespace Files
                 if (App.CurrentInstance.CurrentPageType == typeof(GridViewBrowser) && !isRenamingItem)
                 {
                     var focusedElement = FocusManager.GetFocusedElement(XamlRoot) as FrameworkElement;
-                    if (focusedElement is TextBox)
+                    if (focusedElement is TextBox || focusedElement is PasswordBox)
                     {
                         return;
                     }


### PR DESCRIPTION
Fixes #1047
This PR adds support for bitlocker drives.
When the user clicks on a drive on the sidebar, this PR:
- checks is the drive is bitlocker-encrypted and locked
- displays a dialog to ask for password
- attempts to unlock the drive

Some testing on a pc different from mine is probably in order 😄