### PR TITLE
Move cloud drive detection out of DrivesManager and improve sidebar population

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -61,7 +61,6 @@ namespace Files
             Suspending += OnSuspending;
             LeavingBackground += OnLeavingBackground;
             Clipboard.ContentChanged += Clipboard_ContentChanged;
-            Application.Current.Resuming += App_Resuming;
             // Initialize NLog
             StorageFolder storageFolder = ApplicationData.Current.LocalFolder;
             LogManager.Configuration.Variables["LogPath"] = storageFolder.Path;
@@ -69,31 +68,26 @@ namespace Files
             StartAppCenter();
         }
 
-        private async void App_Resuming(object sender, object e)
-        {
-            await EnsureSettingsAndConfigurationAreBootstrapped();
-        }
-
         internal static async Task EnsureSettingsAndConfigurationAreBootstrapped()
         {
             if (AppSettings == null)
             {
-                AppSettings = await Files.ViewModels.SettingsViewModel.CreateInstance();
+                AppSettings = await SettingsViewModel.CreateInstance();
             }
 
             if (App.AppSettings?.AcrylicTheme == null)
             {
-                Helpers.ThemeHelper.Initialize();
+                ThemeHelper.Initialize();
             }
 
             if (InteractionViewModel == null)
             {
-                InteractionViewModel = new Files.ViewModels.InteractionViewModel();
+                InteractionViewModel = new InteractionViewModel();
             }
 
             if (SidebarPinnedController == null)
             {
-                SidebarPinnedController = await Files.Controllers.SidebarPinnedController.CreateInstance();
+                SidebarPinnedController = await SidebarPinnedController.CreateInstance();
             }
         }
 
@@ -239,6 +233,7 @@ namespace Files
             Logger.Info("App activated");
 
             await EnsureSettingsAndConfigurationAreBootstrapped();
+
             // Window management
             if (!(Window.Current.Content is Frame rootFrame))
             {

--- a/Files/Controllers/IJson.cs
+++ b/Files/Controllers/IJson.cs
@@ -4,8 +4,6 @@
     {
         string JsonFileName { get; }
 
-        void Init();
-
         void SaveModel();
     }
 }

--- a/Files/Controllers/SidebarPinnedController.cs
+++ b/Files/Controllers/SidebarPinnedController.cs
@@ -17,9 +17,18 @@ namespace Files.Controllers
 
         public string JsonFileName { get; } = "PinnedItems.json";
 
-        public SidebarPinnedController()
+        private SidebarPinnedController() { }
+
+        public static Task<SidebarPinnedController> CreateInstance()
         {
-            Init();
+            var instance = new SidebarPinnedController();
+            return instance.InitializeAsync();
+        }
+
+        private async Task<SidebarPinnedController> InitializeAsync()
+        {
+            await LoadAsync();
+            return this;
         }
 
         private async Task LoadAsync()
@@ -72,11 +81,6 @@ namespace Files.Controllers
             }
 
             Model.AddAllItemsToSidebar();
-        }
-
-        public async void Init()
-        {
-            await LoadAsync();
         }
 
         public void SaveModel()

--- a/Files/Controllers/TerminalController.cs
+++ b/Files/Controllers/TerminalController.cs
@@ -20,9 +20,19 @@ namespace Files.Controllers
 
         public string JsonFileName { get; } = "terminal.json";
 
-        public TerminalController()
+        private TerminalController() { }
+
+        public static Task<TerminalController> CreateInstance()
         {
-            Init();
+            var instance = new TerminalController();
+            return instance.InitializeAsync();
+        }
+
+        private async Task<TerminalController> InitializeAsync()
+        {
+            await LoadAsync();
+            await GetInstalledTerminalsAsync();
+            return this;
         }
 
         private async Task LoadAsync()
@@ -91,12 +101,6 @@ namespace Files.Controllers
                 model.ResetToDefaultTerminal();
                 return model;
             }
-        }
-
-        public async void Init()
-        {
-            await LoadAsync();
-            await GetInstalledTerminalsAsync();
         }
 
         public async Task GetInstalledTerminalsAsync()

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -170,6 +170,7 @@
     <Compile Include="DataModels\ShellNewEntry.cs" />
     <Compile Include="Enums\FolderLayoutModes.cs" />
     <Compile Include="Enums\FileSystemStatusCode.cs" />
+    <Compile Include="Filesystem\CloudDrivesManager.cs" />
     <Compile Include="Helpers\AppServiceConnectionHelper.cs" />
     <Compile Include="Filesystem\Cloud\Providers\AmazonDriveProvider.cs" />
     <Compile Include="Helpers\AppUpdater.cs" />

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -630,7 +630,9 @@
     <PRIResource Include="Strings\de-DE\Resources.resw" />
     <PRIResource Include="Strings\es-ES\Resources.resw" />
     <PRIResource Include="Strings\fr-FR\Resources.resw" />
-    <PRIResource Include="Strings\en-US\Resources.resw" />
+    <PRIResource Include="Strings\en-US\Resources.resw">
+      <SubType>Designer</SubType>
+    </PRIResource>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/Files/Filesystem/CloudDrivesManager.cs
+++ b/Files/Filesystem/CloudDrivesManager.cs
@@ -103,7 +103,21 @@ namespace Files.Filesystem
                         {
                             Text = "SidebarCloudDrives".GetLocalized()
                         };
-                        MainPage.SideBarItems.Add(drivesSection);
+
+                        //Get the last location item in the sidebar
+                        var lastLocationItem = MainPage.SideBarItems.LastOrDefault(x => x is LocationItem);
+
+                        if (lastLocationItem != null)
+                        {
+                            //Get the index of the last location item
+                            var lastLocationItemIndex = MainPage.SideBarItems.IndexOf(lastLocationItem);
+                            //Insert the drives title beneath it
+                            MainPage.SideBarItems.Insert(lastLocationItemIndex + 1, drivesSection);
+                        }
+                        else
+                        {
+                            MainPage.SideBarItems.Add(drivesSection);
+                        }
                     }
 
                     var sectionStartIndex = MainPage.SideBarItems.IndexOf(drivesSection);

--- a/Files/Filesystem/CloudDrivesManager.cs
+++ b/Files/Filesystem/CloudDrivesManager.cs
@@ -5,14 +5,9 @@ using Microsoft.Toolkit.Uwp.Extensions;
 using NLog;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
-using Windows.Devices.Enumeration;
-using Windows.Devices.Portable;
-using Windows.Storage;
 using Windows.UI.Core;
 
 namespace Files.Filesystem
@@ -68,9 +63,9 @@ namespace Files.Filesystem
             {
                 await SyncSideBarItemsUI();
             }
-            catch (Exception)       // UI Thread not ready yet, so we defer the pervious operation until it is.
+            catch (Exception) // UI Thread not ready yet, so we defer the pervious operation until it is.
             {
-                Debug.WriteLine($"RefreshUI Exception");
+                System.Diagnostics.Debug.WriteLine($"RefreshUI Exception");
                 // Defer because UI-thread is not ready yet (and DriveItem requires it?)
                 CoreApplication.MainView.Activated += RefreshUI;
             }
@@ -84,7 +79,6 @@ namespace Files.Filesystem
 
         private async Task SyncSideBarItemsUI()
         {
-            Debug.WriteLine("SyncSideBarItemsUI");
             await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
                 lock (MainPage.SideBarItems)

--- a/Files/Filesystem/CloudDrivesManager.cs
+++ b/Files/Filesystem/CloudDrivesManager.cs
@@ -1,0 +1,177 @@
+using Files.Filesystem.Cloud;
+using Files.Views;
+using Microsoft.Toolkit.Mvvm.ComponentModel;
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
+using Windows.Devices.Enumeration;
+using Windows.Devices.Portable;
+using Windows.Storage;
+using Windows.UI.Core;
+
+namespace Files.Filesystem
+{
+    public class CloudDrivesManager : ObservableObject
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+        private List<DriveItem> drivesList = new List<DriveItem>();
+
+        public IReadOnlyList<DriveItem> Drives
+        {
+            get
+            {
+                lock (drivesList)
+                {
+                    return drivesList.ToList().AsReadOnly();
+                }
+            }
+        }
+
+        private async Task EnumerateDrivesAsync()
+        {
+            var cloudProviderController = new CloudProviderController();
+            await cloudProviderController.DetectInstalledCloudProvidersAsync();
+
+            foreach (var provider in cloudProviderController.CloudProviders)
+            {
+                var cloudProviderItem = new DriveItem()
+                {
+                    Text = provider.Name,
+                    Path = provider.SyncFolder,
+                    Type = DriveType.CloudDrive,
+                };
+                lock (drivesList)
+                {
+                    drivesList.Add(cloudProviderItem);
+                }
+            }
+
+            await RefreshUI();
+        }
+
+        public static async Task<CloudDrivesManager> CreateInstance()
+        {
+            var drives = new CloudDrivesManager();
+            await drives.EnumerateDrivesAsync();
+            return drives;
+        }
+
+        private async Task RefreshUI()
+        {
+            try
+            {
+                await SyncSideBarItemsUI();
+            }
+            catch (Exception)       // UI Thread not ready yet, so we defer the pervious operation until it is.
+            {
+                Debug.WriteLine($"RefreshUI Exception");
+                // Defer because UI-thread is not ready yet (and DriveItem requires it?)
+                CoreApplication.MainView.Activated += RefreshUI;
+            }
+        }
+
+        private async void RefreshUI(CoreApplicationView sender, Windows.ApplicationModel.Activation.IActivatedEventArgs args)
+        {
+            await SyncSideBarItemsUI();
+            CoreApplication.MainView.Activated -= RefreshUI;
+        }
+
+        private async Task SyncSideBarItemsUI()
+        {
+            Debug.WriteLine("SyncSideBarItemsUI");
+            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                lock (MainPage.SideBarItems)
+                {
+                    var drivesSection = MainPage.SideBarItems.FirstOrDefault(x => x is HeaderTextItem && x.Text == "Cloud Drives");
+
+                    if (drivesSection != null && Drives.Count == 0)
+                    {
+                        //No drives - remove the header
+                        MainPage.SideBarItems.Remove(drivesSection);
+                    }
+
+                    if (drivesSection == null)
+                    {
+                        drivesSection = new HeaderTextItem()
+                        {
+                            Text = "Cloud Drives"
+                        };
+                        MainPage.SideBarItems.Add(drivesSection);
+                    }
+
+                    var sectionStartIndex = MainPage.SideBarItems.IndexOf(drivesSection);
+
+                    //Remove all existing cloud drives from the sidebar
+                    foreach (var item in MainPage.SideBarItems
+                        .Where(x => x.ItemType == NavigationControlItemType.CloudDrive)
+                        .ToList())
+                    {
+                        MainPage.SideBarItems.Remove(item);
+                    }
+
+                    //Add all cloud drives to the sidebar
+                    var insertAt = sectionStartIndex + 1;
+                    foreach (var drive in Drives.OrderBy(o => o.Text))
+                    {
+                        MainPage.SideBarItems.Insert(insertAt, drive);
+                        insertAt++;
+                    }
+                }
+            });
+        }
+
+        public static async Task<StorageFolderWithPath> GetRootFromPathAsync(string devicePath)
+        {
+            if (!Path.IsPathRooted(devicePath))
+            {
+                return null;
+            }
+            var rootPath = Path.GetPathRoot(devicePath);
+            if (devicePath.StartsWith("\\\\?\\")) // USB device
+            {
+                // Check among already discovered drives
+                StorageFolder matchingDrive = App.AppSettings.CloudDrivesManager.Drives.FirstOrDefault(x =>
+                    Helpers.PathNormalization.NormalizePath(x.Path) == Helpers.PathNormalization.NormalizePath(rootPath))?.Root;
+                if (matchingDrive == null)
+                {
+                    // Check on all removable drives
+                    var remDevices = await DeviceInformation.FindAllAsync(StorageDevice.GetDeviceSelector());
+                    foreach (var item in remDevices)
+                    {
+                        try
+                        {
+                            var root = StorageDevice.FromId(item.Id);
+                            if (Helpers.PathNormalization.NormalizePath(rootPath).Replace("\\\\?\\", "") == root.Name.ToUpperInvariant())
+                            {
+                                matchingDrive = root;
+                                break;
+                            }
+                        }
+                        catch (Exception)
+                        {
+                            // Ignore this..
+                        }
+                    }
+                }
+                if (matchingDrive != null)
+                {
+                    return new StorageFolderWithPath(matchingDrive, rootPath);
+                }
+            }
+            else if (devicePath.StartsWith("\\\\")) // Network share
+            {
+                rootPath = rootPath.LastIndexOf("\\") > 1 ? rootPath.Substring(0, rootPath.LastIndexOf("\\")) : rootPath; // Remove share name
+                return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(rootPath), rootPath);
+            }
+            // It's ok to return null here, on normal drives StorageFolder.GetFolderFromPathAsync works
+            return null;
+        }
+
+    }
+}

--- a/Files/Filesystem/CloudDrivesManager.cs
+++ b/Files/Filesystem/CloudDrivesManager.cs
@@ -1,6 +1,7 @@
 using Files.Filesystem.Cloud;
 using Files.Views;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
+using Microsoft.Toolkit.Uwp.Extensions;
 using NLog;
 using System;
 using System.Collections.Generic;
@@ -88,7 +89,7 @@ namespace Files.Filesystem
             {
                 lock (MainPage.SideBarItems)
                 {
-                    var drivesSection = MainPage.SideBarItems.FirstOrDefault(x => x is HeaderTextItem && x.Text == "Cloud Drives");
+                    var drivesSection = MainPage.SideBarItems.FirstOrDefault(x => x is HeaderTextItem && x.Text == "SidebarCloudDrives".GetLocalized());
 
                     if (drivesSection != null && Drives.Count == 0)
                     {
@@ -100,7 +101,7 @@ namespace Files.Filesystem
                     {
                         drivesSection = new HeaderTextItem()
                         {
-                            Text = "Cloud Drives"
+                            Text = "SidebarCloudDrives".GetLocalized()
                         };
                         MainPage.SideBarItems.Add(drivesSection);
                     }

--- a/Files/Filesystem/CloudDrivesManager.cs
+++ b/Files/Filesystem/CloudDrivesManager.cs
@@ -97,7 +97,7 @@ namespace Files.Filesystem
                         MainPage.SideBarItems.Remove(drivesSection);
                     }
 
-                    if (drivesSection == null)
+                    if (drivesSection == null && Drives.Count > 0)
                     {
                         drivesSection = new HeaderTextItem()
                         {
@@ -139,53 +139,6 @@ namespace Files.Filesystem
                     }
                 }
             });
-        }
-
-        public static async Task<StorageFolderWithPath> GetRootFromPathAsync(string devicePath)
-        {
-            if (!Path.IsPathRooted(devicePath))
-            {
-                return null;
-            }
-            var rootPath = Path.GetPathRoot(devicePath);
-            if (devicePath.StartsWith("\\\\?\\")) // USB device
-            {
-                // Check among already discovered drives
-                StorageFolder matchingDrive = App.AppSettings.CloudDrivesManager.Drives.FirstOrDefault(x =>
-                    Helpers.PathNormalization.NormalizePath(x.Path) == Helpers.PathNormalization.NormalizePath(rootPath))?.Root;
-                if (matchingDrive == null)
-                {
-                    // Check on all removable drives
-                    var remDevices = await DeviceInformation.FindAllAsync(StorageDevice.GetDeviceSelector());
-                    foreach (var item in remDevices)
-                    {
-                        try
-                        {
-                            var root = StorageDevice.FromId(item.Id);
-                            if (Helpers.PathNormalization.NormalizePath(rootPath).Replace("\\\\?\\", "") == root.Name.ToUpperInvariant())
-                            {
-                                matchingDrive = root;
-                                break;
-                            }
-                        }
-                        catch (Exception)
-                        {
-                            // Ignore this..
-                        }
-                    }
-                }
-                if (matchingDrive != null)
-                {
-                    return new StorageFolderWithPath(matchingDrive, rootPath);
-                }
-            }
-            else if (devicePath.StartsWith("\\\\")) // Network share
-            {
-                rootPath = rootPath.LastIndexOf("\\") > 1 ? rootPath.Substring(0, rootPath.LastIndexOf("\\")) : rootPath; // Remove share name
-                return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(rootPath), rootPath);
-            }
-            // It's ok to return null here, on normal drives StorageFolder.GetFolderFromPathAsync works
-            return null;
         }
 
     }

--- a/Files/Filesystem/CloudDrivesManager.cs
+++ b/Files/Filesystem/CloudDrivesManager.cs
@@ -140,6 +140,5 @@ namespace Files.Filesystem
                 }
             });
         }
-
     }
 }

--- a/Files/Filesystem/DriveItem.cs
+++ b/Files/Filesystem/DriveItem.cs
@@ -79,7 +79,7 @@ namespace Files.Filesystem
 
         public DriveItem()
         {
-            ItemType = NavigationControlItemType.OneDrive;
+            ItemType = NavigationControlItemType.CloudDrive;
         }
 
         public DriveItem(StorageFolder root, string deviceId, DriveType type)
@@ -166,6 +166,10 @@ namespace Files.Filesystem
                     Glyph = "\ue9b7";
                     break;
 
+                case DriveType.CloudDrive:
+                    Glyph = "\ue9b7";
+                    break;
+
                 case DriveType.FloppyDisk:
                     Glyph = "\ueb4a";
                     break;
@@ -186,6 +190,7 @@ namespace Files.Filesystem
         FloppyDisk,
         Unknown,
         NoRootDirectory,
-        VirtualDrive
+        VirtualDrive,
+        CloudDrive,
     }
 }

--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -122,7 +122,7 @@ namespace Files.Filesystem
                             MainPage.SideBarItems.Remove(drivesSection);
                         }
 
-                        if (drivesSection == null)
+                        if (drivesSection == null && Drives.Count > 0)
                         {
                             drivesSection = new HeaderTextItem()
                             {

--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -102,7 +102,7 @@ namespace Files.Filesystem
 
         private void StartDeviceWatcher()
         {
-            deviceWatcher.Start();
+            deviceWatcher?.Start();
         }
 
         private async void DeviceWatcher_EnumerationCompleted(DeviceWatcher sender, object args)
@@ -129,20 +129,7 @@ namespace Files.Filesystem
                                 Text = "SidebarDrives".GetLocalized()
                             };
 
-                            //Get the last location item in the sidebar
-                            var lastLocationItem = MainPage.SideBarItems.LastOrDefault(x => x is LocationItem);
-
-                            if (lastLocationItem != null)
-                            {
-                                //Get the index of the last location item
-                                var lastLocationItemIndex = MainPage.SideBarItems.IndexOf(lastLocationItem);
-                                //Insert the drives title beneath it
-                                MainPage.SideBarItems.Insert(lastLocationItemIndex + 1, drivesSection);
-                            }
-                            else
-                            {
-                                MainPage.SideBarItems.Add(drivesSection);
-                            }
+                            MainPage.SideBarItems.Add(drivesSection);
                         }
 
                         var sectionStartIndex = MainPage.SideBarItems.IndexOf(drivesSection);
@@ -158,7 +145,7 @@ namespace Files.Filesystem
 
                         //Add all drives to the sidebar
                         var insertAt = sectionStartIndex + 1;
-                        foreach (var drive in Drives.OrderBy(o => o.Text))
+                        foreach (var drive in Drives)
                         {
                             MainPage.SideBarItems.Insert(insertAt, drive);
                             insertAt++;
@@ -506,7 +493,6 @@ namespace Files.Filesystem
         {
             if (!driveEnumInProgress)
             {
-                this.Dispose();
                 this.StartDeviceWatcher();
             }
         }

--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -88,7 +88,12 @@ namespace Files.Filesystem
 
         private void StartDeviceWatcher()
         {
-            deviceWatcher?.Start();
+            if (deviceWatcher.Status == DeviceWatcherStatus.Created
+                || deviceWatcher.Status == DeviceWatcherStatus.Stopped
+                || deviceWatcher.Status == DeviceWatcherStatus.Aborted)
+            {
+                deviceWatcher?.Start();
+            }
         }
 
         private async void DeviceWatcher_EnumerationCompleted(DeviceWatcher sender, object args)

--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -156,7 +156,6 @@ namespace Files.Filesystem
                             }
                         }
                     }
-
                 });
             }
             catch (Exception)       // UI Thread not ready yet, so we defer the pervious operation until it is.

--- a/Files/Filesystem/INavigationControlItem.cs
+++ b/Files/Filesystem/INavigationControlItem.cs
@@ -14,6 +14,6 @@
         Drive,
         LinuxDistro,
         Location,
-        OneDrive
+        CloudDrive
     }
 }

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -1656,4 +1656,7 @@
   <data name="SettingsWhenLaunchingFiles.Text" xml:space="preserve">
     <value>When Launching Files</value>
   </data>
+  <data name="SidebarCloudDrives" xml:space="preserve">
+    <value>Cloud Drives</value>
+  </data>
 </root>

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -593,7 +593,7 @@ namespace Files.UserControls
                     case NavigationControlItemType.Drive:
                         return DriveNavItemTemplate;
 
-                    case NavigationControlItemType.OneDrive:
+                    case NavigationControlItemType.CloudDrive:
                         return DriveNavItemTemplate;
 
                     case NavigationControlItemType.LinuxDistro:

--- a/Files/ViewModels/SettingsViewModel.cs
+++ b/Files/ViewModels/SettingsViewModel.cs
@@ -78,10 +78,6 @@ namespace Files.ViewModels
             return settings.Initialize();
         }
 
-        private SettingsViewModel() : this(true)
-        {
-        }
-
         private SettingsViewModel(bool initialize)
         {
             if (initialize)

--- a/Files/ViewModels/SettingsViewModel.cs
+++ b/Files/ViewModels/SettingsViewModel.cs
@@ -51,16 +51,6 @@ namespace Files.ViewModels
             DetectRecycleBinPreference();
             DetectQuickLook();
 
-            DrivesManager = await DrivesManager.CreateInstance();
-            //Initialise cloud drives in the background
-            CloudDrivesManager = await CloudDrivesManager.CreateInstance();
-
-            //DetectWSLDistros();
-            TerminalController = new TerminalController();
-
-            // Send analytics to AppCenter
-            TrackAnalytics();
-
             // Load the supported languages
             var supportedLang = ApplicationLanguages.ManifestLanguages;
             DefaultLanguages = new ObservableCollection<DefaultLanguageModel> { new DefaultLanguageModel(null) };
@@ -68,6 +58,16 @@ namespace Files.ViewModels
             {
                 DefaultLanguages.Add(new DefaultLanguageModel(lang));
             }
+
+            DrivesManager = await Files.Filesystem.DrivesManager.CreateInstance();
+            //Initialise cloud drives in the background
+            CloudDrivesManager = await Files.Filesystem.CloudDrivesManager.CreateInstance();
+
+            //DetectWSLDistros();
+            TerminalController = await Files.Controllers.TerminalController.CreateInstance();
+
+            // Send analytics to AppCenter
+            TrackAnalytics();
 
             return this;
         }

--- a/Files/ViewModels/SettingsViewModel.cs
+++ b/Files/ViewModels/SettingsViewModel.cs
@@ -29,20 +29,11 @@ namespace Files.ViewModels
     {
         private readonly ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
 
-        public DrivesManager DrivesManager
-        {
-            get;
-            private set;
-        } = new DrivesManager(false);
+        public DrivesManager DrivesManager { get; private set; }
 
         public CloudDrivesManager CloudDrivesManager { get; private set; }
 
         public TerminalController TerminalController { get; set; }
-
-        private async void Initialize2()
-        {
-            await Initialize();
-        }
 
         private async Task<SettingsViewModel> Initialize()
         {
@@ -59,12 +50,12 @@ namespace Files.ViewModels
                 DefaultLanguages.Add(new DefaultLanguageModel(lang));
             }
 
-            DrivesManager = await Files.Filesystem.DrivesManager.CreateInstance();
+            DrivesManager = await DrivesManager.CreateInstance();
             //Initialise cloud drives in the background
-            CloudDrivesManager = await Files.Filesystem.CloudDrivesManager.CreateInstance();
+            CloudDrivesManager = await CloudDrivesManager.CreateInstance();
 
             //DetectWSLDistros();
-            TerminalController = await Files.Controllers.TerminalController.CreateInstance();
+            TerminalController = await TerminalController.CreateInstance();
 
             // Send analytics to AppCenter
             TrackAnalytics();
@@ -74,17 +65,11 @@ namespace Files.ViewModels
 
         public static Task<SettingsViewModel> CreateInstance()
         {
-            var settings = new SettingsViewModel(false);
+            var settings = new SettingsViewModel();
             return settings.Initialize();
         }
 
-        private SettingsViewModel(bool initialize)
-        {
-            if (initialize)
-            {
-                Initialize2();
-            }
-        }
+        private SettingsViewModel() { }
 
         private void TrackAnalytics()
         {

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -5,11 +5,9 @@ using Files.Helpers;
 using Files.UserControls.MultitaskingControl;
 using Files.ViewModels;
 using Microsoft.Toolkit.Uwp.Extensions;
-using Newtonsoft.Json;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -75,7 +73,7 @@ namespace Files.Views
         {
             if (eventArgs.NavigationMode != NavigationMode.Back)
             {
-                App.AppSettings = new SettingsViewModel();
+                App.AppSettings = await SettingsViewModel.CreateInstance();
                 App.InteractionViewModel = new InteractionViewModel();
                 App.SidebarPinnedController = new SidebarPinnedController();
 

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -73,8 +73,6 @@ namespace Files.Views
         {
             if (eventArgs.NavigationMode != NavigationMode.Back)
             {
-                await App.EnsureSettingsAndConfigurationAreBootstrapped();
-
                 if (eventArgs.Parameter == null || (eventArgs.Parameter is string eventStr && string.IsNullOrEmpty(eventStr)))
                 {
                     try

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -73,11 +73,7 @@ namespace Files.Views
         {
             if (eventArgs.NavigationMode != NavigationMode.Back)
             {
-                App.AppSettings = await SettingsViewModel.CreateInstance();
-                App.InteractionViewModel = new InteractionViewModel();
-                App.SidebarPinnedController = new SidebarPinnedController();
-
-                Helpers.ThemeHelper.Initialize();
+                await App.EnsureSettingsAndConfigurationAreBootstrapped();
 
                 if (eventArgs.Parameter == null || (eventArgs.Parameter is string eventStr && string.IsNullOrEmpty(eventStr)))
                 {

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -7,6 +7,7 @@ using Files.ViewModels.Bundles;
 using Microsoft.Toolkit.Uwp.Extensions;
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Windows.ApplicationModel.AppService;
 using Windows.UI.Xaml.Controls;
@@ -79,19 +80,7 @@ namespace Files.Views
                 }
                 else
                 {
-                    foreach (DriveItem drive in AppSettings.DrivesManager.Drives)
-                    {
-                        if (drive.Path.ToString() == new DirectoryInfo(e.ItemPath).Root.ToString())
-                        {
-                            AppInstance.ContentFrame.Navigate(FolderSettings.GetLayoutType(e.ItemPath), new NavigationArguments()
-                            {
-                                AssociatedTabInstance = AppInstance,
-                                NavPathParam = e.ItemPath
-                            });
-                            return;
-                        }
-                    }
-                    foreach (DriveItem drive in AppSettings.CloudDrivesManager.Drives)
+                    foreach (DriveItem drive in Enumerable.Concat(AppSettings.DrivesManager.Drives, AppSettings.CloudDrivesManager.Drives))
                     {
                         if (drive.Path.ToString() == new DirectoryInfo(e.ItemPath).Root.ToString())
                         {

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -85,6 +85,18 @@ namespace Files.Views
                             return;
                         }
                     }
+                    foreach (DriveItem drive in AppSettings.CloudDrivesManager.Drives)
+                    {
+                        if (drive.Path.ToString() == new DirectoryInfo(e.ItemPath).Root.ToString())
+                        {
+                            AppInstance.ContentFrame.Navigate(FolderSettings.GetLayoutType(e.ItemPath), new NavigationArguments()
+                            {
+                                AssociatedTabInstance = AppInstance,
+                                NavPathParam = e.ItemPath
+                            });
+                            return;
+                        }
+                    }
                 }
             }
             catch (COMException)


### PR DESCRIPTION
DrivesManager was pretty complicated and had to deal with enumerating local and cloud drives, and rendering them both in the sidebar. Keeping this all in sync was leading to duplication and performance issues.

This PR introduces ```CloudDrivesManager``` which takes over responsibility of identifying cloud providers on a system, and rendering these in a section of the sidebar titled "Cloud Drives".

The original ```DrivesManager``` is now a little simpler, and has a rewritten method to add/remove drives in the sidebar.

I have identified that some of the sync and duplication issues appeared to be caused by timing issues likely introduced by various async calls being made from constructors (which obviously are not async methods). To improve this situation, ```CloudDrivesManager```, ```DrivesManager```, and ```SettingsViewModel``` have been tweaked to use a factory constructor pattern. Now instead of ```new```ing up those objects and having async methods called and forgotten about, a new instance can be obtained by calling ```await ClassName.CreateInstance();``` which allows async methods to be called when these objects are setup.

I have seen some areas; particularly stemming from ```SettingsViewModel``` where I feel classes have more responsibility than they need, and have complicated dependencies. For example, ```SettingsViewModel``` is responsible for loading all drives, cloud drives, and a lot of other system information - making it more than just settings. By being responsible for loading all drives, it has a hard dependency on ```DrivesManager```, which in one or more methods directly calls methods on views. ```DrivesManager``` also depends on ```DriveItem``` which also calls the UI to perform updates or run code on the UI thread.

I started going down a deep whole trying to refactor some of this to make changes easier to test with unit tests, but these dependencies make it almost impossible. So I worked my way back out and have done this with the minimal changes. I have some ideas that might help based on what I've done with some Xamarin apps, but I don't know how feasible they will be with a UWP app.

@gave92, please give this a try and see if it stops you duplicated drive issue.