### PR TITLE
Fixed issue where scrolling in details view was broken

### DIFF
--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -608,16 +608,6 @@
     </local:BaseLayout.Resources>
 
     <Grid x:Name="RootGrid" Background="Transparent">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="3*" />
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-
-        <Grid.RowDefinitions>
-            <RowDefinition Height="3*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator
                 Key="{x:Bind PlusKey}"
@@ -673,7 +663,7 @@
 
         <controls:DataGrid
             x:Name="AllView"
-            Grid.Row="3"
+            Grid.Row="0"
             Margin="12,4,0,0"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -663,7 +663,6 @@
 
         <controls:DataGrid
             x:Name="AllView"
-            Grid.Row="0"
             Margin="12,4,0,0"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"


### PR DESCRIPTION
The bug was caused by the DataGrid being placed in the wrong row.
Also removed row/column definitions, as they are unused.