### PR TITLE
Teach rectangle selection to extend existing selection when the Shift key is pressed

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -187,6 +187,7 @@
     <Compile Include="UserControls\Selection\ExtendPreviousItemSelectionStrategy.cs" />
     <Compile Include="Helpers\GenericItemsCollection.cs" />
     <Compile Include="UserControls\Selection\IgnorePreviousItemSelectionStrategy.cs" />
+    <Compile Include="UserControls\Selection\InvertPreviousItemSelectionStrategy.cs" />
     <Compile Include="UserControls\Selection\ItemSelectionStrategy.cs" />
     <Compile Include="View Models\FolderSettingsViewModel.cs" />
     <Compile Include="View Models\Properties\FileProperty.cs" />

--- a/Files/UserControls/Selection/IgnorePreviousItemSelectionStrategy.cs
+++ b/Files/UserControls/Selection/IgnorePreviousItemSelectionStrategy.cs
@@ -26,5 +26,10 @@ namespace Files.UserControls.Selection
         {
             selectedItems.Clear();
         }
+
+        public override void HandleNoItemSelected()
+        {
+            selectedItems.Clear();
+        }
     }
 }

--- a/Files/UserControls/Selection/InvertPreviousItemSelectionStrategy.cs
+++ b/Files/UserControls/Selection/InvertPreviousItemSelectionStrategy.cs
@@ -2,18 +2,22 @@
 
 namespace Files.UserControls.Selection
 {
-    public class ExtendPreviousItemSelectionStrategy : ItemSelectionStrategy
+    internal class InvertPreviousItemSelectionStrategy : ItemSelectionStrategy
     {
         private readonly List<object> prevSelectedItems;
 
-        public ExtendPreviousItemSelectionStrategy(ICollection<object> selectedItems, List<object> prevSelectedItems) : base(selectedItems)
+        public InvertPreviousItemSelectionStrategy(ICollection<object> selectedItems, List<object> prevSelectedItems) : base(selectedItems)
         {
             this.prevSelectedItems = prevSelectedItems;
         }
 
         public override void HandleIntersectionWithItem(object item)
         {
-            if (!selectedItems.Contains(item))
+            if (prevSelectedItems.Contains(item))
+            {
+                selectedItems.Remove(item);
+            }
+            else if (!selectedItems.Contains(item))
             {
                 selectedItems.Add(item);
             }
@@ -22,7 +26,14 @@ namespace Files.UserControls.Selection
         public override void HandleNoIntersectionWithItem(object item)
         {
             // Restore selection on items not intersecting with the rectangle
-            if (!prevSelectedItems.Contains(item))
+            if (prevSelectedItems.Contains(item))
+            {
+                if (!selectedItems.Contains(item))
+                {
+                    selectedItems.Add(item);
+                }
+            }
+            else
             {
                 selectedItems.Remove(item);
             }

--- a/Files/UserControls/Selection/ItemSelectionStrategy.cs
+++ b/Files/UserControls/Selection/ItemSelectionStrategy.cs
@@ -19,5 +19,9 @@ namespace Files.UserControls.Selection
         public virtual void StartSelection()
         {
         }
+
+        public virtual void HandleNoItemSelected()
+        {
+        }
     }
 }

--- a/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
+++ b/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
@@ -23,6 +23,7 @@ namespace Files.UserControls.Selection
         private Dictionary<object, System.Drawing.Rectangle> itemsPosition;
         private IList<DataGridRow> dataGridRows;
         private List<object> prevSelectedItems;
+        private ItemSelectionStrategy selectionStrategy;
 
         public RectangleSelection_DataGrid(DataGrid uiElement, Rectangle selectionRectangle, SelectionChangedEventHandler selectionChanged = null)
         {
@@ -36,11 +37,6 @@ namespace Files.UserControls.Selection
 
         private void RectangleSelection_PointerMoved(object sender, PointerRoutedEventArgs e)
         {
-            var selectedItems = new GenericItemsCollection<object>(uiElement.SelectedItems);
-            var selectionStrategy = e.KeyModifiers == VirtualKeyModifiers.Control ?
-                    (ItemSelectionStrategy)new ExtendPreviousItemSelectionStrategy(selectedItems, prevSelectedItems) :
-                    new IgnorePreviousItemSelectionStrategy(selectedItems);
-
             if (selectionState == SelectionState.Starting)
             {
                 uiElement.CancelEdit();
@@ -155,23 +151,28 @@ namespace Files.UserControls.Selection
                 // Trigger only on left click, do not trigger with touch
                 return;
             }
-            var clickedRow = Interaction.FindParent<DataGridRow>(e.OriginalSource as DependencyObject);
-            if (clickedRow == null)
-            {
-                // If user click outside, reset selection
-                uiElement.CancelEdit();
 
-                var extendExistingSelection = e.KeyModifiers == VirtualKeyModifiers.Control;
-                if (!extendExistingSelection)
-                {
-                    uiElement.SelectedItems.Clear();
-                }
-            }
-            else if (uiElement.SelectedItems.Contains(clickedRow.DataContext))
+            var clickedRow = Interaction.FindParent<DataGridRow>(e.OriginalSource as DependencyObject);
+            if (clickedRow != null && uiElement.SelectedItems.Contains(clickedRow.DataContext))
             {
                 // If the item under the pointer is selected do not trigger selection rectangle
                 return;
             }
+
+            var selectedItems = new GenericItemsCollection<object>(uiElement.SelectedItems);
+            selectionStrategy = e.KeyModifiers == VirtualKeyModifiers.Control ?
+                    new InvertPreviousItemSelectionStrategy(selectedItems, prevSelectedItems) :
+                    e.KeyModifiers == VirtualKeyModifiers.Shift?
+                        (ItemSelectionStrategy)new ExtendPreviousItemSelectionStrategy(selectedItems, prevSelectedItems) :
+                        new IgnorePreviousItemSelectionStrategy(selectedItems);
+
+            if (clickedRow == null)
+            {
+                // If user click outside, reset selection
+                uiElement.CancelEdit();
+                selectionStrategy.HandleNoItemSelected();
+            }
+
             uiElement.PointerMoved -= RectangleSelection_PointerMoved;
             uiElement.PointerMoved += RectangleSelection_PointerMoved;
             if (selectionChanged != null)
@@ -206,6 +207,8 @@ namespace Files.UserControls.Selection
             {
                 OnSelectionEnded();
             }
+
+            selectionStrategy = null;
             selectionState = SelectionState.Inactive;
         }
 

--- a/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
+++ b/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
@@ -160,9 +160,9 @@ namespace Files.UserControls.Selection
             }
 
             var selectedItems = new GenericItemsCollection<object>(uiElement.SelectedItems);
-            selectionStrategy = e.KeyModifiers == VirtualKeyModifiers.Control ?
+            selectionStrategy = e.KeyModifiers.HasFlag(VirtualKeyModifiers.Control) ?
                     new InvertPreviousItemSelectionStrategy(selectedItems, prevSelectedItems) :
-                    e.KeyModifiers == VirtualKeyModifiers.Shift?
+                    e.KeyModifiers.HasFlag(VirtualKeyModifiers.Shift)?
                         (ItemSelectionStrategy)new ExtendPreviousItemSelectionStrategy(selectedItems, prevSelectedItems) :
                         new IgnorePreviousItemSelectionStrategy(selectedItems);
 

--- a/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
+++ b/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
@@ -109,9 +109,9 @@ namespace Files.UserControls.Selection
                 return;
             }
 
-            selectionStrategy = e.KeyModifiers == VirtualKeyModifiers.Control ?
+            selectionStrategy = e.KeyModifiers.HasFlag(VirtualKeyModifiers.Control) ?
                     new InvertPreviousItemSelectionStrategy(uiElement.SelectedItems, prevSelectedItems) :
-                    e.KeyModifiers == VirtualKeyModifiers.Shift ?
+                    e.KeyModifiers.HasFlag(VirtualKeyModifiers.Shift) ?
                         (ItemSelectionStrategy)new ExtendPreviousItemSelectionStrategy(uiElement.SelectedItems, prevSelectedItems) :
                         new IgnorePreviousItemSelectionStrategy(uiElement.SelectedItems);
 

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -130,14 +130,7 @@ namespace Files.Views.LayoutModes
 
         private void GridViewBrowserViewer_PointerPressed(object sender, PointerRoutedEventArgs e)
         {
-            if (e.GetCurrentPoint(sender as Page).Properties.IsLeftButtonPressed)
-            {
-                if (e.KeyModifiers != VirtualKeyModifiers.Control)
-                {
-                    ClearSelection();
-                }
-            }
-            else if (e.GetCurrentPoint(null).Properties.IsMiddleButtonPressed)
+            if (e.GetCurrentPoint(null).Properties.IsMiddleButtonPressed)
             {
                 ParentShellPageInstance.InteractionOperations.ItemPointerPressed(sender, e);
             }


### PR DESCRIPTION
This PR contains several modifications:
1. Shift + Select Rectangle - will extend the existing selection as in Windows Explorer
(unlike Ctrl + Select Rectangle that inverts the existing selection).
If both Shift and Ctrl are selected, Control wins (like in Windows Explorer)
2. The decision on the strategy is done upon mouse click:
you can release Shift, Ctrl afterwards
3. The logic of Clearing Selection was removed from GridViewBrowserViewer,
so the selection strategy can make the relevant decision