### PR TITLE
Prevent rename upon double-click on selected item

### DIFF
--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -676,7 +676,7 @@
             CellEditEnding="AllView_CellEditEnding"
             ClipboardCopyMode="None"
             ColumnHeaderHeight="38"
-            DoubleTapped="{x:Bind ParentShellPageInstance.InteractionOperations.List_ItemDoubleClick}"
+            DoubleTapped="AllView_DoubleTapped"
             DragEnter="List_DragEnter"
             Drop="List_Drop"
             FocusVisualPrimaryThickness="0"


### PR DESCRIPTION
Closes: https://github.com/files-community/Files/issues/2967.
Reintroduces debounce upon edit, as apparently double-click is not a DataGrid feature.
Hence we need to delay the cell edit, so the second tap is captured as a double-click.

Attempts to cancel debounce if selection changes so we don't modify the wrong item.