### PR TITLE
Fixed an issue that would occur when network drives were disconnected

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Files.Common
 {
@@ -47,6 +49,25 @@ namespace Files.Common
             {
                 return DateTime.FromFileTimeUtc(0xFFFFFFFF);
             }
+        }
+
+        public static async Task WithTimeout(this Task task,
+            TimeSpan timeout)
+        {
+            if (task == await Task.WhenAny(task, Task.Delay(timeout)))
+            {
+                await task;
+            }
+        }
+
+        public static async Task<T> WithTimeout<T>(this Task<T> task,
+            TimeSpan timeout)
+        {
+            if (task == await Task.WhenAny(task, Task.Delay(timeout)))
+            {
+                return await task;
+            }
+            return default(T);
         }
     }
 }

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -64,7 +64,7 @@ namespace FilesFullTrust
                 foreach (var drive in DriveInfo.GetDrives())
                 {
                     var recycle_path = Path.Combine(drive.Name, "$Recycle.Bin", sid);
-                    if (!Directory.Exists(recycle_path))
+                    if (drive.DriveType == DriveType.Network || !Directory.Exists(recycle_path))
                     {
                         continue;
                     }

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -83,7 +83,7 @@ namespace FilesFullTrust
                 // Preload context menu for better performace
                 // We query the context menu for the app's local folder
                 var preloadPath = ApplicationData.Current.LocalFolder.Path;
-                using var _ = Win32API.ContextMenu.GetContextMenuForFiles(new string[] { preloadPath }, Shell32.CMF.CMF_NORMAL);
+                using var _ = Win32API.ContextMenu.GetContextMenuForFiles(new string[] { preloadPath }, Shell32.CMF.CMF_NORMAL | Shell32.CMF.CMF_SYNCCASCADEMENU, FilterMenuItems(false));
 
                 // Connect to app service and wait until the connection gets closed
                 appServiceExit = new AutoResetEvent(false);
@@ -324,7 +324,7 @@ namespace FilesFullTrust
                     var showOpenMenu = (bool)message["ShowOpenMenu"];
                     var split = filePath.Split('|').Where(x => !string.IsNullOrWhiteSpace(x));
                     var cMenuLoad = Win32API.ContextMenu.GetContextMenuForFiles(split.ToArray(),
-                        extendedMenu ? Shell32.CMF.CMF_EXTENDEDVERBS : Shell32.CMF.CMF_NORMAL, FilterMenuItems(showOpenMenu));
+                        (extendedMenu ? Shell32.CMF.CMF_EXTENDEDVERBS : Shell32.CMF.CMF_NORMAL) | Shell32.CMF.CMF_SYNCCASCADEMENU, FilterMenuItems(showOpenMenu));
                     table.SetValue("MENU", cMenuLoad);
                     return cMenuLoad;
 

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -76,7 +76,7 @@
                     IsRightTapEnabled="True"
                     RightTapped="NavigationViewDriveItem_RightTapped"
                     Tag="{x:Bind Path}"
-                    ToolTipService.ToolTip="{x:Bind SpaceText}"
+                    ToolTipService.ToolTip="{x:Bind SpaceText, Mode=OneWay}"
                     Visibility="{x:Bind ItemVisibility}">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -924,6 +924,7 @@ namespace Files.Filesystem
                 else if (hFile.ToInt64() == -1)
                 {
                     await EnumFromStorageFolder();
+                    return false;
                 }
                 else
                 {
@@ -957,8 +958,8 @@ namespace Files.Filesystem
                     } while (FindNextFile(hFile, out findData));
 
                     FindClose(hFile);
+                    return true;
                 }
-                return true;
             }
         }
 


### PR DESCRIPTION
Fixes #2174

This PR solves the issue of app hanging on start if a network drive is disconnected.
This is done by:
- loading drive properties in an async method (with timeout) -> fix hang  on app start
- adding a timeout to `EnumerateItemsFromStandardFolder` after which a "Drive disconnected" dialog is shown -> fix hang is the user navigates to a disconnected drive
