### PR TITLE
Remove tab stop to top navigation bar

### DIFF
--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -107,6 +107,7 @@
                                                 CornerRadius="2"
                                                 HighContrastAdjustment="None"
                                                 IsTextScaleFactorEnabled="False"
+                                                IsTabStop="False"
                                                 Style="{StaticResource TabViewButtonStyle}"
                                                 Visibility="{Binding IsAddTabButtonVisible, RelativeSource={RelativeSource TemplatedParent}}" />
 
@@ -834,6 +835,7 @@
                         FontFamily="{StaticResource FluentUIGlyphs}"
                         Header="{x:Bind Header, Mode=OneWay}"
                         IconSource="{x:Bind IconSource, Mode=OneWay}"
+                        IsTabStop="False"
                         Style="{StaticResource UndockedTabViewItemStyle}"
                         ToolTipService.ToolTip="{x:Null}" />
                 </DataTemplate>


### PR DESCRIPTION
The "New Tab" containers and the close buttons are part of the tab stop cycle, however, being in that cycle is pretty pointless, as they do not allow for any other keyboard access (enter key doesn't work, all actions can be completed with ctrl + t / ctrl + w anyway).
I removed them from being set as tab stops to make it more friendly for keyboard users to access.

This is related to feature-request #2540 that I submitted earlier. There are other parts that would be more similar to what I wish to do in the submission, but involves more parts that I'm afraid might cause some unforeseen side effects that at my skill level I wouldn't notice.
Signed-off-by: Eric Chen <ericchen1248@gmail.com>