### PR TITLE
Show dialog when renaming a file and the destination already exists

### DIFF
--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -459,11 +459,11 @@ namespace Files.Filesystem
                 }
                 else if (renamed == FilesystemErrorCode.ERROR_NOTAFILE || renamed == FilesystemErrorCode.ERROR_NOTAFOLDER)
                 {
-                    await DialogDisplayHelper.ShowDialogAsync("RenameError.NameInvalid.Title".GetLocalized(), "RenameError.NameInvalid.Text".GetLocalized());
+                    await DialogDisplayHelper.ShowDialogAsync("RenameError/NameInvalid/Title".GetLocalized(), "RenameError/NameInvalid/Text".GetLocalized());
                 }
                 else if (renamed == FilesystemErrorCode.ERROR_NAMETOOLONG)
                 {
-                    await DialogDisplayHelper.ShowDialogAsync("RenameError.TooLong.Title".GetLocalized(), "RenameError.TooLong.Text".GetLocalized());
+                    await DialogDisplayHelper.ShowDialogAsync("RenameError/TooLong/Title".GetLocalized(), "RenameError/TooLong/Text".GetLocalized());
                 }
                 else if (renamed == FilesystemErrorCode.ERROR_INUSE)
                 {
@@ -472,7 +472,7 @@ namespace Files.Filesystem
                 }
                 else if (renamed == FilesystemErrorCode.ERROR_NOTFOUND)
                 {
-                    await DialogDisplayHelper.ShowDialogAsync("RenameError.ItemDeleted.Title".GetLocalized(), "RenameError.ItemDeleted.Text".GetLocalized());
+                    await DialogDisplayHelper.ShowDialogAsync("RenameError/ItemDeleted/Title".GetLocalized(), "RenameError/ItemDeleted/Text".GetLocalized());
                 }
                 else if (renamed == FilesystemErrorCode.ERROR_ALREADYEXIST)
                 {

--- a/Files/Helpers/StorageItemHelpers.cs
+++ b/Files/Helpers/StorageItemHelpers.cs
@@ -18,21 +18,22 @@ namespace Files.Helpers
 
         public static async Task<FilesystemResult<IStorageItem>> ToStorageItemResult(this IStorageItemWithPath item, IShellPage associatedInstance = null)
         {
-            if (item.Item != null)
-            {
-                return new FilesystemResult<IStorageItem>(item.Item, FilesystemErrorCode.ERROR_SUCCESS);
-            }
+            var returnedItem = new FilesystemResult<IStorageItem>(null, FilesystemErrorCode.ERROR_GENERIC);
             if (!string.IsNullOrEmpty(item.Path))
             {
-                return (item.ItemType == FilesystemItemType.File) ?
-                    ToType<IStorageItem,StorageFile>(associatedInstance != null ?
+                returnedItem = (item.ItemType == FilesystemItemType.File) ?
+                    ToType<IStorageItem, StorageFile>(associatedInstance != null ?
                         await associatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.Path) :
                         await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFileFromPathAsync(item.Path))) :
                     ToType<IStorageItem, StorageFolder>(associatedInstance != null ?
                         await associatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.Path) :
                         await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(item.Path)));
             }
-            return new FilesystemResult<IStorageItem>(null, FilesystemErrorCode.ERROR_GENERIC);
+            if (returnedItem.Result == null && item.Item != null)
+            {
+                returnedItem = new FilesystemResult<IStorageItem>(item.Item, FilesystemErrorCode.ERROR_SUCCESS);
+            }
+            return returnedItem;
         }
 
         public static IStorageItemWithPath FromPathAndType(string customPath, FilesystemItemType? itemType)
@@ -59,7 +60,7 @@ namespace Files.Helpers
             return null;
         }
 
-        public static FilesystemResult<T> ToType<T,V>(FilesystemResult<V> result) where T : class
+        public static FilesystemResult<T> ToType<T, V>(FilesystemResult<V> result) where T : class
         {
             return new FilesystemResult<T>(result.Result as T, result.ErrorCode);
         }

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -426,7 +426,6 @@ namespace Files.Interacts
                         await AssociatedInstance.FilesystemViewModel.SetWorkingDirectoryAsync(folderPath);
                         AssociatedInstance.NavigationToolbar.PathControlDisplayText = folderPath;
 
-                        AssociatedInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
                         AssociatedInstance.ContentFrame.Navigate(sourcePageType, new NavigationArguments()
                         {
                             NavPathParam = folderPath,
@@ -441,7 +440,6 @@ namespace Files.Interacts
                         await AssociatedInstance.FilesystemViewModel.SetWorkingDirectoryAsync(clickedOnItemPath);
                         AssociatedInstance.NavigationToolbar.PathControlDisplayText = clickedOnItemPath;
 
-                        AssociatedInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
                         AssociatedInstance.ContentFrame.Navigate(sourcePageType, new NavigationArguments()
                         {
                             NavPathParam = clickedOnItemPath,
@@ -1083,9 +1081,7 @@ namespace Files.Interacts
         {
             DataPackageView packageView = Clipboard.GetContent();
             string destinationPath = AssociatedInstance.FilesystemViewModel.WorkingDirectory;
-
             await FilesystemHelpers.PerformOperationTypeAsync(packageView.RequestedOperation, packageView, destinationPath, true);
-            AssociatedInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed = false;
         }
 
         public async void CreateFileFromDialogResultType(AddItemType itemType, ShellNewEntry itemInfo)

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -828,96 +828,27 @@ namespace Files.Interacts
                 return true;
             }
 
-            if (!string.IsNullOrWhiteSpace(newName)
-                && !Filesystem.FilesystemHelpers.ContainsRestrictedCharacters(newName)
-                && !Filesystem.FilesystemHelpers.ContainsRestrictedFileName(newName))
+            var renamed = ReturnResult.InProgress;
+            if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
             {
-                var renamed = (FilesystemResult)false;
-                if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
+                renamed = await FilesystemHelpers.RenameAsync(StorageItemHelpers.FromPathAndType(item.ItemPath, FilesystemItemType.Directory),
+                    newName, NameCollisionOption.FailIfExists, true);
+            }
+            else
+            {
+                if (!AppSettings.ShowFileExtensions)
                 {
-                    renamed = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath)
-                        .OnSuccess(async (t) => await FilesystemHelpers.RenameAsync(t, newName, NameCollisionOption.FailIfExists, true));
+                    newName += item.FileExtension;
                 }
-                else
-                {
-                    if (!AppSettings.ShowFileExtensions)
-                    {
-                        newName += item.FileExtension;
-                    }
 
-                    renamed = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
-                        .OnSuccess(async (t) => await FilesystemHelpers.RenameAsync(t, newName, NameCollisionOption.FailIfExists, true));
-                }
-                if (renamed == FilesystemErrorCode.ERROR_UNAUTHORIZED)
-                {
-                    // Try again with MoveFileFromApp
-                    if (!NativeFileOperationsHelper.MoveFileFromApp(item.ItemPath, Path.Combine(Path.GetDirectoryName(item.ItemPath), newName)))
-                    {
-                        Debug.WriteLine(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
-                        return false;
-                    }
-                }
-                else if (renamed == FilesystemErrorCode.ERROR_NOTAFILE || renamed == FilesystemErrorCode.ERROR_NOTAFOLDER)
-                {
-                    await DialogDisplayHelper.ShowDialogAsync("RenameError.NameInvalid.Title".GetLocalized(), "RenameError.NameInvalid.Text".GetLocalized());
-                }
-                else if (renamed == FilesystemErrorCode.ERROR_NAMETOOLONG)
-                {
-                    await DialogDisplayHelper.ShowDialogAsync("RenameError.TooLong.Title".GetLocalized(), "RenameError.TooLong.Text".GetLocalized());
-                }
-                else if (renamed == FilesystemErrorCode.ERROR_INUSE)
-                {
-                    // TODO: proper dialog, retry
-                    await DialogDisplayHelper.ShowDialogAsync("FileInUseDeleteDialog/Title".GetLocalized(), "");
-                }
-                else if (renamed == FilesystemErrorCode.ERROR_NOTFOUND)
-                {
-                    await DialogDisplayHelper.ShowDialogAsync("RenameError.ItemDeleted.Title".GetLocalized(), "RenameError.ItemDeleted.Text".GetLocalized());
-                }
-                else if (renamed == FilesystemErrorCode.ERROR_ALREADYEXIST)
-                {
-                    var ItemAlreadyExistsDialog = new ContentDialog()
-                    {
-                        Title = "ItemAlreadyExistsDialogTitle".GetLocalized(),
-                        Content = "ItemAlreadyExistsDialogContent".GetLocalized(),
-                        PrimaryButtonText = "ItemAlreadyExistsDialogPrimaryButtonText".GetLocalized(),
-                        SecondaryButtonText = "ItemAlreadyExistsDialogSecondaryButtonText".GetLocalized()
-                    };
+                renamed = await FilesystemHelpers.RenameAsync(StorageItemHelpers.FromPathAndType(item.ItemPath, FilesystemItemType.File),
+                    newName, NameCollisionOption.FailIfExists, true);
+            }
 
-                    ContentDialogResult result = await ItemAlreadyExistsDialog.ShowAsync();
-
-                    if (result == ContentDialogResult.Primary)
-                    {
-                        if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
-                        {
-                            renamed = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath)
-                                .OnSuccess(async (t) => await FilesystemHelpers.RenameAsync(t, newName, NameCollisionOption.GenerateUniqueName, true));
-                        }
-                        else
-                        {
-                            renamed = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
-                                .OnSuccess(async (t) => await FilesystemHelpers.RenameAsync(t, newName, NameCollisionOption.GenerateUniqueName, true));
-                        }
-                    }
-                    else if (result == ContentDialogResult.Secondary)
-                    {
-                        if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
-                        {
-                            renamed = await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath)
-                                .OnSuccess(async (t) => await FilesystemHelpers.RenameAsync(t, newName, NameCollisionOption.ReplaceExisting, true));
-                        }
-                        else
-                        {
-                            renamed = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
-                                .OnSuccess(async (t) => await FilesystemHelpers.RenameAsync(t, newName, NameCollisionOption.ReplaceExisting, true));
-                        }
-                    }
-                }
-                if (renamed)
-                {
-                    AssociatedInstance.NavigationToolbar.CanGoForward = false;
-                    return true;
-                }
+            if (renamed == ReturnResult.Success)
+            {
+                AssociatedInstance.NavigationToolbar.CanGoForward = false;
+                return true;
             }
             return false;
         }

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -334,27 +334,31 @@ namespace Files.Filesystem
                 var changeType = (string)args.Request.Message["Type"];
                 var newItem = JsonConvert.DeserializeObject<ShellFileItem>(args.Request.Message.Get("Item", ""));
                 Debug.WriteLine("{0}: {1}", folderPath, changeType);
-                await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+                // If we are currently displaying the reycle bin lets refresh the items
+                if (CurrentFolder?.ItemPath == folderPath)
                 {
-                    // If we are currently displaying the reycle bin lets refresh the items
-                    if (CurrentFolder?.ItemPath == folderPath)
+                    switch (changeType)
                     {
-                        switch (changeType)
-                        {
-                            case "Created":
-                                AddFileOrFolderFromShellFile(newItem);
-                                break;
+                        case "Created":
+                            var newListedItem = AddFileOrFolderFromShellFile(newItem);
+                            if (newListedItem != null)
+                            {
+                                await AddFileOrFolderAsync(newListedItem);
+                            }
+                            break;
 
-                            case "Deleted":
-                                await RemoveFileOrFolderAsync(itemPath);
-                                break;
+                        case "Deleted":
+                            await RemoveFileOrFolderAsync(itemPath);
+                            break;
 
-                            default:
+                        default:
+                            await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                            {
                                 RefreshItems(null);
-                                break;
-                        }
+                            });
+                            break;
                     }
-                });
+                }
             }
             // The fulltrust process signaled that a drive has been connected/disconnected
             else if (args.Request.Message.ContainsKey("DeviceID"))
@@ -1485,10 +1489,13 @@ namespace Files.Filesystem
             }
         }
 
-        private void AddFileOrFolder(ListedItem item)
+        private async Task AddFileOrFolderAsync(ListedItem item)
         {
-            _filesAndFolders.Add(item);
-            IsFolderEmptyTextDisplayed = false;
+            await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+            {
+                _filesAndFolders.Add(item);
+                IsFolderEmptyTextDisplayed = false;
+            });
         }
 
         private async Task AddFileOrFolderAsync(string fileOrFolderPath, string dateReturnFormat)
@@ -1517,6 +1524,7 @@ namespace Files.Filesystem
                 var orderedList = OrderFiles2(tempList);
                 await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
                 {
+                    IsFolderEmptyTextDisplayed = false;
                     OrderFiles(orderedList);
                     UpdateDirectoryInfo();
                 });
@@ -1573,10 +1581,7 @@ namespace Files.Filesystem
             await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
             {
                 _filesAndFolders.Remove(item);
-                if (_filesAndFolders.Count == 0)
-                {
-                    IsFolderEmptyTextDisplayed = true;
-                }
+                IsFolderEmptyTextDisplayed = FilesAndFolders.Count == 0;
                 App.JumpList.RemoveFolder(item.ItemPath);
 
                 UpdateDirectoryInfo();


### PR DESCRIPTION
Fixes #2689

This PR:
- Fixes pasting files to hidden folders
- Fix rename dialog not showing when an item with the same name already exists
- Fix file list not updating in recycle bin when new files are deleted
- Fix a case in which the "empty folder" text was visible after pasting files into a folder with a redo operation