### PR TITLE
Fix properties navigation background

### DIFF
--- a/Files/Views/Pages/Properties.xaml
+++ b/Files/Views/Pages/Properties.xaml
@@ -43,7 +43,7 @@
             PaneDisplayMode="Top"
             SelectionChanged="NavigationView_SelectionChanged"
             SelectionFollowsFocus="Enabled">
-            
+
             <!--  Tabs  -->
             <muxc:NavigationView.MenuItems>
                 <muxc:NavigationViewItem

--- a/Files/Views/Pages/Properties.xaml
+++ b/Files/Views/Pages/Properties.xaml
@@ -14,6 +14,11 @@
     Unloaded="Properties_Unloaded"
     mc:Ignorable="d">
 
+    <Page.Resources>
+        <SolidColorBrush x:Key="NavigationViewExpandedPaneBackground" Color="Transparent" />
+        <SolidColorBrush x:Key="NavigationViewDefaultPaneBackground" Color="Transparent" />
+    </Page.Resources>
+    
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="32" />
@@ -38,7 +43,7 @@
             PaneDisplayMode="Top"
             SelectionChanged="NavigationView_SelectionChanged"
             SelectionFollowsFocus="Enabled">
-
+            
             <!--  Tabs  -->
             <muxc:NavigationView.MenuItems>
                 <muxc:NavigationViewItem


### PR DESCRIPTION
This PR doesn't fix #1689 immediately because `NavigationView` doesn't allow you to override the background if `PaneDisplayMode` is set to `Top`. This bug is related to WinUI. For more information, see this [issue](https://github.com/microsoft/microsoft-ui-xaml/issues/3299). However, you can see that this fix works if you set `PaneDisplayMode` to `Left`.