### PR TITLE
Allow different layout modes and sort directions for individual directories

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -283,10 +283,6 @@ namespace Files
         {
             if (ParentShellPageInstance.ContentPage != null)
             {
-                ParentShellPageInstance.FilesystemViewModel.CancelLoadAndClearFiles();
-                ParentShellPageInstance.FilesystemViewModel.IsLoadingItems = true;
-                ParentShellPageInstance.FilesystemViewModel.IsLoadingItems = false;
-
                 var layoutType = FolderSettings.GetLayoutType(ParentShellPageInstance.FilesystemViewModel.WorkingDirectory);
 
                 ParentShellPageInstance.ContentFrame.Navigate(layoutType, new NavigationArguments()

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -41,6 +41,8 @@ namespace Files
 
         public SettingsViewModel AppSettings => App.AppSettings;
 
+        public FolderSettingsViewModel FolderSettings => ParentShellPageInstance.InstanceViewModel.FolderSettings;
+
         public CurrentInstanceViewModel InstanceViewModel => ParentShellPageInstance.InstanceViewModel;
 
         public DirectoryPropertiesViewModel DirectoryPropertiesViewModel { get; }
@@ -277,7 +279,7 @@ namespace Files
 
         protected abstract ListedItem GetItemFromElement(object element);
 
-        private void AppSettings_LayoutModeChangeRequested(object sender, EventArgs e)
+        private void FolderSettings_LayoutModeChangeRequested(object sender, EventArgs e)
         {
             if (ParentShellPageInstance.ContentPage != null)
             {
@@ -285,7 +287,9 @@ namespace Files
                 ParentShellPageInstance.FilesystemViewModel.IsLoadingItems = true;
                 ParentShellPageInstance.FilesystemViewModel.IsLoadingItems = false;
 
-                ParentShellPageInstance.ContentFrame.Navigate(AppSettings.GetLayoutType(), new NavigationArguments()
+                var layoutType = FolderSettings.GetLayoutType(ParentShellPageInstance.FilesystemViewModel.WorkingDirectory);
+
+                ParentShellPageInstance.ContentFrame.Navigate(layoutType, new NavigationArguments()
                 {
                     NavPathParam = ParentShellPageInstance.FilesystemViewModel.WorkingDirectory,
                     AssociatedTabInstance = ParentShellPageInstance
@@ -304,12 +308,12 @@ namespace Files
         {
             base.OnNavigatedTo(eventArgs);
             // Add item jumping handler
-            AppSettings.LayoutModeChangeRequested += AppSettings_LayoutModeChangeRequested;
             Window.Current.CoreWindow.CharacterReceived += Page_CharacterReceived;
             var parameters = (NavigationArguments)eventArgs.Parameter;
             isSearchResultPage = parameters.IsSearchResultPage;
             ParentShellPageInstance = parameters.AssociatedTabInstance;
             IsItemSelected = false;
+            FolderSettings.LayoutModeChangeRequested += FolderSettings_LayoutModeChangeRequested;
             ParentShellPageInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
 
             if (!isSearchResultPage)
@@ -365,7 +369,7 @@ namespace Files
             ParentShellPageInstance.FilesystemViewModel.CancelLoadAndClearFiles(isSearchResultPage);
             // Remove item jumping handler
             Window.Current.CoreWindow.CharacterReceived -= Page_CharacterReceived;
-            AppSettings.LayoutModeChangeRequested -= AppSettings_LayoutModeChangeRequested;
+            FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
         }
 
         private void UnloadMenuFlyoutItemByName(string nameToUnload)
@@ -901,7 +905,7 @@ namespace Files
 
         public void GridViewSizeIncrease(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
-            AppSettings.GridViewSize = AppSettings.GridViewSize + Constants.Browser.GridViewBrowser.GridViewIncrement; // Make Larger
+            FolderSettings.GridViewSize = FolderSettings.GridViewSize + Constants.Browser.GridViewBrowser.GridViewIncrement; // Make Larger
             if (args != null)
             {
                 args.Handled = true;
@@ -910,7 +914,7 @@ namespace Files
 
         public void GridViewSizeDecrease(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
-            AppSettings.GridViewSize = AppSettings.GridViewSize - Constants.Browser.GridViewBrowser.GridViewIncrement; // Make Smaller
+            FolderSettings.GridViewSize = FolderSettings.GridViewSize - Constants.Browser.GridViewBrowser.GridViewIncrement; // Make Smaller
             if (args != null)
             {
                 args.Handled = true;

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -290,6 +290,9 @@ namespace Files
                     NavPathParam = ParentShellPageInstance.FilesystemViewModel.WorkingDirectory,
                     AssociatedTabInstance = ParentShellPageInstance
                 }, null);
+
+                // Remove old layout from back stack
+                ParentShellPageInstance.ContentFrame.BackStack.RemoveAt(ParentShellPageInstance.ContentFrame.BackStack.Count - 1);
             }
         }
 

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -358,6 +358,8 @@ namespace Files
             ParentShellPageInstance.InstanceViewModel.IsPageTypeNotHome = true; // show controls that were hidden on the home page
             ParentShellPageInstance.Clipboard_ContentChanged(null, null);
 
+            FolderSettings.IsLayoutModeChanging = false;
+
             cachedNewContextMenuEntries = await RegistryHelper.GetNewContextMenuEntries();
 
             FocusFileList(); // Set focus on layout specific file list control

--- a/Files/Enums/LayoutModes.cs
+++ b/Files/Enums/LayoutModes.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.Enums
+{
+    public enum LayoutModes
+    {
+        DetailsView = 0,
+        TilesView,
+        GridView
+    }
+}

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Converters\StringArrayToString.cs" />
     <Compile Include="Converters\UInt32ToString.cs" />
     <Compile Include="DataModels\ShellNewEntry.cs" />
+    <Compile Include="Enums\LayoutModes.cs" />
     <Compile Include="Helpers\AppUpdater.cs" />
     <Compile Include="DataModels\DefaultLanguageModel.cs" />
     <Compile Include="Enums\FileOperationType.cs" />

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -183,6 +183,7 @@
       <DependentUpon>RestartDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="Helpers\RegistryHelper.cs" />
+    <Compile Include="View Models\FolderSettingsViewModel.cs" />
     <Compile Include="View Models\Properties\FileProperty.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\LinqExtensions.cs" />

--- a/Files/Helpers/NativeFileOperationsHelper.cs
+++ b/Files/Helpers/NativeFileOperationsHelper.cs
@@ -210,19 +210,26 @@ namespace Files.Helpers
 
         public static void WriteStringToFile(string filePath, string str)
         {
-            IntPtr hStream = CreateFileFromApp(filePath,
-                    GENERIC_WRITE, 0, IntPtr.Zero, CREATE_ALWAYS, (uint)File_Attributes.BackupSemantics, IntPtr.Zero);
-            if (hStream.ToInt64() == -1) return;
-            byte[] buff = Encoding.UTF8.GetBytes(str);
-            int dwBytesWritten;
-            unsafe
+            if (str == null)
             {
-                fixed (byte* pBuff = buff)
-                {
-                    WriteFile(hStream, pBuff, buff.Length, &dwBytesWritten, IntPtr.Zero);
-                }
+                DeleteFileFromApp(filePath);
             }
-            CloseHandle(hStream);
+            else
+            {
+                IntPtr hStream = CreateFileFromApp(filePath,
+                    GENERIC_WRITE, 0, IntPtr.Zero, CREATE_ALWAYS, (uint)File_Attributes.BackupSemantics, IntPtr.Zero);
+                if (hStream.ToInt64() == -1) return;
+                byte[] buff = Encoding.UTF8.GetBytes(str);
+                int dwBytesWritten;
+                unsafe
+                {
+                    fixed (byte* pBuff = buff)
+                    {
+                        WriteFile(hStream, pBuff, buff.Length, &dwBytesWritten, IntPtr.Zero);
+                    }
+                }
+                CloseHandle(hStream);
+            }
         }
     }
 }

--- a/Files/Helpers/NativeFileOperationsHelper.cs
+++ b/Files/Helpers/NativeFileOperationsHelper.cs
@@ -210,26 +210,19 @@ namespace Files.Helpers
 
         public static void WriteStringToFile(string filePath, string str)
         {
-            if (str == null)
-            {
-                DeleteFileFromApp(filePath);
-            }
-            else
-            {
-                IntPtr hStream = CreateFileFromApp(filePath,
+            IntPtr hStream = CreateFileFromApp(filePath,
                     GENERIC_WRITE, 0, IntPtr.Zero, CREATE_ALWAYS, (uint)File_Attributes.BackupSemantics, IntPtr.Zero);
-                if (hStream.ToInt64() == -1) return;
-                byte[] buff = Encoding.UTF8.GetBytes(str);
-                int dwBytesWritten;
-                unsafe
+            if (hStream.ToInt64() == -1) return;
+            byte[] buff = Encoding.UTF8.GetBytes(str);
+            int dwBytesWritten;
+            unsafe
+            {
+                fixed (byte* pBuff = buff)
                 {
-                    fixed (byte* pBuff = buff)
-                    {
-                        WriteFile(hStream, pBuff, buff.Length, &dwBytesWritten, IntPtr.Zero);
-                    }
+                    WriteFile(hStream, pBuff, buff.Length, &dwBytesWritten, IntPtr.Zero);
                 }
-                CloseHandle(hStream);
             }
+            CloseHandle(hStream);
         }
     }
 }

--- a/Files/Helpers/NativeFileOperationsHelper.cs
+++ b/Files/Helpers/NativeFileOperationsHelper.cs
@@ -210,26 +210,19 @@ namespace Files.Helpers
 
         public static void WriteStringToFile(string filePath, string str)
         {
-            if (str == null)
+            IntPtr hStream = CreateFileFromApp(filePath,
+                GENERIC_WRITE, 0, IntPtr.Zero, CREATE_ALWAYS, (uint)File_Attributes.BackupSemantics, IntPtr.Zero);
+            if (hStream.ToInt64() == -1) return;
+            byte[] buff = Encoding.UTF8.GetBytes(str);
+            int dwBytesWritten;
+            unsafe
             {
-                DeleteFileFromApp(filePath);
-            }
-            else
-            {
-                IntPtr hStream = CreateFileFromApp(filePath,
-                    GENERIC_WRITE, 0, IntPtr.Zero, CREATE_ALWAYS, (uint)File_Attributes.BackupSemantics, IntPtr.Zero);
-                if (hStream.ToInt64() == -1) return;
-                byte[] buff = Encoding.UTF8.GetBytes(str);
-                int dwBytesWritten;
-                unsafe
+                fixed (byte* pBuff = buff)
                 {
-                    fixed (byte* pBuff = buff)
-                    {
-                        WriteFile(hStream, pBuff, buff.Length, &dwBytesWritten, IntPtr.Zero);
-                    }
+                    WriteFile(hStream, pBuff, buff.Length, &dwBytesWritten, IntPtr.Zero);
                 }
-                CloseHandle(hStream);
             }
+            CloseHandle(hStream);
         }
     }
 }

--- a/Files/Helpers/NativeFileOperationsHelper.cs
+++ b/Files/Helpers/NativeFileOperationsHelper.cs
@@ -192,7 +192,10 @@ namespace Files.Helpers
         {
             IntPtr hStream = CreateFileFromApp(filePath,
                 GENERIC_READ, 0, IntPtr.Zero, OPEN_EXISTING, (uint)File_Attributes.BackupSemantics, IntPtr.Zero);
-            if (hStream.ToInt64() == -1) return null;
+            if (hStream.ToInt64() == -1)
+            {
+                return null;
+            }
             byte[] buff = new byte[4096];
             int dwBytesRead;
             string str = null;
@@ -208,11 +211,14 @@ namespace Files.Helpers
             return str;
         }
 
-        public static void WriteStringToFile(string filePath, string str)
+        public static bool WriteStringToFile(string filePath, string str)
         {
             IntPtr hStream = CreateFileFromApp(filePath,
                 GENERIC_WRITE, 0, IntPtr.Zero, CREATE_ALWAYS, (uint)File_Attributes.BackupSemantics, IntPtr.Zero);
-            if (hStream.ToInt64() == -1) return;
+            if (hStream.ToInt64() == -1)
+            {
+                return false;
+            }
             byte[] buff = Encoding.UTF8.GetBytes(str);
             int dwBytesWritten;
             unsafe
@@ -223,6 +229,7 @@ namespace Files.Helpers
                 }
             }
             CloseHandle(hStream);
+            return true;
         }
     }
 }

--- a/Files/Helpers/NativeFileOperationsHelper.cs
+++ b/Files/Helpers/NativeFileOperationsHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using System.Text;
 
 namespace Files.Helpers
 {
@@ -36,6 +37,20 @@ namespace Files.Helpers
         }
 
         public const uint GENERIC_READ = 0x80000000;
+        public const uint GENERIC_WRITE = 0x40000000;
+
+        public const uint FILE_SHARE_READ = 0x00000001;
+        public const uint FILE_SHARE_WRITE = 0x00000002;
+        public const uint FILE_SHARE_DELETE = 0x00000004;
+
+        public const uint CREATE_ALWAYS = 2;
+        public const uint CREATE_NEW = 1;
+        public const uint OPEN_ALWAYS = 4;
+        public const uint OPEN_EXISTING = 3;
+        public const uint TRUNCATE_EXISTING = 5;
+
+        [DllImport("api-ms-win-core-handle-l1-1-0.dll")]
+        public static extern bool CloseHandle(IntPtr hObject);
 
         [DllImport("api-ms-win-core-file-fromapp-l1-1-0.dll", CharSet = CharSet.Auto,
         CallingConvention = CallingConvention.StdCall,
@@ -105,6 +120,28 @@ namespace Files.Helpers
             string lpFileName,
             System.IO.FileAttributes dwFileAttributes);
 
+        [DllImport("api-ms-win-core-file-l1-2-1.dll", CharSet = CharSet.Auto,
+        CallingConvention = CallingConvention.StdCall,
+        SetLastError = true)]
+        public unsafe static extern bool ReadFile(
+            IntPtr hFile,
+            byte* lpBuffer,
+            int nBufferLength,
+            int* lpBytesReturned,
+            IntPtr lpOverlapped
+        );
+
+        [DllImport("api-ms-win-core-file-l1-2-1.dll", CharSet = CharSet.Auto,
+        CallingConvention = CallingConvention.StdCall,
+        SetLastError = true)]
+        public unsafe static extern bool WriteFile(
+            IntPtr hFile,
+            byte* lpBuffer,
+            int nBufferLength,
+            int* lpBytesWritten,
+            IntPtr lpOverlapped
+        );
+
         public enum GET_FILEEX_INFO_LEVELS
         {
             GetFileExInfoStandard,
@@ -149,6 +186,50 @@ namespace Files.Helpers
                 return false;
             }
             return SetFileAttributesFromApp(lpFileName, lpFileInfo.dwFileAttributes & ~dwAttrs);
+        }
+
+        public static string ReadStringFromFile(string filePath)
+        {
+            IntPtr hStream = CreateFileFromApp(filePath,
+                GENERIC_READ, 0, IntPtr.Zero, OPEN_EXISTING, (uint)File_Attributes.BackupSemantics, IntPtr.Zero);
+            if (hStream.ToInt64() == -1) return null;
+            byte[] buff = new byte[4096];
+            int dwBytesRead;
+            string str = null;
+            unsafe
+            {
+                fixed (byte* pBuff = buff)
+                {
+                    ReadFile(hStream, pBuff, 4096 - 1, &dwBytesRead, IntPtr.Zero);
+                    str = Encoding.UTF8.GetString(pBuff, dwBytesRead);
+                }
+            }
+            CloseHandle(hStream);
+            return str;
+        }
+
+        public static void WriteStringToFile(string filePath, string str)
+        {
+            if (str == null)
+            {
+                DeleteFileFromApp(filePath);
+            }
+            else
+            {
+                IntPtr hStream = CreateFileFromApp(filePath,
+                    GENERIC_WRITE, 0, IntPtr.Zero, CREATE_ALWAYS, (uint)File_Attributes.BackupSemantics, IntPtr.Zero);
+                if (hStream.ToInt64() == -1) return;
+                byte[] buff = Encoding.UTF8.GetBytes(str);
+                int dwBytesWritten;
+                unsafe
+                {
+                    fixed (byte* pBuff = buff)
+                    {
+                        WriteFile(hStream, pBuff, buff.Length, &dwBytesWritten, IntPtr.Zero);
+                    }
+                }
+                CloseHandle(hStream);
+            }
         }
     }
 }

--- a/Files/INavigationToolbar.cs
+++ b/Files/INavigationToolbar.cs
@@ -53,7 +53,6 @@ namespace Files.UserControls
 
     public class PathNavigationEventArgs
     {
-        public Type LayoutType { get; set; }
         public string ItemPath { get; set; }
     }
 

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -505,12 +505,12 @@ namespace Files.Interacts
                                     //We can have many sort entries
                                     SortEntry sortEntry = new SortEntry()
                                     {
-                                        AscendingOrder = AppSettings.DirectorySortDirection == Microsoft.Toolkit.Uwp.UI.SortDirection.Ascending
+                                        AscendingOrder = FolderSettings.DirectorySortDirection == Microsoft.Toolkit.Uwp.UI.SortDirection.Ascending
                                     };
 
                                     //Basically we tell to the launched app to follow how we sorted the files in the directory.
 
-                                    var sortOption = AppSettings.DirectorySortOption;
+                                    var sortOption = FolderSettings.DirectorySortOption;
 
                                     switch (sortOption)
                                     {

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -55,6 +55,8 @@ namespace Files.Interacts
 
         public SettingsViewModel AppSettings => App.AppSettings;
 
+        public FolderSettingsViewModel FolderSettings => AssociatedInstance?.InstanceViewModel.FolderSettings;
+
         private AppServiceConnection Connection => AssociatedInstance?.ServiceConnection;
 
         public Interaction(IShellPage appInstance)
@@ -370,7 +372,7 @@ namespace Files.Interacts
             var destFolder = await AssociatedInstance.FilesystemViewModel.GetFolderWithPathFromPathAsync(folderPath);
             if (destFolder)
             {
-                AssociatedInstance.ContentFrame.Navigate(AppSettings.GetLayoutType(), new NavigationArguments()
+                AssociatedInstance.ContentFrame.Navigate(FolderSettings.GetLayoutType(folderPath), new NavigationArguments()
                 {
                     NavPathParam = folderPath,
                     AssociatedTabInstance = AssociatedInstance

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -398,7 +398,6 @@ namespace Files.Interacts
             }
 
             int selectedItemCount;
-            Type sourcePageType = AssociatedInstance.CurrentPageType;
             selectedItemCount = AssociatedInstance.ContentPage.SelectedItems.Count;
             var opened = (FilesystemResult)false;
             string previousDir = AssociatedInstance.FilesystemViewModel.WorkingDirectory;
@@ -429,7 +428,7 @@ namespace Files.Interacts
                         AssociatedInstance.NavigationToolbar.PathControlDisplayText = folderPath;
 
                         AssociatedInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
-                        AssociatedInstance.ContentFrame.Navigate(sourcePageType, new NavigationArguments()
+                        AssociatedInstance.ContentFrame.Navigate(AssociatedInstance.InstanceViewModel.FolderSettings.GetLayoutType(folderPath), new NavigationArguments()
                         {
                             NavPathParam = folderPath,
                             AssociatedTabInstance = AssociatedInstance
@@ -444,7 +443,7 @@ namespace Files.Interacts
                         AssociatedInstance.NavigationToolbar.PathControlDisplayText = clickedOnItemPath;
 
                         AssociatedInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
-                        AssociatedInstance.ContentFrame.Navigate(sourcePageType, new NavigationArguments()
+                        AssociatedInstance.ContentFrame.Navigate(AssociatedInstance.InstanceViewModel.FolderSettings.GetLayoutType(clickedOnItemPath), new NavigationArguments()
                         {
                             NavPathParam = clickedOnItemPath,
                             AssociatedTabInstance = AssociatedInstance

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -424,9 +424,7 @@ namespace Files.Interacts
                     }
                     if (opened)
                     {
-                        await AssociatedInstance.FilesystemViewModel.SetWorkingDirectoryAsync(folderPath);
                         AssociatedInstance.NavigationToolbar.PathControlDisplayText = folderPath;
-
                         AssociatedInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
                         AssociatedInstance.ContentFrame.Navigate(AssociatedInstance.InstanceViewModel.FolderSettings.GetLayoutType(folderPath), new NavigationArguments()
                         {
@@ -439,9 +437,7 @@ namespace Files.Interacts
                 {
                     if (clickedOnItem.PrimaryItemAttribute == StorageItemTypes.Folder)
                     {
-                        await AssociatedInstance.FilesystemViewModel.SetWorkingDirectoryAsync(clickedOnItemPath);
                         AssociatedInstance.NavigationToolbar.PathControlDisplayText = clickedOnItemPath;
-
                         AssociatedInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
                         AssociatedInstance.ContentFrame.Navigate(AssociatedInstance.InstanceViewModel.FolderSettings.GetLayoutType(clickedOnItemPath), new NavigationArguments()
                         {

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -1935,6 +1935,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -1934,6 +1934,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -1892,43 +1892,43 @@
         </trans-unit>
         <trans-unit id="UpdateConsentDialogCloseButtonText" translate="yes" xml:space="preserve">
           <source>No</source>
-          <target state="new">No</target>
+          <target state="translated">No</target>
         </trans-unit>
         <trans-unit id="UpdateConsentDialogContent" translate="yes" xml:space="preserve">
           <source>Do you want to download and install the latest version of Files?</source>
-          <target state="new">Do you want to download and install the latest version of Files?</target>
+          <target state="translated">¿Quieres descargar e instalar la última versión de Files?</target>
         </trans-unit>
         <trans-unit id="UpdateConsentDialogPrimaryButtonText" translate="yes" xml:space="preserve">
           <source>Yes</source>
-          <target state="new">Yes</target>
+          <target state="translated">Si</target>
         </trans-unit>
         <trans-unit id="UpdateConsentDialogTitle" translate="yes" xml:space="preserve">
           <source>Updates Available</source>
-          <target state="new">Updates Available</target>
+          <target state="translated">Actualizaciones disponibles</target>
         </trans-unit>
         <trans-unit id="SettingsFilesAndFoldersHideSystemItems.Header" translate="yes" xml:space="preserve">
           <source>Hide protected operating system files (Recommended)</source>
-          <target state="new">Hide protected operating system files (Recommended)</target>
+          <target state="translated">Ocultar archivos protegidos del sistema operativo (Recomendado)</target>
         </trans-unit>
         <trans-unit id="SettingsFilesAndFoldersHideSystemItems.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Hide protected operating system files (Recommended)</source>
-          <target state="new">Hide protected operating system files (Recommended)</target>
+          <target state="translated">Ocultar archivos protegidos del sistema operativo (Recomendado)</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutNewFile.Text" translate="yes" xml:space="preserve">
           <source>File</source>
-          <target state="new">File</target>
+          <target state="translated">Archivo</target>
         </trans-unit>
         <trans-unit id="AddDialogListFileHeader" translate="yes" xml:space="preserve">
           <source>File</source>
-          <target state="new">File</target>
+          <target state="translated">Archivo</target>
         </trans-unit>
         <trans-unit id="AddDialogListFileSubHeader" translate="yes" xml:space="preserve">
           <source>Creates an empty file</source>
-          <target state="new">Creates an empty file</target>
+          <target state="translated">Crea un archivo vacío</target>
         </trans-unit>
         <trans-unit id="NewFile" translate="yes" xml:space="preserve">
           <source>New File</source>
-          <target state="new">New File</target>
+          <target state="translated">Nuevo archivo</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="fr-FR" original="FILES/STRINGS/EN-US/RESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
-      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.6915.0" tool-company="Microsoft"/>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.6915.0" tool-company="Microsoft" />
     </header>
     <body>
       <group id="FILES/STRINGS/EN-US/RESOURCES.RESW" datatype="resx">
@@ -1933,6 +1933,14 @@
         <trans-unit id="SettingsSearchUnindexedItems.Header" translate="yes" xml:space="preserve">
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.he-IL.xlf
+++ b/Files/MultilingualResources/Files.he-IL.xlf
@@ -1934,6 +1934,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.hi-IN.xlf
+++ b/Files/MultilingualResources/Files.hi-IN.xlf
@@ -1944,6 +1944,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.hu-HU.xlf
+++ b/Files/MultilingualResources/Files.hu-HU.xlf
@@ -1934,6 +1934,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -1933,7 +1933,15 @@
         </trans-unit>
         <trans-unit id="SettingsSearchUnindexedItems.Header" translate="yes" xml:space="preserve">
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
-          <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
+          <target state="translated">Mostra contenuti non indicizzati durante la ricerca (più lento)</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="translated">Abilita impostazioni di visualizzazione per cartella</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="translated">Abilita impostazioni di visualizzazione per cartella</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -1934,6 +1934,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -1946,6 +1946,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.or-IN.xlf
+++ b/Files/MultilingualResources/Files.or-IN.xlf
@@ -1944,6 +1944,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -1943,6 +1943,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.pt-BR.xlf
+++ b/Files/MultilingualResources/Files.pt-BR.xlf
@@ -1934,6 +1934,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -1934,6 +1934,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -1939,6 +1939,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -1941,6 +1941,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -1934,6 +1934,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -1939,6 +1939,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.zh-Hant.xlf
+++ b/Files/MultilingualResources/Files.zh-Hant.xlf
@@ -1943,6 +1943,14 @@
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
           <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
         </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
+        <trans-unit id="SettingsAreLayoutPreferencesPerFolder.Header" translate="yes" xml:space="preserve">
+          <source>Enable folder view preferences per folder</source>
+          <target state="new">Enable folder view preferences per folder</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -1563,4 +1563,10 @@
   <data name="SettingsSearchUnindexedItems.Header" xml:space="preserve">
     <value>Show unindexed items when searching for files and folders (searches may take longer)</value>
   </data>
+  <data name="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" xml:space="preserve">
+    <value>Enable folder view preferences per folder</value>
+  </data>
+  <data name="SettingsAreLayoutPreferencesPerFolder.Header" xml:space="preserve">
+    <value>Enable folder view preferences per folder</value>
+  </data>
 </root>

--- a/Files/Strings/es-ES/Resources.resw
+++ b/Files/Strings/es-ES/Resources.resw
@@ -1392,4 +1392,34 @@
   <data name="PropertiesDialogTabDetails.Content" xml:space="preserve">
     <value>Detalles</value>
   </data>
+  <data name="UpdateConsentDialogCloseButtonText" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="UpdateConsentDialogContent" xml:space="preserve">
+    <value>¿Quieres descargar e instalar la última versión de Files?</value>
+  </data>
+  <data name="UpdateConsentDialogPrimaryButtonText" xml:space="preserve">
+    <value>Si</value>
+  </data>
+  <data name="UpdateConsentDialogTitle" xml:space="preserve">
+    <value>Actualizaciones disponibles</value>
+  </data>
+  <data name="SettingsFilesAndFoldersHideSystemItems.Header" xml:space="preserve">
+    <value>Ocultar archivos protegidos del sistema operativo (Recomendado)</value>
+  </data>
+  <data name="SettingsFilesAndFoldersHideSystemItems.AutomationProperties.Name" xml:space="preserve">
+    <value>Ocultar archivos protegidos del sistema operativo (Recomendado)</value>
+  </data>
+  <data name="BaseLayoutContextFlyoutNewFile.Text" xml:space="preserve">
+    <value>Archivo</value>
+  </data>
+  <data name="AddDialogListFileHeader" xml:space="preserve">
+    <value>Archivo</value>
+  </data>
+  <data name="AddDialogListFileSubHeader" xml:space="preserve">
+    <value>Crea un archivo vacío</value>
+  </data>
+  <data name="NewFile" xml:space="preserve">
+    <value>Nuevo archivo</value>
+  </data>
 </root>

--- a/Files/Strings/fr-FR/Resources.resw
+++ b/Files/Strings/fr-FR/Resources.resw
@@ -1047,14 +1047,29 @@
   <data name="PropertiesDialogHidden.Text" xml:space="preserve">
     <value>Caché</value>
   </data>
+  <data name="PropertyItemFolderPathDisplay" xml:space="preserve">
+    <value>Chemin du dossier</value>
+  </data>
+  <data name="PropertyItemTypeText" xml:space="preserve">
+    <value>Type d'élément</value>
+  </data>
   <data name="PropertyTitle" xml:space="preserve">
     <value>Titre</value>
+  </data>
+  <data name="PropertySubject" xml:space="preserve">
+    <value>Objet</value>
   </data>
   <data name="PropertyComment" xml:space="preserve">
     <value>Commentaires</value>
   </data>
   <data name="PropertyCopyright" xml:space="preserve">
     <value>Copyright</value>
+  </data>
+  <data name="PropertyDateCreated" xml:space="preserve">
+    <value>Date de création</value>
+  </data>
+  <data name="PropertyDateModified" xml:space="preserve">
+    <value>Date de modification</value>
   </data>
   <data name="PropertyBitDepth" xml:space="preserve">
     <value>Profondeur de couleur</value>
@@ -1067,6 +1082,12 @@
   </data>
   <data name="PropertyVerticalResolution" xml:space="preserve">
     <value>Résolution verticale</value>
+  </data>
+  <data name="PropertyHorizontalSize" xml:space="preserve">
+    <value>Largeur</value>
+  </data>
+  <data name="PropertyVerticalSize" xml:space="preserve">
+    <value>Hauteur</value>
   </data>
   <data name="PropertyLatitude" xml:space="preserve">
     <value>Latitude</value>
@@ -1110,6 +1131,18 @@
   <data name="PropertyYear" xml:space="preserve">
     <value>Année</value>
   </data>
+  <data name="PropertySectionCore" xml:space="preserve">
+    <value>Fichier</value>
+  </data>
+  <data name="PropertySectionImage" xml:space="preserve">
+    <value>Image</value>
+  </data>
+  <data name="PropertySectionMusic" xml:space="preserve">
+    <value>Musique</value>
+  </data>
+  <data name="PropertyContributor" xml:space="preserve">
+    <value>Contributeur</value>
+  </data>
   <data name="PropertyVersion" xml:space="preserve">
     <value>Version</value>
   </data>
@@ -1143,6 +1176,9 @@
   <data name="PropertyColorSpace_Value65535" xml:space="preserve">
     <value>Non spécifié</value>
   </data>
+  <data name="StatusCenterTeachingTip.Title" xml:space="preserve">
+    <value>Centre de status</value>
+  </data>
   <data name="SettingsAboutLicense.AutomationProperties.Name" xml:space="preserve">
     <value>Licence</value>
   </data>
@@ -1157,5 +1193,59 @@
   </data>
   <data name="SettingsAppearanceDateFormatsTip.AutomationProperties.Name" xml:space="preserve">
     <value>En savoir plus sur les formats de date</value>
+  </data>
+  <data name="NavSearchButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Rechercher</value>
+  </data>
+  <data name="SearchPagePathBoxOverrideText" xml:space="preserve">
+    <value>Résultats de recherche dans</value>
+  </data>
+  <data name="SearchTabHeaderText" xml:space="preserve">
+    <value>Résultats de recherche</value>
+  </data>
+  <data name="SettingsAboutContributorsListViewItem.AutomationProperties.Name" xml:space="preserve">
+    <value>Voir qui a contribué à Files</value>
+  </data>
+  <data name="SettingsAboutReleaseNotesListViewItem.AutomationProperties.Name" xml:space="preserve">
+    <value>Découvrez les nouveautés de Files</value>
+  </data>
+  <data name="SettingsAboutSupportUsListViewItem.AutomationProperties.Name" xml:space="preserve">
+    <value>Soutenez-nous sur PayPal</value>
+  </data>
+  <data name="SettingsListAndSortDirectoriesAlongsideFiles.Header" xml:space="preserve">
+    <value>Lister et trier les dossiers au milieu des fichiers</value>
+  </data>
+  <data name="PropertiesDialogTabDetails.Content" xml:space="preserve">
+    <value>Détails</value>
+  </data>
+  <data name="UpdateConsentDialogCloseButtonText" xml:space="preserve">
+    <value>Non</value>
+  </data>
+  <data name="UpdateConsentDialogContent" xml:space="preserve">
+    <value>Voulez-vous télécharger et installer la dernière version de Files ?</value>
+  </data>
+  <data name="UpdateConsentDialogPrimaryButtonText" xml:space="preserve">
+    <value>Oui</value>
+  </data>
+  <data name="UpdateConsentDialogTitle" xml:space="preserve">
+    <value>Mise à jour disponible</value>
+  </data>
+  <data name="SettingsFilesAndFoldersHideSystemItems.Header" xml:space="preserve">
+    <value>Masquer les fichiers protégés du système (Recommandé)</value>
+  </data>
+  <data name="SettingsFilesAndFoldersHideSystemItems.AutomationProperties.Name" xml:space="preserve">
+    <value>Masquer les fichiers protégés du système (Recommandé)</value>
+  </data>
+  <data name="BaseLayoutContextFlyoutNewFile.Text" xml:space="preserve">
+    <value>Fichier</value>
+  </data>
+  <data name="AddDialogListFileHeader" xml:space="preserve">
+    <value>Fichier</value>
+  </data>
+  <data name="AddDialogListFileSubHeader" xml:space="preserve">
+    <value>Crée un fichier vide</value>
+  </data>
+  <data name="NewFile" xml:space="preserve">
+    <value>Nouveau fichier</value>
   </data>
 </root>

--- a/Files/Strings/hu-HU/Resources.resw
+++ b/Files/Strings/hu-HU/Resources.resw
@@ -1152,6 +1152,9 @@
   <data name="PropertyAperture" xml:space="preserve">
     <value>Rekesz</value>
   </data>
+  <data name="PropertyChannelCount" xml:space="preserve">
+    <value>Csatornák száma</value>
+  </data>
   <data name="PropertyFormat" xml:space="preserve">
     <value>Formátum</value>
   </data>
@@ -1193,6 +1196,18 @@
   </data>
   <data name="PropertyPublisher" xml:space="preserve">
     <value>Kiadó</value>
+  </data>
+  <data name="PropertyThumbnailLargePath" xml:space="preserve">
+    <value>Nagy indexkép Path</value>
+  </data>
+  <data name="PropertyThumbnailLargeUri" xml:space="preserve">
+    <value>Nagy indexkép URI</value>
+  </data>
+  <data name="PropertyThumbnailSmallPath" xml:space="preserve">
+    <value>Kis indexkép Path</value>
+  </data>
+  <data name="PropertyThumbnailSmallUri" xml:space="preserve">
+    <value>Kis indexkép URI</value>
   </data>
   <data name="PropertyWriter" xml:space="preserve">
     <value>Író</value>
@@ -1373,5 +1388,23 @@
   </data>
   <data name="UpdateConsentDialogTitle" xml:space="preserve">
     <value>Frissítés elérhető</value>
+  </data>
+  <data name="SettingsFilesAndFoldersHideSystemItems.Header" xml:space="preserve">
+    <value>Védett operációs rendszer fájlok elrejtése (Ajánlott)</value>
+  </data>
+  <data name="SettingsFilesAndFoldersHideSystemItems.AutomationProperties.Name" xml:space="preserve">
+    <value>Védett operációs rendszer fájlok elrejtése (Ajánlott)</value>
+  </data>
+  <data name="BaseLayoutContextFlyoutNewFile.Text" xml:space="preserve">
+    <value>Fájl</value>
+  </data>
+  <data name="AddDialogListFileHeader" xml:space="preserve">
+    <value>Fájl</value>
+  </data>
+  <data name="AddDialogListFileSubHeader" xml:space="preserve">
+    <value>Létrehoz egy üres fájlt</value>
+  </data>
+  <data name="NewFile" xml:space="preserve">
+    <value>Új Fájl</value>
   </data>
 </root>

--- a/Files/Strings/it-IT/Resources.resw
+++ b/Files/Strings/it-IT/Resources.resw
@@ -1455,4 +1455,13 @@
   <data name="NewFile" xml:space="preserve">
     <value>Nuovo File</value>
   </data>
+  <data name="SettingsSearchUnindexedItems.Header" xml:space="preserve">
+    <value>Mostra contenuti non indicizzati durante la ricerca (più lento)</value>
+  </data>
+  <data name="SettingsAreLayoutPreferencesPerFolder.AutomationProperties.Name" xml:space="preserve">
+    <value>Abilita impostazioni di visualizzazione per cartella</value>
+  </data>
+  <data name="SettingsAreLayoutPreferencesPerFolder.Header" xml:space="preserve">
+    <value>Abilita impostazioni di visualizzazione per cartella</value>
+  </data>
 </root>

--- a/Files/UserControls/MultitaskingControl/BaseMultitaskingControl.cs
+++ b/Files/UserControls/MultitaskingControl/BaseMultitaskingControl.cs
@@ -192,9 +192,9 @@ namespace Files.UserControls.MultitaskingControl
             RemoveTab(args.Item as TabItem);
         }
 
-        protected void TabView_AddTabButtonClick(TabView sender, object args)
+        protected async void TabView_AddTabButtonClick(TabView sender, object args)
         {
-            MainPage.AddNewTabAsync();
+            await MainPage.AddNewTabAsync();
         }
 
         public void MultitaskingControl_Loaded(object sender, RoutedEventArgs e)

--- a/Files/UserControls/NavigationToolbar.xaml.cs
+++ b/Files/UserControls/NavigationToolbar.xaml.cs
@@ -632,8 +632,7 @@ namespace Files.UserControls
                             dragOverTimer.Stop();
                             ItemDraggedOverPathItem?.Invoke(this, new PathNavigationEventArgs()
                             {
-                                ItemPath = dragOverPath,
-                                LayoutType = AppSettings.GetLayoutType()
+                                ItemPath = dragOverPath
                             });
                             dragOverPath = null;
                         }
@@ -717,8 +716,7 @@ namespace Files.UserControls
             var itemTappedPath = ((sender as TextBlock).DataContext as PathBoxItem).Path;
             ToolbarPathItemInvoked?.Invoke(this, new PathNavigationEventArgs()
             {
-                ItemPath = itemTappedPath,
-                LayoutType = AppSettings.GetLayoutType()
+                ItemPath = itemTappedPath
             });
         }
 

--- a/Files/UserControls/StatusBarControl.xaml
+++ b/Files/UserControls/StatusBarControl.xaml
@@ -115,7 +115,7 @@
                     <MenuFlyout>
                         <MenuFlyoutItem
                             x:Uid="StatusBarControlGridViewLarge"
-                            Command="{x:Bind AppSettings.ToggleLayoutModeGridViewLarge}"
+                            Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewLarge}"
                             Text="Grid View (Large)">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xE9A0;" />
@@ -123,7 +123,7 @@
                         </MenuFlyoutItem>
                         <MenuFlyoutItem
                             x:Uid="StatusBarControlGridViewMedium"
-                            Command="{x:Bind AppSettings.ToggleLayoutModeGridViewMedium}"
+                            Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewMedium}"
                             Text="Grid View (Medium)">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEA72;" />
@@ -131,7 +131,7 @@
                         </MenuFlyoutItem>
                         <MenuFlyoutItem
                             x:Uid="StatusBarControlGridViewSmall"
-                            Command="{x:Bind AppSettings.ToggleLayoutModeGridViewSmall}"
+                            Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewSmall}"
                             Text="Grid View (Small)">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEBA1;" />
@@ -139,7 +139,7 @@
                         </MenuFlyoutItem>
                         <MenuFlyoutItem
                             x:Uid="StatusBarControlTilesView"
-                            Command="{x:Bind AppSettings.ToggleLayoutModeTiles}"
+                            Command="{x:Bind FolderSettings.ToggleLayoutModeTiles}"
                             Text="Tiles View">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF100;" />
@@ -147,7 +147,7 @@
                         </MenuFlyoutItem>
                         <MenuFlyoutItem
                             x:Uid="StatusBarControlDetailsView"
-                            Command="{x:Bind AppSettings.ToggleLayoutModeDetailsView}"
+                            Command="{x:Bind FolderSettings.ToggleLayoutModeDetailsView}"
                             Text="Details View">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF101;" />

--- a/Files/UserControls/StatusBarControl.xaml.cs
+++ b/Files/UserControls/StatusBarControl.xaml.cs
@@ -8,6 +8,7 @@ namespace Files.UserControls
     public sealed partial class StatusBarControl : UserControl
     {
         public SettingsViewModel AppSettings => App.AppSettings;
+        public FolderSettingsViewModel FolderSettings { get; set; } = null;
         public DirectoryPropertiesViewModel DirectoryPropertiesViewModel { get; set; } = null;
         public SelectedItemsPropertiesViewModel SelectedItemsPropertiesViewModel { get; set; } = null;
         public ICommand SelectAllInvokedCommand { get; set; }

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -52,14 +52,12 @@ namespace Files
 
             DrivesWidgetInvoked?.Invoke(this, new DrivesWidgetInvokedEventArgs()
             {
-                Path = NavigationPath,
-                LayoutType = AppSettings.GetLayoutType()
+                Path = NavigationPath
             });
         }
 
         public class DrivesWidgetInvokedEventArgs : EventArgs
         {
-            public Type LayoutType { get; set; }
             public string Path { get; set; }
         }
 

--- a/Files/UserControls/Widgets/LibraryCards.xaml.cs
+++ b/Files/UserControls/Widgets/LibraryCards.xaml.cs
@@ -108,15 +108,13 @@ namespace Files
             }
             LibraryCardInvoked?.Invoke(this, new LibraryCardInvokedEventArgs()
             {
-                Path = NavigationPath,
-                LayoutType = AppSettings.GetLayoutType()
+                Path = NavigationPath
             });
         }
     }
 
     public class LibraryCardInvokedEventArgs : EventArgs
     {
-        public Type LayoutType { get; set; }
         public string Path { get; set; }
     }
 

--- a/Files/UserControls/Widgets/RecentFiles.xaml.cs
+++ b/Files/UserControls/Widgets/RecentFiles.xaml.cs
@@ -48,8 +48,7 @@ namespace Files
                 var folderPath = filePath.Substring(0, filePath.Length - clickedOnItem.Name.Length);
                 RecentFilesOpenLocationInvoked?.Invoke(this, new PathNavigationEventArgs()
                 {
-                    ItemPath = folderPath,
-                    LayoutType = AppSettings.GetLayoutType()
+                    ItemPath = folderPath
                 });
             }
         }
@@ -149,8 +148,7 @@ namespace Files
             var path = (e.ClickedItem as RecentItem).RecentPath;
             RecentFileInvoked?.Invoke(this, new PathNavigationEventArgs()
             {
-                ItemPath = path,
-                LayoutType = AppSettings.GetLayoutType()
+                ItemPath = path
             });
         }
 

--- a/Files/View Models/CurrentInstanceViewModel.cs
+++ b/Files/View Models/CurrentInstanceViewModel.cs
@@ -11,6 +11,13 @@ namespace Files.View_Models
          * values being manipulated inside the setter blocks.
          */
 
+        public FolderSettingsViewModel FolderSettings { get; }
+
+        public CurrentInstanceViewModel(IShellPage associatedInstance)
+        {
+            FolderSettings = new FolderSettingsViewModel(associatedInstance);
+        }
+
         private bool _IsPageTypeSearchResults = false;
 
         public bool IsPageTypeSearchResults

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -288,14 +288,6 @@ namespace Files.View_Models
                 this.DirectorySortDirection = App.AppSettings.DefaultDirectorySortDirection;
             }
 
-            public LayoutPreferences(LayoutModes layoutMode, int gridViewSize, SortOption sortOption, SortDirection sortDirection)
-            {
-                this.LayoutMode = layoutMode;
-                this.GridViewSize = gridViewSize;
-                this.DirectorySortOption = sortOption;
-                this.DirectorySortDirection = sortDirection;
-            }
-
             public static LayoutPreferences FromCompositeValue(ApplicationDataCompositeValue compositeValue)
             {
                 var layoutPreference = new LayoutPreferences();

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -4,7 +4,6 @@ using Microsoft.Toolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp.UI;
 using Newtonsoft.Json;
 using System;
-using System.IO;
 using Windows.Storage;
 
 namespace Files.View_Models
@@ -214,7 +213,7 @@ namespace Files.View_Models
 
         private static LayoutPreferences GetLayoutPreferencesForPath(string folderPath)
         {
-            var str = Helpers.NativeFileOperationsHelper.ReadStringFromFile(Path.Combine(folderPath,"files.desktop.ini"));
+            var str = Helpers.NativeFileOperationsHelper.ReadStringFromFile($"{folderPath}:files_layoutmode");
             if (string.IsNullOrEmpty(str))
             {
                 return LayoutPreferences.DefaultLayoutPreferences; // Either global setting or smart guess
@@ -224,14 +223,12 @@ namespace Files.View_Models
 
         private static void UpdateLayoutPreferencesForPath(string folderPath, LayoutPreferences prefs)
         {
-            var settingsFilePath = Path.Combine(folderPath, "files.desktop.ini");
             if (prefs == LayoutPreferences.DefaultLayoutPreferences)
             {
-                Helpers.NativeFileOperationsHelper.DeleteFileFromApp(settingsFilePath);
+                Helpers.NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", null);
                 return; // Do not create setting if it's default
             }
-            Helpers.NativeFileOperationsHelper.WriteStringToFile(settingsFilePath, JsonConvert.SerializeObject(prefs));
-            Helpers.NativeFileOperationsHelper.SetFileAttribute(settingsFilePath, System.IO.FileAttributes.Hidden);
+            Helpers.NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", JsonConvert.SerializeObject(prefs));
         }
 
         private LayoutPreferences LayoutPreference { get; set; }

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -213,7 +213,7 @@ namespace Files.View_Models
 
         private static LayoutPreferences GetLayoutPreferencesForPath(string folderPath)
         {
-            var str = Helpers.NativeFileOperationsHelper.ReadStringFromFile(System.IO.Path.Combine(folderPath, "files.desktop.ini"));
+            var str = Helpers.NativeFileOperationsHelper.ReadStringFromFile($"{folderPath}:files_layoutmode");
             if (string.IsNullOrEmpty(str))
             {
                 return LayoutPreferences.DefaultLayoutPreferences; // Either global setting or smart guess
@@ -223,14 +223,12 @@ namespace Files.View_Models
 
         private static void UpdateLayoutPreferencesForPath(string folderPath, LayoutPreferences prefs)
         {
-            var prefsFilePath = System.IO.Path.Combine(folderPath, "files.desktop.ini");
             if (LayoutPreferences.DefaultLayoutPreferences.Equals(prefs))
             {
-                Helpers.NativeFileOperationsHelper.DeleteFileFromApp(prefsFilePath);
+                Helpers.NativeFileOperationsHelper.DeleteFileFromApp($"{folderPath}:files_layoutmode");
                 return; // Do not create setting if it's default
             }
-            Helpers.NativeFileOperationsHelper.WriteStringToFile(prefsFilePath, JsonConvert.SerializeObject(prefs));
-            Helpers.NativeFileOperationsHelper.SetFileAttribute(prefsFilePath, System.IO.FileAttributes.Hidden);
+            Helpers.NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", JsonConvert.SerializeObject(prefs));
         }
 
         private LayoutPreferences LayoutPreference { get; set; }

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -225,7 +225,7 @@ namespace Files.View_Models
         {
             if (prefs == LayoutPreferences.DefaultLayoutPreferences)
             {
-                Helpers.NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", null);
+                Helpers.NativeFileOperationsHelper.DeleteFileFromApp($"{folderPath}:files_layoutmode");
                 return; // Do not create setting if it's default
             }
             Helpers.NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", JsonConvert.SerializeObject(prefs));

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -29,7 +29,6 @@ namespace Files.View_Models
                 if (layoutMode != value)
                 {
                     SetLayoutModeForPath(associatedInstance.FilesystemViewModel.WorkingDirectory, value, gridViewSize);
-                    IsLayoutModeChanging = true;
                 }
                 SetProperty(ref layoutMode, value);
             }
@@ -45,7 +44,12 @@ namespace Files.View_Models
 
         public Type GetLayoutType(string folderPath)
         {
-            (LayoutMode, GridViewSize) = GetLayoutModeForPath(folderPath);
+            var oldLayoutMode = layoutMode;
+            (layoutMode, gridViewSize) = GetLayoutModeForPath(folderPath);
+            if (oldLayoutMode != layoutMode)
+            {
+                IsLayoutModeChanging = true;
+            }
 
             Type type = null;
             switch (LayoutMode)

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -121,8 +121,9 @@ namespace Files.View_Models
                     }
                     else if (LayoutMode != 0) // Resize grid view
                     {
-                        gridViewSize = (value >= Constants.Browser.GridViewBrowser.GridViewSizeSmall) ? value : Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Set grid size to allow immediate UI update
+                        var newValue = (value >= Constants.Browser.GridViewBrowser.GridViewSizeSmall) ? value : Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Set grid size to allow immediate UI update
                         //Set(value);
+                        SetProperty(ref gridViewSize, newValue);
 
                         if (LayoutMode != 2) // Only update layout mode if it isn't already in grid view
                         {
@@ -144,8 +145,9 @@ namespace Files.View_Models
                     }
                     else // Size up from tiles to grid
                     {
-                        gridViewSize = (LayoutMode == 1) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeMax) ? value : Constants.Browser.GridViewBrowser.GridViewSizeMax; // Set grid size to allow immediate UI update
+                        var newValue = (LayoutMode == 1) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeMax) ? value : Constants.Browser.GridViewBrowser.GridViewSizeMax; // Set grid size to allow immediate UI update
                         //Set(gridViewSize);
+                        SetProperty(ref gridViewSize, newValue);
 
                         if (LayoutMode != 2) // Only update layout mode if it isn't already in grid view
                         {

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -1,0 +1,166 @@
+﻿using Microsoft.Toolkit.Mvvm.ComponentModel;
+using Microsoft.Toolkit.Mvvm.Input;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.View_Models
+{
+    public class FolderSettingsViewModel : ObservableObject
+    {
+        private IShellPage associatedInstance;
+
+        public FolderSettingsViewModel(IShellPage associatedInstance)
+        {
+            this.associatedInstance = associatedInstance;
+            DetectGridViewSize();
+        }
+
+        private int layoutMode;
+        public int LayoutMode
+        {
+            get => layoutMode; // Details View
+            set => SetProperty(ref layoutMode, value);
+        }
+
+        public Type GetLayoutType(string folderPath)
+        {
+            Type type = null;
+            switch (LayoutMode)
+            {
+                case 0:
+                    type = typeof(GenericFileBrowser);
+                    break;
+
+                case 1:
+                    type = typeof(GridViewBrowser);
+                    break;
+
+                case 2:
+                    type = typeof(GridViewBrowser);
+                    break;
+
+                default:
+                    type = typeof(GenericFileBrowser);
+                    break;
+            }
+            return type;
+        }
+
+        public event EventHandler LayoutModeChangeRequested;
+        public event EventHandler GridViewSizeChangeRequested;
+
+        public RelayCommand ToggleLayoutModeGridViewLarge => new RelayCommand(() =>
+        {
+            LayoutMode = 2; // Grid View
+
+            GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeLarge; // Size
+
+            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
+        });
+
+        public RelayCommand ToggleLayoutModeGridViewMedium => new RelayCommand(() =>
+        {
+            LayoutMode = 2; // Grid View
+
+            GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeMedium; // Size
+
+            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
+        });
+
+        public RelayCommand ToggleLayoutModeGridViewSmall => new RelayCommand(() =>
+        {
+            LayoutMode = 2; // Grid View
+
+            GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Size
+
+            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
+        });
+
+        public RelayCommand ToggleLayoutModeTiles => new RelayCommand(() =>
+        {
+            LayoutMode = 1; // Tiles View
+
+            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
+        });
+
+        public RelayCommand ToggleLayoutModeDetailsView => new RelayCommand(() =>
+        {
+            LayoutMode = 0; // Details View
+
+            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
+        });
+
+        private void DetectGridViewSize()
+        {
+            //gridViewSize = Get(Constants.Browser.GridViewBrowser.GridViewSizeSmall, "GridViewSize"); // Get GridView Size
+        }
+
+        private int gridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Default Size
+
+        public int GridViewSize
+        {
+            get => gridViewSize;
+            set
+            {
+                if (value < gridViewSize) // Size down
+                {
+                    if (LayoutMode == 1) // Size down from tiles to list
+                    {
+                        LayoutMode = 0;
+                        //Set(0, "LayoutMode");
+                        LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
+                    }
+                    else if (LayoutMode == 2 && value < Constants.Browser.GridViewBrowser.GridViewSizeSmall) // Size down from grid to tiles
+                    {
+                        LayoutMode = 1;
+                        //Set(1, "LayoutMode");
+                        LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
+                    }
+                    else if (LayoutMode != 0) // Resize grid view
+                    {
+                        gridViewSize = (value >= Constants.Browser.GridViewBrowser.GridViewSizeSmall) ? value : Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Set grid size to allow immediate UI update
+                        //Set(value);
+
+                        if (LayoutMode != 2) // Only update layout mode if it isn't already in grid view
+                        {
+                            LayoutMode = 2;
+                            //Set(2, "LayoutMode");
+                            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
+                        }
+
+                        GridViewSizeChangeRequested?.Invoke(this, EventArgs.Empty);
+                    }
+                }
+                else // Size up
+                {
+                    if (LayoutMode == 0) // Size up from list to tiles
+                    {
+                        LayoutMode = 1;
+                        //Set(1, "LayoutMode");
+                        LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
+                    }
+                    else // Size up from tiles to grid
+                    {
+                        gridViewSize = (LayoutMode == 1) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeMax) ? value : Constants.Browser.GridViewBrowser.GridViewSizeMax; // Set grid size to allow immediate UI update
+                        //Set(gridViewSize);
+
+                        if (LayoutMode != 2) // Only update layout mode if it isn't already in grid view
+                        {
+                            LayoutMode = 2;
+                            //Set(2, "LayoutMode");
+                            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
+                        }
+
+                        if (value < Constants.Browser.GridViewBrowser.GridViewSizeMax) // Don't request a grid resize if it is already at the max size
+                        {
+                            GridViewSizeChangeRequested?.Invoke(this, EventArgs.Empty);
+                        }
+                    }
+                }
+            }
+        }        
+    }
+}

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Files.Enums;
+using Files.Helpers;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp.UI;
@@ -52,15 +53,15 @@ namespace Files.View_Models
             Type type = null;
             switch (LayoutMode)
             {
-                case LayoutModes.DETAILS_VIEW:
+                case LayoutModes.DetailsView:
                     type = typeof(GenericFileBrowser);
                     break;
 
-                case LayoutModes.TILES_VIEW:
+                case LayoutModes.TilesView:
                     type = typeof(GridViewBrowser);
                     break;
 
-                case LayoutModes.GRID_VIEW:
+                case LayoutModes.GridView:
                     type = typeof(GridViewBrowser);
                     break;
 
@@ -76,7 +77,7 @@ namespace Files.View_Models
 
         public RelayCommand ToggleLayoutModeGridViewLarge => new RelayCommand(() =>
         {
-            LayoutMode = LayoutModes.GRID_VIEW; // Grid View
+            LayoutMode = LayoutModes.GridView; // Grid View
 
             GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeLarge; // Size
 
@@ -85,7 +86,7 @@ namespace Files.View_Models
 
         public RelayCommand ToggleLayoutModeGridViewMedium => new RelayCommand(() =>
         {
-            LayoutMode = LayoutModes.GRID_VIEW; // Grid View
+            LayoutMode = LayoutModes.GridView; // Grid View
 
             GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeMedium; // Size
 
@@ -94,7 +95,7 @@ namespace Files.View_Models
 
         public RelayCommand ToggleLayoutModeGridViewSmall => new RelayCommand(() =>
         {
-            LayoutMode = LayoutModes.GRID_VIEW; // Grid View
+            LayoutMode = LayoutModes.GridView; // Grid View
 
             GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Size
 
@@ -103,14 +104,14 @@ namespace Files.View_Models
 
         public RelayCommand ToggleLayoutModeTiles => new RelayCommand(() =>
         {
-            LayoutMode = LayoutModes.TILES_VIEW; // Tiles View
+            LayoutMode = LayoutModes.TilesView; // Tiles View
 
             LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
         });
 
         public RelayCommand ToggleLayoutModeDetailsView => new RelayCommand(() =>
         {
-            LayoutMode = LayoutModes.DETAILS_VIEW; // Details View
+            LayoutMode = LayoutModes.DetailsView; // Details View
 
             LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
         });
@@ -122,24 +123,24 @@ namespace Files.View_Models
             {
                 if (value < LayoutPreference.GridViewSize) // Size down
                 {
-                    if (LayoutMode == LayoutModes.TILES_VIEW) // Size down from tiles to list
+                    if (LayoutMode == LayoutModes.TilesView) // Size down from tiles to list
                     {
                         LayoutMode = 0;
                         LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                     }
-                    else if (LayoutMode == LayoutModes.GRID_VIEW && value < Constants.Browser.GridViewBrowser.GridViewSizeSmall) // Size down from grid to tiles
+                    else if (LayoutMode == LayoutModes.GridView && value < Constants.Browser.GridViewBrowser.GridViewSizeSmall) // Size down from grid to tiles
                     {
-                        LayoutMode = LayoutModes.TILES_VIEW;
+                        LayoutMode = LayoutModes.TilesView;
                         LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                     }
-                    else if (LayoutMode != LayoutModes.DETAILS_VIEW) // Resize grid view
+                    else if (LayoutMode != LayoutModes.DetailsView) // Resize grid view
                     {
                         var newValue = (value >= Constants.Browser.GridViewBrowser.GridViewSizeSmall) ? value : Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Set grid size to allow immediate UI update
                         SetProperty(ref LayoutPreference.GridViewSize, newValue, nameof(GridViewSize));
 
-                        if (LayoutMode != LayoutModes.GRID_VIEW) // Only update layout mode if it isn't already in grid view
+                        if (LayoutMode != LayoutModes.GridView) // Only update layout mode if it isn't already in grid view
                         {
-                            LayoutMode = LayoutModes.GRID_VIEW;
+                            LayoutMode = LayoutModes.GridView;
                             LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                         }
                         else
@@ -154,17 +155,17 @@ namespace Files.View_Models
                 {
                     if (LayoutMode == 0) // Size up from list to tiles
                     {
-                        LayoutMode = LayoutModes.TILES_VIEW;
+                        LayoutMode = LayoutModes.TilesView;
                         LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                     }
                     else // Size up from tiles to grid
                     {
-                        var newValue = (LayoutMode == LayoutModes.TILES_VIEW) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeMax) ? value : Constants.Browser.GridViewBrowser.GridViewSizeMax; // Set grid size to allow immediate UI update
+                        var newValue = (LayoutMode == LayoutModes.TilesView) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeMax) ? value : Constants.Browser.GridViewBrowser.GridViewSizeMax; // Set grid size to allow immediate UI update
                         SetProperty(ref LayoutPreference.GridViewSize, newValue, nameof(GridViewSize));
 
-                        if (LayoutMode != LayoutModes.GRID_VIEW) // Only update layout mode if it isn't already in grid view
+                        if (LayoutMode != LayoutModes.GridView) // Only update layout mode if it isn't already in grid view
                         {
-                            LayoutMode = LayoutModes.GRID_VIEW;
+                            LayoutMode = LayoutModes.GridView;
                             LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                         }
                         else
@@ -241,7 +242,7 @@ namespace Files.View_Models
 
         private static LayoutPreferences ReadLayoutPreferencesFromAds(string folderPath)
         {
-            var str = Helpers.NativeFileOperationsHelper.ReadStringFromFile($"{folderPath}:files_layoutmode");
+            var str = NativeFileOperationsHelper.ReadStringFromFile($"{folderPath}:files_layoutmode");
             return string.IsNullOrEmpty(str) ? null : JsonConvert.DeserializeObject<LayoutPreferences>(str);
         }
 
@@ -249,10 +250,10 @@ namespace Files.View_Models
         {
             if (LayoutPreferences.DefaultLayoutPreferences.Equals(prefs))
             {
-                Helpers.NativeFileOperationsHelper.DeleteFileFromApp($"{folderPath}:files_layoutmode");
+                NativeFileOperationsHelper.DeleteFileFromApp($"{folderPath}:files_layoutmode");
                 return false;
             }
-            return Helpers.NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", JsonConvert.SerializeObject(prefs));
+            return NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", JsonConvert.SerializeObject(prefs));
         }
 
         private static LayoutPreferences ReadLayoutPreferencesFromSettings(string folderPath)
@@ -304,22 +305,24 @@ namespace Files.View_Models
 
             public static LayoutPreferences FromCompositeValue(ApplicationDataCompositeValue compositeValue)
             {
-                var layoutPreference = new LayoutPreferences();
-                layoutPreference.LayoutMode = (LayoutModes)(int)compositeValue[nameof(LayoutMode)];
-                layoutPreference.GridViewSize = (int)compositeValue[nameof(GridViewSize)];
-                layoutPreference.DirectorySortOption = (SortOption)(int)compositeValue[nameof(DirectorySortOption)];
-                layoutPreference.DirectorySortDirection = (SortDirection)(int)compositeValue[nameof(DirectorySortDirection)];
-                return layoutPreference;
+                return new LayoutPreferences
+                {
+                    LayoutMode = (LayoutModes)(int)compositeValue[nameof(LayoutMode)],
+                    GridViewSize = (int)compositeValue[nameof(GridViewSize)],
+                    DirectorySortOption = (SortOption)(int)compositeValue[nameof(DirectorySortOption)],
+                    DirectorySortDirection = (SortDirection)(int)compositeValue[nameof(DirectorySortDirection)]
+                };
             }
 
             public ApplicationDataCompositeValue ToCompositeValue()
             {
-                var compositeValue = new ApplicationDataCompositeValue();
-                compositeValue[nameof(LayoutMode)] = (int)this.LayoutMode;
-                compositeValue[nameof(GridViewSize)] = this.GridViewSize;
-                compositeValue[nameof(DirectorySortOption)] = (int)this.DirectorySortOption;
-                compositeValue[nameof(DirectorySortDirection)] = (int)this.DirectorySortDirection;
-                return compositeValue;
+                return new ApplicationDataCompositeValue()
+                {
+                    { nameof(LayoutMode), (int)this.LayoutMode },
+                    { nameof(GridViewSize), this.GridViewSize },
+                    { nameof(DirectorySortOption), (int)this.DirectorySortOption },
+                    { nameof(DirectorySortDirection), (int)this.DirectorySortDirection },
+                };
             }
 
             public override bool Equals(object obj)
@@ -347,13 +350,6 @@ namespace Files.View_Models
             {
                 return base.GetHashCode();
             }
-        }
-
-        public enum LayoutModes
-        {
-            DETAILS_VIEW = 0,
-            TILES_VIEW,
-            GRID_VIEW
         }
     }
 }

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -223,7 +223,7 @@ namespace Files.View_Models
 
         private static void UpdateLayoutPreferencesForPath(string folderPath, LayoutPreferences prefs)
         {
-            if (prefs == LayoutPreferences.DefaultLayoutPreferences)
+            if (LayoutPreferences.DefaultLayoutPreferences.Equals(prefs))
             {
                 Helpers.NativeFileOperationsHelper.DeleteFileFromApp($"{folderPath}:files_layoutmode");
                 return; // Do not create setting if it's default
@@ -276,6 +276,32 @@ namespace Files.View_Models
                 compositeValue[nameof(DirectorySortOption)] = (int)this.DirectorySortOption;
                 compositeValue[nameof(DirectorySortDirection)] = (int)this.DirectorySortDirection;
                 return compositeValue;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj == null)
+                {
+                    return false;
+                }
+                if (obj == this)
+                {
+                    return true;
+                }
+                if (obj is LayoutPreferences prefs)
+                {
+                    return (
+                        prefs.LayoutMode == this.LayoutMode &&
+                        prefs.GridViewSize == this.GridViewSize &&
+                        prefs.DirectorySortOption == this.DirectorySortOption &&
+                        prefs.DirectorySortDirection == this.DirectorySortDirection);
+                }
+                return base.Equals(obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
             }
         }
 

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -213,7 +213,7 @@ namespace Files.View_Models
 
         private static LayoutPreferences GetLayoutPreferencesForPath(string folderPath)
         {
-            var str = Helpers.NativeFileOperationsHelper.ReadStringFromFile($"{folderPath}:files_layoutmode");
+            var str = Helpers.NativeFileOperationsHelper.ReadStringFromFile(System.IO.Path.Combine(folderPath, "files.desktop.ini"));
             if (string.IsNullOrEmpty(str))
             {
                 return LayoutPreferences.DefaultLayoutPreferences; // Either global setting or smart guess
@@ -223,12 +223,14 @@ namespace Files.View_Models
 
         private static void UpdateLayoutPreferencesForPath(string folderPath, LayoutPreferences prefs)
         {
+            var prefsFilePath = System.IO.Path.Combine(folderPath, "files.desktop.ini");
             if (LayoutPreferences.DefaultLayoutPreferences.Equals(prefs))
             {
-                Helpers.NativeFileOperationsHelper.DeleteFileFromApp($"{folderPath}:files_layoutmode");
+                Helpers.NativeFileOperationsHelper.DeleteFileFromApp(prefsFilePath);
                 return; // Do not create setting if it's default
             }
-            Helpers.NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", JsonConvert.SerializeObject(prefs));
+            Helpers.NativeFileOperationsHelper.WriteStringToFile(prefsFilePath, JsonConvert.SerializeObject(prefs));
+            Helpers.NativeFileOperationsHelper.SetFileAttribute(prefsFilePath, System.IO.FileAttributes.Hidden);
         }
 
         private LayoutPreferences LayoutPreference { get; set; }

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -4,6 +4,7 @@ using Microsoft.Toolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp.UI;
 using Newtonsoft.Json;
 using System;
+using System.IO;
 using Windows.Storage;
 
 namespace Files.View_Models
@@ -213,7 +214,7 @@ namespace Files.View_Models
 
         private static LayoutPreferences GetLayoutPreferencesForPath(string folderPath)
         {
-            var str = Helpers.NativeFileOperationsHelper.ReadStringFromFile($"{folderPath}:files_layoutmode");
+            var str = Helpers.NativeFileOperationsHelper.ReadStringFromFile(Path.Combine(folderPath,"files.desktop.ini"));
             if (string.IsNullOrEmpty(str))
             {
                 return LayoutPreferences.DefaultLayoutPreferences; // Either global setting or smart guess
@@ -223,12 +224,14 @@ namespace Files.View_Models
 
         private static void UpdateLayoutPreferencesForPath(string folderPath, LayoutPreferences prefs)
         {
+            var settingsFilePath = Path.Combine(folderPath, "files.desktop.ini");
             if (prefs == LayoutPreferences.DefaultLayoutPreferences)
             {
-                Helpers.NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", null);
+                Helpers.NativeFileOperationsHelper.DeleteFileFromApp(settingsFilePath);
                 return; // Do not create setting if it's default
             }
-            Helpers.NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", JsonConvert.SerializeObject(prefs));
+            Helpers.NativeFileOperationsHelper.WriteStringToFile(settingsFilePath, JsonConvert.SerializeObject(prefs));
+            Helpers.NativeFileOperationsHelper.SetFileAttribute(settingsFilePath, System.IO.FileAttributes.Hidden);
         }
 
         private LayoutPreferences LayoutPreference { get; set; }

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -216,8 +216,8 @@ namespace Files.View_Models
             var fixPath = folderPath.TrimEnd('\\');
             if (dataContainer.Values.ContainsKey(fixPath))
             {
-                var val = (Windows.Foundation.Rect)dataContainer.Values[fixPath];
-                return new LayoutPreferences((LayoutModes)(int)val.X, (int)val.Y, (SortOption)(int)val.Width, (SortDirection)(int)val.Height);
+                var val = (ApplicationDataCompositeValue)dataContainer.Values[fixPath];
+                return LayoutPreferences.FromCompositeValue(val);
             }
             else
             {
@@ -236,7 +236,7 @@ namespace Files.View_Models
                     return; // Do not create setting if it's default
                 }
             }
-            dataContainer.Values[fixPath] = new Windows.Foundation.Rect((int)prefs.LayoutMode, prefs.GridViewSize, (int)prefs.DirectorySortOption, (int)prefs.DirectorySortDirection);
+            dataContainer.Values[fixPath] = prefs.ToCompositeValue();
         }
 
         private LayoutPreferences LayoutPreference { get; set; }
@@ -264,6 +264,26 @@ namespace Files.View_Models
                 this.GridViewSize = gridViewSize;
                 this.DirectorySortOption = sortOption;
                 this.DirectorySortDirection = sortDirection;
+            }
+
+            public static LayoutPreferences FromCompositeValue(ApplicationDataCompositeValue compositeValue)
+            {
+                var layoutPreference = new LayoutPreferences();
+                layoutPreference.LayoutMode = (LayoutModes)(int)compositeValue[nameof(LayoutMode)];
+                layoutPreference.GridViewSize = (int)compositeValue[nameof(GridViewSize)];
+                layoutPreference.DirectorySortOption = (SortOption)(int)compositeValue[nameof(DirectorySortOption)];
+                layoutPreference.DirectorySortDirection = (SortDirection)(int)compositeValue[nameof(DirectorySortDirection)];
+                return layoutPreference;
+            }
+
+            public ApplicationDataCompositeValue ToCompositeValue()
+            {
+                var compositeValue = new ApplicationDataCompositeValue();
+                compositeValue[nameof(LayoutMode)] = (int)this.LayoutMode;
+                compositeValue[nameof(GridViewSize)] = this.GridViewSize;
+                compositeValue[nameof(DirectorySortOption)] = (int)this.DirectorySortOption;
+                compositeValue[nameof(DirectorySortDirection)] = (int)this.DirectorySortDirection;
+                return compositeValue;
             }
         }
 

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -29,14 +29,23 @@ namespace Files.View_Models
                 if (layoutMode != value)
                 {
                     SetLayoutModeForPath(associatedInstance.FilesystemViewModel.WorkingDirectory, value, gridViewSize);
+                    IsLayoutModeChanging = true;
                 }
                 SetProperty(ref layoutMode, value);
             }
         }
 
+        private bool isLayoutModeChanging;
+
+        public bool IsLayoutModeChanging
+        {
+            get => isLayoutModeChanging;
+            set => SetProperty(ref isLayoutModeChanging, value);
+        }
+
         public Type GetLayoutType(string folderPath)
         {
-            (layoutMode, gridViewSize) = GetLayoutModeForPath(folderPath);
+            (LayoutMode, GridViewSize) = GetLayoutModeForPath(folderPath);
 
             Type type = null;
             switch (LayoutMode)
@@ -170,7 +179,7 @@ namespace Files.View_Models
                         GridViewSizeChangeRequested?.Invoke(this, EventArgs.Empty);
                     }
                 }
-                else // Size up
+                else if (value > gridViewSize) // Size up
                 {
                     if (LayoutMode == 0) // Size up from list to tiles
                     {

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.Toolkit.Mvvm.ComponentModel;
+﻿using Files.Enums;
+using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
+using Microsoft.Toolkit.Uwp.UI;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.Storage;
 
 namespace Files.View_Models
@@ -212,6 +210,46 @@ namespace Files.View_Models
                     }
                 }
             }
+        }
+
+        public event EventHandler SortOptionPreferenceUpdated;
+
+        public event EventHandler SortDirectionPreferenceUpdated;
+
+        public SortOption DirectorySortOption
+        {
+            get => (SortOption)SortOptionByte;
+            set
+            {
+                SortOptionByte = (byte)value;
+                SortOptionPreferenceUpdated?.Invoke(this, new EventArgs());
+            }
+        }
+
+        public SortDirection DirectorySortDirection
+        {
+            get => (SortDirection)SortDirectionByte;
+            set
+            {
+                SortDirectionByte = (byte)value;
+                SortDirectionPreferenceUpdated?.Invoke(this, new EventArgs());
+            }
+        }
+
+        private byte sortOptionByte = (byte)0;
+
+        private byte SortOptionByte
+        {
+            get => sortOptionByte;
+            set => SetProperty(ref sortOptionByte, value);
+        }
+
+        private byte sortDirectionByte = 0;
+
+        private byte SortDirectionByte
+        {
+            get => sortDirectionByte;
+            set => SetProperty(ref sortDirectionByte, value);
         }
     }
 }

--- a/Files/View Models/FolderSettingsViewModel.cs
+++ b/Files/View Models/FolderSettingsViewModel.cs
@@ -213,15 +213,29 @@ namespace Files.View_Models
 
         private static LayoutPreferences GetLayoutPreferencesForPath(string folderPath)
         {
-            var layoutPrefs = ReadLayoutPreferencesFromAds(folderPath);
-            return layoutPrefs ?? ReadLayoutPreferencesFromSettings(folderPath);
+            if (App.AppSettings.AreLayoutPreferencesPerFolder)
+            {
+                var layoutPrefs = ReadLayoutPreferencesFromAds(folderPath);
+                return layoutPrefs ?? ReadLayoutPreferencesFromSettings(folderPath);
+            }
+            return LayoutPreferences.DefaultLayoutPreferences;
         }
 
         private static void UpdateLayoutPreferencesForPath(string folderPath, LayoutPreferences prefs)
         {
-            if (!WriteLayoutPreferencesToAds(folderPath, prefs))
+            if (App.AppSettings.AreLayoutPreferencesPerFolder)
             {
-                WriteLayoutPreferencesToSettings(folderPath, prefs);
+                if (!WriteLayoutPreferencesToAds(folderPath, prefs))
+                {
+                    WriteLayoutPreferencesToSettings(folderPath, prefs);
+                }
+            }
+            else
+            {
+                App.AppSettings.DefaultLayoutMode = prefs.LayoutMode;
+                App.AppSettings.DefaultGridViewSize = prefs.GridViewSize;
+                App.AppSettings.DefaultDirectorySortOption = prefs.DirectorySortOption;
+                App.AppSettings.DefaultDirectorySortDirection = prefs.DirectorySortDirection;
             }
         }
 

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -1372,7 +1372,10 @@ namespace Files.Filesystem
                                     {
                                         case FILE_ACTION_ADDED:
                                             Debug.WriteLine("File " + FileName + " added to working directory.");
-                                            AddFileOrFolderAsync(FileName, returnformat).GetAwaiter().GetResult();
+                                            if (Path.GetFileName(FileName) != "files.desktop.ini" || AppSettings.AreHiddenItemsVisible)
+                                            {
+                                                AddFileOrFolderAsync(FileName, returnformat).GetAwaiter().GetResult();
+                                            }
                                             break;
 
                                         case FILE_ACTION_REMOVED:

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -46,6 +46,7 @@ namespace Files.Filesystem
         private BulkObservableCollection<ListedItem> _filesAndFolders;
         public ReadOnlyObservableCollection<ListedItem> FilesAndFolders { get; }
         public SettingsViewModel AppSettings => App.AppSettings;
+        public FolderSettingsViewModel FolderSettings => AssociatedInstance?.InstanceViewModel.FolderSettings;
         private bool shouldDisplayFileExtensions = false;
         public ListedItem CurrentFolder { get; private set; }
         public CollectionViewSource viewSource;
@@ -177,12 +178,12 @@ namespace Files.Filesystem
 
         public bool IsSortedByName
         {
-            get => AppSettings.DirectorySortOption == SortOption.Name;
+            get => FolderSettings.DirectorySortOption == SortOption.Name;
             set
             {
                 if (value)
                 {
-                    AppSettings.DirectorySortOption = SortOption.Name;
+                    FolderSettings.DirectorySortOption = SortOption.Name;
                     NotifyPropertyChanged(nameof(IsSortedByName));
                 }
             }
@@ -190,12 +191,12 @@ namespace Files.Filesystem
 
         public bool IsSortedByDate
         {
-            get => AppSettings.DirectorySortOption == SortOption.DateModified;
+            get => FolderSettings.DirectorySortOption == SortOption.DateModified;
             set
             {
                 if (value)
                 {
-                    AppSettings.DirectorySortOption = SortOption.DateModified;
+                    FolderSettings.DirectorySortOption = SortOption.DateModified;
                     NotifyPropertyChanged(nameof(IsSortedByDate));
                 }
             }
@@ -203,12 +204,12 @@ namespace Files.Filesystem
 
         public bool IsSortedByType
         {
-            get => AppSettings.DirectorySortOption == SortOption.FileType;
+            get => FolderSettings.DirectorySortOption == SortOption.FileType;
             set
             {
                 if (value)
                 {
-                    AppSettings.DirectorySortOption = SortOption.FileType;
+                    FolderSettings.DirectorySortOption = SortOption.FileType;
                     NotifyPropertyChanged(nameof(IsSortedByType));
                 }
             }
@@ -216,12 +217,12 @@ namespace Files.Filesystem
 
         public bool IsSortedBySize
         {
-            get => AppSettings.DirectorySortOption == SortOption.Size;
+            get => FolderSettings.DirectorySortOption == SortOption.Size;
             set
             {
                 if (value)
                 {
-                    AppSettings.DirectorySortOption = SortOption.Size;
+                    FolderSettings.DirectorySortOption = SortOption.Size;
                     NotifyPropertyChanged(nameof(IsSortedBySize));
                 }
             }
@@ -229,10 +230,10 @@ namespace Files.Filesystem
 
         public bool IsSortedAscending
         {
-            get => AppSettings.DirectorySortDirection == SortDirection.Ascending;
+            get => FolderSettings.DirectorySortDirection == SortDirection.Ascending;
             set
             {
-                AppSettings.DirectorySortDirection = value ? SortDirection.Ascending : SortDirection.Descending;
+                FolderSettings.DirectorySortDirection = value ? SortDirection.Ascending : SortDirection.Descending;
                 NotifyPropertyChanged(nameof(IsSortedAscending));
                 NotifyPropertyChanged(nameof(IsSortedDescending));
             }
@@ -243,7 +244,7 @@ namespace Files.Filesystem
             get => !IsSortedAscending;
             set
             {
-                AppSettings.DirectorySortDirection = value ? SortDirection.Descending : SortDirection.Ascending;
+                FolderSettings.DirectorySortDirection = value ? SortDirection.Descending : SortDirection.Ascending;
                 NotifyPropertyChanged(nameof(IsSortedAscending));
                 NotifyPropertyChanged(nameof(IsSortedDescending));
             }
@@ -475,7 +476,7 @@ namespace Files.Filesystem
             static object orderByNameFunc(ListedItem item) => item.ItemName;
             Func<ListedItem, object> orderFunc = orderByNameFunc;
             NaturalStringComparer naturalStringComparer = new NaturalStringComparer();
-            switch (AppSettings.DirectorySortOption)
+            switch (FolderSettings.DirectorySortOption)
             {
                 case SortOption.Name:
                     orderFunc = orderByNameFunc;
@@ -500,9 +501,9 @@ namespace Files.Filesystem
             IOrderedEnumerable<ListedItem> ordered;
             List<ListedItem> orderedList;
 
-            if (AppSettings.DirectorySortDirection == SortDirection.Ascending)
+            if (FolderSettings.DirectorySortDirection == SortDirection.Ascending)
             {
-                if (AppSettings.DirectorySortOption == SortOption.Name)
+                if (FolderSettings.DirectorySortOption == SortOption.Name)
                 {
                     if (AppSettings.ListAndSortDirectoriesAlongsideFiles)
                     {
@@ -527,9 +528,9 @@ namespace Files.Filesystem
             }
             else
             {
-                if (AppSettings.DirectorySortOption == SortOption.FileType)
+                if (FolderSettings.DirectorySortOption == SortOption.FileType)
                 {
-                    if (AppSettings.DirectorySortOption == SortOption.Name)
+                    if (FolderSettings.DirectorySortOption == SortOption.Name)
                     {
                         if (AppSettings.ListAndSortDirectoriesAlongsideFiles)
                         {
@@ -554,7 +555,7 @@ namespace Files.Filesystem
                 }
                 else
                 {
-                    if (AppSettings.DirectorySortOption == SortOption.Name)
+                    if (FolderSettings.DirectorySortOption == SortOption.Name)
                     {
                         if (AppSettings.ListAndSortDirectoriesAlongsideFiles)
                         {
@@ -580,9 +581,9 @@ namespace Files.Filesystem
             }
 
             // Further order by name if applicable
-            if (AppSettings.DirectorySortOption != SortOption.Name)
+            if (FolderSettings.DirectorySortOption != SortOption.Name)
             {
-                if (AppSettings.DirectorySortDirection == SortDirection.Ascending)
+                if (FolderSettings.DirectorySortDirection == SortDirection.Ascending)
                 {
                     ordered = ordered.ThenBy(orderByNameFunc, naturalStringComparer);
                 }

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -31,7 +31,6 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media.Imaging;
 using static Files.Helpers.NativeDirectoryChangesHelper;
-using static Files.Helpers.NativeFileOperationsHelper;
 using static Files.Helpers.NativeFindStorageItemHelper;
 using FileAttributes = System.IO.FileAttributes;
 
@@ -1289,8 +1288,8 @@ namespace Files.Filesystem
             string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
 
             Debug.WriteLine("WatchForDirectoryChanges: {0}", path);
-            hWatchDir = CreateFileFromApp(path, 1, 1 | 2 | 4,
-                IntPtr.Zero, 3, (uint)File_Attributes.BackupSemantics | (uint)File_Attributes.Overlapped, IntPtr.Zero);
+            hWatchDir = NativeFileOperationsHelper.CreateFileFromApp(path, 1, 1 | 2 | 4,
+                IntPtr.Zero, 3, (uint)NativeFileOperationsHelper.File_Attributes.BackupSemantics | (uint)NativeFileOperationsHelper.File_Attributes.Overlapped, IntPtr.Zero);
             if (hWatchDir.ToInt64() == -1)
             {
                 return;

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -1372,10 +1372,7 @@ namespace Files.Filesystem
                                     {
                                         case FILE_ACTION_ADDED:
                                             Debug.WriteLine("File " + FileName + " added to working directory.");
-                                            if (Path.GetFileName(FileName) != "files.desktop.ini" || AppSettings.AreHiddenItemsVisible)
-                                            {
-                                                AddFileOrFolderAsync(FileName, returnformat).GetAwaiter().GetResult();
-                                            }
+                                            AddFileOrFolderAsync(FileName, returnformat).GetAwaiter().GetResult();
                                             break;
 
                                         case FILE_ACTION_REMOVED:

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -9,7 +9,6 @@ using Microsoft.AppCenter.Analytics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp.Extensions;
-using Microsoft.Toolkit.Uwp.UI;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -27,10 +26,6 @@ namespace Files.View_Models
     public class SettingsViewModel : ObservableObject
     {
         private readonly ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
-
-        public event EventHandler SortOptionPreferenceUpdated;
-
-        public event EventHandler SortDirectionPreferenceUpdated;
 
         public DrivesManager DrivesManager { get; }
 
@@ -106,38 +101,6 @@ namespace Files.View_Models
         {
             get => new GridLength(Math.Min(Math.Max(Get(200d), 200d), 500d), GridUnitType.Pixel);
             set => Set(value.Value);
-        }
-
-        public SortOption DirectorySortOption
-        {
-            get => (SortOption)SortOptionByte;
-            set
-            {
-                SortOptionByte = (byte)value;
-                SortOptionPreferenceUpdated?.Invoke(this, new EventArgs());
-            }
-        }
-
-        public SortDirection DirectorySortDirection
-        {
-            get => (SortDirection)SortDirectionByte;
-            set
-            {
-                SortDirectionByte = (byte)value;
-                SortDirectionPreferenceUpdated?.Invoke(this, new EventArgs());
-            }
-        }
-
-        private byte SortOptionByte
-        {
-            get => Get((byte)0);
-            set => Set(value);
-        }
-
-        private byte SortDirectionByte
-        {
-            get => Get((byte)0);
-            set => Set(value);
         }
 
         public async void DetectQuickLook()

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -42,7 +42,6 @@ namespace Files.View_Models
             PinSidebarLocationItems();
             DetectRecycleBinPreference();
             DetectQuickLook();
-            DetectGridViewSize();
             DrivesManager = new DrivesManager();
 
             //DetectWSLDistros();
@@ -632,157 +631,7 @@ namespace Files.View_Models
 
         public AcrylicTheme AcrylicTheme { get; set; }
 
-        public int LayoutMode
-        {
-            get => Get(0); // Details View
-            set => Set(value);
-        }
-
-        public Type GetLayoutType()
-        {
-            Type type = null;
-            switch (LayoutMode)
-            {
-                case 0:
-                    type = typeof(GenericFileBrowser);
-                    break;
-
-                case 1:
-                    type = typeof(GridViewBrowser);
-                    break;
-
-                case 2:
-                    type = typeof(GridViewBrowser);
-                    break;
-
-                default:
-                    type = typeof(GenericFileBrowser);
-                    break;
-            }
-            return type;
-        }
-
-        public event EventHandler LayoutModeChangeRequested;
-
-        public RelayCommand ToggleLayoutModeGridViewLarge => new RelayCommand(() =>
-        {
-            LayoutMode = 2; // Grid View
-
-            GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeLarge; // Size
-
-            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
-        });
-
-        public RelayCommand ToggleLayoutModeGridViewMedium => new RelayCommand(() =>
-        {
-            LayoutMode = 2; // Grid View
-
-            GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeMedium; // Size
-
-            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
-        });
-
-        public RelayCommand ToggleLayoutModeGridViewSmall => new RelayCommand(() =>
-        {
-            LayoutMode = 2; // Grid View
-
-            GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Size
-
-            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
-        });
-
-        public RelayCommand ToggleLayoutModeTiles => new RelayCommand(() =>
-        {
-            LayoutMode = 1; // Tiles View
-
-            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
-        });
-
-        public RelayCommand ToggleLayoutModeDetailsView => new RelayCommand(() =>
-        {
-            LayoutMode = 0; // Details View
-
-            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
-        });
-
-        private void DetectGridViewSize()
-        {
-            gridViewSize = Get(Constants.Browser.GridViewBrowser.GridViewSizeSmall, "GridViewSize"); // Get GridView Size
-        }
-
-        private int gridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Default Size
-
-        public int GridViewSize
-        {
-            get => gridViewSize;
-            set
-            {
-                if (value < gridViewSize) // Size down
-                {
-                    if (LayoutMode == 1) // Size down from tiles to list
-                    {
-                        LayoutMode = 0;
-                        Set(0, "LayoutMode");
-                        LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
-                    }
-                    else if (LayoutMode == 2 && value < Constants.Browser.GridViewBrowser.GridViewSizeSmall) // Size down from grid to tiles
-                    {
-                        LayoutMode = 1;
-                        Set(1, "LayoutMode");
-                        LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
-                    }
-                    else if (LayoutMode != 0) // Resize grid view
-                    {
-                        gridViewSize = (value >= Constants.Browser.GridViewBrowser.GridViewSizeSmall) ? value : Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Set grid size to allow immediate UI update
-                        Set(value);
-
-                        if (LayoutMode != 2) // Only update layout mode if it isn't already in grid view
-                        {
-                            LayoutMode = 2;
-                            Set(2, "LayoutMode");
-                            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
-                        }
-
-                        GridViewSizeChangeRequested?.Invoke(this, EventArgs.Empty);
-                    }
-                }
-                else // Size up
-                {
-                    if (LayoutMode == 0) // Size up from list to tiles
-                    {
-                        LayoutMode = 1;
-                        Set(1, "LayoutMode");
-                        LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
-                    }
-                    else // Size up from tiles to grid
-                    {
-                        gridViewSize = (LayoutMode == 1) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeMax) ? value : Constants.Browser.GridViewBrowser.GridViewSizeMax; // Set grid size to allow immediate UI update
-                        Set(gridViewSize);
-
-                        if (LayoutMode != 2) // Only update layout mode if it isn't already in grid view
-                        {
-                            LayoutMode = 2;
-                            Set(2, "LayoutMode");
-                            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
-                        }
-
-                        if (value < Constants.Browser.GridViewBrowser.GridViewSizeMax) // Don't request a grid resize if it is already at the max size
-                        {
-                            GridViewSizeChangeRequested?.Invoke(this, EventArgs.Empty);
-                        }
-                    }
-                }
-            }
-        }
-
-        public event EventHandler GridViewSizeChangeRequested;
-
-        public void Dispose()
-        {
-            DrivesManager?.Dispose();
-        }
-
-        #region ReadAndSaveSettings
+#region ReadAndSaveSettings
 
         public bool Set<TValue>(TValue value, [CallerMemberName] string propertyName = null)
         {
@@ -861,6 +710,11 @@ namespace Files.View_Models
 
         private delegate bool TryParseDelegate<TValue>(string inValue, out TValue parsedValue);
 
-        #endregion ReadAndSaveSettings
+#endregion ReadAndSaveSettings
+
+        public void Dispose()
+        {
+            DrivesManager?.Dispose();
+        }
     }
 }

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -631,6 +631,18 @@ namespace Files.View_Models
 
         public AcrylicTheme AcrylicTheme { get; set; }
 
+        public int DefaultLayoutMode
+        {
+            get => Get(0); // Details View	
+            set => Set(value);
+        }
+
+        public int DefaultGridViewSize
+        {
+            get => Get(Constants.Browser.GridViewBrowser.GridViewSizeSmall);
+            set => Set(value);
+        }
+
 #region ReadAndSaveSettings
 
         public bool Set<TValue>(TValue value, [CallerMemberName] string propertyName = null)

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -613,9 +613,9 @@ namespace Files.View_Models
             set => Set(value);
         }
 
-        public FolderSettingsViewModel.LayoutModes DefaultLayoutMode
+        public LayoutModes DefaultLayoutMode
         {
-            get => (FolderSettingsViewModel.LayoutModes)Get((byte)FolderSettingsViewModel.LayoutModes.DETAILS_VIEW); // Details View
+            get => (LayoutModes)Get((byte)LayoutModes.DetailsView); // Details View
             set => Set((byte)value);
         }
 

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -9,6 +9,7 @@ using Microsoft.AppCenter.Analytics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp.Extensions;
+using Microsoft.Toolkit.Uwp.UI;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -603,10 +604,10 @@ namespace Files.View_Models
 
         public AcrylicTheme AcrylicTheme { get; set; }
 
-        public int DefaultLayoutMode
+        public FolderSettingsViewModel.LayoutModes DefaultLayoutMode
         {
-            get => Get(0); // Details View	
-            set => Set(value);
+            get => (FolderSettingsViewModel.LayoutModes)Get((byte)FolderSettingsViewModel.LayoutModes.DETAILS_VIEW); // Details View
+            set => Set((byte)value);
         }
 
         public int DefaultGridViewSize
@@ -615,7 +616,19 @@ namespace Files.View_Models
             set => Set(value);
         }
 
-#region ReadAndSaveSettings
+        public SortDirection DefaultDirectorySortDirection
+        {
+            get => (SortDirection)Get((byte)SortDirection.Ascending);
+            set => Set((byte)value);
+        }
+
+        public SortOption DefaultDirectorySortOption
+        {
+            get => (SortOption)Get((byte)SortOption.Name);
+            set => Set((byte)value);
+        }
+
+        #region ReadAndSaveSettings
 
         public bool Set<TValue>(TValue value, [CallerMemberName] string propertyName = null)
         {

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -604,6 +604,15 @@ namespace Files.View_Models
 
         public AcrylicTheme AcrylicTheme { get; set; }
 
+        /// <summary>
+        /// Enables saving layout mode, gridview size, sort direction per folder
+        /// </summary>
+        public bool AreLayoutPreferencesPerFolder
+        {
+            get => Get(true);
+            set => Set(value);
+        }
+
         public FolderSettingsViewModel.LayoutModes DefaultLayoutMode
         {
             get => (FolderSettingsViewModel.LayoutModes)Get((byte)FolderSettingsViewModel.LayoutModes.DETAILS_VIEW); // Details View

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -30,6 +30,10 @@
                 x:Key="BoolToVisibilityConverter"
                 FalseValue="Collapsed"
                 TrueValue="Visible" />
+            <converters:BoolToVisibilityConverter
+                x:Key="NegatedBoolToVisibilityConverter"
+                FalseValue="Visible"
+                TrueValue="Collapsed" />
 
             <MenuFlyout
                 x:Key="BaseLayoutContextFlyout"
@@ -663,7 +667,8 @@
             SelectionChanged="AllView_SelectionChanged"
             SelectionMode="Extended"
             Sorting="AllView_Sorting"
-            Style="{StaticResource LeftAlignedDataGridStyle}">
+            Style="{StaticResource LeftAlignedDataGridStyle}"
+            Visibility="{x:Bind FolderSettings.IsLayoutModeChanging, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
             <controls:DataGrid.Resources>
                 <ResourceDictionary>
                     <ResourceDictionary.ThemeDictionaries>

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -654,7 +654,6 @@
             IsDoubleTapEnabled="True"
             IsRightTapEnabled="True"
             ItemsSource="{x:Bind ParentShellPageInstance.FilesystemViewModel.FilesAndFolders, Mode=OneWay}"
-            LoadingRow="AllView_LoadingRow"
             PointerPressed="{x:Bind ParentShellPageInstance.InteractionOperations.ItemPointerPressed}"
             PreparingCellForEdit="AllView_PreparingCellForEdit"
             PreviewKeyDown="AllView_PreviewKeyDown"

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -92,7 +92,7 @@
                     </MenuFlyoutSubItem.Icon>
                     <MenuFlyoutItem
                         x:Uid="StatusBarControlGridViewLarge"
-                        Command="{x:Bind AppSettings.ToggleLayoutModeGridViewLarge}"
+                        Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewLarge}"
                         Text="Grid View (Large)">
                         <MenuFlyoutItem.Icon>
                             <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xE9A0;" />
@@ -100,7 +100,7 @@
                     </MenuFlyoutItem>
                     <MenuFlyoutItem
                         x:Uid="StatusBarControlGridViewMedium"
-                        Command="{x:Bind AppSettings.ToggleLayoutModeGridViewMedium}"
+                        Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewMedium}"
                         Text="Grid View (Medium)">
                         <MenuFlyoutItem.Icon>
                             <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEA72;" />
@@ -108,7 +108,7 @@
                     </MenuFlyoutItem>
                     <MenuFlyoutItem
                         x:Uid="StatusBarControlGridViewSmall"
-                        Command="{x:Bind AppSettings.ToggleLayoutModeGridViewSmall}"
+                        Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewSmall}"
                         Text="Grid View (Small)">
                         <MenuFlyoutItem.Icon>
                             <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEBA1;" />
@@ -116,7 +116,7 @@
                     </MenuFlyoutItem>
                     <MenuFlyoutItem
                         x:Uid="StatusBarControlTilesView"
-                        Command="{x:Bind AppSettings.ToggleLayoutModeTiles}"
+                        Command="{x:Bind FolderSettings.ToggleLayoutModeTiles}"
                         Text="Tiles View">
                         <MenuFlyoutItem.Icon>
                             <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF100;" />
@@ -124,7 +124,7 @@
                     </MenuFlyoutItem>
                     <MenuFlyoutItem
                         x:Uid="StatusBarControlDetailsView"
-                        Command="{x:Bind AppSettings.ToggleLayoutModeDetailsView}"
+                        Command="{x:Bind FolderSettings.ToggleLayoutModeDetailsView}"
                         Text="Details View">
                         <MenuFlyoutItem.Icon>
                             <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF101;" />

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -124,12 +124,14 @@ namespace Files
         {
             base.OnNavigatedTo(eventArgs);
             ParentShellPageInstance.FilesystemViewModel.PropertyChanged += ViewModel_PropertyChanged;
+            AllView.LoadingRow += AllView_LoadingRow;
         }
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
             base.OnNavigatingFrom(e);
             ParentShellPageInstance.FilesystemViewModel.PropertyChanged -= ViewModel_PropertyChanged;
+            AllView.LoadingRow -= AllView_LoadingRow;
         }
 
         private void AppSettings_ThemeModeChanged(object sender, EventArgs e)

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -43,23 +43,23 @@ namespace Files
             {
                 if (value == nameColumn)
                 {
-                    AppSettings.DirectorySortOption = SortOption.Name;
+                    FolderSettings.DirectorySortOption = SortOption.Name;
                 }
                 else if (value == dateColumn)
                 {
-                    AppSettings.DirectorySortOption = SortOption.DateModified;
+                    FolderSettings.DirectorySortOption = SortOption.DateModified;
                 }
                 else if (value == typeColumn)
                 {
-                    AppSettings.DirectorySortOption = SortOption.FileType;
+                    FolderSettings.DirectorySortOption = SortOption.FileType;
                 }
                 else if (value == sizeColumn)
                 {
-                    AppSettings.DirectorySortOption = SortOption.Size;
+                    FolderSettings.DirectorySortOption = SortOption.Size;
                 }
                 else
                 {
-                    AppSettings.DirectorySortOption = SortOption.Name;
+                    FolderSettings.DirectorySortOption = SortOption.Name;
                 }
 
                 if (value != sortedColumn)
@@ -70,7 +70,7 @@ namespace Files
                         sortedColumn.SortDirection = null;
                     }
                 }
-                value.SortDirection = AppSettings.DirectorySortDirection == SortDirection.Ascending ? DataGridSortDirection.Ascending : DataGridSortDirection.Descending;
+                value.SortDirection = FolderSettings.DirectorySortDirection == SortDirection.Ascending ? DataGridSortDirection.Ascending : DataGridSortDirection.Descending;
                 sortedColumn = value;
             }
         }
@@ -82,24 +82,6 @@ namespace Files
             base.BaseLayoutItemContextFlyout = BaseLayoutItemContextFlyout;
 
             tapDebounceTimer = new DispatcherTimer();
-            switch (AppSettings.DirectorySortOption)
-            {
-                case SortOption.Name:
-                    SortedColumn = nameColumn;
-                    break;
-
-                case SortOption.DateModified:
-                    SortedColumn = dateColumn;
-                    break;
-
-                case SortOption.FileType:
-                    SortedColumn = typeColumn;
-                    break;
-
-                case SortOption.Size:
-                    SortedColumn = sizeColumn;
-                    break;
-            }
 
             var selectionRectangle = RectangleSelection.Create(AllView, SelectionRectangle, AllView_SelectionChanged);
             selectionRectangle.SelectionStarted += SelectionRectangle_SelectionStarted;
@@ -125,6 +107,7 @@ namespace Files
             base.OnNavigatedTo(eventArgs);
             ParentShellPageInstance.FilesystemViewModel.PropertyChanged += ViewModel_PropertyChanged;
             AllView.LoadingRow += AllView_LoadingRow;
+            ViewModel_PropertyChanged(null, new PropertyChangedEventArgs("DirectorySortOption"));
         }
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
@@ -197,7 +180,7 @@ namespace Files
         {
             if (e.PropertyName == "DirectorySortOption")
             {
-                switch (AppSettings.DirectorySortOption)
+                switch (FolderSettings.DirectorySortOption)
                 {
                     case SortOption.Name:
                         SortedColumn = nameColumn;

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -15,7 +15,8 @@
     NavigationCacheMode="Enabled"
     PointerPressed="GridViewBrowserViewer_PointerPressed"
     PointerWheelChanged="BaseLayout_PointerWheelChanged"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    x:Name="PageRoot">
     <local:BaseLayout.Resources>
         <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
 
@@ -531,9 +532,8 @@
         </MenuFlyout>
 
         <DataTemplate x:Name="GridViewBrowserTemplate" x:DataType="local2:ListedItem">
-            <!--Width="{x:Bind FolderSettings.GridViewSize, Mode=OneWay}"-->
             <Grid
-                Width="100"
+                Width="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}"
                 Height="Auto"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
@@ -552,8 +552,8 @@
                 </Grid.RowDefinitions>
                 <Grid
                     Grid.Row="0"
-                    Width="100"
-                    Height="100"
+                    Width="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}"
+                    Height="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}"
                     Opacity="{x:Bind Opacity, Mode=OneWay}"
                     Tag="ItemImage">
                     <Grid
@@ -583,8 +583,8 @@
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         x:Load="{x:Bind LoadUnknownTypeGlyph, Mode=OneWay}">
-                        <Viewbox MaxWidth="100"
-                                 MaxHeight="100">
+                        <Viewbox MaxWidth="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}"
+                                 MaxHeight="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}">
                             <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEA00;" />
                         </Viewbox>
                     </Grid>
@@ -604,8 +604,8 @@
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         x:Load="{x:Bind IsLinkItem, Mode=OneWay}">
-                        <Viewbox MaxWidth="100"
-                                 MaxHeight="100">
+                        <Viewbox MaxWidth="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}"
+                                 MaxHeight="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}">
                             <FontIcon
                                 FontFamily="{StaticResource FluentUIGlyphs}"
                                 FontSize="28"
@@ -630,7 +630,7 @@
                 </Grid>
                 <Grid
                     Grid.Row="1"
-                    MaxWidth="100"
+                    MaxWidth="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}"
                     Margin="5,0,5,10"
                     HorizontalAlignment="Center">
                     <Grid.ColumnDefinitions>
@@ -662,7 +662,7 @@
                     x:Load="False">
                     <TextBox
                         x:Name="GridViewTextBoxItemName"
-                        Width="100"
+                        Width="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}"
                         Margin="0"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -19,6 +19,10 @@
     x:Name="PageRoot">
     <local:BaseLayout.Resources>
         <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
+        <converters:BoolToVisibilityConverter
+            x:Key="NegatedBoolToVisibilityConverter"
+            FalseValue="Visible"
+            TrueValue="Collapsed" />
 
         <MenuFlyout
             x:Key="BaseLayoutContextFlyout"
@@ -919,7 +923,8 @@
             ItemsSource="{x:Bind ParentShellPageInstance.FilesystemViewModel.FilesAndFolders}"
             PreviewKeyDown="FileList_PreviewKeyDown"
             SelectionChanged="FileList_SelectionChanged"
-            SelectionMode="Extended">
+            SelectionMode="Extended"
+            Visibility="{x:Bind FolderSettings.IsLayoutModeChanging, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
             <Interactivity:Interaction.Behaviors>
                 <Core:DataTriggerBehavior Binding="{x:Bind InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}" Value="True">
                     <Core:ChangePropertyAction

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -68,7 +68,7 @@
                 </MenuFlyoutSubItem.Icon>
                 <MenuFlyoutItem
                     x:Uid="StatusBarControlGridViewLarge"
-                    Command="{x:Bind AppSettings.ToggleLayoutModeGridViewLarge}"
+                    Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewLarge}"
                     Text="Grid View (Large)">
                     <MenuFlyoutItem.Icon>
                         <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xE9A0;" />
@@ -76,7 +76,7 @@
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
                     x:Uid="StatusBarControlGridViewMedium"
-                    Command="{x:Bind AppSettings.ToggleLayoutModeGridViewMedium}"
+                    Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewMedium}"
                     Text="Grid View (Medium)">
                     <MenuFlyoutItem.Icon>
                         <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEA72;" />
@@ -84,7 +84,7 @@
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
                     x:Uid="StatusBarControlGridViewSmall"
-                    Command="{x:Bind AppSettings.ToggleLayoutModeGridViewSmall}"
+                    Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewSmall}"
                     Text="Grid View (Small)">
                     <MenuFlyoutItem.Icon>
                         <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEBA1;" />
@@ -92,7 +92,7 @@
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
                     x:Uid="StatusBarControlTilesView"
-                    Command="{x:Bind AppSettings.ToggleLayoutModeTiles}"
+                    Command="{x:Bind FolderSettings.ToggleLayoutModeTiles}"
                     Text="Tiles View">
                     <MenuFlyoutItem.Icon>
                         <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF100;" />
@@ -100,7 +100,7 @@
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
                     x:Uid="StatusBarControlDetailsView"
-                    Command="{x:Bind AppSettings.ToggleLayoutModeDetailsView}"
+                    Command="{x:Bind FolderSettings.ToggleLayoutModeDetailsView}"
                     Text="Details View">
                     <MenuFlyoutItem.Icon>
                         <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF101;" />
@@ -531,8 +531,9 @@
         </MenuFlyout>
 
         <DataTemplate x:Name="GridViewBrowserTemplate" x:DataType="local2:ListedItem">
+            <!--Width="{x:Bind FolderSettings.GridViewSize, Mode=OneWay}"-->
             <Grid
-                Width="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}"
+                Width="100"
                 Height="Auto"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
@@ -551,8 +552,8 @@
                 </Grid.RowDefinitions>
                 <Grid
                     Grid.Row="0"
-                    Width="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}"
-                    Height="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}"
+                    Width="100"
+                    Height="100"
                     Opacity="{x:Bind Opacity, Mode=OneWay}"
                     Tag="ItemImage">
                     <Grid
@@ -582,7 +583,8 @@
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         x:Load="{x:Bind LoadUnknownTypeGlyph, Mode=OneWay}">
-                        <Viewbox MaxWidth="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}" MaxHeight="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}">
+                        <Viewbox MaxWidth="100"
+                                 MaxHeight="100">
                             <FontIcon FontFamily="{StaticResource FluentUIGlyphs}" Glyph="&#xEA00;" />
                         </Viewbox>
                     </Grid>
@@ -602,7 +604,8 @@
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         x:Load="{x:Bind IsLinkItem, Mode=OneWay}">
-                        <Viewbox MaxWidth="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}" MaxHeight="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}">
+                        <Viewbox MaxWidth="100"
+                                 MaxHeight="100">
                             <FontIcon
                                 FontFamily="{StaticResource FluentUIGlyphs}"
                                 FontSize="28"
@@ -627,7 +630,7 @@
                 </Grid>
                 <Grid
                     Grid.Row="1"
-                    MaxWidth="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}"
+                    MaxWidth="100"
                     Margin="5,0,5,10"
                     HorizontalAlignment="Center">
                     <Grid.ColumnDefinitions>
@@ -659,7 +662,7 @@
                     x:Load="False">
                     <TextBox
                         x:Name="GridViewTextBoxItemName"
-                        Width="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}"
+                        Width="100"
                         Margin="0"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Files.Filesystem;
+﻿using Files.Enums;
+using Files.Filesystem;
 using Files.UserControls.Selection;
 using System;
 using System.Collections;
@@ -84,14 +85,14 @@ namespace Files
 
         private void SetItemTemplate()
         {
-            FileList.ItemTemplate = (FolderSettings.LayoutMode == LayoutModes.TILES_VIEW) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
+            FileList.ItemTemplate = (FolderSettings.LayoutMode == LayoutModes.TilesView) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
 
             // Set GridViewSize event handlers
-            if (FolderSettings.LayoutMode == LayoutModes.TILES_VIEW)
+            if (FolderSettings.LayoutMode == LayoutModes.TilesView)
             {
                 FolderSettings.GridViewSizeChangeRequested -= AppSettings_GridViewSizeChangeRequested;
             }
-            else if (FolderSettings.LayoutMode == LayoutModes.GRID_VIEW)
+            else if (FolderSettings.LayoutMode == LayoutModes.GridView)
             {
                 currentIconSize = GetIconSize(); // Get icon size for jumps from other layouts directly to a grid size
                 FolderSettings.GridViewSizeChangeRequested -= AppSettings_GridViewSizeChangeRequested;
@@ -186,7 +187,7 @@ namespace Files
             TextBox textBox = null;
 
             // Handle layout differences between tiles browser and photo album
-            if (FolderSettings.LayoutMode == LayoutModes.GRID_VIEW)
+            if (FolderSettings.LayoutMode == LayoutModes.GridView)
             {
                 Popup popup = (gridViewItem.ContentTemplateRoot as Grid).FindName("EditPopup") as Popup;
                 TextBlock textBlock = (gridViewItem.ContentTemplateRoot as Grid).FindName("ItemName") as TextBlock;
@@ -271,7 +272,7 @@ namespace Files
 
         private void EndRename(TextBox textBox)
         {
-            if (FolderSettings.LayoutMode == LayoutModes.GRID_VIEW)
+            if (FolderSettings.LayoutMode == LayoutModes.GridView)
             {
                 Popup popup = textBox.Parent as Popup;
                 TextBlock textBlock = (popup.Parent as Grid).Children[1] as TextBlock;
@@ -398,7 +399,7 @@ namespace Files
 
         private uint GetIconSize()
         {
-            if (FolderSettings.LayoutMode == LayoutModes.TILES_VIEW || FolderSettings.GridViewSize < Constants.Browser.GridViewBrowser.GridViewSizeSmall + 75)
+            if (FolderSettings.LayoutMode == LayoutModes.TilesView || FolderSettings.GridViewSize < Constants.Browser.GridViewBrowser.GridViewSizeSmall + 75)
             {
                 return 80; // Small thumbnail
             }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -14,6 +14,7 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
+using static Files.View_Models.FolderSettingsViewModel;
 using Interaction = Files.Interacts.Interaction;
 
 namespace Files
@@ -83,14 +84,14 @@ namespace Files
 
         private void SetItemTemplate()
         {
-            FileList.ItemTemplate = (FolderSettings.LayoutMode == 1) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
+            FileList.ItemTemplate = (FolderSettings.LayoutMode == LayoutModes.TILES_VIEW) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
 
             // Set GridViewSize event handlers
-            if (FolderSettings.LayoutMode == 1)
+            if (FolderSettings.LayoutMode == LayoutModes.TILES_VIEW)
             {
                 FolderSettings.GridViewSizeChangeRequested -= AppSettings_GridViewSizeChangeRequested;
             }
-            else if (FolderSettings.LayoutMode == 2)
+            else if (FolderSettings.LayoutMode == LayoutModes.GRID_VIEW)
             {
                 currentIconSize = GetIconSize(); // Get icon size for jumps from other layouts directly to a grid size
                 FolderSettings.GridViewSizeChangeRequested -= AppSettings_GridViewSizeChangeRequested;
@@ -185,7 +186,7 @@ namespace Files
             TextBox textBox = null;
 
             // Handle layout differences between tiles browser and photo album
-            if (FolderSettings.LayoutMode == 2)
+            if (FolderSettings.LayoutMode == LayoutModes.GRID_VIEW)
             {
                 Popup popup = (gridViewItem.ContentTemplateRoot as Grid).FindName("EditPopup") as Popup;
                 TextBlock textBlock = (gridViewItem.ContentTemplateRoot as Grid).FindName("ItemName") as TextBlock;
@@ -270,7 +271,7 @@ namespace Files
 
         private void EndRename(TextBox textBox)
         {
-            if (FolderSettings.LayoutMode == 2)
+            if (FolderSettings.LayoutMode == LayoutModes.GRID_VIEW)
             {
                 Popup popup = textBox.Parent as Popup;
                 TextBlock textBlock = (popup.Parent as Grid).Children[1] as TextBlock;
@@ -397,7 +398,7 @@ namespace Files
 
         private uint GetIconSize()
         {
-            if (FolderSettings.LayoutMode == 1 || FolderSettings.GridViewSize < Constants.Browser.GridViewBrowser.GridViewSizeSmall + 75)
+            if (FolderSettings.LayoutMode == LayoutModes.TILES_VIEW || FolderSettings.GridViewSize < Constants.Browser.GridViewBrowser.GridViewSizeSmall + 75)
             {
                 return 80; // Small thumbnail
             }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -11,6 +11,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Navigation;
 using Interaction = Files.Interacts.Interaction;
 
 namespace Files
@@ -27,8 +28,14 @@ namespace Files
 
             var selectionRectangle = RectangleSelection.Create(FileList, SelectionRectangle, FileList_SelectionChanged);
             selectionRectangle.SelectionEnded += SelectionRectangle_SelectionEnded;
-            App.AppSettings.LayoutModeChangeRequested += AppSettings_LayoutModeChangeRequested;
+        }
 
+        protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
+        {
+            base.OnNavigatedTo(eventArgs);
+            currentIconSize = GetIconSize();
+            FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
+            FolderSettings.LayoutModeChangeRequested += FolderSettings_LayoutModeChangeRequested;
             SetItemTemplate(); // Set ItemTemplate
         }
 
@@ -43,24 +50,24 @@ namespace Files
             FileList.Focus(FocusState.Programmatic);
         }
 
-        private void AppSettings_LayoutModeChangeRequested(object sender, EventArgs e)
+        private void FolderSettings_LayoutModeChangeRequested(object sender, EventArgs e)
         {
             SetItemTemplate(); // Set ItemTemplate
         }
 
         private void SetItemTemplate()
         {
-            FileList.ItemTemplate = (App.AppSettings.LayoutMode == 1) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
+            FileList.ItemTemplate = (FolderSettings.LayoutMode == 1) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
 
             // Set GridViewSize event handlers
-            if (App.AppSettings.LayoutMode == 1)
+            if (FolderSettings.LayoutMode == 1)
             {
-                App.AppSettings.GridViewSizeChangeRequested -= AppSettings_GridViewSizeChangeRequested;
+                FolderSettings.GridViewSizeChangeRequested -= AppSettings_GridViewSizeChangeRequested;
             }
-            else if (App.AppSettings.LayoutMode == 2)
+            else if (FolderSettings.LayoutMode == 2)
             {
                 currentIconSize = GetIconSize(); // Get icon size for jumps from other layouts directly to a grid size
-                App.AppSettings.GridViewSizeChangeRequested += AppSettings_GridViewSizeChangeRequested;
+                FolderSettings.GridViewSizeChangeRequested += AppSettings_GridViewSizeChangeRequested;
             }
         }
 
@@ -151,7 +158,7 @@ namespace Files
             TextBox textBox = null;
 
             // Handle layout differences between tiles browser and photo album
-            if (App.AppSettings.LayoutMode == 2)
+            if (FolderSettings.LayoutMode == 2)
             {
                 Popup popup = (gridViewItem.ContentTemplateRoot as Grid).FindName("EditPopup") as Popup;
                 TextBlock textBlock = (gridViewItem.ContentTemplateRoot as Grid).FindName("ItemName") as TextBlock;
@@ -236,7 +243,7 @@ namespace Files
 
         private void EndRename(TextBox textBox)
         {
-            if (App.AppSettings.LayoutMode == 2)
+            if (FolderSettings.LayoutMode == 2)
             {
                 Popup popup = textBox.Parent as Popup;
                 TextBlock textBlock = (popup.Parent as Grid).Children[1] as TextBlock;
@@ -359,19 +366,19 @@ namespace Files
             }
         }
 
-        private uint currentIconSize = GetIconSize();
+        private uint currentIconSize;
 
-        private static uint GetIconSize()
+        private uint GetIconSize()
         {
-            if (App.AppSettings.LayoutMode == 1 || App.AppSettings.GridViewSize < Constants.Browser.GridViewBrowser.GridViewSizeSmall + 75)
+            if (FolderSettings.LayoutMode == 1 || FolderSettings.GridViewSize < Constants.Browser.GridViewBrowser.GridViewSizeSmall + 75)
             {
                 return 80; // Small thumbnail
             }
-            else if (App.AppSettings.GridViewSize < Constants.Browser.GridViewBrowser.GridViewSizeMedium + 25)
+            else if (FolderSettings.GridViewSize < Constants.Browser.GridViewBrowser.GridViewSizeMedium + 25)
             {
                 return 120; // Medium thumbnail
             }
-            else if (App.AppSettings.GridViewSize < Constants.Browser.GridViewBrowser.GridViewSizeMedium - 50)
+            else if (FolderSettings.GridViewSize < Constants.Browser.GridViewBrowser.GridViewSizeMedium - 50)
             {
                 return 160; // Large thumbnail
             }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -23,6 +23,7 @@ namespace Files
         public GridViewBrowser()
         {
             InitializeComponent();
+            this.DataContext = this;
             base.BaseLayoutContextFlyout = BaseLayoutContextFlyout;
             base.BaseLayoutItemContextFlyout = BaseLayoutItemContextFlyout;
 
@@ -57,7 +58,11 @@ namespace Files
 
         private void SetItemTemplate()
         {
-            FileList.ItemTemplate = (FolderSettings.LayoutMode == 1) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
+            var template = (FolderSettings.LayoutMode == 1) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
+            if (template != FileList.ItemTemplate)
+            {
+                FileList.ItemTemplate = template;
+            }
 
             // Set GridViewSize event handlers
             if (FolderSettings.LayoutMode == 1)
@@ -67,6 +72,7 @@ namespace Files
             else if (FolderSettings.LayoutMode == 2)
             {
                 currentIconSize = GetIconSize(); // Get icon size for jumps from other layouts directly to a grid size
+                FolderSettings.GridViewSizeChangeRequested -= AppSettings_GridViewSizeChangeRequested;
                 FolderSettings.GridViewSizeChangeRequested += AppSettings_GridViewSizeChangeRequested;
             }
         }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -58,11 +58,7 @@ namespace Files
 
         private void SetItemTemplate()
         {
-            var template = (FolderSettings.LayoutMode == 1) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
-            if (template != FileList.ItemTemplate)
-            {
-                FileList.ItemTemplate = template;
-            }
+            FileList.ItemTemplate = (FolderSettings.LayoutMode == 1) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
 
             // Set GridViewSize event handlers
             if (FolderSettings.LayoutMode == 1)

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -124,7 +124,7 @@ namespace Files.Views
                             }
                             else
                             {
-                                AddNewTabAsync();
+                                await AddNewTabAsync();
                             }
                         }
                         else if (App.AppSettings.ContinueLastSessionOnStartUp)
@@ -139,22 +139,22 @@ namespace Files.Views
                             }
                             else
                             {
-                                AddNewTabAsync();
+                                await AddNewTabAsync();
                             }
                         }
                         else
                         {
-                            AddNewTabAsync();
+                            await AddNewTabAsync();
                         }
                     }
                     catch (Exception)
                     {
-                        AddNewTabAsync();
+                        await AddNewTabAsync();
                     }
                 }
                 else if (string.IsNullOrEmpty(navArgs))
                 {
-                    AddNewTabAsync();
+                    await AddNewTabAsync();
                 }
                 else
                 {

--- a/Files/Views/ModernShellPage.xaml
+++ b/Files/Views/ModernShellPage.xaml
@@ -225,7 +225,8 @@
                         DirectoryPropertiesViewModel="{x:Bind ContentPage.DirectoryPropertiesViewModel, Mode=OneWay}"
                         InvertSelectionInvokedCommand="{x:Bind InteractionOperations.InvertContentPageSelction, Mode=OneWay}"
                         SelectAllInvokedCommand="{x:Bind InteractionOperations.SelectAllContentPageItems, Mode=OneWay}"
-                        SelectedItemsPropertiesViewModel="{x:Bind ContentPage.SelectedItemsPropertiesViewModel, Mode=OneWay}" />
+                        SelectedItemsPropertiesViewModel="{x:Bind ContentPage.SelectedItemsPropertiesViewModel, Mode=OneWay}"
+                        FolderSettings="{x:Bind InstanceViewModel.FolderSettings, Mode=OneWay}"/>
                 </Grid>
             </Custom:DropShadowPanel>
         </Grid>

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -132,8 +132,8 @@ namespace Files.Views.Pages
                 navToolbar.PathBoxItemDropped += ModernShellPage_PathBoxItemDropped;
             }
 
-            AppSettings.SortDirectionPreferenceUpdated += AppSettings_SortDirectionPreferenceUpdated;
-            AppSettings.SortOptionPreferenceUpdated += AppSettings_SortOptionPreferenceUpdated;
+            InstanceViewModel.FolderSettings.SortDirectionPreferenceUpdated += AppSettings_SortDirectionPreferenceUpdated;
+            InstanceViewModel.FolderSettings.SortOptionPreferenceUpdated += AppSettings_SortOptionPreferenceUpdated;
 
             Window.Current.CoreWindow.PointerPressed += CoreWindow_PointerPressed;
             SystemNavigationManager.GetForCurrentView().BackRequested += ModernShellPage_BackRequested;
@@ -1214,8 +1214,8 @@ namespace Files.Views.Pages
                 navToolbar.PathBoxItemDropped -= ModernShellPage_PathBoxItemDropped;
             }
 
-            AppSettings.SortDirectionPreferenceUpdated -= AppSettings_SortDirectionPreferenceUpdated;
-            AppSettings.SortOptionPreferenceUpdated -= AppSettings_SortOptionPreferenceUpdated;
+            InstanceViewModel.FolderSettings.SortDirectionPreferenceUpdated -= AppSettings_SortDirectionPreferenceUpdated;
+            InstanceViewModel.FolderSettings.SortOptionPreferenceUpdated -= AppSettings_SortOptionPreferenceUpdated;
 
             if (FilesystemViewModel != null)    // Prevent weird case of this being null when many tabs are opened/closed quickly
             {

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -63,7 +63,7 @@ namespace Files.Views.Pages
         }
 
         public ItemViewModel FilesystemViewModel { get; private set; } = null;
-        public CurrentInstanceViewModel InstanceViewModel { get; } = new CurrentInstanceViewModel();
+        public CurrentInstanceViewModel InstanceViewModel { get; }
         private BaseLayout contentPage = null;
 
         public BaseLayout ContentPage
@@ -91,6 +91,7 @@ namespace Files.Views.Pages
         {
             InitializeComponent();
 
+            InstanceViewModel = new CurrentInstanceViewModel(this);
             filesystemHelpers = new FilesystemHelpers(this, App.CancellationToken);
             storageHistoryHelpers = new StorageHistoryHelpers(new StorageHistoryOperations(this, App.CancellationToken));
 
@@ -145,7 +146,7 @@ namespace Files.Views.Pages
             var invokedItem = (args.SelectedItem as ListedItem);
             if (invokedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
             {
-                ContentFrame.Navigate(AppSettings.GetLayoutType(), new NavigationArguments()
+                ContentFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(invokedItem.ItemPath), new NavigationArguments()
                 {
                     NavPathParam = invokedItem.ItemPath,
                     AssociatedTabInstance = this
@@ -178,7 +179,7 @@ namespace Files.Views.Pages
             if (args.ChosenSuggestion == null && !string.IsNullOrWhiteSpace(args.QueryText))
             {
                 App.InteractionViewModel.IsContentLoadingIndicatorVisible = true;
-                ContentFrame.Navigate(AppSettings.GetLayoutType(), new NavigationArguments()
+                ContentFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(FilesystemViewModel.WorkingDirectory), new NavigationArguments()
                 {
                     AssociatedTabInstance = this,
                     IsSearchResultPage = true,
@@ -309,7 +310,7 @@ namespace Files.Views.Pages
             }
 
             ContentFrame.Navigate(
-                sourcePageType == null ? App.AppSettings.GetLayoutType() : sourcePageType,
+                sourcePageType == null ? InstanceViewModel.FolderSettings.GetLayoutType(navigationPath) : sourcePageType,
                 new NavigationArguments()
                 {
                     NavPathParam = navigationPath,
@@ -504,7 +505,7 @@ namespace Files.Views.Pages
                 {
                     flyoutItem.Click += (sender, args) =>
                     {
-                        ContentFrame.Navigate(AppSettings.GetLayoutType(),
+                        ContentFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(childFolder.Path),
                                               new NavigationArguments()
                                               {
                                                   NavPathParam = childFolder.Path,
@@ -519,7 +520,7 @@ namespace Files.Views.Pages
 
         private void ModernShellPage_NavigationRequested(object sender, PathNavigationEventArgs e)
         {
-            ContentFrame.Navigate(e.LayoutType, new NavigationArguments()
+            ContentFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(e.ItemPath), new NavigationArguments()
             {
                 NavPathParam = e.ItemPath,
                 AssociatedTabInstance = this
@@ -571,7 +572,7 @@ namespace Files.Views.Pages
                     if (resFolder || FilesystemViewModel.CheckFolderAccessWithWin32(currentInput))
                     {
                         var pathToNavigate = resFolder.Result?.Path ?? currentInput;
-                        ContentFrame.Navigate(AppSettings.GetLayoutType(),
+                        ContentFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(pathToNavigate),
                                               new NavigationArguments()
                                               {
                                                   NavPathParam = pathToNavigate,
@@ -813,7 +814,7 @@ namespace Files.Views.Pages
 
             if (NavigationPath != "")
             {
-                ContentFrame.Navigate(AppSettings.GetLayoutType(),
+                ContentFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(NavigationPath),
                                       new NavigationArguments()
                                       {
                                           NavPathParam = NavigationPath,

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -1116,9 +1116,14 @@ namespace Files.Views.Pages
             Frame instanceContentFrame = ContentFrame;
             if (instanceContentFrame.CanGoBack)
             {
-                var previousSourcePageType = instanceContentFrame.BackStack[instanceContentFrame.BackStack.Count - 1].SourcePageType;
-                SelectSidebarItemFromPath(previousSourcePageType);
-                InstanceViewModel.FolderSettings.IsLayoutModeChanging = previousSourcePageType != CurrentPageType;
+                var previousPageContent = instanceContentFrame.BackStack[instanceContentFrame.BackStack.Count - 1];
+                var previousPageNavPath = previousPageContent.Parameter as NavigationArguments;
+                if (previousPageContent.SourcePageType != typeof(YourHome))
+                {
+                    // Update layout type
+                    InstanceViewModel.FolderSettings.GetLayoutType(previousPageNavPath.IsSearchResultPage ? previousPageNavPath.SearchPathParam : previousPageNavPath.NavPathParam);
+                }
+                SelectSidebarItemFromPath(previousPageContent.SourcePageType);
                 instanceContentFrame.GoBack();
             }
         }
@@ -1127,13 +1132,16 @@ namespace Files.Views.Pages
         {
             NavigationToolbar.CanGoForward = false;
             Frame instanceContentFrame = ContentFrame;
-
             if (instanceContentFrame.CanGoForward)
             {
-                var incomingSourcePageType = instanceContentFrame.ForwardStack[instanceContentFrame.ForwardStack.Count - 1].SourcePageType;
-                var Parameter = instanceContentFrame.ForwardStack[instanceContentFrame.ForwardStack.Count - 1].Parameter;
-                SelectSidebarItemFromPath(incomingSourcePageType);
-                InstanceViewModel.FolderSettings.IsLayoutModeChanging = incomingSourcePageType != CurrentPageType;
+                var incomingPageContent = instanceContentFrame.ForwardStack[instanceContentFrame.ForwardStack.Count - 1];
+                var incomingPageNavPath = incomingPageContent.Parameter as NavigationArguments;
+                if (incomingPageContent.SourcePageType != typeof(YourHome))
+                {
+                    // Update layout type
+                    InstanceViewModel.FolderSettings.GetLayoutType(incomingPageNavPath.IsSearchResultPage ? incomingPageNavPath.SearchPathParam : incomingPageNavPath.NavPathParam);
+                }
+                SelectSidebarItemFromPath(incomingPageContent.SourcePageType);
                 instanceContentFrame.GoForward();
             }
         }

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -1116,9 +1116,9 @@ namespace Files.Views.Pages
             Frame instanceContentFrame = ContentFrame;
             if (instanceContentFrame.CanGoBack)
             {
-                FilesystemViewModel.CancelLoadAndClearFiles();
                 var previousSourcePageType = instanceContentFrame.BackStack[instanceContentFrame.BackStack.Count - 1].SourcePageType;
                 SelectSidebarItemFromPath(previousSourcePageType);
+                InstanceViewModel.FolderSettings.IsLayoutModeChanging = previousSourcePageType != CurrentPageType;
                 instanceContentFrame.GoBack();
             }
         }
@@ -1130,10 +1130,10 @@ namespace Files.Views.Pages
 
             if (instanceContentFrame.CanGoForward)
             {
-                FilesystemViewModel.CancelLoadAndClearFiles();
                 var incomingSourcePageType = instanceContentFrame.ForwardStack[instanceContentFrame.ForwardStack.Count - 1].SourcePageType;
                 var Parameter = instanceContentFrame.ForwardStack[instanceContentFrame.ForwardStack.Count - 1].Parameter;
                 SelectSidebarItemFromPath(incomingSourcePageType);
+                InstanceViewModel.FolderSettings.IsLayoutModeChanging = incomingSourcePageType != CurrentPageType;
                 instanceContentFrame.GoForward();
             }
         }
@@ -1142,7 +1142,6 @@ namespace Files.Views.Pages
         {
             NavigationToolbar.CanNavigateToParent = false;
             Frame instanceContentFrame = ContentFrame;
-            FilesystemViewModel.CancelLoadAndClearFiles();
             var instance = FilesystemViewModel;
             string parentDirectoryOfPath = instance.WorkingDirectory.TrimEnd('\\');
             var lastSlashIndex = parentDirectoryOfPath.LastIndexOf("\\");

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -545,7 +545,6 @@ namespace Files.Views.Pages
                 if (currentInput.Equals("Home", StringComparison.OrdinalIgnoreCase)
                     || currentInput.Equals("NewTab".GetLocalized(), StringComparison.OrdinalIgnoreCase))
                 {
-                    await FilesystemViewModel.SetWorkingDirectoryAsync("NewTab".GetLocalized());
                     ContentFrame.Navigate(typeof(YourHome),
                                           new NavigationArguments()
                                           {
@@ -1119,13 +1118,12 @@ namespace Files.Views.Pages
             {
                 FilesystemViewModel.CancelLoadAndClearFiles();
                 var previousSourcePageType = instanceContentFrame.BackStack[instanceContentFrame.BackStack.Count - 1].SourcePageType;
-
                 SelectSidebarItemFromPath(previousSourcePageType);
                 instanceContentFrame.GoBack();
             }
         }
 
-        public async void Forward_Click()
+        public void Forward_Click()
         {
             NavigationToolbar.CanGoForward = false;
             Frame instanceContentFrame = ContentFrame;
@@ -1136,7 +1134,6 @@ namespace Files.Views.Pages
                 var incomingSourcePageType = instanceContentFrame.ForwardStack[instanceContentFrame.ForwardStack.Count - 1].SourcePageType;
                 var Parameter = instanceContentFrame.ForwardStack[instanceContentFrame.ForwardStack.Count - 1].Parameter;
                 SelectSidebarItemFromPath(incomingSourcePageType);
-                await FilesystemViewModel.SetWorkingDirectoryAsync((Parameter as NavigationArguments).NavPathParam);
                 instanceContentFrame.GoForward();
             }
         }

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -1155,7 +1155,7 @@ namespace Files.Views.Pages
             }
 
             SelectSidebarItemFromPath();
-            instanceContentFrame.Navigate(CurrentPageType,
+            instanceContentFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(parentDirectoryOfPath),
                                           new NavigationArguments()
                                           {
                                               NavPathParam = parentDirectoryOfPath,

--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -55,7 +55,10 @@
                 Margin="{StaticResource PropertyNameMargin}"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-                <usercontrols:FileIcon ItemSize="80" ViewModel="{x:Bind ViewModel}" />
+                <usercontrols:FileIcon
+                    AutomationProperties.AccessibilityView="Raw"
+                    ItemSize="80"
+                    ViewModel="{x:Bind ViewModel}" />
             </Grid>
             <TextBox
                 x:Name="ItemFileName"

--- a/Files/Views/SettingsPages/FilesAndFolders.xaml
+++ b/Files/Views/SettingsPages/FilesAndFolders.xaml
@@ -62,6 +62,12 @@
                     Header="Show unindexed items when searching for files and folders (searches may take longer)"
                     HeaderTemplate="{StaticResource CustomHeaderStyle}"
                     IsOn="{x:Bind AppSettings.SearchUnindexedItems, Mode=TwoWay}" />
+
+                <ToggleSwitch
+                    x:Uid="SettingsAreLayoutPreferencesPerFolder"
+                    Header="Enable folder view preferences per folder"
+                    HeaderTemplate="{StaticResource CustomHeaderStyle}"
+                    IsOn="{x:Bind AppSettings.AreLayoutPreferencesPerFolder, Mode=TwoWay}" />
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -16,8 +16,9 @@ namespace Files
 {
     public sealed partial class YourHome : Page
     {
+        private IShellPage AppInstance = null;
         public SettingsViewModel AppSettings => App.AppSettings;
-        public IShellPage AppInstance = null;
+        public FolderSettingsViewModel FolderSettings => AppInstance?.InstanceViewModel.FolderSettings;
         public AppServiceConnection Connection => AppInstance?.ServiceConnection;
 
         public YourHome()
@@ -60,7 +61,7 @@ namespace Files
             {
                 if (new DirectoryInfo(e.ItemPath).Root.ToString().Contains(@"C:\"))
                 {
-                    AppInstance.ContentFrame.Navigate(AppSettings.GetLayoutType(), new NavigationArguments()
+                    AppInstance.ContentFrame.Navigate(FolderSettings.GetLayoutType(e.ItemPath), new NavigationArguments()
                     {
                         AssociatedTabInstance = AppInstance,
                         NavPathParam = e.ItemPath
@@ -72,7 +73,7 @@ namespace Files
                     {
                         if (drive.Path.ToString() == new DirectoryInfo(e.ItemPath).Root.ToString())
                         {
-                            AppInstance.ContentFrame.Navigate(AppSettings.GetLayoutType(), new NavigationArguments()
+                            AppInstance.ContentFrame.Navigate(FolderSettings.GetLayoutType(e.ItemPath), new NavigationArguments()
                             {
                                 AssociatedTabInstance = AppInstance,
                                 NavPathParam = e.ItemPath
@@ -92,7 +93,7 @@ namespace Files
 
         private void RecentFilesWidget_RecentFilesOpenLocationInvoked(object sender, UserControls.PathNavigationEventArgs e)
         {
-            AppInstance.ContentFrame.Navigate(e.LayoutType, new NavigationArguments()
+            AppInstance.ContentFrame.Navigate(FolderSettings.GetLayoutType(e.ItemPath), new NavigationArguments()
             {
                 NavPathParam = e.ItemPath,
                 AssociatedTabInstance = AppInstance
@@ -101,7 +102,7 @@ namespace Files
 
         private void LibraryLocationCardsWidget_LibraryCardInvoked(object sender, LibraryCardInvokedEventArgs e)
         {
-            AppInstance.ContentFrame.Navigate(e.LayoutType, new NavigationArguments()
+            AppInstance.ContentFrame.Navigate(FolderSettings.GetLayoutType(e.Path), new NavigationArguments()
             {
                 NavPathParam = e.Path,
                 AssociatedTabInstance = AppInstance
@@ -111,7 +112,7 @@ namespace Files
 
         private void DrivesWidget_DrivesWidgetInvoked(object sender, DrivesWidget.DrivesWidgetInvokedEventArgs e)
         {
-            AppInstance.ContentFrame.Navigate(e.LayoutType, new NavigationArguments()
+            AppInstance.ContentFrame.Navigate(FolderSettings.GetLayoutType(e.Path), new NavigationArguments()
             {
                 NavPathParam = e.Path,
                 AssociatedTabInstance = AppInstance


### PR DESCRIPTION
Closes #530

This PR adds support for storing the layout mode on a per-folder basis.

Notes:
- Per folder settings: layout mode, gridview size, sort column, sort direction
- If a folder is renamed/moved the settings are preserved
- Adds a toggle in settings to disable per folder settings and use a global view mode
- Global view mode also acts as default view mode when per folder settings are enabled