### PR TITLE
Set focus on file list when changing folder

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -151,6 +151,8 @@ namespace Files
             }
         }
 
+        public abstract void FocusFileList();
+
         public abstract void SelectAllItems();
 
         public virtual void InvertSelection()
@@ -348,6 +350,8 @@ namespace Files
 
             ParentShellPageInstance.InstanceViewModel.IsPageTypeNotHome = true; // show controls that were hidden on the home page
             ParentShellPageInstance.Clipboard_ContentChanged(null, null);
+
+            FocusFileList(); // Set focus on layout specific file list control
         }
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -175,6 +175,11 @@ namespace Files
             AllView.ScrollIntoView(item, null);
         }
 
+        public override void FocusFileList()
+        {
+            AllView.Focus(FocusState.Programmatic);
+        }
+
         public override void FocusSelectedItems()
         {
             AllView.ScrollIntoView(AllView.ItemsSource.Cast<ListedItem>().Last(), null);

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -38,6 +38,11 @@ namespace Files
             FileList.Focus(FocusState.Programmatic);
         }
 
+        public override void FocusFileList()
+        {
+            FileList.Focus(FocusState.Programmatic);
+        }
+
         private void AppSettings_LayoutModeChangeRequested(object sender, EventArgs e)
         {
             SetItemTemplate(); // Set ItemTemplate


### PR DESCRIPTION
Fixes #2510 

This PR sets the focus on the file list when changing directory so arrow keys work without the need to press TAB or click on the file list first