### PR TITLE
Fix CloseHandle definition

### DIFF
--- a/Files/Helpers/NativeIoDeviceControlHelper.cs
+++ b/Files/Helpers/NativeIoDeviceControlHelper.cs
@@ -40,7 +40,7 @@ namespace Files.Helpers
             IntPtr lpOverlapped
         );
 
-        [DllImport("api-ms-win-core-io-l1-1-0.dll", SetLastError = true)]
+        [DllImport("api-ms-win-core-handle-l1-1-0.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool CloseHandle(IntPtr hObject);
 


### PR DESCRIPTION
Hi @tsvietOK 
In the current master version I get an immediate crash when trying to eject drives from Files.
Crash only happens in Release mode.
This PR solves this by defining the correct DLL for the `NativeIoDeviceControlHelper.cs->CloseHandle` function, dll taken from [here](https://docs.microsoft.com/en-us/uwp/win32-and-com/win32-apis).
Do you agree with this solution?