### PR TITLE
Prevent addition of item if failed to retrieve find data

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1553,6 +1553,13 @@ namespace Files.ViewModels
 
             IntPtr hFile = FindFirstFileExFromApp(fileOrFolderPath, findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero,
                                                   additionalFlags);
+            if (hFile.ToInt64() == -1)
+            {
+                // If we cannot find the file (probably since it doesn't exist anymore)
+                // simply exit without adding it
+                return;
+            }
+
             FindClose(hFile);
 
             ListedItem listedItem = null;


### PR DESCRIPTION
When we get notified about new item we call `AddFileOrFolderAsync` 
to add the item to the view model. 
However, by the time we run, the file might not exist already
(e.g., temporary lock file created by different programs).

In this case our call to `FindFirstFileExFromApp` fails and returns
uninitialized find data. Unfortunately, we were not checking this
failure and used the invalid find data to populate the item.

As a result we got what looked like unexpected and very 
suspicious folders / files in Chinese 
(and we all know that only unexpected files in Russian are scarier).

Resolves (at least partially): https://github.com/files-community/Files/issues/2109