### PR TITLE
Fixed an issue where the full trust process would crash when deleting hidden items

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -462,12 +462,12 @@ namespace FilesFullTrust
                         }
                         using var shi = new ShellItem(fileToDeletePath);
                         op.QueueDeleteOperation(shi);
-                        op.PostDeleteItem += async (s, e) =>
-                        {
-                            await args.Request.SendResponseAsync(new ValueSet() {
-                                { "Success", e.Result.Succeeded } });
-                        };
+                        var deleteTcs = new TaskCompletionSource<bool>();
+                        op.PostDeleteItem += (s, e) => deleteTcs.TrySetResult(e.Result.Succeeded);
                         op.PerformOperations();
+                        var result = await deleteTcs.Task;
+                        await args.Request.SendResponseAsync(new ValueSet() {
+                            { "Success", result } });
                     }
                     break;
 


### PR DESCRIPTION
Fixes an issue for which deleting hidden files/folders doesn't work and make the fulltrust process crash (#2638 whopsie)