### PR TITLE
Continue where you left off fixes

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -415,7 +415,7 @@ namespace Files
 
         private void SaveSessionTabs() // Enumerates through all tabs and gets the Path property and saves it to AppSettings.LastSessionPages
         {
-            AppSettings.LastSessionPages = MainPage.AppInstances.Select(x => x.Path ?? ResourceController.GetTranslation("NewTab")).ToArray();
+            AppSettings.LastSessionPages = MainPage.AppInstances.DefaultIfEmpty().Select(x => x != null ? x.Path : ResourceController.GetTranslation("NewTab")).ToArray();
         }
 
         // Occurs when an exception is not handled on the UI thread.

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
@@ -343,6 +343,7 @@ namespace Files.UserControls
         {
             if (Items.Count == 1)
             {
+                MainPage.AppInstances.Remove(tabItem);
                 await ApplicationView.GetForCurrentView().TryConsolidateAsync();
             }
             else if (Items.Count > 1)

--- a/Files/UserControls/MultitaskingControl/VerticalTabView.xaml.cs
+++ b/Files/UserControls/MultitaskingControl/VerticalTabView.xaml.cs
@@ -333,6 +333,7 @@ namespace Files.UserControls
         {
             if (Items.Count == 1)
             {
+                MainPage.AppInstances.Remove(tabItem);
                 App.CloseApp();
             }
             else if (Items.Count > 1)

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -111,6 +111,7 @@ namespace Files.Views
                                 {
                                     await AddNewTab(typeof(ModernShellPage), path);
                                 }
+                                App.AppSettings.LastSessionPages = new string[] { ResourceController.GetTranslation("NewTab") };
                             }
                             else
                             {


### PR DESCRIPTION
Fixed:
- When opening second instance while first one is already opened, saved tabpages won't be transferred
- When closing last tabpage, launching new instance won't have path of last session closed tabpage 