### PR TITLE
Shortcut: Fixed selected range and renaming

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -834,7 +834,7 @@ namespace Files.Interacts
             }
             else
             {
-                if (!AppSettings.ShowFileExtensions)
+                if (item.IsShortcutItem || !AppSettings.ShowFileExtensions)
                 {
                     newName += item.FileExtension;
                 }

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -298,7 +298,7 @@ namespace Files
             renamingTextBox.Focus(FocusState.Programmatic); // Without this,the user cannot edit the text box when renaming via right-click
 
             int selectedTextLength = SelectedItem.ItemName.Length;
-            if (AppSettings.ShowFileExtensions)
+            if (!SelectedItem.IsShortcutItem && AppSettings.ShowFileExtensions)
             {
                 selectedTextLength -= extensionLength;
             }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -195,7 +195,7 @@ namespace Files
             textBox.KeyDown += RenameTextBox_KeyDown;
 
             int selectedTextLength = SelectedItem.ItemName.Length;
-            if (App.AppSettings.ShowFileExtensions)
+            if (!SelectedItem.IsShortcutItem && App.AppSettings.ShowFileExtensions)
             {
                 selectedTextLength -= extensionLength;
             }


### PR DESCRIPTION
- Fixed an issue where when renaming a shortcut, its extension is cleared.
- Fixed selected name range when trying to rename shortcut.
Before:
![image](https://user-images.githubusercontent.com/20501502/103114390-05558a80-4667-11eb-86ef-94e8ff08cdce.png)
After:
![image](https://user-images.githubusercontent.com/20501502/103114409-1c947800-4667-11eb-8dcb-02d61649126e.png)