### PR TITLE
Use accent color in drive allocation chart

### DIFF
--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -16,6 +16,28 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary
+                    x:Key="Light">
+                    <SolidColorBrush
+                        x:Key="ProgressRingBackgroundThemeBrush"
+                        Color="#c3c3c3" />
+                </ResourceDictionary>
+
+                <ResourceDictionary
+                    x:Key="Dark">
+                    <SolidColorBrush
+                        x:Key="ProgressRingBackgroundThemeBrush"
+                        Color="#191919" />
+                </ResourceDictionary>
+
+                <ResourceDictionary
+                    x:Key="HighContrast">
+                    <SolidColorBrush
+                        x:Key="ProgressRingBackgroundThemeBrush"
+                        Color="#c3c3c3" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
     </local:PropertiesTab.Resources>
 
@@ -207,7 +229,7 @@
                     Width="15"
                     Height="15"
                     Margin="0,0,10,0"
-                    Fill="DodgerBlue"
+                    Fill="{ThemeResource SystemAccentColor}"
                     RadiusX="2"
                     RadiusY="2" />
                 <TextBlock
@@ -235,7 +257,7 @@
                     Width="15"
                     Height="15"
                     Margin="0,0,10,0"
-                    Fill="Gray"
+                    Fill="{ThemeResource ProgressRingBackgroundThemeBrush}"
                     RadiusX="2"
                     RadiusY="2" />
                 <TextBlock
@@ -334,18 +356,15 @@
                 Text="{x:Bind ViewModel.DriveCapacity, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.DriveCapacityVisibiity, Mode=OneWay}" />
 
-            <toolkit:RadialProgressBar
+            <muxc:ProgressRing
                 Grid.Row="17"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"
                 Width="70"
                 Height="70"
                 Margin="10"
-                Foreground="DodgerBlue"
+                IsIndeterminate="False"
                 Maximum="{x:Bind ViewModel.DriveCapacityDoubleValue, Mode=OneWay}"
-                Minimum="0"
-                Outline="Gray"
-                Thickness="10"
                 Visibility="{x:Bind ViewModel.DriveCapacityVisibiity, Mode=OneWay}"
                 Value="{x:Bind ViewModel.DriveUsedSpaceDoubleValue, Mode=OneWay}" />
 


### PR DESCRIPTION
Fixes #3132 
Before:
![image](https://user-images.githubusercontent.com/20501502/104963672-b855a180-59e3-11eb-995a-78a70ca07509.png)
![image](https://user-images.githubusercontent.com/20501502/104963690-bee41900-59e3-11eb-833a-beb7d3da7e6f.png)
After:
![image](https://user-images.githubusercontent.com/20501502/104963699-c6a3bd80-59e3-11eb-93ee-440f0cc53e03.png)
![image](https://user-images.githubusercontent.com/20501502/104963717-d4594300-59e3-11eb-98e1-62a585dc5f1a.png)
