### PR TITLE
Increased max GridView size

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -745,7 +745,7 @@ namespace Files
 
         public void GridViewSizeIncrease(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
-            AppSettings.GridViewSize = AppSettings.GridViewSize + 25; // Make Larger
+            AppSettings.GridViewSize = AppSettings.GridViewSize + Constants.Browser.GridViewBrowser.GridViewIncrement; // Make Larger
             if (args != null)
             {
                 args.Handled = true;
@@ -754,7 +754,7 @@ namespace Files
 
         public void GridViewSizeDecrease(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
-            AppSettings.GridViewSize = AppSettings.GridViewSize - 25; // Make Smaller
+            AppSettings.GridViewSize = AppSettings.GridViewSize - Constants.Browser.GridViewBrowser.GridViewIncrement; // Make Smaller
             if (args != null)
             {
                 args.Handled = true;

--- a/Files/Constants.cs
+++ b/Files/Constants.cs
@@ -6,6 +6,8 @@
         {
             public static class GridViewBrowser
             {
+                public const int GridViewIncrement = 20;
+
                 public const int GridViewSizeMax = 300; // Max achievable ctrl + scroll, not a default layout size.
 
                 public const int GridViewSizeLarge = 220;

--- a/Files/Constants.cs
+++ b/Files/Constants.cs
@@ -6,6 +6,8 @@
         {
             public static class GridViewBrowser
             {
+                public const int GridViewSizeMax = 320; // Max achievable ctrl + scroll, not a default layout size.
+
                 public const int GridViewSizeLarge = 220;
 
                 public const int GridViewSizeMedium = 160;

--- a/Files/Constants.cs
+++ b/Files/Constants.cs
@@ -6,7 +6,7 @@
         {
             public static class GridViewBrowser
             {
-                public const int GridViewSizeMax = 320; // Max achievable ctrl + scroll, not a default layout size.
+                public const int GridViewSizeMax = 300; // Max achievable ctrl + scroll, not a default layout size.
 
                 public const int GridViewSizeLarge = 220;
 

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -648,7 +648,7 @@ namespace Files.View_Models
                     }
                     else // Size up from tiles to grid
                     {
-                        gridViewSize = (LayoutMode == 1) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeLarge) ? value : Constants.Browser.GridViewBrowser.GridViewSizeLarge; // Set grid size to allow immediate UI update
+                        gridViewSize = (LayoutMode == 1) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeMax) ? value : Constants.Browser.GridViewBrowser.GridViewSizeMax; // Set grid size to allow immediate UI update
                         Set(gridViewSize);
 
                         if (LayoutMode != 2) // Only update layout mode if it isn't already in grid view
@@ -658,7 +658,7 @@ namespace Files.View_Models
                             LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                         }
 
-                        if (value < Constants.Browser.GridViewBrowser.GridViewSizeLarge) // Don't request a grid resize if it is already at the max size
+                        if (value < Constants.Browser.GridViewBrowser.GridViewSizeMax) // Don't request a grid resize if it is already at the max size
                         {
                             GridViewSizeChangeRequested?.Invoke(this, EventArgs.Empty);
                         }


### PR DESCRIPTION
Fixes #2560

Allows a user to use _ctrl + scroll_ or _ctrl + +_ to resize the GridView to larger than the "Grid View (Large)" default. No new menu option is added and no changes are made to the existing menu sizes.

Max before:
![Max 220](https://user-images.githubusercontent.com/46000533/101526738-b71d6780-3995-11eb-94f0-7ec000ff7e42.jpg)

Max after:
![Max 320](https://user-images.githubusercontent.com/46000533/101526776-c6041a00-3995-11eb-951a-2742755a77bd.jpg)

