### PR TITLE
Fixed an issue with sorting items

### DIFF
--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -330,19 +330,17 @@ namespace Files
 
         private async void AllView_Sorting(object sender, DataGridColumnEventArgs e)
         {
-            bool hasNoSorting = e.Column.SortDirection == null;
-
             if (e.Column == SortedColumn)
+            {
                 App.CurrentInstance.FilesystemViewModel.IsSortedAscending = !App.CurrentInstance.FilesystemViewModel.IsSortedAscending;
+                e.Column.SortDirection = App.CurrentInstance.FilesystemViewModel.IsSortedAscending ? DataGridSortDirection.Ascending : DataGridSortDirection.Descending;
+            }
             else if (e.Column != iconColumn)
+            {
                 SortedColumn = e.Column;
-
-            if (hasNoSorting) // This must be the first because the value of DataGridSortDirection.Ascending is 0
                 e.Column.SortDirection = DataGridSortDirection.Ascending;
-            else if (e.Column.SortDirection == DataGridSortDirection.Ascending)
-                e.Column.SortDirection = DataGridSortDirection.Descending;
-            else if (e.Column.SortDirection == DataGridSortDirection.Descending)
-                e.Column.SortDirection = DataGridSortDirection.Ascending;
+                App.CurrentInstance.FilesystemViewModel.IsSortedAscending = true;
+            }
 
             if (!AssociatedViewModel.IsLoadingItems && AssociatedViewModel.FilesAndFolders.Count > 0)
             {

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -330,10 +330,19 @@ namespace Files
 
         private async void AllView_Sorting(object sender, DataGridColumnEventArgs e)
         {
+            bool hasNoSorting = e.Column.SortDirection == null;
+
             if (e.Column == SortedColumn)
                 App.CurrentInstance.FilesystemViewModel.IsSortedAscending = !App.CurrentInstance.FilesystemViewModel.IsSortedAscending;
             else if (e.Column != iconColumn)
                 SortedColumn = e.Column;
+
+            if (hasNoSorting) // This must be the first because the value of DataGridSortDirection.Ascending is 0
+                e.Column.SortDirection = DataGridSortDirection.Ascending;
+            else if (e.Column.SortDirection == DataGridSortDirection.Ascending)
+                e.Column.SortDirection = DataGridSortDirection.Descending;
+            else if (e.Column.SortDirection == DataGridSortDirection.Descending)
+                e.Column.SortDirection = DataGridSortDirection.Ascending;
 
             if (!AssociatedViewModel.IsLoadingItems && AssociatedViewModel.FilesAndFolders.Count > 0)
             {


### PR DESCRIPTION
Fixes #1727 
I fixed it by setting the property `e.Column.SortDirection` to the opposite direction of its previous value.