### PR TITLE
Fixed an issue where opening the properties window would crash the app

### DIFF
--- a/Files/Views/Pages/Properties.xaml
+++ b/Files/Views/Pages/Properties.xaml
@@ -31,7 +31,7 @@
             VerticalAlignment="Center"
             Text="Properties" />
 
-        <muxc:NavigationView
+        <NavigationView
             x:Name="NavigationView"
             Grid.Row="1"
             AllowDrop="False"
@@ -40,44 +40,47 @@
             IsPaneToggleButtonVisible="False"
             IsSettingsVisible="False"
             PaneDisplayMode="Top"
+            SelectionFollowsFocus="Enabled"
             SelectionChanged="NavigationView_SelectionChanged"
-            SelectionFollowsFocus="Enabled">
+            SelectedItem="{x:Bind TabGeneral}">
 
             <!--  Tabs  -->
-            <muxc:NavigationView.MenuItems>
-                <muxc:NavigationViewItem
+            <NavigationView.MenuItems>
+                <NavigationViewItem
                     x:Name="TabGeneral"
                     x:Uid="PropertiesDialogTabGeneral"
                     Content="General"
                     Tag="General">
-                    <muxc:NavigationViewItem.Icon>
+                    <NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xea00;" />
-                    </muxc:NavigationViewItem.Icon>
-                </muxc:NavigationViewItem>
-                <muxc:NavigationViewItem
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem
                     x:Name="TabShorcut"
                     x:Uid="PropertiesDialogTabShortcut"
                     Content="Shortcut"
                     Tag="Shortcut"
                     Visibility="Collapsed">
-                    <muxc:NavigationViewItem.Icon>
+                    <NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF10A;" />
-                    </muxc:NavigationViewItem.Icon>
-                </muxc:NavigationViewItem>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
 
-                <muxc:NavigationViewItem
+                <NavigationViewItem
                     x:Name="TabDetails"
                     x:Uid="PropertiesDialogTabDetailsImage"
                     Content="Details"
                     Tag="Details"
                     Visibility="Collapsed">
-                    <muxc:NavigationViewItem.Icon>
+                    <NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xea8d;" />
-                    </muxc:NavigationViewItem.Icon>
-                </muxc:NavigationViewItem>
-            </muxc:NavigationView.MenuItems>
-            <Frame x:Name="contentFrame" IsNavigationStackEnabled="False" />
-        </muxc:NavigationView>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.MenuItems>
+            
+            <Frame x:Name="contentFrame" IsNavigationStackEnabled="False" Grid.Row="1"/>
+        </NavigationView>
+
         <Grid Grid.Row="2" Padding="8">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />

--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -225,7 +225,7 @@ namespace Files
             }
         }
 
-        private void NavigationView_SelectionChanged(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs args)
+        private void NavigationView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
         {
             var navParam = new PropertyNavParam()
             {


### PR DESCRIPTION
I am mostly certain that issue #2537 is caused by a bug in the Microsoft.Ui.Xaml NavigationView.
Switching to the Windows.Ui NavigationView seems to be an effective workaround to this bug.