### PR TITLE
Fix: Ensure OneDrive Accounts registry key is not null

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -328,6 +328,11 @@ namespace FilesFullTrust
                 case "GetOneDriveAccounts":
                     using (var oneDriveAccountsKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\OneDrive\Accounts", false))
                     {
+                        if (oneDriveAccountsKey == null)
+                        {
+                            await args.Request.SendResponseAsync(new ValueSet());
+                        }
+
                         var oneDriveAccounts = new ValueSet();
                         foreach (var account in oneDriveAccountsKey.GetSubKeyNames())
                         {

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -331,6 +331,7 @@ namespace FilesFullTrust
                         if (oneDriveAccountsKey == null)
                         {
                             await args.Request.SendResponseAsync(new ValueSet());
+                            return;
                         }
 
                         var oneDriveAccounts = new ValueSet();


### PR DESCRIPTION
Fixes #3230
Fix for OneDrive error in FullTrust log file of issue #3230