### PR TITLE
Fixed suggested keyboard shortcut in navbar menu

### DIFF
--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -1018,9 +1018,9 @@
                             </MenuFlyoutItem.Icon>
                             <MenuFlyoutItem.KeyboardAccelerators>
                                 <KeyboardAccelerator
-                                    Key="Right"
+                                    Key="Add"
                                     IsEnabled="False"
-                                    Modifiers="Control" />
+                                    Modifiers="Menu,Shift" />
                             </MenuFlyoutItem.KeyboardAccelerators>
                         </MenuFlyoutItem>
                         <MenuFlyoutItem

--- a/Files/Views/PaneHolderPage.xaml.cs
+++ b/Files/Views/PaneHolderPage.xaml.cs
@@ -204,15 +204,6 @@ namespace Files.Views
             }
         }
 
-        public void Clipboard_ContentChanged(object sender, object e)
-        {
-        }
-
-        public void Refresh_Click()
-        {
-            ActivePane?.Refresh_Click();
-        }
-
         public void Dispose()
         {
             PaneLeft?.Dispose();


### PR DESCRIPTION
The add pane menu in the navigation bar currently displays "ctrl + right" to open the right pane, the correct shortcut is instead *alt + shift + "+"* (or *ctrl + shift + right*)

![image](https://user-images.githubusercontent.com/9673091/103406332-a27a5c80-4b5a-11eb-9bf9-090a18589c5b.png)
