### PR TITLE
Improved support for HighContrast themes

### DIFF
--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -30,8 +30,8 @@
                             <SolidColorBrush x:Key="CloudDriveSyncStatusOnlineColor" Color="#0078D7" />
                             <SolidColorBrush x:Key="CloudDriveSyncStatusOfflineColor" Color="#30BB03" />
                             <SolidColorBrush x:Key="CloudDriveSyncStatusExcludedColor" Color="#AAAAAA" />
-                            <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="#201F1E" />
-                            <SolidColorBrush x:Key="SystemControlPageBackgroundMediumAltMediumBrush" Color="#99000000" />
+                            <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{ThemeResource SystemColorWindowColor}" />
+                            <SolidColorBrush x:Key="SystemControlPageBackgroundMediumAltMediumBrush" Color="{ThemeResource SystemColorWindowColor}" />
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>

--- a/Files/ResourceDictionaries/TabView_themeresources.xaml
+++ b/Files/ResourceDictionaries/TabView_themeresources.xaml
@@ -7,7 +7,6 @@
     <ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Light">
             <StaticResource x:Key="TabViewBackground" ResourceKey="SystemControlBackgroundListLowBrush" />
-            <Color x:Key="TabViewBackgroundFixed">#FFF3F2F1</Color>
             <StaticResource x:Key="TabViewItemHeaderBackground" ResourceKey="SystemControlTransparentBrush" />
             <StaticResource x:Key="TabViewItemHeaderBackgroundSelected" ResourceKey="ApplicationPageBackgroundThemeBrush" />
             <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver" ResourceKey="SystemAltMediumLowColor" />
@@ -55,7 +54,6 @@
 
         <ResourceDictionary x:Key="Dark">
             <StaticResource x:Key="TabViewBackground" ResourceKey="SystemControlBackgroundBaseLowBrush" />
-            <Color x:Key="TabViewBackgroundFixed">#161514</Color>
             <StaticResource x:Key="TabViewItemHeaderBackground" ResourceKey="SystemControlTransparentBrush" />
             <Color x:Key="TabViewItemHeaderBackgroundSelected">#292827</Color>
             <StaticResource x:Key="TabViewItemHeaderBackgroundPointerOver" ResourceKey="SystemAltMediumLowColor" />

--- a/Files/UserControls/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/ModernNavigationToolbar.xaml
@@ -18,6 +18,23 @@
     mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush 
+                        x:Key="PathBoxHoverBrush"
+                        Color="{StaticResource SystemRevealListLowColor}"/>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush 
+                        x:Key="PathBoxHoverBrush"
+                        Color="{StaticResource SystemRevealListLowColor}"/>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <SolidColorBrush 
+                        x:Key="PathBoxHoverBrush"
+                        Color="{ThemeResource SystemColorWindowColor}"/>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/ResourceDictionaries/ToolbarButtonStyle.xaml" />
 
@@ -791,11 +808,7 @@
                 PointerPressed="ManualPathEntryItem_Click">
                 <Interactivity:Interaction.Behaviors>
                     <Core:EventTriggerBehavior EventName="PointerEntered">
-                        <Core:ChangePropertyAction PropertyName="Background">
-                            <Core:ChangePropertyAction.Value>
-                                <SolidColorBrush Color="{ThemeResource SystemRevealListLowColor}" />
-                            </Core:ChangePropertyAction.Value>
-                        </Core:ChangePropertyAction>
+                        <Core:ChangePropertyAction PropertyName="Background" Value="{ThemeResource PathBoxHoverBrush}"/>
                     </Core:EventTriggerBehavior>
 
                     <Core:EventTriggerBehavior EventName="PointerExited">

--- a/Files/UserControls/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/ModernNavigationToolbar.xaml
@@ -623,7 +623,11 @@
                                 TargetTheme="Dark"
                                 Color="Transparent" />
                         </ResourceDictionary>
-                        <ResourceDictionary x:Key="HighContrast" />
+                        <ResourceDictionary x:Key="HighContrast">
+                            <SolidColorBrush 
+                                x:Key="TransparentGridRevealBorderBrush"
+                                Color="{ThemeResource SystemColorWindowTextColor}"/>
+                        </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>

--- a/Files/UserControls/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/ModernNavigationToolbar.xaml
@@ -20,19 +20,13 @@
         <ResourceDictionary>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
-                    <SolidColorBrush 
-                        x:Key="PathBoxHoverBrush"
-                        Color="{StaticResource SystemRevealListLowColor}"/>
+                    <SolidColorBrush x:Key="PathBoxHoverBrush" Color="{StaticResource SystemRevealListLowColor}" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
-                    <SolidColorBrush 
-                        x:Key="PathBoxHoverBrush"
-                        Color="{StaticResource SystemRevealListLowColor}"/>
+                    <SolidColorBrush x:Key="PathBoxHoverBrush" Color="{StaticResource SystemRevealListLowColor}" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
-                    <SolidColorBrush 
-                        x:Key="PathBoxHoverBrush"
-                        Color="{ThemeResource SystemColorWindowColor}"/>
+                    <SolidColorBrush x:Key="PathBoxHoverBrush" Color="{ThemeResource SystemColorWindowColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
             <ResourceDictionary.MergedDictionaries>
@@ -641,9 +635,7 @@
                                 Color="Transparent" />
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="HighContrast">
-                            <SolidColorBrush 
-                                x:Key="TransparentGridRevealBorderBrush"
-                                Color="{ThemeResource SystemColorWindowTextColor}"/>
+                            <SolidColorBrush x:Key="TransparentGridRevealBorderBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>
@@ -808,7 +800,7 @@
                 PointerPressed="ManualPathEntryItem_Click">
                 <Interactivity:Interaction.Behaviors>
                     <Core:EventTriggerBehavior EventName="PointerEntered">
-                        <Core:ChangePropertyAction PropertyName="Background" Value="{ThemeResource PathBoxHoverBrush}"/>
+                        <Core:ChangePropertyAction PropertyName="Background" Value="{ThemeResource PathBoxHoverBrush}" />
                     </Core:EventTriggerBehavior>
 
                     <Core:EventTriggerBehavior EventName="PointerExited">

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -3,12 +3,13 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:Windows10version1903="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
+    xmlns:converters="using:Files.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Files.UserControls"
     xmlns:local1="using:Files"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives" xmlns:converters="using:Files.Converters"
+    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -755,12 +756,10 @@
                                 TintOpacity="0.5" />
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="HighContrast">
-                            <SolidColorBrush
-                                x:Key="TabViewBackground"
-                                Color="{ThemeResource SystemColorActiveCaptionColor}"/>
+                            <SolidColorBrush x:Key="TabViewBackground" Color="{ThemeResource SystemColorActiveCaptionColor}" />
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
-                
+
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -8,7 +8,7 @@
     xmlns:local1="using:Files"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
+    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives" xmlns:converters="using:Files.Converters"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -733,14 +733,34 @@
                     </Style>
                 </ResourceDictionary>
                 <ResourceDictionary>
-                    <AcrylicBrush
-                        x:Key="TabViewBackground"
-                        Windows10version1903:TintLuminosityOpacity="0.75"
-                        AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
-                        BackgroundSource="HostBackdrop"
-                        FallbackColor="{ThemeResource TabViewBackgroundFixed}"
-                        TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
-                        TintOpacity="0.5" />
+                    <ResourceDictionary.ThemeDictionaries>
+                        <ResourceDictionary x:Key="Light">
+                            <AcrylicBrush
+                                x:Key="TabViewBackground"
+                                Windows10version1903:TintLuminosityOpacity="0.75"
+                                AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
+                                BackgroundSource="HostBackdrop"
+                                FallbackColor="#FFF3F2F1"
+                                TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
+                                TintOpacity="0.5" />
+                        </ResourceDictionary>
+                        <ResourceDictionary x:Key="Dark">
+                            <AcrylicBrush
+                                x:Key="TabViewBackground"
+                                Windows10version1903:TintLuminosityOpacity="0.75"
+                                AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
+                                BackgroundSource="HostBackdrop"
+                                FallbackColor="#161514"
+                                TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
+                                TintOpacity="0.5" />
+                        </ResourceDictionary>
+                        <ResourceDictionary x:Key="HighContrast">
+                            <SolidColorBrush
+                                x:Key="TabViewBackground"
+                                Color="{ThemeResource SystemColorActiveCaptionColor}"/>
+                        </ResourceDictionary>
+                    </ResourceDictionary.ThemeDictionaries>
+                
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -1,226 +1,224 @@
 ﻿<UserControl
-	x:Class="Files.Controls.SidebarControl"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:Windows10version1903="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:local="using:Files.Controls"
-	xmlns:local1="using:Files"
-	xmlns:local2="using:Files.Filesystem"
-	xmlns:local3="using:Files.Views"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-	d:DesignHeight="768"
-	d:DesignWidth="200"
-	mc:Ignorable="d">
-	<UserControl.Resources>
-		<ResourceDictionary>
-			<ResourceDictionary.ThemeDictionaries>
-				<ResourceDictionary x:Key="Light">
+    x:Class="Files.Controls.SidebarControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:Windows10version1903="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:Files.Controls"
+    xmlns:local1="using:Files"
+    xmlns:local2="using:Files.Filesystem"
+    xmlns:local3="using:Files.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    d:DesignHeight="768"
+    d:DesignWidth="200"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
                     <AcrylicBrush
-						x:Key="NavigationViewExpandedPaneBackground"
-						Windows10version1903:TintLuminosityOpacity="0.9"
-						AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
-						BackgroundSource="HostBackdrop"
-						FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
-						TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
-						TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
+                        x:Key="NavigationViewExpandedPaneBackground"
+                        Windows10version1903:TintLuminosityOpacity="0.9"
+                        AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
+                        TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
+                        TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
                 </ResourceDictionary>
-				<ResourceDictionary x:Key="Dark">
+                <ResourceDictionary x:Key="Dark">
                     <AcrylicBrush
-						x:Key="NavigationViewExpandedPaneBackground"
-						Windows10version1903:TintLuminosityOpacity="0.9"
-						AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
-						BackgroundSource="HostBackdrop"
-						FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
-						TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
-						TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
+                        x:Key="NavigationViewExpandedPaneBackground"
+                        Windows10version1903:TintLuminosityOpacity="0.9"
+                        AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
+                        TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
+                        TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
                 </ResourceDictionary>
-				<ResourceDictionary x:Key="HighContrast">
-                    <SolidColorBrush 
-						x:Key="NavigationViewExpandedPaneBackground" 
-						Color="{ThemeResource SystemColorWindowColor}" />
+                <ResourceDictionary x:Key="HighContrast">
+                    <SolidColorBrush x:Key="NavigationViewExpandedPaneBackground" Color="{ThemeResource SystemColorWindowColor}" />
                 </ResourceDictionary>
-			</ResourceDictionary.ThemeDictionaries>
-			<DataTemplate x:Key="LocationNavItem" x:DataType="local2:LocationItem">
-				<muxc:NavigationViewItem
-						AllowDrop="True"
-						BorderThickness="0.8"
-						Content="{x:Bind Text}"
-						DataContext="{x:Bind}"
-						DragEnter="NavigationViewItem_DragEnter"
-						DragLeave="NavigationViewItem_DragLeave"
-						DragOver="NavigationViewLocationItem_DragOver"
-						Drop="NavigationViewLocationItem_Drop"
-						IsRightTapEnabled="True"
-						RightTapped="NavigationViewLocationItem_RightTapped"
-						Tag="{x:Bind Path}">
-					<muxc:NavigationViewItem.Icon>
-						<FontIcon
-							FontFamily="{x:Bind Font}"
-							FontSize="18"
-							Glyph="{x:Bind Glyph}" />
-					</muxc:NavigationViewItem.Icon>
-				</muxc:NavigationViewItem>
-			</DataTemplate>
+            </ResourceDictionary.ThemeDictionaries>
+            <DataTemplate x:Key="LocationNavItem" x:DataType="local2:LocationItem">
+                <muxc:NavigationViewItem
+                    AllowDrop="True"
+                    BorderThickness="0.8"
+                    Content="{x:Bind Text}"
+                    DataContext="{x:Bind}"
+                    DragEnter="NavigationViewItem_DragEnter"
+                    DragLeave="NavigationViewItem_DragLeave"
+                    DragOver="NavigationViewLocationItem_DragOver"
+                    Drop="NavigationViewLocationItem_Drop"
+                    IsRightTapEnabled="True"
+                    RightTapped="NavigationViewLocationItem_RightTapped"
+                    Tag="{x:Bind Path}">
+                    <muxc:NavigationViewItem.Icon>
+                        <FontIcon
+                            FontFamily="{x:Bind Font}"
+                            FontSize="18"
+                            Glyph="{x:Bind Glyph}" />
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
+            </DataTemplate>
 
-			<DataTemplate x:Key="DriveNavItem" x:DataType="local2:DriveItem">
-				<muxc:NavigationViewItem
-					Padding="0"
-					AllowDrop="True"
-					BorderThickness="0.8"
-					Content="{x:Bind Text}"
-					DataContext="{x:Bind}"
-					DragEnter="NavigationViewItem_DragEnter"
-					DragLeave="NavigationViewItem_DragLeave"
-					DragOver="NavigationViewDriveItem_DragOver"
-					Drop="NavigationViewDriveItem_Drop"
-					IsRightTapEnabled="True"
-					RightTapped="NavigationViewDriveItem_RightTapped"
-					Tag="{x:Bind Path}"
-					ToolTipService.ToolTip="{x:Bind SpaceText}"
-					Visibility="{x:Bind ItemVisibility}">
-					<muxc:NavigationViewItem.Icon>
-						<FontIcon
-							FontFamily="{StaticResource FluentUIGlyphs}"
-							FontSize="18"
-							Glyph="{x:Bind Glyph}" />
-					</muxc:NavigationViewItem.Icon>
-				</muxc:NavigationViewItem>
-			</DataTemplate>
+            <DataTemplate x:Key="DriveNavItem" x:DataType="local2:DriveItem">
+                <muxc:NavigationViewItem
+                    Padding="0"
+                    AllowDrop="True"
+                    BorderThickness="0.8"
+                    Content="{x:Bind Text}"
+                    DataContext="{x:Bind}"
+                    DragEnter="NavigationViewItem_DragEnter"
+                    DragLeave="NavigationViewItem_DragLeave"
+                    DragOver="NavigationViewDriveItem_DragOver"
+                    Drop="NavigationViewDriveItem_Drop"
+                    IsRightTapEnabled="True"
+                    RightTapped="NavigationViewDriveItem_RightTapped"
+                    Tag="{x:Bind Path}"
+                    ToolTipService.ToolTip="{x:Bind SpaceText}"
+                    Visibility="{x:Bind ItemVisibility}">
+                    <muxc:NavigationViewItem.Icon>
+                        <FontIcon
+                            FontFamily="{StaticResource FluentUIGlyphs}"
+                            FontSize="18"
+                            Glyph="{x:Bind Glyph}" />
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
+            </DataTemplate>
 
-			<DataTemplate x:Key="LinuxNavItem" x:DataType="local1:WSLDistroItem">
-				<muxc:NavigationViewItem
-					Padding="0"
-					BorderThickness="0.8"
-					Content="{x:Bind Text}"
-					DataContext="{x:Bind}"
-					DragEnter="NavigationViewItem_DragEnter"
-					DragLeave="NavigationViewItem_DragLeave"
-					Tag="{x:Bind Path}">
-					<muxc:NavigationViewItem.Icon>
-						<BitmapIcon
-							Width="30"
-							Height="30"
-							ShowAsMonochrome="False"
-							UriSource="{x:Bind Logo}" />
-					</muxc:NavigationViewItem.Icon>
-				</muxc:NavigationViewItem>
-			</DataTemplate>
+            <DataTemplate x:Key="LinuxNavItem" x:DataType="local1:WSLDistroItem">
+                <muxc:NavigationViewItem
+                    Padding="0"
+                    BorderThickness="0.8"
+                    Content="{x:Bind Text}"
+                    DataContext="{x:Bind}"
+                    DragEnter="NavigationViewItem_DragEnter"
+                    DragLeave="NavigationViewItem_DragLeave"
+                    Tag="{x:Bind Path}">
+                    <muxc:NavigationViewItem.Icon>
+                        <BitmapIcon
+                            Width="30"
+                            Height="30"
+                            ShowAsMonochrome="False"
+                            UriSource="{x:Bind Logo}" />
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
+            </DataTemplate>
 
-			<DataTemplate x:Key="HeaderItem" x:DataType="local2:INavigationControlItem">
-				<muxc:NavigationViewItemHeader Content="{x:Bind Text}" />
-			</DataTemplate>
+            <DataTemplate x:Key="HeaderItem" x:DataType="local2:INavigationControlItem">
+                <muxc:NavigationViewItemHeader Content="{x:Bind Text}" />
+            </DataTemplate>
 
-			<local:NavItemDataTemplateSelector
-				x:Key="NavItemSelector"
-				DriveNavItemTemplate="{StaticResource DriveNavItem}"
-				HeaderNavItemTemplate="{StaticResource HeaderItem}"
-				LinuxNavItemTemplate="{StaticResource LinuxNavItem}"
-				LocationNavItemTemplate="{StaticResource LocationNavItem}" />
-		</ResourceDictionary>
-	</UserControl.Resources>
+            <local:NavItemDataTemplateSelector
+                x:Key="NavItemSelector"
+                DriveNavItemTemplate="{StaticResource DriveNavItem}"
+                HeaderNavItemTemplate="{StaticResource HeaderItem}"
+                LinuxNavItemTemplate="{StaticResource LinuxNavItem}"
+                LocationNavItemTemplate="{StaticResource LocationNavItem}" />
+        </ResourceDictionary>
+    </UserControl.Resources>
 
-	<Grid>
-		<muxc:NavigationView
-			x:Name="SidebarNavView"
-			HorizontalAlignment="Stretch"
-			IsBackButtonVisible="Collapsed"
-			IsPaneOpen="True"
-			IsPaneToggleButtonVisible="False"
-			IsSettingsVisible="False"
-			IsTitleBarAutoPaddingEnabled="False"
-			ItemInvoked="Sidebar_ItemInvoked"
-			MenuItemTemplateSelector="{StaticResource NavItemSelector}"
-			MenuItemsSource="{x:Bind local3:MainPage.sideBarItems, Mode=OneWay}"
-			OpenPaneLength="500"
-			PaneDisplayMode="Left"
-			SelectedItem="{x:Bind SelectedSidebarItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-			<muxc:NavigationView.PaneFooter>
-				<Grid>
-					<muxc:NavigationViewItem
-						x:Name="SettingsButton"
-						x:Uid="SidebarSettingsButton"
-						HorizontalAlignment="Stretch"
-						HorizontalContentAlignment="Left"
-						AutomationProperties.Name="Settings"
-						Tapped="SettingsButton_Tapped"
+    <Grid>
+        <muxc:NavigationView
+            x:Name="SidebarNavView"
+            HorizontalAlignment="Stretch"
+            IsBackButtonVisible="Collapsed"
+            IsPaneOpen="True"
+            IsPaneToggleButtonVisible="False"
+            IsSettingsVisible="False"
+            IsTitleBarAutoPaddingEnabled="False"
+            ItemInvoked="Sidebar_ItemInvoked"
+            MenuItemTemplateSelector="{StaticResource NavItemSelector}"
+            MenuItemsSource="{x:Bind local3:MainPage.sideBarItems, Mode=OneWay}"
+            OpenPaneLength="500"
+            PaneDisplayMode="Left"
+            SelectedItem="{x:Bind SelectedSidebarItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+            <muxc:NavigationView.PaneFooter>
+                <Grid>
+                    <muxc:NavigationViewItem
+                        x:Name="SettingsButton"
+                        x:Uid="SidebarSettingsButton"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Left"
+                        AutomationProperties.Name="Settings"
                         IsTapEnabled="True"
-                        SelectsOnInvoked="False">
+                        SelectsOnInvoked="False"
+                        Tapped="SettingsButton_Tapped">
                         <muxc:NavigationViewItem.Content>
                             <TextBlock
-								x:Uid="SidebarSettings"
-								Grid.Column="1"
-								Padding="2,0,0,0"
-								VerticalAlignment="Center"
-								Text="Settings" />
-						</muxc:NavigationViewItem.Content>
+                                x:Uid="SidebarSettings"
+                                Grid.Column="1"
+                                Padding="2,0,0,0"
+                                VerticalAlignment="Center"
+                                Text="Settings" />
+                        </muxc:NavigationViewItem.Content>
                         <muxc:NavigationViewItem.Icon>
                             <FontIcon
-								FontFamily="{StaticResource FluentUIGlyphs}"
-								FontSize="18"
-								Glyph="&#xEB5D;" />
+                                FontFamily="{StaticResource FluentUIGlyphs}"
+                                FontSize="18"
+                                Glyph="&#xEB5D;" />
                         </muxc:NavigationViewItem.Icon>
-					</muxc:NavigationViewItem>
-				</Grid>
-			</muxc:NavigationView.PaneFooter>
-			<muxc:NavigationView.Resources>
-				<ResourceDictionary>
-					<MenuFlyout x:Name="SideBarItemContextFlyout" x:FieldModifier="public">
-						<MenuFlyout.Items>
-							<MenuFlyoutItem
-								x:Name="EmptyRecycleBin"
-								x:Uid="BaseLayoutContextFlyoutEmptyRecycleBin"
-								x:Load="{x:Bind ShowEmptyRecycleBin, Mode=OneWay}"
-								Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.EmptyRecycleBin_ClickAsync}"
-								IsEnabled="{x:Bind RecycleBinHasItems, Mode=OneWay}"
-								Text="Empty recycle bin">
-								<MenuFlyoutItem.Icon>
-									<FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutItem
-								x:Name="OpenInNewTab"
-								x:Uid="SideBarOpenInNewTab"
-								Click="OpenInNewTab_Click"
-								Text="Open in new tab">
-								<MenuFlyoutItem.Icon>
-									<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF106;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutItem
-								x:Name="OpenInNewWindow"
-								x:Uid="SideBarOpenInNewWindow"
-								Click="OpenInNewWindow_Click"
-								Text="Open in new window">
-								<MenuFlyoutItem.Icon>
-									<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF107;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutItem
-								x:Name="UnpinItem"
-								x:Uid="SideBarUnpinFromSideBar"
-								x:Load="{x:Bind ShowUnpinItem, Mode=OneWay}"
-								Click="{x:Bind local1:App.UnpinItem_Click}"
-								Text="Unpin from Sidebar">
-								<MenuFlyoutItem.Icon>
-									<FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEB20;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutItem
-								x:Name="PropertiesFolder"
-								x:Uid="BaseLayoutContextFlyoutPropertiesFolder"
-								x:Load="{x:Bind ShowProperties, Mode=OneWay}"
-								Click="Properties_Click"
-								Text="Properties">
-								<MenuFlyoutItem.Icon>
-									<FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xea8d;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-						</MenuFlyout.Items>
-					</MenuFlyout>
-				</ResourceDictionary>
-			</muxc:NavigationView.Resources>
-		</muxc:NavigationView>
-	</Grid>
+                    </muxc:NavigationViewItem>
+                </Grid>
+            </muxc:NavigationView.PaneFooter>
+            <muxc:NavigationView.Resources>
+                <ResourceDictionary>
+                    <MenuFlyout x:Name="SideBarItemContextFlyout" x:FieldModifier="public">
+                        <MenuFlyout.Items>
+                            <MenuFlyoutItem
+                                x:Name="EmptyRecycleBin"
+                                x:Uid="BaseLayoutContextFlyoutEmptyRecycleBin"
+                                x:Load="{x:Bind ShowEmptyRecycleBin, Mode=OneWay}"
+                                Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.EmptyRecycleBin_ClickAsync}"
+                                IsEnabled="{x:Bind RecycleBinHasItems, Mode=OneWay}"
+                                Text="Empty recycle bin">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem
+                                x:Name="OpenInNewTab"
+                                x:Uid="SideBarOpenInNewTab"
+                                Click="OpenInNewTab_Click"
+                                Text="Open in new tab">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF106;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem
+                                x:Name="OpenInNewWindow"
+                                x:Uid="SideBarOpenInNewWindow"
+                                Click="OpenInNewWindow_Click"
+                                Text="Open in new window">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF107;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem
+                                x:Name="UnpinItem"
+                                x:Uid="SideBarUnpinFromSideBar"
+                                x:Load="{x:Bind ShowUnpinItem, Mode=OneWay}"
+                                Click="{x:Bind local1:App.UnpinItem_Click}"
+                                Text="Unpin from Sidebar">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEB20;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem
+                                x:Name="PropertiesFolder"
+                                x:Uid="BaseLayoutContextFlyoutPropertiesFolder"
+                                x:Load="{x:Bind ShowProperties, Mode=OneWay}"
+                                Click="Properties_Click"
+                                Text="Properties">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xea8d;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                        </MenuFlyout.Items>
+                    </MenuFlyout>
+                </ResourceDictionary>
+            </muxc:NavigationView.Resources>
+        </muxc:NavigationView>
+    </Grid>
 </UserControl>

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -1,220 +1,226 @@
 ﻿<UserControl
-    x:Class="Files.Controls.SidebarControl"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:Windows10version1903="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:Files.Controls"
-    xmlns:local1="using:Files"
-    xmlns:local2="using:Files.Filesystem"
-    xmlns:local3="using:Files.Views"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    d:DesignHeight="768"
-    d:DesignWidth="200"
-    mc:Ignorable="d">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary>
+	x:Class="Files.Controls.SidebarControl"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:Windows10version1903="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:local="using:Files.Controls"
+	xmlns:local1="using:Files"
+	xmlns:local2="using:Files.Filesystem"
+	xmlns:local3="using:Files.Views"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	d:DesignHeight="768"
+	d:DesignWidth="200"
+	mc:Ignorable="d">
+	<UserControl.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.ThemeDictionaries>
+				<ResourceDictionary x:Key="Light">
                     <AcrylicBrush
-                        x:Key="NavigationViewExpandedPaneBackground"
-                        Windows10version1903:TintLuminosityOpacity="0.9"
-                        AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
-                        BackgroundSource="HostBackdrop"
-                        FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
-                        TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
-                        TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
+						x:Key="NavigationViewExpandedPaneBackground"
+						Windows10version1903:TintLuminosityOpacity="0.9"
+						AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
+						BackgroundSource="HostBackdrop"
+						FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
+						TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
+						TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
                 </ResourceDictionary>
-                <ResourceDictionary>
-                    <DataTemplate x:Key="LocationNavItem" x:DataType="local2:LocationItem">
-                        <muxc:NavigationViewItem
-                            AllowDrop="True"
-                            BorderThickness="0.8"
-                            Content="{x:Bind Text}"
-                            DataContext="{x:Bind}"
-                            DragEnter="NavigationViewItem_DragEnter"
-                            DragLeave="NavigationViewItem_DragLeave"
-                            DragOver="NavigationViewLocationItem_DragOver"
-                            Drop="NavigationViewLocationItem_Drop"
-                            IsRightTapEnabled="True"
-                            RightTapped="NavigationViewLocationItem_RightTapped"
-                            Tag="{x:Bind Path}">
-                            <muxc:NavigationViewItem.Icon>
-                                <FontIcon
-                                    FontFamily="{x:Bind Font}"
-                                    FontSize="18"
-                                    Glyph="{x:Bind Glyph}" />
-                            </muxc:NavigationViewItem.Icon>
-                        </muxc:NavigationViewItem>
-                    </DataTemplate>
-
-                    <DataTemplate x:Key="DriveNavItem" x:DataType="local2:DriveItem">
-                        <muxc:NavigationViewItem
-                            Padding="0"
-                            AllowDrop="True"
-                            BorderThickness="0.8"
-                            Content="{x:Bind Text}"
-                            DataContext="{x:Bind}"
-                            DragEnter="NavigationViewItem_DragEnter"
-                            DragLeave="NavigationViewItem_DragLeave"
-                            DragOver="NavigationViewDriveItem_DragOver"
-                            Drop="NavigationViewDriveItem_Drop"
-                            IsRightTapEnabled="True"
-                            RightTapped="NavigationViewDriveItem_RightTapped"
-                            Tag="{x:Bind Path}"
-                            ToolTipService.ToolTip="{x:Bind SpaceText}"
-                            Visibility="{x:Bind ItemVisibility}">
-                            <muxc:NavigationViewItem.Icon>
-                                <FontIcon
-                                    FontFamily="{StaticResource FluentUIGlyphs}"
-                                    FontSize="18"
-                                    Glyph="{x:Bind Glyph}" />
-                            </muxc:NavigationViewItem.Icon>
-                        </muxc:NavigationViewItem>
-                    </DataTemplate>
-
-                    <DataTemplate x:Key="LinuxNavItem" x:DataType="local1:WSLDistroItem">
-                        <muxc:NavigationViewItem
-                            Padding="0"
-                            BorderThickness="0.8"
-                            Content="{x:Bind Text}"
-                            DataContext="{x:Bind}"
-                            DragEnter="NavigationViewItem_DragEnter"
-                            DragLeave="NavigationViewItem_DragLeave"
-                            Tag="{x:Bind Path}">
-                            <muxc:NavigationViewItem.Icon>
-                                <BitmapIcon
-                                    Width="30"
-                                    Height="30"
-                                    ShowAsMonochrome="False"
-                                    UriSource="{x:Bind Logo}" />
-                            </muxc:NavigationViewItem.Icon>
-                        </muxc:NavigationViewItem>
-                    </DataTemplate>
-
-                    <DataTemplate x:Key="HeaderItem" x:DataType="local2:INavigationControlItem">
-                        <muxc:NavigationViewItemHeader Content="{x:Bind Text}" />
-                    </DataTemplate>
-
-                    <local:NavItemDataTemplateSelector
-                        x:Key="NavItemSelector"
-                        DriveNavItemTemplate="{StaticResource DriveNavItem}"
-                        HeaderNavItemTemplate="{StaticResource HeaderItem}"
-                        LinuxNavItemTemplate="{StaticResource LinuxNavItem}"
-                        LocationNavItemTemplate="{StaticResource LocationNavItem}" />
+				<ResourceDictionary x:Key="Dark">
+                    <AcrylicBrush
+						x:Key="NavigationViewExpandedPaneBackground"
+						Windows10version1903:TintLuminosityOpacity="0.9"
+						AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
+						BackgroundSource="HostBackdrop"
+						FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
+						TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
+						TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
                 </ResourceDictionary>
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </UserControl.Resources>
-
-    <Grid>
-        <muxc:NavigationView
-            x:Name="SidebarNavView"
-            HorizontalAlignment="Stretch"
-            IsBackButtonVisible="Collapsed"
-            IsPaneOpen="True"
-            IsPaneToggleButtonVisible="False"
-            IsSettingsVisible="False"
-            IsTitleBarAutoPaddingEnabled="False"
-            ItemInvoked="Sidebar_ItemInvoked"
-            MenuItemTemplateSelector="{StaticResource NavItemSelector}"
-            MenuItemsSource="{x:Bind local3:MainPage.sideBarItems, Mode=OneWay}"
-            OpenPaneLength="500"
-            PaneDisplayMode="Left"
-            SelectedItem="{x:Bind SelectedSidebarItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-            <muxc:NavigationView.PaneFooter>
-                <Grid>
-                    <Button
-                        x:Name="SettingsButton"
-                        x:Uid="SidebarSettingsButton"
-                        Height="40"
-                        HorizontalAlignment="Stretch"
-                        HorizontalContentAlignment="Left"
-                        AutomationProperties.Name="Settings"
-                        Background="Transparent"
-                        BorderBrush="{ThemeResource ButtonRevealBorderBrush}"
-                        Click="SettingsButton_Click"
-                        CornerRadius="0">
-                        <Button.Content>
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="34" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <FontIcon
-                                    VerticalAlignment="Center"
-                                    FontFamily="{StaticResource FluentUIGlyphs}"
-                                    FontSize="18"
-                                    Glyph="&#xEB5D;" />
-                                <TextBlock
-                                    x:Uid="SidebarSettings"
-                                    Grid.Column="1"
-                                    Padding="2,0,0,0"
-                                    VerticalAlignment="Center"
-                                    Text="Settings" />
-                            </Grid>
-                        </Button.Content>
-                    </Button>
-                </Grid>
-            </muxc:NavigationView.PaneFooter>
-            <muxc:NavigationView.Resources>
-                <ResourceDictionary>
-                    <MenuFlyout x:Name="SideBarItemContextFlyout" x:FieldModifier="public">
-                        <MenuFlyout.Items>
-                            <MenuFlyoutItem
-                                x:Name="EmptyRecycleBin"
-                                x:Uid="BaseLayoutContextFlyoutEmptyRecycleBin"
-                                x:Load="{x:Bind ShowEmptyRecycleBin, Mode=OneWay}"
-                                Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.EmptyRecycleBin_ClickAsync}"
-                                IsEnabled="{x:Bind RecycleBinHasItems, Mode=OneWay}"
-                                Text="Empty recycle bin">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                            <MenuFlyoutItem
-                                x:Name="OpenInNewTab"
-                                x:Uid="SideBarOpenInNewTab"
-                                Click="OpenInNewTab_Click"
-                                Text="Open in new tab">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF106;" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                            <MenuFlyoutItem
-                                x:Name="OpenInNewWindow"
-                                x:Uid="SideBarOpenInNewWindow"
-                                Click="OpenInNewWindow_Click"
-                                Text="Open in new window">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF107;" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                            <MenuFlyoutItem
-                                x:Name="UnpinItem"
-                                x:Uid="SideBarUnpinFromSideBar"
-                                x:Load="{x:Bind ShowUnpinItem, Mode=OneWay}"
-                                Click="{x:Bind local1:App.UnpinItem_Click}"
-                                Text="Unpin from Sidebar">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEB20;" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                            <MenuFlyoutItem
-                                x:Name="PropertiesFolder"
-                                x:Uid="BaseLayoutContextFlyoutPropertiesFolder"
-                                x:Load="{x:Bind ShowProperties, Mode=OneWay}"
-                                Click="Properties_Click"
-                                Text="Properties">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xea8d;" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                        </MenuFlyout.Items>
-                    </MenuFlyout>
+				<ResourceDictionary x:Key="HighContrast">
+                    <SolidColorBrush 
+						x:Key="NavigationViewExpandedPaneBackground" 
+						Color="{ThemeResource SystemColorWindowColor}" />
                 </ResourceDictionary>
-            </muxc:NavigationView.Resources>
-        </muxc:NavigationView>
-    </Grid>
+			</ResourceDictionary.ThemeDictionaries>
+			<DataTemplate x:Key="LocationNavItem" x:DataType="local2:LocationItem">
+				<muxc:NavigationViewItem
+						AllowDrop="True"
+						BorderThickness="0.8"
+						Content="{x:Bind Text}"
+						DataContext="{x:Bind}"
+						DragEnter="NavigationViewItem_DragEnter"
+						DragLeave="NavigationViewItem_DragLeave"
+						DragOver="NavigationViewLocationItem_DragOver"
+						Drop="NavigationViewLocationItem_Drop"
+						IsRightTapEnabled="True"
+						RightTapped="NavigationViewLocationItem_RightTapped"
+						Tag="{x:Bind Path}">
+					<muxc:NavigationViewItem.Icon>
+						<FontIcon
+							FontFamily="{x:Bind Font}"
+							FontSize="18"
+							Glyph="{x:Bind Glyph}" />
+					</muxc:NavigationViewItem.Icon>
+				</muxc:NavigationViewItem>
+			</DataTemplate>
+
+			<DataTemplate x:Key="DriveNavItem" x:DataType="local2:DriveItem">
+				<muxc:NavigationViewItem
+					Padding="0"
+					AllowDrop="True"
+					BorderThickness="0.8"
+					Content="{x:Bind Text}"
+					DataContext="{x:Bind}"
+					DragEnter="NavigationViewItem_DragEnter"
+					DragLeave="NavigationViewItem_DragLeave"
+					DragOver="NavigationViewDriveItem_DragOver"
+					Drop="NavigationViewDriveItem_Drop"
+					IsRightTapEnabled="True"
+					RightTapped="NavigationViewDriveItem_RightTapped"
+					Tag="{x:Bind Path}"
+					ToolTipService.ToolTip="{x:Bind SpaceText}"
+					Visibility="{x:Bind ItemVisibility}">
+					<muxc:NavigationViewItem.Icon>
+						<FontIcon
+							FontFamily="{StaticResource FluentUIGlyphs}"
+							FontSize="18"
+							Glyph="{x:Bind Glyph}" />
+					</muxc:NavigationViewItem.Icon>
+				</muxc:NavigationViewItem>
+			</DataTemplate>
+
+			<DataTemplate x:Key="LinuxNavItem" x:DataType="local1:WSLDistroItem">
+				<muxc:NavigationViewItem
+					Padding="0"
+					BorderThickness="0.8"
+					Content="{x:Bind Text}"
+					DataContext="{x:Bind}"
+					DragEnter="NavigationViewItem_DragEnter"
+					DragLeave="NavigationViewItem_DragLeave"
+					Tag="{x:Bind Path}">
+					<muxc:NavigationViewItem.Icon>
+						<BitmapIcon
+							Width="30"
+							Height="30"
+							ShowAsMonochrome="False"
+							UriSource="{x:Bind Logo}" />
+					</muxc:NavigationViewItem.Icon>
+				</muxc:NavigationViewItem>
+			</DataTemplate>
+
+			<DataTemplate x:Key="HeaderItem" x:DataType="local2:INavigationControlItem">
+				<muxc:NavigationViewItemHeader Content="{x:Bind Text}" />
+			</DataTemplate>
+
+			<local:NavItemDataTemplateSelector
+				x:Key="NavItemSelector"
+				DriveNavItemTemplate="{StaticResource DriveNavItem}"
+				HeaderNavItemTemplate="{StaticResource HeaderItem}"
+				LinuxNavItemTemplate="{StaticResource LinuxNavItem}"
+				LocationNavItemTemplate="{StaticResource LocationNavItem}" />
+		</ResourceDictionary>
+	</UserControl.Resources>
+
+	<Grid>
+		<muxc:NavigationView
+			x:Name="SidebarNavView"
+			HorizontalAlignment="Stretch"
+			IsBackButtonVisible="Collapsed"
+			IsPaneOpen="True"
+			IsPaneToggleButtonVisible="False"
+			IsSettingsVisible="False"
+			IsTitleBarAutoPaddingEnabled="False"
+			ItemInvoked="Sidebar_ItemInvoked"
+			MenuItemTemplateSelector="{StaticResource NavItemSelector}"
+			MenuItemsSource="{x:Bind local3:MainPage.sideBarItems, Mode=OneWay}"
+			OpenPaneLength="500"
+			PaneDisplayMode="Left"
+			SelectedItem="{x:Bind SelectedSidebarItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+			<muxc:NavigationView.PaneFooter>
+				<Grid>
+					<muxc:NavigationViewItem
+						x:Name="SettingsButton"
+						x:Uid="SidebarSettingsButton"
+						HorizontalAlignment="Stretch"
+						HorizontalContentAlignment="Left"
+						AutomationProperties.Name="Settings"
+						Tapped="SettingsButton_Tapped"
+                        IsTapEnabled="True"
+                        SelectsOnInvoked="False">
+                        <muxc:NavigationViewItem.Content>
+                            <TextBlock
+								x:Uid="SidebarSettings"
+								Grid.Column="1"
+								Padding="2,0,0,0"
+								VerticalAlignment="Center"
+								Text="Settings" />
+						</muxc:NavigationViewItem.Content>
+                        <muxc:NavigationViewItem.Icon>
+                            <FontIcon
+								FontFamily="{StaticResource FluentUIGlyphs}"
+								FontSize="18"
+								Glyph="&#xEB5D;" />
+                        </muxc:NavigationViewItem.Icon>
+					</muxc:NavigationViewItem>
+				</Grid>
+			</muxc:NavigationView.PaneFooter>
+			<muxc:NavigationView.Resources>
+				<ResourceDictionary>
+					<MenuFlyout x:Name="SideBarItemContextFlyout" x:FieldModifier="public">
+						<MenuFlyout.Items>
+							<MenuFlyoutItem
+								x:Name="EmptyRecycleBin"
+								x:Uid="BaseLayoutContextFlyoutEmptyRecycleBin"
+								x:Load="{x:Bind ShowEmptyRecycleBin, Mode=OneWay}"
+								Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.EmptyRecycleBin_ClickAsync}"
+								IsEnabled="{x:Bind RecycleBinHasItems, Mode=OneWay}"
+								Text="Empty recycle bin">
+								<MenuFlyoutItem.Icon>
+									<FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+							<MenuFlyoutItem
+								x:Name="OpenInNewTab"
+								x:Uid="SideBarOpenInNewTab"
+								Click="OpenInNewTab_Click"
+								Text="Open in new tab">
+								<MenuFlyoutItem.Icon>
+									<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF106;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+							<MenuFlyoutItem
+								x:Name="OpenInNewWindow"
+								x:Uid="SideBarOpenInNewWindow"
+								Click="OpenInNewWindow_Click"
+								Text="Open in new window">
+								<MenuFlyoutItem.Icon>
+									<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF107;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+							<MenuFlyoutItem
+								x:Name="UnpinItem"
+								x:Uid="SideBarUnpinFromSideBar"
+								x:Load="{x:Bind ShowUnpinItem, Mode=OneWay}"
+								Click="{x:Bind local1:App.UnpinItem_Click}"
+								Text="Unpin from Sidebar">
+								<MenuFlyoutItem.Icon>
+									<FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEB20;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+							<MenuFlyoutItem
+								x:Name="PropertiesFolder"
+								x:Uid="BaseLayoutContextFlyoutPropertiesFolder"
+								x:Load="{x:Bind ShowProperties, Mode=OneWay}"
+								Click="Properties_Click"
+								Text="Properties">
+								<MenuFlyoutItem.Icon>
+									<FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xea8d;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+						</MenuFlyout.Items>
+					</MenuFlyout>
+				</ResourceDictionary>
+			</muxc:NavigationView.Resources>
+		</muxc:NavigationView>
+	</Grid>
 </UserControl>

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -133,7 +133,7 @@
                         HorizontalContentAlignment="Left"
                         AutomationProperties.Name="Settings"
                         Background="Transparent"
-                        BorderBrush="{StaticResource ButtonRevealBorderBrush}"
+                        BorderBrush="{ThemeResource ButtonRevealBorderBrush}"
                         Click="SettingsButton_Click"
                         CornerRadius="0">
                         <Button.Content>

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -245,14 +245,6 @@ namespace Files.Controls
             App.rightClickedItem = sidebarItem.DataContext as DriveItem;
         }
 
-        private void SettingsButton_Click(object sender, RoutedEventArgs e)
-        {
-            Frame rootFrame = Window.Current.Content as Frame;
-            rootFrame.Navigate(typeof(Settings));
-
-            return;
-        }
-
         private void OpenInNewTab_Click(object sender, RoutedEventArgs e)
         {
             App.CurrentInstance.InteractionOperations.OpenPathInNewTab(App.rightClickedItem.Path.ToString());
@@ -380,6 +372,14 @@ namespace Files.Controls
                 };
                 await App.CurrentInstance.InteractionOperations.OpenPropertiesWindow(listedItem);
             }
+        }
+
+        private void SettingsButton_Tapped(object sender, TappedRoutedEventArgs e)
+        {
+            Frame rootFrame = Window.Current.Content as Frame;
+            rootFrame.Navigate(typeof(Settings));
+
+            return;
         }
     }
 

--- a/Files/UserControls/Widgets/LibraryCards.xaml
+++ b/Files/UserControls/Widgets/LibraryCards.xaml
@@ -38,7 +38,7 @@
                                         <SolidColorBrush x:Key="YourHomeCardBackgroundColor" Color="#161514" />
                                     </ResourceDictionary>
                                     <ResourceDictionary x:Name="HighContrast">
-                                        <SolidColorBrush x:Key="YourHomeCardBackgroundColor" Color="Black" />
+                                        <SolidColorBrush x:Key="YourHomeCardBackgroundColor" Color="{ThemeResource SystemColorButtonFaceColor}" />
                                     </ResourceDictionary>
                                 </ResourceDictionary.ThemeDictionaries>
                             </ResourceDictionary>

--- a/Files/Views/ModernShellPage.xaml
+++ b/Files/Views/ModernShellPage.xaml
@@ -18,6 +18,24 @@
     mc:Ignorable="d">
     <Page.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush
+                        x:Key="SidebarBorderBrush"
+                        Color="Transparent"/>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush
+                        x:Key="SidebarBorderBrush"
+                        Color="Transparent"/>
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <SolidColorBrush
+                        x:Key="SidebarBorderBrush"
+                        Color="{ThemeResource SystemColorWindowTextColor}"/>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+            
             <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
             <Style x:Key="DefaultGridSplitterStyle" TargetType="Custom:GridSplitter">
                 <Setter Property="IsTabStop" Value="True" />
@@ -32,7 +50,7 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Custom:GridSplitter">
-                            <Grid x:Name="RootGrid" Background="Transparent">
+                            <Grid x:Name="RootGrid" Background="Transparent" BorderBrush="{ThemeResource SidebarBorderBrush}" BorderThickness="1,0,0,0">
                                 <ContentPresenter
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"

--- a/Files/Views/ModernShellPage.xaml
+++ b/Files/Views/ModernShellPage.xaml
@@ -20,22 +20,16 @@
         <ResourceDictionary>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
-                    <SolidColorBrush
-                        x:Key="SidebarBorderBrush"
-                        Color="Transparent"/>
+                    <SolidColorBrush x:Key="SidebarBorderBrush" Color="Transparent" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
-                    <SolidColorBrush
-                        x:Key="SidebarBorderBrush"
-                        Color="Transparent"/>
+                    <SolidColorBrush x:Key="SidebarBorderBrush" Color="Transparent" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
-                    <SolidColorBrush
-                        x:Key="SidebarBorderBrush"
-                        Color="{ThemeResource SystemColorWindowTextColor}"/>
+                    <SolidColorBrush x:Key="SidebarBorderBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
-            
+
             <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
             <Style x:Key="DefaultGridSplitterStyle" TargetType="Custom:GridSplitter">
                 <Setter Property="IsTabStop" Value="True" />
@@ -50,7 +44,11 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Custom:GridSplitter">
-                            <Grid x:Name="RootGrid" Background="Transparent" BorderBrush="{ThemeResource SidebarBorderBrush}" BorderThickness="1,0,0,0">
+                            <Grid
+                                x:Name="RootGrid"
+                                Background="Transparent"
+                                BorderBrush="{ThemeResource SidebarBorderBrush}"
+                                BorderThickness="1,0,0,0">
                                 <ContentPresenter
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"

--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -97,7 +97,15 @@ namespace Files
                 {
                     backgroundBrush.TintLuminosityOpacity = 0.9;
                 }
-                Background = backgroundBrush;
+
+                if (!(new AccessibilitySettings()).HighContrast)
+                {
+                    Background = backgroundBrush;
+                }
+                else
+                {
+                    Background = Application.Current.Resources["ApplicationPageBackgroundThemeBrush"] as SolidColorBrush;
+                }
             });
         }
 

--- a/Files/Views/Settings.xaml
+++ b/Files/Views/Settings.xaml
@@ -15,28 +15,26 @@
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
                     <AcrylicBrush
-						x:Key="NavigationViewExpandedPaneBackground"
-						Windows10version1903:TintLuminosityOpacity="0.9"
-						AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
-						BackgroundSource="HostBackdrop"
-						FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
-						TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
-						TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
+                        x:Key="NavigationViewExpandedPaneBackground"
+                        Windows10version1903:TintLuminosityOpacity="0.9"
+                        AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
+                        TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
+                        TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
                     <AcrylicBrush
-						x:Key="NavigationViewExpandedPaneBackground"
-						Windows10version1903:TintLuminosityOpacity="0.9"
-						AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
-						BackgroundSource="HostBackdrop"
-						FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
-						TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
-						TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
+                        x:Key="NavigationViewExpandedPaneBackground"
+                        Windows10version1903:TintLuminosityOpacity="0.9"
+                        AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
+                        BackgroundSource="HostBackdrop"
+                        FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
+                        TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
+                        TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
-                    <SolidColorBrush 
-						x:Key="NavigationViewExpandedPaneBackground" 
-						Color="{ThemeResource SystemColorWindowColor}" />
+                    <SolidColorBrush x:Key="NavigationViewExpandedPaneBackground" Color="{ThemeResource SystemColorWindowColor}" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>

--- a/Files/Views/Settings.xaml
+++ b/Files/Views/Settings.xaml
@@ -11,14 +11,35 @@
     NavigationCacheMode="Enabled"
     mc:Ignorable="d">
     <Page.Resources>
-        <AcrylicBrush
-            x:Key="NavigationViewExpandedPaneBackground"
-            Windows10version1903:TintLuminosityOpacity="0.9"
-            AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
-            BackgroundSource="HostBackdrop"
-            FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
-            TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
-            TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <AcrylicBrush
+						x:Key="NavigationViewExpandedPaneBackground"
+						Windows10version1903:TintLuminosityOpacity="0.9"
+						AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
+						BackgroundSource="HostBackdrop"
+						FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
+						TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
+						TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <AcrylicBrush
+						x:Key="NavigationViewExpandedPaneBackground"
+						Windows10version1903:TintLuminosityOpacity="0.9"
+						AlwaysUseFallback="{x:Bind AppSettings.AcrylicEnabled, Mode=OneWay}"
+						BackgroundSource="HostBackdrop"
+						FallbackColor="{x:Bind AppSettings.AcrylicTheme.FallbackColor, Mode=OneWay}"
+						TintColor="{x:Bind AppSettings.AcrylicTheme.TintColor, Mode=OneWay}"
+						TintOpacity="{x:Bind AppSettings.AcrylicTheme.TintOpacity, Mode=OneWay}" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <SolidColorBrush 
+						x:Key="NavigationViewExpandedPaneBackground" 
+						Color="{ThemeResource SystemColorWindowColor}" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
     </Page.Resources>
 
     <Grid>


### PR DESCRIPTION
Switch many areas of the app to use the provided SystemColor* universal resources for HighContrast themes. 

Before vs After:
![image](https://user-images.githubusercontent.com/20365014/96755316-8d39c280-13a0-11eb-8ed3-b6bb6497ccf5.png)


Final result:
![image](https://user-images.githubusercontent.com/20365014/96756750-84e28700-13a2-11eb-9ac2-7ec004cb5da1.png)
