### PR TITLE
Search area: Fix bug where opening the search ASB for the first time would fail to move focus

### DIFF
--- a/Files/INavigationToolbar.cs
+++ b/Files/INavigationToolbar.cs
@@ -9,7 +9,7 @@ namespace Files.UserControls
 {
     public interface INavigationToolbar
     {
-        public bool IsSearchReigonVisible { get; set; }
+        public bool IsSearchRegionVisible { get; set; }
         public bool IsEditModeEnabled { get; set; }
         public bool CanRefresh { get; set; }
         public bool CanCopyPathInPage { get; set; }

--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -870,7 +870,7 @@
                 Width="36"
                 Height="32"
                 Margin="0,0,4,0"
-                x:Load="{x:Bind IsSearchReigonVisible, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+                x:Load="{x:Bind IsSearchRegionVisible, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
                 AutomationProperties.Name="Search"
                 Background="Transparent"
                 Click="SearchButton_Click"
@@ -887,20 +887,20 @@
             </Button>
 
             <AutoSuggestBox
-                x:Name="SearchReigon"
+                x:Name="SearchRegion"
                 x:Uid="NavigationToolbarSearchReigon"
                 Width="300"
                 Margin="0,0,4,0"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
-                LostFocus="SearchReigon_LostFocus"
+                LostFocus="SearchRegion_LostFocus"
                 PlaceholderText="Search"
-                QuerySubmitted="SearchReigon_QuerySubmitted"
-                SuggestionChosen="SearchReigon_SuggestionChosen"
+                QuerySubmitted="SearchRegion_QuerySubmitted"
+                SuggestionChosen="SearchRegion_SuggestionChosen"
                 TextBoxStyle="{StaticResource AutoSuggestBoxTextBoxStyleFixed}"
-                TextChanged="SearchReigon_TextChanged"
+                TextChanged="SearchRegion_TextChanged"
                 UpdateTextOnSelect="False"
-                Visibility="{x:Bind IsSearchReigonVisible, Mode=OneWay}">
+                Visibility="{x:Bind IsSearchRegionVisible, Mode=OneWay}">
                 <AutoSuggestBox.QueryIcon>
                     <FontIcon
                         FontFamily="{StaticResource FluentUIGlyphs}"

--- a/Files/UserControls/NavigationToolbar.xaml.cs
+++ b/Files/UserControls/NavigationToolbar.xaml.cs
@@ -467,20 +467,20 @@ namespace Files.UserControls
 
         public string PathText { get; set; }
 
-        private bool _IsSearchReigonVisible = false;
+        private bool _IsSearchRegionVisible = false;
 
-        public bool IsSearchReigonVisible
+        public bool IsSearchRegionVisible
         {
             get
             {
-                return _IsSearchReigonVisible;
+                return _IsSearchRegionVisible;
             }
             set
             {
-                if (value != _IsSearchReigonVisible)
+                if (value != _IsSearchRegionVisible)
                 {
-                    _IsSearchReigonVisible = value;
-                    NotifyPropertyChanged("IsSearchReigonVisible");
+                    _IsSearchRegionVisible = value;
+                    NotifyPropertyChanged("IsSearchRegionVisible");
                 }
             }
         }
@@ -877,30 +877,34 @@ namespace Files.UserControls
             RefreshRequested?.Invoke(this, EventArgs.Empty);
         }
 
-        private void SearchReigon_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        private void SearchRegion_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
         {
             SearchQuerySubmitted?.Invoke(sender, args);
         }
 
-        private void SearchReigon_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        private void SearchRegion_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
         {
             SearchTextChanged?.Invoke(sender, args);
         }
 
-        private void SearchReigon_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+        private void SearchRegion_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
         {
             SearchSuggestionChosen?.Invoke(sender, args);
-            IsSearchReigonVisible = false;
+            IsSearchRegionVisible = false;
         }
 
         private void SearchButton_Click(object sender, RoutedEventArgs e)
         {
-            IsSearchReigonVisible = true;
+            IsSearchRegionVisible = true;
 
-            SearchReigon.Focus(FocusState.Programmatic);
+            // Given that binding and layouting might take a few cycles, when calling UpdateLayout
+            // we can guarantee that the focus call will be able to find an open ASB
+            SearchRegion.UpdateLayout();
+
+            SearchRegion.Focus(FocusState.Programmatic);
         }
 
-        private void SearchReigon_LostFocus(object sender, RoutedEventArgs e)
+        private void SearchRegion_LostFocus(object sender, RoutedEventArgs e)
         {
             if (FocusManager.GetFocusedElement() is FlyoutBase ||
                 FocusManager.GetFocusedElement() is AppBarButton ||
@@ -909,16 +913,16 @@ namespace Files.UserControls
                 return;
             }
 
-            SearchReigon.Text = "";
-            IsSearchReigonVisible = false;
+            SearchRegion.Text = "";
+            IsSearchRegionVisible = false;
         }
 
-        public void ClearSearchBoxQueryText(bool collapseSearchReigon = false)
+        public void ClearSearchBoxQueryText(bool collapseSearchRegion = false)
         {
-            SearchReigon.Text = "";
-            if (IsSearchReigonVisible && collapseSearchReigon)
+            SearchRegion.Text = "";
+            if (IsSearchRegionVisible && collapseSearchRegion)
             {
-                IsSearchReigonVisible = false;
+                IsSearchRegionVisible = false;
             }
         }
 

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -1093,7 +1093,7 @@ namespace Files.Views
                     break;
 
                 case (false, false, false, true, VirtualKey.Space): // space, quick look
-                    if (!NavigationToolbar.IsEditModeEnabled && !NavigationToolbar.IsSearchReigonVisible)
+                    if (!NavigationToolbar.IsEditModeEnabled && !NavigationToolbar.IsSearchRegionVisible)
                     {
                         if (ContentPage.IsQuickLookEnabled)
                         {


### PR DESCRIPTION
Issue was that settings it's visibility for the first time resulted in a race condition where the focus was set before the rendering cycles necessary were finished.

This PR also renames "SearchReigon" to "SearchRegion" as this was a typo.

Fixes #2982