### PR TITLE
Automatically refresh view when an item visibility is changed

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -870,14 +870,15 @@ namespace Files.Interacts
             return false;
         }
 
-        public void SetHiddenAttributeItems(ListedItem item, bool isHidden)
+        /// <summary>
+        /// Set a single file or folder to hidden or unhidden an refresh the
+        /// view after setting the flag
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="isHidden"></param>
+        public void SetHiddenAttributeItem(ListedItem item, bool isHidden)
         {
-            // When multiple files are selected to be made hidden at once item gets null
-            if (item != null)
-            {
-                item.IsHiddenItem = isHidden;
-            }
-            // The view area needs a refresh when the hidden flag had been set
+            item.IsHiddenItem = isHidden;
             AssociatedInstance.ContentPage.ResetItemOpacity();
         }
 

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -870,22 +870,11 @@ namespace Files.Interacts
             return false;
         }
 
-        public bool SetHiddenAttributeItems(ListedItem item, bool isHidden)
+        public void SetHiddenAttributeItems(ListedItem item, bool isHidden)
         {
-            // Item is not null and therefore we have a single item which we need to update accordingly. In case item is null we have multiple
-            // items at once
-            if (item != null)
-            {
-                var viewItem = AssociatedInstance.ContentPage.SelectedItems.Where(p => p.ItemName == item.ItemName).FirstOrDefault();
-                if (viewItem != null)
-                {
-                    viewItem.IsHiddenItem = isHidden;
-                }
-
-                AssociatedInstance.ContentPage.ResetItemOpacity();
-            }
-
-            return true;
+            item.IsHiddenItem = isHidden;
+            // The view area needs a refresh when the hidden flag had been set
+            AssociatedInstance.ContentPage.ResetItemOpacity();
         }
 
         public async void RestoreItem_Click(object sender, RoutedEventArgs e)

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -872,7 +872,11 @@ namespace Files.Interacts
 
         public void SetHiddenAttributeItems(ListedItem item, bool isHidden)
         {
-            item.IsHiddenItem = isHidden;
+            // When multiple files are selected to be made hidden at once item gets null
+            if (item != null)
+            {
+                item.IsHiddenItem = isHidden;
+            }
             // The view area needs a refresh when the hidden flag had been set
             AssociatedInstance.ContentPage.ResetItemOpacity();
         }

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -870,6 +870,24 @@ namespace Files.Interacts
             return false;
         }
 
+        public bool SetHiddenAttributeItems(ListedItem item, bool isHidden)
+        {
+            // Item is not null and therefore we have a single item which we need to update accordingly. In case item is null we have multiple
+            // items at once
+            if (item != null)
+            {
+                var viewItem = AssociatedInstance.ContentPage.SelectedItems.Where(p => p.ItemName == item.ItemName).FirstOrDefault();
+                if (viewItem != null)
+                {
+                    viewItem.IsHiddenItem = isHidden;
+                }
+
+                AssociatedInstance.ContentPage.ResetItemOpacity();
+            }
+
+            return true;
+        }
+
         public async void RestoreItem_Click(object sender, RoutedEventArgs e)
         {
             if (AssociatedInstance.ContentPage.IsItemSelected)

--- a/Files/Views/Pages/PropertiesGeneral.xaml.cs
+++ b/Files/Views/Pages/PropertiesGeneral.xaml.cs
@@ -48,8 +48,21 @@ namespace Files.Views
                           ViewModel.ItemName));
                 }
 
-                // Handle the visibility attribute
-                await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => AppInstance.InteractionOperations.SetHiddenAttributeItems(item, ViewModel.IsHidden));
+                // Handle the hidden attribute
+                if (BaseProperties is CombinedProperties)
+                {
+                    // Handle each file independently
+                    var items = (BaseProperties as CombinedProperties).List;
+                    foreach (var fileOrFolder in items)
+                    {
+                        await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => AppInstance.InteractionOperations.SetHiddenAttributeItem(fileOrFolder, ViewModel.IsHidden));
+                    }
+                }
+                else
+                {
+                    // Handle the visibility attribute for a single file
+                    await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => AppInstance.InteractionOperations.SetHiddenAttributeItem(item, ViewModel.IsHidden));
+                }
             }
         }
     }

--- a/Files/Views/Pages/PropertiesGeneral.xaml.cs
+++ b/Files/Views/Pages/PropertiesGeneral.xaml.cs
@@ -47,6 +47,9 @@ namespace Files.Views
                           ViewModel.OriginalItemName,
                           ViewModel.ItemName));
                 }
+
+                // Handle the visibility attribute
+                await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => AppInstance.InteractionOperations.SetHiddenAttributeItems(item, ViewModel.IsHidden));
             }
         }
     }


### PR DESCRIPTION
The PR works for single files only so far... Still no refresh when setting multiple files to hidden at once (or vice versa).

Another issue is also not fixed yet. Deletion of hidden files. The .NET library cannot directly delete hidden files and / or folders, we would need WIN32 API for that. But we can remove the hidden flag prior deletion ;-).

Fixes #2785