### PR TITLE
Reduce unnecessary work during extended property initialization and use new item icon in GridView

### DIFF
--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -749,7 +749,6 @@
                         <DataTemplate x:DataType="local2:ListedItem">
                             <Grid
                                 x:Name="Icon"
-                                EffectiveViewportChanged="Icon_EffectiveViewportChanged"
                                 Opacity="{x:Bind Opacity, Mode=OneWay}"
                                 ToolTipService.ToolTip="{x:Bind FolderTooltipText}">
                                 <Rectangle

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -536,25 +536,18 @@ namespace Files
             }
         }
 
-        private async void Icon_EffectiveViewportChanged(FrameworkElement sender, EffectiveViewportChangedEventArgs args)
+        private async void AllView_LoadingRow(object sender, DataGridRowEventArgs e)
         {
-            var parentRow = Interacts.Interaction.FindParent<DataGridRow>(sender);
-            if (parentRow.DataContext is ListedItem item &&
-                !item.ItemPropertiesInitialized &&
-                args.BringIntoViewDistanceX < sender.ActualHeight)
+            InitializeDrag(e.Row);
+
+            if (e.Row.DataContext is ListedItem item && !item.ItemPropertiesInitialized)
             {
                 await Window.Current.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
                 {
-                    ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(parentRow.DataContext as ListedItem);
-                    (parentRow.DataContext as ListedItem).ItemPropertiesInitialized = true;
-                    //sender.EffectiveViewportChanged -= Icon_EffectiveViewportChanged;
+                    ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(item);
+                    item.ItemPropertiesInitialized = true;
                 });
             }
-        }
-
-        private void AllView_LoadingRow(object sender, DataGridRowEventArgs e)
-        {
-            InitializeDrag(e.Row);
         }
 
         protected override ListedItem GetItemFromElement(object element)

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -592,7 +592,7 @@
                         VerticalAlignment="Stretch"
                         x:Load="{x:Bind LoadUnknownTypeGlyph, Mode=OneWay}">
                         <Viewbox MaxWidth="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}" MaxHeight="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}">
-                            <SymbolIcon Symbol="Page2" />
+                            <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEA00;" />
                         </Viewbox>
                     </Grid>
                     <Grid

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -356,15 +356,15 @@ namespace Files
 
         private async void Grid_EffectiveViewportChanged(FrameworkElement sender, EffectiveViewportChangedEventArgs args)
         {
-            if (sender.DataContext != null && (!(sender.DataContext as ListedItem).ItemPropertiesInitialized) && (args.BringIntoViewDistanceX < sender.ActualHeight))
+            if (sender.DataContext is ListedItem item && (!item.ItemPropertiesInitialized) && (args.BringIntoViewDistanceX < sender.ActualHeight))
             {
                 await Window.Current.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
                 {
-                    ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(sender.DataContext as ListedItem, _iconSize);
-                    (sender.DataContext as ListedItem).ItemPropertiesInitialized = true;
+                    ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(item, _iconSize);
+                    item.ItemPropertiesInitialized = true;
                 });
 
-                (sender as UIElement).CanDrag = FileList.SelectedItems.Contains(sender.DataContext as ListedItem); // Update CanDrag
+                sender.CanDrag = FileList.SelectedItems.Contains(item); // Update CanDrag
             }
         }
 


### PR DESCRIPTION
For the DataGrid layout (ListView) we no longer fire the EffectiveViewportChanged event on every item whenever they are scrolled into view. Since we now use the built-in LoadingRow event instead, this has the implication of reducing unneeded calculations for each item. It wouldn't be unreasonable to predict this change has a small, albeit positive impact on scrolling in directories with lots of rows loaded. 

Additionally, we reduce unnecessary casts with both layouts and use the FluentUI asset for the uninitialized thumbnail icon in GridView.