### PR TITLE
Rework filesystem exception handling

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -604,11 +604,13 @@ namespace Files
                 }
                 else if (item.PrimaryItemAttribute == StorageItemTypes.File)
                 {
-                    selectedStorageItems.Add(await ParentShellPageInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath));
+                    await ParentShellPageInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
+                        .OnSuccess(t => selectedStorageItems.Add(t));
                 }
                 else if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    selectedStorageItems.Add(await ParentShellPageInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath));
+                    await ParentShellPageInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath)
+                        .OnSuccess(t => selectedStorageItems.Add(t));
                 }
             }
 

--- a/Files/Commands/Paste.cs
+++ b/Files/Commands/Paste.cs
@@ -116,20 +116,13 @@ namespace Files.Commands
                             progress.Report(progressValue);
                         }
 
-                        try
-                        {
-                            ClonedDirectoryOutput pastedOutput = await CloneDirectoryAsync(
-                                (StorageFolder)item,
-                                await AppInstance.FilesystemViewModel.GetFolderFromPathAsync(destinationPath),
-                                item.Name);
-                            pastedSourceItems.Add(item);
-                            pastedItems.Add(pastedOutput.FolderOutput);
-                        }
-                        catch (FileNotFoundException)
-                        {
-                            // Folder was moved/deleted in the meantime
-                            continue;
-                        }
+                        await AppInstance.FilesystemViewModel.GetFolderFromPathAsync(destinationPath)
+                            .OnSuccess(t => CloneDirectoryAsync((StorageFolder)item, t, item.Name))
+                            .OnSuccess(t =>
+                            {
+                                pastedSourceItems.Add(item);
+                                pastedItems.Add(t);
+                            });
                     }
                 }
                 else if (item.IsOfType(StorageItemTypes.File))
@@ -141,32 +134,33 @@ namespace Files.Commands
                         progress.Report(progressValue);
                     }
 
-                    try
+                    var res = await AppInstance.FilesystemViewModel.GetFolderFromPathAsync(destinationPath);
+                    if (res)
                     {
                         StorageFile clipboardFile = (StorageFile)item;
-                        StorageFile pastedFile = await clipboardFile.CopyAsync(
-                            await AppInstance.FilesystemViewModel.GetFolderFromPathAsync(destinationPath),
-                            item.Name,
-                            NameCollisionOption.GenerateUniqueName);
-                        pastedSourceItems.Add(item);
-                        pastedItems.Add(pastedFile);
-                    }
-                    catch (UnauthorizedAccessException)
-                    {
-                        // Try again with CopyFileFromApp
-                        if (NativeDirectoryChangesHelper.CopyFileFromApp(item.Path, Path.Combine(destinationPath, item.Name), true))
+                        var pasted = await clipboardFile.CopyAsync(res.Result, item.Name, NameCollisionOption.GenerateUniqueName).AsTask().Wrap();
+                        if (pasted)
                         {
                             pastedSourceItems.Add(item);
+                            pastedItems.Add(pasted.Result);
                         }
-                        else
+                        else if (pasted.ErrorCode == FilesystemErrorCode.ERROR_UNAUTHORIZED)
                         {
-                            Debug.WriteLine(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
+                            // Try again with CopyFileFromApp
+                            if (NativeDirectoryChangesHelper.CopyFileFromApp(item.Path, Path.Combine(destinationPath, item.Name), true))
+                            {
+                                pastedSourceItems.Add(item);
+                            }
+                            else
+                            {
+                                Debug.WriteLine(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
+                            }
                         }
-                    }
-                    catch (FileNotFoundException)
-                    {
-                        // File was moved/deleted in the meantime
-                        continue;
+                        else if (pasted.ErrorCode == FilesystemErrorCode.ERROR_NOTFOUND)
+                        {
+                            // File was moved/deleted in the meantime
+                            continue;
+                        }
                     }
                 }
             }
@@ -185,29 +179,28 @@ namespace Files.Commands
             {
                 foreach (IStorageItem item in pastedSourceItems)
                 {
-                    try
+                    var deleted = (FilesystemResult)false;
+                    if (string.IsNullOrEmpty(item.Path))
                     {
-                        if (string.IsNullOrEmpty(item.Path))
-                        {
-                            // Can't move (only copy) files from MTP devices because:
-                            // StorageItems returned in DataPackageView are read-only
-                            // The item.Path property will be empty and there's no way of retrieving a new StorageItem with R/W access
-                            continue;
-                        }
-                        if (item.IsOfType(StorageItemTypes.File))
-                        {
-                            // If we reached this we are not in an MTP device, using StorageFile.* is ok here
-                            StorageFile file = await StorageFile.GetFileFromPathAsync(item.Path);
-                            await file.DeleteAsync(StorageDeleteOption.PermanentDelete);
-                        }
-                        else if (item.IsOfType(StorageItemTypes.Folder))
-                        {
-                            // If we reached this we are not in an MTP device, using StorageFolder.* is ok here
-                            StorageFolder folder = await StorageFolder.GetFolderFromPathAsync(item.Path);
-                            await folder.DeleteAsync(StorageDeleteOption.PermanentDelete);
-                        }
+                        // Can't move (only copy) files from MTP devices because:
+                        // StorageItems returned in DataPackageView are read-only
+                        // The item.Path property will be empty and there's no way of retrieving a new StorageItem with R/W access
+                        continue;
                     }
-                    catch (UnauthorizedAccessException)
+                    if (item.IsOfType(StorageItemTypes.File))
+                    {
+                        // If we reached this we are not in an MTP device, using StorageFile.* is ok here
+                        deleted = await AppInstance.FilesystemViewModel.GetFileFromPathAsync(item.Path)
+                            .OnSuccess(t => t.DeleteAsync(StorageDeleteOption.PermanentDelete).AsTask());
+                    }
+                    else if (item.IsOfType(StorageItemTypes.Folder))
+                    {
+                        // If we reached this we are not in an MTP device, using StorageFolder.* is ok here
+                        deleted = await AppInstance.FilesystemViewModel.GetFolderFromPathAsync(item.Path)
+                            .OnSuccess(t => t.DeleteAsync(StorageDeleteOption.PermanentDelete).AsTask());
+                    }
+
+                    if (deleted == FilesystemErrorCode.ERROR_UNAUTHORIZED)
                     {
                         // Try again with DeleteFileFromApp
                         if (!NativeDirectoryChangesHelper.DeleteFileFromApp(item.Path))
@@ -215,12 +208,11 @@ namespace Files.Commands
                             Debug.WriteLine(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
                         }
                     }
-                    catch (FileNotFoundException)
+                    else if (deleted == FilesystemErrorCode.ERROR_NOTFOUND)
                     {
                         // File or Folder was moved/deleted in the meantime
                         continue;
                     }
-                    ListedItem listedItem = AppInstance.FilesystemViewModel.FilesAndFolders.FirstOrDefault(listedItem => listedItem.ItemPath.Equals(item.Path, StringComparison.OrdinalIgnoreCase));
                 }
             }
 
@@ -237,13 +229,7 @@ namespace Files.Commands
             packageView.ReportOperationCompleted(acceptedOperation);
         }
 
-        public class ClonedDirectoryOutput
-        {
-            public StorageFolder FolderOutput { get; set; }
-            // TODO: simplify/remove this class
-        }
-
-        public async static Task<ClonedDirectoryOutput> CloneDirectoryAsync(StorageFolder SourceFolder, StorageFolder DestinationFolder, string sourceRootName)
+        public async static Task<StorageFolder> CloneDirectoryAsync(StorageFolder SourceFolder, StorageFolder DestinationFolder, string sourceRootName)
         {
             var createdRoot = await DestinationFolder.CreateFolderAsync(sourceRootName, CreationCollisionOption.GenerateUniqueName);
             DestinationFolder = createdRoot;
@@ -258,10 +244,7 @@ namespace Files.Commands
                 await CloneDirectoryAsync(folderinSourceDir, DestinationFolder, folderinSourceDir.Name);
             }
 
-            return new ClonedDirectoryOutput()
-            {
-                FolderOutput = createdRoot,
-            };
+            return createdRoot;
         }
 
         public static long CalculateTotalItemsSize(IReadOnlyList<IStorageItem> itemsPasting)

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -179,6 +179,7 @@
     </Compile>
     <Compile Include="Filesystem\CloudDriveSyncStatus.cs" />
     <Compile Include="Filesystem\PropertiesData.cs" />
+    <Compile Include="Filesystem\StorageFileHelpers\FilesystemResult.cs" />
     <Compile Include="Filesystem\StorageFileHelpers\StorageFileExtensions.cs" />
     <Compile Include="Filesystem\StorageFileHelpers\IStorageItemWithPath.cs" />
     <Compile Include="Filesystem\StorageFileHelpers\StorageFileWithPath.cs" />

--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -244,20 +244,16 @@ namespace Files.Filesystem
                     continue;
                 }
 
-                StorageFolder folder = null;
-                try
-                {
-                    folder = await StorageFolder.GetFolderFromPathAsync(drive.Name);
-                }
-                catch (UnauthorizedAccessException ex)
+                var res = await StorageFolder.GetFolderFromPathAsync(drive.Name).AsTask().Wrap();
+                if (res == FilesystemErrorCode.ERROR_UNAUTHORIZED)
                 {
                     unauthorizedAccessDetected = true;
-                    Logger.Warn($"{ex.GetType()}: Attemting to add the device, {drive.Name}, failed at the StorageFolder initialization step. This device will be ignored.");
+                    Logger.Warn($"{res.ErrorCode.ToString()}: Attemting to add the device, {drive.Name}, failed at the StorageFolder initialization step. This device will be ignored.");
                     continue;
                 }
-                catch (ArgumentException ex)
+                else if (!res)
                 {
-                    Logger.Warn($"{ex.GetType()}: Attemting to add the device, {drive.Name}, failed at the StorageFolder initialization step. This device will be ignored.");
+                    Logger.Warn($"{res.ErrorCode.ToString()}: Attemting to add the device, {drive.Name}, failed at the StorageFolder initialization step. This device will be ignored.");
                     continue;
                 }
 
@@ -307,7 +303,7 @@ namespace Files.Filesystem
                         break;
                 }
 
-                var driveItem = new DriveItem(folder, type);
+                var driveItem = new DriveItem(res.Result, type);
 
                 Logger.Info($"Drive added: {driveItem.Path}, {driveItem.Type}");
 

--- a/Files/Filesystem/StorageFileHelpers/FilesystemResult.cs
+++ b/Files/Filesystem/StorageFileHelpers/FilesystemResult.cs
@@ -61,7 +61,7 @@ namespace Files.Filesystem
 
     public static class TaskExtensions
     {
-        private static FilesystemErrorCode GetErrorCode(Exception ex)
+        private static FilesystemErrorCode GetErrorCode(Exception ex, Type T = null)
         {
             if (ex is UnauthorizedAccessException)
             {
@@ -83,7 +83,8 @@ namespace Files.Filesystem
             }
             else if (ex is ArgumentException) // Item was invalid
             {
-                return FilesystemErrorCode.ERROR_NOTAFOLDER;
+                return (T == typeof(StorageFolder) || T == typeof(StorageFolderWithPath)) ?
+                    FilesystemErrorCode.ERROR_NOTAFOLDER : FilesystemErrorCode.ERROR_NOTAFILE;
             }
             else if ((uint)ex.HResult == 0x800700A1 // The specified path is invalid (usually an mtp device was disconnected)
                 || (uint)ex.HResult == 0x8007016A // The cloud file provider is not running
@@ -105,7 +106,7 @@ namespace Files.Filesystem
             }
             catch (Exception ex)
             {
-                return new FilesystemResult<T>(default(T), GetErrorCode(ex));
+                return new FilesystemResult<T>(default(T), GetErrorCode(ex, typeof(T)));
             }
         }
 

--- a/Files/Filesystem/StorageFileHelpers/FilesystemResult.cs
+++ b/Files/Filesystem/StorageFileHelpers/FilesystemResult.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+
+namespace Files.Filesystem
+{
+    [Flags]
+    public enum FilesystemErrorCode
+    {
+        ERROR_OK = 0,
+        ERROR_GENERIC = 1,
+        ERROR_UNAUTHORIZED = 2,
+        ERROR_NOTFOUND = 4,
+        ERROR_INUSE = 8,
+        ERROR_NAMETOOLONG = 16,
+        ERROR_NOTAFOLDER = 32,
+        ERROR_NOTAFILE = 64
+    }
+
+    public static class FilesystemErrorCodeExtensions
+    {
+        public static bool HasFlag(this FilesystemErrorCode errorCode, FilesystemErrorCode flag)
+        {
+            return (errorCode & flag) != FilesystemErrorCode.ERROR_OK;
+        }
+    }
+
+    public class FilesystemResult<T> : FilesystemResult
+    {
+        public FilesystemResult(T result, FilesystemErrorCode errorCode) : base(errorCode)
+        {
+            this.Result = result;
+        }
+
+        public T Result { get; private set; }
+
+        public static implicit operator T(FilesystemResult<T> res) => res.Result;
+    }
+
+    public class FilesystemResult
+    {
+        public FilesystemResult(FilesystemErrorCode errorCode)
+        {
+            this.ErrorCode = errorCode;
+        }
+
+        public FilesystemErrorCode ErrorCode { get; private set; }
+
+        public static implicit operator FilesystemErrorCode(FilesystemResult res) => res.ErrorCode;
+        public static explicit operator FilesystemResult(FilesystemErrorCode res) => new FilesystemResult(res);
+
+        public static implicit operator bool(FilesystemResult res) => 
+            res.ErrorCode == FilesystemErrorCode.ERROR_OK;
+        public static explicit operator FilesystemResult(bool res) =>
+            new FilesystemResult(res ? FilesystemErrorCode.ERROR_OK : FilesystemErrorCode.ERROR_GENERIC);
+    }
+
+    public static class TaskExtensions
+    {
+        private static FilesystemErrorCode GetErrorCode(Exception ex)
+        {
+            if (ex is UnauthorizedAccessException)
+            {
+                return FilesystemErrorCode.ERROR_UNAUTHORIZED;
+            }
+            else if (ex is FileNotFoundException // Item was deleted
+                || ex is System.Runtime.InteropServices.COMException // Item's drive was ejected
+                || (uint)ex.HResult == 0x8007000F) // The system cannot find the drive specified
+            {
+                return FilesystemErrorCode.ERROR_NOTFOUND;
+            }
+            else if (ex is IOException || ex is FileLoadException)
+            {
+                return FilesystemErrorCode.ERROR_INUSE;
+            }
+            else if (ex is PathTooLongException)
+            {
+                return FilesystemErrorCode.ERROR_NAMETOOLONG;
+            }
+            else if (ex is ArgumentException) // Item was invalid
+            {
+                return FilesystemErrorCode.ERROR_NOTAFOLDER;
+            }
+            else if ((uint)ex.HResult == 0x800700A1 // The specified path is invalid (usually an mtp device was disconnected)
+                || (uint)ex.HResult == 0x8007016A // The cloud file provider is not running
+                || (uint)ex.HResult == 0x8000000A) // The data necessary to complete this operation is not yet available)
+            {
+                return FilesystemErrorCode.ERROR_GENERIC;
+            }
+            else
+            {
+                return FilesystemErrorCode.ERROR_GENERIC;
+            }
+        }
+
+        public async static Task<FilesystemResult<T>> Wrap<T>(this Task<T> wrapped)
+        {
+            try
+            {
+                return new FilesystemResult<T>(await wrapped, FilesystemErrorCode.ERROR_OK);
+            }
+            catch (Exception ex)
+            {
+                return new FilesystemResult<T>(default(T), GetErrorCode(ex));
+            }
+        }
+
+        public async static Task<FilesystemResult> Wrap(this Task wrapped)
+        {
+            try
+            {
+                await wrapped;
+                return new FilesystemResult(FilesystemErrorCode.ERROR_OK);
+            }
+            catch (Exception ex)
+            {
+                return new FilesystemResult(GetErrorCode(ex));
+            }
+        }
+
+        public async static Task<FilesystemResult<T>> OnSuccess<T>(this Task<FilesystemResult<T>> wrapped, Func<T, Task<T>> func)
+        {
+            var res = await wrapped;
+            if (res)
+            {
+                return await func(res.Result).Wrap();
+            }
+            return res;
+        }
+
+        public async static Task<FilesystemResult> OnSuccess<T>(this Task<FilesystemResult<T>> wrapped, Func<T, Task> func)
+        {
+            var res = await wrapped;
+            if (res)
+            {
+                return await func(res.Result).Wrap();
+            }
+            return res;
+        }
+
+        public async static Task<FilesystemResult> OnSuccess<T>(this Task<FilesystemResult<T>> wrapped, Action<T> func)
+        {
+            var res = await wrapped;
+            if (res)
+            {
+                func(res.Result);
+            }
+            return res;
+        }
+    }
+}

--- a/Files/Filesystem/StorageFileHelpers/FilesystemResult.cs
+++ b/Files/Filesystem/StorageFileHelpers/FilesystemResult.cs
@@ -17,8 +17,9 @@ namespace Files.Filesystem
         ERROR_NOTFOUND = 4,
         ERROR_INUSE = 8,
         ERROR_NAMETOOLONG = 16,
-        ERROR_NOTAFOLDER = 32,
-        ERROR_NOTAFILE = 64
+        ERROR_ALREADYEXIST = 32,
+        ERROR_NOTAFOLDER = 64,
+        ERROR_NOTAFILE = 128
     }
 
     public static class FilesystemErrorCodeExtensions
@@ -85,6 +86,10 @@ namespace Files.Filesystem
             {
                 return (T == typeof(StorageFolder) || T == typeof(StorageFolderWithPath)) ?
                     FilesystemErrorCode.ERROR_NOTAFOLDER : FilesystemErrorCode.ERROR_NOTAFILE;
+            }
+            else if ((uint)ex.HResult == 0x800700B7)
+            {
+                return FilesystemErrorCode.ERROR_ALREADYEXIST;
             }
             else if ((uint)ex.HResult == 0x800700A1 // The specified path is invalid (usually an mtp device was disconnected)
                 || (uint)ex.HResult == 0x8007016A // The cloud file provider is not running

--- a/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -81,7 +81,7 @@ namespace Files.Filesystem
             return pathBoxItems;
         }
 
-        public async static Task<StorageFolderWithPath> GetFolderWithPathFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
+        public async static Task<StorageFolderWithPath> DangerousGetFolderWithPathFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
         {
             if (rootFolder != null)
             {
@@ -124,23 +124,16 @@ namespace Files.Filesystem
             }
             else
             {
-                try
-                {
-                    return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(value));
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    return await GetFolderWithPathFromPathAsync(Directory.GetParent(value).FullName, rootFolder, parentFolder).ConfigureAwait(false);
-                }
+                return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(value));
             }
         }
 
-        public async static Task<StorageFolder> GetFolderFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
+        public async static Task<StorageFolder> DangerousGetFolderFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
         {
-            return (await GetFolderWithPathFromPathAsync(value, rootFolder, parentFolder)).Folder;
+            return (await DangerousGetFolderWithPathFromPathAsync(value, rootFolder, parentFolder)).Folder;
         }
 
-        public async static Task<StorageFileWithPath> GetFileWithPathFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
+        public async static Task<StorageFileWithPath> DangerousGetFileWithPathFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
         {
             if (rootFolder != null)
             {
@@ -187,9 +180,9 @@ namespace Files.Filesystem
             }
         }
 
-        public async static Task<StorageFile> GetFileFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
+        public async static Task<StorageFile> DangerousGetFileFromPathAsync(string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
         {
-            return (await GetFileWithPathFromPathAsync(value, rootFolder, parentFolder)).File;
+            return (await DangerousGetFileWithPathFromPathAsync(value, rootFolder, parentFolder)).File;
         }
 
         public async static Task<IList<StorageFolderWithPath>> GetFoldersWithPathAsync(this StorageFolderWithPath parentFolder, uint maxNumberOfItems = uint.MaxValue)

--- a/Files/Helpers/PathNormalization.cs
+++ b/Files/Helpers/PathNormalization.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NLog;
+using System;
 using System.IO;
 
 namespace Files.Helpers
@@ -22,9 +23,17 @@ namespace Files.Helpers
                     path += Path.DirectorySeparatorChar;
                 }
 
-                return Path.GetFullPath(new Uri(path).LocalPath)
-                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                .ToUpperInvariant();
+                try
+                {
+                    return Path.GetFullPath(new Uri(path).LocalPath)
+                        .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                        .ToUpperInvariant();
+                }
+                catch (UriFormatException ex)
+                {
+                    LogManager.GetCurrentClassLogger().Error(ex, path);
+                    throw;
+                }
             }
         }
     }

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -80,7 +80,8 @@ namespace Files.Interacts
             if (UserProfilePersonalizationSettings.IsSupported())
             {
                 // Get the path of the selected file
-                StorageFile sourceFile = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(AssociatedInstance.ContentPage.SelectedItem.ItemPath);
+                var sourceFile = (StorageFile)await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(AssociatedInstance.ContentPage.SelectedItem.ItemPath);
+                if (sourceFile == null) return;
 
                 // Get the app's local folder to use as the destination folder.
                 StorageFolder localFolder = ApplicationData.Current.LocalFolder;
@@ -89,7 +90,8 @@ namespace Files.Interacts
                 // Generate unique name if the file already exists.
                 // If the file you are trying to set as the wallpaper has the same name as the current wallpaper,
                 // the system will ignore the request and no-op the operation
-                StorageFile file = await sourceFile.CopyAsync(localFolder, sourceFile.Name, NameCollisionOption.GenerateUniqueName);
+                var file = (StorageFile)await sourceFile.CopyAsync(localFolder, sourceFile.Name, NameCollisionOption.GenerateUniqueName).AsTask().Wrap();
+                if (file == null) return;
 
                 UserProfilePersonalizationSettings profileSettings = UserProfilePersonalizationSettings.Current;
                 if (type == WallpaperType.Desktop)
@@ -327,21 +329,21 @@ namespace Files.Interacts
         public async void OpenFileLocation_Click(object sender, RoutedEventArgs e)
         {
             var item = AssociatedInstance.ContentPage.SelectedItem as ShortcutItem;
-            try
+            var folderPath = Path.GetDirectoryName(item.TargetPath);
+            // Check if destination path exists
+            var destFolder = await AssociatedInstance.FilesystemViewModel.GetFolderWithPathFromPathAsync(folderPath);
+            if (destFolder)
             {
-                var folderPath = Path.GetDirectoryName(item.TargetPath);
-                // Check if destination path exists
-                var destFolder = await AssociatedInstance.FilesystemViewModel.GetFolderWithPathFromPathAsync(folderPath);
                 AssociatedInstance.ContentFrame.Navigate(AppSettings.GetLayoutType(), new NavigationArguments() { NavPathParam = folderPath, AssociatedTabInstance = AssociatedInstance });
             }
-            catch (FileNotFoundException)
+            else if (destFolder == FilesystemErrorCode.ERROR_NOTFOUND)
             {
                 await DialogDisplayHelper.ShowDialog("FileNotFoundDialog/Title".GetLocalized(), "FileNotFoundDialog/Text".GetLocalized());
             }
-            catch (Exception ex)
+            else
             {
                 await DialogDisplayHelper.ShowDialog("InvalidItemDialogTitle".GetLocalized(),
-                    string.Format("InvalidItemDialogContent".GetLocalized()), Environment.NewLine, ex.Message);
+                    string.Format("InvalidItemDialogContent".GetLocalized()), Environment.NewLine, destFolder.ErrorCode.ToString());
             }
         }
 
@@ -353,148 +355,153 @@ namespace Files.Interacts
                 return;
             }
 
-            try
+            int selectedItemCount;
+            Type sourcePageType = AssociatedInstance.CurrentPageType;
+            selectedItemCount = AssociatedInstance.ContentPage.SelectedItems.Count;
+            var opened = (FilesystemResult)false;
+
+            // Access MRU List
+            var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
+
+            if (selectedItemCount == 1)
             {
-                int selectedItemCount;
-                Type sourcePageType = AssociatedInstance.CurrentPageType;
-                selectedItemCount = AssociatedInstance.ContentPage.SelectedItems.Count;
-
-                // Access MRU List
-                var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
-
-                if (selectedItemCount == 1)
+                var clickedOnItem = AssociatedInstance.ContentPage.SelectedItem;
+                var clickedOnItemPath = clickedOnItem.ItemPath;
+                if (clickedOnItem.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    var clickedOnItem = AssociatedInstance.ContentPage.SelectedItem;
-                    var clickedOnItemPath = clickedOnItem.ItemPath;
-                    if (clickedOnItem.PrimaryItemAttribute == StorageItemTypes.Folder)
-                    {
-                        var childFolder = await AssociatedInstance.FilesystemViewModel.GetFolderWithPathFromPathAsync(
-                            (clickedOnItem as ShortcutItem)?.TargetPath ?? clickedOnItem.ItemPath);
-
-                        // Add location to MRU List
-                        mostRecentlyUsed.Add(childFolder.Folder, childFolder.Path);
-
-                        await AssociatedInstance.FilesystemViewModel.SetWorkingDirectory(childFolder.Path);
-                        AssociatedInstance.NavigationToolbar.PathControlDisplayText = childFolder.Path;
-
-                        AssociatedInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
-                        AssociatedInstance.ContentFrame.Navigate(sourcePageType, new NavigationArguments() { NavPathParam = childFolder.Path, AssociatedTabInstance = AssociatedInstance }, new SuppressNavigationTransitionInfo());
-                    }
-                    else if (clickedOnItem.IsShortcutItem)
-                    {
-                        var shortcutItem = (ShortcutItem)clickedOnItem;
-                        if (string.IsNullOrEmpty(shortcutItem.TargetPath))
+                    opened = await AssociatedInstance.FilesystemViewModel.GetFolderWithPathFromPathAsync(
+                        (clickedOnItem as ShortcutItem)?.TargetPath ?? clickedOnItem.ItemPath)
+                        .OnSuccess(async childFolder =>
                         {
-                            await InvokeWin32Component(shortcutItem.ItemPath);
-                        }
-                        else
-                        {
-                            if (!shortcutItem.IsUrl)
-                            {
-                                var childFile = await AssociatedInstance.FilesystemViewModel.GetFileWithPathFromPathAsync(shortcutItem.TargetPath);
-                                // Add location to MRU List
-                                mostRecentlyUsed.Add(childFile.File, childFile.Path);
-                            }
-                            await InvokeWin32Component(shortcutItem.TargetPath, shortcutItem.Arguments, shortcutItem.RunAsAdmin, shortcutItem.WorkingDirectory);
-                        }
+                            // Add location to MRU List
+                            mostRecentlyUsed.Add(childFolder.Folder, childFolder.Path);
+
+                            await AssociatedInstance.FilesystemViewModel.SetWorkingDirectory(childFolder.Path);
+                            AssociatedInstance.NavigationToolbar.PathControlDisplayText = childFolder.Path;
+
+                            AssociatedInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
+                            AssociatedInstance.ContentFrame.Navigate(sourcePageType, new NavigationArguments() { NavPathParam = childFolder.Path, AssociatedTabInstance = AssociatedInstance }, new SuppressNavigationTransitionInfo());
+                        });
+                }
+                else if (clickedOnItem.IsShortcutItem)
+                {
+                    var shortcutItem = (ShortcutItem)clickedOnItem;
+                    if (string.IsNullOrEmpty(shortcutItem.TargetPath))
+                    {
+                        await InvokeWin32Component(shortcutItem.ItemPath);
                     }
                     else
                     {
-                        var childFile = await AssociatedInstance.FilesystemViewModel.GetFileWithPathFromPathAsync(clickedOnItem.ItemPath);
-                        // Add location to MRU List
-                        mostRecentlyUsed.Add(childFile.File, childFile.Path);
-
-                        if (displayApplicationPicker)
+                        if (!shortcutItem.IsUrl)
                         {
-                            var options = new LauncherOptions
+                            StorageFileWithPath childFile = await AssociatedInstance.FilesystemViewModel.GetFileWithPathFromPathAsync(shortcutItem.TargetPath);
+                            if (childFile != null)
                             {
-                                DisplayApplicationPicker = true
-                            };
-                            await Launcher.LaunchFileAsync(childFile.File, options);
+                                // Add location to MRU List
+                                mostRecentlyUsed.Add(childFile.File, childFile.Path);
+                            }
                         }
-                        else
+                        await InvokeWin32Component(shortcutItem.TargetPath, shortcutItem.Arguments, shortcutItem.RunAsAdmin, shortcutItem.WorkingDirectory);
+                    }
+                    opened = (FilesystemResult)true;
+                }
+                else
+                {
+                    opened = await AssociatedInstance.FilesystemViewModel.GetFileWithPathFromPathAsync(clickedOnItem.ItemPath)
+                        .OnSuccess(async childFile =>
                         {
-                            //try using launcher first
-                            bool launchSuccess = false;
+                            // Add location to MRU List
+                            mostRecentlyUsed.Add(childFile.File, childFile.Path);
 
-                            try
+                            if (displayApplicationPicker)
                             {
+                                var options = new LauncherOptions
+                                {
+                                    DisplayApplicationPicker = true
+                                };
+                                await Launcher.LaunchFileAsync(childFile.File, options);
+                            }
+                            else
+                            {
+                                //try using launcher first
+                                bool launchSuccess = false;
+
                                 StorageFileQueryResult fileQueryResult = null;
 
                                 //Get folder to create a file query (to pass to apps like Photos, Movies & TV..., needed to scroll through the folder like what Windows Explorer does)
                                 StorageFolder currFolder = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(Path.GetDirectoryName(clickedOnItem.ItemPath));
 
-                                QueryOptions queryOptions = new QueryOptions(CommonFileQuery.DefaultQuery, null);
-
-                                //We can have many sort entries
-                                SortEntry sortEntry = new SortEntry()
+                                if (currFolder != null)
                                 {
-                                    AscendingOrder = AppSettings.DirectorySortDirection == Microsoft.Toolkit.Uwp.UI.SortDirection.Ascending,
-                                };
+                                    QueryOptions queryOptions = new QueryOptions(CommonFileQuery.DefaultQuery, null);
 
-                                var sortOption = AppSettings.DirectorySortOption;
+                                    //We can have many sort entries
+                                    SortEntry sortEntry = new SortEntry()
+                                    {
+                                        AscendingOrder = AppSettings.DirectorySortDirection == Microsoft.Toolkit.Uwp.UI.SortDirection.Ascending,
+                                    };
 
-                                switch (sortOption)
-                                {
-                                    case Enums.SortOption.Name:
-                                        sortEntry.PropertyName = "System.ItemNameDisplay";
-                                        queryOptions.SortOrder.Clear();
-                                        break;
+                                    var sortOption = AppSettings.DirectorySortOption;
 
-                                    case Enums.SortOption.DateModified:
-                                        sortEntry.PropertyName = "System.DateModified";
-                                        queryOptions.SortOrder.Clear();
-                                        break;
+                                    switch (sortOption)
+                                    {
+                                        case Enums.SortOption.Name:
+                                            sortEntry.PropertyName = "System.ItemNameDisplay";
+                                            queryOptions.SortOrder.Clear();
+                                            break;
 
-                                    case Enums.SortOption.Size:
-                                        //Unfortunately this is unsupported | Remarks: https://docs.microsoft.com/en-us/uwp/api/windows.storage.search.queryoptions.sortorder?view=winrt-19041
+                                        case Enums.SortOption.DateModified:
+                                            sortEntry.PropertyName = "System.DateModified";
+                                            queryOptions.SortOrder.Clear();
+                                            break;
 
-                                        //sortEntry.PropertyName = "System.TotalFileSize";
-                                        //queryOptions.SortOrder.Clear();
-                                        break;
+                                        case Enums.SortOption.Size:
+                                            //Unfortunately this is unsupported | Remarks: https://docs.microsoft.com/en-us/uwp/api/windows.storage.search.queryoptions.sortorder?view=winrt-19041
 
-                                    case Enums.SortOption.FileType:
-                                        //Unfortunately this is unsupported | Remarks: https://docs.microsoft.com/en-us/uwp/api/windows.storage.search.queryoptions.sortorder?view=winrt-19041
+                                            //sortEntry.PropertyName = "System.TotalFileSize";
+                                            //queryOptions.SortOrder.Clear();
+                                            break;
 
-                                        //sortEntry.PropertyName = "System.FileExtension";
-                                        //queryOptions.SortOrder.Clear();
-                                        break;
+                                        case Enums.SortOption.FileType:
+                                            //Unfortunately this is unsupported | Remarks: https://docs.microsoft.com/en-us/uwp/api/windows.storage.search.queryoptions.sortorder?view=winrt-19041
 
-                                    default:
-                                        //keep the default one in SortOrder IList
-                                        break;
+                                            //sortEntry.PropertyName = "System.FileExtension";
+                                            //queryOptions.SortOrder.Clear();
+                                            break;
+
+                                        default:
+                                            //keep the default one in SortOrder IList
+                                            break;
+                                    }
+
+                                    //Basically we tell to the launched app to follow how we sorted the files in the directory.
+                                    queryOptions.SortOrder.Add(sortEntry);
+
+                                    fileQueryResult = currFolder.CreateFileQueryWithOptions(queryOptions);
+
+                                    var options = new LauncherOptions
+                                    {
+                                        NeighboringFilesQuery = fileQueryResult
+                                    };
+
+                                    //Now launch file with options.
+                                    launchSuccess = await Launcher.LaunchFileAsync(childFile.File, options);
                                 }
 
-                                //Basically we tell to the launched app to follow how we sorted the files in the directory.
-                                queryOptions.SortOrder.Add(sortEntry);
-
-                                fileQueryResult = currFolder.CreateFileQueryWithOptions(queryOptions);
-
-                                var options = new LauncherOptions
-                                {
-                                    NeighboringFilesQuery = fileQueryResult
-                                };
-
-                                //Now launch file with options.
-                                launchSuccess = await Launcher.LaunchFileAsync(childFile.File, options);
+                                if (!launchSuccess)
+                                    await InvokeWin32Component(clickedOnItem.ItemPath);
                             }
-                            catch (Exception ex)
-                            {
-                                //well...
-                                Debug.WriteLine("Error in Interaction\\OpenSelectedItems() || " + ex.Message);
-                            }
-
-                            if (!launchSuccess)
-                                await InvokeWin32Component(clickedOnItem.ItemPath);
-                        }
-                    }
+                        });
                 }
-                else if (selectedItemCount > 1)
+            }
+            else if (selectedItemCount > 1)
+            {
+                foreach (ListedItem clickedOnItem in AssociatedInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.File
+                    && !x.IsShortcutItem))
                 {
-                    foreach (ListedItem clickedOnItem in AssociatedInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.File
-                        && !x.IsShortcutItem))
+                    StorageFileWithPath childFile = await AssociatedInstance.FilesystemViewModel.GetFileWithPathFromPathAsync(clickedOnItem.ItemPath);
+                    if (childFile != null)
                     {
-                        var childFile = await AssociatedInstance.FilesystemViewModel.GetFileWithPathFromPathAsync(clickedOnItem.ItemPath);
                         // Add location to MRU List
                         mostRecentlyUsed.Add(childFile.File, childFile.Path);
 
@@ -507,18 +514,20 @@ namespace Files.Interacts
                             await Launcher.LaunchFileAsync(childFile.File, options);
                         }
                     }
-                    if (!displayApplicationPicker)
-                    {
-                        var applicationPath = string.Join('|', AssociatedInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.File).Select(x => x.ItemPath));
-                        await InvokeWin32Component(applicationPath);
-                    }
-                    foreach (ListedItem clickedOnItem in AssociatedInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.Folder))
-                    {
-                        await MainPage.AddNewTab(typeof(ModernShellPage), (clickedOnItem as ShortcutItem)?.TargetPath ?? clickedOnItem.ItemPath);
-                    }
                 }
+                if (!displayApplicationPicker)
+                {
+                    var applicationPath = string.Join('|', AssociatedInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.File).Select(x => x.ItemPath));
+                    await InvokeWin32Component(applicationPath);
+                }
+                foreach (ListedItem clickedOnItem in AssociatedInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.Folder))
+                {
+                    await MainPage.AddNewTab(typeof(ModernShellPage), (clickedOnItem as ShortcutItem)?.TargetPath ?? clickedOnItem.ItemPath);
+                }
+                opened = (FilesystemResult)true;
             }
-            catch (FileNotFoundException)
+
+            if (opened.ErrorCode == FilesystemErrorCode.ERROR_NOTFOUND)
             {
                 await DialogDisplayHelper.ShowDialog("FileNotFoundDialog/Title".GetLocalized(), "FileNotFoundDialog/Text".GetLocalized());
                 AssociatedInstance.NavigationToolbar.CanRefresh = false;
@@ -593,7 +602,7 @@ namespace Files.Interacts
                 await newWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
                     Frame frame = new Frame();
-                    frame.Navigate(typeof(Properties), new PropertiesPageNavigationArguments() {Item = item, AppInstanceArgument = AssociatedInstance }, new SuppressNavigationTransitionInfo());
+                    frame.Navigate(typeof(Properties), new PropertiesPageNavigationArguments() { Item = item, AppInstanceArgument = AssociatedInstance }, new SuppressNavigationTransitionInfo());
                     Window.Current.Content = frame;
                     Window.Current.Activate();
 
@@ -658,13 +667,19 @@ namespace Files.Interacts
                 }
                 else if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    var folderAsItem = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath);
-                    items.Add(folderAsItem);
+                    StorageFolder folderAsItem = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath);
+                    if (folderAsItem != null)
+                    {
+                        items.Add(folderAsItem);
+                    }
                 }
                 else
                 {
-                    var fileAsItem = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath);
-                    items.Add(fileAsItem);
+                    StorageFile fileAsItem = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath);
+                    if (fileAsItem != null)
+                    {
+                        items.Add(fileAsItem);
+                    }
                 }
             }
 
@@ -776,20 +791,18 @@ namespace Files.Interacts
                 && !ContainsRestrictedCharacters(newName)
                 && !ContainsRestrictedFileName(newName))
             {
-                try
+                var renamed = (FilesystemResult)false;
+                if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
-                    {
-                        var folder = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath);
-                        await folder.RenameAsync(newName, NameCollisionOption.FailIfExists);
-                    }
-                    else
-                    {
-                        var file = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath);
-                        await file.RenameAsync(newName, NameCollisionOption.FailIfExists);
-                    }
+                    renamed = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath)
+                        .OnSuccess(t => t.RenameAsync(newName, NameCollisionOption.FailIfExists).AsTask());
                 }
-                catch (UnauthorizedAccessException)
+                else
+                {
+                    renamed = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
+                        .OnSuccess(t => t.RenameAsync(newName, NameCollisionOption.FailIfExists).AsTask());
+                }
+                if (renamed.ErrorCode == FilesystemErrorCode.ERROR_UNAUTHORIZED)
                 {
                     // Try again with MoveFileFromApp
                     if (!NativeDirectoryChangesHelper.MoveFileFromApp(item.ItemPath, Path.Combine(Path.GetDirectoryName(item.ItemPath), newName)))
@@ -798,76 +811,69 @@ namespace Files.Interacts
                         return false;
                     }
                 }
-                catch (Exception ex)
+                else if (renamed.ErrorCode == FilesystemErrorCode.ERROR_NOTAFILE || renamed.ErrorCode == FilesystemErrorCode.ERROR_NOTAFOLDER)
                 {
-                    if (ex is ArgumentException)
+                    await DialogDisplayHelper.ShowDialog("RenameError.NameInvalid.Title".GetLocalized(), "RenameError.NameInvalid.Text".GetLocalized());
+                }
+                else if (renamed.ErrorCode == FilesystemErrorCode.ERROR_NAMETOOLONG)
+                {
+                    await DialogDisplayHelper.ShowDialog("RenameError.TooLong.Title".GetLocalized(), "RenameError.TooLong.Text".GetLocalized());
+                }
+                else if (renamed.ErrorCode == FilesystemErrorCode.ERROR_INUSE)
+                {
+                    // TODO: proper dialog, retry
+                    await DialogDisplayHelper.ShowDialog("FileInUseDeleteDialog/Title".GetLocalized(), "");
+                }
+                else if (renamed.ErrorCode == FilesystemErrorCode.ERROR_NOTFOUND)
+                {
+                    await DialogDisplayHelper.ShowDialog("RenameError.ItemDeleted.Title".GetLocalized(), "RenameError.ItemDeleted.Text".GetLocalized());
+                }
+                else if (!renamed)
+                {
+                    var ItemAlreadyExistsDialog = new ContentDialog()
                     {
-                        await DialogDisplayHelper.ShowDialog("RenameError.NameInvalid.Title".GetLocalized(), "RenameError.NameInvalid.Text".GetLocalized());
-                    }
-                    else if (ex is PathTooLongException)
+                        Title = "ItemAlreadyExistsDialogTitle".GetLocalized(),
+                        Content = "ItemAlreadyExistsDialogContent".GetLocalized(),
+                        PrimaryButtonText = "ItemAlreadyExistsDialogPrimaryButtonText".GetLocalized(),
+                        SecondaryButtonText = "ItemAlreadyExistsDialogSecondaryButtonText".GetLocalized()
+                    };
+
+                    ContentDialogResult result = await ItemAlreadyExistsDialog.ShowAsync();
+
+                    if (result == ContentDialogResult.Primary)
                     {
-                        await DialogDisplayHelper.ShowDialog("RenameError.TooLong.Title".GetLocalized(), "RenameError.TooLong.Text".GetLocalized());
-                    }
-                    else if (ex is FileNotFoundException)
-                    {
-                        await DialogDisplayHelper.ShowDialog("RenameError.ItemDeleted.Title".GetLocalized(), "RenameError.ItemDeleted.Text".GetLocalized());
-                    }
-                    else
-                    {
-                        var ItemAlreadyExistsDialog = new ContentDialog()
+                        if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                         {
-                            Title = "ItemAlreadyExistsDialogTitle".GetLocalized(),
-                            Content = "ItemAlreadyExistsDialogContent".GetLocalized(),
-                            PrimaryButtonText = "ItemAlreadyExistsDialogPrimaryButtonText".GetLocalized(),
-                            SecondaryButtonText = "ItemAlreadyExistsDialogSecondaryButtonText".GetLocalized()
-                        };
-
-                        ContentDialogResult result = await ItemAlreadyExistsDialog.ShowAsync();
-
-                        if (result == ContentDialogResult.Primary)
-                        {
-                            if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
-                            {
-                                var folder = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath);
-
-                                await folder.RenameAsync(newName, NameCollisionOption.GenerateUniqueName);
-
-                                App.JumpList.RemoveFolder(folder.Path);
-                            }
-                            else
-                            {
-                                var file = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath);
-
-                                await file.RenameAsync(newName, NameCollisionOption.GenerateUniqueName);
-                            }
+                            renamed = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath)
+                                .OnSuccess(t => t.RenameAsync(newName, NameCollisionOption.GenerateUniqueName).AsTask());
                         }
-                        else if (result == ContentDialogResult.Secondary)
+                        else
                         {
-                            if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
-                            {
-                                var folder = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath);
-
-                                await folder.RenameAsync(newName, NameCollisionOption.ReplaceExisting);
-
-                                App.JumpList.RemoveFolder(folder.Path);
-                            }
-                            else
-                            {
-                                var file = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath);
-
-                                await file.RenameAsync(newName, NameCollisionOption.ReplaceExisting);
-                            }
+                            renamed = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
+                                .OnSuccess(t => t.RenameAsync(newName, NameCollisionOption.GenerateUniqueName).AsTask());
+                        }
+                    }
+                    else if (result == ContentDialogResult.Secondary)
+                    {
+                        if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
+                        {
+                            renamed = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath)
+                                .OnSuccess(t => t.RenameAsync(newName, NameCollisionOption.ReplaceExisting).AsTask());
+                        }
+                        else
+                        {
+                            renamed = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
+                                .OnSuccess(t => t.RenameAsync(newName, NameCollisionOption.ReplaceExisting).AsTask());
                         }
                     }
                 }
+                if (renamed)
+                {
+                    AssociatedInstance.NavigationToolbar.CanGoForward = false;
+                    return true;
+                }
             }
-            else
-            {
-                return false;
-            }
-
-            AssociatedInstance.NavigationToolbar.CanGoForward = false;
-            return true;
+            return false;
         }
 
         public async void RestoreItem_Click(object sender, RoutedEventArgs e)
@@ -876,37 +882,47 @@ namespace Files.Interacts
             {
                 foreach (ListedItem listedItem in AssociatedInstance.ContentPage.SelectedItems)
                 {
-                    try
+                    var restored = FilesystemErrorCode.ERROR_GENERIC;
+                    var recycleBinItem = listedItem as RecycleBinItem;
+                    if (listedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
                     {
-                        var recycleBinItem = listedItem as RecycleBinItem;
-                        if (listedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
+                        var sourceFolder = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(recycleBinItem.ItemPath);
+                        var destFolder = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(Path.GetDirectoryName(recycleBinItem.ItemOriginalPath));
+                        restored = sourceFolder.ErrorCode | destFolder.ErrorCode;
+                        if (sourceFolder && destFolder)
                         {
-                            StorageFolder sourceFolder = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(recycleBinItem.ItemPath);
-                            StorageFolder destFolder = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(Path.GetDirectoryName(recycleBinItem.ItemOriginalPath));
-                            await MoveDirectoryAsync(sourceFolder, destFolder, recycleBinItem.ItemName);
-                            await sourceFolder.DeleteAsync(StorageDeleteOption.PermanentDelete);
+                            restored = await MoveDirectoryAsync(sourceFolder.Result, destFolder.Result, recycleBinItem.ItemName).Wrap()
+                                .OnSuccess(t => sourceFolder.Result.DeleteAsync(StorageDeleteOption.PermanentDelete).AsTask());
+                        }
+                    }
+                    else
+                    {
+                        var sourceFile = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(recycleBinItem.ItemPath);
+                        var destFolder = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(Path.GetDirectoryName(recycleBinItem.ItemOriginalPath));
+                        restored = sourceFile.ErrorCode | destFolder.ErrorCode;
+                        if (sourceFile && destFolder)
+                        {
+                            restored = await sourceFile.Result.MoveAsync(destFolder.Result, Path.GetFileName(recycleBinItem.ItemOriginalPath), NameCollisionOption.GenerateUniqueName).AsTask().Wrap();
+                        }
+                    }
+                    // Recycle bin also stores a file starting with $I for each item
+                    var iFilePath = Path.Combine(Path.GetDirectoryName(recycleBinItem.ItemPath), Path.GetFileName(recycleBinItem.ItemPath).Replace("$R", "$I"));
+                    await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(iFilePath)
+                        .OnSuccess(iFile => iFile.DeleteAsync().AsTask());
+                    if (restored != FilesystemErrorCode.ERROR_OK)
+                    {
+                        if (restored.HasFlag(FilesystemErrorCode.ERROR_UNAUTHORIZED))
+                        {
+                            await DialogDisplayHelper.ShowDialog("AccessDeniedDeleteDialog/Title".GetLocalized(), "AccessDeniedDeleteDialog/Text".GetLocalized());
+                        }
+                        else if (restored.HasFlag(FilesystemErrorCode.ERROR_UNAUTHORIZED))
+                        {
+                            await DialogDisplayHelper.ShowDialog("FileNotFoundDialog/Title".GetLocalized(), "FileNotFoundDialog/Text".GetLocalized());
                         }
                         else
                         {
-                            var file = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(recycleBinItem.ItemPath);
-                            var destinationFolder = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(Path.GetDirectoryName(recycleBinItem.ItemOriginalPath));
-                            await file.MoveAsync(destinationFolder, Path.GetFileName(recycleBinItem.ItemOriginalPath), NameCollisionOption.GenerateUniqueName);
+                            await DialogDisplayHelper.ShowDialog("ItemAlreadyExistsDialogTitle".GetLocalized(), "ItemAlreadyExistsDialogContent".GetLocalized());
                         }
-                        // Recycle bin also stores a file starting with $I for each item
-                        var iFilePath = Path.Combine(Path.GetDirectoryName(recycleBinItem.ItemPath), Path.GetFileName(recycleBinItem.ItemPath).Replace("$R", "$I"));
-                        await (await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(iFilePath)).DeleteAsync(StorageDeleteOption.PermanentDelete);
-                    }
-                    catch (UnauthorizedAccessException)
-                    {
-                        await DialogDisplayHelper.ShowDialog("AccessDeniedDeleteDialog/Title".GetLocalized(), "AccessDeniedDeleteDialog/Text".GetLocalized());
-                    }
-                    catch (FileNotFoundException)
-                    {
-                        await DialogDisplayHelper.ShowDialog("FileNotFoundDialog/Title".GetLocalized(), "FileNotFoundDialog/Text".GetLocalized());
-                    }
-                    catch (Exception)
-                    {
-                        await DialogDisplayHelper.ShowDialog("ItemAlreadyExistsDialogTitle".GetLocalized(), "ItemAlreadyExistsDialogContent".GetLocalized());
                     }
                 }
             }
@@ -938,37 +954,36 @@ namespace Files.Interacts
                 RequestedOperation = DataPackageOperation.Move
             };
             List<IStorageItem> items = new List<IStorageItem>();
-
+            var cut = (FilesystemResult)false;
             if (AssociatedInstance.ContentPage.IsItemSelected)
             {
                 // First, reset DataGrid Rows that may be in "cut" command mode
                 AssociatedInstance.ContentPage.ResetItemOpacity();
 
-                try
+                foreach (ListedItem listedItem in AssociatedInstance.ContentPage.SelectedItems)
                 {
-                    foreach (ListedItem listedItem in AssociatedInstance.ContentPage.SelectedItems)
-                    {
-                        // Dim opacities accordingly
-                        AssociatedInstance.ContentPage.SetItemOpacity(listedItem);
+                    // Dim opacities accordingly
+                    AssociatedInstance.ContentPage.SetItemOpacity(listedItem);
 
-                        if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
-                        {
-                            var item = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(listedItem.ItemPath);
-                            items.Add(item);
-                        }
-                        else
-                        {
-                            var item = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(listedItem.ItemPath);
-                            items.Add(item);
-                        }
+                    if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
+                    {
+                        cut = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(listedItem.ItemPath)
+                            .OnSuccess(t => items.Add(t));
+                        if (!cut) break;
+                    }
+                    else
+                    {
+                        cut = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(listedItem.ItemPath)
+                            .OnSuccess(t => items.Add(t));
+                        if (!cut) break;
                     }
                 }
-                catch (FileNotFoundException)
+                if (cut.ErrorCode == FilesystemErrorCode.ERROR_NOTFOUND)
                 {
                     AssociatedInstance.ContentPage.ResetItemOpacity();
                     return;
                 }
-                catch (UnauthorizedAccessException)
+                else if (cut.ErrorCode == FilesystemErrorCode.ERROR_UNAUTHORIZED)
                 {
                     // Try again with fulltrust process
                     if (Connection != null)
@@ -1015,26 +1030,26 @@ namespace Files.Interacts
             List<IStorageItem> items = new List<IStorageItem>();
 
             CopySourcePath = AssociatedInstance.FilesystemViewModel.WorkingDirectory;
+            var copied = (FilesystemResult)false;
 
             if (AssociatedInstance.ContentPage.IsItemSelected)
             {
-                try
+                foreach (ListedItem listedItem in AssociatedInstance.ContentPage.SelectedItems)
                 {
-                    foreach (ListedItem listedItem in AssociatedInstance.ContentPage.SelectedItems)
+                    if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
                     {
-                        if (listedItem.PrimaryItemAttribute == StorageItemTypes.File)
-                        {
-                            var item = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(listedItem.ItemPath);
-                            items.Add(item);
-                        }
-                        else
-                        {
-                            var item = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(listedItem.ItemPath);
-                            items.Add(item);
-                        }
+                        copied = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(listedItem.ItemPath)
+                            .OnSuccess(t => items.Add(t));
+                        if (!copied) break;
+                    }
+                    else
+                    {
+                        copied = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(listedItem.ItemPath)
+                            .OnSuccess(t => items.Add(t));
+                        if (!copied) break;
                     }
                 }
-                catch (UnauthorizedAccessException)
+                if (copied.ErrorCode == FilesystemErrorCode.ERROR_UNAUTHORIZED)
                 {
                     // Try again with fulltrust process
                     if (Connection != null)
@@ -1139,9 +1154,6 @@ namespace Files.Interacts
                 currentPath = AssociatedInstance.FilesystemViewModel.WorkingDirectory;
             }
 
-            StorageFolderWithPath folderWithPath = await AssociatedInstance.FilesystemViewModel.GetFolderWithPathFromPathAsync(currentPath);
-            StorageFolder folderToCreateItem = folderWithPath.Folder;
-
             // Show rename dialog
             RenameDialog renameDialog = new RenameDialog();
             var renameResult = await renameDialog.ShowAsync();
@@ -1152,27 +1164,29 @@ namespace Files.Interacts
 
             // Create file based on dialog result
             string userInput = renameDialog.storedRenameInput;
-            try
+            var folderRes = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(currentPath);
+            FilesystemResult created = folderRes;
+            if (folderRes)
             {
                 switch (itemType)
                 {
                     case AddItemType.Folder:
                         userInput = !string.IsNullOrWhiteSpace(userInput) ? userInput : "NewFolder".GetLocalized();
-                        await folderToCreateItem.CreateFolderAsync(userInput, CreationCollisionOption.GenerateUniqueName);
+                        created = await folderRes.Result.CreateFolderAsync(userInput, CreationCollisionOption.GenerateUniqueName).AsTask().Wrap();
                         break;
 
                     case AddItemType.TextDocument:
                         userInput = !string.IsNullOrWhiteSpace(userInput) ? userInput : "NewTextDocument".GetLocalized();
-                        await folderToCreateItem.CreateFileAsync(userInput + ".txt", CreationCollisionOption.GenerateUniqueName);
+                        created = await folderRes.Result.CreateFileAsync(userInput + ".txt", CreationCollisionOption.GenerateUniqueName).AsTask().Wrap();
                         break;
 
                     case AddItemType.BitmapImage:
                         userInput = !string.IsNullOrWhiteSpace(userInput) ? userInput : "NewBitmapImage".GetLocalized();
-                        await folderToCreateItem.CreateFileAsync(userInput + ".bmp", CreationCollisionOption.GenerateUniqueName);
+                        created = await folderRes.Result.CreateFileAsync(userInput + ".bmp", CreationCollisionOption.GenerateUniqueName).AsTask().Wrap();
                         break;
                 }
             }
-            catch (UnauthorizedAccessException)
+            if (created == FilesystemErrorCode.ERROR_UNAUTHORIZED)
             {
                 await DialogDisplayHelper.ShowDialog("AccessDeniedCreateDialog/Title".GetLocalized(), "AccessDeniedCreateDialog/Text".GetLocalized());
             }
@@ -1245,8 +1259,10 @@ namespace Files.Interacts
         public async Task<string> GetHashForFile(ListedItem fileItem, string nameOfAlg, CancellationToken token, Microsoft.UI.Xaml.Controls.ProgressBar progress)
         {
             HashAlgorithmProvider algorithmProvider = HashAlgorithmProvider.OpenAlgorithm(nameOfAlg);
-            var itemFromPath = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync((fileItem as ShortcutItem)?.TargetPath ?? fileItem.ItemPath);
-            var stream = await itemFromPath.OpenStreamForReadAsync();
+            StorageFile itemFromPath = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync((fileItem as ShortcutItem)?.TargetPath ?? fileItem.ItemPath);
+            if (itemFromPath == null) return "";
+            Stream stream = await itemFromPath.OpenStreamForReadAsync().Wrap();
+            if (stream == null) return "";
             var inputStream = stream.AsInputStream();
             var str = inputStream.AsStreamForRead();
             var cap = (long)(0.5 * str.Length) / 100;

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -667,19 +667,13 @@ namespace Files.Interacts
                 }
                 else if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    StorageFolder folderAsItem = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath);
-                    if (folderAsItem != null)
-                    {
-                        items.Add(folderAsItem);
-                    }
+                    await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath)
+                        .OnSuccess(folderAsItem => items.Add(folderAsItem));
                 }
                 else
                 {
-                    StorageFile fileAsItem = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath);
-                    if (fileAsItem != null)
-                    {
-                        items.Add(fileAsItem);
-                    }
+                    await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
+                        .OnSuccess(fileAsItem => items.Add(fileAsItem));
                 }
             }
 

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -796,7 +796,7 @@ namespace Files.Interacts
                     renamed = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
                         .OnSuccess(t => t.RenameAsync(newName, NameCollisionOption.FailIfExists).AsTask());
                 }
-                if (renamed.ErrorCode == FilesystemErrorCode.ERROR_UNAUTHORIZED)
+                if (renamed == FilesystemErrorCode.ERROR_UNAUTHORIZED)
                 {
                     // Try again with MoveFileFromApp
                     if (!NativeDirectoryChangesHelper.MoveFileFromApp(item.ItemPath, Path.Combine(Path.GetDirectoryName(item.ItemPath), newName)))
@@ -805,24 +805,24 @@ namespace Files.Interacts
                         return false;
                     }
                 }
-                else if (renamed.ErrorCode == FilesystemErrorCode.ERROR_NOTAFILE || renamed.ErrorCode == FilesystemErrorCode.ERROR_NOTAFOLDER)
+                else if (renamed == FilesystemErrorCode.ERROR_NOTAFILE || renamed == FilesystemErrorCode.ERROR_NOTAFOLDER)
                 {
                     await DialogDisplayHelper.ShowDialog("RenameError.NameInvalid.Title".GetLocalized(), "RenameError.NameInvalid.Text".GetLocalized());
                 }
-                else if (renamed.ErrorCode == FilesystemErrorCode.ERROR_NAMETOOLONG)
+                else if (renamed == FilesystemErrorCode.ERROR_NAMETOOLONG)
                 {
                     await DialogDisplayHelper.ShowDialog("RenameError.TooLong.Title".GetLocalized(), "RenameError.TooLong.Text".GetLocalized());
                 }
-                else if (renamed.ErrorCode == FilesystemErrorCode.ERROR_INUSE)
+                else if (renamed == FilesystemErrorCode.ERROR_INUSE)
                 {
                     // TODO: proper dialog, retry
                     await DialogDisplayHelper.ShowDialog("FileInUseDeleteDialog/Title".GetLocalized(), "");
                 }
-                else if (renamed.ErrorCode == FilesystemErrorCode.ERROR_NOTFOUND)
+                else if (renamed == FilesystemErrorCode.ERROR_NOTFOUND)
                 {
                     await DialogDisplayHelper.ShowDialog("RenameError.ItemDeleted.Title".GetLocalized(), "RenameError.ItemDeleted.Text".GetLocalized());
                 }
-                else if (!renamed)
+                else if (renamed == FilesystemErrorCode.ERROR_ALREADYEXIST)
                 {
                     var ItemAlreadyExistsDialog = new ContentDialog()
                     {
@@ -913,7 +913,7 @@ namespace Files.Interacts
                         {
                             await DialogDisplayHelper.ShowDialog("FileNotFoundDialog/Title".GetLocalized(), "FileNotFoundDialog/Text".GetLocalized());
                         }
-                        else
+                        else if (restored.HasFlag(FilesystemErrorCode.ERROR_ALREADYEXIST))
                         {
                             await DialogDisplayHelper.ShowDialog("ItemAlreadyExistsDialogTitle".GetLocalized(), "ItemAlreadyExistsDialogContent".GetLocalized());
                         }

--- a/Files/View Models/Properties/DriveProperties.cs
+++ b/Files/View Models/Properties/DriveProperties.cs
@@ -42,10 +42,7 @@ namespace Files.View_Models.Properties
             {
                 var properties = Task.Run(async () =>
                 {
-                    return await diskRoot.Properties.RetrievePropertiesAsync(new[] {
-                    freeSpace,
-                    capacity,
-                    fileSystem });
+                    return await diskRoot.Properties.RetrievePropertiesAsync(new[] { freeSpace, capacity, fileSystem });
                 }).Result;
 
                 ViewModel.DriveCapacityValue = (ulong)properties[capacity];

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -265,11 +265,7 @@ namespace Files.View_Models
                 PinOneDriveToSideBar = false;
             }
 
-            try
-            {
-                await StorageFolder.GetFolderFromPathAsync(OneDrivePath);
-            }
-            catch (Exception)
+            if (!await StorageFolder.GetFolderFromPathAsync(OneDrivePath).AsTask().Wrap())
             {
                 PinOneDriveToSideBar = false;
             }

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -491,7 +491,15 @@ namespace Files.Views.Pages
                                 }
                             }
 
-                            if (!await Launcher.LaunchUriAsync(new Uri(currentInput)))
+                            try
+                            {
+                                if (!await Launcher.LaunchUriAsync(new Uri(currentInput)))
+                                {
+                                    await DialogDisplayHelper.ShowDialog("InvalidItemDialogTitle".GetLocalized(),
+                                        string.Format("InvalidItemDialogContent".GetLocalized(), Environment.NewLine, resFolder.ErrorCode.ToString()));
+                                }
+                            }
+                            catch (UriFormatException)
                             {
                                 await DialogDisplayHelper.ShowDialog("InvalidItemDialogTitle".GetLocalized(),
                                     string.Format("InvalidItemDialogContent".GetLocalized(), Environment.NewLine, resFolder.ErrorCode.ToString()));

--- a/Files/Views/SettingsPages/Preferences.xaml.cs
+++ b/Files/Views/SettingsPages/Preferences.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Files.DataModels;
+using Files.Filesystem;
 using Files.View_Models;
 using System;
 using Windows.Storage;
@@ -22,11 +23,7 @@ namespace Files.SettingsPages
 
         private async void TryGetOneDriveFolder()
         {
-            try
-            {
-                await StorageFolder.GetFolderFromPathAsync(AppSettings.OneDrivePath);
-            }
-            catch
+            if (!await StorageFolder.GetFolderFromPathAsync(AppSettings.OneDrivePath).AsTask().Wrap())
             {
                 AppSettings.PinOneDriveToSideBar = false;
                 OneDrivePin.IsEnabled = false;


### PR DESCRIPTION
Fixes #1831
Fixes #2164
Fixes #2265
Fixes #1707

Hi all, this PR contains a proposal on how to improve exception handling/reliability for filesystem operations.
This PR wraps all filesystem operations in a `FilesystemResult` object which contains the operation result (e.g. a StorageFolder) and an error code. In case of error, instead of throwing an exception, the error is returned in the `ErrorCode` field and the result is set to `null`.

Examples:
1) Where we don't care about *why* the function has failed we can simply check if the result is `null`
```cs
StorgeFile file = await ParentShellPageInstance.FilesystemViewModel.GetFileFromPathAsync(PATH);
if (file != null)
{
    // Succeeded
    selectedStorageItems.Add(file);
}
```
or shorter
```cs
await ParentShellPageInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
    .OnSuccess(t => selectedStorageItems.Add(t));
```
2) If we *do* care about why the function has failed we can check the error code
```cs
var res = await ParentShellPageInstance.FilesystemViewModel.GetFolderFromPathAsync(PATH);
if (res)
{
    // Succeeded, res.Result contains the returned StorageFolder
}
else if (res == FilesystemErrorCode.ERROR_UNAUTHORIZED)
{
    // Equivalent to UnauthorizedAccessException
}
else
{
    // All other error cases
}
```
3) Any file operation can be converted to the "new style" using the `Wrap()` extension method
```cs
var deleted = await res.Result.DeleteAsync(deleteOption).AsTask().Wrap(); ----> does not throw and returns a FilesystemResult
```

This PR already changes most of the code to use the "new style" exception handling and adds the proper checks to the returned result.  This avoids to have to wrap everything in `try/catch` blocks, allows for finer error handling and should make the app more robust. Please let me know what you think of this proposal 😃