### PR TITLE
Fixed an issue where trying to move a parent directory to a child directory would crash the app

### DIFF
--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -280,6 +280,12 @@ namespace Files.Filesystem
                                                      IProgress<FilesystemErrorCode> errorCode,
                                                      CancellationToken cancellationToken)
         {
+            if (Path.GetFileName(source.Path) == destination)
+            {
+                errorCode?.Report(FilesystemErrorCode.ERROR_SUCCESS);
+                return null;
+            }
+
             IStorageHistory history = await CopyAsync(source, destination, progress, errorCode, cancellationToken);
 
             if (string.IsNullOrWhiteSpace(source.Path))

--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -280,7 +280,7 @@ namespace Files.Filesystem
                                                      IProgress<FilesystemErrorCode> errorCode,
                                                      CancellationToken cancellationToken)
         {
-            if (Path.GetFileName(source.Path) == destination)
+            if (source.Path == destination)
             {
                 errorCode?.Report(FilesystemErrorCode.ERROR_SUCCESS);
                 return null;

--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -282,11 +282,17 @@ namespace Files.Filesystem
         {
             if (source.Path == destination)
             {
+                progress?.Report(100.0f);
                 errorCode?.Report(FilesystemErrorCode.ERROR_SUCCESS);
                 return null;
             }
 
             IStorageHistory history = await CopyAsync(source, destination, progress, errorCode, cancellationToken);
+            if (history == null)
+            {
+                // If copy was not performed we don't continue to delete to prevent data loss
+                return null;
+            }
 
             if (string.IsNullOrWhiteSpace(source.Path))
             {

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -1079,6 +1079,7 @@ namespace Files.Interacts
             DataPackageView packageView = Clipboard.GetContent();
             string destinationPath = AssociatedInstance.FilesystemViewModel.WorkingDirectory;
             await FilesystemHelpers.PerformOperationTypeAsync(packageView.RequestedOperation, packageView, destinationPath, true);
+            AssociatedInstance.ContentPage.ResetItemOpacity();
         }
 
         public async void CreateFileFromDialogResultType(AddItemType itemType, ShellNewEntry itemInfo)


### PR DESCRIPTION
Closes: https://github.com/files-community/Files/issues/1546
Closes: https://github.com/files-community/Files/issues/1545

Breaking change: do not proceed to Deletion during Move
if Copy failed (to prevent data loss)