### PR TITLE
Added ability to paste images from clipboard directly into folder

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -188,7 +188,7 @@ namespace Files
                 // Clipboard.GetContent() will throw UnauthorizedAccessException
                 // if the app window is not in the foreground and active
                 DataPackageView packageView = Clipboard.GetContent();
-                if (packageView.Contains(StandardDataFormats.StorageItems))
+                if (packageView.Contains(StandardDataFormats.StorageItems) || packageView.Contains(StandardDataFormats.Bitmap))
                 {
                     App.InteractionViewModel.IsPasteEnabled = true;
                 }

--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -539,7 +539,7 @@ namespace Files.Filesystem
                     using var imageStream = await imgSource.OpenReadAsync();
                     var folder = await StorageFolder.GetFolderFromPathAsync(destination);
                     // Set the name of the file to be the current time and date
-                    var file = await folder.CreateFileAsync($"{DateTime.Now:mm-dd-yy-HHmmss}.png");
+                    var file = await folder.CreateFileAsync($"{DateTime.Now:mm-dd-yy-HHmmss}.png", CreationCollisionOption.GenerateUniqueName);
 
                     using var stream = await file.OpenAsync(FileAccessMode.ReadWrite);
                     await imageStream.AsStreamForRead().CopyToAsync(stream.AsStreamForWrite());

--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -13,7 +13,9 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Graphics.Imaging;
 using Windows.Storage;
+using Windows.Storage.Streams;
 using static Files.Helpers.NativeFindStorageItemHelper;
 using FileAttributes = System.IO.FileAttributes;
 
@@ -505,33 +507,53 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> CopyItemsFromClipboard(DataPackageView packageView, string destination, bool registerHistory)
         {
-            if (!packageView.Contains(StandardDataFormats.StorageItems))
+            if (packageView.Contains(StandardDataFormats.StorageItems))
             {
-                // Happens if you copy some text and then you Ctrl+V in Files
-                // Should this be done in ModernShellPage?
-                return ReturnResult.BadArgumentException;
+                IReadOnlyList<IStorageItem> source;
+                try
+                {
+                    source = await packageView.GetStorageItemsAsync();
+                }
+                catch (Exception ex) when ((uint)ex.HResult == 0x80040064 || (uint)ex.HResult == 0x8004006A)
+                {
+                    return ReturnResult.UnknownException;
+                }
+                ReturnResult returnStatus = ReturnResult.InProgress;
+
+                List<string> destinations = new List<string>();
+                foreach (IStorageItem item in source)
+                {
+                    destinations.Add(Path.Combine(destination, item.Name));
+                }
+
+                returnStatus = await CopyItemsAsync(source, destinations, registerHistory);
+
+                return returnStatus;
             }
 
-            IReadOnlyList<IStorageItem> source;
-            try
+            if (packageView.Contains(StandardDataFormats.Bitmap))
             {
-                source = await packageView.GetStorageItemsAsync();
-            }
-            catch (Exception ex) when ((uint)ex.HResult == 0x80040064 || (uint)ex.HResult == 0x8004006A)
-            {
-                return ReturnResult.UnknownException;
-            }
-            ReturnResult returnStatus = ReturnResult.InProgress;
+                try
+                {
+                    var imgSource = await packageView.GetBitmapAsync();
+                    using var imageStream = await imgSource.OpenReadAsync();
+                    var folder = await StorageFolder.GetFolderFromPathAsync(destination);
+                    // Set the name of the file to be the current time and date
+                    var file = await folder.CreateFileAsync($"{DateTime.Now:mm-dd-yy-HHmmss}.png");
 
-            List<string> destinations = new List<string>();
-            foreach (IStorageItem item in source)
-            {
-                destinations.Add(Path.Combine(destination, item.Name));
+                    using var stream = await file.OpenAsync(FileAccessMode.ReadWrite);
+                    await imageStream.AsStreamForRead().CopyToAsync(stream.AsStreamForWrite());
+                    return ReturnResult.Success;
+                }
+                catch (Exception)
+                {
+                    return ReturnResult.UnknownException;
+                }
             }
 
-            returnStatus = await CopyItemsAsync(source, destinations, registerHistory);
-
-            return returnStatus;
+            // Happens if you copy some text and then you Ctrl+V in Files
+            // Should this be done in ModernShellPage?
+            return ReturnResult.BadArgumentException;
         }
 
         #endregion Copy


### PR DESCRIPTION
Closes #3029

Images pasted are saved as pngs with the current date and time as the name.