### PR TITLE
Fixed a crash that sometimes occurs when pressing Ctrl + C / V / X

### DIFF
--- a/Files/Commands/Paste.cs
+++ b/Files/Commands/Paste.cs
@@ -53,14 +53,15 @@ namespace Files.Commands
 
         private static async Task PasteItem(DataPackageView packageView, string destinationPath, DataPackageOperation acceptedOperation, IShellPage AppInstance, IProgress<uint> progress)
         {
-            IReadOnlyList<IStorageItem> itemsToPaste = await packageView.GetStorageItemsAsync();
-
             if (!packageView.Contains(StandardDataFormats.StorageItems))
             {
                 // Happens if you copy some text and then you Ctrl+V in FilesUWP
                 // Should this be done in ModernShellPage?
                 return;
             }
+            
+            IReadOnlyList<IStorageItem> itemsToPaste = await packageView.GetStorageItemsAsync();
+
             if (AppInstance.FilesystemViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
             {
                 // Do not paste files and folders inside the recycle bin

--- a/Files/Dialogs/BitlockerDialog.xaml.cs
+++ b/Files/Dialogs/BitlockerDialog.xaml.cs
@@ -47,7 +47,7 @@ namespace Files.Dialogs
             {
                 if (e.Key.Equals(VirtualKey.Enter))
                 {
-                    var element = Windows.UI.Xaml.Input.FocusManager.GetFocusedElement(XamlRoot) as Button;
+                    var element = Windows.UI.Xaml.Input.FocusManager.GetFocusedElement() as Button;
                     if (element == null || element.Name == "PrimaryButton")
                     {
                         if (!IsPrimaryButtonEnabled) return;

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -974,6 +974,10 @@ namespace Files.Interacts
                     return;
                 }
             }
+            if (!items.Any())
+            {
+                return;
+            }
             dataPackage.SetStorageItems(items);
             Clipboard.SetContent(dataPackage);
             try

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -401,7 +401,7 @@ namespace Files
             {
                 if (App.CurrentInstance.CurrentPageType == typeof(GenericFileBrowser))
                 {
-                    var focusedElement = FocusManager.GetFocusedElement(XamlRoot) as FrameworkElement;
+                    var focusedElement = FocusManager.GetFocusedElement() as FrameworkElement;
                     if (focusedElement is TextBox || focusedElement is PasswordBox ||
                         Interacts.Interaction.FindParent<ContentDialog>(focusedElement) != null)
                     {

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -303,7 +303,7 @@ namespace Files
             {
                 if (App.CurrentInstance.CurrentPageType == typeof(GridViewBrowser) && !isRenamingItem)
                 {
-                    var focusedElement = FocusManager.GetFocusedElement(XamlRoot) as FrameworkElement;
+                    var focusedElement = FocusManager.GetFocusedElement() as FrameworkElement;
                     if (focusedElement is TextBox || focusedElement is PasswordBox ||
                         Interacts.Interaction.FindParent<ContentDialog>(focusedElement) != null)
                     {


### PR DESCRIPTION
Fixes #1982

- Fix crash when clicking ctrl-x and no file is selected
- Fix crash when clicking ctrl-v and clipboard does not contain files
- Fix crash when clicking ctrl- c/v/x and windows version is 1809