### PR TITLE
Make ScrollViewer lookup in Rectangle Selection robust

### DIFF
--- a/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
+++ b/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
@@ -148,6 +148,19 @@ namespace Files.UserControls.Selection
             selectionState = SelectionState.Inactive;
         }
 
+        private void RectangleSelection_LayoutUpdated(object sender, object e)
+        {
+            if (scrollViewer == null)
+            {
+                scrollViewer = Interaction.FindChild<ScrollViewer>(uiElement);
+            }
+
+            if (scrollViewer != null)
+            {
+                uiElement.LayoutUpdated -= RectangleSelection_LayoutUpdated;
+            }
+        }
+
         private void InitEvents(object sender, RoutedEventArgs e)
         {
             if (!uiElement.IsLoaded)
@@ -161,7 +174,12 @@ namespace Files.UserControls.Selection
                 uiElement.PointerReleased += RectangleSelection_PointerReleased;
                 uiElement.PointerCaptureLost += RectangleSelection_PointerReleased;
                 uiElement.PointerCanceled += RectangleSelection_PointerReleased;
+
                 scrollViewer = Interaction.FindChild<ScrollViewer>(uiElement);
+                if (scrollViewer == null)
+                {
+                    uiElement.LayoutUpdated += RectangleSelection_LayoutUpdated;
+                }
             }
         }
     }


### PR DESCRIPTION
There is a race in RectangleSelection_ListViewBase where we try to
find ScrollViewer in the VisualTree upon uiElement.Loaded.

Unfortunately, Loaded might be handled before all the children
of uiElement are loaded, and in this case ScrollViewer is still not found.

When this happens we actually don't have rectangle selection available.

The idea in this PR is to register for LayoutUpdated if scroll viewer is
not found upon Loaded (and to unregister once found).