### PR TITLE
SidebarControl: Adapt pane width to AppSettings SidebarWidth

### DIFF
--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -136,7 +136,7 @@
             ItemInvoked="Sidebar_ItemInvoked"
             MenuItemTemplateSelector="{StaticResource NavItemSelector}"
             MenuItemsSource="{x:Bind local3:MainPage.SideBarItems, Mode=OneWay}"
-            OpenPaneLength="500"
+            OpenPaneLength="{x:Bind AppSettings.SidebarWidth.Value, Mode=OneWay}"
             PaneDisplayMode="Left"
             SelectedItem="{x:Bind SelectedSidebarItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
             <muxc:NavigationView.Resources>

--- a/Files/Views/ModernShellPage.xaml
+++ b/Files/Views/ModernShellPage.xaml
@@ -162,7 +162,9 @@
         </Grid.ColumnDefinitions>
 
         <Grid>
-            <controls:SidebarControl x:Name="SidebarControl" EmptyRecycleBinCommand="{x:Bind InteractionOperations.EmptyRecycleBin, Mode=OneWay}" />
+            <controls:SidebarControl 
+                x:Name="SidebarControl" 
+                EmptyRecycleBinCommand="{x:Bind InteractionOperations.EmptyRecycleBin, Mode=OneWay}" />
         </Grid>
 
         <Grid Grid.Column="1">


### PR DESCRIPTION
Now scrollbar is visible independently from sidebar width.
Before:
![image](https://user-images.githubusercontent.com/20501502/102560349-b2b22680-40da-11eb-9d28-2afa56172561.png)
After:
![image](https://user-images.githubusercontent.com/20501502/102560358-b776da80-40da-11eb-99a3-233ca448b783.png)
