### PR TITLE
Fixed an issue where there was a delay when deleting items

### DIFF
--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -316,7 +316,7 @@ namespace Files.Filesystem
                                                        bool permanently,
                                                        CancellationToken cancellationToken)
         {
-            bool deleteFromRecycleBin = await recycleBinHelpers.IsRecycleBinItem(source.Path);
+            bool deleteFromRecycleBin = recycleBinHelpers.IsPathUnderRecycleBin(source.Path);
 
             FilesystemResult fsResult = FilesystemErrorCode.ERROR_INPROGRESS;
 

--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -107,7 +107,7 @@ namespace Files.Filesystem
             ReturnResult returnStatus = ReturnResult.InProgress;
             banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
 
-            var pathsUnderRecycleBin = getPathsUnderRecycleBin(source);
+            var pathsUnderRecycleBin = GetPathsUnderRecycleBin(source);
 
             if (App.AppSettings.ShowConfirmDeleteDialog && showDialog) // Check if the setting to show a confirmation dialog is on
             {
@@ -173,7 +173,7 @@ namespace Files.Filesystem
             return returnStatus;
         }
 
-        private ISet<string> getPathsUnderRecycleBin(IEnumerable<IStorageItemWithPath> source)
+        private ISet<string> GetPathsUnderRecycleBin(IEnumerable<IStorageItemWithPath> source)
         {
             return source.Select(item => item.Path).Where(path => recycleBinHelpers.IsPathUnderRecycleBin(path)).ToHashSet();
         }

--- a/Files/Helpers/RecycleBinHelpers.cs
+++ b/Files/Helpers/RecycleBinHelpers.cs
@@ -14,7 +14,7 @@ namespace Files.Helpers
     public class RecycleBinHelpers : IDisposable
     {
         #region Private Members
-        private static readonly Regex RECYCLE_BIN_PATH_REGEX = new Regex(@"\w:\\\$Recycle\.Bin\\.*");
+        private static readonly Regex recycleBinPathRegex = new Regex(@"\w:\\\$Recycle\.Bin\\.*");
 
         private IShellPage associatedInstance;
 
@@ -75,7 +75,7 @@ namespace Files.Helpers
 
         public bool IsPathUnderRecycleBin(string path)
         {
-            return RECYCLE_BIN_PATH_REGEX.IsMatch(path);
+            return recycleBinPathRegex.IsMatch(path);
         }
 
         #region IDisposable

--- a/Files/Helpers/RecycleBinHelpers.cs
+++ b/Files/Helpers/RecycleBinHelpers.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.AppService;
 using Windows.Foundation.Collections;
@@ -13,6 +14,7 @@ namespace Files.Helpers
     public class RecycleBinHelpers : IDisposable
     {
         #region Private Members
+        private static readonly Regex RECYCLE_BIN_PATH_REGEX = new Regex(@"\w:\\\$Recycle\.Bin\\.*");
 
         private IShellPage associatedInstance;
 
@@ -69,6 +71,11 @@ namespace Files.Helpers
             }
 
             return recycleBinItems.Any((shellItem) => shellItem.RecyclePath == path);
+        }
+
+        public bool IsPathUnderRecycleBin(string path)
+        {
+            return RECYCLE_BIN_PATH_REGEX.IsMatch(path);
         }
 
         #region IDisposable


### PR DESCRIPTION
Fixes #2672
Fixes #2732

There is a significant lag on deletion, especially when numerous files are deleted.
This is significantly impacted by checking whether the file is in Recycle Bin.

This PR somewhat helps by:
* Delaying the check until the dialog presentation
(resolves the issue for those who disabled the dialog)
* Instead of searching in recycle bin just use path to decide
if the item is under recycle bin