### PR TITLE
Settings: Use documented NavigationView adaptive behavior and always set title bar

### DIFF
--- a/Files/Views/Settings.xaml
+++ b/Files/Views/Settings.xaml
@@ -52,6 +52,7 @@
         <muxc:NavigationView
             x:Name="SettingsPane"
             BackRequested="SettingsPane_BackRequested"
+            CompactModeThresholdWidth="0"
             IsBackButtonVisible="Visible"
             IsBackEnabled="True"
             IsPaneOpen="True"
@@ -59,7 +60,7 @@
             IsSettingsVisible="False"
             IsTitleBarAutoPaddingEnabled="False"
             OpenPaneLength="250"
-            PaneDisplayMode="LeftCompact"
+            PaneDisplayMode="Auto"
             SelectionChanged="SettingsPane_SelectionChanged">
 
             <muxc:NavigationView.PaneHeader>
@@ -140,17 +141,5 @@
             </muxc:NavigationView.MenuItems>
             <Frame x:Name="SettingsContentFrame" Padding="14,30,0,0" />
         </muxc:NavigationView>
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup>
-                <VisualState>
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{x:Bind SettingsPane.CompactModeThresholdWidth}" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SettingsPane.PaneDisplayMode" Value="Left" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
     </Grid>
 </Page>

--- a/Files/Views/Settings.xaml.cs
+++ b/Files/Views/Settings.xaml.cs
@@ -5,6 +5,7 @@ using Windows.ApplicationModel.Resources.Core;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Files
 {
@@ -15,6 +16,11 @@ namespace Files
         public Settings()
         {
             this.InitializeComponent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
+        {
+            base.OnNavigatedTo(eventArgs);
 
             var CoreTitleBar = CoreApplication.GetCurrentView().TitleBar;
             CoreTitleBar.ExtendViewIntoTitleBar = true;
@@ -31,6 +37,12 @@ namespace Files
             }
 
             SettingsPane.SelectedItem = SettingsPane.MenuItems[0];
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs eventArgs)
+        {
+            var currentView = SystemNavigationManager.GetForCurrentView();
+            currentView.BackRequested -= OnBackRequested;
         }
 
         private void OnBackRequested(object sender, BackRequestedEventArgs e)


### PR DESCRIPTION
- Remove AdaptiveTrigger for window width in favor of using the `PaneDisplayMode="Auto"` setting with `CompactModeThresholdWidth="0"` for identical behavior
- Fix bug where the titlebar (custom drag region) was only set when the Settings page is first created (fixes #1498)