### PR TITLE
Fixes with IFilesystemOperations

### DIFF
--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -391,7 +391,7 @@ namespace Files.Filesystem
                     // Get newest file
                     ShellFileItem item = nameMatchItems.Where((item) => item.RecycleDate != null).OrderBy((item) => item.RecycleDate).FirstOrDefault();
 
-                    return new StorageHistory(FileOperationType.Recycle, source, new PathWithType(item.RecyclePath, source.ItemType));
+                    return new StorageHistory(FileOperationType.Recycle, source, new PathWithType(item?.RecyclePath, source.ItemType));
                 }
 
                 return new StorageHistory(FileOperationType.Delete, source, null);

--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -563,10 +563,14 @@ namespace Files.Filesystem
             IReadOnlyList<IStorageItem> source = await packageView.GetStorageItemsAsync();
             ReturnResult returnStatus = ReturnResult.InProgress;
 
+            List<string> destinations = new List<string>();
             foreach (IStorageItem item in source)
             {
-                returnStatus = await CopyItemAsync(item, Path.Combine(destination, item.Name), registerHistory);
+                destinations.Add(Path.Combine(destination, item.Name));
             }
+
+            returnStatus = await CopyItemsAsync(source, destinations, true);
+
             return returnStatus;
         }
 
@@ -693,10 +697,14 @@ namespace Files.Filesystem
             IReadOnlyList<IStorageItem> source = await packageView.GetStorageItemsAsync();
             ReturnResult returnStatus = ReturnResult.InProgress;
 
+            List<string> destinations = new List<string>();
             foreach (IStorageItem item in source)
             {
-                returnStatus = await MoveItemAsync(item, Path.Combine(destination, item.Name), registerHistory);
+                destinations.Add(Path.Combine(destination, item.Name));
             }
+
+            returnStatus = await MoveItemsAsync(source, destinations, true);
+
             return returnStatus;
         }
 

--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -569,7 +569,7 @@ namespace Files.Filesystem
                 destinations.Add(Path.Combine(destination, item.Name));
             }
 
-            returnStatus = await CopyItemsAsync(source, destinations, true);
+            returnStatus = await CopyItemsAsync(source, destinations, registerHistory);
 
             return returnStatus;
         }
@@ -703,7 +703,7 @@ namespace Files.Filesystem
                 destinations.Add(Path.Combine(destination, item.Name));
             }
 
-            returnStatus = await MoveItemsAsync(source, destinations, true);
+            returnStatus = await MoveItemsAsync(source, destinations, registerHistory);
 
             return returnStatus;
         }


### PR DESCRIPTION
Fixed `NullReferenceException` in `IFilesystemOperations.DeleteAsync()`? (It does not crash for me but adding `?` should do the trick)
...and fixed an issue where undoing/redoing copy/move operation would only undo/redo one item

Closes #2496 