### PR TITLE
Fix crash when viewing properties for drives and multiple items

### DIFF
--- a/Files/View Models/Properties/FileProperties.cs
+++ b/Files/View Models/Properties/FileProperties.cs
@@ -218,6 +218,11 @@ namespace Files.View_Models.Properties
 
         public override async void GetSpecialProperties()
         {
+            ViewModel.IsReadOnly = NativeFileOperationsHelper.HasFileAttribute(
+                Item.ItemPath, System.IO.FileAttributes.ReadOnly);
+            ViewModel.IsHidden = NativeFileOperationsHelper.HasFileAttribute(
+                Item.ItemPath, System.IO.FileAttributes.Hidden);
+
             ViewModel.ItemSizeVisibility = Visibility.Visible;
             ViewModel.ItemSize = ByteSize.FromBytes(Item.FileSizeBytes).ToBinaryString().ConvertSizeAbbreviation()
                 + " (" + ByteSize.FromBytes(Item.FileSizeBytes).Bytes.ToString("#,##0") + " " + "ItemSizeBytes".GetLocalized() + ")";
@@ -463,6 +468,30 @@ namespace Files.View_Models.Properties
         {
             switch (e.PropertyName)
             {
+                case "IsReadOnly":
+                    if (ViewModel.IsReadOnly)
+                    {
+                        NativeFileOperationsHelper.SetFileAttribute(
+                            Item.ItemPath, System.IO.FileAttributes.ReadOnly);
+                    }
+                    else
+                    {
+                        NativeFileOperationsHelper.UnsetFileAttribute(
+                            Item.ItemPath, System.IO.FileAttributes.ReadOnly);
+                    }
+                    break;
+                case "IsHidden":
+                    if (ViewModel.IsHidden)
+                    {
+                        NativeFileOperationsHelper.SetFileAttribute(
+                            Item.ItemPath, System.IO.FileAttributes.Hidden);
+                    }
+                    else
+                    {
+                        NativeFileOperationsHelper.UnsetFileAttribute(
+                            Item.ItemPath, System.IO.FileAttributes.Hidden);
+                    }
+                    break;
                 case "ShortcutItemPath":
                 case "ShortcutItemWorkingDir":
                 case "ShortcutItemArguments":

--- a/Files/View Models/Properties/FolderProperties.cs
+++ b/Files/View Models/Properties/FolderProperties.cs
@@ -74,6 +74,9 @@ namespace Files.View_Models.Properties
 
         public async override void GetSpecialProperties()
         {
+            ViewModel.IsHidden = NativeFileOperationsHelper.HasFileAttribute(
+                Item.ItemPath, System.IO.FileAttributes.Hidden);
+
             if (Item.IsShortcutItem)
             {
                 ViewModel.ItemSizeVisibility = Visibility.Visible;
@@ -227,6 +230,18 @@ namespace Files.View_Models.Properties
         {
             switch (e.PropertyName)
             {
+                case "IsHidden":
+                    if (ViewModel.IsHidden)
+                    {
+                        NativeFileOperationsHelper.SetFileAttribute(
+                            Item.ItemPath, System.IO.FileAttributes.Hidden);
+                    }
+                    else
+                    {
+                        NativeFileOperationsHelper.UnsetFileAttribute(
+                            Item.ItemPath, System.IO.FileAttributes.Hidden);
+                    }
+                    break;
                 case "ShortcutItemPath":
                 case "ShortcutItemWorkingDir":
                 case "ShortcutItemArguments":

--- a/Files/View Models/SelectedItemsPropertiesViewModel.cs
+++ b/Files/View Models/SelectedItemsPropertiesViewModel.cs
@@ -768,52 +768,32 @@ namespace Files.View_Models
             set => SetProperty(ref detailsSectionVisibility_Media, value);
         }
 
+        private bool isReadOnly;
+
         public bool IsReadOnly
         {
-            get
-            {
-                return NativeFileOperationsHelper.HasFileAttribute(
-                    Path.Combine(ItemPath, ItemName), FileAttributes.ReadOnly);
-            }
-
+            get => isReadOnly;
             set
             {
-                if (value)
-                {
-                    NativeFileOperationsHelper.SetFileAttribute(
-                        Path.Combine(ItemPath, ItemName), FileAttributes.ReadOnly);
-                }
-                else
-                {
-                    NativeFileOperationsHelper.UnsetFileAttribute(
-                        Path.Combine(ItemPath, ItemName), FileAttributes.ReadOnly);
-                }
-                base.OnPropertyChanged(nameof(IsReadOnly));
+                IsReadOnlyEnabled = true;
+                SetProperty(ref isReadOnly, value);
             }
         }
 
+        private bool isReadOnlyEnabled;
+
+        public bool IsReadOnlyEnabled
+        {
+            get => isReadOnlyEnabled;
+            set => SetProperty(ref isReadOnlyEnabled, value);
+        }
+
+        private bool isHidden;
+
         public bool IsHidden
         {
-            get
-            {
-                return NativeFileOperationsHelper.HasFileAttribute(
-                    Path.Combine(ItemPath, ItemName), FileAttributes.Hidden);
-            }
-
-            set
-            {
-                if (value)
-                {
-                    NativeFileOperationsHelper.SetFileAttribute(
-                        Path.Combine(ItemPath, ItemName), FileAttributes.Hidden);
-                }
-                else
-                {
-                    NativeFileOperationsHelper.UnsetFileAttribute(
-                        Path.Combine(ItemPath, ItemName), FileAttributes.Hidden);
-                }
-                base.OnPropertyChanged(nameof(IsHidden));
-            }
+            get => isHidden;
+            set => SetProperty(ref isHidden, value);
         }
     }
 }

--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -362,6 +362,7 @@
                 <CheckBox
                     x:Uid="PropertiesDialogReadOnly"
                     Content="Read-only"
+                    IsEnabled="{x:Bind ViewModel.IsReadOnlyEnabled, Mode=OneWay}"
                     IsChecked="{x:Bind ViewModel.IsReadOnly, Mode=TwoWay}"/>
                 <CheckBox
                     x:Uid="PropertiesDialogHidden"


### PR DESCRIPTION
Fixes #2340

Hidden checkbox -> enabled for File, Folder and Combined properties
Read-Only checkbox -> enabled for File and Combined (if all items are files) properties as folders do not have a read-only property themselves