### PR TITLE
Fixes for some Uid

### DIFF
--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -1321,10 +1321,6 @@
           <source>Access Denied</source>
           <target state="translated">Zugriff verweigert</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="translated">Eine Option anzeigen, um den Speicherort des ausgewählten Elements zu kopieren</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="translated">Alle Elemente im Kontextmenü anzeigen</target>
@@ -1428,6 +1424,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="translated">Eine Option anzeigen, um den Speicherort des ausgewählten Elements zu kopieren</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -1318,10 +1318,6 @@
           <source>Access Denied</source>
           <target state="translated">Acceso Denegado</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="translated">Mostrar en el menú contextual una opción para copiar la ubicación del archivo seleccionado</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="translated">Mostrar todos los elementos del menú contextual</target>
@@ -1425,6 +1421,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="translated">Mostrar archivos recientes en la página de inicio</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="translated">Mostrar en el menú contextual una opción para copiar la ubicación del archivo seleccionado</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -1319,10 +1319,6 @@
           <source>Access Denied</source>
           <target state="translated">Accès refusé</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="new">Show all context menu items</target>
@@ -1426,6 +1422,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="new">Show an option to copy the location of the selected item</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.he-IL.xlf
+++ b/Files/MultilingualResources/Files.he-IL.xlf
@@ -1318,10 +1318,6 @@
           <source>Access Denied</source>
           <target state="translated" state-qualifier="tm-suggestion">הגישה נדחתה</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="new">Show all context menu items</target>
@@ -1425,6 +1421,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="new">Show an option to copy the location of the selected item</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.hi-IN.xlf
+++ b/Files/MultilingualResources/Files.hi-IN.xlf
@@ -1330,10 +1330,6 @@
           <source>Access Denied</source>
           <target state="new">Access Denied</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="new">Show all context menu items</target>
@@ -1437,6 +1433,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="new">Show an option to copy the location of the selected item</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.hu-HU.xlf
+++ b/Files/MultilingualResources/Files.hu-HU.xlf
@@ -1342,10 +1342,6 @@
           <source>Terminal Applications</source>
           <target state="translated">Parancssor Programok</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="translated">Kijelölt elem helyének másolása lehetőség megjelenítése</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="translated">Összes menü lehetőség megjelenítése</target>
@@ -1404,7 +1400,7 @@
         </trans-unit>
         <trans-unit id="SettingsWidgetsTitle.Text" translate="yes" xml:space="preserve">
           <source>Widgets</source>
-          <target state="transleted">Widgetek</target>
+          <target state="translated">Widgetek</target>
         </trans-unit>
         <trans-unit id="SettingsWidgets.Content" translate="yes" xml:space="preserve">
           <source>Widgets</source>
@@ -1425,6 +1421,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="translated">Legutóbbi megnyitottak megjelenítése a fő oldalon</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="translated">Kijelölt elem helyének másolása lehetőség megjelenítése</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -1319,10 +1319,6 @@
           <source>Access Denied</source>
           <target state="translated">Accesso Negato</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="translated">Mostra un'opzione per copiare il percorso dell'elemento selezionato</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="translated">Mostra tutti gli elementi nel menu contestuale</target>
@@ -1426,6 +1422,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="translated">Mostra un'opzione per copiare il percorso dell'elemento selezionato</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -1318,10 +1318,6 @@
           <source>Access Denied</source>
           <target state="translated">アクセスが拒否されました</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="translated">選択したアイテムの場所をコピーするオプションを表示する</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="translated">すべてのコンテキストメニュー項目を表示する</target>
@@ -1425,6 +1421,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="translated">選択したアイテムの場所をコピーするオプションを表示する</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -1332,10 +1332,6 @@
           <source>Access Denied</source>
           <target state="new">Access Denied</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="new">Show all context menu items</target>
@@ -1439,6 +1435,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="new">Show an option to copy the location of the selected item</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.or-IN.xlf
+++ b/Files/MultilingualResources/Files.or-IN.xlf
@@ -1330,10 +1330,6 @@
           <source>Access Denied</source>
           <target state="new">Access Denied</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="new">Show all context menu items</target>
@@ -1437,6 +1433,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="new">Show an option to copy the location of the selected item</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -1331,10 +1331,6 @@
           <source>Access Denied</source>
           <target state="new">Access Denied</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="new">Show all context menu items</target>
@@ -1438,6 +1434,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="new">Show an option to copy the location of the selected item</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.pt-BR.xlf
+++ b/Files/MultilingualResources/Files.pt-BR.xlf
@@ -1318,10 +1318,6 @@
           <source>Access Denied</source>
           <target state="translated">Acesso negado</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="translated">Mostra uma opção para copiar a localização do item selecionado</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="translated">Mostrar todos os itens do menu de contexto</target>
@@ -1425,6 +1421,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="translated">Mostra uma opção para copiar a localização do item selecionado</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -1319,10 +1319,6 @@
           <source>Access Denied</source>
           <target state="new">Access Denied</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="new">Show all context menu items</target>
@@ -1426,6 +1422,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="new">Show an option to copy the location of the selected item</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -1272,7 +1272,7 @@
         </trans-unit>
         <trans-unit id="SettingsPreferencesCopyLocationSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
+          <target state="translated">தேர்வுசெய்யப்பட்ட உருப்படியின் இருப்பிடத்தை நகலெடுக்க ஒரு பொத்தானைக் காண்பி</target>
         </trans-unit>
         <trans-unit id="SettingsPreferencesPinOneDriveSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Pin OneDrive to the sidebar</source>
@@ -1322,11 +1322,6 @@
           <source>Access Denied</source>
           <target state="translated">Access Denied
 அணுகல் மறுக்கப்பட்டது</target>
-        </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="translated">Show an option to copy the location of the selected item
-தேர்வுசெய்யப்பட்ட உருப்படியின் இருப்பிடத்தை நகலெடுக்க ஒரு பொத்தானைக் காண்பி</target>
         </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
@@ -1431,6 +1426,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="translated">தேர்வுசெய்யப்பட்ட உருப்படியின் இருப்பிடத்தை நகலெடுக்க ஒரு பொத்தானைக் காண்பி</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -1327,10 +1327,6 @@
           <source>Access Denied</source>
           <target state="new">Access Denied</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="new">Show all context menu items</target>
@@ -1434,6 +1430,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="new">Show an option to copy the location of the selected item</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -1319,10 +1319,6 @@
           <source>Access Denied</source>
           <target state="new">Access Denied</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="new">Show all context menu items</target>
@@ -1426,6 +1422,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="new">Show an option to copy the location of the selected item</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -1323,10 +1323,6 @@
           <source>Access Denied</source>
           <target state="new">Access Denied</target>
         </trans-unit>
-        <trans-unit id="CopyLocationToggleSwitch.Header" translate="yes" xml:space="preserve">
-          <source>Show an option to copy the location of the selected item</source>
-          <target state="new">Show an option to copy the location of the selected item</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesContextMenuSwitch.Header" translate="yes" xml:space="preserve">
           <source>Show all context menu items</source>
           <target state="new">Show all context menu items</target>
@@ -1430,6 +1426,10 @@
         <trans-unit id="SettingsWidgetsShowRecentFiles.Header" translate="yes" xml:space="preserve">
           <source>Show recent files on the home page</source>
           <target state="new">Show recent files on the home page</target>
+        </trans-unit>
+        <trans-unit id="SettingsPreferencesCopyLocationSwitch.Header" translate="yes" xml:space="preserve">
+          <source>Show an option to copy the location of the selected item</source>
+          <target state="new">Show an option to copy the location of the selected item</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/Strings/de-DE/Resources.resw
+++ b/Files/Strings/de-DE/Resources.resw
@@ -996,9 +996,6 @@
   <data name="AccessDeniedCreateDialog.Title" xml:space="preserve">
     <value>Zugriff verweigert</value>
   </data>
-  <data name="CopyLocationToggleSwitch.Header" xml:space="preserve">
-    <value>Eine Option anzeigen, um den Speicherort des ausgewählten Elements zu kopieren</value>
-  </data>
   <data name="SettingsPreferencesContextMenuSwitch.Header" xml:space="preserve">
     <value>Alle Elemente im Kontextmenü anzeigen</value>
   </data>
@@ -1031,5 +1028,8 @@
   </data>
   <data name="SettingsShowFileOwnerInProperties.Header" xml:space="preserve">
     <value>Den Besitzer in den Eigenschaften anzeigen</value>
+  </data>
+  <data name="SettingsPreferencesCopyLocationSwitch.Header" xml:space="preserve">
+    <value>Eine Option anzeigen, um den Speicherort des ausgewählten Elements zu kopieren</value>
   </data>
 </root>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -1119,7 +1119,7 @@
   <data name="SettingsPreferencesTerminalApplications.Header" xml:space="preserve">
     <value>Terminal Applications</value>
   </data>
-  <data name="CopyLocationToggleSwitch.Header" xml:space="preserve">
+  <data name="SettingsPreferencesCopyLocationSwitch.Header" xml:space="preserve">
     <value>Show an option to copy the location of the selected item</value>
   </data>
   <data name="SettingsPreferencesContextMenuSwitch.Header" xml:space="preserve">

--- a/Files/Strings/es-ES/Resources.resw
+++ b/Files/Strings/es-ES/Resources.resw
@@ -975,9 +975,6 @@
   <data name="AccessDeniedCreateDialog.Title" xml:space="preserve">
     <value>Acceso Denegado</value>
   </data>
-  <data name="CopyLocationToggleSwitch.Header" xml:space="preserve">
-    <value>Mostrar en el menú contextual una opción para copiar la ubicación del archivo seleccionado</value>
-  </data>
   <data name="SettingsPreferencesContextMenuSwitch.Header" xml:space="preserve">
     <value>Mostrar todos los elementos del menú contextual</value>
   </data>
@@ -1055,5 +1052,8 @@
   </data>
   <data name="SettingsWidgetsShowRecentFiles.Header" xml:space="preserve">
     <value>Mostrar archivos recientes en la página de inicio</value>
+  </data>
+  <data name="SettingsPreferencesCopyLocationSwitch.Header" xml:space="preserve">
+    <value>Mostrar en el menú contextual una opción para copiar la ubicación del archivo seleccionado</value>
   </data>
 </root>

--- a/Files/Strings/hu-HU/Resources.resw
+++ b/Files/Strings/hu-HU/Resources.resw
@@ -151,7 +151,7 @@
     <value>Külön köszönet:</value>
   </data>
   <data name="SettingsAboutSubmitFeedback.Text" xml:space="preserve">
-    <value>Feedback küldése</value>
+    <value>Visszajelzés küldése</value>
   </data>
   <data name="SettingsAboutSubmitFeedbackDescription.Text" xml:space="preserve">
     <value>Részletesebb információ küldése a hibáról a fejlesztőknek</value>
@@ -577,16 +577,16 @@
     <value>Új lap (Ctrl + T)</value>
   </data>
   <data name="ItemSelected.Text" xml:space="preserve">
-    <value>kijelölt fájl</value>
+    <value>kijelölt elem</value>
   </data>
   <data name="ItemsSelected.Text" xml:space="preserve">
-    <value>kijelölt fájlok</value>
+    <value>kijelölt elem</value>
   </data>
   <data name="ItemCount.Text" xml:space="preserve">
     <value>Fájl</value>
   </data>
   <data name="ItemsCount.Text" xml:space="preserve">
-    <value>Fájlok</value>
+    <value>Elem</value>
   </data>
   <data name="DeleteInProgress.Title" xml:space="preserve">
     <value>Fájlok törlése</value>
@@ -691,7 +691,7 @@
     <value>Legutóbbi</value>
   </data>
   <data name="SettingsPreferencesAppLanguage.Text" xml:space="preserve">
-    <value>App Nyelve</value>
+    <value>Program Nyelve</value>
   </data>
   <data name="TabStripDragAndDropUIOverrideCaption" xml:space="preserve">
     <value>Lap áthelyezése ide</value>
@@ -700,7 +700,7 @@
     <value>Státusz</value>
   </data>
   <data name="SettingsOnStartupOpenAddPageButton.Content" xml:space="preserve">
-    <value>Új oldal hozzáadása</value>
+    <value>Oldal hozzáadása</value>
   </data>
   <data name="SettingsOnStartupOpenSpecificPagesUserControlChangePage.Text" xml:space="preserve">
     <value>Oldal helyének változtatása</value>
@@ -898,10 +898,10 @@
     <value>Lapok megnyitása</value>
   </data>
   <data name="SettingsMultitaskingAdaptive.Content" xml:space="preserve">
-    <value>Alkalmazkodó (Ajánlott)</value>
+    <value>Autómatikus (Ajánlott)</value>
   </data>
   <data name="SettingsMultitaskingAdaptiveDescription.Text" xml:space="preserve">
-    <value>A legjobb multitaszking kiválasztása az ablak méretétől függően. Amikor az ablak kicsi, a vízszintes lap lánc egy menüvé alakul navigációs sávban.</value>
+    <value>A legjobb lehetőség kiválasztása az ablak méretétől függően. Amikor az ablak kicsi, a vízszintes lap lánc egy menüvé alakul navigációs sávban.</value>
   </data>
   <data name="SettingsMultitaskingHorizontal.Content" xml:space="preserve">
     <value>Vízszintes</value>
@@ -979,7 +979,7 @@
     <value>Beállítások</value>
   </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
-    <value>App Nyelve</value>
+    <value>Program Nyelve</value>
   </data>
   <data name="SettingsPreferencesContextMenuSwitch.AutomationProperties.Name" xml:space="preserve">
     <value>Összes menü lehetőség megjelenítése</value>
@@ -1014,9 +1014,6 @@
   <data name="SettingsPreferencesTerminalApplications.Header" xml:space="preserve">
     <value>Parancssor Programok</value>
   </data>
-  <data name="CopyLocationToggleSwitch.Header" xml:space="preserve">
-    <value>Kijelölt elem helyének másolása lehetőség megjelenítése</value>
-  </data>
   <data name="SettingsPreferencesContextMenuSwitch.Header" xml:space="preserve">
     <value>Összes menü lehetőség megjelenítése</value>
   </data>
@@ -1049,5 +1046,35 @@
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Ide</value>
+  </data>
+  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+    <value>Meghajtók</value>
+  </data>
+  <data name="SettingsWidgetsShowLibraryCards.AutomationProperties.Name" xml:space="preserve">
+    <value>Könyvtárak megjelenítése a fő oldalon</value>
+  </data>
+  <data name="SettingsWidgetsShowLibraryCards.Header" xml:space="preserve">
+    <value>Könyvtárak megjelenítése a fő oldalon</value>
+  </data>
+  <data name="SettingsWidgetsTitle.Text" xml:space="preserve">
+    <value>Widgetek</value>
+  </data>
+  <data name="SettingsWidgets.Content" xml:space="preserve">
+    <value>Widgetek</value>
+  </data>
+  <data name="SettingsWidgetsShowDrives.AutomationProperties.Name" xml:space="preserve">
+    <value>Meghajtók megjelenítése a fő oldalon</value>
+  </data>
+  <data name="SettingsWidgetsShowDrives.Header" xml:space="preserve">
+    <value>Könyvtárak megjelenítése a fő oldalon</value>
+  </data>
+  <data name="SettingsWidgetsShowRecentFiles.AutomationProperties.Name" xml:space="preserve">
+    <value>Legutóbb megnyitottak megjelenítése a fő oldalon</value>
+  </data>
+  <data name="SettingsWidgetsShowRecentFiles.Header" xml:space="preserve">
+    <value>Legutóbbi megnyitottak megjelenítése a fő oldalon</value>
+  </data>
+  <data name="SettingsPreferencesCopyLocationSwitch.Header" xml:space="preserve">
+    <value>Kijelölt elem helyének másolása lehetőség megjelenítése</value>
   </data>
 </root>

--- a/Files/Strings/it-IT/Resources.resw
+++ b/Files/Strings/it-IT/Resources.resw
@@ -996,9 +996,6 @@
   <data name="AccessDeniedCreateDialog.Title" xml:space="preserve">
     <value>Accesso Negato</value>
   </data>
-  <data name="CopyLocationToggleSwitch.Header" xml:space="preserve">
-    <value>Mostra un'opzione per copiare il percorso dell'elemento selezionato</value>
-  </data>
   <data name="SettingsPreferencesContextMenuSwitch.Header" xml:space="preserve">
     <value>Mostra tutti gli elementi nel menu contestuale</value>
   </data>
@@ -1031,5 +1028,8 @@
   </data>
   <data name="SettingsShowFileOwnerInProperties.Header" xml:space="preserve">
     <value>Mostra Proprietario del file nelle proprietà</value>
+  </data>
+  <data name="SettingsPreferencesCopyLocationSwitch.Header" xml:space="preserve">
+    <value>Mostra un'opzione per copiare il percorso dell'elemento selezionato</value>
   </data>
 </root>

--- a/Files/Strings/ja-JP/Resources.resw
+++ b/Files/Strings/ja-JP/Resources.resw
@@ -996,9 +996,6 @@
   <data name="AccessDeniedCreateDialog.Title" xml:space="preserve">
     <value>アクセスが拒否されました</value>
   </data>
-  <data name="CopyLocationToggleSwitch.Header" xml:space="preserve">
-    <value>選択したアイテムの場所をコピーするオプションを表示する</value>
-  </data>
   <data name="SettingsPreferencesContextMenuSwitch.Header" xml:space="preserve">
     <value>すべてのコンテキストメニュー項目を表示する</value>
   </data>
@@ -1031,5 +1028,8 @@
   </data>
   <data name="SettingsShowFileOwnerInProperties.Header" xml:space="preserve">
     <value>プロパティに所有者を表示する</value>
+  </data>
+  <data name="SettingsPreferencesCopyLocationSwitch.Header" xml:space="preserve">
+    <value>選択したアイテムの場所をコピーするオプションを表示する</value>
   </data>
 </root>

--- a/Files/Strings/pt-BR/Resources.resw
+++ b/Files/Strings/pt-BR/Resources.resw
@@ -996,9 +996,6 @@
   <data name="AccessDeniedCreateDialog.Title" xml:space="preserve">
     <value>Acesso negado</value>
   </data>
-  <data name="CopyLocationToggleSwitch.Header" xml:space="preserve">
-    <value>Mostra uma opção para copiar a localização do item selecionado</value>
-  </data>
   <data name="SettingsPreferencesContextMenuSwitch.Header" xml:space="preserve">
     <value>Mostrar todos os itens do menu de contexto</value>
   </data>
@@ -1046,5 +1043,8 @@
   </data>
   <data name="SettingsOpenItemsWithOneclick.Header" xml:space="preserve">
     <value>Abra os itens com um único clique</value>
+  </data>
+  <data name="SettingsPreferencesCopyLocationSwitch.Header" xml:space="preserve">
+    <value>Mostra uma opção para copiar a localização do item selecionado</value>
   </data>
 </root>

--- a/Files/Strings/ta/Resources.resw
+++ b/Files/Strings/ta/Resources.resw
@@ -919,6 +919,9 @@
   <data name="SettingsPreferencesContextMenuSwitch.AutomationProperties.Name" xml:space="preserve">
     <value>அனைத்து சூழல் மெனு உருப்படிகளையும் காண்பி</value>
   </data>
+  <data name="SettingsPreferencesCopyLocationSwitch.AutomationProperties.Name" xml:space="preserve">
+    <value>தேர்வுசெய்யப்பட்ட உருப்படியின் இருப்பிடத்தை நகலெடுக்க ஒரு பொத்தானைக் காண்பி</value>
+  </data>
   <data name="SettingsPreferencesPinOneDriveSwitch.AutomationProperties.Name" xml:space="preserve">
     <value>Pin OneDrive to the sidebar</value>
   </data>
@@ -943,10 +946,6 @@
   <data name="AccessDeniedCreateDialog.Title" xml:space="preserve">
     <value>Access Denied
 அணுகல் மறுக்கப்பட்டது</value>
-  </data>
-  <data name="CopyLocationToggleSwitch.Header" xml:space="preserve">
-    <value>Show an option to copy the location of the selected item
-தேர்வுசெய்யப்பட்ட உருப்படியின் இருப்பிடத்தை நகலெடுக்க ஒரு பொத்தானைக் காண்பி</value>
   </data>
   <data name="SettingsPreferencesContextMenuSwitch.Header" xml:space="preserve">
     <value>அனைத்து சூழல் மெனு உருப்படிகளையும் காண்பி</value>
@@ -983,5 +982,8 @@
   </data>
   <data name="SettingsOpenItemsWithOneclick.Header" xml:space="preserve">
     <value>Open items with a single click</value>
+  </data>
+  <data name="SettingsPreferencesCopyLocationSwitch.Header" xml:space="preserve">
+    <value>தேர்வுசெய்யப்பட்ட உருப்படியின் இருப்பிடத்தை நகலெடுக்க ஒரு பொத்தானைக் காண்பி</value>
   </data>
 </root>

--- a/Files/Views/SettingsPages/Appearance.xaml
+++ b/Files/Views/SettingsPages/Appearance.xaml
@@ -63,6 +63,7 @@
 
                 <ToggleSwitch
                     x:Name="AcrylicSidebarSwitch"
+                    x:Uid="SettingsAppearanceAcrylicSidebar"
                     Header="Acrylic sidebar"
                     HeaderTemplate="{StaticResource CustomHeaderStyle}"
                     IsOn="{x:Bind AppSettings.AcrylicEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolNegationConverter}}" />


### PR DESCRIPTION
- Fixed the Uid for "CopyLocationToggleSwitch" in string resources

_In **Preferences.xaml** the Uid was correct, but in the string resources an incorrect id was used_

Changes to **Resources.resw** :

**Before:**
![Captura de pantalla 2020-11-05 211604](https://user-images.githubusercontent.com/61259627/98310609-304b2880-1fac-11eb-99ba-00dd42e60e46.png)
**After:**
![Captura de pantalla 2020-11-05 211614](https://user-images.githubusercontent.com/61259627/98310623-35a87300-1fac-11eb-8fd4-a45fdee65495.png)

-----------------------------------------

Changes to **Appearance.xaml:**
- Added missing Uid for "AcrylicSidebarSwitch"

![Captura de pantalla 2020-11-05 211927](https://user-images.githubusercontent.com/61259627/98310770-9a63cd80-1fac-11eb-9d27-59dc305ed73c.png)

