### PR TITLE
Improved the exception handling when updating drive properties

### DIFF
--- a/Files/Filesystem/DriveItem.cs
+++ b/Files/Filesystem/DriveItem.cs
@@ -109,16 +109,19 @@ namespace Files.Filesystem
                 var properties = await Root.Properties.RetrievePropertiesAsync(new[] { "System.FreeSpace", "System.Capacity" })
                     .AsTask().WithTimeoutAsync(TimeSpan.FromSeconds(5));
 
-                MaxSpace = ByteSize.FromBytes((ulong)properties["System.Capacity"]);
-                FreeSpace = ByteSize.FromBytes((ulong)properties["System.FreeSpace"]);
-                SpaceUsed = MaxSpace - FreeSpace;
+                if (properties["System.Capacity"] != null && properties["System.FreeSpace"] != null)
+                {
+                    MaxSpace = ByteSize.FromBytes((ulong)properties["System.Capacity"]);
+                    FreeSpace = ByteSize.FromBytes((ulong)properties["System.FreeSpace"]);
+                    SpaceUsed = MaxSpace - FreeSpace;
 
-                SpaceText = string.Format(
-                    "DriveFreeSpaceAndCapacity".GetLocalized(),
-                    FreeSpace.ToBinaryString().ConvertSizeAbbreviation(),
-                    MaxSpace.ToBinaryString().ConvertSizeAbbreviation());
+                    SpaceText = string.Format(
+                        "DriveFreeSpaceAndCapacity".GetLocalized(),
+                        FreeSpace.ToBinaryString().ConvertSizeAbbreviation(),
+                        MaxSpace.ToBinaryString().ConvertSizeAbbreviation());
+                }
             }
-            catch (NullReferenceException)
+            catch (Exception)
             {
                 SpaceText = "DriveCapacityUnknown".GetLocalized();
                 SpaceUsed = ByteSize.FromBytes(0);


### PR DESCRIPTION
I've fixed annoying `NullReferenceException` not being caught in `DriveItem.UpdatePropertiesAsync()` and needed to be always Continued.
Now I can finally sleep well.

BEFORE:
![image](https://user-images.githubusercontent.com/53011783/102397796-acd71b00-3fde-11eb-8e01-8638ca549a3a.png)

AFTER:
No `NullReferenceException`