### PR TITLE
Switch to inactive tab when files are dragged over for a certain duration

### DIFF
--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -758,6 +758,7 @@
             AddTabButtonClick="TabView_AddTabButtonClick"
             AllowDropTabs="True"
             CanDragTabs="True"
+            DragLeave="TabStrip_DragLeave"
             IsAddTabButtonVisible="True"
             SelectedIndex="{x:Bind local1:App.InteractionViewModel.TabStripSelectedIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
             SelectionChanged="TabStrip_SelectionChanged"
@@ -770,7 +771,6 @@
             TabItemsSource="{x:Bind Items, Mode=OneWay}"
             TabStripDragOver="TabStrip_TabStripDragOver"
             TabStripDrop="TabStrip_TabStripDrop"
-            DragLeave="TabStrip_DragLeave"
             TabWidthMode="Equal">
             <muxc:TabView.TabItemTemplate>
                 <DataTemplate x:DataType="local:TabItem">

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -776,7 +776,8 @@
                     <muxc:TabViewItem
                         Margin="2,0,2,0"
                         AllowDrop="True"
-                        DragOver="TabViewItem_DragOver"
+                        DragEnter="TabViewItem_DragEnter"
+                        DragLeave="TabViewItem_DragLeave"
                         Drop="TabViewItem_Drop"
                         FontFamily="{StaticResource FluentUIGlyphs}"
                         Header="{x:Bind Header, Mode=OneWay}"

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -770,6 +770,7 @@
             TabItemsSource="{x:Bind Items, Mode=OneWay}"
             TabStripDragOver="TabStrip_TabStripDragOver"
             TabStripDrop="TabStrip_TabStripDrop"
+            DragLeave="TabStrip_DragLeave"
             TabWidthMode="Equal">
             <muxc:TabView.TabItemTemplate>
                 <DataTemplate x:DataType="local:TabItem">

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
@@ -28,16 +28,21 @@ namespace Files.UserControls
 
         public const string TabPathIdentifier = "FilesTabViewItemPath";
 
-        public HorizontalMultitaskingControl()
-        {
-            this.InitializeComponent();
-        }
-
         public SettingsViewModel AppSettings => App.AppSettings;
 
         public void SelectionChanged() => TabStrip_SelectionChanged(null, null);
 
         public ObservableCollection<TabItem> Items => MainPage.AppInstances;
+
+        private readonly DispatcherTimer tabHoverTimer = new DispatcherTimer();
+        private TabViewItem hoveredTabViewItem = null;
+
+        public HorizontalMultitaskingControl()
+        {
+            this.InitializeComponent();
+            tabHoverTimer.Interval = TimeSpan.FromMilliseconds(500);
+            tabHoverTimer.Tick += TabHoverSelected;
+        }
 
         public async Task SetSelectedTabInfo(string text, string currentPathForTabIcon)
         {
@@ -244,18 +249,35 @@ namespace Files.UserControls
             {
                 e.AcceptedOperation = DataPackageOperation.None;
             }
+            tabHoverTimer.Stop();
         }
 
-        private void TabViewItem_DragOver(object sender, DragEventArgs e)
+        private void TabViewItem_DragEnter(object sender, DragEventArgs e)
         {
             if (e.DataView.AvailableFormats.Contains(StandardDataFormats.StorageItems))
             {
                 e.AcceptedOperation = DataPackageOperation.Move;
+                tabHoverTimer.Start();
+                hoveredTabViewItem = sender as TabViewItem;
             }
             else
             {
                 e.AcceptedOperation = DataPackageOperation.None;
             }
+        }
+
+        private void TabViewItem_DragLeave(object sender, DragEventArgs e)
+        {
+            tabHoverTimer.Stop();
+            hoveredTabViewItem = null;
+        }
+
+        // Select tab that is hovered over for a certain duration
+        private void TabHoverSelected(object sender, object e)
+        {
+            tabHoverTimer.Stop();
+            if (hoveredTabViewItem != null)
+                HorizontalTabView.SelectedItem = hoveredTabViewItem;
         }
 
         private void TabStrip_TabDragStarting(TabView sender, TabViewTabDragStartingEventArgs args)

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
@@ -249,6 +249,7 @@ namespace Files.UserControls
             {
                 e.AcceptedOperation = DataPackageOperation.None;
             }
+            HorizontalTabView.CanReorderTabs = true;
             tabHoverTimer.Stop();
         }
 
@@ -256,6 +257,7 @@ namespace Files.UserControls
         {
             if (e.DataView.AvailableFormats.Contains(StandardDataFormats.StorageItems))
             {
+                HorizontalTabView.CanReorderTabs = false;
                 e.AcceptedOperation = DataPackageOperation.Move;
                 tabHoverTimer.Start();
                 hoveredTabViewItem = sender as TabViewItem;
@@ -291,15 +293,25 @@ namespace Files.UserControls
         {
             if (e.DataView.Properties.ContainsKey(TabPathIdentifier))
             {
+                HorizontalTabView.CanReorderTabs = true;
                 e.AcceptedOperation = DataPackageOperation.Move;
                 e.DragUIOverride.Caption = ResourceController.GetTranslation("TabStripDragAndDropUIOverrideCaption");
                 e.DragUIOverride.IsCaptionVisible = true;
                 e.DragUIOverride.IsGlyphVisible = false;
+            } else
+            {
+                HorizontalTabView.CanReorderTabs = false;
             }
+        }
+
+        private void TabStrip_DragLeave(object sender, DragEventArgs e)
+        {
+            HorizontalTabView.CanReorderTabs = true;
         }
 
         private async void TabStrip_TabStripDrop(object sender, DragEventArgs e)
         {
+            HorizontalTabView.CanReorderTabs = true;
             if (!(sender is TabView tabStrip))
             {
                 return;

--- a/Files/UserControls/MultitaskingControl/VerticalTabViewControl.xaml
+++ b/Files/UserControls/MultitaskingControl/VerticalTabViewControl.xaml
@@ -628,6 +628,7 @@
             Background="Transparent"
             CanDragTabs="True"
             CanReorderTabs="True"
+            DragLeave="TabStrip_DragLeave"
             IsAddTabButtonVisible="True"
             SelectedIndex="{x:Bind local1:App.InteractionViewModel.TabStripSelectedIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
             SelectionChanged="TabStrip_SelectionChanged"
@@ -649,7 +650,7 @@
                 <DataTemplate x:DataType="local:TabItem">
                     <muxc:TabViewItem
                         AllowDrop="True"
-                        DragOver="TabViewItem_DragOver"
+                        DragEnter="TabViewItem_DragEnter"
                         Drop="TabViewItem_Drop"
                         FontFamily="{StaticResource FluentUIGlyphs}"
                         Header="{x:Bind Header, Mode=OneWay}"

--- a/Files/UserControls/MultitaskingControl/VerticalTabViewControl.xaml
+++ b/Files/UserControls/MultitaskingControl/VerticalTabViewControl.xaml
@@ -651,6 +651,7 @@
                     <muxc:TabViewItem
                         AllowDrop="True"
                         DragEnter="TabViewItem_DragEnter"
+                        DragLeave="TabViewItem_DragLeave"
                         Drop="TabViewItem_Drop"
                         FontFamily="{StaticResource FluentUIGlyphs}"
                         Header="{x:Bind Header, Mode=OneWay}"


### PR DESCRIPTION
Dragging files over a tab will switch to it after 0.5s

Uses a `DispatcherTimer` with a 500ms interval. The timer is reset if the files are dropped into the tab, or if the tab is not longer dragged over.

Resolves #1968 