### PR TITLE
Fix: Excessive whitespace above the files list when a folder contains a small number of items

### DIFF
--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -673,7 +673,7 @@
 
         <controls:DataGrid
             x:Name="AllView"
-            Grid.Row="3"
+            Grid.Row="0"
             Margin="12,4,0,0"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"


### PR DESCRIPTION
This fix is to address issue #3259 