### PR TITLE
Customize default NavView settings item icon upon load

### DIFF
--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -1227,10 +1227,6 @@
           <source>Vertical tab strip</source>
           <target state="translated">Vertikale Tab-Ansicht</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Einstellungen</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">Sprache</target>

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -342,10 +342,6 @@
           <source>List View</source>
           <target state="translated">Details</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Einstellungen</target>
-        </trans-unit>
         <trans-unit id="nameColumn.Header" translate="yes" xml:space="preserve">
           <source>Name</source>
           <target state="translated">Name</target>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -342,10 +342,6 @@
           <source>List View</source>
           <target state="translated">Detalles</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Ajustes</target>
-        </trans-unit>
         <trans-unit id="nameColumn.Header" translate="yes" xml:space="preserve">
           <source>Name</source>
           <target state="translated">Nombre</target>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -1226,10 +1226,6 @@
           <source>Vertical tab strip</source>
           <target state="translated">Barra de pestañas vertical</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Ajustes</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">Idioma</target>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -342,10 +342,6 @@
           <source>List View</source>
           <target state="translated">Vue liste</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated" state-qualifier="tm-suggestion">Paramètres</target>
-        </trans-unit>
         <trans-unit id="PropertiesItemMD5Hash.Text" translate="yes" xml:space="preserve">
           <source>MD5Hash:</source>
           <target state="final">Hash MD5 :</target>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -1226,10 +1226,6 @@
           <source>Vertical tab strip</source>
           <target state="new">Vertical tab strip</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated" state-qualifier="tm-suggestion">Paramètres</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">Langue de l'application</target>

--- a/Files/MultilingualResources/Files.he-IL.xlf
+++ b/Files/MultilingualResources/Files.he-IL.xlf
@@ -1226,10 +1226,6 @@
           <source>Vertical tab strip</source>
           <target state="new">Vertical tab strip</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated" state-qualifier="tm-suggestion">הגדרות</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="new">App Language</target>

--- a/Files/MultilingualResources/Files.he-IL.xlf
+++ b/Files/MultilingualResources/Files.he-IL.xlf
@@ -310,10 +310,6 @@
           <source>Videos</source>
           <target state="translated" state-qualifier="tm-suggestion">סרטוני וידאו</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated" state-qualifier="tm-suggestion">הגדרות</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutSortBy.Text" translate="yes" xml:space="preserve">
           <source>Sort by</source>
           <target state="translated" state-qualifier="tm-suggestion">מיין לפי</target>

--- a/Files/MultilingualResources/Files.hi-IN.xlf
+++ b/Files/MultilingualResources/Files.hi-IN.xlf
@@ -1238,10 +1238,6 @@
           <source>Vertical tab strip</source>
           <target state="new">Vertical tab strip</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">सेटिंग्स</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="new">App Language</target>

--- a/Files/MultilingualResources/Files.hi-IN.xlf
+++ b/Files/MultilingualResources/Files.hi-IN.xlf
@@ -317,10 +317,6 @@
           <source>Videos</source>
           <target state="translated">चलचित्र</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">सेटिंग्स</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutSortBy.Text" translate="yes" xml:space="preserve">
           <source>Sort by</source>
           <target state="translated">द्वारा सॉर्ट करें</target>

--- a/Files/MultilingualResources/Files.hu-HU.xlf
+++ b/Files/MultilingualResources/Files.hu-HU.xlf
@@ -1258,10 +1258,6 @@
           <source>Vertical tab strip</source>
           <target state="translated">Függőleges lap lánc</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Beállítások</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">Program Nyelve</target>

--- a/Files/MultilingualResources/Files.hu-HU.xlf
+++ b/Files/MultilingualResources/Files.hu-HU.xlf
@@ -326,10 +326,6 @@
           <source>Videos</source>
           <target state="translated">Videók</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Beállítások</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutSortBy.Text" translate="yes" xml:space="preserve">
           <source>Sort by</source>
           <target state="translated">Rendezés</target>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -1227,10 +1227,6 @@
           <source>Vertical tab strip</source>
           <target state="translated">Barra schede verticale</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Impostazioni</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">Lingua dell'App</target>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -283,10 +283,6 @@
           <source>Videos</source>
           <target state="translated">Video</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Impostazioni</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutSortBy.Text" translate="yes" xml:space="preserve">
           <source>Sort by</source>
           <target state="translated">Ordina per</target>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -1226,10 +1226,6 @@
           <source>Vertical tab strip</source>
           <target state="translated">垂直タブストリップ</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">設定</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">言語</target>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -302,10 +302,6 @@
           <source>Videos</source>
           <target state="translated">ビデオ</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">設定</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutSortBy.Text" translate="yes" xml:space="preserve">
           <source>Sort by</source>
           <target state="translated">並べ替え</target>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -349,10 +349,6 @@
           <source>List View</source>
           <target state="translated" state-qualifier="tm-suggestion">Lijstweergave</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated" state-qualifier="tm-suggestion">Instellingen</target>
-        </trans-unit>
         <trans-unit id="nameColumn.Header" translate="yes" xml:space="preserve">
           <source>Name</source>
           <target state="translated">Naam</target>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -1240,10 +1240,6 @@
           <source>Vertical tab strip</source>
           <target state="new">Vertical tab strip</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Instellingen</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="new">App Language</target>

--- a/Files/MultilingualResources/Files.or-IN.xlf
+++ b/Files/MultilingualResources/Files.or-IN.xlf
@@ -317,10 +317,6 @@
           <source>Videos</source>
           <target state="translated">ଚଳଚ୍ଚିତ୍ରଗୁଡିକ</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">ସେଟିଂସମୂହ</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutSortBy.Text" translate="yes" xml:space="preserve">
           <source>Sort by</source>
           <target state="translated">ଦ୍ୱାରା କ୍ରମ</target>

--- a/Files/MultilingualResources/Files.or-IN.xlf
+++ b/Files/MultilingualResources/Files.or-IN.xlf
@@ -1238,10 +1238,6 @@
           <source>Vertical tab strip</source>
           <target state="new">Vertical tab strip</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">ସେଟିଂସମୂହ</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="new">App Language</target>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -1237,10 +1237,6 @@
           <source>Vertical tab strip</source>
           <target state="translated">Pionowy pasek z karami</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ustawienia</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">Język aplikacji</target>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -349,10 +349,6 @@
           <source>List View</source>
           <target state="translated">Widok listy</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated" state-qualifier="tm-suggestion">Ustawienia</target>
-        </trans-unit>
         <trans-unit id="nameColumn.Header" translate="yes" xml:space="preserve">
           <source>Name</source>
           <target state="translated">Nazwa</target>

--- a/Files/MultilingualResources/Files.pt-BR.xlf
+++ b/Files/MultilingualResources/Files.pt-BR.xlf
@@ -1226,10 +1226,6 @@
           <source>Vertical tab strip</source>
           <target state="translated">Faixa de tabulação vertical</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated" state-qualifier="tm-suggestion">Configurações</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">Idioma do aplicativo</target>

--- a/Files/MultilingualResources/Files.pt-BR.xlf
+++ b/Files/MultilingualResources/Files.pt-BR.xlf
@@ -310,10 +310,6 @@
           <source>Videos</source>
           <target state="translated">Vídeos</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Configurações</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutSortBy.Text" translate="yes" xml:space="preserve">
           <source>Sort by</source>
           <target state="translated">Classificar por</target>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -1226,10 +1226,6 @@
           <source>Vertical tab strip</source>
           <target state="translated">Вертикальная полоса вкладок</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Параметры</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">Язык приложения</target>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -358,10 +358,6 @@
           <source>List View</source>
           <target state="translated">Таблица</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Параметры</target>
-        </trans-unit>
         <trans-unit id="WelcomeDialog.Title" translate="yes" xml:space="preserve">
           <source>Welcome to Files!</source>
           <target state="translated">Добро пожаловать в Files!</target>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -1230,10 +1230,6 @@
           <source>Vertical tab strip</source>
           <target state="new">Vertical tab strip</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated" state-qualifier="tm-suggestion">அமைப்புகள்</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">பயன்பாட்டு மொழி</target>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -304,10 +304,6 @@
           <source>Videos</source>
           <target state="translated">காணொளிகள்</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">அமைப்புகள்</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutSortBy.Text" translate="yes" xml:space="preserve">
           <source>Sort by</source>
           <target state="translated">இதன்படி வரிசைப்படுத்து</target>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -1235,10 +1235,6 @@
           <source>Vertical tab strip</source>
           <target state="new">Vertical tab strip</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">Ayarlar</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="new">App Language</target>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -351,10 +351,6 @@
           <source>List View</source>
           <target state="translated">Liste Görünümü</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Özellikler</target>
-        </trans-unit>
         <trans-unit id="nameColumn.Header" translate="yes" xml:space="preserve">
           <source>Name</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Adı</target>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -1226,10 +1226,6 @@
           <source>Vertical tab strip</source>
           <target state="translated">Вертикальна смуга вкладок</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Налаштування</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">Мова програми</target>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -250,10 +250,6 @@
           <source>Videos</source>
           <target state="translated">Відео</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">Налаштування</target>
-        </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutSortBy.Text" translate="yes" xml:space="preserve">
           <source>Sort by</source>
           <target state="translated">Сортування</target>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -344,10 +344,6 @@
           <source>List View</source>
           <target state="translated">列表</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">设置</target>
-        </trans-unit>
         <trans-unit id="nameColumn.Header" translate="yes" xml:space="preserve">
           <source>Name</source>
           <target state="translated">名称</target>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -1231,10 +1231,6 @@
           <source>Vertical tab strip</source>
           <target state="translated">垂直排列标签页</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">设置</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="translated">应用语言</target>

--- a/Files/MultilingualResources/Files.zh-Hant.xlf
+++ b/Files/MultilingualResources/Files.zh-Hant.xlf
@@ -349,10 +349,6 @@
           <source>List View</source>
           <target state="translated">列表</target>
         </trans-unit>
-        <trans-unit id="SidebarSettings.Text" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="translated">設定</target>
-        </trans-unit>
         <trans-unit id="nameColumn.Header" translate="yes" xml:space="preserve">
           <source>Name</source>
           <target state="translated">名稱</target>

--- a/Files/MultilingualResources/Files.zh-Hant.xlf
+++ b/Files/MultilingualResources/Files.zh-Hant.xlf
@@ -1281,10 +1281,6 @@
           <source>Vertical tab strip</source>
           <target state="new">Vertical tab strip</target>
         </trans-unit>
-        <trans-unit id="SidebarSettingsButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
-          <source>Settings</source>
-          <target state="new">Settings</target>
-        </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>App Language</source>
           <target state="new">App Language</target>

--- a/Files/Strings/de-DE/Resources.resw
+++ b/Files/Strings/de-DE/Resources.resw
@@ -264,9 +264,6 @@
   <data name="StatusBarControlListView.Text" xml:space="preserve">
     <value>Details</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Einstellungen</value>
-  </data>
   <data name="nameColumn.Header" xml:space="preserve">
     <value>Name</value>
   </data>

--- a/Files/Strings/de-DE/Resources.resw
+++ b/Files/Strings/de-DE/Resources.resw
@@ -927,9 +927,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>Vertikale Tab-Ansicht</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Einstellungen</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>Sprache</value>
   </data>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -363,9 +363,6 @@
   <data name="SidebarVideos" xml:space="preserve">
     <value>Videos</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Settings</value>
-  </data>
   <data name="BaseLayoutContextFlyoutSortBy.Text" xml:space="preserve">
     <value>Sort by</value>
   </data>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -1068,9 +1068,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>Vertical tab strip</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Settings</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>App Language</value>
   </data>

--- a/Files/Strings/es-ES/Resources.resw
+++ b/Files/Strings/es-ES/Resources.resw
@@ -264,9 +264,6 @@
   <data name="StatusBarControlListView.Text" xml:space="preserve">
     <value>Detalles</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Ajustes</value>
-  </data>
   <data name="nameColumn.Header" xml:space="preserve">
     <value>Nombre</value>
   </data>

--- a/Files/Strings/es-ES/Resources.resw
+++ b/Files/Strings/es-ES/Resources.resw
@@ -906,9 +906,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>Barra de pestañas vertical</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Ajustes</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>Idioma</value>
   </data>

--- a/Files/Strings/fr-FR/Resources.resw
+++ b/Files/Strings/fr-FR/Resources.resw
@@ -924,9 +924,6 @@
   <data name="NavUpButton.AutomationProperties.Name" xml:space="preserve">
     <value>Remonter d'un dossier</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Paramètres</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>Langue de l'application</value>
   </data>

--- a/Files/Strings/fr-FR/Resources.resw
+++ b/Files/Strings/fr-FR/Resources.resw
@@ -264,9 +264,6 @@
   <data name="StatusBarControlListView.Text" xml:space="preserve">
     <value>Vue liste</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Paramètres</value>
-  </data>
   <data name="PropertiesItemMD5Hash.Text" xml:space="preserve">
     <value>Hash MD5 :</value>
   </data>

--- a/Files/Strings/he-IL/Resources.resw
+++ b/Files/Strings/he-IL/Resources.resw
@@ -621,9 +621,6 @@
   <data name="NavForwardButton.AutomationProperties.Name" xml:space="preserve">
     <value>נווט קדימה</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>הגדרות</value>
-  </data>
   <data name="AccessDeniedCreateDialog.Title" xml:space="preserve">
     <value>הגישה נדחתה</value>
   </data>

--- a/Files/Strings/he-IL/Resources.resw
+++ b/Files/Strings/he-IL/Resources.resw
@@ -189,9 +189,6 @@
   <data name="SidebarVideos" xml:space="preserve">
     <value>סרטוני וידאו</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>הגדרות</value>
-  </data>
   <data name="BaseLayoutContextFlyoutSortBy.Text" xml:space="preserve">
     <value>מיין לפי</value>
   </data>

--- a/Files/Strings/hi-IN/Resources.resw
+++ b/Files/Strings/hi-IN/Resources.resw
@@ -825,7 +825,4 @@
   <data name="NavForwardButton.AutomationProperties.Name" xml:space="preserve">
     <value>आगे नेविगेट करें</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>सेटिंग्स</value>
-  </data>
 </root>

--- a/Files/Strings/hi-IN/Resources.resw
+++ b/Files/Strings/hi-IN/Resources.resw
@@ -240,9 +240,6 @@
   <data name="SidebarVideos" xml:space="preserve">
     <value>चलचित्र</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>सेटिंग्स</value>
-  </data>
   <data name="BaseLayoutContextFlyoutSortBy.Text" xml:space="preserve">
     <value>द्वारा सॉर्ट करें</value>
   </data>

--- a/Files/Strings/hu-HU/Resources.resw
+++ b/Files/Strings/hu-HU/Resources.resw
@@ -951,9 +951,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>Függőleges lap lánc</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Beállítások</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>Program Nyelve</value>
   </data>

--- a/Files/Strings/hu-HU/Resources.resw
+++ b/Files/Strings/hu-HU/Resources.resw
@@ -252,9 +252,6 @@
   <data name="SidebarVideos" xml:space="preserve">
     <value>Videók</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Beállítások</value>
-  </data>
   <data name="BaseLayoutContextFlyoutSortBy.Text" xml:space="preserve">
     <value>Rendezés</value>
   </data>
@@ -1097,5 +1094,239 @@
   </data>
   <data name="PropertiesDialogHidden.Text" xml:space="preserve">
     <value>Rejtett</value>
+  </data>
+  <data name="PropertyRatingText" xml:space="preserve">
+    <value>Minősítés</value>
+  </data>
+  <data name="PropertyItemFolderPathDisplay" xml:space="preserve">
+    <value>Mappa elérési útja</value>
+  </data>
+  <data name="PropertyItemTypeText" xml:space="preserve">
+    <value>Elem típusa</value>
+  </data>
+  <data name="PropertyTitle" xml:space="preserve">
+    <value>Cím</value>
+  </data>
+  <data name="PropertySubject" xml:space="preserve">
+    <value>Téma</value>
+  </data>
+  <data name="PropertyComment" xml:space="preserve">
+    <value>Megjegyzés</value>
+  </data>
+  <data name="PropertyCopyright" xml:space="preserve">
+    <value>Szerzői jog</value>
+  </data>
+  <data name="PropertyDateModified" xml:space="preserve">
+    <value>Módosítás dátuma</value>
+  </data>
+  <data name="PropertyBitDepth" xml:space="preserve">
+    <value>Bitmélység</value>
+  </data>
+  <data name="PropertyDimensions" xml:space="preserve">
+    <value>Méretek</value>
+  </data>
+  <data name="PropertyHorizontalSize" xml:space="preserve">
+    <value>Széleség</value>
+  </data>
+  <data name="PropertyVerticalSize" xml:space="preserve">
+    <value>Magasság</value>
+  </data>
+  <data name="PropertyHorizontalResolution" xml:space="preserve">
+    <value>Vízszintes felbontás</value>
+  </data>
+  <data name="PropertyVerticalResolution" xml:space="preserve">
+    <value>Függőleges felbontás</value>
+  </data>
+  <data name="PropertyCompressionText" xml:space="preserve">
+    <value>Tömörítés</value>
+  </data>
+  <data name="PropertyColorSpace" xml:space="preserve">
+    <value>Színtér</value>
+  </data>
+  <data name="PropertyLongitudeDecimal" xml:space="preserve">
+    <value>Szélesség (egész)</value>
+  </data>
+  <data name="PropertyLatitudeDecimal" xml:space="preserve">
+    <value>Magasság (egész)</value>
+  </data>
+  <data name="PropertyLatitude" xml:space="preserve">
+    <value>Szélesség</value>
+  </data>
+  <data name="PropertyLongitude" xml:space="preserve">
+    <value>Magasság</value>
+  </data>
+  <data name="PropertyLatitudeRef" xml:space="preserve">
+    <value>Szélesség Ref</value>
+  </data>
+  <data name="PropertyLongitudeRef" xml:space="preserve">
+    <value>Magasság Ref</value>
+  </data>
+  <data name="PropertyAltitude" xml:space="preserve">
+    <value>Magasság</value>
+  </data>
+  <data name="PropertyDateTaken" xml:space="preserve">
+    <value>Létrehozás dátuma</value>
+  </data>
+  <data name="PropertyCameraManufacturer" xml:space="preserve">
+    <value>Fényképezőgép gyártója</value>
+  </data>
+  <data name="PropertyCameraModel" xml:space="preserve">
+    <value>Fényképezőgép modell</value>
+  </data>
+  <data name="PropertyExposureTime" xml:space="preserve">
+    <value>Expozíciós idő</value>
+  </data>
+  <data name="PropertyFocalLength" xml:space="preserve">
+    <value>Fókusztávolság</value>
+  </data>
+  <data name="PropertyAperture" xml:space="preserve">
+    <value>Rekesz</value>
+  </data>
+  <data name="PropertyFormat" xml:space="preserve">
+    <value>Formátum</value>
+  </data>
+  <data name="PropertyAlbumArtist" xml:space="preserve">
+    <value>Album előadója</value>
+  </data>
+  <data name="PropertyAlbumTitle" xml:space="preserve">
+    <value>Album</value>
+  </data>
+  <data name="PropertyArtist" xml:space="preserve">
+    <value>Előadó</value>
+  </data>
+  <data name="PropertyBeatsPerMinute" xml:space="preserve">
+    <value>Ütem Per Perc</value>
+  </data>
+  <data name="PropertyComposer" xml:space="preserve">
+    <value>Zeneszerző</value>
+  </data>
+  <data name="PropertyConductor" xml:space="preserve">
+    <value>Zeneszerző</value>
+  </data>
+  <data name="PropertyDiscNumber" xml:space="preserve">
+    <value>Lemez száma</value>
+  </data>
+  <data name="PropertyGenre" xml:space="preserve">
+    <value>Műfaj</value>
+  </data>
+  <data name="PropertyTrackNumber" xml:space="preserve">
+    <value>Szám száma</value>
+  </data>
+  <data name="PropertyDuration" xml:space="preserve">
+    <value>Hossz</value>
+  </data>
+  <data name="PropertyDateReleased" xml:space="preserve">
+    <value>Megjelenés dátuma</value>
+  </data>
+  <data name="PropertyProducer" xml:space="preserve">
+    <value>Producer</value>
+  </data>
+  <data name="PropertyPublisher" xml:space="preserve">
+    <value>Kiadó</value>
+  </data>
+  <data name="PropertyWriter" xml:space="preserve">
+    <value>Író</value>
+  </data>
+  <data name="PropertyYear" xml:space="preserve">
+    <value>Év</value>
+  </data>
+  <data name="PropertyRevisionNumber" xml:space="preserve">
+    <value>Felülvizsgálat száma</value>
+  </data>
+  <data name="PropertyVersion" xml:space="preserve">
+    <value>Verzió</value>
+  </data>
+  <data name="PropertyDateCreated" xml:space="preserve">
+    <value>Létrehozás dátuma</value>
+  </data>
+  <data name="PropertyDateSaved" xml:space="preserve">
+    <value>Mentés dátuma</value>
+  </data>
+  <data name="PropertyDatePrinted" xml:space="preserve">
+    <value>Nyomtatás dátuma</value>
+  </data>
+  <data name="PropertyTotalEditingTime" xml:space="preserve">
+    <value>Teljes szerkeztési idő</value>
+  </data>
+  <data name="PropertyTemplate" xml:space="preserve">
+    <value>Minta</value>
+  </data>
+  <data name="PropertyWordCount" xml:space="preserve">
+    <value>Szavak száma</value>
+  </data>
+  <data name="PropertyCharacterCount" xml:space="preserve">
+    <value>Karakterek száma</value>
+  </data>
+  <data name="PropertyLineCount" xml:space="preserve">
+    <value>Sorok száma</value>
+  </data>
+  <data name="PropertyParagraphCount" xml:space="preserve">
+    <value>Bekezdések száma</value>
+  </data>
+  <data name="PropertyPageCount" xml:space="preserve">
+    <value>Lapok száma</value>
+  </data>
+  <data name="PropertyFrameRate" xml:space="preserve">
+    <value>Képkockák sebessége</value>
+  </data>
+  <data name="PropertyCompression" xml:space="preserve">
+    <value>Tömörítés</value>
+  </data>
+  <data name="PropertyFrameWidth" xml:space="preserve">
+    <value>Szélesség</value>
+  </data>
+  <data name="PropertyFrameHeight" xml:space="preserve">
+    <value>Magasság</value>
+  </data>
+  <data name="PropertyOrientation" xml:space="preserve">
+    <value>Tájolás</value>
+  </data>
+  <data name="PropertySectionCore" xml:space="preserve">
+    <value>Leírás</value>
+  </data>
+  <data name="PropertySectionImage" xml:space="preserve">
+    <value>Kép</value>
+  </data>
+  <data name="PropertySectionPhoto" xml:space="preserve">
+    <value>Fotó</value>
+  </data>
+  <data name="PropertySectionGPS" xml:space="preserve">
+    <value>GPS</value>
+  </data>
+  <data name="PropertySectionMedia" xml:space="preserve">
+    <value>Média</value>
+  </data>
+  <data name="PropertySectionAudio" xml:space="preserve">
+    <value>Audió</value>
+  </data>
+  <data name="PropertySectionMusic" xml:space="preserve">
+    <value>Zene</value>
+  </data>
+  <data name="PropertySectionVideo" xml:space="preserve">
+    <value>Videó</value>
+  </data>
+  <data name="PropertySectionDocument" xml:space="preserve">
+    <value>Dokumentum</value>
+  </data>
+  <data name="PropertyAddress" xml:space="preserve">
+    <value>Elérhetőség</value>
+  </data>
+  <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
+    <value>Hiba</value>
+  </data>
+  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Újra</value>
+  </data>
+  <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
+    <value>Bezárás mindenképpen</value>
+  </data>
+  <data name="PropertySaveErrorDialog.CloseButtonText" xml:space="preserve">
+    <value>Mégsem</value>
+  </data>
+  <data name="ClearPropertiesFlyoutConfirmation.Content" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="ClearPropertiesButton.Content" xml:space="preserve">
+    <value>Összes tulajdonság törlése</value>
   </data>
 </root>

--- a/Files/Strings/it-IT/Resources.resw
+++ b/Files/Strings/it-IT/Resources.resw
@@ -219,9 +219,6 @@
   <data name="SidebarVideos" xml:space="preserve">
     <value>Video</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Impostazioni</value>
-  </data>
   <data name="BaseLayoutContextFlyoutSortBy.Text" xml:space="preserve">
     <value>Ordina per</value>
   </data>

--- a/Files/Strings/it-IT/Resources.resw
+++ b/Files/Strings/it-IT/Resources.resw
@@ -927,9 +927,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>Barra schede verticale</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Impostazioni</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>Lingua dell'App</value>
   </data>

--- a/Files/Strings/ja-JP/Resources.resw
+++ b/Files/Strings/ja-JP/Resources.resw
@@ -927,9 +927,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>垂直タブストリップ</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>設定</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>言語</value>
   </data>

--- a/Files/Strings/ja-JP/Resources.resw
+++ b/Files/Strings/ja-JP/Resources.resw
@@ -234,9 +234,6 @@
   <data name="SidebarVideos" xml:space="preserve">
     <value>ビデオ</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>設定</value>
-  </data>
   <data name="BaseLayoutContextFlyoutSortBy.Text" xml:space="preserve">
     <value>並べ替え</value>
   </data>

--- a/Files/Strings/nl-NL/Resources.resw
+++ b/Files/Strings/nl-NL/Resources.resw
@@ -264,9 +264,6 @@
   <data name="StatusBarControlListView.Text" xml:space="preserve">
     <value>Lijstweergave</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Instellingen</value>
-  </data>
   <data name="nameColumn.Header" xml:space="preserve">
     <value>Naam</value>
   </data>

--- a/Files/Strings/nl-NL/Resources.resw
+++ b/Files/Strings/nl-NL/Resources.resw
@@ -861,7 +861,4 @@
   <data name="NavForwardButton.AutomationProperties.Name" xml:space="preserve">
     <value>Vooruit gaan</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Instellingen</value>
-  </data>
 </root>

--- a/Files/Strings/or-IN/Resources.resw
+++ b/Files/Strings/or-IN/Resources.resw
@@ -240,9 +240,6 @@
   <data name="SidebarVideos" xml:space="preserve">
     <value>ଚଳଚ୍ଚିତ୍ରଗୁଡିକ</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>ସେଟିଂସମୂହ</value>
-  </data>
   <data name="BaseLayoutContextFlyoutSortBy.Text" xml:space="preserve">
     <value>ଦ୍ୱାରା କ୍ରମ</value>
   </data>

--- a/Files/Strings/or-IN/Resources.resw
+++ b/Files/Strings/or-IN/Resources.resw
@@ -813,7 +813,4 @@
   <data name="NavForwardButton.AutomationProperties.Name" xml:space="preserve">
     <value>ଅଗ୍ରଗାମୀ ନେଭିଗେଟ୍ କରନ୍ତୁ</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>ସେଟିଂସମୂହ</value>
-  </data>
 </root>

--- a/Files/Strings/pl-PL/Resources.resw
+++ b/Files/Strings/pl-PL/Resources.resw
@@ -924,9 +924,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>Pionowy pasek z karami</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Ustawienia</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>Język aplikacji</value>
   </data>

--- a/Files/Strings/pl-PL/Resources.resw
+++ b/Files/Strings/pl-PL/Resources.resw
@@ -264,9 +264,6 @@
   <data name="StatusBarControlListView.Text" xml:space="preserve">
     <value>Widok listy</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Ustawienia</value>
-  </data>
   <data name="nameColumn.Header" xml:space="preserve">
     <value>Nazwa</value>
   </data>

--- a/Files/Strings/pt-BR/Resources.resw
+++ b/Files/Strings/pt-BR/Resources.resw
@@ -927,9 +927,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>Faixa de tabulação vertical</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Configurações</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>Idioma do aplicativo</value>
   </data>

--- a/Files/Strings/pt-BR/Resources.resw
+++ b/Files/Strings/pt-BR/Resources.resw
@@ -240,9 +240,6 @@
   <data name="SidebarVideos" xml:space="preserve">
     <value>Vídeos</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Configurações</value>
-  </data>
   <data name="BaseLayoutContextFlyoutSortBy.Text" xml:space="preserve">
     <value>Classificar por</value>
   </data>

--- a/Files/Strings/ru-RU/Resources.resw
+++ b/Files/Strings/ru-RU/Resources.resw
@@ -924,9 +924,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>Вертикальная полоса вкладок</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Параметры</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>Язык приложения</value>
   </data>

--- a/Files/Strings/ru-RU/Resources.resw
+++ b/Files/Strings/ru-RU/Resources.resw
@@ -273,9 +273,6 @@
   <data name="StatusBarControlListView.Text" xml:space="preserve">
     <value>Таблица</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Параметры</value>
-  </data>
   <data name="WelcomeDialog.Title" xml:space="preserve">
     <value>Добро пожаловать в Files!</value>
   </data>

--- a/Files/Strings/ta/Resources.resw
+++ b/Files/Strings/ta/Resources.resw
@@ -892,9 +892,6 @@
   <data name="NavUpButton.AutomationProperties.Name" xml:space="preserve">
     <value>ஒரு கோப்புறை மேல் செல்</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>அமைப்புகள்</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>பயன்பாட்டு மொழி</value>
   </data>

--- a/Files/Strings/ta/Resources.resw
+++ b/Files/Strings/ta/Resources.resw
@@ -231,9 +231,6 @@
   <data name="SidebarVideos" xml:space="preserve">
     <value>காணொளிகள்</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>அமைப்புகள்</value>
-  </data>
   <data name="BaseLayoutContextFlyoutSortBy.Text" xml:space="preserve">
     <value>இதன்படி வரிசைப்படுத்து</value>
   </data>

--- a/Files/Strings/tr-TR/Resources.resw
+++ b/Files/Strings/tr-TR/Resources.resw
@@ -264,9 +264,6 @@
   <data name="StatusBarControlListView.Text" xml:space="preserve">
     <value>Liste Görünümü</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Özellikler</value>
-  </data>
   <data name="nameColumn.Header" xml:space="preserve">
     <value>Adı</value>
   </data>

--- a/Files/Strings/tr-TR/Resources.resw
+++ b/Files/Strings/tr-TR/Resources.resw
@@ -690,7 +690,4 @@
   <data name="NavForwardButton.AutomationProperties.Name" xml:space="preserve">
     <value>İleri Git</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Ayarlar</value>
-  </data>
 </root>

--- a/Files/Strings/uk-UA/Resources.resw
+++ b/Files/Strings/uk-UA/Resources.resw
@@ -195,9 +195,6 @@
   <data name="SidebarVideos" xml:space="preserve">
     <value>Відео</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>Налаштування</value>
-  </data>
   <data name="BaseLayoutContextFlyoutSortBy.Text" xml:space="preserve">
     <value>Сортування</value>
   </data>

--- a/Files/Strings/uk-UA/Resources.resw
+++ b/Files/Strings/uk-UA/Resources.resw
@@ -924,9 +924,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>Вертикальна смуга вкладок</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Налаштування</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>Мова програми</value>
   </data>

--- a/Files/Strings/zh-Hans/Resources.resw
+++ b/Files/Strings/zh-Hans/Resources.resw
@@ -264,9 +264,6 @@
   <data name="StatusBarControlListView.Text" xml:space="preserve">
     <value>列表</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>设置</value>
-  </data>
   <data name="nameColumn.Header" xml:space="preserve">
     <value>名称</value>
   </data>

--- a/Files/Strings/zh-Hans/Resources.resw
+++ b/Files/Strings/zh-Hans/Resources.resw
@@ -927,9 +927,6 @@
   <data name="VerticalTabStrip.AutomationProperties.Name" xml:space="preserve">
     <value>垂直排列标签页</value>
   </data>
-  <data name="SidebarSettingsButton.AutomationProperties.Name" xml:space="preserve">
-    <value>设置</value>
-  </data>
   <data name="SettingsPreferencesAppLanguage.AutomationProperties.Name" xml:space="preserve">
     <value>应用语言</value>
   </data>

--- a/Files/Strings/zh-Hant/Resources.resw
+++ b/Files/Strings/zh-Hant/Resources.resw
@@ -264,9 +264,6 @@
   <data name="StatusBarControlListView.Text" xml:space="preserve">
     <value>列表</value>
   </data>
-  <data name="SidebarSettings.Text" xml:space="preserve">
-    <value>設定</value>
-  </data>
   <data name="nameColumn.Header" xml:space="preserve">
     <value>名稱</value>
   </data>

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -131,7 +131,7 @@
             IsBackButtonVisible="Collapsed"
             IsPaneOpen="True"
             IsPaneToggleButtonVisible="False"
-            IsSettingsVisible="False"
+            IsSettingsVisible="True"
             IsTitleBarAutoPaddingEnabled="False"
             ItemInvoked="Sidebar_ItemInvoked"
             MenuItemTemplateSelector="{StaticResource NavItemSelector}"
@@ -139,34 +139,6 @@
             OpenPaneLength="500"
             PaneDisplayMode="Left"
             SelectedItem="{x:Bind SelectedSidebarItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-            <muxc:NavigationView.PaneFooter>
-                <Grid>
-                    <muxc:NavigationViewItem
-                        x:Name="SettingsButton"
-                        x:Uid="SidebarSettingsButton"
-                        HorizontalAlignment="Stretch"
-                        HorizontalContentAlignment="Left"
-                        AutomationProperties.Name="Settings"
-                        IsTapEnabled="True"
-                        SelectsOnInvoked="False"
-                        Tapped="SettingsButton_Tapped">
-                        <muxc:NavigationViewItem.Content>
-                            <TextBlock
-                                x:Uid="SidebarSettings"
-                                Grid.Column="1"
-                                Padding="2,0,0,0"
-                                VerticalAlignment="Center"
-                                Text="Settings" />
-                        </muxc:NavigationViewItem.Content>
-                        <muxc:NavigationViewItem.Icon>
-                            <FontIcon
-                                FontFamily="{StaticResource FluentUIGlyphs}"
-                                FontSize="18"
-                                Glyph="&#xEB5D;" />
-                        </muxc:NavigationViewItem.Icon>
-                    </muxc:NavigationViewItem>
-                </Grid>
-            </muxc:NavigationView.PaneFooter>
             <muxc:NavigationView.Resources>
                 <ResourceDictionary>
                     <MenuFlyout x:Name="SideBarItemContextFlyout" x:FieldModifier="public">

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -12,6 +12,7 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 
 namespace Files.Controls
 {
@@ -60,6 +61,7 @@ namespace Files.Controls
         public SidebarControl()
         {
             this.InitializeComponent();
+            SidebarNavView.Loaded += SidebarNavView_Loaded;
         }
 
         private INavigationControlItem _SelectedSidebarItem;
@@ -467,6 +469,20 @@ namespace Files.Controls
         private async void EjectDevice_Click(object sender, RoutedEventArgs e)
         {
             await Interaction.EjectDeviceAsync(App.RightClickedItem.Path);
+        }
+
+        private void SidebarNavView_Loaded(object sender, RoutedEventArgs e)
+        {
+            var settings = (Microsoft.UI.Xaml.Controls.NavigationViewItem)SidebarNavView.SettingsItem;
+            settings.SelectsOnInvoked = false;
+            settings.Icon = new FontIcon()
+            {
+                FontSize = 18,
+                FontFamily = App.Current.Resources["FluentUIGlyphs"] as FontFamily,
+                Glyph = "\xEB5D"
+            };
+
+            SidebarNavView.Loaded -= SidebarNavView_Loaded;
         }
     }
 

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -205,6 +205,15 @@ namespace Files.Views.Pages
         {
             var invokedItemContainer = e.InvokedItemContainer;
 
+            // All items must have DataContext except Settings item
+            if (invokedItemContainer.DataContext is null)
+            {
+                Frame rootFrame = Window.Current.Content as Frame;
+                rootFrame.Navigate(typeof(Settings));
+
+                return;
+            }
+
             string navigationPath; // path to navigate
             Type sourcePageType = null; // type of page to navigate
 


### PR DESCRIPTION
We now use a customized version of the WinUI NavigationView's default Settings item. The only side effect is the item's new icon loads in slightly after the control is loaded.

Fixes #2536 