### PR TITLE
GridView: Remove inefficient code and eliminate EffectiveViewportChanged event

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -809,6 +809,12 @@ namespace Files
             var deferral = e.GetDeferral();
 
             ListedItem item = GetItemFromElement(sender);
+
+            if(item is null && sender is GridViewItem gvi)
+            {
+                item = gvi.Content as ListedItem;
+            }
+
             SetSelectedItemOnUi(item);
 
             if (dragOverItem != item)

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -537,13 +537,8 @@
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
                 Background="Transparent"
-                DataContext="{x:Bind}"
-                DataContextChanged="FileListGridItem_DataContextChanged"
-                EffectiveViewportChanged="Grid_EffectiveViewportChanged"
                 IsRightTapEnabled="True"
-                PointerPressed="FileListGridItem_PointerPressed"
                 RightTapped="StackPanel_RightTapped"
-                Tag="ItemRoot"
                 ToolTipService.ToolTip="{x:Bind ItemName}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
@@ -680,13 +675,8 @@
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
                 Background="Transparent"
-                DataContext="{x:Bind}"
-                DataContextChanged="FileListGridItem_DataContextChanged"
-                EffectiveViewportChanged="Grid_EffectiveViewportChanged"
                 IsRightTapEnabled="True"
-                PointerPressed="FileListGridItem_PointerPressed"
                 RightTapped="StackPanel_RightTapped"
-                Tag="ItemRoot"
                 ToolTipService.ToolTip="{x:Bind ItemName}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -907,6 +897,7 @@
             VerticalContentAlignment="Stretch"
             x:FieldModifier="public"
             AllowDrop="{x:Bind InstanceViewModel.IsPageTypeSearchResults, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
+            ChoosingItemContainer="FileList_ChoosingItemContainer"
             ContainerContentChanging="FileList_ContainerContentChanging"
             DoubleTapped="{x:Bind ParentShellPageInstance.InteractionOperations.List_ItemDoubleClick}"
             DragEnter="List_DragEnter"


### PR DESCRIPTION
Please test GridView layout behavior (especially dragging and dropping) against the current builds to find regressions. I'm also wondering if this improves responsiveness and resource consumption in large directories.