### PR TITLE
[Delay bug] - Move sorting to background task

### DIFF
--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -986,6 +986,7 @@ namespace Files.Filesystem
                                 var itemPath = Path.Combine(path, findData.cFileName);
                                 if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden && !AppSettings.AreHiddenItemsVisible)
                                 {
+                                    hasNextFile = FindNextFile(hFile, out findData);
                                     continue;
                                 }
 

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -43,12 +43,12 @@ namespace Files.Filesystem
         private static SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
         private IntPtr hWatchDir;
         private IAsyncAction aWatcherAction;
+        private BulkObservableCollection<ListedItem> _filesAndFolders;
         public ReadOnlyObservableCollection<ListedItem> FilesAndFolders { get; }
         public SettingsViewModel AppSettings => App.AppSettings;
         private bool shouldDisplayFileExtensions = false;
         public ListedItem CurrentFolder { get; private set; }
         public CollectionViewSource viewSource;
-        public BulkObservableCollection<ListedItem> _filesAndFolders;
         private CancellationTokenSource _addFilesCTS, _semaphoreCTS;
         private StorageFolder _rootFolder;
 
@@ -411,11 +411,39 @@ namespace Files.Filesystem
             }
         }
 
-        public void OrderFiles()
+        public void OrderFiles(IList<ListedItem> orderedList = null)
         {
-            if (_filesAndFolders.Count == 0)
+            if (orderedList == null)
             {
-                return;
+                orderedList = OrderFiles2(_filesAndFolders);
+            }
+            _filesAndFolders.BeginBulkOperation();
+            for (var i = 0; i < orderedList.Count; i++)
+            {
+                if (i < _filesAndFolders.Count)
+                {
+                    if (_filesAndFolders[i] != orderedList[i])
+                    {
+                        _filesAndFolders.Insert(i, orderedList[i]);
+                    }
+                }
+                else
+                {
+                    _filesAndFolders.Add(orderedList[i]);
+                }
+            }
+            while (_filesAndFolders.Count > orderedList.Count)
+            {
+                _filesAndFolders.RemoveAt(_filesAndFolders.Count - 1);
+            }
+            _filesAndFolders.EndBulkOperation();
+        }
+
+        private IList<ListedItem> OrderFiles2(IList<ListedItem> listToSort)
+        {
+            if (listToSort.Count == 0)
+            {
+                return listToSort.ToList();
             }
 
             static object orderByNameFunc(ListedItem item) => item.ItemName;
@@ -450,11 +478,11 @@ namespace Files.Filesystem
             {
                 if (AppSettings.DirectorySortOption == SortOption.Name)
                 {
-                    ordered = _filesAndFolders.OrderBy(folderThenFileAsync).ThenBy(orderFunc, naturalStringComparer);
+                    ordered = listToSort.OrderBy(folderThenFileAsync).ThenBy(orderFunc, naturalStringComparer);
                 }
                 else
                 {
-                    ordered = _filesAndFolders.OrderBy(folderThenFileAsync).ThenBy(orderFunc);
+                    ordered = listToSort.OrderBy(folderThenFileAsync).ThenBy(orderFunc);
                 }
             }
             else
@@ -463,22 +491,22 @@ namespace Files.Filesystem
                 {
                     if (AppSettings.DirectorySortOption == SortOption.Name)
                     {
-                        ordered = _filesAndFolders.OrderBy(folderThenFileAsync).ThenByDescending(orderFunc, naturalStringComparer);
+                        ordered = listToSort.OrderBy(folderThenFileAsync).ThenByDescending(orderFunc, naturalStringComparer);
                     }
                     else
                     {
-                        ordered = _filesAndFolders.OrderBy(folderThenFileAsync).ThenByDescending(orderFunc);
+                        ordered = listToSort.OrderBy(folderThenFileAsync).ThenByDescending(orderFunc);
                     }
                 }
                 else
                 {
                     if (AppSettings.DirectorySortOption == SortOption.Name)
                     {
-                        ordered = _filesAndFolders.OrderByDescending(folderThenFileAsync).ThenByDescending(orderFunc, naturalStringComparer);
+                        ordered = listToSort.OrderByDescending(folderThenFileAsync).ThenByDescending(orderFunc, naturalStringComparer);
                     }
                     else
                     {
-                        ordered = _filesAndFolders.OrderByDescending(folderThenFileAsync).ThenByDescending(orderFunc);
+                        ordered = listToSort.OrderByDescending(folderThenFileAsync).ThenByDescending(orderFunc);
                     }
                 }
             }
@@ -497,18 +525,7 @@ namespace Files.Filesystem
             }
             orderedList = ordered.ToList();
 
-            List<ListedItem> originalList = _filesAndFolders.ToList();
-
-            _filesAndFolders.BeginBulkOperation();
-            for (var i = 0; i < originalList.Count; i++)
-            {
-                if (originalList[i] != orderedList[i])
-                {
-                    _filesAndFolders.RemoveAt(i);
-                    _filesAndFolders.Insert(i, orderedList[i]);
-                }
-            }
-            _filesAndFolders.EndBulkOperation();
+            return orderedList;
         }
 
         private bool _isLoadingItems = false;
@@ -542,11 +559,18 @@ namespace Files.Filesystem
                     return;
                 }
                 var wasSyncStatusLoaded = false;
-                bool needsIconOverlay = true;
                 try
                 {
                     if (item.PrimaryItemAttribute == StorageItemTypes.File)
                     {
+                        var fileIconInfo = await LoadIconOverlayAsync(matchingItem.ItemPath, thumbnailSize);
+                        if (fileIconInfo.Icon != null && !matchingItem.IsLinkItem)
+                        {
+                            matchingItem.FileImage = fileIconInfo.Icon;
+                            matchingItem.LoadUnknownTypeGlyph = false;
+                            matchingItem.LoadFileIcon = true;
+                        }
+                        matchingItem.IconOverlay = fileIconInfo.Overlay;
                         if (!item.IsShortcutItem && !item.IsHiddenItem)
                         {
                             StorageFile matchingStorageItem = await GetFileFromPathAsync(item.ItemPath);
@@ -556,50 +580,21 @@ namespace Files.Filesystem
                                 matchingItem.ItemType = matchingStorageItem.DisplayType;
                                 var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageItem);
                                 matchingItem.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
-                                if (!matchingItem.SyncStatusUI.LoadSyncStatus)
-                                {
-                                    // Always load them from AppServiceConnection
-                                    needsIconOverlay = true;
-                                }
                                 wasSyncStatusLoaded = true;
-                            }
-
-                            if (needsIconOverlay)
-                            {
-                                var fileIconInfo = await LoadIconOverlayAsync(matchingItem.ItemPath, thumbnailSize);
-                                if (fileIconInfo.Icon != null && !matchingItem.IsLinkItem)
-                                {
-                                    matchingItem.FileImage = fileIconInfo.Icon;
-                                    matchingItem.LoadUnknownTypeGlyph = false;
-                                    matchingItem.LoadFileIcon = true;
-                                }
-                                matchingItem.IconOverlay = fileIconInfo.Overlay;
-                            }
-                            else
-                            {
-                                if (!matchingItem.IsLinkItem)
-                                {
-                                    var filesystemIcon = await matchingStorageItem.GetThumbnailAsync(ThumbnailMode.ListView, thumbnailSize, ThumbnailOptions.UseCurrentScale);
-                                    if (filesystemIcon != null)
-                                    {
-                                        var bitmapIcon = new BitmapImage();
-                                        matchingItem.FileImage = bitmapIcon;
-                                        await bitmapIcon.SetSourceAsync(filesystemIcon);
-                                        matchingItem.LoadUnknownTypeGlyph = false;
-                                        matchingItem.LoadFileIcon = true;
-                                    }
-                                    else
-                                    {
-                                        matchingItem.LoadUnknownTypeGlyph = true;
-                                        matchingItem.LoadFileIcon = false;
-                                    }
-                                }
-                                matchingItem.IconOverlay = null;
                             }
                         }
                     }
                     else
                     {
+                        var fileIconInfo = await LoadIconOverlayAsync(matchingItem.ItemPath, thumbnailSize);
+                        if (fileIconInfo.Icon != null && fileIconInfo.IsCustom) // Only set folder icon if it's a custom icon
+                        {
+                            matchingItem.FileImage = fileIconInfo.Icon;
+                            matchingItem.LoadUnknownTypeGlyph = false;
+                            matchingItem.LoadFolderGlyph = false;
+                            matchingItem.LoadFileIcon = true;
+                        }
+                        matchingItem.IconOverlay = fileIconInfo.Overlay;
                         if (!item.IsShortcutItem && !item.IsHiddenItem)
                         {
                             StorageFolder matchingStorageItem = await GetFolderFromPathAsync(item.ItemPath);
@@ -609,22 +604,8 @@ namespace Files.Filesystem
                                 matchingItem.ItemType = matchingStorageItem.DisplayType;
                                 var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageItem);
                                 matchingItem.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
-                                if (!matchingItem.SyncStatusUI.LoadSyncStatus)
-                                {
-                                    needsIconOverlay = true;
-                                }
                                 wasSyncStatusLoaded = true;
                             }
-
-                            var fileIconInfo = await LoadIconOverlayAsync(matchingItem.ItemPath, thumbnailSize);
-                            if (fileIconInfo.Icon != null && fileIconInfo.IsCustom) // Only set folder icon if it's a custom icon
-                            {
-                                matchingItem.FileImage = fileIconInfo.Icon;
-                                matchingItem.LoadUnknownTypeGlyph = false;
-                                matchingItem.LoadFolderGlyph = false;
-                                matchingItem.LoadFileIcon = true;
-                            }
-                            matchingItem.IconOverlay = fileIconInfo.Overlay;
                         }
                     }
                 }
@@ -803,34 +784,50 @@ namespace Files.Filesystem
                 FileSizeBytes = 0
             };
 
-            if (Connection != null)
+            await Task.Run(async () =>
             {
-                var value = new ValueSet();
-                value.Add("Arguments", "RecycleBin");
-                value.Add("action", "Enumerate");
-                // Send request to fulltrust process to enumerate recyclebin items
-                var response = await Connection.SendMessageAsync(value);
-                // If the request was canceled return now
-                if (_addFilesCTS.IsCancellationRequested)
+                if (Connection != null)
                 {
-                    IsLoadingItems = false;
-                    return;
-                }
-                if (response.Status == AppServiceResponseStatus.Success
-                    && response.Message.ContainsKey("Enumerate"))
-                {
-                    var folderContentsList = JsonConvert.DeserializeObject<List<ShellFileItem>>((string)response.Message["Enumerate"]);
-                    for (int count = 0; count < folderContentsList.Count; count++)
+                    var value = new ValueSet();
+                    value.Add("Arguments", "RecycleBin");
+                    value.Add("action", "Enumerate");
+                    // Send request to fulltrust process to enumerate recyclebin items
+                    var response = await Connection.SendMessageAsync(value);
+                    // If the request was canceled return now
+                    if (_addFilesCTS.IsCancellationRequested)
                     {
-                        var item = folderContentsList[count];
-                        AddFileOrFolderFromShellFile(item, returnformat);
-                        if (count % 300 == 0)
+                        return;
+                    }
+                    if (response.Status == AppServiceResponseStatus.Success
+                        && response.Message.ContainsKey("Enumerate"))
+                    {
+                        var folderContentsList = JsonConvert.DeserializeObject<List<ShellFileItem>>((string)response.Message["Enumerate"]);
+                        var tempList = new List<ListedItem>();
+                        for (int count = 0; count < folderContentsList.Count; count++)
                         {
-                            OrderFiles();
+                            var item = folderContentsList[count];
+                            var listedItem = AddFileOrFolderFromShellFile(item, returnformat);
+                            if (listedItem != null)
+                            {
+                                tempList.Add(listedItem);
+                            }
+                            if (count % 64 == 0)
+                            {
+                                var orderedList = OrderFiles2(tempList);
+                                await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                                {
+                                    OrderFiles(orderedList);
+                                });
+                            }
                         }
+                        var finalList = OrderFiles2(tempList);
+                        await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                        {
+                            OrderFiles(finalList);
+                        });
                     }
                 }
-            }
+            });
         }
 
         public async Task<bool> EnumerateItemsFromStandardFolderAsync(string path)
@@ -851,7 +848,6 @@ namespace Files.Filesystem
                     await DialogDisplayHelper.ShowDialogAsync(
                        "AccessDeniedDeleteDialog/Title".GetLocalized(),
                        "SubDirectoryAccessDenied".GetLocalized());
-                    IsLoadingItems = false;
                     return false;
                 }
             }
@@ -860,7 +856,6 @@ namespace Files.Filesystem
                 await DialogDisplayHelper.ShowDialogAsync(
                     "FolderNotFoundDialog/Title".GetLocalized(),
                     "FolderNotFoundDialog/Text".GetLocalized());
-                IsLoadingItems = false;
                 return false;
             }
             else
@@ -873,7 +868,6 @@ namespace Files.Filesystem
                 else
                 {
                     await DialogDisplayHelper.ShowDialogAsync("DriveUnpluggedDialog/Title".GetLocalized(), res.ErrorCode.ToString());
-                    IsLoadingItems = false;
                     return false;
                 }
             }
@@ -984,7 +978,6 @@ namespace Files.Filesystem
                 if (hFile == IntPtr.Zero)
                 {
                     await DialogDisplayHelper.ShowDialogAsync("DriveUnpluggedDialog/Title".GetLocalized(), "");
-                    IsLoadingItems = false;
                     return false;
                 }
                 else if (hFile.ToInt64() == -1)
@@ -994,49 +987,64 @@ namespace Files.Filesystem
                 }
                 else
                 {
-                    do
+                    await Task.Run(async () =>
                     {
-                        if (((FileAttributes)findData.dwFileAttributes & FileAttributes.System) != FileAttributes.System)
+                        var tempList = new List<ListedItem>();
+                        do
                         {
-                            var itemPath = Path.Combine(path, findData.cFileName);
-                            if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden && !AppSettings.AreHiddenItemsVisible)
+                            if (((FileAttributes)findData.dwFileAttributes & FileAttributes.System) != FileAttributes.System)
                             {
-                                continue;
-                            }
+                                var itemPath = Path.Combine(path, findData.cFileName);
+                                if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden && !AppSettings.AreHiddenItemsVisible)
+                                {
+                                    continue;
+                                }
 
-                            if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
-                            {
-                                await Task.Run(() =>
+                                if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
                                 {
-                                    AddFile(findData, path, returnformat);
-                                    ++count;
-                                });
-                            }
-                            else if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
-                            {
-                                if (findData.cFileName != "." && findData.cFileName != "..")
-                                {
-                                    await Task.Run(() =>
+                                    var listedItem = await AddFile(findData, path, returnformat);
+                                    if (listedItem != null)
                                     {
-                                        AddFolder(findData, path, returnformat);
+                                        tempList.Add(listedItem);
                                         ++count;
-                                    });
-
+                                    }
+                                }
+                                else if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
+                                {
+                                    if (findData.cFileName != "." && findData.cFileName != "..")
+                                    {
+                                        var listedItem = AddFolder(findData, path, returnformat);
+                                        if (listedItem != null)
+                                        {
+                                            tempList.Add(listedItem);
+                                            ++count;
+                                        }
+                                    }
                                 }
                             }
-                        }
-                        if (_addFilesCTS.IsCancellationRequested)
-                        {
-                            break;
-                        }
+                            if (_addFilesCTS.IsCancellationRequested)
+                            {
+                                break;
+                            }
 
-                        if (count % 300 == 0)
-                        {
-                            OrderFiles();
-                        }
-                    } while (FindNextFile(hFile, out findData));
+                            if (count % 64 == 0)
+                            {
+                                var orderedList = OrderFiles2(tempList);
+                                await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                                {
+                                    OrderFiles(orderedList);
+                                });
+                            }
+                        } while (FindNextFile(hFile, out findData));
 
-                    FindClose(hFile);
+                        FindClose(hFile);
+
+                        var finalList = OrderFiles2(tempList);
+                        await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                        {
+                            OrderFiles(finalList);
+                        });
+                    });
                     return true;
                 }
             }
@@ -1278,7 +1286,7 @@ namespace Files.Filesystem
             Debug.WriteLine("Task exiting...");
         }
 
-        public async void AddFileOrFolderFromShellFile(ShellFileItem item, string dateReturnFormat = null)
+        public ListedItem AddFileOrFolderFromShellFile(ShellFileItem item, string dateReturnFormat = null)
         {
             if (dateReturnFormat == null)
             {
@@ -1288,28 +1296,25 @@ namespace Files.Filesystem
 
             if (item.IsFolder)
             {
-                await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                // Folder
+                return new RecycleBinItem(null, dateReturnFormat)
                 {
-                    // Folder
-                    _filesAndFolders.Add(new RecycleBinItem(null, dateReturnFormat)
-                    {
-                        PrimaryItemAttribute = StorageItemTypes.Folder,
-                        ItemName = item.FileName,
-                        ItemDateModifiedReal = item.RecycleDate,
-                        ItemType = item.FileType,
-                        IsHiddenItem = false,
-                        Opacity = 1,
-                        LoadFolderGlyph = true,
-                        FileImage = null,
-                        LoadFileIcon = false,
-                        ItemPath = item.RecyclePath, // this is the true path on disk so other stuff can work as is
-                        ItemOriginalPath = item.FilePath,
-                        LoadUnknownTypeGlyph = false,
-                        FileSize = null,
-                        FileSizeBytes = 0,
-                        //FolderTooltipText = tooltipString,
-                    });
-                });
+                    PrimaryItemAttribute = StorageItemTypes.Folder,
+                    ItemName = item.FileName,
+                    ItemDateModifiedReal = item.RecycleDate,
+                    ItemType = item.FileType,
+                    IsHiddenItem = false,
+                    Opacity = 1,
+                    LoadFolderGlyph = true,
+                    FileImage = null,
+                    LoadFileIcon = false,
+                    ItemPath = item.RecyclePath, // this is the true path on disk so other stuff can work as is
+                    ItemOriginalPath = item.FilePath,
+                    LoadUnknownTypeGlyph = false,
+                    FileSize = null,
+                    FileSizeBytes = 0,
+                    //FolderTooltipText = tooltipString,
+                };
             }
             else
             {
@@ -1336,31 +1341,25 @@ namespace Files.Filesystem
                 {
                     itemFileExtension = Path.GetExtension(item.FileName);
                 }
-                await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                return new RecycleBinItem(null, dateReturnFormat)
                 {
-                    _filesAndFolders.Add(new RecycleBinItem(null, dateReturnFormat)
-                    {
-                        PrimaryItemAttribute = StorageItemTypes.File,
-                        FileExtension = itemFileExtension,
-                        LoadUnknownTypeGlyph = true,
-                        FileImage = null,
-                        LoadFileIcon = false,
-                        LoadFolderGlyph = false,
-                        IsHiddenItem = false,
-                        Opacity = 1,
-                        ItemName = itemName,
-                        ItemDateModifiedReal = item.RecycleDate,
-                        ItemType = item.FileType,
-                        ItemPath = item.RecyclePath, // this is the true path on disk so other stuff can work as is
-                        ItemOriginalPath = item.FilePath,
-                        FileSize = item.FileSize,
-                        FileSizeBytes = (long)item.FileSizeBytes
-                    });
-                });
+                    PrimaryItemAttribute = StorageItemTypes.File,
+                    FileExtension = itemFileExtension,
+                    LoadUnknownTypeGlyph = true,
+                    FileImage = null,
+                    LoadFileIcon = false,
+                    LoadFolderGlyph = false,
+                    IsHiddenItem = false,
+                    Opacity = 1,
+                    ItemName = itemName,
+                    ItemDateModifiedReal = item.RecycleDate,
+                    ItemType = item.FileType,
+                    ItemPath = item.RecyclePath, // this is the true path on disk so other stuff can work as is
+                    ItemOriginalPath = item.FilePath,
+                    FileSize = item.FileSize,
+                    FileSizeBytes = (long)item.FileSizeBytes
+                };
             }
-
-            IsFolderEmptyTextDisplayed = false;
-            UpdateDirectoryInfo();
         }
 
         private void AddFileOrFolder(ListedItem item)
@@ -1378,7 +1377,7 @@ namespace Files.Filesystem
                                                   additionalFlags);
             FindClose(hFile);
 
-            await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+            await CoreApplication.MainView.ExecuteOnUIThreadAsync(async () =>
             {
                 if ((findData.dwFileAttributes & 0x10) > 0) // FILE_ATTRIBUTE_DIRECTORY
                 {
@@ -1386,7 +1385,7 @@ namespace Files.Filesystem
                 }
                 else
                 {
-                    AddFile(findData, Directory.GetParent(fileOrFolderPath).FullName, dateReturnFormat);
+                    await AddFile(findData, Directory.GetParent(fileOrFolderPath).FullName, dateReturnFormat);
                 }
                 UpdateDirectoryInfo();
             });
@@ -1461,12 +1460,11 @@ namespace Files.Filesystem
             }
         }
 
-        private async void AddFolder(WIN32_FIND_DATA findData, string pathRoot, string dateReturnFormat)
+        private ListedItem AddFolder(WIN32_FIND_DATA findData, string pathRoot, string dateReturnFormat)
         {
             if (_addFilesCTS.IsCancellationRequested)
             {
-                IsLoadingItems = false;
-                return;
+                return null;
             }
 
             DateTime itemDate;
@@ -1481,7 +1479,7 @@ namespace Files.Filesystem
             catch (ArgumentException)
             {
                 // Invalid date means invalid findData, do not add to list
-                return;
+                return null;
             }
             var itemPath = Path.Combine(pathRoot, findData.cFileName);
 
@@ -1493,32 +1491,27 @@ namespace Files.Filesystem
                 opacity = 0.4;
             }
 
-            await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+            return new ListedItem(null, dateReturnFormat)
             {
-                _filesAndFolders.Add(new ListedItem(null, dateReturnFormat)
-                {
-                    PrimaryItemAttribute = StorageItemTypes.Folder,
-                    ItemName = findData.cFileName,
-                    ItemDateModifiedReal = itemDate,
-                    ItemType = "FileFolderListItem".GetLocalized(),
-                    LoadFolderGlyph = true,
-                    FileImage = null,
-                    IsHiddenItem = isHidden,
-                    Opacity = opacity,
-                    LoadFileIcon = false,
-                    ItemPath = itemPath,
-                    LoadUnknownTypeGlyph = false,
-                    FileSize = null,
-                    FileSizeBytes = 0,
-                    ContainsFilesOrFolders = CheckForFilesFolders(itemPath)
-                    //FolderTooltipText = tooltipString,
-                });
-            });
-
-            IsFolderEmptyTextDisplayed = false;
+                PrimaryItemAttribute = StorageItemTypes.Folder,
+                ItemName = findData.cFileName,
+                ItemDateModifiedReal = itemDate,
+                ItemType = "FileFolderListItem".GetLocalized(),
+                LoadFolderGlyph = true,
+                FileImage = null,
+                IsHiddenItem = isHidden,
+                Opacity = opacity,
+                LoadFileIcon = false,
+                ItemPath = itemPath,
+                LoadUnknownTypeGlyph = false,
+                FileSize = null,
+                FileSizeBytes = 0,
+                ContainsFilesOrFolders = CheckForFilesFolders(itemPath)
+                //FolderTooltipText = tooltipString,
+            };
         }
 
-        private async void AddFile(WIN32_FIND_DATA findData, string pathRoot, string dateReturnFormat)
+        private async Task<ListedItem> AddFile(WIN32_FIND_DATA findData, string pathRoot, string dateReturnFormat)
         {
             var itemPath = Path.Combine(pathRoot, findData.cFileName);
 
@@ -1563,7 +1556,7 @@ namespace Files.Filesystem
             catch (ArgumentException)
             {
                 // Invalid date means invalid findData, do not add to list
-                return;
+                return null;
             }
 
             long itemSizeBytes = findData.GetSize();
@@ -1586,25 +1579,23 @@ namespace Files.Filesystem
 
             if (_addFilesCTS.IsCancellationRequested)
             {
-                IsLoadingItems = false;
-                return;
+                return null;
             }
 
             if (findData.cFileName.EndsWith(".lnk") || findData.cFileName.EndsWith(".url"))
             {
                 if (Connection != null)
                 {
-                    var response = Connection.SendMessageAsync(new ValueSet()
+                    var response = await Connection.SendMessageAsync(new ValueSet()
                     {
                         { "Arguments", "FileOperation" },
                         { "fileop", "ParseLink" },
                         { "filepath", itemPath }
-                    }).AsTask().Result;
+                    });
                     // If the request was canceled return now
                     if (_addFilesCTS.IsCancellationRequested)
                     {
-                        IsLoadingItems = false;
-                        return;
+                        return null;
                     }
                     if (response.Status == AppServiceResponseStatus.Success
                         && response.Message.ContainsKey("TargetPath"))
@@ -1626,71 +1617,65 @@ namespace Files.Filesystem
                             opacity = 0.4;
                         }
 
-                        await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                        return new ShortcutItem(null, dateReturnFormat)
                         {
-                            _filesAndFolders.Add(new ShortcutItem(null, dateReturnFormat)
-                            {
-                                PrimaryItemAttribute = (bool)response.Message["IsFolder"] ? StorageItemTypes.Folder : StorageItemTypes.File,
-                                FileExtension = itemFileExtension,
-                                IsHiddenItem = isHidden,
-                                Opacity = opacity,
-                                FileImage = null,
-                                LoadFileIcon = !(bool)response.Message["IsFolder"] && itemThumbnailImgVis,
-                                LoadUnknownTypeGlyph = !(bool)response.Message["IsFolder"] && !isUrl && itemEmptyImgVis,
-                                LoadFolderGlyph = (bool)response.Message["IsFolder"],
-                                ItemName = itemName,
-                                ItemDateModifiedReal = itemModifiedDate,
-                                ItemDateAccessedReal = itemLastAccessDate,
-                                ItemDateCreatedReal = itemCreatedDate,
-                                ItemType = isUrl ? "ShortcutWebLinkFileType".GetLocalized() : "ShortcutFileType".GetLocalized(),
-                                ItemPath = itemPath,
-                                FileSize = itemSize,
-                                FileSizeBytes = itemSizeBytes,
-                                TargetPath = target,
-                                Arguments = (string)response.Message["Arguments"],
-                                WorkingDirectory = (string)response.Message["WorkingDirectory"],
-                                RunAsAdmin = (bool)response.Message["RunAsAdmin"],
-                                IsUrl = isUrl,
-                                ContainsFilesOrFolders = containsFilesOrFolders
-                            });
-                        });
+                            PrimaryItemAttribute = (bool)response.Message["IsFolder"] ? StorageItemTypes.Folder : StorageItemTypes.File,
+                            FileExtension = itemFileExtension,
+                            IsHiddenItem = isHidden,
+                            Opacity = opacity,
+                            FileImage = null,
+                            LoadFileIcon = !(bool)response.Message["IsFolder"] && itemThumbnailImgVis,
+                            LoadUnknownTypeGlyph = !(bool)response.Message["IsFolder"] && !isUrl && itemEmptyImgVis,
+                            LoadFolderGlyph = (bool)response.Message["IsFolder"],
+                            ItemName = itemName,
+                            ItemDateModifiedReal = itemModifiedDate,
+                            ItemDateAccessedReal = itemLastAccessDate,
+                            ItemDateCreatedReal = itemCreatedDate,
+                            ItemType = isUrl ? "ShortcutWebLinkFileType".GetLocalized() : "ShortcutFileType".GetLocalized(),
+                            ItemPath = itemPath,
+                            FileSize = itemSize,
+                            FileSizeBytes = itemSizeBytes,
+                            TargetPath = target,
+                            Arguments = (string)response.Message["Arguments"],
+                            WorkingDirectory = (string)response.Message["WorkingDirectory"],
+                            RunAsAdmin = (bool)response.Message["RunAsAdmin"],
+                            IsUrl = isUrl,
+                            ContainsFilesOrFolders = containsFilesOrFolders
+                        };
                     }
                 }
             }
             else
             {
-                await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                bool isHidden = (((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden);
+                double opacity = 1;
+
+                if (isHidden)
                 {
-                    bool isHidden = (((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden);
-                    double opacity = 1;
+                    opacity = 0.4;
+                }
 
-                    if (isHidden)
-                    {
-                        opacity = 0.4;
-                    }
-
-                    _filesAndFolders.Add(new ListedItem(null, dateReturnFormat)
-                    {
-                        PrimaryItemAttribute = StorageItemTypes.File,
-                        FileExtension = itemFileExtension,
-                        LoadUnknownTypeGlyph = itemEmptyImgVis,
-                        FileImage = null,
-                        LoadFileIcon = itemThumbnailImgVis,
-                        LoadFolderGlyph = itemFolderImgVis,
-                        ItemName = itemName,
-                        IsHiddenItem = isHidden,
-                        Opacity = opacity,
-                        ItemDateModifiedReal = itemModifiedDate,
-                        ItemDateAccessedReal = itemLastAccessDate,
-                        ItemDateCreatedReal = itemCreatedDate,
-                        ItemType = itemType,
-                        ItemPath = itemPath,
-                        FileSize = itemSize,
-                        FileSizeBytes = itemSizeBytes
-                    });
-                    IsFolderEmptyTextDisplayed = false;
-                });
+                return new ListedItem(null, dateReturnFormat)
+                {
+                    PrimaryItemAttribute = StorageItemTypes.File,
+                    FileExtension = itemFileExtension,
+                    LoadUnknownTypeGlyph = itemEmptyImgVis,
+                    FileImage = null,
+                    LoadFileIcon = itemThumbnailImgVis,
+                    LoadFolderGlyph = itemFolderImgVis,
+                    ItemName = itemName,
+                    IsHiddenItem = isHidden,
+                    Opacity = opacity,
+                    ItemDateModifiedReal = itemModifiedDate,
+                    ItemDateAccessedReal = itemLastAccessDate,
+                    ItemDateCreatedReal = itemCreatedDate,
+                    ItemType = itemType,
+                    ItemPath = itemPath,
+                    FileSize = itemSize,
+                    FileSizeBytes = itemSizeBytes
+                };
             }
+            return null;
         }
 
         public void AddItemsToCollectionAsync(string path)
@@ -1706,7 +1691,6 @@ namespace Files.Filesystem
             {
                 if (_addFilesCTS.IsCancellationRequested)
                 {
-                    IsLoadingItems = false;
                     return;
                 }
                 await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
@@ -1726,10 +1710,9 @@ namespace Files.Filesystem
                         LoadUnknownTypeGlyph = false,
                         FileSize = null,
                         FileSizeBytes = 0
-                            //FolderTooltipText = tooltipString,
-                        });
+                        //FolderTooltipText = tooltipString,
+                    });
                 });
-                IsFolderEmptyTextDisplayed = false;
             }
         }
 
@@ -1807,7 +1790,6 @@ namespace Files.Filesystem
             }
             if (_addFilesCTS.IsCancellationRequested)
             {
-                IsLoadingItems = false;
                 return;
             }
 
@@ -1822,7 +1804,6 @@ namespace Files.Filesystem
                 {
                     _filesAndFolders.Add(new ListedItem(file.FolderRelativeId, dateReturnFormat)
                     {
-
                         PrimaryItemAttribute = StorageItemTypes.File,
                         FileExtension = itemFileExtension,
                         IsHiddenItem = false,
@@ -1840,8 +1821,6 @@ namespace Files.Filesystem
                     });
                 });
             }
-
-            IsFolderEmptyTextDisplayed = false;
         }
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")


### PR DESCRIPTION
This PR:

- Changes the logic so the items loading operation happens in a single background task
This PR wraps the whole file loading loop with a `Task.Run()` and once every 64 items it updates the UI
Also it tries to do the sorting in the background thread instead of the UI thread

- Revert edits to LoadExtendedItemProperties
The changes currently made in the delay bug branch do not appear to give any performance benefits (fulltrust process is still called for each file) but it breaks thumbnails for hidden and shortcut items
