### PR TITLE
Properly clear and disconnect ItemSource upon navigating away from layout mode Page

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -384,16 +384,18 @@ namespace Files
             // Remove item jumping handler
             Window.Current.CoreWindow.CharacterReceived -= Page_CharacterReceived;
             FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
-        }
 
-        protected override void OnNavigatedFrom(NavigationEventArgs e)
-        {
             var parameter = e.Parameter as NavigationArguments;
             if (!parameter.IsLayoutSwitch)
             {
                 ParentShellPageInstance.FilesystemViewModel.CancelLoadAndClearFiles();
             }
         }
+
+        //protected override void OnNavigatedFrom(NavigationEventArgs e)
+        //{
+
+        //}
 
         private void UnloadMenuFlyoutItemByName(string nameToUnload)
         {

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -16,7 +16,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-    NavigationCacheMode="Enabled"
+    NavigationCacheMode="Disabled"
     PointerWheelChanged="BaseLayout_PointerWheelChanged"
     mc:Ignorable="d">
 
@@ -680,7 +680,6 @@
             Holding="AllView_Holding"
             IsDoubleTapEnabled="True"
             IsRightTapEnabled="True"
-            ItemsSource="{x:Bind ParentShellPageInstance.FilesystemViewModel.FilesAndFolders, Mode=OneWay}"
             PointerPressed="{x:Bind ParentShellPageInstance.InteractionOperations.ItemPointerPressed}"
             PreparingCellForEdit="AllView_PreparingCellForEdit"
             PreviewKeyDown="AllView_PreviewKeyDown"

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -108,6 +108,7 @@ namespace Files.Views.LayoutModes
         protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
         {
             base.OnNavigatedTo(eventArgs);
+            AllView.ItemsSource = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders;
             ParentShellPageInstance.FilesystemViewModel.PropertyChanged += ViewModel_PropertyChanged;
             AllView.LoadingRow += AllView_LoadingRow;
             AppSettings.ThemeModeChanged += AppSettings_ThemeModeChanged;
@@ -140,6 +141,7 @@ namespace Files.Views.LayoutModes
             ParentShellPageInstance.FilesystemViewModel.PropertyChanged -= ViewModel_PropertyChanged;
             AllView.LoadingRow -= AllView_LoadingRow;
             AppSettings.ThemeModeChanged -= AppSettings_ThemeModeChanged;
+            AllView.ItemsSource = null;
         }
 
         private void AppSettings_ThemeModeChanged(object sender, EventArgs e)

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -15,7 +15,7 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     x:Name="PageRoot"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-    NavigationCacheMode="Enabled"
+    NavigationCacheMode="Disabled"
     PointerPressed="GridViewBrowserViewer_PointerPressed"
     PointerWheelChanged="BaseLayout_PointerWheelChanged"
     mc:Ignorable="d">
@@ -925,7 +925,6 @@
             IsDoubleTapEnabled="True"
             IsItemClickEnabled="True"
             ItemClick="FileList_ItemClick"
-            ItemsSource="{x:Bind ParentShellPageInstance.FilesystemViewModel.FilesAndFolders}"
             PreviewKeyDown="FileList_PreviewKeyDown"
             SelectionChanged="FileList_SelectionChanged"
             SelectionMode="Extended"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -34,6 +34,7 @@ namespace Files.Views.LayoutModes
         protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
         {
             base.OnNavigatedTo(eventArgs);
+            FileList.ItemsSource = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders;
             currentIconSize = GetIconSize();
             FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
             FolderSettings.LayoutModeChangeRequested += FolderSettings_LayoutModeChangeRequested;
@@ -50,6 +51,7 @@ namespace Files.Views.LayoutModes
             base.OnNavigatingFrom(e);
             FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
             FolderSettings.GridViewSizeChangeRequested -= FolderSettings_GridViewSizeChangeRequested;
+            FileList.ItemsSource = null;
         }
 
         private async void SelectionRectangle_SelectionEnded(object sender, EventArgs e)

--- a/Files/Views/ModernShellPage.xaml
+++ b/Files/Views/ModernShellPage.xaml
@@ -241,7 +241,6 @@
                     Grid.Row="2"
                     x:FieldModifier="public"
                     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-                    CacheSize="2"
                     Navigated="ItemDisplayFrame_Navigated" />
 
                 <controls:StatusBarControl


### PR DESCRIPTION
We also disable caching of the layout mode pages which should cause them to be recreated every time. It also may prevent unnecessary caching of content.

**Don't merge this change. This is for testing whether memory is freed more frequently now compared to master.**