### PR TITLE
Recycle Bin: Fixed recycle bin path detection

### DIFF
--- a/Files/Helpers/RecycleBinHelpers.cs
+++ b/Files/Helpers/RecycleBinHelpers.cs
@@ -14,7 +14,7 @@ namespace Files.Helpers
     public class RecycleBinHelpers : IDisposable
     {
         #region Private Members
-        private static readonly Regex recycleBinPathRegex = new Regex(@"\w:\\\$Recycle\.Bin\\.*");
+        private static readonly Regex recycleBinPathRegex = new Regex(@"\w:\\\$Recycle\.Bin\\.*", RegexOptions.IgnoreCase);
 
         private IShellPage associatedInstance;
 


### PR DESCRIPTION
For some reason items in recycle bin have path in upper case:
```
C:\$Recycle.Bin\S-1-5-21-2705651487-3556957933-866194168-1001\$RHYMD0V.tdesktop-theme
V:\$RECYCLE.BIN\S-1-5-21-2705651487-3556957933-866194168-1001\$R2QN0MI.exe
```