### PR TITLE
Improve performance while occurring a large set of entry changes

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1652,6 +1652,9 @@ namespace Files.ViewModels
                             NLog.LogManager.GetCurrentClassLogger().Error(ex, ex.Message);
                         }
                     }
+
+                    await OrderFilesAndFoldersAsync();
+                    await ApplyFilesAndFoldersChangesAsync();
                 }
             }
             catch
@@ -1741,8 +1744,6 @@ namespace Files.ViewModels
         private async Task AddFileOrFolderAsync(ListedItem item)
         {
             filesAndFolders.Add(item);
-            await OrderFilesAndFoldersAsync();
-            await ApplyFilesAndFoldersChangesAsync();
             await SaveCurrentListToCacheAsync(WorkingDirectory);
         }
 
@@ -1775,8 +1776,6 @@ namespace Files.ViewModels
             if (listedItem != null)
             {
                 filesAndFolders.Add(listedItem);
-                await OrderFilesAndFoldersAsync();
-                await ApplyFilesAndFoldersChangesAsync();
                 await SaveCurrentListToCacheAsync(WorkingDirectory);
             }
         }
@@ -1856,7 +1855,6 @@ namespace Files.ViewModels
         public async Task RemoveFileOrFolderAsync(ListedItem item)
         {
             filesAndFolders.Remove(item);
-            await ApplyFilesAndFoldersChangesAsync();
             await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
             {
                 App.JumpList.RemoveFolder(item.ItemPath);


### PR DESCRIPTION
Instead of calling `ApplyFilesAndFoldersChangesAsync` directly after each filesystem change, accumulate those changes and update them one time with an interval sampler to improve performance while occurring a large set of entries changes.