### PR TITLE
Select first DataGrid column when pressing F2

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -91,7 +91,7 @@ namespace Files
                 if (value != selectedItems)
                 {
                     selectedItems = value;
-                    if (selectedItems.Count == 0)
+                    if (selectedItems.Count == 0 || selectedItems[0] == null)
                     {
                         IsItemSelected = false;
                         SelectedItem = null;

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -176,8 +176,11 @@ namespace Files.Views.LayoutModes
 
         public override void StartRenameItem()
         {
-            AllView.CurrentColumn = AllView.Columns[1];
-            AllView.BeginEdit();
+            if (AllView.SelectedIndex != -1)
+            {
+                AllView.CurrentColumn = AllView.Columns[1];
+                AllView.BeginEdit();
+            }
         }
 
         private void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -1115,17 +1115,17 @@ namespace Files.Views
                     break;
             };
 
-            if (CurrentPageType == typeof(GridViewBrowser))
+            switch (args.KeyboardAccelerator.Key)
             {
-                switch (args.KeyboardAccelerator.Key)
-                {
-                    case VirtualKey.F2: //F2, rename
+                case VirtualKey.F2: //F2, rename
+                    if (CurrentPageType == typeof(GenericFileBrowser) || CurrentPageType == typeof(GridViewBrowser))
+                    {
                         if (ContentPage.IsItemSelected)
                         {
                             InteractionOperations.RenameItem_Click(null, null);
                         }
-                        break;
-                }
+                    }
+                    break;
             }
         }
 


### PR DESCRIPTION
This PR sets the file name column as the active DataGrid column on folder navigation, so pressing "F2" works without the need to click the list with the mouse first.
(thanks @Don-Vito for the SetCurrentCellCore method)