### PR TITLE
Fixed several rename issues

### DIFF
--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -251,9 +251,14 @@ namespace Files
 
             if (AppSettings.DoubleTapToRenameFiles == false) // Check if the double tap to rename files setting is off
             {
-                AllView.CancelEdit(); // Cancel the edit operation
-                App.CurrentInstance.InteractionOperations.OpenItem_Click(null, null); // Open the file instead
-                return;
+                // Only cancel if this event was triggered by a tap
+                // Do not cancel when user presses F2 or context menu
+                if (e.EditingEventArgs is TappedRoutedEventArgs)
+                {
+                    AllView.CancelEdit(); // Cancel the edit operation
+                    App.CurrentInstance.InteractionOperations.OpenItem_Click(null, null); // Open the file instead
+                    return;
+                }
             }
 
             int extensionLength = SelectedItem.FileExtension?.Length ?? 0;

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -288,7 +288,7 @@ namespace Files
 
         private async void AllView_CellEditEnding(object sender, DataGridCellEditEndingEventArgs e)
         {
-            if (e.EditAction == DataGridEditAction.Cancel)
+            if (e.EditAction == DataGridEditAction.Cancel || renamingTextBox == null)
             {
                 return;
             }
@@ -308,7 +308,10 @@ namespace Files
 
         private void AllView_CellEditEnded(object sender, DataGridCellEditEndedEventArgs e)
         {
-            renamingTextBox.TextChanged -= TextBox_TextChanged;
+            if (renamingTextBox != null)
+            {
+                renamingTextBox.TextChanged -= TextBox_TextChanged;
+            }
             FileNameTeachingTip.IsOpen = false;
             isRenamingItem = false;
         }


### PR DESCRIPTION
Fixes #1713, fixes #1626, fixes #1451

Fix crash when trying to rename a file with "double tap to rename files" turned off

Related AppCenter issues: [1](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/64750744u/overview), [2](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/2181257174u/overview)
