### PR TITLE
Implemented tab drag and drop functionality

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -97,9 +97,9 @@ namespace Files.Interacts
             await LockScreen.SetImageFileAsync(file);
         }
 
-        public void OpenNewTab()
+        public async void OpenNewTab()
         {
-            MainPage.AddNewTab(typeof(ModernShellPage), ResourceController.GetTranslation("NewTab"));
+            await MainPage.AddNewTab(typeof(ModernShellPage), ResourceController.GetTranslation("NewTab"));
         }
 
         public async void OpenInNewWindowItem_Click(object sender, RoutedEventArgs e)
@@ -117,22 +117,22 @@ namespace Files.Interacts
         {
             foreach (ListedItem listedItem in CurrentInstance.ContentPage.SelectedItems)
             {
-                await CoreWindow.GetForCurrentThread().Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                await CoreWindow.GetForCurrentThread().Dispatcher.RunAsync(CoreDispatcherPriority.Low, async () =>
                 {
-                    MainPage.AddNewTab(typeof(ModernShellPage), listedItem.ItemPath);
+                    await MainPage.AddNewTab(typeof(ModernShellPage), listedItem.ItemPath);
                 });
             }
         }
 
-        public void OpenPathInNewTab(string path)
+        public async void OpenPathInNewTab(string path)
         {
-            MainPage.AddNewTab(typeof(ModernShellPage), path);
+            await MainPage.AddNewTab(typeof(ModernShellPage), path);
         }
 
-        public async void OpenPathInNewWindow(string path)
+        public static async Task<bool> OpenPathInNewWindow(string path)
         {
             var folderUri = new Uri("files-uwp:" + "?folder=" + path);
-            await Launcher.LaunchUriAsync(folderUri);
+            return await Launcher.LaunchUriAsync(folderUri);
         }
 
         public async void OpenDirectoryInTerminal(object sender, RoutedEventArgs e)
@@ -431,7 +431,7 @@ namespace Files.Interacts
                 {
                     foreach (ListedItem clickedOnItem in CurrentInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.Folder))
                     {
-                        MainPage.AddNewTab(typeof(ModernShellPage), clickedOnItem.ItemPath);
+                        await MainPage.AddNewTab(typeof(ModernShellPage), clickedOnItem.ItemPath);
                     }
                     foreach (ListedItem clickedOnItem in CurrentInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.File))
                     {
@@ -1352,9 +1352,9 @@ namespace Files.Interacts
                     .ContinueWith(async (x) =>
                 {
                     await destFolder_InBuffer.DeleteAsync(StorageDeleteOption.PermanentDelete);
-                    await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                    await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
                     {
-                        MainPage.AddNewTab(typeof(ModernShellPage), destinationPath + "\\" + selectedItem.DisplayName + "_Extracted");
+                        await MainPage.AddNewTab(typeof(ModernShellPage), destinationPath + "\\" + selectedItem.DisplayName + "_Extracted");
                     });
                 });
                 banner.Report(100);

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -834,4 +834,7 @@
   <data name="SettingsPreferencesAppLanguageRestartRequired.Text" xml:space="preserve">
     <value>Restart required</value>
   </data>
+  <data name="TabStripDragAndDropUIOverrideCaption" xml:space="preserve">
+    <value>Move tab here</value>
+  </data>
 </root>

--- a/Files/UserControls/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/ModernNavigationToolbar.xaml
@@ -799,7 +799,7 @@
                 x:Load="{x:Bind AppSettings.IsMultitaskingControlVisible, Mode=OneWay}"
                 Visibility="Visible">
                 <Button.Flyout>
-                    <Flyout Opened="Flyout_Opened" Closed="Flyout_Closed">
+                    <Flyout x:Name="VerticalTabViewFlyout" Opened="Flyout_Opened" Closed="Flyout_Closed">
                         <local:VerticalTabView
                             Margin="-6"
                             x:Name="verticalTabs"

--- a/Files/UserControls/ModernNavigationToolbar.xaml.cs
+++ b/Files/UserControls/ModernNavigationToolbar.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Files.Filesystem;
 using Files.Interacts;
 using Files.View_Models;
+using Files.Views;
 using Files.Views.Pages;
 using System;
 using System.Collections.ObjectModel;
@@ -27,6 +28,13 @@ namespace Files.UserControls
         public ModernNavigationToolbar()
         {
             this.InitializeComponent();
+
+            MainPage.OnTabItemDraggedOver += MainPage_OnTabItemDraggedOver;
+        }
+
+        private void MainPage_OnTabItemDraggedOver(object sender, bool e)
+        {
+            VerticalTabViewFlyout.ShowAt(VerticalTabStripInvokeButton);
         }
 
         private bool manualEntryBoxLoaded = false;

--- a/Files/UserControls/SidebarControl.cs
+++ b/Files/UserControls/SidebarControl.cs
@@ -1,4 +1,5 @@
 ﻿using Files.Filesystem;
+using Files.Interacts;
 using Files.View_Models;
 using System;
 using System.ComponentModel;
@@ -183,9 +184,9 @@ namespace Files.Controls
             App.CurrentInstance.InteractionOperations.OpenPathInNewTab(App.rightClickedItem.Path.ToString());
         }
 
-        private void OpenInNewWindow_Click(object sender, RoutedEventArgs e)
+        private async void OpenInNewWindow_Click(object sender, RoutedEventArgs e)
         {
-            App.CurrentInstance.InteractionOperations.OpenPathInNewWindow(App.rightClickedItem.Path.ToString());
+            await Interaction.OpenPathInNewWindow(App.rightClickedItem.Path.ToString());
         }
     }
 

--- a/Files/UserControls/VerticalTabView.xaml
+++ b/Files/UserControls/VerticalTabView.xaml
@@ -548,7 +548,14 @@
             AddTabButtonClick="verticalTabView_AddTabButtonClick"
             SelectionChanged="TabStrip_SelectionChanged"
             TabCloseRequested="TabStrip_TabCloseRequested"
-            TabWidthMode="Equal">
+            TabWidthMode="Equal"
+            CanDragTabs="True"
+            AllowDropTabs="True"
+            TabDragStarting="TabStrip_TabDragStarting"
+            TabStripDragOver="TabStrip_TabStripDragOver"
+            TabStripDrop="TabStrip_TabStripDrop"
+            TabDragCompleted="TabStrip_TabDragCompleted"
+            TabDroppedOutside="TabStrip_TabDroppedOutside">
             <muxc:TabView.Resources>
                 <StaticResource x:Key="TabViewItemHeaderBackgroundSelected" ResourceKey="ApplicationPageBackgroundThemeBrush" />
                 <Thickness x:Key="TabViewHeaderPadding">0,0,0,0</Thickness>


### PR DESCRIPTION
Implemented tab drag and drop functionality across app instances, dragging tab outside creates a new instance of the app.

![gPm3JA3lLr](https://user-images.githubusercontent.com/51203900/87363307-7eb46180-c58e-11ea-84ef-2da90eb4324b.gif)

Also fixed opening new window by providing custom path.