### PR TITLE
Fix crash when clipboard changes before InteractionViewModel is set

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -176,6 +176,11 @@ namespace Files
 
         private void Clipboard_ContentChanged(object sender, object e)
         {
+            if (App.InteractionViewModel == null)
+            {
+                return;
+            }
+
             try
             {
                 // Clipboard.GetContent() will throw UnauthorizedAccessException


### PR DESCRIPTION
During debugging I often encounter the problem when copy-paste crashes the app.
This happens when InteractionViewModel is not initialized.
I didn't want to postpone the registration of Clipboard changed,
as in the future we might want to add handling even if InteractionViewModel
is still not initialized. So simply added a safe-check.