### PR TITLE
Fix a crash that would occur when no multitasking option was selected

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -258,7 +258,10 @@ namespace Files
             App.CurrentInstance.InstanceViewModel.IsPageTypeRecycleBin = workingDir.StartsWith(App.AppSettings.RecycleBinPath);
             App.CurrentInstance.InstanceViewModel.IsPageTypeMtpDevice = workingDir.StartsWith("\\\\?\\");
 
-            await App.MultitaskingControl?.SetSelectedTabInfo(new DirectoryInfo(workingDir).Name, workingDir);
+            if (App.MultitaskingControl != null)
+            {
+                await App.MultitaskingControl.SetSelectedTabInfo(new DirectoryInfo(workingDir).Name, workingDir);
+            }
             App.CurrentInstance.FilesystemViewModel.RefreshItems();
 
             App.MultitaskingControl?.SelectionChanged();

--- a/Files/Views/SettingsPages/Multitasking.xaml
+++ b/Files/Views/SettingsPages/Multitasking.xaml
@@ -35,7 +35,8 @@
                             x:Name="AdaptiveMultToggle"
                             x:Uid="SettingsMultitaskingAdaptive"
                             Content="Adaptive (Recommended)"
-                            IsChecked="{x:Bind AppSettings.IsMultitaskingExperienceAdaptive, Mode=TwoWay}" />
+                            GroupName="MultitaskingSettingRadioGroup"
+                            IsChecked="{x:Bind AppSettings.IsMultitaskingExperienceAdaptive, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <TextBlock
                             x:Uid="SettingsMultitaskingAdaptiveDescription"
                             MaxWidth="450"
@@ -49,7 +50,8 @@
                             x:Uid="SettingsMultitaskingHorizontal"
                             Margin="0,18,0,0"
                             Content="Horizontal"
-                            IsChecked="{x:Bind AppSettings.IsHorizontalTabStripEnabled, Mode=TwoWay}" />
+                            GroupName="MultitaskingSettingRadioGroup"
+                            IsChecked="{x:Bind AppSettings.IsHorizontalTabStripEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <TextBlock
                             x:Uid="SettingsMultitaskingHorizontalDescription"
                             MaxWidth="450"
@@ -63,7 +65,8 @@
                             x:Uid="SettingsMultitaskingVertical"
                             Margin="0,18,0,0"
                             Content="Vertical"
-                            IsChecked="{x:Bind AppSettings.IsVerticalTabFlyoutEnabled, Mode=TwoWay}" />
+                            GroupName="MultitaskingSettingRadioGroup"
+                            IsChecked="{x:Bind AppSettings.IsVerticalTabFlyoutEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                         <TextBlock
                             x:Uid="SettingsMultitaskingVerticalDescription"
                             MaxWidth="450"


### PR DESCRIPTION
Fixes #1961, fixes #1971, fixes #1936, fixes #1939, maybe fixes #1958
Appcenter: [2431183698u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/2431183698u/overview)

Sometimes after changing multitasking setting (adaptive, horizontal, vertical) all 3 multitasking options get disabled/deselected.

If this happens, from there on, app crashes with NullPointerException in BaseLayout, with a stacktrace similar to:
>2020-09-18 00:24:03.6905|ERROR|Files.App|Object reference not set to an instance of an object.|System.NullReferenceException: Object reference not set to an instance of an object. at Files.BaseLayout.OnNavigatedTo(NavigationEventArgs eventArgs) at System.Threading.WinRTSynchronizationContextBase.Invoker.InvokeCore()