### PR TITLE
Appcenter fixes

### DIFF
--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -380,16 +380,19 @@ namespace Files.Filesystem
                 {
                     // Enumerate Recycle Bin
                     List<ShellFileItem> items = await recycleBinHelpers.EnumerateRecycleBin();
-                    List<ShellFileItem> nameMatchItems;
+                    List<ShellFileItem> nameMatchItems = new List<ShellFileItem>();
 
                     // Get name matching files
-                    if (Path.GetExtension(source.Path) == ".lnk" || Path.GetExtension(source.Path) == ".url") // We need to check if it is a shortcut file
+                    if (items != null)
                     {
-                        nameMatchItems = items.Where((item) => item.FilePath == Path.Combine(Path.GetDirectoryName(source.Path), Path.GetFileNameWithoutExtension(source.Path))).ToList();
-                    }
-                    else
-                    {
-                        nameMatchItems = items.Where((item) => item.FilePath == source.Path).ToList();
+                        if (Path.GetExtension(source.Path) == ".lnk" || Path.GetExtension(source.Path) == ".url") // We need to check if it is a shortcut file
+                        {
+                            nameMatchItems = items.Where((item) => item.FilePath == Path.Combine(Path.GetDirectoryName(source.Path), Path.GetFileNameWithoutExtension(source.Path))).ToList();
+                        }
+                        else
+                        {
+                            nameMatchItems = items.Where((item) => item.FilePath == source.Path).ToList();
+                        }
                     }
 
                     // Get newest file

--- a/Files/Helpers/JumpListManager.cs
+++ b/Files/Helpers/JumpListManager.cs
@@ -95,11 +95,17 @@ namespace Files.Helpers
 
         public async void RemoveFolder(string path)
         {
-            if (JumpListItemPaths.Contains(path))
+            // Updating the jumplist may fail randomly with error: FileLoadException: File in use
+            // In that case app should just catch the error and proceed as usual
+            try
             {
-                JumpListItemPaths.Remove(path);
-                await UpdateAsync();
+                if (JumpListItemPaths.Contains(path))
+                {
+                    JumpListItemPaths.Remove(path);
+                    await UpdateAsync();
+                }
             }
+            catch { }
         }
 
         private async Task UpdateAsync()

--- a/Files/Helpers/RegistryHelper.cs
+++ b/Files/Helpers/RegistryHelper.cs
@@ -100,7 +100,7 @@ namespace Files.Helpers
                 .OnSuccess(t => t.CreateFileAsync("file" + extension, CreationCollisionOption.OpenIfExists).AsTask());
 
             var displayType = sampleFile ? sampleFile.Result.DisplayType : string.Format("{0} {1}", "file", extension);
-            var thumbnail = sampleFile ? await sampleFile.Result.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.ListView, 24, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale) : null;
+            var thumbnail = sampleFile ? await FilesystemTasks.Wrap(() => sampleFile.Result.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.ListView, 24, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale).AsTask()) : null;
 
             var entry = new ShellNewEntry()
             {

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -848,6 +848,10 @@ namespace Files.Filesystem
                     }
                 }
             }
+            catch (ObjectDisposedException ex)
+            {
+                NLog.LogManager.GetCurrentClassLogger().Warn(ex, ex.Message);
+            }
             finally
             {
                 semaphoreSlim.Release();

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -1173,6 +1173,10 @@ namespace Files.Filesystem
                         break;
                     }
                 }
+                catch (NotImplementedException)
+                {
+                    break;
+                }
                 catch (Exception ex) when (ex is UnauthorizedAccessException || ex is FileNotFoundException)
                 {
                     ++count;

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -1169,7 +1169,7 @@ namespace Files.Filesystem
                         break;
                     }
                 }
-                catch (UnauthorizedAccessException)
+                catch (Exception ex) when (ex is UnauthorizedAccessException || ex is FileNotFoundException)
                 {
                     ++count;
                     continue;

--- a/Files/View Models/SelectedItemsPropertiesViewModel.cs
+++ b/Files/View Models/SelectedItemsPropertiesViewModel.cs
@@ -540,7 +540,7 @@ namespace Files.View_Models
             IsSelectedItemShortcut = false;
 
             //check if the selected item is an image file
-            string ItemExtension = await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => contentPage.SelectedItem.FileExtension);
+            string ItemExtension = await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => contentPage?.SelectedItem?.FileExtension);
             if (!string.IsNullOrEmpty(ItemExtension) && SelectedItemsCount == 1)
             {
                 if (ItemExtension.Equals(".png", StringComparison.OrdinalIgnoreCase)

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -211,21 +211,21 @@ namespace Files.Views.Pages
 
         private async void SidebarControl_RecycleBinItemRightTapped(object sender, EventArgs e)
         {
-            var value = new ValueSet
+            var recycleBinHasItems = false;
+            if (ServiceConnection != null)
+            {
+                var value = new ValueSet
                 {
                     { "Arguments", "RecycleBin" },
                     { "action", "Query" }
                 };
-
-            var response = await ServiceConnection.SendMessageAsync(value);
-            if (response.Status == AppServiceResponseStatus.Success && response.Message.TryGetValue("NumItems", out var numItems))
-            {
-                SidebarControl.RecycleBinHasItems = (long)numItems > 0;
+                var response = await ServiceConnection.SendMessageAsync(value);
+                if (response.Status == AppServiceResponseStatus.Success && response.Message.TryGetValue("NumItems", out var numItems))
+                {
+                    recycleBinHasItems = (long)numItems > 0;
+                }
             }
-            else
-            {
-                SidebarControl.RecycleBinHasItems = false;
-            }
+            SidebarControl.RecycleBinHasItems = recycleBinHasItems;
         }
 
         private async void SidebarControl_SidebarItemDropped(object sender, Controls.SidebarItemDroppedEventArgs e)

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -1146,16 +1146,11 @@ namespace Files.Views.Pages
             Frame instanceContentFrame = ContentFrame;
             FilesystemViewModel.CancelLoadAndClearFiles();
             var instance = FilesystemViewModel;
-            string parentDirectoryOfPath;
-            // Check that there isn't a slash at the end
-            if ((instance.WorkingDirectory.Count() - 1) - instance.WorkingDirectory.LastIndexOf("\\") > 0)
+            string parentDirectoryOfPath = instance.WorkingDirectory.TrimEnd('\\');
+            var lastSlashIndex = parentDirectoryOfPath.LastIndexOf("\\");
+            if (lastSlashIndex != -1)
             {
-                parentDirectoryOfPath = instance.WorkingDirectory.Remove(instance.WorkingDirectory.LastIndexOf("\\"));
-            }
-            else  // Slash found at end
-            {
-                var currentPathWithoutEndingSlash = instance.WorkingDirectory.Remove(instance.WorkingDirectory.LastIndexOf("\\"));
-                parentDirectoryOfPath = currentPathWithoutEndingSlash.Remove(currentPathWithoutEndingSlash.LastIndexOf("\\"));
+                parentDirectoryOfPath = instance.WorkingDirectory.Remove(lastSlashIndex);
             }
 
             SelectSidebarItemFromPath();

--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -36,7 +36,6 @@ namespace Files
         public Properties()
         {
             InitializeComponent();
-            propertiesDialog = Interaction.FindParent<ContentDialog>(this);
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -67,6 +66,7 @@ namespace Files
             }
             else
             {
+                propertiesDialog = Interaction.FindParent<ContentDialog>(this);
                 propertiesDialog.Closed += PropertiesDialog_Closed;
             }
         }
@@ -194,7 +194,7 @@ namespace Files
             }
             else
             {
-                propertiesDialog.Hide();
+                propertiesDialog?.Hide();
             }
         }
 
@@ -206,7 +206,7 @@ namespace Files
             }
             else
             {
-                propertiesDialog.Hide();
+                propertiesDialog?.Hide();
             }
         }
 
@@ -220,7 +220,7 @@ namespace Files
                 }
                 else
                 {
-                    propertiesDialog.Hide();
+                    propertiesDialog?.Hide();
                 }
             }
         }

--- a/Files/Views/SettingsPages/About.xaml.cs
+++ b/Files/Views/SettingsPages/About.xaml.cs
@@ -36,8 +36,10 @@ namespace Files.SettingsPages
             {
                 await Launcher.LaunchUriAsync(new Uri(@"https://paypal.me/yaichenbaum"));
             }
-
-            (FeedbackListView.Items[FeedbackListView.SelectedIndex] as ListViewItem).IsSelected = false;
+            if (FeedbackListView.SelectedIndex != -1)
+            {
+                (FeedbackListView.Items[FeedbackListView.SelectedIndex] as ListViewItem).IsSelected = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #2652

This PR fixes a few crashing bugs that were detected by AppCenter for version 0.23.
Each commit fixes a specific appcenter issue, the commit name is the appcenter error number.
These has been lumped in a single PR since they are mostly one-line fixes/exception handling, let me know if this is acceptable or if should I open a PR for each of them.

6e99d4f / [681497578u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/681497578u/overview)
Fixes an issue where the app crashes when updating the jump list

376cfbd / [1346245124u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/1346245124u/overview)
Fixes an issue where the app crashes when navigating up

462aad7 / [2134525649u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/2134525649u/overview)
Fixes an issue where the app crashes when tapping on an item in the About settings page

cf476b0 / [1407639912u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/1407639912u/overview)
Fixes an issue where the app crashes when opening file properties on Windows 1803

30362e7 / [1782844498u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/1782844498u/overview)
Fixes an issue where the app crashes when undoing a copy operation

0f26b5e / [4140837726u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/4140837726u/overview)
Fixes an issue where the app crashes when right clicking on the recyclebin sidebar item

c9530b6 / [661635400u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/661635400u/overview)
Fixes an issue where the app crashes when opening the context menu

c9530b6 / [470478233u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/470478233u/overview)
Fixes an issue where the app crashes due to an FileNotFoundException during file enumeration

62e84a6 / [2753013842u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/2753013842u/overview)
Fixes an issue where the app crashes on startup (#2652)

d06d3dc / [2511593153u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/2511593153u/overview)
Fixes an issue where the app crashes due to an ObjectDisposedException during file enumeration

6de25a4 / [3301491942u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/3301491942u/overview)
Fixes an issue where the app crashes due to an NotImplementedException during file enumeration