### PR TITLE
Fixed a couple issues in ItemViewModel

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -145,7 +145,7 @@ namespace Files
                 var changeType = (string)args.Request.Message["Type"];
                 var newItem = JsonConvert.DeserializeObject<ShellFileItem>(args.Request.Message.Get("Item", ""));
                 Debug.WriteLine("{0}: {1}", folderPath, changeType);
-                await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                await CoreApplication.MainView.ExecuteOnUIThreadAsync(async () =>
                 {
                     // If we are currently displaying the reycle bin lets refresh the items
                     if (CurrentInstance.FilesystemViewModel?.CurrentFolder?.ItemPath == folderPath)
@@ -157,7 +157,7 @@ namespace Files
                                 break;
 
                             case "Deleted":
-                                CurrentInstance.FilesystemViewModel.RemoveFileOrFolder(itemPath);
+                                await CurrentInstance.FilesystemViewModel.RemoveFileOrFolder(itemPath);
                                 break;
 
                             default:

--- a/Files/Commands/Delete.cs
+++ b/Files/Commands/Delete.cs
@@ -197,7 +197,7 @@ namespace Files.Commands
                     await (await ItemViewModel.GetFileFromPathAsync(iFilePath)).DeleteAsync(StorageDeleteOption.PermanentDelete);
                 }
 
-                AppInstance.FilesystemViewModel.RemoveFileOrFolder(storItem);
+                await AppInstance.FilesystemViewModel.RemoveFileOrFolder(storItem);
                 itemsDeleted++;
             }
         }

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -6,6 +6,7 @@ using Files.Helpers;
 using Files.View_Models;
 using Files.Views;
 using Microsoft.Toolkit.Uwp.Extensions;
+using Microsoft.Toolkit.Uwp.Helpers;
 using Microsoft.Toolkit.Uwp.UI;
 using System;
 using System.Collections.Generic;
@@ -610,7 +611,7 @@ namespace Files.Filesystem
                 // simply drop this instance
                 await semaphoreSlim.WaitAsync(_semaphoreCTS.Token);
             }
-            catch (OperationCanceledException)
+            catch (Exception ex) when (ex is OperationCanceledException || ex is ObjectDisposedException)
             {
                 return;
             }
@@ -877,19 +878,19 @@ namespace Files.Filesystem
             {
                 FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
                 int additionalFlags = FIND_FIRST_EX_LARGE_FETCH;
-
                 IntPtr hFile = FindFirstFileExFromApp(path + "\\*.*", findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero,
                                                       additionalFlags);
-                FileTimeToSystemTime(ref findData.ftLastWriteTime, out SYSTEMTIME systemTimeOutput);
-                var itemDate = new DateTime(
-                    systemTimeOutput.Year,
-                    systemTimeOutput.Month,
-                    systemTimeOutput.Day,
-                    systemTimeOutput.Hour,
-                    systemTimeOutput.Minute,
-                    systemTimeOutput.Second,
-                    systemTimeOutput.Milliseconds,
-                    DateTimeKind.Utc);
+
+                DateTime itemDate = DateTime.UtcNow;
+                try
+                {
+                    FileTimeToSystemTime(ref findData.ftLastWriteTime, out SYSTEMTIME systemTimeOutput);
+                    itemDate = new DateTime(
+                        systemTimeOutput.Year, systemTimeOutput.Month, systemTimeOutput.Day,
+                        systemTimeOutput.Hour, systemTimeOutput.Minute, systemTimeOutput.Second, systemTimeOutput.Milliseconds,
+                        DateTimeKind.Utc);
+                }
+                catch (ArgumentException) { }
 
                 CurrentFolder = new ListedItem(_rootFolder.FolderRelativeId, returnformat)
                 {
@@ -1109,27 +1110,27 @@ namespace Files.Filesystem
                                     {
                                         case FILE_ACTION_ADDED:
                                             Debug.WriteLine("File " + FileName + " added to working directory.");
-                                            AddFileOrFolder(FileName, returnformat);
+                                            AddFileOrFolder(FileName, returnformat).GetAwaiter().GetResult();
                                             break;
 
                                         case FILE_ACTION_REMOVED:
                                             Debug.WriteLine("File " + FileName + " removed from working directory.");
-                                            RemoveFileOrFolder(FileName);
+                                            RemoveFileOrFolder(FileName).GetAwaiter().GetResult();
                                             break;
 
                                         case FILE_ACTION_MODIFIED:
                                             Debug.WriteLine("File " + FileName + " had attributes modified in the working directory.");
-                                            UpdateFileOrFolder(FilesAndFolders.ToList().First(x => x.ItemPath.Equals(FileName)));
+                                            UpdateFileOrFolder(FileName).GetAwaiter().GetResult();
                                             break;
 
                                         case FILE_ACTION_RENAMED_OLD_NAME:
                                             Debug.WriteLine("File " + FileName + " will be renamed in the working directory.");
-                                            RemoveFileOrFolder(FileName);
+                                            RemoveFileOrFolder(FileName).GetAwaiter().GetResult();
                                             break;
 
                                         case FILE_ACTION_RENAMED_NEW_NAME:
                                             Debug.WriteLine("File " + FileName + " was renamed in the working directory.");
-                                            AddFileOrFolder(FileName, returnformat);
+                                            AddFileOrFolder(FileName, returnformat).GetAwaiter().GetResult();
                                             break;
 
                                         default:
@@ -1233,13 +1234,13 @@ namespace Files.Filesystem
             UpdateDirectoryInfo();
         }
 
-        public void AddFileOrFolder(ListedItem item)
+        private void AddFileOrFolder(ListedItem item)
         {
             _filesAndFolders.Add(item);
             IsFolderEmptyTextDisplayed = false;
         }
 
-        private void AddFileOrFolder2(string fileOrFolderPath, string dateReturnFormat)
+        private async Task AddFileOrFolder(string fileOrFolderPath, string dateReturnFormat)
         {
             FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
             int additionalFlags = FIND_FIRST_EX_CASE_SENSITIVE;
@@ -1248,32 +1249,18 @@ namespace Files.Filesystem
                                                   additionalFlags);
             FindClose(hFile);
 
-            if ((findData.dwFileAttributes & 0x10) > 0) // FILE_ATTRIBUTE_DIRECTORY
+            await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
             {
-                AddFolder(findData, Directory.GetParent(fileOrFolderPath).FullName, dateReturnFormat);
-            }
-            else
-            {
-                AddFile(findData, Directory.GetParent(fileOrFolderPath).FullName, dateReturnFormat);
-            }
-        }
-
-        private async void AddFileOrFolder(string path, string dateReturnFormat)
-        {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
-                () =>
+                if ((findData.dwFileAttributes & 0x10) > 0) // FILE_ATTRIBUTE_DIRECTORY
                 {
-                    try
-                    {
-                        AddFileOrFolder2(path, dateReturnFormat);
-                    }
-                    catch (Exception)
-                    {
-                        // Ignore this..
-                    }
-
-                    UpdateDirectoryInfo();
-                });
+                    AddFolder(findData, Directory.GetParent(fileOrFolderPath).FullName, dateReturnFormat);
+                }
+                else
+                {
+                    AddFile(findData, Directory.GetParent(fileOrFolderPath).FullName, dateReturnFormat);
+                }
+                UpdateDirectoryInfo();
+            });
         }
 
         private void UpdateDirectoryInfo()
@@ -1291,7 +1278,7 @@ namespace Files.Filesystem
             }
         }
 
-        public async void UpdateFileOrFolder(ListedItem item)
+        private async Task UpdateFileOrFolder(ListedItem item)
         {
             IStorageItem storageItem = null;
             if (item.PrimaryItemAttribute == StorageItemTypes.File)
@@ -1305,36 +1292,43 @@ namespace Files.Filesystem
             if (storageItem != null)
             {
                 var syncStatus = await CheckCloudDriveSyncStatus(storageItem);
-                await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
-                    () =>
-                    {
-                        item.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
-                    });
+                await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                {
+                    item.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
+                });
             }
         }
 
-        public async void RemoveFileOrFolder(ListedItem item)
-        {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
-                () =>
-                {
-                    _filesAndFolders.Remove(item);
-                    if (_filesAndFolders.Count == 0)
-                    {
-                        IsFolderEmptyTextDisplayed = true;
-                    }
-                    App.JumpList.RemoveFolder(item.ItemPath);
-
-                    UpdateDirectoryInfo();
-                });
-        }
-
-        public void RemoveFileOrFolder(string path)
+        private async Task UpdateFileOrFolder(string path)
         {
             var matchingItem = FilesAndFolders.ToList().FirstOrDefault(x => x.ItemPath.Equals(path));
             if (matchingItem != null)
             {
-                RemoveFileOrFolder(matchingItem);
+                await UpdateFileOrFolder(matchingItem);
+            }
+        }
+
+        public async Task RemoveFileOrFolder(ListedItem item)
+        {
+            await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+            {
+                _filesAndFolders.Remove(item);
+                if (_filesAndFolders.Count == 0)
+                {
+                    IsFolderEmptyTextDisplayed = true;
+                }
+                App.JumpList.RemoveFolder(item.ItemPath);
+
+                UpdateDirectoryInfo();
+            });
+        }
+
+        public async Task RemoveFileOrFolder(string path)
+        {
+            var matchingItem = FilesAndFolders.ToList().FirstOrDefault(x => x.ItemPath.Equals(path));
+            if (matchingItem != null)
+            {
+                await RemoveFileOrFolder(matchingItem);
             }
         }
 
@@ -1346,16 +1340,20 @@ namespace Files.Filesystem
                 return;
             }
 
-            FileTimeToSystemTime(ref findData.ftLastWriteTime, out SYSTEMTIME systemTimeOutput);
-            var itemDate = new DateTime(
-                systemTimeOutput.Year,
-                systemTimeOutput.Month,
-                systemTimeOutput.Day,
-                systemTimeOutput.Hour,
-                systemTimeOutput.Minute,
-                systemTimeOutput.Second,
-                systemTimeOutput.Milliseconds,
-                DateTimeKind.Utc);
+            DateTime itemDate;
+            try
+            {
+                FileTimeToSystemTime(ref findData.ftLastWriteTime, out SYSTEMTIME systemTimeOutput);
+                itemDate = new DateTime(
+                    systemTimeOutput.Year, systemTimeOutput.Month, systemTimeOutput.Day,
+                    systemTimeOutput.Hour, systemTimeOutput.Minute, systemTimeOutput.Second, systemTimeOutput.Milliseconds,
+                    DateTimeKind.Utc);
+            }
+            catch (ArgumentException)
+            {
+                // Invalid date means invalid findData, do not add to list
+                return;
+            }
             var itemPath = Path.Combine(pathRoot, findData.cFileName);
 
             _filesAndFolders.Add(new ListedItem(null, dateReturnFormat)
@@ -1399,23 +1397,32 @@ namespace Files.Filesystem
                 }
             }
 
-            FileTimeToSystemTime(ref findData.ftLastWriteTime, out SYSTEMTIME systemModifiedDateOutput);
-            var itemModifiedDate = new DateTime(
-                systemModifiedDateOutput.Year, systemModifiedDateOutput.Month, systemModifiedDateOutput.Day,
-                systemModifiedDateOutput.Hour, systemModifiedDateOutput.Minute, systemModifiedDateOutput.Second, systemModifiedDateOutput.Milliseconds,
-                DateTimeKind.Utc);
+            DateTime itemModifiedDate, itemCreatedDate, itemLastAccessDate;
+            try
+            {
+                FileTimeToSystemTime(ref findData.ftLastWriteTime, out SYSTEMTIME systemModifiedDateOutput);
+                itemModifiedDate = new DateTime(
+                    systemModifiedDateOutput.Year, systemModifiedDateOutput.Month, systemModifiedDateOutput.Day,
+                    systemModifiedDateOutput.Hour, systemModifiedDateOutput.Minute, systemModifiedDateOutput.Second, systemModifiedDateOutput.Milliseconds,
+                    DateTimeKind.Utc);
 
-            FileTimeToSystemTime(ref findData.ftCreationTime, out SYSTEMTIME systemCreatedDateOutput);
-            var itemCreatedDate = new DateTime(
-                systemCreatedDateOutput.Year, systemCreatedDateOutput.Month, systemCreatedDateOutput.Day,
-                systemCreatedDateOutput.Hour, systemCreatedDateOutput.Minute, systemCreatedDateOutput.Second, systemCreatedDateOutput.Milliseconds,
-                DateTimeKind.Utc);
+                FileTimeToSystemTime(ref findData.ftCreationTime, out SYSTEMTIME systemCreatedDateOutput);
+                itemCreatedDate = new DateTime(
+                    systemCreatedDateOutput.Year, systemCreatedDateOutput.Month, systemCreatedDateOutput.Day,
+                    systemCreatedDateOutput.Hour, systemCreatedDateOutput.Minute, systemCreatedDateOutput.Second, systemCreatedDateOutput.Milliseconds,
+                    DateTimeKind.Utc);
 
-            FileTimeToSystemTime(ref findData.ftLastAccessTime, out SYSTEMTIME systemLastAccessOutput);
-            var itemLastAccessDate = new DateTime(
-                systemLastAccessOutput.Year, systemLastAccessOutput.Month, systemLastAccessOutput.Day,
-                systemLastAccessOutput.Hour, systemLastAccessOutput.Minute, systemLastAccessOutput.Second, systemLastAccessOutput.Milliseconds,
-                DateTimeKind.Utc);
+                FileTimeToSystemTime(ref findData.ftLastAccessTime, out SYSTEMTIME systemLastAccessOutput);
+                itemLastAccessDate = new DateTime(
+                    systemLastAccessOutput.Year, systemLastAccessOutput.Month, systemLastAccessOutput.Day,
+                    systemLastAccessOutput.Hour, systemLastAccessOutput.Minute, systemLastAccessOutput.Second, systemLastAccessOutput.Milliseconds,
+                    DateTimeKind.Utc);
+            }
+            catch (ArgumentException)
+            {
+                // Invalid date means invalid findData, do not add to list
+                return;
+            }
 
             long itemSizeBytes = findData.GetSize();
             var itemSize = ByteSize.FromBytes(itemSizeBytes).ToBinaryString().ConvertSizeAbbreviation();


### PR DESCRIPTION
Fixes #2172
Fixes [2428289282u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/2428289282u/overview)

@duke7553 this PR hopes to solve a couple of issues in ItemViewModel that cause app crash. I'd be happy if you could take a look at it as well.

1) Fix crash when temporary files are quickly created and deleted (e.g. when saving a Word file in Onedrive folder as in #2172)
Changed the functions AddFileOrFolder, UpdateFileOrFolder, RemoveFileOrFolder from `async void` to `async Task` so the `catch` statement in WatchForDirectoryChanges can actually work (exceptions are not caught if not awaited).

2) Fix files/folders with funny/garbled names appearing in the file list in the same above situation
What happens is that sometimes WIN32_FIND_DATA seems to contain garbage data, this is handled by catching the ArgumentException generated when trying to read the date from the WIN32_FIND_DATA structure. If this happens the structure is assumed to be corrupted and the file is not added to the list.
