### PR TITLE
Improve startup performance

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -413,7 +413,7 @@ namespace Files
             var deferral = e.SuspendingOperation.GetDeferral();
             //TODO: Save application state and stop any background activity
 
-            AppSettings?.Dispose();
+            DrivesManager?.Dispose();
             deferral.Complete();
         }
 

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -50,6 +50,9 @@ namespace Files
         public static InteractionViewModel InteractionViewModel { get; set; }
         public static JumpListManager JumpList { get; } = new JumpListManager();
         public static SidebarPinnedController SidebarPinnedController { get; set; }
+        public static CloudDrivesManager CloudDrivesManager { get; set; }
+        public static DrivesManager DrivesManager { get; set; }
+
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         public static class AppData
@@ -80,12 +83,34 @@ namespace Files
         {
             if (AppSettings == null)
             {
+                //We can't create AppSettings at the same time as everything else as other dependencies depend on AppSettings
                 AppSettings = await SettingsViewModel.CreateInstance();
+                if (App.AppSettings?.AcrylicTheme == null)
+                {
+                    Helpers.ThemeHelper.Initialize();
+                }
             }
 
-            if (App.AppSettings?.AcrylicTheme == null)
+            if (CloudDrivesManager == null)
             {
-                ThemeHelper.Initialize();
+                //Enumerate cloud drives on in the background. It will update the UI itself when finished
+                _ = Files.Filesystem.CloudDrivesManager.Instance.ContinueWith(o =>
+                  {
+                      CloudDrivesManager = o.Result;
+                  });
+            }
+
+            //Start off a list of tasks we need to run before we can continue startup
+            var tasksToRun = new List<Task>();
+
+            if (SidebarPinnedController == null)
+            {
+                tasksToRun.Add(Files.Controllers.SidebarPinnedController.CreateInstance().ContinueWith(o => SidebarPinnedController = o.Result));
+            }
+
+            if (DrivesManager == null)
+            {
+                tasksToRun.Add(Files.Filesystem.DrivesManager.Instance.ContinueWith(o => DrivesManager = o.Result));
             }
 
             if (InteractionViewModel == null)
@@ -93,9 +118,10 @@ namespace Files
                 InteractionViewModel = new InteractionViewModel();
             }
 
-            if (SidebarPinnedController == null)
+            if (tasksToRun.Any())
             {
-                SidebarPinnedController = await SidebarPinnedController.CreateInstance();
+                //Only proceed when all tasks are completed
+                await Task.WhenAll(tasksToRun);
             }
         }
 
@@ -118,7 +144,7 @@ namespace Files
 
         private void OnLeavingBackground(object sender, LeavingBackgroundEventArgs e)
         {
-            AppSettings?.DrivesManager?.ResumeDeviceWatcher();
+            DrivesManager?.ResumeDeviceWatcher();
         }
 
         public static INavigationControlItem RightClickedItem;

--- a/Files/Filesystem/Cloud/CloudProviderController.cs
+++ b/Files/Filesystem/Cloud/CloudProviderController.cs
@@ -7,11 +7,9 @@ namespace Files.Filesystem.Cloud
 {
     public class CloudProviderController
     {
-        private List<CloudProvider> cloudProviders;
+        private List<CloudProvider> cloudProviders = new List<CloudProvider>();
 
-        public CloudProviderController()
-        {
-            CloudProviderDetectors = new List<ICloudProviderDetector>
+        public List<ICloudProviderDetector> CloudProviderDetectors => new List<ICloudProviderDetector>
             {
                 new GoogleDriveCloudProvider(),
                 new DropBoxCloudProvider(),
@@ -22,11 +20,6 @@ namespace Files.Filesystem.Cloud
                 new AmazonDriveProvider()
             };
 
-            CloudProviders = new List<CloudProvider>();
-        }
-
-        public List<ICloudProviderDetector> CloudProviderDetectors { get; set; }
-
         public List<CloudProvider> CloudProviders
         {
             get => cloudProviders.Where(x => !string.IsNullOrEmpty(x.SyncFolder)).ToList();
@@ -35,10 +28,17 @@ namespace Files.Filesystem.Cloud
 
         public async Task DetectInstalledCloudProvidersAsync()
         {
+            var tasks = new List<Task<IList<CloudProvider>>>();
+            var results = new List<CloudProvider>();
+
             foreach (var provider in CloudProviderDetectors)
             {
-                await provider.DetectAsync(cloudProviders);
+                tasks.Add(provider.DetectAsync());
             }
+
+            await Task.WhenAll(tasks);
+
+            cloudProviders = tasks.SelectMany(o => o.Result).ToList();
         }
     }
 }

--- a/Files/Filesystem/Cloud/ICloudProviderDetector.cs
+++ b/Files/Filesystem/Cloud/ICloudProviderDetector.cs
@@ -5,6 +5,6 @@ namespace Files.Filesystem.Cloud
 {
     public interface ICloudProviderDetector
     {
-        Task DetectAsync(List<CloudProvider> cloudProviders);
+        Task<IList<CloudProvider>> DetectAsync();
     }
 }

--- a/Files/Filesystem/Cloud/Providers/AmazonDriveProvider.cs
+++ b/Files/Filesystem/Cloud/Providers/AmazonDriveProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Enums;
 using Microsoft.Win32;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -7,32 +8,31 @@ namespace Files.Filesystem.Cloud.Providers
 {
     public class AmazonDriveProvider : ICloudProviderDetector
     {
-        public async Task DetectAsync(List<CloudProvider> cloudProviders)
+        public async Task<IList<CloudProvider>> DetectAsync()
         {
-            await Task.Run(() =>
+            try
             {
-                try
+                using var key = Registry.ClassesRoot.OpenSubKey(@"CLSID\{9B57F475-CCB0-4C85-88A9-2AA9A6C0809A}\Instance\InitPropertyBag");
+                var syncedFolder = (string)key?.GetValue("TargetFolderPath");
+
+                if (syncedFolder == null)
                 {
-                    using var key = Registry.ClassesRoot.OpenSubKey(@"CLSID\{9B57F475-CCB0-4C85-88A9-2AA9A6C0809A}\Instance\InitPropertyBag");
-                    var syncedFolder = (string)key?.GetValue("TargetFolderPath");
+                    return Array.Empty<CloudProvider>();
+                }
 
-                    if (syncedFolder == null)
-                    {
-                        return;
-                    }
-
-                    cloudProviders.Add(new CloudProvider()
+                return new[] { new CloudProvider()
                     {
                         ID = CloudProviders.AmazonDrive,
                         Name = "Amazon Drive",
                         SyncFolder = syncedFolder
-                    });
-                }
-                catch
-                {
-                    // Not detected
-                }
-            });
+                    }
+                };
+            }
+            catch
+            {
+                // Not detected
+                return Array.Empty<CloudProvider>();
+            }
         }
     }
 }

--- a/Files/Filesystem/Cloud/Providers/AppleCloudProvider.cs
+++ b/Files/Filesystem/Cloud/Providers/AppleCloudProvider.cs
@@ -9,7 +9,7 @@ namespace Files.Filesystem.Cloud.Providers
 {
     public class AppleCloudProvider : ICloudProviderDetector
     {
-        public async Task DetectAsync(List<CloudProvider> cloudProviders)
+        public async Task<IList<CloudProvider>> DetectAsync()
         {
             try
             {
@@ -17,16 +17,18 @@ namespace Files.Filesystem.Cloud.Providers
                 var iCloudPath = "iCloudDrive";
                 var driveFolder = await StorageFolder.GetFolderFromPathAsync(Path.Combine(userPath, iCloudPath));
 
-                cloudProviders.Add(new CloudProvider()
-                {
-                    ID = CloudProviders.AppleCloud,
-                    Name = "iCloud",
-                    SyncFolder = driveFolder.Path
-                });
+                return new[] { new CloudProvider()
+                    {
+                        ID = CloudProviders.AppleCloud,
+                        Name = "iCloud",
+                        SyncFolder = driveFolder.Path
+                    }
+                };
             }
             catch
             {
                 // Not detected
+                return Array.Empty<CloudProvider>();
             }
         }
     }

--- a/Files/Filesystem/Cloud/Providers/BoxCloudProvider.cs
+++ b/Files/Filesystem/Cloud/Providers/BoxCloudProvider.cs
@@ -9,7 +9,7 @@ namespace Files.Filesystem.Cloud.Providers
 {
     public class BoxCloudProvider : ICloudProviderDetector
     {
-        public async Task DetectAsync(List<CloudProvider> cloudProviders)
+        public async Task<IList<CloudProvider>> DetectAsync()
         {
             try
             {
@@ -29,18 +29,22 @@ namespace Files.Filesystem.Cloud.Providers
 
                     if (!string.IsNullOrEmpty(syncPath))
                     {
-                        cloudProviders.Add(new CloudProvider()
+                        return new[] { new CloudProvider()
                         {
                             ID = CloudProviders.Box,
                             Name = "Box",
                             SyncFolder = syncPath
-                        });
+                        }
+                        };
                     }
                 }
+
+                return Array.Empty<CloudProvider>();
             }
             catch
             {
                 // Not detected
+                return Array.Empty<CloudProvider>();
             }
         }
     }

--- a/Files/Filesystem/Cloud/Providers/DropBoxCloudProvider.cs
+++ b/Files/Filesystem/Cloud/Providers/DropBoxCloudProvider.cs
@@ -10,7 +10,7 @@ namespace Files.Filesystem.Cloud.Providers
 {
     public class DropBoxCloudProvider : ICloudProviderDetector
     {
-        public async Task DetectAsync(List<CloudProvider> cloudProviders)
+        public async Task<IList<CloudProvider>> DetectAsync()
         {
             try
             {
@@ -18,11 +18,12 @@ namespace Files.Filesystem.Cloud.Providers
                 var jsonPath = Path.Combine(UserDataPaths.GetDefault().LocalAppData, infoPath);
                 var configFile = await StorageFile.GetFileFromPathAsync(jsonPath);
                 var jsonObj = JObject.Parse(await FileIO.ReadTextAsync(configFile));
+                var results = new List<CloudProvider>();
 
                 if (jsonObj.ContainsKey("personal"))
                 {
                     var dropboxPath = (string)jsonObj["personal"]["path"];
-                    cloudProviders.Add(new CloudProvider()
+                    results.Add(new CloudProvider()
                     {
                         ID = CloudProviders.DropBox,
                         Name = "Dropbox",
@@ -33,17 +34,20 @@ namespace Files.Filesystem.Cloud.Providers
                 if (jsonObj.ContainsKey("business"))
                 {
                     var dropboxPath = (string)jsonObj["business"]["path"];
-                    cloudProviders.Add(new CloudProvider()
+                    results.Add(new CloudProvider()
                     {
                         ID = CloudProviders.DropBox,
                         Name = "Dropbox Business",
                         SyncFolder = dropboxPath
                     });
                 }
+
+                return results;
             }
             catch
             {
                 // Not detected
+                return Array.Empty<CloudProvider>();
             }
         }
     }

--- a/Files/Filesystem/Cloud/Providers/GoogleDriveCloudProvider.cs
+++ b/Files/Filesystem/Cloud/Providers/GoogleDriveCloudProvider.cs
@@ -10,7 +10,7 @@ namespace Files.Filesystem.Cloud.Providers
 {
     public class GoogleDriveCloudProvider : ICloudProviderDetector
     {
-        public async Task DetectAsync(List<CloudProvider> cloudProviders)
+        public async Task<IList<CloudProvider>> DetectAsync()
         {
             try
             {
@@ -29,13 +29,15 @@ namespace Files.Filesystem.Cloud.Providers
                     // Open the connection and execute the command
                     con.Open();
                     var reader = cmd.ExecuteReader();
+                    var results = new List<CloudProvider>();
+
                     while (reader.Read())
                     {
                         // Extract the data from the reader
                         string path = reader["data_value"]?.ToString();
                         if (string.IsNullOrWhiteSpace(path))
                         {
-                            return;
+                            return Array.Empty<CloudProvider>();
                         }
 
                         // By default, the path will be prefixed with "\\?\" (unless another app has explicitly changed it).
@@ -62,13 +64,16 @@ namespace Files.Filesystem.Cloud.Providers
                             googleCloud.Name = "Google Drive";
                         }
 
-                        cloudProviders.Add(googleCloud);
+                        results.Add(googleCloud);
                     }
+
+                    return results;
                 }
             }
             catch
             {
                 // Not detected
+                return Array.Empty<CloudProvider>();
             }
         }
     }

--- a/Files/Filesystem/Cloud/Providers/OneDriveCloudProvider.cs
+++ b/Files/Filesystem/Cloud/Providers/OneDriveCloudProvider.cs
@@ -11,7 +11,7 @@ namespace Files.Filesystem.Cloud.Providers
 {
     public class OneDriveCloudProvider : ICloudProviderDetector
     {
-        public async Task DetectAsync(List<CloudProvider> cloudProviders)
+        public async Task<IList<CloudProvider>> DetectAsync()
         {
             try
             {
@@ -22,22 +22,30 @@ namespace Files.Filesystem.Cloud.Providers
                 }, TimeSpan.FromSeconds(10));
                 if (status == AppServiceResponseStatus.Success)
                 {
+                    var results = new List<CloudProvider>();
                     foreach (var key in response.Message.Keys
                         .OrderByDescending(o => string.Equals(o, "OneDrive", StringComparison.OrdinalIgnoreCase))
                         .ThenBy(o => o))
                     {
-                        cloudProviders.Add(new CloudProvider()
+                        results.Add(new CloudProvider()
                         {
                             ID = CloudProviders.OneDrive,
                             Name = key,
                             SyncFolder = (string)response.Message[key]
                         });
                     }
+
+                    return results;
+                }
+                else
+                {
+                    return Array.Empty<CloudProvider>();
                 }
             }
             catch
             {
                 // Not detected
+                return Array.Empty<CloudProvider>();
             }
         }
     }

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -708,7 +708,7 @@ namespace Files.Interacts
                 }
                 else
                 {
-                    await OpenPropertiesWindowAsync(App.AppSettings.DrivesManager.Drives
+                    await OpenPropertiesWindowAsync(App.DrivesManager.Drives
                         .Single(x => x.Path.Equals(AssociatedInstance.FilesystemViewModel.CurrentFolder.ItemPath)));
                 }
             }

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -420,7 +420,7 @@ namespace Files.ViewModels
             {
                 var deviceId = (string)args.Request.Message["DeviceID"];
                 var eventType = (DeviceEvent)(int)args.Request.Message["EventType"];
-                await AppSettings.DrivesManager.HandleWin32DriveEvent(eventType, deviceId);
+                await App.DrivesManager.HandleWin32DriveEvent(eventType, deviceId);
             }
             // Complete the deferral so that the platform knows that we're done responding to the app service call.
             // Note for error handling: this must be called even if SendResponseAsync() throws an exception.

--- a/Files/ViewModels/SettingsViewModel.cs
+++ b/Files/ViewModels/SettingsViewModel.cs
@@ -838,10 +838,5 @@ namespace Files.ViewModels
         private delegate bool TryParseDelegate<TValue>(string inValue, out TValue parsedValue);
 
         #endregion ReadAndSaveSettings
-
-        public void Dispose()
-        {
-            App.DrivesManager?.Dispose();
-        }
     }
 }

--- a/Files/ViewModels/SettingsViewModel.cs
+++ b/Files/ViewModels/SettingsViewModel.cs
@@ -29,8 +29,6 @@ namespace Files.ViewModels
     {
         private readonly ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
 
-        public DrivesManager DrivesManager { get; private set; }
-
         public CloudDrivesManager CloudDrivesManager { get; private set; }
 
         public TerminalController TerminalController { get; set; }
@@ -49,10 +47,6 @@ namespace Files.ViewModels
             {
                 DefaultLanguages.Add(new DefaultLanguageModel(lang));
             }
-
-            DrivesManager = await DrivesManager.CreateInstance();
-            //Initialise cloud drives in the background
-            CloudDrivesManager = await CloudDrivesManager.CreateInstance();
 
             //DetectWSLDistros();
             TerminalController = await TerminalController.CreateInstance();
@@ -560,7 +554,7 @@ namespace Files.ViewModels
                 }
             }
         }
-        
+
         /// <summary>
         /// Gets or sets the value indicating whether the preview pane should adapt to the width of the view.
         /// </summary>
@@ -847,7 +841,7 @@ namespace Files.ViewModels
 
         public void Dispose()
         {
-            DrivesManager?.Dispose();
+            App.DrivesManager?.Dispose();
         }
     }
 }

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using Files.Common;
-using Files.Controllers;
 using Files.Filesystem;
 using Files.Helpers;
 using Files.UserControls.MultitaskingControl;

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -182,8 +182,6 @@ namespace Files.Views
             FilesystemHelpers = new FilesystemHelpers(this, cancellationTokenSource.Token);
             storageHistoryHelpers = new StorageHistoryHelpers(new StorageHistoryOperations(this, cancellationTokenSource.Token));
 
-            AppSettings.DrivesManager.PropertyChanged += DrivesManager_PropertyChanged;
-            AppSettings.PropertyChanged += AppSettings_PropertyChanged;
             DisplayFilesystemConsentDialog();
 
             var flowDirectionSetting = ResourceContext.GetForCurrentView().QualifierValues["LayoutDirection"];
@@ -221,6 +219,9 @@ namespace Files.Views
 
             Window.Current.CoreWindow.PointerPressed += CoreWindow_PointerPressed;
             SystemNavigationManager.GetForCurrentView().BackRequested += ModernShellPage_BackRequested;
+
+            App.DrivesManager.PropertyChanged += DrivesManager_PropertyChanged;
+            AppSettings.PropertyChanged += AppSettings_PropertyChanged;
         }
 
         private void AppSettings_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -778,9 +779,9 @@ namespace Files.Views
 
         private async void DisplayFilesystemConsentDialog()
         {
-            if (AppSettings.DrivesManager.ShowUserConsentOnInit)
+            if (App.DrivesManager?.ShowUserConsentOnInit ?? false)
             {
-                AppSettings.DrivesManager.ShowUserConsentOnInit = false;
+                App.DrivesManager.ShowUserConsentOnInit = false;
                 var consentDialogDisplay = new ConsentDialog();
                 await consentDialogDisplay.ShowAsync(ContentDialogPlacement.Popup);
             }
@@ -1200,7 +1201,7 @@ namespace Files.Views
             SystemNavigationManager.GetForCurrentView().BackRequested -= ModernShellPage_BackRequested;
             App.Current.Suspending -= Current_Suspending;
             App.Current.LeavingBackground -= OnLeavingBackground;
-            AppSettings.DrivesManager.PropertyChanged -= DrivesManager_PropertyChanged;
+            App.DrivesManager.PropertyChanged -= DrivesManager_PropertyChanged;
             AppSettings.PropertyChanged -= AppSettings_PropertyChanged;
             NavigationToolbar.EditModeEnabled -= NavigationToolbar_EditModeEnabled;
             NavigationToolbar.PathBoxQuerySubmitted -= NavigationToolbar_QuerySubmitted;

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -80,7 +80,7 @@ namespace Files.Views
                 }
                 else
                 {
-                    foreach (DriveItem drive in Enumerable.Concat(AppSettings.DrivesManager.Drives, AppSettings.CloudDrivesManager.Drives))
+                    foreach (DriveItem drive in Enumerable.Concat(App.DrivesManager.Drives, AppSettings.CloudDrivesManager.Drives))
                     {
                         if (drive.Path.ToString() == new DirectoryInfo(e.ItemPath).Root.ToString())
                         {


### PR DESCRIPTION
This PR improves startup performance and gets the user to an interactive state quicker by making the following changes:

- `CloudDrivesManager` and `DrivesManager` have been removed from `SettingsViewModel` to allow app settings to be loaded and made available to launch the app as early as possible.
- `CloudDrivesManager` and `DrivesManager` are instantiated using an async singleton pattern with them being constructed as early as possible, while not delaying the launch of the UI should one of them require longer to complete.
- Certain initial dependencies are created in parallel to shave off a little more startup time.
- `ICloudProviderDetector`'s are loading asynchronously in parallel so that `CloudDrivesManager` only takes as long as the slowest `ICloudProviderDetector`. This is mainly where `OneDriveCloudProvider` relies on FullTrust and can be delayed by FullTrust loading slowly. With this design, all other `ICloudProviderDetector`'s can complete while waiting for the slowest one.


In future there would be further opportunities to speed up the initial load by adding cloud drives to the UI individually as they load so that fast `ICloudProviderDetectors` appear straight away, and slower ones will gracefully appear in the UI a little later. However for now I don't feel any of the `ICloudProviderDetectors`'s are slow enough to require even more changes.

