### PR TITLE
[#2190] - Checked for UnauthorizedAccessException on a selected directory

### DIFF
--- a/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -124,7 +124,14 @@ namespace Files.Filesystem
             }
             else
             {
-                return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(value));
+                try
+                {
+                    return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(value));
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return await GetFolderWithPathFromPathAsync(Directory.GetParent(value).FullName, rootFolder, parentFolder).ConfigureAwait(false);
+                }
             }
         }
 


### PR DESCRIPTION
[#2190] - Checked for UnauthorizedAccessException on a selected directory. When the exception occurs, GetFolderWithPathFromPathAsync will be called recursively each time with a parent path of the folder for which we don't have necessary access rights.