### PR TITLE
Improve codebase quality in properties

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -443,6 +443,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="ResourceDictionaries\PropertiesStyles.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="ResourceDictionaries\TabView_themeresources.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -263,6 +263,7 @@
     <Compile Include="View Models\Properties\DriveProperties.cs" />
     <Compile Include="View Models\Properties\FileProperties.cs" />
     <Compile Include="View Models\Properties\FolderProperties.cs" />
+    <Compile Include="View Models\Properties\PropertiesTab.cs" />
     <Compile Include="Views\LayoutModes\GenericFileBrowser.xaml.cs">
       <DependentUpon>GenericFileBrowser.xaml</DependentUpon>
     </Compile>

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -188,6 +188,9 @@
     <Compile Include="Program.cs" />
     <Compile Include="ResourceController.cs" />
     <Compile Include="INavigationToolbar.cs" />
+    <Compile Include="UserControls\FileIcon.xaml.cs">
+      <DependentUpon>FileIcon.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UserControls\MenuFlyoutItemWithImage.xaml.cs">
       <DependentUpon>MenuFlyoutItemWithImage.xaml</DependentUpon>
     </Compile>
@@ -443,6 +446,10 @@
     <Page Include="ResourceDictionaries\TabView_themeresources.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UserControls\FileIcon.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="UserControls\MenuFlyoutItemWithImage.xaml">
       <SubType>Designer</SubType>

--- a/Files/ResourceDictionaries/PropertiesStyles.xaml
+++ b/Files/ResourceDictionaries/PropertiesStyles.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Files.ResourceDictionaries">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Style TargetType="StackPanel" x:Key="PropertiesTab">
         <Setter Property="Padding" Value="14,0,14,14"/>

--- a/Files/ResourceDictionaries/PropertiesStyles.xaml
+++ b/Files/ResourceDictionaries/PropertiesStyles.xaml
@@ -32,7 +32,7 @@
         <Setter Property="IsTextSelectionEnabled" Value="True"/>
     </Style>
 
-    <Style TargetType="TextBox" x:Key="PropertyValueTextBox">
+    <Style TargetType="TextBox" BasedOn="{StaticResource DefaultTextBoxStyle}" x:Key="PropertyValueTextBox">
         <Setter Property="Margin" Value="{StaticResource PropertyValueMargin}"/>
         <Setter Property="VerticalAlignment" Value="{StaticResource PropertyValueVerticalAlignment}"/>
         <Setter Property="HorizontalAlignment" Value="Stretch"/>

--- a/Files/ResourceDictionaries/PropertiesStyles.xaml
+++ b/Files/ResourceDictionaries/PropertiesStyles.xaml
@@ -1,0 +1,42 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Files.ResourceDictionaries">
+
+    <Style TargetType="StackPanel" x:Key="PropertiesTab">
+        <Setter Property="Padding" Value="14,0,14,14"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+    </Style>
+
+    <Thickness x:Key="PropertyNameMargin">0,7</Thickness>
+    <Thickness x:Key="PropertyValueMargin">20,0,0,0</Thickness>
+    <VerticalAlignment x:Key="PropertyValueVerticalAlignment">Center</VerticalAlignment>
+
+    <Style TargetType="TextBlock" x:Key="PropertyName">
+        <Setter Property="Margin" Value="{StaticResource PropertyNameMargin}"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+
+    <Style TargetType="Grid" x:Key="PropertyValueGrid">
+        <Setter Property="Margin" Value="{StaticResource PropertyValueMargin}"/>
+        <Setter Property="VerticalAlignment" Value="{StaticResource PropertyValueVerticalAlignment}"/>
+    </Style>
+
+    <Style TargetType="Grid" x:Key="PropertyValueStackPanel">
+        <Setter Property="Margin" Value="{StaticResource PropertyValueMargin}"/>
+        <Setter Property="VerticalAlignment" Value="{StaticResource PropertyValueVerticalAlignment}"/>
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="PropertyValueTextBlock">
+        <Setter Property="Margin" Value="{StaticResource PropertyValueMargin}"/>
+        <Setter Property="VerticalAlignment" Value="{StaticResource PropertyValueVerticalAlignment}"/>
+        <Setter Property="IsTextSelectionEnabled" Value="True"/>
+    </Style>
+
+    <Style TargetType="TextBox" x:Key="PropertyValueTextBox">
+        <Setter Property="Margin" Value="{StaticResource PropertyValueMargin}"/>
+        <Setter Property="VerticalAlignment" Value="{StaticResource PropertyValueVerticalAlignment}"/>
+        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Setter Property="BorderThickness" Value="1"/>
+    </Style>
+</ResourceDictionary>

--- a/Files/UserControls/FileIcon.xaml
+++ b/Files/UserControls/FileIcon.xaml
@@ -1,0 +1,67 @@
+﻿<UserControl
+    x:Class="Files.UserControls.FileIcon"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Files.UserControls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <StackPanel>
+        <Image
+            x:Name="FolderGlyphIcon"
+            Width="{x:Bind ItemSize}"
+            Height="{x:Bind ItemSize}"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            x:Load="{x:Bind ViewModel.LoadFolderGlyph}"
+            Stretch="Uniform">
+            <Image.Source>
+                <SvgImageSource
+                    RasterizePixelHeight="128"
+                    RasterizePixelWidth="128"
+                    UriSource="{x:Bind ViewModel.FolderIconSource}" />
+            </Image.Source>
+        </Image>
+        <FontIcon
+            x:Name="EmptyImageIcon"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Stretch"
+            x:Load="{x:Bind ViewModel.LoadUnknownTypeGlyph, Mode=OneWay}"
+            FontFamily="{StaticResource FluentUIGlyphs}"
+            FontSize="{x:Bind ItemSize}"
+            Glyph="&#xea00;" />
+        <FontIcon
+            x:Name="CombinedItemsIcon"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Stretch"
+            x:Load="{x:Bind ViewModel.LoadCombinedItemsGlyph, Mode=OneWay}"
+            FontFamily="{StaticResource CustomGlyph}"
+            FontSize="{x:Bind LargerItemSize}"
+            Glyph="&#xF109;" />
+        <FontIcon
+            x:Name="DriveItemIcon"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Stretch"
+            x:Load="{x:Bind ViewModel.LoadDriveItemGlyph, Mode=OneWay}"
+            FontFamily="{StaticResource FluentUIGlyphs}"
+            FontSize="{x:Bind LargerItemSize}"
+            Glyph="{x:Bind ViewModel.DriveItemGlyphSource, Mode=OneWay}" />
+        <FontIcon
+            x:Name="WebShortcutGlyph"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Stretch"
+            x:Load="{x:Bind ViewModel.LoadLinkIcon, Mode=OneWay}"
+            FontFamily="{StaticResource FluentUIGlyphs}"
+            FontSize="{x:Bind ItemSize}"
+            Glyph="&#xEAAB;" />
+        <Image
+            x:Name="ItemIcon"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            x:Load="{x:Bind ViewModel.LoadFileIcon, Mode=OneWay}"
+            Source="{x:Bind ViewModel.FileIconSource, Mode=OneWay}" />
+    </StackPanel>
+</UserControl>

--- a/Files/UserControls/FileIcon.xaml.cs
+++ b/Files/UserControls/FileIcon.xaml.cs
@@ -1,0 +1,29 @@
+﻿using Files.View_Models;
+using Windows.UI.Xaml.Controls;
+
+namespace Files.UserControls
+{
+    public sealed partial class FileIcon : UserControl
+    {
+        private double itemSize;
+
+        public SelectedItemsPropertiesViewModel ViewModel { get; set; }
+        public double ItemSize { get; set; }
+
+        public double Size
+        {
+            get => itemSize;
+            set
+            {
+                itemSize = value;
+                LargerItemSize = itemSize + 2.0;
+            }
+        }
+        private double LargerItemSize { get; set; }
+        
+        public FileIcon()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/Files/UserControls/FileIcon.xaml.cs
+++ b/Files/UserControls/FileIcon.xaml.cs
@@ -5,12 +5,10 @@ namespace Files.UserControls
 {
     public sealed partial class FileIcon : UserControl
     {
-        private double itemSize;
-
         public SelectedItemsPropertiesViewModel ViewModel { get; set; }
-        public double ItemSize { get; set; }
 
-        public double Size
+        private double itemSize;
+        public double ItemSize
         {
             get => itemSize;
             set
@@ -20,7 +18,7 @@ namespace Files.UserControls
             }
         }
         private double LargerItemSize { get; set; }
-        
+
         public FileIcon()
         {
             this.InitializeComponent();

--- a/Files/View Models/Properties/PropertiesTab.cs
+++ b/Files/View Models/Properties/PropertiesTab.cs
@@ -1,0 +1,50 @@
+﻿using Files.Filesystem;
+using System.Collections.Generic;
+using Windows.Storage;
+using Windows.UI.Core;
+using Windows.UI.Xaml.Navigation;
+
+namespace Files.View_Models.Properties
+{
+    class PropertiesTab
+    {
+        public BaseProperties BaseProperties { get; set; }
+
+        public SelectedItemsPropertiesViewModel ViewModel { get; set; }
+
+        public void HandlePropertiesLoaded()
+        {
+            if (BaseProperties != null)
+            {
+                BaseProperties.GetSpecialProperties();
+            }
+        }
+
+        public void HandleNavigation(NavigationEventArgs e, CoreDispatcher dispatcher)
+        {
+            ViewModel = new SelectedItemsPropertiesViewModel();
+            var np = e.Parameter as Files.Properties.PropertyNavParam;
+
+            if (np.navParameter is ListedItem)
+            {
+                var listedItem = np.navParameter as ListedItem;
+                if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
+                {
+                    BaseProperties = new FileProperties(ViewModel, np.tokenSource, dispatcher, null, listedItem);
+                }
+                else if (listedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
+                {
+                    BaseProperties = new FolderProperties(ViewModel, np.tokenSource, dispatcher, listedItem);
+                }
+            }
+            else if (np.navParameter is List<ListedItem>)
+            {
+                BaseProperties = new CombinedProperties(ViewModel, np.tokenSource, dispatcher, np.navParameter as List<ListedItem>);
+            }
+            else if (np.navParameter is DriveItem)
+            {
+                BaseProperties = new DriveProperties(ViewModel, np.navParameter as DriveItem);
+            }
+        }
+    }
+}

--- a/Files/View Models/Properties/PropertiesTab.cs
+++ b/Files/View Models/Properties/PropertiesTab.cs
@@ -1,18 +1,19 @@
 ﻿using Files.Filesystem;
 using System.Collections.Generic;
 using Windows.Storage;
-using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
 namespace Files.View_Models.Properties
 {
-    class PropertiesTab
+    public abstract class PropertiesTab : Page
     {
         public BaseProperties BaseProperties { get; set; }
 
         public SelectedItemsPropertiesViewModel ViewModel { get; set; }
 
-        public void HandlePropertiesLoaded()
+        protected void Properties_Loaded(object sender, RoutedEventArgs e)
         {
             if (BaseProperties != null)
             {
@@ -20,7 +21,7 @@ namespace Files.View_Models.Properties
             }
         }
 
-        public void HandleNavigation(NavigationEventArgs e, CoreDispatcher dispatcher)
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             ViewModel = new SelectedItemsPropertiesViewModel();
             var np = e.Parameter as Files.Properties.PropertyNavParam;
@@ -30,21 +31,23 @@ namespace Files.View_Models.Properties
                 var listedItem = np.navParameter as ListedItem;
                 if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
                 {
-                    BaseProperties = new FileProperties(ViewModel, np.tokenSource, dispatcher, null, listedItem);
+                    BaseProperties = new FileProperties(ViewModel, np.tokenSource, Dispatcher, null, listedItem);
                 }
                 else if (listedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    BaseProperties = new FolderProperties(ViewModel, np.tokenSource, dispatcher, listedItem);
+                    BaseProperties = new FolderProperties(ViewModel, np.tokenSource, Dispatcher, listedItem);
                 }
             }
             else if (np.navParameter is List<ListedItem>)
             {
-                BaseProperties = new CombinedProperties(ViewModel, np.tokenSource, dispatcher, np.navParameter as List<ListedItem>);
+                BaseProperties = new CombinedProperties(ViewModel, np.tokenSource, Dispatcher, np.navParameter as List<ListedItem>);
             }
             else if (np.navParameter is DriveItem)
             {
                 BaseProperties = new DriveProperties(ViewModel, np.navParameter as DriveItem);
             }
+
+            base.OnNavigatedTo(e);
         }
     }
 }

--- a/Files/View Models/Properties/PropertiesTab.cs
+++ b/Files/View Models/Properties/PropertiesTab.cs
@@ -13,6 +13,8 @@ namespace Files.View_Models.Properties
 
         public SelectedItemsPropertiesViewModel ViewModel { get; set; }
 
+        protected Microsoft.UI.Xaml.Controls.ProgressBar ItemMD5HashProgress = null;
+
         protected void Properties_Loaded(object sender, RoutedEventArgs e)
         {
             if (BaseProperties != null)
@@ -31,7 +33,7 @@ namespace Files.View_Models.Properties
                 var listedItem = np.navParameter as ListedItem;
                 if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
                 {
-                    BaseProperties = new FileProperties(ViewModel, np.tokenSource, Dispatcher, null, listedItem);
+                    BaseProperties = new FileProperties(ViewModel, np.tokenSource, Dispatcher, ItemMD5HashProgress, listedItem);
                 }
                 else if (listedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {

--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -167,7 +167,7 @@
                 x:Name="ItemMD5HashProgress"
                 Grid.Row="6"
                 Grid.Column="1"
-                Margin="20,0,0,0"
+                Margin="{StaticResource PropertyValueMargin}"
                 VerticalAlignment="Center"
                 ShowError="{x:Bind ViewModel.ItemMD5HashCalcError, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.ItemMD5HashProgressVisibility, Mode=OneWay}" />

--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -55,7 +55,7 @@
                 Margin="{StaticResource PropertyNameMargin}"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-                <usercontrols:FileIcon ViewModel="{x:Bind ViewModel}" ItemSize="70"/>
+                <usercontrols:FileIcon ViewModel="{x:Bind PropertiesTab.ViewModel}" ItemSize="70"/>
             </Grid>
             <TextBox
                 x:Name="ItemFileName"
@@ -63,8 +63,8 @@
                 Grid.Row="0"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
-                Text="{x:Bind ViewModel.ItemName, Mode=TwoWay}"
-                Visibility="{x:Bind ViewModel.ItemNameVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.ItemName, Mode=TwoWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemNameVisibility, Mode=OneWay}" />
 
             <MenuFlyoutSeparator
                 Grid.Row="1"
@@ -79,14 +79,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Item type:"
-                Visibility="{x:Bind ViewModel.ItemTypeVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemTypeVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemTypeValue"
                 Grid.Row="2"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.ItemType, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.ItemTypeVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.ItemType, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemTypeVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesDriveFileSystem"
@@ -94,14 +94,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="File system:"
-                Visibility="{x:Bind ViewModel.DriveFileSystemVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.DriveFileSystemVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="DriveFileSystemValue"
                 Grid.Row="3"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.DriveFileSystem, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.DriveFileSystemVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.DriveFileSystem, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.DriveFileSystemVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesItemPath"
@@ -109,15 +109,15 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Path:"
-                Visibility="{x:Bind ViewModel.ItemPathVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemPathVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemPathValue"
                 Grid.Row="4"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.ItemPath, Mode=OneWay}"
+                Text="{x:Bind PropertiesTab.ViewModel.ItemPath, Mode=OneWay}"
                 TextWrapping="Wrap"
-                Visibility="{x:Bind ViewModel.ItemPathVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemPathVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesItemSize"
@@ -125,12 +125,12 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Size:"
-                Visibility="{x:Bind ViewModel.ItemSizeVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemSizeVisibility, Mode=OneWay}" />
             <Grid
                 Grid.Row="5"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueGrid}"
-                Visibility="{x:Bind ViewModel.ItemSizeVisibility, Mode=OneWay}">
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemSizeVisibility, Mode=OneWay}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" MinWidth="100" />
                     <ColumnDefinition Width="*" />
@@ -139,13 +139,13 @@
                     x:Name="itemSizeValue"
                     Grid.Column="0"
                     IsTextSelectionEnabled="True"
-                    Text="{x:Bind ViewModel.ItemSize, Mode=OneWay}" />
+                    Text="{x:Bind PropertiesTab.ViewModel.ItemSize, Mode=OneWay}" />
                 <muxc:ProgressRing
                     x:Name="ItemSizeProgress"
                     Grid.Column="1"
                     Margin="0,-10"
                     HorizontalAlignment="Left"
-                    Visibility="{x:Bind ViewModel.ItemSizeProgressVisibility, Mode=OneWay}" />
+                    Visibility="{x:Bind PropertiesTab.ViewModel.ItemSizeProgressVisibility, Mode=OneWay}" />
             </Grid>
 
             <TextBlock
@@ -155,22 +155,22 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="MD5Hash:"
-                Visibility="{x:Bind ViewModel.ItemMD5HashVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemMD5HashVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemMD5HashValue"
                 Grid.Row="6"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.ItemMD5Hash, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.ItemMD5HashVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.ItemMD5Hash, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemMD5HashVisibility, Mode=OneWay}" />
             <muxc:ProgressBar
                 x:Name="ItemMD5HashProgress"
                 Grid.Row="6"
                 Grid.Column="1"
                 Margin="20,0,0,0"
                 VerticalAlignment="Center"
-                ShowError="{x:Bind ViewModel.ItemMD5HashCalcError, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.ItemMD5HashProgressVisibility, Mode=OneWay}" />
+                ShowError="{x:Bind PropertiesTab.ViewModel.ItemMD5HashCalcError, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemMD5HashProgressVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Name="PropertiesCount"
@@ -179,14 +179,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Contains:"
-                Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemFilesAndFoldersCountValue"
                 Grid.Row="7"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.FilesAndFoldersCountString, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.FilesAndFoldersCountString, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
 
             <MenuFlyoutSeparator
                 Grid.Row="8"
@@ -199,7 +199,7 @@
                 Grid.Column="0"
                 Margin="0,7"
                 Orientation="Horizontal"
-                Visibility="{x:Bind ViewModel.DriveUsedSpaceVisibiity, Mode=OneWay}">
+                Visibility="{x:Bind PropertiesTab.ViewModel.DriveUsedSpaceVisibiity, Mode=OneWay}">
                 <Rectangle
                     Width="15"
                     Height="15"
@@ -217,15 +217,15 @@
                 Grid.Row="9"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.DriveUsedSpace, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.DriveUsedSpaceVisibiity, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.DriveUsedSpace, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.DriveUsedSpaceVisibiity, Mode=OneWay}" />
 
             <StackPanel
                 Grid.Row="10"
                 Grid.Column="0"
                 Margin="{StaticResource PropertyNameMargin}"
                 Orientation="Horizontal"
-                Visibility="{x:Bind ViewModel.DriveFreeSpaceVisibiity, Mode=OneWay}">
+                Visibility="{x:Bind PropertiesTab.ViewModel.DriveFreeSpaceVisibiity, Mode=OneWay}">
                 <Rectangle
                     Width="15"
                     Height="15"
@@ -242,8 +242,8 @@
                 Grid.Row="10"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.DriveFreeSpace, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.DriveFreeSpaceVisibiity, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.DriveFreeSpace, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.DriveFreeSpaceVisibiity, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesCreated"
@@ -251,14 +251,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Created:"
-                Visibility="{x:Bind ViewModel.ItemCreatedTimestampVisibiity, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemCreatedTimestampVisibiity, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemCreatedTimestampValue"
                 Grid.Row="11"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.ItemCreatedTimestamp, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.ItemCreatedTimestampVisibiity, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.ItemCreatedTimestamp, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemCreatedTimestampVisibiity, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesModified"
@@ -266,14 +266,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Modified:"
-                Visibility="{x:Bind ViewModel.ItemModifiedTimestampVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemModifiedTimestampVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemModifiedTimestampValue"
                 Grid.Row="12"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.ItemModifiedTimestamp, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.ItemModifiedTimestampVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.ItemModifiedTimestamp, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemModifiedTimestampVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesAccessed"
@@ -281,14 +281,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Accessed:"
-                Visibility="{x:Bind ViewModel.ItemAccessedTimestampVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemAccessedTimestampVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemAccessedTimestampValue"
                 Grid.Row="13"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.ItemAccessedTimestamp, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.ItemAccessedTimestampVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.ItemAccessedTimestamp, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemAccessedTimestampVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesOwner"
@@ -296,21 +296,21 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Owner:"
-                Visibility="{x:Bind ViewModel.ItemFileOwnerVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemFileOwnerVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Uid="ItemFileOwnerValue"
                 Grid.Row="14"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.ItemFileOwner, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.ItemFileOwnerVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.ItemFileOwner, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemFileOwnerVisibility, Mode=OneWay}" />
 
             <MenuFlyoutSeparator
                 Grid.Row="15"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"
                 Margin="-12,0"
-                Visibility="{x:Bind ViewModel.LastSeparatorVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.LastSeparatorVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesDriveCapacity"
@@ -318,14 +318,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Capacity:"
-                Visibility="{x:Bind ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
             <TextBlock
                 x:Uid="driveCapacityValue"
                 Grid.Row="16"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.DriveCapacity, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.DriveCapacity, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
 
             <toolkit:RadialProgressBar
                 Grid.Row="17"
@@ -335,12 +335,12 @@
                 Height="70"
                 Margin="10"
                 Foreground="DodgerBlue"
-                Maximum="{x:Bind ViewModel.DriveCapacityDoubleValue, Mode=OneWay}"
+                Maximum="{x:Bind PropertiesTab.ViewModel.DriveCapacityDoubleValue, Mode=OneWay}"
                 Minimum="0"
                 Outline="Gray"
                 Thickness="10"
-                Visibility="{x:Bind ViewModel.DriveCapacityVisibiity, Mode=OneWay}"
-                Value="{x:Bind ViewModel.DriveUsedSpaceDoubleValue, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.DriveCapacityVisibiity, Mode=OneWay}"
+                Value="{x:Bind PropertiesTab.ViewModel.DriveUsedSpaceDoubleValue, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesAttributes"
@@ -350,7 +350,7 @@
                 VerticalAlignment="Center"
                 FontWeight="SemiBold"
                 Text="Attributes:"
-                Visibility="{x:Bind ViewModel.ItemAttributesVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemAttributesVisibility, Mode=OneWay}" />
             <StackPanel
                 Grid.Row="18"
                 Grid.Column="1"
@@ -358,7 +358,7 @@
                 VerticalAlignment="Center"
                 Orientation="Horizontal"
                 Spacing="16"
-                Visibility="{x:Bind ViewModel.ItemAttributesVisibility, Mode=OneWay}">
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemAttributesVisibility, Mode=OneWay}">
                 <CheckBox
                     x:Uid="PropertiesDialogReadOnly"
                     Content="Read-only"

--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -4,13 +4,22 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Files.Views.Pages"
+    xmlns:usercontrols="using:Files.UserControls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
     Loaded="Properties_Loaded"
     mc:Ignorable="d">
 
-    <StackPanel Padding="14,0,14,14" VerticalAlignment="Top">
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <StackPanel Style="{StaticResource PropertiesTab}">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -43,72 +52,17 @@
                 Grid.Column="0"
                 Width="80"
                 Height="80"
-                Margin="0,7"
+                Margin="{StaticResource PropertyNameMargin}"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-                <Image
-                    x:Name="FolderGlyphIcon"
-                    Width="70"
-                    Height="70"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    x:Load="{x:Bind ViewModel.LoadFolderGlyph}"
-                    Stretch="Uniform">
-                    <Image.Source>
-                        <SvgImageSource
-                            RasterizePixelHeight="128"
-                            RasterizePixelWidth="128"
-                            UriSource="{x:Bind ViewModel.FolderIconSource}" />
-                    </Image.Source>
-                </Image>
-                <FontIcon
-                    x:Name="EmptyImageIcon"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Stretch"
-                    x:Load="{x:Bind ViewModel.LoadUnknownTypeGlyph, Mode=OneWay}"
-                    FontFamily="{StaticResource FluentUIGlyphs}"
-                    FontSize="70"
-                    Glyph="&#xea00;" />
-                <FontIcon
-                    x:Name="CombinedItemsIcon"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Stretch"
-                    x:Load="{x:Bind ViewModel.LoadCombinedItemsGlyph, Mode=OneWay}"
-                    FontFamily="{StaticResource CustomGlyph}"
-                    FontSize="72"
-                    Glyph="&#xF109;" />
-                <FontIcon
-                    x:Name="DriveItemIcon"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Stretch"
-                    x:Load="{x:Bind ViewModel.LoadDriveItemGlyph, Mode=OneWay}"
-                    FontFamily="{StaticResource FluentUIGlyphs}"
-                    FontSize="70"
-                    Glyph="{x:Bind ViewModel.DriveItemGlyphSource, Mode=OneWay}" />
-                <FontIcon
-                    x:Name="WebShortcutGlyph"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Stretch"
-                    x:Load="{x:Bind ViewModel.LoadLinkIcon, Mode=OneWay}"
-                    FontFamily="{StaticResource FluentUIGlyphs}"
-                    FontSize="70"
-                    Glyph="&#xEAAB;" />
-                <Image
-                    x:Name="itemIcon"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    x:Load="{x:Bind ViewModel.LoadFileIcon, Mode=OneWay}"
-                    Source="{x:Bind ViewModel.FileIconSource, Mode=OneWay}" />
+                <usercontrols:FileIcon ViewModel="{x:Bind ViewModel}" ItemSize="70"/>
             </Grid>
             <TextBox
                 x:Name="ItemFileName"
                 x:Uid="PropertiesItemFileName"
                 Grid.Row="0"
                 Grid.Column="1"
-                Margin="20,0"
-                HorizontalAlignment="Stretch"
-                VerticalAlignment="Center"
-                BorderThickness="1"
+                Style="{StaticResource PropertyValueTextBox}"
                 Text="{x:Bind ViewModel.ItemName, Mode=TwoWay}"
                 Visibility="{x:Bind ViewModel.ItemNameVisibility, Mode=OneWay}" />
 
@@ -123,17 +77,14 @@
                 x:Uid="PropertiesItemType"
                 Grid.Row="2"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Item type:"
                 Visibility="{x:Bind ViewModel.ItemTypeVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemTypeValue"
                 Grid.Row="2"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.ItemType, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.ItemTypeVisibility, Mode=OneWay}" />
 
@@ -141,17 +92,14 @@
                 x:Uid="PropertiesDriveFileSystem"
                 Grid.Row="3"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="File system:"
                 Visibility="{x:Bind ViewModel.DriveFileSystemVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="DriveFileSystemValue"
                 Grid.Row="3"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.DriveFileSystem, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.DriveFileSystemVisibility, Mode=OneWay}" />
 
@@ -159,17 +107,14 @@
                 x:Uid="PropertiesItemPath"
                 Grid.Row="4"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Path:"
                 Visibility="{x:Bind ViewModel.ItemPathVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemPathValue"
                 Grid.Row="4"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.ItemPath, Mode=OneWay}"
                 TextWrapping="Wrap"
                 Visibility="{x:Bind ViewModel.ItemPathVisibility, Mode=OneWay}" />
@@ -178,15 +123,13 @@
                 x:Uid="PropertiesItemSize"
                 Grid.Row="5"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Size:"
                 Visibility="{x:Bind ViewModel.ItemSizeVisibility, Mode=OneWay}" />
             <Grid
                 Grid.Row="5"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
+                Style="{StaticResource PropertyValueGrid}"
                 Visibility="{x:Bind ViewModel.ItemSizeVisibility, Mode=OneWay}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" MinWidth="100" />
@@ -210,17 +153,14 @@
                 x:Uid="PropertiesItemMD5Hash"
                 Grid.Row="6"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="MD5Hash:"
                 Visibility="{x:Bind ViewModel.ItemMD5HashVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemMD5HashValue"
                 Grid.Row="6"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.ItemMD5Hash, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.ItemMD5HashVisibility, Mode=OneWay}" />
             <muxc:ProgressBar
@@ -237,17 +177,14 @@
                 x:Uid="PropertiesFilesAndFoldersCount"
                 Grid.Row="7"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Contains:"
                 Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemFilesAndFoldersCountValue"
                 Grid.Row="7"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.FilesAndFoldersCountString, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
 
@@ -279,16 +216,14 @@
                 x:Name="driveUsedSpaceValue"
                 Grid.Row="9"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.DriveUsedSpace, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.DriveUsedSpaceVisibiity, Mode=OneWay}" />
 
             <StackPanel
                 Grid.Row="10"
                 Grid.Column="0"
-                Margin="0,7"
+                Margin="{StaticResource PropertyNameMargin}"
                 Orientation="Horizontal"
                 Visibility="{x:Bind ViewModel.DriveFreeSpaceVisibiity, Mode=OneWay}">
                 <Rectangle
@@ -306,9 +241,7 @@
                 x:Name="driveFreeSpaceValue"
                 Grid.Row="10"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.DriveFreeSpace, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.DriveFreeSpaceVisibiity, Mode=OneWay}" />
 
@@ -316,17 +249,14 @@
                 x:Uid="PropertiesCreated"
                 Grid.Row="11"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Created:"
                 Visibility="{x:Bind ViewModel.ItemCreatedTimestampVisibiity, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemCreatedTimestampValue"
                 Grid.Row="11"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.ItemCreatedTimestamp, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.ItemCreatedTimestampVisibiity, Mode=OneWay}" />
 
@@ -334,17 +264,14 @@
                 x:Uid="PropertiesModified"
                 Grid.Row="12"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Modified:"
                 Visibility="{x:Bind ViewModel.ItemModifiedTimestampVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemModifiedTimestampValue"
                 Grid.Row="12"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.ItemModifiedTimestamp, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.ItemModifiedTimestampVisibility, Mode=OneWay}" />
 
@@ -352,17 +279,14 @@
                 x:Uid="PropertiesAccessed"
                 Grid.Row="13"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Accessed:"
                 Visibility="{x:Bind ViewModel.ItemAccessedTimestampVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemAccessedTimestampValue"
                 Grid.Row="13"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.ItemAccessedTimestamp, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.ItemAccessedTimestampVisibility, Mode=OneWay}" />
 
@@ -370,17 +294,14 @@
                 x:Uid="PropertiesOwner"
                 Grid.Row="14"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Owner:"
                 Visibility="{x:Bind ViewModel.ItemFileOwnerVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Uid="ItemFileOwnerValue"
                 Grid.Row="14"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.ItemFileOwner, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.ItemFileOwnerVisibility, Mode=OneWay}" />
 
@@ -395,17 +316,14 @@
                 x:Uid="PropertiesDriveCapacity"
                 Grid.Row="16"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Capacity:"
                 Visibility="{x:Bind ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
             <TextBlock
                 x:Uid="driveCapacityValue"
                 Grid.Row="16"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.DriveCapacity, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
 
@@ -428,7 +346,7 @@
                 x:Uid="PropertiesAttributes"
                 Grid.Row="18"
                 Grid.Column="0"
-                Margin="0,7"
+                Margin="{StaticResource PropertyNameMargin}"
                 VerticalAlignment="Center"
                 FontWeight="SemiBold"
                 Text="Attributes:"
@@ -436,7 +354,7 @@
             <StackPanel
                 Grid.Row="18"
                 Grid.Column="1"
-                Margin="20,0,0,0"
+                Margin="{StaticResource PropertyValueMargin}"
                 VerticalAlignment="Center"
                 Orientation="Horizontal"
                 Spacing="16"

--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -1,9 +1,11 @@
-﻿<Page
+﻿<local1:PropertiesTab
+    xmlns:local1="using:Files.View_Models.Properties"
     x:Class="Files.PropertiesGeneral"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Files.Views.Pages"
+    xmlns:local2="using:Files"
     xmlns:usercontrols="using:Files.UserControls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -11,13 +13,13 @@
     Loaded="Properties_Loaded"
     mc:Ignorable="d">
 
-    <Page.Resources>
+    <local1:PropertiesTab.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
-    </Page.Resources>
+    </local1:PropertiesTab.Resources>
 
     <StackPanel Style="{StaticResource PropertiesTab}">
         <Grid>
@@ -55,7 +57,7 @@
                 Margin="{StaticResource PropertyNameMargin}"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-                <usercontrols:FileIcon ViewModel="{x:Bind PropertiesTab.ViewModel}" ItemSize="70"/>
+                <usercontrols:FileIcon ViewModel="{x:Bind ViewModel}" ItemSize="70"/>
             </Grid>
             <TextBox
                 x:Name="ItemFileName"
@@ -63,8 +65,8 @@
                 Grid.Row="0"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
-                Text="{x:Bind PropertiesTab.ViewModel.ItemName, Mode=TwoWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemNameVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.ItemName, Mode=TwoWay}"
+                Visibility="{x:Bind ViewModel.ItemNameVisibility, Mode=OneWay}" />
 
             <MenuFlyoutSeparator
                 Grid.Row="1"
@@ -79,14 +81,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Item type:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemTypeVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ItemTypeVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemTypeValue"
                 Grid.Row="2"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.ItemType, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemTypeVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.ItemType, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.ItemTypeVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesDriveFileSystem"
@@ -94,14 +96,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="File system:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.DriveFileSystemVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.DriveFileSystemVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="DriveFileSystemValue"
                 Grid.Row="3"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.DriveFileSystem, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.DriveFileSystemVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.DriveFileSystem, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.DriveFileSystemVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesItemPath"
@@ -109,15 +111,15 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Path:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemPathVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ItemPathVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemPathValue"
                 Grid.Row="4"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.ItemPath, Mode=OneWay}"
+                Text="{x:Bind ViewModel.ItemPath, Mode=OneWay}"
                 TextWrapping="Wrap"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemPathVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ItemPathVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesItemSize"
@@ -125,12 +127,12 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Size:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemSizeVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ItemSizeVisibility, Mode=OneWay}" />
             <Grid
                 Grid.Row="5"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueGrid}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemSizeVisibility, Mode=OneWay}">
+                Visibility="{x:Bind ViewModel.ItemSizeVisibility, Mode=OneWay}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" MinWidth="100" />
                     <ColumnDefinition Width="*" />
@@ -139,13 +141,13 @@
                     x:Name="itemSizeValue"
                     Grid.Column="0"
                     IsTextSelectionEnabled="True"
-                    Text="{x:Bind PropertiesTab.ViewModel.ItemSize, Mode=OneWay}" />
+                    Text="{x:Bind ViewModel.ItemSize, Mode=OneWay}" />
                 <muxc:ProgressRing
                     x:Name="ItemSizeProgress"
                     Grid.Column="1"
                     Margin="0,-10"
                     HorizontalAlignment="Left"
-                    Visibility="{x:Bind PropertiesTab.ViewModel.ItemSizeProgressVisibility, Mode=OneWay}" />
+                    Visibility="{x:Bind ViewModel.ItemSizeProgressVisibility, Mode=OneWay}" />
             </Grid>
 
             <TextBlock
@@ -155,22 +157,22 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="MD5Hash:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemMD5HashVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ItemMD5HashVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemMD5HashValue"
                 Grid.Row="6"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.ItemMD5Hash, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemMD5HashVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.ItemMD5Hash, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.ItemMD5HashVisibility, Mode=OneWay}" />
             <muxc:ProgressBar
                 x:Name="ItemMD5HashProgress"
                 Grid.Row="6"
                 Grid.Column="1"
                 Margin="20,0,0,0"
                 VerticalAlignment="Center"
-                ShowError="{x:Bind PropertiesTab.ViewModel.ItemMD5HashCalcError, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemMD5HashProgressVisibility, Mode=OneWay}" />
+                ShowError="{x:Bind ViewModel.ItemMD5HashCalcError, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.ItemMD5HashProgressVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Name="PropertiesCount"
@@ -179,14 +181,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Contains:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemFilesAndFoldersCountValue"
                 Grid.Row="7"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.FilesAndFoldersCountString, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.FilesAndFoldersCountString, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
 
             <MenuFlyoutSeparator
                 Grid.Row="8"
@@ -199,7 +201,7 @@
                 Grid.Column="0"
                 Margin="0,7"
                 Orientation="Horizontal"
-                Visibility="{x:Bind PropertiesTab.ViewModel.DriveUsedSpaceVisibiity, Mode=OneWay}">
+                Visibility="{x:Bind ViewModel.DriveUsedSpaceVisibiity, Mode=OneWay}">
                 <Rectangle
                     Width="15"
                     Height="15"
@@ -217,15 +219,15 @@
                 Grid.Row="9"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.DriveUsedSpace, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.DriveUsedSpaceVisibiity, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.DriveUsedSpace, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.DriveUsedSpaceVisibiity, Mode=OneWay}" />
 
             <StackPanel
                 Grid.Row="10"
                 Grid.Column="0"
                 Margin="{StaticResource PropertyNameMargin}"
                 Orientation="Horizontal"
-                Visibility="{x:Bind PropertiesTab.ViewModel.DriveFreeSpaceVisibiity, Mode=OneWay}">
+                Visibility="{x:Bind ViewModel.DriveFreeSpaceVisibiity, Mode=OneWay}">
                 <Rectangle
                     Width="15"
                     Height="15"
@@ -242,8 +244,8 @@
                 Grid.Row="10"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.DriveFreeSpace, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.DriveFreeSpaceVisibiity, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.DriveFreeSpace, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.DriveFreeSpaceVisibiity, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesCreated"
@@ -251,14 +253,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Created:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemCreatedTimestampVisibiity, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ItemCreatedTimestampVisibiity, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemCreatedTimestampValue"
                 Grid.Row="11"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.ItemCreatedTimestamp, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemCreatedTimestampVisibiity, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.ItemCreatedTimestamp, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.ItemCreatedTimestampVisibiity, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesModified"
@@ -266,14 +268,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Modified:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemModifiedTimestampVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ItemModifiedTimestampVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemModifiedTimestampValue"
                 Grid.Row="12"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.ItemModifiedTimestamp, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemModifiedTimestampVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.ItemModifiedTimestamp, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.ItemModifiedTimestampVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesAccessed"
@@ -281,14 +283,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Accessed:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemAccessedTimestampVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ItemAccessedTimestampVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Name="itemAccessedTimestampValue"
                 Grid.Row="13"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.ItemAccessedTimestamp, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemAccessedTimestampVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.ItemAccessedTimestamp, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.ItemAccessedTimestampVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesOwner"
@@ -296,21 +298,21 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Owner:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemFileOwnerVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ItemFileOwnerVisibility, Mode=OneWay}" />
             <TextBlock
                 x:Uid="ItemFileOwnerValue"
                 Grid.Row="14"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.ItemFileOwner, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemFileOwnerVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.ItemFileOwner, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.ItemFileOwnerVisibility, Mode=OneWay}" />
 
             <MenuFlyoutSeparator
                 Grid.Row="15"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"
                 Margin="-12,0"
-                Visibility="{x:Bind PropertiesTab.ViewModel.LastSeparatorVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.LastSeparatorVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesDriveCapacity"
@@ -318,14 +320,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Capacity:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
             <TextBlock
                 x:Uid="driveCapacityValue"
                 Grid.Row="16"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.DriveCapacity, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.DriveCapacity, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
 
             <toolkit:RadialProgressBar
                 Grid.Row="17"
@@ -335,12 +337,12 @@
                 Height="70"
                 Margin="10"
                 Foreground="DodgerBlue"
-                Maximum="{x:Bind PropertiesTab.ViewModel.DriveCapacityDoubleValue, Mode=OneWay}"
+                Maximum="{x:Bind ViewModel.DriveCapacityDoubleValue, Mode=OneWay}"
                 Minimum="0"
                 Outline="Gray"
                 Thickness="10"
-                Visibility="{x:Bind PropertiesTab.ViewModel.DriveCapacityVisibiity, Mode=OneWay}"
-                Value="{x:Bind PropertiesTab.ViewModel.DriveUsedSpaceDoubleValue, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.DriveCapacityVisibiity, Mode=OneWay}"
+                Value="{x:Bind ViewModel.DriveUsedSpaceDoubleValue, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesAttributes"
@@ -350,7 +352,7 @@
                 VerticalAlignment="Center"
                 FontWeight="SemiBold"
                 Text="Attributes:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemAttributesVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ItemAttributesVisibility, Mode=OneWay}" />
             <StackPanel
                 Grid.Row="18"
                 Grid.Column="1"
@@ -358,7 +360,7 @@
                 VerticalAlignment="Center"
                 Orientation="Horizontal"
                 Spacing="16"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemAttributesVisibility, Mode=OneWay}">
+                Visibility="{x:Bind ViewModel.ItemAttributesVisibility, Mode=OneWay}">
                 <CheckBox
                     x:Uid="PropertiesDialogReadOnly"
                     Content="Read-only"
@@ -370,4 +372,4 @@
             </StackPanel>
         </Grid>
     </StackPanel>
-</Page>
+</local1:PropertiesTab>

--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -1,11 +1,9 @@
-﻿<local1:PropertiesTab
-    xmlns:local1="using:Files.View_Models.Properties"
+﻿<local:PropertiesTab
     x:Class="Files.PropertiesGeneral"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:Files.Views.Pages"
-    xmlns:local2="using:Files"
+    xmlns:local="using:Files.View_Models.Properties"
     xmlns:usercontrols="using:Files.UserControls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -13,13 +11,13 @@
     Loaded="Properties_Loaded"
     mc:Ignorable="d">
 
-    <local1:PropertiesTab.Resources>
+    <local:PropertiesTab.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
-    </local1:PropertiesTab.Resources>
+    </local:PropertiesTab.Resources>
 
     <StackPanel Style="{StaticResource PropertiesTab}">
         <Grid>
@@ -372,4 +370,4 @@
             </StackPanel>
         </Grid>
     </StackPanel>
-</local1:PropertiesTab>
+</local:PropertiesTab>

--- a/Files/Views/Pages/PropertiesGeneral.xaml.cs
+++ b/Files/Views/Pages/PropertiesGeneral.xaml.cs
@@ -3,40 +3,23 @@ using Files.View_Models.Properties;
 using Microsoft.Toolkit.Uwp.Helpers;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
 
 namespace Files
 {
-    public sealed partial class PropertiesGeneral : Page
+    public sealed partial class PropertiesGeneral : PropertiesTab
     {
-        private readonly PropertiesTab PropertiesTab;
-
         public PropertiesGeneral()
         {
             this.InitializeComponent();
-            PropertiesTab = new PropertiesTab();
-        }
-
-        private void Properties_Loaded(object sender, RoutedEventArgs e)
-        {
-            PropertiesTab.HandlePropertiesLoaded();
-        }
-
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            PropertiesTab.HandleNavigation(e, Dispatcher);
-            base.OnNavigatedTo(e);
         }
 
         public async Task SaveChanges(ListedItem item)
         {
-            if (PropertiesTab.ViewModel.OriginalItemName != null)
+            if (ViewModel.OriginalItemName != null)
             {
                 await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => App.CurrentInstance.InteractionOperations.RenameFileItem(item,
-                      PropertiesTab.ViewModel.OriginalItemName,
-                      PropertiesTab.ViewModel.ItemName));
+                      ViewModel.OriginalItemName,
+                      ViewModel.ItemName));
             }
         }
     }

--- a/Files/Views/Pages/PropertiesGeneral.xaml.cs
+++ b/Files/Views/Pages/PropertiesGeneral.xaml.cs
@@ -1,77 +1,42 @@
 using Files.Filesystem;
-using Files.View_Models;
 using Files.View_Models.Properties;
 using Microsoft.Toolkit.Uwp.Helpers;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
-using Windows.Storage;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
-// Il modello di elemento Pagina vuota è documentato all'indirizzo https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace Files
 {
-    /// <summary>
-    /// Pagina vuota che può essere usata autonomamente oppure per l'esplorazione all'interno di un frame.
-    /// </summary>
     public sealed partial class PropertiesGeneral : Page
     {
-        public BaseProperties BaseProperties { get; set; }
-
-        public SelectedItemsPropertiesViewModel ViewModel { get; set; }
+        private readonly PropertiesTab PropertiesTab;
 
         public PropertiesGeneral()
         {
             this.InitializeComponent();
+            PropertiesTab = new PropertiesTab();
         }
 
         private void Properties_Loaded(object sender, RoutedEventArgs e)
         {
-            if (BaseProperties != null)
-            {
-                BaseProperties.GetSpecialProperties();
-            }
+            PropertiesTab.HandlePropertiesLoaded();
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            ViewModel = new SelectedItemsPropertiesViewModel();
-            var np = e.Parameter as Properties.PropertyNavParam;
-
-            if (np.navParameter is ListedItem)
-            {
-                var listedItem = np.navParameter as ListedItem;
-                if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
-                {
-                    BaseProperties = new FileProperties(ViewModel, np.tokenSource, Dispatcher, ItemMD5HashProgress, listedItem);
-                }
-                else if (listedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
-                {
-                    BaseProperties = new FolderProperties(ViewModel, np.tokenSource, Dispatcher, listedItem);
-                }
-            }
-            else if (np.navParameter is List<ListedItem>)
-            {
-                BaseProperties = new CombinedProperties(ViewModel, np.tokenSource, Dispatcher, np.navParameter as List<ListedItem>);
-            }
-            else if (np.navParameter is DriveItem)
-            {
-                BaseProperties = new DriveProperties(ViewModel, np.navParameter as DriveItem);
-            }
-
+            PropertiesTab.HandleNavigation(e, Dispatcher);
             base.OnNavigatedTo(e);
         }
 
         public async Task SaveChanges(ListedItem item)
         {
-            if (ViewModel.OriginalItemName != null)
+            if (PropertiesTab.ViewModel.OriginalItemName != null)
             {
                 await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => App.CurrentInstance.InteractionOperations.RenameFileItem(item,
-                      ViewModel.OriginalItemName,
-                      ViewModel.ItemName));
+                      PropertiesTab.ViewModel.OriginalItemName,
+                      PropertiesTab.ViewModel.ItemName));
             }
         }
     }

--- a/Files/Views/Pages/PropertiesGeneral.xaml.cs
+++ b/Files/Views/Pages/PropertiesGeneral.xaml.cs
@@ -11,6 +11,7 @@ namespace Files
         public PropertiesGeneral()
         {
             this.InitializeComponent();
+            base.ItemMD5HashProgress = ItemMD5HashProgress;
         }
 
         public async Task SaveChanges(ListedItem item)

--- a/Files/Views/Pages/PropertiesShortcut.xaml
+++ b/Files/Views/Pages/PropertiesShortcut.xaml
@@ -5,10 +5,19 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Files.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:usercontrols="using:Files.UserControls"
     Loaded="Properties_Loaded"
     mc:Ignorable="d">
 
-    <StackPanel Padding="14,0,14,14" VerticalAlignment="Top">
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <StackPanel Style="{StaticResource PropertiesTab}">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -30,56 +39,17 @@
                 Grid.Column="0"
                 Width="80"
                 Height="80"
-                Margin="0,7"
+                Margin="{StaticResource PropertyNameMargin}"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-                <Image
-                    x:Name="FolderGlyphIcon2"
-                    Width="70"
-                    Height="70"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    x:Load="{x:Bind ViewModel.LoadFolderGlyph}"
-                    Stretch="Uniform">
-                    <Image.Source>
-                        <SvgImageSource
-                            RasterizePixelHeight="128"
-                            RasterizePixelWidth="128"
-                            UriSource="{x:Bind ViewModel.FolderIconSource}" />
-                    </Image.Source>
-                </Image>
-                <FontIcon
-                    x:Name="EmptyImageIcon2"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Stretch"
-                    x:Load="{x:Bind ViewModel.LoadUnknownTypeGlyph, Mode=OneWay}"
-                    FontFamily="{StaticResource FluentUIGlyphs}"
-                    FontSize="70"
-                    Glyph="&#xea00;" />
-                <FontIcon
-                    x:Name="WebShortcutGlyph2"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Stretch"
-                    x:Load="{x:Bind ViewModel.LoadLinkIcon, Mode=OneWay}"
-                    FontFamily="{StaticResource FluentUIGlyphs}"
-                    FontSize="70"
-                    Glyph="&#xEAAB;" />
-                <Image
-                    x:Name="itemIcon2"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    x:Load="{x:Bind ViewModel.LoadFileIcon, Mode=OneWay}"
-                    Source="{x:Bind ViewModel.FileIconSource, Mode=OneWay}" />
+                <usercontrols:FileIcon ViewModel="{x:Bind ViewModel}" ItemSize="70"/>
             </Grid>
             <TextBox
                 x:Name="itemFileName2"
                 x:Uid="PropertiesItemFileName"
                 Grid.Row="0"
                 Grid.Column="1"
-                Margin="20,0"
-                HorizontalAlignment="Stretch"
-                VerticalAlignment="Center"
-                BorderThickness="1"
+                Style="{StaticResource PropertyValueTextBox}"
                 IsReadOnly="True"
                 Text="{x:Bind ViewModel.ItemName, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.ItemNameVisibility, Mode=OneWay}" />
@@ -95,17 +65,14 @@
                 x:Uid="PropertiesShortcutItemType"
                 Grid.Row="2"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Shortcut type:"
                 Visibility="Visible" />
             <TextBlock
                 x:Name="shortcutItemTypeValue"
                 Grid.Row="2"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
-                IsTextSelectionEnabled="True"
+                Style="{StaticResource PropertyValueTextBlock}"
                 Text="{x:Bind ViewModel.ShortcutItemType, Mode=OneWay}"
                 Visibility="Visible" />
 
@@ -113,16 +80,14 @@
                 x:Uid="PropertiesShortcutItemPath"
                 Grid.Row="3"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Destination:"
                 Visibility="Visible" />
             <TextBox
                 x:Name="shortcutItemPathValue"
                 Grid.Row="3"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
+                Style="{StaticResource PropertyValueTextBox}"
                 Text="{x:Bind ViewModel.ShortcutItemPath, Mode=TwoWay}"
                 Visibility="Visible" />
 
@@ -130,16 +95,14 @@
                 x:Uid="PropertiesShortcutItemArgs"
                 Grid.Row="4"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Arguments:"
                 Visibility="{x:Bind ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}" />
             <TextBox
                 x:Name="shortcutItemArgsValue"
                 Grid.Row="4"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
+                Style="{StaticResource PropertyValueTextBox}"
                 Text="{x:Bind ViewModel.ShortcutItemArguments, Mode=TwoWay}"
                 Visibility="{x:Bind ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}" />
 
@@ -147,16 +110,14 @@
                 x:Uid="PropertiesShortcutItemWorkingDir"
                 Grid.Row="5"
                 Grid.Column="0"
-                Margin="0,7"
-                FontWeight="SemiBold"
+                Style="{StaticResource PropertyName}"
                 Text="Working directory:"
                 Visibility="{x:Bind ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}" />
             <TextBox
                 x:Name="shortcutItemWorkingDirValue"
                 Grid.Row="5"
                 Grid.Column="1"
-                Margin="20,0,0,0"
-                VerticalAlignment="Center"
+                Style="{StaticResource PropertyValueTextBox}"
                 Text="{x:Bind ViewModel.ShortcutItemWorkingDir, Mode=TwoWay}"
                 Visibility="{x:Bind ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}" />
 
@@ -171,7 +132,7 @@
                 Grid.Row="7"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"
-                Margin="20,0,0,0"
+                Margin="{StaticResource PropertyValueMargin}"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 Orientation="Horizontal"

--- a/Files/Views/Pages/PropertiesShortcut.xaml
+++ b/Files/Views/Pages/PropertiesShortcut.xaml
@@ -1,21 +1,21 @@
-﻿<Page
+﻿<local:PropertiesTab
     x:Class="Files.PropertiesShortcut"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:Files.Views.Pages"
+    xmlns:local="using:Files.View_Models.Properties"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:usercontrols="using:Files.UserControls"
     Loaded="Properties_Loaded"
     mc:Ignorable="d">
 
-    <Page.Resources>
+    <local:PropertiesTab.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
-    </Page.Resources>
+    </local:PropertiesTab.Resources>
 
     <StackPanel Style="{StaticResource PropertiesTab}">
         <Grid>
@@ -42,7 +42,7 @@
                 Margin="{StaticResource PropertyNameMargin}"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-                <usercontrols:FileIcon ViewModel="{x:Bind PropertiesTab.ViewModel}" ItemSize="70"/>
+                <usercontrols:FileIcon ViewModel="{x:Bind ViewModel}" ItemSize="70"/>
             </Grid>
             <TextBox
                 x:Name="itemFileName2"
@@ -51,8 +51,8 @@
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
                 IsReadOnly="True"
-                Text="{x:Bind PropertiesTab.ViewModel.ItemName, Mode=OneWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ItemNameVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.ItemName, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.ItemNameVisibility, Mode=OneWay}" />
 
             <MenuFlyoutSeparator
                 Grid.Row="1"
@@ -73,7 +73,7 @@
                 Grid.Row="2"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind PropertiesTab.ViewModel.ShortcutItemType, Mode=OneWay}"
+                Text="{x:Bind ViewModel.ShortcutItemType, Mode=OneWay}"
                 Visibility="Visible" />
 
             <TextBlock
@@ -88,7 +88,7 @@
                 Grid.Row="3"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
-                Text="{x:Bind PropertiesTab.ViewModel.ShortcutItemPath, Mode=TwoWay}"
+                Text="{x:Bind ViewModel.ShortcutItemPath, Mode=TwoWay}"
                 Visibility="Visible" />
 
             <TextBlock
@@ -97,14 +97,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Arguments:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}" />
             <TextBox
                 x:Name="shortcutItemArgsValue"
                 Grid.Row="4"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
-                Text="{x:Bind PropertiesTab.ViewModel.ShortcutItemArguments, Mode=TwoWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.ShortcutItemArguments, Mode=TwoWay}"
+                Visibility="{x:Bind ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesShortcutItemWorkingDir"
@@ -112,14 +112,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Working directory:"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}" />
             <TextBox
                 x:Name="shortcutItemWorkingDirValue"
                 Grid.Row="5"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
-                Text="{x:Bind PropertiesTab.ViewModel.ShortcutItemWorkingDir, Mode=TwoWay}"
-                Visibility="{x:Bind PropertiesTab.ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}" />
+                Text="{x:Bind ViewModel.ShortcutItemWorkingDir, Mode=TwoWay}"
+                Visibility="{x:Bind ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}" />
 
             <MenuFlyoutSeparator
                 Grid.Row="6"
@@ -142,11 +142,11 @@
                     x:Name="OpenLinkButton"
                     x:Uid="PropertiesDialogOpenLinkButton"
                     MinWidth="100"
-                    x:Load="{x:Bind PropertiesTab.ViewModel.IsSelectedItemShortcut, Mode=OneWay}"
-                    Command="{x:Bind PropertiesTab.ViewModel.ShortcutItemOpenLinkCommand, Mode=OneWay}"
+                    x:Load="{x:Bind ViewModel.IsSelectedItemShortcut, Mode=OneWay}"
+                    Command="{x:Bind ViewModel.ShortcutItemOpenLinkCommand, Mode=OneWay}"
                     Content="Open file location"
                     Style="{ThemeResource ButtonRevealStyle}" />
             </StackPanel>
         </Grid>
     </StackPanel>
-</Page>
+</local:PropertiesTab>

--- a/Files/Views/Pages/PropertiesShortcut.xaml
+++ b/Files/Views/Pages/PropertiesShortcut.xaml
@@ -42,7 +42,7 @@
                 Margin="{StaticResource PropertyNameMargin}"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-                <usercontrols:FileIcon ViewModel="{x:Bind ViewModel}" ItemSize="70"/>
+                <usercontrols:FileIcon ViewModel="{x:Bind PropertiesTab.ViewModel}" ItemSize="70"/>
             </Grid>
             <TextBox
                 x:Name="itemFileName2"
@@ -51,8 +51,8 @@
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
                 IsReadOnly="True"
-                Text="{x:Bind ViewModel.ItemName, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.ItemNameVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.ItemName, Mode=OneWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ItemNameVisibility, Mode=OneWay}" />
 
             <MenuFlyoutSeparator
                 Grid.Row="1"
@@ -73,7 +73,7 @@
                 Grid.Row="2"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.ShortcutItemType, Mode=OneWay}"
+                Text="{x:Bind PropertiesTab.ViewModel.ShortcutItemType, Mode=OneWay}"
                 Visibility="Visible" />
 
             <TextBlock
@@ -88,7 +88,7 @@
                 Grid.Row="3"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
-                Text="{x:Bind ViewModel.ShortcutItemPath, Mode=TwoWay}"
+                Text="{x:Bind PropertiesTab.ViewModel.ShortcutItemPath, Mode=TwoWay}"
                 Visibility="Visible" />
 
             <TextBlock
@@ -97,14 +97,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Arguments:"
-                Visibility="{x:Bind ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}" />
             <TextBox
                 x:Name="shortcutItemArgsValue"
                 Grid.Row="4"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
-                Text="{x:Bind ViewModel.ShortcutItemArguments, Mode=TwoWay}"
-                Visibility="{x:Bind ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.ShortcutItemArguments, Mode=TwoWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}" />
 
             <TextBlock
                 x:Uid="PropertiesShortcutItemWorkingDir"
@@ -112,14 +112,14 @@
                 Grid.Column="0"
                 Style="{StaticResource PropertyName}"
                 Text="Working directory:"
-                Visibility="{x:Bind ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}" />
+                Visibility="{x:Bind PropertiesTab.ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}" />
             <TextBox
                 x:Name="shortcutItemWorkingDirValue"
                 Grid.Row="5"
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
-                Text="{x:Bind ViewModel.ShortcutItemWorkingDir, Mode=TwoWay}"
-                Visibility="{x:Bind ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}" />
+                Text="{x:Bind PropertiesTab.ViewModel.ShortcutItemWorkingDir, Mode=TwoWay}"
+                Visibility="{x:Bind PropertiesTab.ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}" />
 
             <MenuFlyoutSeparator
                 Grid.Row="6"
@@ -142,8 +142,8 @@
                     x:Name="OpenLinkButton"
                     x:Uid="PropertiesDialogOpenLinkButton"
                     MinWidth="100"
-                    x:Load="{x:Bind ViewModel.IsSelectedItemShortcut, Mode=OneWay}"
-                    Command="{x:Bind ViewModel.ShortcutItemOpenLinkCommand, Mode=OneWay}"
+                    x:Load="{x:Bind PropertiesTab.ViewModel.IsSelectedItemShortcut, Mode=OneWay}"
+                    Command="{x:Bind PropertiesTab.ViewModel.ShortcutItemOpenLinkCommand, Mode=OneWay}"
                     Content="Open file location"
                     Style="{ThemeResource ButtonRevealStyle}" />
             </StackPanel>

--- a/Files/Views/Pages/PropertiesShortcut.xaml.cs
+++ b/Files/Views/Pages/PropertiesShortcut.xaml.cs
@@ -1,7 +1,4 @@
 ﻿using Files.View_Models.Properties;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Navigation;
 
 namespace Files
 {

--- a/Files/Views/Pages/PropertiesShortcut.xaml.cs
+++ b/Files/Views/Pages/PropertiesShortcut.xaml.cs
@@ -5,25 +5,11 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Files
 {
-    public sealed partial class PropertiesShortcut : Page
+    public sealed partial class PropertiesShortcut : PropertiesTab
     {
-        private readonly PropertiesTab PropertiesTab;
-
         public PropertiesShortcut()
         {
             this.InitializeComponent();
-            PropertiesTab = new PropertiesTab();
-        }
-
-        private void Properties_Loaded(object sender, RoutedEventArgs e)
-        {
-            PropertiesTab.HandlePropertiesLoaded();
-        }
-
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            PropertiesTab.HandleNavigation(e, Dispatcher);
-            base.OnNavigatedTo(e);
         }
     }
 }

--- a/Files/Views/Pages/PropertiesShortcut.xaml.cs
+++ b/Files/Views/Pages/PropertiesShortcut.xaml.cs
@@ -1,64 +1,28 @@
-﻿using Files.Filesystem;
-using Files.View_Models;
-using Files.View_Models.Properties;
-using System.Collections.Generic;
-using Windows.Storage;
+﻿using Files.View_Models.Properties;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
-// Il modello di elemento Pagina vuota è documentato all'indirizzo https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace Files
 {
-    /// <summary>
-    /// Pagina vuota che può essere usata autonomamente oppure per l'esplorazione all'interno di un frame.
-    /// </summary>
     public sealed partial class PropertiesShortcut : Page
     {
-        public BaseProperties BaseProperties { get; set; }
-
-        public SelectedItemsPropertiesViewModel ViewModel { get; set; }
+        private readonly PropertiesTab PropertiesTab;
 
         public PropertiesShortcut()
         {
             this.InitializeComponent();
+            PropertiesTab = new PropertiesTab();
         }
 
         private void Properties_Loaded(object sender, RoutedEventArgs e)
         {
-            if (BaseProperties != null)
-            {
-                BaseProperties.GetSpecialProperties();
-            }
+            PropertiesTab.HandlePropertiesLoaded();
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            ViewModel = new SelectedItemsPropertiesViewModel();
-            var np = e.Parameter as Properties.PropertyNavParam;
-
-            if (np.navParameter is ListedItem)
-            {
-                var listedItem = np.navParameter as ListedItem;
-                if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
-                {
-                    BaseProperties = new FileProperties(ViewModel, np.tokenSource, Dispatcher, null, listedItem);
-                }
-                else if (listedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
-                {
-                    BaseProperties = new FolderProperties(ViewModel, np.tokenSource, Dispatcher, listedItem);
-                }
-            }
-            else if (np.navParameter is List<ListedItem>)
-            {
-                BaseProperties = new CombinedProperties(ViewModel, np.tokenSource, Dispatcher, np.navParameter as List<ListedItem>);
-            }
-            else if (np.navParameter is DriveItem)
-            {
-                BaseProperties = new DriveProperties(ViewModel, np.navParameter as DriveItem);
-            }
-
+            PropertiesTab.HandleNavigation(e, Dispatcher);
             base.OnNavigatedTo(e);
         }
     }


### PR DESCRIPTION
resolves #1836 
Changes:
- Refactor icon into a custom control
- Add common stylings for property title (left column), property value (right column) & for the property tabs

I tried to create a base style for property values since there are TextBoxes as well as TextBlocks, but I couldn't find a way to use a style for multiple target types. If there is a way to do this, please let me know.

The icon control contains a property called LargerItemSize which is 2 px larger than the original ItemSize because 2 images (CombinedItemsIcon and DriveItemIcon) had a 2px larger FontSize. Since I'm not sure if that is intentional I made its size 2px larger as well.