### PR TITLE
Fixed issue where preview pane would open itself after switching tabs or closing settings

### DIFF
--- a/Files/UserControls/PreviewPane.xaml.cs
+++ b/Files/UserControls/PreviewPane.xaml.cs
@@ -78,7 +78,11 @@ namespace Files.UserControls
         public bool IsHorizontal
         {
             get => (bool)GetValue(IsHorizontalProperty);
-            set => SetValue(IsHorizontalProperty, value);
+            set
+            {
+                SetValue(IsHorizontalProperty, value);
+                EdgeTransitionLocation = value ? EdgeTransitionLocation.Bottom : EdgeTransitionLocation.Right;
+            }
         }
 
         public static DependencyProperty EdgeTransitionLocationProperty =

--- a/Files/ViewModels/CurrentInstanceViewModel.cs
+++ b/Files/ViewModels/CurrentInstanceViewModel.cs
@@ -114,16 +114,5 @@ namespace Files.ViewModels
             get => isPageTypeCloudDrive;
             set => SetProperty(ref isPageTypeCloudDrive, value);
         }
-
-        private bool previewPaneEnabled;
-
-        /// <summary>
-        /// Gets or sets the value indicating whether the preview pane should be shown.
-        /// </summary>
-        public bool PreviewPaneEnabled
-        {
-            get => previewPaneEnabled;
-            set => SetProperty(ref previewPaneEnabled, value);
-        }
     }
 }

--- a/Files/ViewModels/Previews/HtmlPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/HtmlPreviewViewModel.cs
@@ -37,6 +37,7 @@ namespace Files.ViewModels.Previews
                 Debug.WriteLine(e);
             }
             base.LoadSystemFileProperties();
+            RaiseLoadedEvent();
         }
     }
 }

--- a/Files/Views/ModernShellPage.xaml
+++ b/Files/Views/ModernShellPage.xaml
@@ -260,7 +260,7 @@
                     NewWindowInvokedCommand="{x:Bind InteractionOperations.OpenNewWindow, Mode=OneWay}"
                     OpenInTerminalInvokedCommand="{x:Bind InteractionOperations.OpenDirectoryInDefaultTerminal, Mode=OneWay}"
                     PasteInvokedCommand="{x:Bind InteractionOperations.PasteItemsFromClipboard, Mode=OneWay}"
-                    PreviewPaneEnabled="{x:Bind InstanceViewModel.PreviewPaneEnabled, Mode=TwoWay}"
+                    PreviewPaneEnabled="{x:Bind PreviewPaneEnabled, Mode=TwoWay}"
                     ShowMultiPaneControls="{x:Bind converters1:MultiBooleanConverter.AndConvert(IsMultiPaneEnabled, IsPageMainPane), Mode=OneWay}" />
 
                 <Frame
@@ -274,7 +274,7 @@
                     x:Name="PreviewPaneGridSplitter"
                     Grid.Row="1"
                     Grid.Column="1"
-                    x:Load="{x:Bind InstanceViewModel.PreviewPaneEnabled, Mode=OneWay}"
+                    x:Load="{x:Bind PreviewPaneEnabled, Mode=OneWay}"
                     Background="Transparent"
                     ResizeBehavior="BasedOnAlignment">
                     <Custom:GridSplitter.Element>
@@ -295,7 +295,7 @@
                     x:Name="PreviewPane"
                     Grid.Row="1"
                     Grid.Column="2"
-                    x:Load="{x:Bind InstanceViewModel.PreviewPaneEnabled, Mode=OneWay}"
+                    x:Load="{x:Bind PreviewPaneEnabled, Mode=OneWay}"
                     SelectedItems="{x:Bind ContentPage.SelectedItems, Mode=OneWay}" />
 
                 <controls:StatusBarControl
@@ -334,62 +334,5 @@
                 <TranslateTransform X="0" />
             </Custom:GridSplitter.RenderTransform>
         </Custom:GridSplitter>
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup>
-                <VisualState>
-                    <VisualState.StateTriggers>
-                        <triggers:IsEqualStateTrigger Value="{x:Bind InstanceViewModel.PreviewPaneEnabled, Mode=OneWay}" To="False" />
-                        <triggers:IsEqualStateTrigger Value="{x:Bind InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}" To="False" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="PreviewPaneRow.Height" Value="0" />
-                        <Setter Target="PreviewPaneColumn.Width" Value="0" />
-                        <Setter Target="PreviewPaneGridSplitter.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-                <VisualState>
-                    <VisualState.StateTriggers>
-                        <triggers:IsEqualStateTrigger Value="{x:Bind AppSettings.EnableAdaptivePreviewPane, Mode=OneWay}" To="False" />
-                        <triggers:CompareStateTrigger
-                            Comparison="GreaterThan"
-                            Value="{x:Bind RootGridWidth, Mode=OneWay}"
-                            To="1000" />
-                    </VisualState.StateTriggers>
-
-                    <VisualState.Setters>
-                        <Setter Target="PreviewPane.(Grid.Row)" Value="2" />
-                        <Setter Target="PreviewPane.(Grid.Column)" Value="2" />
-
-                        <Setter Target="PreviewPaneGridSplitter.(Grid.Row)" Value="2" />
-                        <Setter Target="PreviewPaneGridSplitter.(Grid.Column)" Value="1" />
-                        <Setter Target="PreviewPaneGridSplitter.Width" Value="2" />
-
-                        <Setter Target="PreviewPaneRow.Height" Value="4" />
-                        <Setter Target="PreviewPane.IsHorizontal" Value="False" />
-                    </VisualState.Setters>
-                </VisualState>
-                <VisualState>
-                    <VisualState.StateTriggers>
-                        <triggers:CompareStateTrigger
-                            Comparison="LessThanOrEqual"
-                            Value="{x:Bind RootGridWidth, Mode=OneWay}"
-                            To="1000" />
-                        <!--<AdaptiveTrigger MinWindowWidth="0" />-->
-                    </VisualState.StateTriggers>
-
-                    <VisualState.Setters>
-                        <Setter Target="PreviewPane.(Grid.Row)" Value="4" />
-                        <Setter Target="PreviewPane.(Grid.Column)" Value="0" />
-
-                        <Setter Target="PreviewPaneGridSplitter.(Grid.Row)" Value="3" />
-                        <Setter Target="PreviewPaneGridSplitter.(Grid.Column)" Value="0" />
-                        <Setter Target="PreviewPaneGridSplitter.Height" Value="2" />
-
-                        <Setter Target="PreviewPaneColumn.Width" Value="0" />
-                        <Setter Target="PreviewPane.IsHorizontal" Value="True" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
     </Grid>
 </Page>

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -1084,7 +1084,7 @@ namespace Files.Views
                     break;
 
                 case (true, false, false, true, VirtualKey.P):
-                    InstanceViewModel.PreviewPaneEnabled = !InstanceViewModel.PreviewPaneEnabled;
+                    PreviewPaneEnabled = !PreviewPaneEnabled;
                     break;
 
                 case (true, false, false, true, VirtualKey.R): // ctrl + r, refresh
@@ -1295,16 +1295,68 @@ namespace Files.Views
             return DataPackageOperation.None;
         }
 
-        // Binding directly to the actual width raise property changed notifications
-        // This is a workaroumd
-        public double RootGridWidth
+        private bool previewPaneEnabled;
+
+        /// <summary>
+        /// Gets or sets the value indicating whether the preview pane should be shown.
+        /// </summary>
+        public bool PreviewPaneEnabled
         {
-            get => RootGrid.ActualWidth;
+            get => previewPaneEnabled;
+            set
+            {
+                previewPaneEnabled = value;
+                NotifyPropertyChanged(nameof(PreviewPaneEnabled));
+                UpdatePositioning();
+            }
         }
 
         private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            NotifyPropertyChanged(nameof(RootGridWidth));
+            UpdatePositioning();
+        }
+
+        /// <summary>
+        /// Call this function to update the positioning of the preview pane.
+        /// This is a workaround as the VisualStateManager causes problems. 
+        /// </summary>
+        private void UpdatePositioning()
+        {
+            if (!PreviewPaneEnabled || !InstanceViewModel.IsPageTypeNotHome)
+            {
+                PreviewPaneRow.Height = new GridLength(0);
+                PreviewPaneColumn.Width = new GridLength(0);
+                //PreviewPaneGridSplitter.Visibility = Visibility.Collapsed;
+
+            }
+            else if (RootGrid.ActualWidth > 1000)
+            {
+                PreviewPane.SetValue(Grid.RowProperty, 2);
+                PreviewPane.SetValue(Grid.ColumnProperty, 2);
+
+                PreviewPaneGridSplitter.SetValue(Grid.RowProperty, 2);
+                PreviewPaneGridSplitter.SetValue(Grid.ColumnProperty, 1);
+                PreviewPaneGridSplitter.Width = 2;
+                PreviewPaneGridSplitter.Height = RootGrid.ActualHeight;
+
+                PreviewPaneRow.Height = new GridLength(0);
+                PreviewPaneColumn.Width = new GridLength(300);
+                PreviewPane.IsHorizontal = false;
+            }
+            else if (RootGrid.ActualWidth < 1000)
+            {
+                PreviewPaneRow.Height = new GridLength(200);
+                PreviewPaneColumn.Width = new GridLength(0);
+
+                PreviewPane.SetValue(Grid.RowProperty, 4);
+                PreviewPane.SetValue(Grid.ColumnProperty, 0);
+
+                PreviewPaneGridSplitter.SetValue(Grid.RowProperty, 3);
+                PreviewPaneGridSplitter.SetValue(Grid.ColumnProperty, 0);
+                PreviewPaneGridSplitter.Height = 2;
+                PreviewPaneGridSplitter.Width = RootGrid.Width;
+                PreviewPane.IsHorizontal = true;
+            }
         }
     }
 

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -1329,7 +1329,7 @@ namespace Files.Views
                 //PreviewPaneGridSplitter.Visibility = Visibility.Collapsed;
 
             }
-            else if (RootGrid.ActualWidth > 1000)
+            else if (RootGrid.ActualWidth > 1000 || !AppSettings.EnableAdaptivePreviewPane)
             {
                 PreviewPane.SetValue(Grid.RowProperty, 2);
                 PreviewPane.SetValue(Grid.ColumnProperty, 2);

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -976,6 +976,14 @@ namespace Files.Views
                 InitialPageType = typeof(ModernShellPage),
                 NavigationArg = parameters.IsSearchResultPage ? parameters.SearchPathParam : parameters.NavPathParam
             };
+
+            if(ItemDisplayFrame.CurrentSourcePageType == typeof(YourHome))
+            {
+                UpdatePositioning(true);
+            } else
+            {
+                UpdatePositioning();
+            }
         }
 
         private async void KeyboardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
@@ -1313,21 +1321,28 @@ namespace Files.Views
 
         private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            UpdatePositioning();
+            UpdatePositioning(!InstanceViewModel.IsPageTypeNotHome);
         }
 
         /// <summary>
         /// Call this function to update the positioning of the preview pane.
         /// This is a workaround as the VisualStateManager causes problems. 
         /// </summary>
-        private void UpdatePositioning()
+        private void UpdatePositioning(bool IsHome = false)
         {
-            if (!PreviewPaneEnabled || !InstanceViewModel.IsPageTypeNotHome)
+            if (!PreviewPaneEnabled || IsHome)
             {
                 PreviewPaneRow.Height = new GridLength(0);
                 PreviewPaneColumn.Width = new GridLength(0);
-                //PreviewPaneGridSplitter.Visibility = Visibility.Collapsed;
+                if(PreviewPaneGridSplitter != null)
+                {
+                    PreviewPaneGridSplitter.Visibility = Visibility.Collapsed;
+                }
 
+                if (PreviewPane != null)
+                {
+                    PreviewPane.Visibility = Visibility.Collapsed;
+                }
             }
             else if (RootGrid.ActualWidth > 1000 || !AppSettings.EnableAdaptivePreviewPane)
             {
@@ -1342,6 +1357,9 @@ namespace Files.Views
                 PreviewPaneRow.Height = new GridLength(0);
                 PreviewPaneColumn.Width = new GridLength(300);
                 PreviewPane.IsHorizontal = false;
+
+                PreviewPane.Visibility = Visibility.Visible;
+                PreviewPaneGridSplitter.Visibility = Visibility.Visible;
             }
             else if (RootGrid.ActualWidth < 1000)
             {
@@ -1356,6 +1374,9 @@ namespace Files.Views
                 PreviewPaneGridSplitter.Height = 2;
                 PreviewPaneGridSplitter.Width = RootGrid.Width;
                 PreviewPane.IsHorizontal = true;
+
+                PreviewPane.Visibility = Visibility.Visible;
+                PreviewPaneGridSplitter.Visibility = Visibility.Visible;
             }
         }
     }


### PR DESCRIPTION
Closes #3252 
The issue was caused by the VisualStateManager attempting to change the properties of the Pane while it was closed, which would load it in.
Changing the layout programmatically instead fixes this issue.

This PR also includes a fix for an issue where Html previews would not load.