### PR TITLE
Appcenter fixes 2

### DIFF
--- a/Files/Helpers/RegistryHelper.cs
+++ b/Files/Helpers/RegistryHelper.cs
@@ -110,7 +110,7 @@ namespace Files.Helpers
                 Command = (string)key.GetValue("Command"),
                 //Name = (string)key.GetValue("ItemName"),
                 //IconPath = (string)key.GetValue("IconPath"),
-                Icon = thumbnail,
+                Icon = thumbnail?.Result,
                 Data = data
             };
 

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -1005,9 +1005,9 @@ namespace Files.Interacts
                 return;
             }
             dataPackage.SetStorageItems(items);
-            Clipboard.SetContent(dataPackage);
             try
             {
+                Clipboard.SetContent(dataPackage);
                 Clipboard.Flush();
             }
             catch

--- a/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
+++ b/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
@@ -38,6 +38,7 @@ namespace Files.UserControls.Selection
             if (selectionState == SelectionState.Starting)
             {
                 // Clear selected items once if the pointer is pressed and moved
+                uiElement.CancelEdit();
                 uiElement.SelectedItems.Clear();
                 OnSelectionStarted();
                 selectionState = SelectionState.Active;
@@ -157,6 +158,7 @@ namespace Files.UserControls.Selection
             if (clickedRow == null)
             {
                 // If user click outside, reset selection
+                uiElement.CancelEdit();
                 uiElement.SelectedItems.Clear();
             }
             else if (uiElement.SelectedItems.Contains(clickedRow.DataContext))

--- a/Files/UserControls/Widgets/RecentFiles.xaml.cs
+++ b/Files/UserControls/Widgets/RecentFiles.xaml.cs
@@ -71,12 +71,13 @@ namespace Files
                 {
                     // Skip item until consent is provided
                 }
-                catch (Exception ex) when (
-                    ex is COMException
-                    || ex is FileNotFoundException
-                    || ex is ArgumentException
-                    || (uint)ex.HResult == 0x8007016A // The cloud file provider is not running
-                    || (uint)ex.HResult == 0x8000000A) // The data necessary to complete this operation is not yet available
+                // Exceptions include but are not limited to:
+                // COMException, FileNotFoundException, ArgumentException, DirectoryNotFoundException
+                // 0x8007016A -> The cloud file provider is not running
+                // 0x8000000A -> The data necessary to complete this operation is not yet available
+                // 0x80004005 -> Unspecified error
+                // 0x80270301 -> ?
+                catch (Exception ex)
                 {
                     mostRecentlyUsed.Remove(mruToken);
                     System.Diagnostics.Debug.WriteLine(ex);

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -1244,6 +1244,10 @@ namespace Files.Filesystem
 
         private async Task<bool> CheckBitlockerStatusAsync(StorageFolder rootFolder)
         {
+            if (rootFolder == null || rootFolder.Properties == null)
+            {
+                return false;
+            }
             if (Path.IsPathRooted(WorkingDirectory) && Path.GetPathRoot(WorkingDirectory) == WorkingDirectory)
             {
                 IDictionary<string, object> extraProperties = await rootFolder.Properties.RetrievePropertiesAsync(new string[] { "System.Volume.BitLockerProtection" });

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -1177,7 +1177,10 @@ namespace Files.Filesystem
                 {
                     break;
                 }
-                catch (Exception ex) when (ex is UnauthorizedAccessException || ex is FileNotFoundException)
+                catch (Exception ex) when (
+                    ex is UnauthorizedAccessException 
+                    || ex is FileNotFoundException
+                    || (uint)ex.HResult == 0x80070490) // ERROR_NOT_FOUND
                 {
                     ++count;
                     continue;

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -285,6 +285,12 @@ namespace Files
                 return;
             }
 
+            if (SelectedItem == null)
+            {
+                AllView.CancelEdit(); // Cancel the edit operation
+                return;
+            }
+
             int extensionLength = SelectedItem.FileExtension?.Length ?? 0;
             oldItemName = SelectedItem.ItemName;
 

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -617,7 +617,7 @@ namespace Files.Views.Pages
                                         string.Format("InvalidItemDialogContent".GetLocalized(), Environment.NewLine, resFolder.ErrorCode.ToString()));
                                 }
                             }
-                            catch (UriFormatException)
+                            catch (Exception ex) when (ex is UriFormatException || ex is ArgumentException)
                             {
                                 await DialogDisplayHelper.ShowDialogAsync("InvalidItemDialogTitle".GetLocalized(),
                                     string.Format("InvalidItemDialogContent".GetLocalized(), Environment.NewLine, resFolder.ErrorCode.ToString()));

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -555,10 +555,6 @@ namespace Files.Views.Pages
                 }
                 else
                 {
-                    var workingDir = string.IsNullOrEmpty(FilesystemViewModel.WorkingDirectory)
-                        ? AppSettings.HomePath
-                        : FilesystemViewModel.WorkingDirectory;
-
                     currentInput = StorageFileExtensions.GetPathWithoutEnvironmentVariable(currentInput);
                     if (currentSelectedPath == currentInput)
                     {
@@ -588,6 +584,11 @@ namespace Files.Views.Pages
                         }
                         else // Not a file or not accessible
                         {
+                            var workingDir = string.IsNullOrEmpty(FilesystemViewModel.WorkingDirectory)
+                                    || CurrentPageType == typeof(YourHome)
+                                ? AppSettings.HomePath
+                                : FilesystemViewModel.WorkingDirectory;
+
                             // Launch terminal application if possible
                             foreach (var terminal in AppSettings.TerminalController.Model.Terminals)
                             {
@@ -600,8 +601,7 @@ namespace Files.Views.Pages
                                         {
                                             { "WorkingDirectory", workingDir },
                                             { "Application", terminal.Path },
-                                            { "Arguments", string.Format(terminal.Arguments,
-                                            Helpers.PathNormalization.NormalizePath(FilesystemViewModel.WorkingDirectory)) }
+                                            { "Arguments", string.Format(terminal.Arguments, workingDir) }
                                         };
                                         await ServiceConnection.SendMessageAsync(value);
                                     }


### PR DESCRIPTION
Fixes #2680
Fixes #2652 (again)

This PR fixes some more crashing bugs that were detected by AppCenter for versions 0.23 and 0.23.1.
Each commit fixes a specific appcenter issue, the commit name is the appcenter error number.
They are mostly one-line fixes/null-checking/exception handling

ae7a748 / [1800236206u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/1800236206u/overview)
Fixes an issue where the app crashes when loading the recent file list

41ee5bf / [3096666166u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/3096666166u/overview)
Fixes an issue where the app crashes when enumerating folder contents

3ed4a4f / [1862552362u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/1862552362u/overview)
Fixes an issue where the app crashes when copying items

b153bf1 / [1467217610u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/1467217610u/overview)
Fixes an issue where the app crashes when renaming items

dc0f93a / [3365583470u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/3365583470u/overview)
Fixes an issue where the app crashes when using the selection rectangle

6d60c34 / [2236120821u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/2236120821u/overview)
Fixes an issue where the app crashes when enumerating folder contents

c880e54 / [3869644426u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/3869644426u/overview)
Fixes an issue where the app crashes when typing an invalid path in the addressbar

15c1e96 / [4073659172u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/4073659172u/overview)
Fixes an issue where the app crashes when typing "cmd.exe" while on the Home page

69f8ee2 / [3661855027u](https://appcenter.ms/orgs/Files-UWP/apps/Files/crashes/errors/3661855027u/overview)
One more fix for #2652
