### PR TITLE
Ensure current cell is deselected when clicking outside of DataGrid

### DIFF
--- a/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
+++ b/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
@@ -22,7 +22,6 @@ namespace Files.UserControls.Selection
         private ScrollBar scrollBar;
         private SelectionChangedEventHandler selectionChanged;
 
-
         private Point originDragPoint;
         private Dictionary<object, System.Drawing.Rectangle> itemsPosition;
         private IList<DataGridRow> dataGridRows;

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -664,6 +664,7 @@
             AllowDrop="{x:Bind InstanceViewModel.IsPageTypeSearchResults, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
             AutoGenerateColumns="False"
             Background="Transparent"
+            BeginningEdit="AllView_BeginningEdit"
             CanUserReorderColumns="False"
             CanUserSortColumns="True"
             CellEditEnded="AllView_CellEditEnded"

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -217,50 +217,18 @@ namespace Files.Views.LayoutModes
         private TextBox renamingTextBox;
 
         private DispatcherTimer tapDebounceTimer;
-
-        private void AllView_PreparingCellForEdit(object sender, DataGridPreparingCellForEditEventArgs e)
+        private void AllView_BeginningEdit(object sender, DataGridBeginningEditEventArgs e)
         {
             if (ParentShellPageInstance.FilesystemViewModel.WorkingDirectory.StartsWith(AppSettings.RecycleBinPath))
             {
                 // Do not rename files and folders inside the recycle bin
-                AllView.CancelEdit(); // Cancel the edit operation
+                e.Cancel = true;
                 return;
             }
+        }
 
-            // Only cancel if this event was triggered by a tap
-            // Do not cancel when user presses F2 or context menu
-            if (e.EditingEventArgs is TappedRoutedEventArgs)
-            {
-                if (AppSettings.OpenItemsWithOneclick)
-                {
-                    AllView.CancelEdit(); // Cancel the edit operation
-                    return;
-                }
-
-                if (!tapDebounceTimer.IsEnabled)
-                {
-                    tapDebounceTimer.Debounce(() =>
-                    {
-                        tapDebounceTimer.Stop();
-                        AllView.BeginEdit(); // EditingEventArgs will be null
-                    }, TimeSpan.FromMilliseconds(700), false);
-                }
-                else
-                {
-                    tapDebounceTimer.Stop();
-                    ParentShellPageInstance.InteractionOperations.OpenItem_Click(null, null); // Open selected files
-                }
-
-                AllView.CancelEdit(); // Cancel the edit operation
-                return;
-            }
-
-            if (SelectedItem == null)
-            {
-                AllView.CancelEdit(); // Cancel the edit operation
-                return;
-            }
-
+        private void AllView_PreparingCellForEdit(object sender, DataGridPreparingCellForEditEventArgs e)
+        {
             int extensionLength = SelectedItem.FileExtension?.Length ?? 0;
             oldItemName = SelectedItem.ItemName;
 

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -225,6 +225,13 @@ namespace Files.Views.LayoutModes
                 e.Cancel = true;
                 return;
             }
+
+            if (e.EditingEventArgs is TappedRoutedEventArgs && AppSettings.OpenItemsWithOneclick)
+            {
+                // If for some reason we started renaming by a click in a one-click mode, cancel it
+                e.Cancel = true;
+                return;
+            }
         }
 
         private void AllView_PreparingCellForEdit(object sender, DataGridPreparingCellForEditEventArgs e)


### PR DESCRIPTION
Closes: https://github.com/files-community/Files/issues/2231

Root cause:
* When the user clicks outside of the AllView datagrid we manually clean the selection
* But from the datagrid perspective the "current cell" did not change
* Hence clicking on this "current cell" again triggers editing
(as per data grid specification)

Some implementation notes:
* To deselect the current cell we are forced to use reflection
as the relevant method is internal
* The PR removes "edit protections" that are not needed anymore
* The remaining protections are moved to BeginningEdit

