### PR TITLE
Make optional/move repetitive checks of property values outside item enumeration loop

### DIFF
--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -160,21 +160,73 @@ namespace Files.Filesystem
             return false;
         }
 
-        public ListedItem(string folderRelativeId)
+        /// <summary>
+        /// Create an item object, optionally with an explicitly-specified dateReturnFormat.
+        /// </summary>
+        /// <param name="folderRelativeId"></param>
+        /// <param name="dateReturnFormat">Specify a date return format to reduce redundant checks of this setting.</param>
+        public ListedItem(string folderRelativeId, string dateReturnFormat = null)
         {
             FolderRelativeId = folderRelativeId;
+            if (dateReturnFormat != null)
+            {
+                DateReturnFormat = dateReturnFormat;
+            }
+            else
+            {
+                ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+                string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
+                DateReturnFormat = returnformat;
+            }
         }
 
-        public static string GetFriendlyDate(DateTimeOffset d)
-        {
-            ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
-            var elapsed = DateTimeOffset.Now - d;
+        private string DateReturnFormat { get; }
 
-            string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
+        private string GetFriendlyDate(DateTimeOffset d)
+        {
+            var elapsed = DateTimeOffset.Now - d;
 
             if (elapsed.TotalDays > 7)
             {
-                return d.ToString(returnformat);
+                return d.ToString(DateReturnFormat);
+            }
+            else if (elapsed.TotalDays > 2)
+            {
+                return string.Format(ResourceController.GetTranslation("DaysAgo"), elapsed.Days);
+            }
+            else if (elapsed.TotalDays > 1)
+            {
+                return string.Format(ResourceController.GetTranslation("DayAgo"), elapsed.Days);
+            }
+            else if (elapsed.TotalHours > 2)
+            {
+                return string.Format(ResourceController.GetTranslation("HoursAgo"), elapsed.Hours);
+            }
+            else if (elapsed.TotalHours > 1)
+            {
+                return string.Format(ResourceController.GetTranslation("HourAgo"), elapsed.Hours);
+            }
+            else if (elapsed.TotalMinutes > 2)
+            {
+                return string.Format(ResourceController.GetTranslation("MinutesAgo"), elapsed.Minutes);
+            }
+            else if (elapsed.TotalMinutes > 1)
+            {
+                return string.Format(ResourceController.GetTranslation("MinuteAgo"), elapsed.Minutes);
+            }
+            else
+            {
+                return string.Format(ResourceController.GetTranslation("SecondsAgo"), elapsed.Seconds);
+            }
+        }
+
+        public static string GetFriendlyDateFromFormat(DateTimeOffset d, string returnFormat)
+        {
+            var elapsed = DateTimeOffset.Now - d;
+
+            if (elapsed.TotalDays > 7)
+            {
+                return d.ToString(returnFormat);
             }
             else if (elapsed.TotalDays > 2)
             {
@@ -213,7 +265,7 @@ namespace Files.Filesystem
 
     public class RecycleBinItem : ListedItem
     {
-        public RecycleBinItem(string folderRelativeId) : base(folderRelativeId)
+        public RecycleBinItem(string folderRelativeId, string returnFormat) : base(folderRelativeId, returnFormat)
         {
         }
 
@@ -223,7 +275,7 @@ namespace Files.Filesystem
 
     public class ShortcutItem : ListedItem
     {
-        public ShortcutItem(string folderRelativeId) : base(folderRelativeId)
+        public ShortcutItem(string folderRelativeId, string returnFormat) : base(folderRelativeId, returnFormat)
         {
         }
 

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -770,22 +770,6 @@ namespace Files.Filesystem
             string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
             shouldDisplayFileExtensions = App.AppSettings.ShowFileExtensions;
 
-            CurrentFolder = new ListedItem(_rootFolder.FolderRelativeId, returnformat)
-            {
-                PrimaryItemAttribute = StorageItemTypes.Folder,
-                ItemPropertiesInitialized = true,
-                ItemName = _rootFolder.Name,
-                ItemDateModifiedReal = (await _rootFolder.GetBasicPropertiesAsync()).DateModified,
-                ItemType = _rootFolder.DisplayType,
-                LoadFolderGlyph = true,
-                FileImage = null,
-                LoadFileIcon = false,
-                ItemPath = string.IsNullOrEmpty(_rootFolder.Path) ? _currentStorageFolder.Path : _rootFolder.Path,
-                LoadUnknownTypeGlyph = false,
-                FileSize = null,
-                FileSizeBytes = 0
-            };
-
             if (await CheckBitlockerStatus(_rootFolder))
             {
                 var bitlockerDialog = new Dialogs.BitlockerDialog(Path.GetPathRoot(WorkingDirectory));
@@ -818,6 +802,21 @@ namespace Files.Filesystem
 
             if (enumFromStorageFolder)
             {
+                CurrentFolder = new ListedItem(_rootFolder.FolderRelativeId, returnformat)
+                {
+                    PrimaryItemAttribute = StorageItemTypes.Folder,
+                    ItemPropertiesInitialized = true,
+                    ItemName = _rootFolder.Name,
+                    ItemDateModifiedReal = (await _rootFolder.GetBasicPropertiesAsync()).DateModified,
+                    ItemType = _rootFolder.DisplayType,
+                    LoadFolderGlyph = true,
+                    FileImage = null,
+                    LoadFileIcon = false,
+                    ItemPath = string.IsNullOrEmpty(_rootFolder.Path) ? _currentStorageFolder.Path : _rootFolder.Path,
+                    LoadUnknownTypeGlyph = false,
+                    FileSize = null,
+                    FileSizeBytes = 0
+                };
                 await EnumFromStorageFolder();
             }
             else
@@ -827,6 +826,32 @@ namespace Files.Filesystem
 
                 IntPtr hFile = FindFirstFileExFromApp(path + "\\*.*", findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero,
                                                       additionalFlags);
+                FileTimeToSystemTime(ref findData.ftLastWriteTime, out SYSTEMTIME systemTimeOutput);
+                var itemDate = new DateTime(
+                    systemTimeOutput.Year,
+                    systemTimeOutput.Month,
+                    systemTimeOutput.Day,
+                    systemTimeOutput.Hour,
+                    systemTimeOutput.Minute,
+                    systemTimeOutput.Second,
+                    systemTimeOutput.Milliseconds,
+                    DateTimeKind.Utc);
+
+                CurrentFolder = new ListedItem(_rootFolder.FolderRelativeId, returnformat)
+                {
+                    PrimaryItemAttribute = StorageItemTypes.Folder,
+                    ItemPropertiesInitialized = true,
+                    ItemName = _rootFolder.Name,
+                    ItemDateModifiedReal = itemDate,
+                    ItemType = _rootFolder.DisplayType,
+                    LoadFolderGlyph = true,
+                    FileImage = null,
+                    LoadFileIcon = false,
+                    ItemPath = string.IsNullOrEmpty(_rootFolder.Path) ? _currentStorageFolder.Path : _rootFolder.Path,
+                    LoadUnknownTypeGlyph = false,
+                    FileSize = null,
+                    FileSizeBytes = 0
+                };
 
                 var count = 0;
                 if (hFile.ToInt64() == -1)

--- a/Files/View Models/Properties/BaseProperties.cs
+++ b/Files/View Models/Properties/BaseProperties.cs
@@ -1,4 +1,5 @@
 ﻿using ByteSizeLib;
+using Files.Enums;
 using Files.Filesystem;
 using Files.Helpers;
 using System;
@@ -6,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.UI.Core;
 using static Files.Helpers.NativeFindStorageItemHelper;
@@ -33,8 +35,12 @@ namespace Files.View_Models.Properties
             propertiesName.Add(dateAccessedProperty);
             propertiesName.Add(fileOwnerProperty);
             IDictionary<string, object> extraProperties = await properties.RetrievePropertiesAsync(propertiesName);
+
+            ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+            string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
+
             // Cannot get date and owner in MTP devices
-            ViewModel.ItemAccessedTimestamp = ListedItem.GetFriendlyDate((DateTimeOffset)(extraProperties[dateAccessedProperty] ?? DateTimeOffset.Now));
+            ViewModel.ItemAccessedTimestamp = ListedItem.GetFriendlyDateFromFormat((DateTimeOffset)(extraProperties[dateAccessedProperty] ?? DateTimeOffset.Now), returnformat);
 
             if (App.AppSettings.ShowFileOwner)
             {

--- a/Files/View Models/Properties/FileProperties.cs
+++ b/Files/View Models/Properties/FileProperties.cs
@@ -1,4 +1,5 @@
 ﻿using ByteSizeLib;
+using Files.Enums;
 using Files.Filesystem;
 using Files.Helpers;
 using Microsoft.Toolkit.Mvvm.Input;
@@ -261,7 +262,10 @@ namespace Files.View_Models.Properties
                 return;
             }
 
-            ViewModel.ItemCreatedTimestamp = ListedItem.GetFriendlyDate(file.DateCreated);
+            ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+            string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
+
+            ViewModel.ItemCreatedTimestamp = ListedItem.GetFriendlyDateFromFormat(file.DateCreated, returnformat);
             GetOtherProperties(file.Properties);
 
             // Get file MD5 hash

--- a/Files/View Models/Properties/FolderProperties.cs
+++ b/Files/View Models/Properties/FolderProperties.cs
@@ -1,4 +1,5 @@
 ﻿using ByteSizeLib;
+using Files.Enums;
 using Files.Filesystem;
 using Files.Helpers;
 using Microsoft.Toolkit.Mvvm.Input;
@@ -78,13 +79,15 @@ namespace Files.View_Models.Properties
                 // Can't show any other property
                 return;
             }
+            ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+            string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
 
             StorageFolder storageFolder;
             var isItemSelected = await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => App.CurrentInstance.ContentPage.IsItemSelected);
             if (isItemSelected)
             {
                 storageFolder = await ItemViewModel.GetFolderFromPathAsync(Item.ItemPath);
-                ViewModel.ItemCreatedTimestamp = ListedItem.GetFriendlyDate(storageFolder.DateCreated);
+                ViewModel.ItemCreatedTimestamp = ListedItem.GetFriendlyDateFromFormat(storageFolder.DateCreated, returnformat);
                 GetOtherProperties(storageFolder.Properties);
                 GetFolderSize(storageFolder, TokenSource.Token);
             }
@@ -134,7 +137,7 @@ namespace Files.View_Models.Properties
                 else
                 {
                     storageFolder = await ItemViewModel.GetFolderFromPathAsync(parentDirectory.ItemPath);
-                    ViewModel.ItemCreatedTimestamp = ListedItem.GetFriendlyDate(storageFolder.DateCreated);
+                    ViewModel.ItemCreatedTimestamp = ListedItem.GetFriendlyDateFromFormat(storageFolder.DateCreated, returnformat);
                     GetOtherProperties(storageFolder.Properties);
                     GetFolderSize(storageFolder, TokenSource.Token);
                 }


### PR DESCRIPTION
Slightly improve CPU usage by making some property checks less repetitive in the enumeration loop by being optional arguments.