### PR TITLE
[Do not merge] - Show localized names for folders

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -492,14 +492,14 @@ namespace Files.ViewModels
         {
             if (orderedList == null)
             {
-                orderedList = OrderFiles2(_filesAndFolders);
+                orderedList = OrderFiles2(filesAndFolders);
             }
-            var oldIndex = _filesAndFolders.IndexOf(item);
+            var oldIndex = filesAndFolders.IndexOf(item);
             var newIndex = orderedList.IndexOf(item);
             if (newIndex != oldIndex)
             {
-                _filesAndFolders.RemoveAt(oldIndex);
-                _filesAndFolders.Insert(newIndex, item);
+                filesAndFolders.RemoveAt(oldIndex);
+                filesAndFolders.Insert(newIndex, item);
             }
         }
 
@@ -725,7 +725,7 @@ namespace Files.ViewModels
                                 if (matchingStorageItem.DisplayName != matchingStorageItem.Name)
                                 {
                                     matchingItem.ItemName = matchingStorageItem.DisplayName;
-                                    if (FolderSettings.DirectorySortOption == SortOption.Name && !_isLoadingItems)
+                                    if (FolderSettings.DirectorySortOption == SortOption.Name && !isLoadingItems)
                                     {
                                         InsertFileInOrder(matchingItem);
                                     }

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -497,7 +497,8 @@ namespace Files.ViewModels
             var newIndex = orderedList.IndexOf(item);
             if (newIndex != oldIndex)
             {
-                _filesAndFolders.Move(oldIndex, newIndex);
+                _filesAndFolders.RemoveAt(oldIndex);
+                _filesAndFolders.Insert(newIndex, item);
             }
         }
 

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -497,8 +497,7 @@ namespace Files.ViewModels
             var newIndex = orderedList.IndexOf(item);
             if (newIndex != oldIndex)
             {
-                _filesAndFolders.RemoveAt(oldIndex);
-                _filesAndFolders.Insert(newIndex, item);
+                _filesAndFolders.Move(oldIndex, newIndex);
             }
         }
 

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -707,6 +707,7 @@ namespace Files.ViewModels
                             StorageFolder matchingStorageItem = await GetFolderFromPathAsync(item.ItemPath);
                             if (matchingStorageItem != null)
                             {
+                                matchingItem.ItemName = matchingStorageItem.DisplayName;
                                 matchingItem.FolderRelativeId = matchingStorageItem.FolderRelativeId;
                                 matchingItem.ItemType = matchingStorageItem.DisplayType;
                                 var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageItem);
@@ -1053,7 +1054,7 @@ namespace Files.ViewModels
                 {
                     PrimaryItemAttribute = StorageItemTypes.Folder,
                     ItemPropertiesInitialized = true,
-                    ItemName = _rootFolder.Name,
+                    ItemName = _rootFolder.DisplayName,
                     ItemDateModifiedReal = (await _rootFolder.GetBasicPropertiesAsync()).DateModified,
                     ItemType = _rootFolder.DisplayType,
                     LoadFolderGlyph = true,
@@ -1891,7 +1892,7 @@ namespace Files.ViewModels
                 _filesAndFolders.Add(new ListedItem(folder.FolderRelativeId, dateReturnFormat)
                 {
                     PrimaryItemAttribute = StorageItemTypes.Folder,
-                    ItemName = folder.Name,
+                    ItemName = folder.DisplayName,
                     ItemDateModifiedReal = basicProperties.DateModified,
                     ItemType = folder.DisplayType,
                     IsHiddenItem = false,

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -487,6 +487,21 @@ namespace Files.ViewModels
             //_filesAndFolders.EndBulkOperation();
         }
 
+        public void InsertFileInOrder(ListedItem item, IList<ListedItem> orderedList = null)
+        {
+            if (orderedList == null)
+            {
+                orderedList = OrderFiles2(_filesAndFolders);
+            }
+            var oldIndex = _filesAndFolders.IndexOf(item);
+            var newIndex = orderedList.IndexOf(item);
+            if (newIndex != oldIndex)
+            {
+                _filesAndFolders.RemoveAt(oldIndex);
+                _filesAndFolders.Insert(newIndex, item);
+            }
+        }
+
         private IList<ListedItem> OrderFiles2(IList<ListedItem> listToSort)
         {
             if (listToSort.Count == 0)
@@ -707,7 +722,14 @@ namespace Files.ViewModels
                             StorageFolder matchingStorageItem = await GetFolderFromPathAsync(item.ItemPath);
                             if (matchingStorageItem != null)
                             {
-                                matchingItem.ItemName = matchingStorageItem.DisplayName;
+                                if (matchingStorageItem.DisplayName != matchingStorageItem.Name)
+                                {
+                                    matchingItem.ItemName = matchingStorageItem.DisplayName;
+                                    if (FolderSettings.DirectorySortOption == SortOption.Name && !_isLoadingItems)
+                                    {
+                                        InsertFileInOrder(matchingItem);
+                                    }
+                                }
                                 matchingItem.FolderRelativeId = matchingStorageItem.FolderRelativeId;
                                 matchingItem.ItemType = matchingStorageItem.DisplayType;
                                 var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageItem);

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -565,7 +565,7 @@
                 Background="Transparent"
                 IsRightTapEnabled="True"
                 RightTapped="StackPanel_RightTapped"
-                ToolTipService.ToolTip="{x:Bind ItemName}">
+                ToolTipService.ToolTip="{x:Bind ItemName, Mode=OneWay}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -670,7 +670,7 @@
                         Grid.Column="1"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
-                        Text="{x:Bind ItemName}"
+                        Text="{x:Bind ItemName, Mode=OneWay}"
                         TextTrimming="CharacterEllipsis"
                         TextWrapping="NoWrap" />
                 </Grid>
@@ -684,7 +684,7 @@
                         Margin="0"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
-                        Text="{x:Bind ItemName}"
+                        Text="{x:Bind ItemName, Mode=OneWay}"
                         TextAlignment="Center"
                         TextChanged="GridViewTextBoxItemName_TextChanged"
                         TextWrapping="Wrap" />
@@ -703,7 +703,7 @@
                 Background="Transparent"
                 IsRightTapEnabled="True"
                 RightTapped="StackPanel_RightTapped"
-                ToolTipService.ToolTip="{x:Bind ItemName}">
+                ToolTipService.ToolTip="{x:Bind ItemName, Mode=OneWay}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="90" />
@@ -802,7 +802,7 @@
                             Margin="0,0,10,0"
                             HorizontalAlignment="Left"
                             ScrollViewer.VerticalScrollBarVisibility="Auto"
-                            Text="{x:Bind ItemName}"
+                            Text="{x:Bind ItemName, Mode=OneWay}"
                             TextAlignment="Left"
                             TextTrimming="CharacterEllipsis"
                             TextWrapping="Wrap" />
@@ -813,7 +813,7 @@
                             Margin="0,0,10,0"
                             HorizontalAlignment="Left"
                             ScrollViewer.VerticalScrollBarVisibility="Auto"
-                            Text="{x:Bind ItemName}"
+                            Text="{x:Bind ItemName, Mode=OneWay}"
                             TextAlignment="Left"
                             TextWrapping="Wrap"
                             Visibility="Collapsed" />

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -467,7 +467,7 @@ namespace Files.Views
                         suggestions = currPath.Select(x => new ListedItem(null)
                         {
                             ItemPath = x.Path,
-                            ItemName = x.Folder.Name
+                            ItemName = x.Folder.DisplayName
                         }).ToList();
                     }
                     else if (currPath.Any())
@@ -476,12 +476,12 @@ namespace Files.Views
                         suggestions = currPath.Select(x => new ListedItem(null)
                         {
                             ItemPath = x.Path,
-                            ItemName = x.Folder.Name
+                            ItemName = x.Folder.DisplayName
                         }).Concat(
                             subPath.Select(x => new ListedItem(null)
                             {
                                 ItemPath = x.Path,
-                                ItemName = Path.Combine(currPath.First().Folder.Name, x.Folder.Name)
+                                ItemName = Path.Combine(currPath.First().Folder.DisplayName, x.Folder.DisplayName)
                             })).ToList();
                     }
                     else


### PR DESCRIPTION
Opening this PR just to gather some suggestions.

This PR shows the localized name for system folders (e.g "Program Files" -> "Programmi" in Italian)
To not slow down file loading, the localized name is fetched in LoadExtendedItemProperties() but this has another problem: the file list won't be sorted by name anymore. Ordering the list again works but it's quite ugly.

@jakoss how hard would it be to cache the localized names? I'd cache them separately from the file list cache and save the filesystem path + localized name