### PR TITLE
Un-initialize Drag and Drop events on items

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -392,11 +392,6 @@ namespace Files
             }
         }
 
-        //protected override void OnNavigatedFrom(NavigationEventArgs e)
-        //{
-
-        //}
-
         private void UnloadMenuFlyoutItemByName(string nameToUnload)
         {
             if (FindName(nameToUnload) is MenuFlyoutItemBase menuItem) // Prevent crash if the MenuFlyoutItem is missing

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -972,6 +972,15 @@ namespace Files
             }
         }
 
+        protected void UninitializeDrag(UIElement element)
+        {
+            element.AllowDrop = false;
+            element.DragStarting -= Item_DragStarting;
+            element.DragOver -= Item_DragOver;
+            element.DragLeave -= Item_DragLeave;
+            element.Drop -= Item_Drop;
+        }
+
         // VirtualKey doesn't support / accept plus and minus by default.
         public readonly VirtualKey PlusKey = (VirtualKey)187;
 

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -384,16 +384,18 @@ namespace Files
             // Remove item jumping handler
             Window.Current.CoreWindow.CharacterReceived -= Page_CharacterReceived;
             FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
-        }
 
-        protected override void OnNavigatedFrom(NavigationEventArgs e)
-        {
             var parameter = e.Parameter as NavigationArguments;
             if (!parameter.IsLayoutSwitch)
             {
                 ParentShellPageInstance.FilesystemViewModel.CancelLoadAndClearFiles();
             }
         }
+
+        //protected override void OnNavigatedFrom(NavigationEventArgs e)
+        //{
+
+        //}
 
         private void UnloadMenuFlyoutItemByName(string nameToUnload)
         {

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -16,7 +16,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-    NavigationCacheMode="Enabled"
+    NavigationCacheMode="Disabled"
     PointerWheelChanged="BaseLayout_PointerWheelChanged"
     mc:Ignorable="d">
 
@@ -680,7 +680,6 @@
             Holding="AllView_Holding"
             IsDoubleTapEnabled="True"
             IsRightTapEnabled="True"
-            ItemsSource="{x:Bind ParentShellPageInstance.FilesystemViewModel.FilesAndFolders, Mode=OneWay}"
             PointerPressed="{x:Bind ParentShellPageInstance.InteractionOperations.ItemPointerPressed}"
             PreparingCellForEdit="AllView_PreparingCellForEdit"
             PreviewKeyDown="AllView_PreviewKeyDown"

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -767,14 +767,6 @@
                         Value="5" />
                 </Core:DataTriggerBehavior>
             </Interactivity:Interaction.Behaviors>
-            <controls:DataGrid.CellStyle>
-                <Style TargetType="controls:DataGridCell">
-                    <Setter Property="BorderThickness" Value="0" />
-                    <Setter Property="AllowFocusOnInteraction" Value="True" />
-                    <Setter Property="FocusVisualPrimaryThickness" Value="0" />
-                    <Setter Property="FocusVisualSecondaryThickness" Value="0" />
-                </Style>
-            </controls:DataGrid.CellStyle>
             <controls:DataGrid.Columns>
                 <controls:DataGridTemplateColumn
                     x:Name="iconColumn"

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -108,6 +108,7 @@ namespace Files.Views.LayoutModes
         protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
         {
             base.OnNavigatedTo(eventArgs);
+            AllView.ItemsSource = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders;
             ParentShellPageInstance.FilesystemViewModel.PropertyChanged += ViewModel_PropertyChanged;
             AllView.LoadingRow += AllView_LoadingRow;
             AppSettings.ThemeModeChanged += AppSettings_ThemeModeChanged;
@@ -140,6 +141,7 @@ namespace Files.Views.LayoutModes
             ParentShellPageInstance.FilesystemViewModel.PropertyChanged -= ViewModel_PropertyChanged;
             AllView.LoadingRow -= AllView_LoadingRow;
             AppSettings.ThemeModeChanged -= AppSettings_ThemeModeChanged;
+            AllView.ItemsSource = null;
         }
 
         private void AppSettings_ThemeModeChanged(object sender, EventArgs e)

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -141,10 +141,19 @@ namespace Files.Views.LayoutModes
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
+            var rows = new List<DataGridRow>();
+            Interaction.FindChildren<DataGridRow>(rows, AllView);
+            foreach (DataGridRow row in rows)
+            {
+                row.CanDrag = false;
+                base.UninitializeDrag(row);
+            }
+            rows.Clear();
             base.OnNavigatingFrom(e);
             ParentShellPageInstance.FilesystemViewModel.PropertyChanged -= ViewModel_PropertyChanged;
             AllView.LoadingRow -= AllView_LoadingRow;
             AppSettings.ThemeModeChanged -= AppSettings_ThemeModeChanged;
+            
             AllView.ItemsSource = null;
         }
 

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -115,6 +115,7 @@ namespace Files.Views.LayoutModes
             AllView.ItemsSource = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders;
             ParentShellPageInstance.FilesystemViewModel.PropertyChanged += ViewModel_PropertyChanged;
             AllView.LoadingRow += AllView_LoadingRow;
+            AllView.UnloadingRow += AllView_UnloadingRow;
             AppSettings.ThemeModeChanged += AppSettings_ThemeModeChanged;
             ViewModel_PropertyChanged(null, new PropertyChangedEventArgs("DirectorySortOption"));
             var parameters = (NavigationArguments)eventArgs.Parameter;
@@ -122,6 +123,12 @@ namespace Files.Views.LayoutModes
             {
                 ReloadItemIcons();
             }
+        }
+
+        private void AllView_UnloadingRow(object sender, DataGridRowEventArgs e)
+        {
+            e.Row.CanDrag = false;
+            base.UninitializeDrag(e.Row);
         }
 
         private void ReloadItemIcons()
@@ -141,17 +148,10 @@ namespace Files.Views.LayoutModes
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
-            var rows = new List<DataGridRow>();
-            Interaction.FindChildren<DataGridRow>(rows, AllView);
-            foreach (DataGridRow row in rows)
-            {
-                row.CanDrag = false;
-                base.UninitializeDrag(row);
-            }
-            rows.Clear();
             base.OnNavigatingFrom(e);
             ParentShellPageInstance.FilesystemViewModel.PropertyChanged -= ViewModel_PropertyChanged;
             AllView.LoadingRow -= AllView_LoadingRow;
+            AllView.UnloadingRow -= AllView_UnloadingRow;
             AppSettings.ThemeModeChanged -= AppSettings_ThemeModeChanged;
             
             AllView.ItemsSource = null;
@@ -188,6 +188,7 @@ namespace Files.Views.LayoutModes
             {
                 var rows = new List<DataGridRow>();
                 Interaction.FindChildren<DataGridRow>(rows, AllView);
+                
                 foreach (DataGridRow row in rows)
                 {
                     row.CanDrag = SelectedItems.Contains(row.DataContext);
@@ -488,7 +489,7 @@ namespace Files.Views.LayoutModes
         private void AllView_LoadingRow(object sender, DataGridRowEventArgs e)
         {
             InitializeDrag(e.Row);
-
+ 
             if (e.Row.DataContext is ListedItem item && !item.ItemPropertiesInitialized)
             {
                 ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(item);

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -15,7 +15,7 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     x:Name="PageRoot"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-    NavigationCacheMode="Enabled"
+    NavigationCacheMode="Disabled"
     PointerPressed="GridViewBrowserViewer_PointerPressed"
     PointerWheelChanged="BaseLayout_PointerWheelChanged"
     mc:Ignorable="d">
@@ -925,7 +925,6 @@
             IsDoubleTapEnabled="True"
             IsItemClickEnabled="True"
             ItemClick="FileList_ItemClick"
-            ItemsSource="{x:Bind ParentShellPageInstance.FilesystemViewModel.FilesAndFolders}"
             PreviewKeyDown="FileList_PreviewKeyDown"
             SelectionChanged="FileList_SelectionChanged"
             SelectionMode="Extended"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -34,6 +34,7 @@ namespace Files.Views.LayoutModes
         protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
         {
             base.OnNavigatedTo(eventArgs);
+            FileList.ItemsSource = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders;
             currentIconSize = GetIconSize();
             FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
             FolderSettings.LayoutModeChangeRequested += FolderSettings_LayoutModeChangeRequested;
@@ -50,6 +51,7 @@ namespace Files.Views.LayoutModes
             base.OnNavigatingFrom(e);
             FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
             FolderSettings.GridViewSizeChangeRequested -= FolderSettings_GridViewSizeChangeRequested;
+            FileList.ItemsSource = null;
         }
 
         private async void SelectionRectangle_SelectionEnded(object sender, EventArgs e)

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -3,6 +3,7 @@ using Files.Filesystem;
 using Files.UserControls.Selection;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.System;
@@ -48,9 +49,18 @@ namespace Files.Views.LayoutModes
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
+            var selectorItems = new List<SelectorItem>();
+            Interaction.FindChildren<SelectorItem>(selectorItems, FileList);
+            foreach (SelectorItem gvi in selectorItems)
+            {
+                base.UninitializeDrag(gvi);
+                gvi.PointerPressed -= FileListGridItem_PointerPressed;
+            }
+            selectorItems.Clear();
             base.OnNavigatingFrom(e);
             FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
             FolderSettings.GridViewSizeChangeRequested -= FolderSettings_GridViewSizeChangeRequested;
+            
             FileList.ItemsSource = null;
         }
 

--- a/Files/Views/ModernShellPage.xaml
+++ b/Files/Views/ModernShellPage.xaml
@@ -241,7 +241,6 @@
                     Grid.Row="2"
                     x:FieldModifier="public"
                     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-                    CacheSize="2"
                     Navigated="ItemDisplayFrame_Navigated" />
 
                 <controls:StatusBarControl


### PR DESCRIPTION
We may never ship this, but these changes are reasonable and won't hurt in my opinion. This PR shouldn't break anything, but memory usage and scrolling performance should still be compared to master for potential regressions.

Addresses the part of #2843 that doesn't involve TabView at all, but item instances instead.