### PR TITLE
Fix for Files crashing when attempting to access unmounted ISO

### DIFF
--- a/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -128,8 +128,9 @@ namespace Files.Filesystem
                 {
                     return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(value));
                 }
-                catch (UnauthorizedAccessException)
+                catch (Exception ex)
                 {
+                    NLog.LogManager.GetCurrentClassLogger().Error(ex, ex.Message);
                     return await GetFolderWithPathFromPathAsync(Directory.GetParent(value).FullName, rootFolder, parentFolder).ConfigureAwait(false);
                 }
             }


### PR DESCRIPTION
Expanded the catch clause in StorageFileExtension to include a wider range of exceptions & logged out the error message.