### PR TITLE
Fixed a crash that would sometimes occur when right clicking an item using a touch screen

### DIFF
--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -544,6 +544,7 @@
             PreparingCellForEdit="AllView_PreparingCellForEdit"
             PreviewKeyDown="AllView_PreviewKeyDown"
             RightTapped="AllView_RightTapped"
+            Holding="AllView_Holding"
             RowDetailsVisibilityMode="Collapsed"
             ScrollViewer.IsScrollInertiaEnabled="True"
             SelectionChanged="AllView_SelectionChanged"

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -376,6 +376,16 @@ namespace Files
 
         public void AllView_RightTapped(object sender, RightTappedRoutedEventArgs e)
         {
+            HandleRightClick(sender, e);
+        }
+
+        public void AllView_Holding(object sender, HoldingRoutedEventArgs e)
+        {
+            HandleRightClick(sender, e);
+        }
+
+        private void HandleRightClick(object sender, RoutedEventArgs e)
+        {
             var rowPressed = Interacts.Interaction.FindParent<DataGridRow>(e.OriginalSource as DependencyObject);
             if (rowPressed != null)
             {


### PR DESCRIPTION
Fixes #1208 
I implemented an event handler at `AllView` on `Holding` event.
To avoid code duplication, I moved the code from `AllView_RightTapped` to a new method called `HandleRightClick`.