### PR TITLE
Increased the delay required to trigger double tap to rename

### DIFF
--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -298,7 +298,7 @@ namespace Files
                     {
                         tapDebounceTimer.Stop();
                         AllView.BeginEdit(); // EditingEventArgs will be null
-                    }, TimeSpan.FromMilliseconds(1000), false);
+                    }, TimeSpan.FromMilliseconds(700), false);
                 }
                 else
                 {

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -298,7 +298,7 @@ namespace Files
                     {
                         tapDebounceTimer.Stop();
                         AllView.BeginEdit(); // EditingEventArgs will be null
-                    }, TimeSpan.FromMilliseconds(500), false);
+                    }, TimeSpan.FromMilliseconds(1000), false);
                 }
                 else
                 {


### PR DESCRIPTION
This fixes an issue where double clicking an item would sometimes trigger the rename option.