### PR TITLE
Fixed an issue where holding the ctrl key when using the selection rectangle would clear the current selection

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -67,7 +67,8 @@ namespace Files.Interacts
 
         public void List_ItemDoubleClick(object sender, DoubleTappedRoutedEventArgs e)
         {
-            if (!AppSettings.OpenItemsWithOneclick)
+            // Skip opening selected items if the double tap doesn't capture an item
+            if ((e.OriginalSource as FrameworkElement)?.DataContext is ListedItem && !AppSettings.OpenItemsWithOneclick)
             {
                 OpenSelectedItems(false);
             }

--- a/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
+++ b/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Windows.Foundation;
+using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -35,11 +36,16 @@ namespace Files.UserControls.Selection
 
         private void RectangleSelection_PointerMoved(object sender, PointerRoutedEventArgs e)
         {
+            var extendExistingSelection = e.KeyModifiers == VirtualKeyModifiers.Control;
+
             if (selectionState == SelectionState.Starting)
             {
-                // Clear selected items once if the pointer is pressed and moved
                 uiElement.CancelEdit();
-                uiElement.SelectedItems.Clear();
+                if (!extendExistingSelection)
+                {
+                    // Clear selected items once if the pointer is pressed and moved
+                    uiElement.SelectedItems.Clear();
+                }
                 OnSelectionStarted();
                 selectionState = SelectionState.Active;
             }
@@ -86,7 +92,7 @@ namespace Files.UserControls.Selection
                                 uiElement.SelectedItems.Add(item.Key);
                             }
                         }
-                        else
+                        else if (!extendExistingSelection)
                         {
                             uiElement.SelectedItems.Remove(item.Key);
                         }
@@ -159,7 +165,12 @@ namespace Files.UserControls.Selection
             {
                 // If user click outside, reset selection
                 uiElement.CancelEdit();
-                uiElement.SelectedItems.Clear();
+
+                var extendExistingSelection = e.KeyModifiers == VirtualKeyModifiers.Control;
+                if (!extendExistingSelection)
+                {
+                    uiElement.SelectedItems.Clear();
+                }
             }
             else if (uiElement.SelectedItems.Contains(clickedRow.DataContext))
             {

--- a/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
+++ b/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Windows.Foundation;
+using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
@@ -30,10 +31,15 @@ namespace Files.UserControls.Selection
 
         private void RectangleSelection_PointerMoved(object sender, PointerRoutedEventArgs e)
         {
+            var extendExistingSelection = e.KeyModifiers == VirtualKeyModifiers.Control;
+
             if (selectionState == SelectionState.Starting)
             {
                 // Clear selected items once if the pointer is pressed and moved
-                uiElement.SelectedItems.Clear();
+                if (!extendExistingSelection)
+                {
+                    uiElement.SelectedItems.Clear();
+                }
                 OnSelectionStarted();
                 selectionState = SelectionState.Active;
             }
@@ -71,7 +77,7 @@ namespace Files.UserControls.Selection
                                 uiElement.SelectedItems.Add(item.Key);
                             }
                         }
-                        else
+                        else if (!extendExistingSelection)
                         {
                             uiElement.SelectedItems.Remove(item.Key);
                         }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -133,7 +133,10 @@ namespace Files
         {
             if (e.GetCurrentPoint(sender as Page).Properties.IsLeftButtonPressed)
             {
-                ClearSelection();
+                if (e.KeyModifiers != VirtualKeyModifiers.Control)
+                {
+                    ClearSelection();
+                }
             }
             else if (e.GetCurrentPoint(null).Properties.IsMiddleButtonPressed)
             {


### PR DESCRIPTION
A fix for https://github.com/files-community/Files/issues/2137.
In addition to the above, preserves existing selection 
(when ctrl is pressed) if clicking at no item (similar to explorer).

Please be gentle - this is my first commit in this repo :blush:
