### PR TITLE
Added properties to the context menu for items in the sidebar

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -640,7 +640,7 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Mvvm">
-      <Version>7.0.0-preview2</Version>
+      <Version>7.0.0-preview3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp">
       <Version>6.1.1</Version>

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -569,7 +569,7 @@ namespace Files.Interacts
             }
         }
 
-        private async Task OpenPropertiesWindow(object item)
+        public async Task OpenPropertiesWindow(object item)
         {
             if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
             {

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -201,6 +201,16 @@
                                     <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEB20;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
+                            <MenuFlyoutItem
+                                x:Name="PropertiesFolder"
+                                x:Uid="BaseLayoutContextFlyoutPropertiesFolder"
+                                x:Load="{x:Bind ShowProperties, Mode=OneWay}"
+                                Click="Properties_Click"
+                                Text="Properties">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xea8d;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
                         </MenuFlyout.Items>
                     </MenuFlyout>
                 </ResourceDictionary>

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -60,6 +60,24 @@ namespace Files.Controls
             }
         }
 
+        private bool _ShowProperties;
+
+        public bool ShowProperties
+        {
+            get
+            {
+                return _ShowProperties;
+            }
+            set
+            {
+                if (value != _ShowProperties)
+                {
+                    _ShowProperties = value;
+                    NotifyPropertyChanged(nameof(ShowProperties));
+                }
+            }
+        }
+
         private bool _ShowEmptyRecycleBin;
 
         public bool ShowEmptyRecycleBin
@@ -195,10 +213,12 @@ namespace Files.Controls
 
                 ShowEmptyRecycleBin = true;
                 ShowUnpinItem = true;
+                ShowProperties = false;
             }
             else
             {
                 ShowEmptyRecycleBin = false;
+                ShowProperties = true;
             }
 
             SideBarItemContextFlyout.ShowAt(sidebarItem, e.GetPosition(sidebarItem));
@@ -211,6 +231,7 @@ namespace Files.Controls
 
             ShowUnpinItem = false;
             ShowEmptyRecycleBin = false;
+            ShowProperties = true;
 
             SideBarItemContextFlyout.ShowAt(sidebarItem, e.GetPosition(sidebarItem));
 
@@ -330,6 +351,28 @@ namespace Files.Controls
             var deferral = e.GetDeferral();
             ItemOperations.PasteItemWithStatus(e.DataView, driveItem.Path, e.AcceptedOperation);
             deferral.Complete();
+        }
+
+        private async void Properties_Click(object sender, RoutedEventArgs e)
+        {
+            var item = (sender as MenuFlyoutItem).DataContext;
+
+            if (item is DriveItem)
+            {
+                await App.CurrentInstance.InteractionOperations.OpenPropertiesWindow(item);
+            }
+            else if (item is LocationItem)
+            {
+                ListedItem listedItem = new ListedItem(null)
+                {
+                    ItemPath = (item as LocationItem).Path,
+                    ItemName = (item as LocationItem).Text,
+                    PrimaryItemAttribute = Windows.Storage.StorageItemTypes.Folder,
+                    ItemType = ResourceController.GetTranslation("FileFolderListItem"),
+                    LoadFolderGlyph = true
+                };
+                await App.CurrentInstance.InteractionOperations.OpenPropertiesWindow(listedItem);
+            }
         }
     }
 

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -218,7 +218,14 @@ namespace Files.Controls
             else
             {
                 ShowEmptyRecycleBin = false;
-                ShowProperties = true;
+                // Set to true if properties should be displayed for pinned folders
+                ShowProperties = false;
+            }
+
+            // Additional check needed because ShowProperties is set to true if not recycle bin
+            if (item.IsDefaultLocation)
+            {
+                ShowProperties = false;
             }
 
             SideBarItemContextFlyout.ShowAt(sidebarItem, e.GetPosition(sidebarItem));

--- a/Files/View Models/Properties/FolderProperties.cs
+++ b/Files/View Models/Properties/FolderProperties.cs
@@ -80,7 +80,17 @@ namespace Files.View_Models.Properties
             }
 
             StorageFolder storageFolder;
-            var isItemSelected = await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => App.CurrentInstance.ContentPage.IsItemSelected);
+            bool isItemSelected;
+
+            try
+            {
+                isItemSelected = await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => App.CurrentInstance.ContentPage.IsItemSelected);
+            }
+            catch
+            {
+                isItemSelected = true;
+            }
+
             if (isItemSelected)
             {
                 storageFolder = await ItemViewModel.GetFolderFromPathAsync(Item.ItemPath);


### PR DESCRIPTION
This PR implements #1212 
In this issue, it was suggested to add properties for pinned items as well. I implemented this capability but the `FolderProperties` view model causes several issues. I fixed a thrown exception when the use is on the home page. But I was not able to fix an issue where the properties of the current folder in the file browser are shown.
As a result, implementing properties context menu for pinned items requires breaking to the `FolderProperties` view model which are beyond the range of this PR.