### PR TITLE
Fixed and issue with the context menu not appearing when right clicking on exe files

### DIFF
--- a/Files.Launcher/Files.Launcher.csproj
+++ b/Files.Launcher/Files.Launcher.csproj
@@ -27,6 +27,7 @@
     <WarningLevel>4</WarningLevel>
     <LangVersion>8.0</LangVersion>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -37,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>8.0</LangVersion>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />

--- a/Files.Launcher/Win32API_ContextMenu.cs
+++ b/Files.Launcher/Win32API_ContextMenu.cs
@@ -288,6 +288,12 @@ namespace FilesFullTrust
 
             private static string GetCommandString(Shell32.IContextMenu cMenu, uint offset, Shell32.GCS flags = Shell32.GCS.GCS_VERBW)
             {
+                if (offset > 5000)
+                {
+                    // Hackish workaround to avoid an AccessViolationException on some items, 
+                    // notably the "Run with graphic processor" menu item of NVidia cards
+                    return null;
+                }
                 SafeCoTaskMemString commandString = null;
                 try
                 {


### PR DESCRIPTION
Fixes #1944 

Issue was due to a memory access error that was for some reason happening when parsing the "Run with graphic processor" context-menu item that appears on PCs with NVidia graphic cards.

This bug was hard to track down because it was happening only on azure release builds: this was because azure builds the Files.Launcher project as x64 while local build uses x86. This PR changes the "Prefer32Bit" option to false in order to have consistent behavior when building locally and on azure. Let me know if it's ok to include this change.
