### PR TITLE
[Hidden files] - Fix opening hidden folder in new tab

### DIFF
--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -828,30 +828,27 @@ namespace Files.Filesystem
             {
                 _rootFolder = res.Result;
             }
-            else if (res == FilesystemErrorCode.ERROR_UNAUTHORIZED)
+            else if (_workingRoot != null)
             {
-                if (!CheckFolderAccessWithWin32(path)) // The folder is really inaccessible
+                _rootFolder = _currentStorageFolder.Folder;
+                enumFromStorageFolder = true;
+            }
+            else if (!CheckFolderAccessWithWin32(path)) // The folder is really inaccessible
+            {
+                if (res == FilesystemErrorCode.ERROR_UNAUTHORIZED)
                 {
                     //TODO: proper dialog
                     await DialogDisplayHelper.ShowDialogAsync(
-                       "AccessDeniedDeleteDialog/Title".GetLocalized(),
-                       "SubDirectoryAccessDenied".GetLocalized());
+                        "AccessDeniedDeleteDialog/Title".GetLocalized(),
+                        "SubDirectoryAccessDenied".GetLocalized());
                     return false;
                 }
-            }
-            else if (res == FilesystemErrorCode.ERROR_NOTFOUND)
-            {
-                await DialogDisplayHelper.ShowDialogAsync(
-                    "FolderNotFoundDialog/Title".GetLocalized(),
-                    "FolderNotFoundDialog/Text".GetLocalized());
-                return false;
-            }
-            else
-            {
-                if (_workingRoot != null)
+                else if (res == FilesystemErrorCode.ERROR_NOTFOUND)
                 {
-                    _rootFolder = _currentStorageFolder.Folder;
-                    enumFromStorageFolder = true;
+                    await DialogDisplayHelper.ShowDialogAsync(
+                        "FolderNotFoundDialog/Title".GetLocalized(),
+                        "FolderNotFoundDialog/Text".GetLocalized());
+                    return false;
                 }
                 else
                 {

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -385,16 +385,16 @@ namespace Files.Views.Pages
         {
             var nextPathItemTitle = NavigationToolbar.PathComponents
                 [NavigationToolbar.PathComponents.IndexOf(pathItem) + 1].Title;
-            IList<StorageFolderWithPath> childFolders = new List<StorageFolderWithPath>();
+            IList<StorageFolderWithPath> childFolders = null;
 
             StorageFolderWithPath folder = await FilesystemViewModel.GetFolderWithPathFromPathAsync(pathItem.Path);
             if (folder != null)
             {
-                childFolders = await folder.GetFoldersWithPathAsync(string.Empty);
+                childFolders = (await FilesystemTasks.Wrap(() => folder.GetFoldersWithPathAsync(string.Empty))).Result;
             }
             flyout.Items?.Clear();
 
-            if (childFolders.Count == 0)
+            if (childFolders == null || childFolders.Count == 0)
             {
                 var flyoutItem = new MenuFlyoutItem
                 {


### PR DESCRIPTION
For #2303
Fixes #2376

Fixes the following open points in #2303:
- [x] Opening a hidden folder in a new tab will crash the app
- [x] Properties opened by clicking a hidden folder empty space will show properties of the parent folder