### PR TITLE
Fixed an issue where previously empty directories would still display "This folder is empty" after pasting an item

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -1152,6 +1152,7 @@ namespace Files.Interacts
             string destinationPath = AssociatedInstance.FilesystemViewModel.WorkingDirectory;
 
             await FilesystemHelpers.PerformOperationTypeAsync(packageView.RequestedOperation, packageView, destinationPath, true);
+            AssociatedInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
         }
 
         public async void CreateFileFromDialogResultType(AddItemType itemType)


### PR DESCRIPTION
Fixes #2486 