### PR TITLE
Improve layout mode switching 2

### DIFF
--- a/Files/ViewModels/FolderSettingsViewModel.cs
+++ b/Files/ViewModels/FolderSettingsViewModel.cs
@@ -30,7 +30,6 @@ namespace Files.ViewModels
                 if (SetProperty(ref LayoutPreference.LayoutMode, value, nameof(LayoutMode)))
                 {
                     UpdateLayoutPreferencesForPath(associatedInstance.FilesystemViewModel.WorkingDirectory, LayoutPreference);
-                    LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                 }
             }
         }
@@ -83,6 +82,8 @@ namespace Files.ViewModels
             LayoutMode = FolderLayoutModes.GridView; // Grid View
 
             GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeLarge; // Size
+
+            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
         });
 
         public RelayCommand ToggleLayoutModeGridViewMedium => new RelayCommand(() =>
@@ -90,6 +91,8 @@ namespace Files.ViewModels
             LayoutMode = FolderLayoutModes.GridView; // Grid View
 
             GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeMedium; // Size
+
+            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
         });
 
         public RelayCommand ToggleLayoutModeGridViewSmall => new RelayCommand(() =>
@@ -97,16 +100,22 @@ namespace Files.ViewModels
             LayoutMode = FolderLayoutModes.GridView; // Grid View
 
             GridViewSize = Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Size
+
+            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
         });
 
         public RelayCommand ToggleLayoutModeTiles => new RelayCommand(() =>
         {
             LayoutMode = FolderLayoutModes.TilesView; // Tiles View
+
+            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
         });
 
         public RelayCommand ToggleLayoutModeDetailsView => new RelayCommand(() =>
         {
             LayoutMode = FolderLayoutModes.DetailsView; // Details View
+
+            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
         });
 
         public int GridViewSize
@@ -119,10 +128,12 @@ namespace Files.ViewModels
                     if (LayoutMode == FolderLayoutModes.TilesView) // Size down from tiles to list
                     {
                         LayoutMode = 0;
+                        LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                     }
                     else if (LayoutMode == FolderLayoutModes.GridView && value < Constants.Browser.GridViewBrowser.GridViewSizeSmall) // Size down from grid to tiles
                     {
                         LayoutMode = FolderLayoutModes.TilesView;
+                        LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                     }
                     else if (LayoutMode != FolderLayoutModes.DetailsView) // Resize grid view
                     {
@@ -132,6 +143,7 @@ namespace Files.ViewModels
                         if (LayoutMode != FolderLayoutModes.GridView) // Only update layout mode if it isn't already in grid view
                         {
                             LayoutMode = FolderLayoutModes.GridView;
+                            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                         }
                         else
                         {
@@ -146,6 +158,7 @@ namespace Files.ViewModels
                     if (LayoutMode == 0) // Size up from list to tiles
                     {
                         LayoutMode = FolderLayoutModes.TilesView;
+                        LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                     }
                     else // Size up from tiles to grid
                     {
@@ -155,6 +168,7 @@ namespace Files.ViewModels
                         if (LayoutMode != FolderLayoutModes.GridView) // Only update layout mode if it isn't already in grid view
                         {
                             LayoutMode = FolderLayoutModes.GridView;
+                            LayoutModeChangeRequested?.Invoke(this, EventArgs.Empty);
                         }
                         else
                         {

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -67,10 +67,11 @@ namespace Files.Views.LayoutModes
         {
             if (FolderSettings.LayoutMode == FolderLayoutModes.GridView || FolderSettings.LayoutMode == FolderLayoutModes.TilesView)
             {
-                var oldTemplate = FileList.ItemTemplate;
                 SetItemTemplate(); // Set ItemTemplate
-                if (oldTemplate != FileList.ItemTemplate)
+                var requestedIconSize = GetIconSize();
+                if (requestedIconSize != currentIconSize)
                 {
+                    currentIconSize = requestedIconSize;
                     ReloadItemIcons();
                 }
             }
@@ -87,7 +88,6 @@ namespace Files.Views.LayoutModes
             }
             else if (FolderSettings.LayoutMode == FolderLayoutModes.GridView)
             {
-                currentIconSize = GetIconSize(); // Get icon size for jumps from other layouts directly to a grid size
                 FolderSettings.GridViewSizeChangeRequested -= FolderSettings_GridViewSizeChangeRequested;
                 FolderSettings.GridViewSizeChangeRequested += FolderSettings_GridViewSizeChangeRequested;
             }
@@ -377,6 +377,10 @@ namespace Files.Views.LayoutModes
             {
                 return Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Small thumbnail
             }
+            else if (FolderSettings.GridViewSize <= Constants.Browser.GridViewBrowser.GridViewSizeSmall)
+            {
+                return Constants.Browser.GridViewBrowser.GridViewSizeSmall; // Small thumbnail
+            }
             else if (FolderSettings.GridViewSize <= Constants.Browser.GridViewBrowser.GridViewSizeMedium)
             {
                 return Constants.Browser.GridViewBrowser.GridViewSizeMedium; // Medium thumbnail
@@ -387,7 +391,7 @@ namespace Files.Views.LayoutModes
             }
             else
             {
-                return 240; // Extra large thumbnail
+                return Constants.Browser.GridViewBrowser.GridViewSizeMax; // Extra large thumbnail
             }
         }
 
@@ -405,11 +409,13 @@ namespace Files.Views.LayoutModes
 
         private void ReloadItemIcons()
         {
+            System.Diagnostics.Debug.WriteLine("Reloading icons to size: {0}", currentIconSize);
             foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders)
             {
                 listedItem.ItemPropertiesInitialized = false;
                 if (FileList.ContainerFromItem(listedItem) != null)
                 {
+                    System.Diagnostics.Debug.WriteLine("Reloading icon size: {0}", currentIconSize);
                     ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(listedItem, currentIconSize);
                     listedItem.ItemPropertiesInitialized = true;
                 }
@@ -444,12 +450,13 @@ namespace Files.Views.LayoutModes
             }
             args.ItemContainer.DataContext = args.Item;
 
-            if (args.Item is ListedItem item && (!item.ItemPropertiesInitialized))
+            if (args.Item is ListedItem item && !item.ItemPropertiesInitialized)
             {
                 args.ItemContainer.PointerPressed += FileListGridItem_PointerPressed;
                 InitializeDrag(args.ItemContainer);
                 args.ItemContainer.CanDrag = args.ItemContainer.IsSelected; // Update CanDrag
 
+                System.Diagnostics.Debug.WriteLine("Loading icon size: {0}", currentIconSize);
                 ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(item, currentIconSize);
                 item.ItemPropertiesInitialized = true;
             }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -409,13 +409,11 @@ namespace Files.Views.LayoutModes
 
         private void ReloadItemIcons()
         {
-            System.Diagnostics.Debug.WriteLine("Reloading icons to size: {0}", currentIconSize);
             foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders)
             {
                 listedItem.ItemPropertiesInitialized = false;
                 if (FileList.ContainerFromItem(listedItem) != null)
                 {
-                    System.Diagnostics.Debug.WriteLine("Reloading icon size: {0}", currentIconSize);
                     ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(listedItem, currentIconSize);
                     listedItem.ItemPropertiesInitialized = true;
                 }
@@ -456,7 +454,6 @@ namespace Files.Views.LayoutModes
                 InitializeDrag(args.ItemContainer);
                 args.ItemContainer.CanDrag = args.ItemContainer.IsSelected; // Update CanDrag
 
-                System.Diagnostics.Debug.WriteLine("Loading icon size: {0}", currentIconSize);
                 ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(item, currentIconSize);
                 item.ItemPropertiesInitialized = true;
             }


### PR DESCRIPTION
Small change after #2887

Avoid reloading icons when going from tilesview to gridview small (icon size is the same)
Use small icon size for gridview small
Increase max icon size to GridViewSizeMax
Revert changes to FolderSettingsViewModel.cs 