### PR TITLE
Reduced font size for the drives widget space text

### DIFF
--- a/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -139,6 +139,7 @@
                                         TextWrapping="NoWrap" />
                                     <muxc:ProgressBar Maximum="{x:Bind MaxSpace.GigaBytes, Mode=OneWay}" Value="{x:Bind SpaceUsed.GigaBytes, Mode=OneWay}" />
                                     <TextBlock
+                                        FontSize="12"
                                         Text="{x:Bind SpaceText, Mode=OneWay}"
                                         TextWrapping="Wrap"
                                         ToolTipService.ToolTip="{x:Bind SpaceText, Mode=OneWay}" />

--- a/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -140,6 +140,7 @@
                                     <muxc:ProgressBar Maximum="{x:Bind MaxSpace.GigaBytes, Mode=OneWay}" Value="{x:Bind SpaceUsed.GigaBytes, Mode=OneWay}" />
                                     <TextBlock
                                         FontSize="12"
+                                        MaxLines="2"
                                         Text="{x:Bind SpaceText, Mode=OneWay}"
                                         TextWrapping="Wrap"
                                         ToolTipService.ToolTip="{x:Bind SpaceText, Mode=OneWay}" />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39923744/100132721-d07dca00-2e53-11eb-8b38-4629d9c058b1.png)
Fixes #2428