### PR TITLE
Fix NullReferenceException for some scenarios

### DIFF
--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -79,6 +79,8 @@ namespace Files.View_Models
 
         private async void PopulatePinnedSidebarItems()
         {
+            App.SidebarPinned = new SidebarPinnedModel();
+
             StorageFolder cacheFolder = ApplicationData.Current.LocalCacheFolder;
 
             StorageFile pinnedItemsFile;

--- a/Files/Views/InstanceTabsView.xaml.cs
+++ b/Files/Views/InstanceTabsView.xaml.cs
@@ -39,7 +39,6 @@ namespace Files
             tabView = TabStrip;
 
             App.AppSettings = new SettingsViewModel();
-            App.SidebarPinned = new SidebarPinnedModel();
             App.InteractionViewModel = new InteractionViewModel();
 
             // Turn on Navigation Cache


### PR DESCRIPTION
`new SidebarPinnedModel()` should be called before using.