### PR TITLE
Fixed issue where shortcut items would not be cached properly

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -845,7 +845,7 @@ namespace Files
 
             foreach (ListedItem item in ParentShellPageInstance.ContentPage.SelectedItems)
             {
-                if (item is ShortcutItem)
+                if (item.IsShortcutItem)
                 {
                     // Can't drag shortcut items
                     continue;
@@ -958,7 +958,7 @@ namespace Files
             ListedItem rowItem = GetItemFromElement(sender);
             if (rowItem != null)
             {
-                await ParentShellPageInstance.InteractionOperations.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, (rowItem as ShortcutItem)?.TargetPath ?? rowItem.ItemPath, true);
+                await ParentShellPageInstance.InteractionOperations.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, rowItem.TargetPath ?? rowItem.ItemPath, true);
             }
             deferral.Complete();
         }

--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -275,10 +275,18 @@ namespace Files.Filesystem
         }
 
         public bool IsRecycleBinItem => this is RecycleBinItem;
-        public bool IsShortcutItem => this is ShortcutItem;
-        public bool IsLinkItem => IsShortcutItem && ((ShortcutItem)this).IsUrl;
 
         public bool IsPinned => App.SidebarPinnedController.Model.Items.Contains(itemPath);
+
+        #region ShortcutProperties
+        public bool IsShortcutItem { get; set; }
+        public bool IsLinkItem => IsShortcutItem && this.IsUrl;
+        public string TargetPath { get; set; }
+        public string Arguments { get; set; }
+        public string WorkingDirectory { get; set; }
+        public bool RunAsAdmin { get; set; }
+        public bool IsUrl { get; set; }
+        #endregion
     }
 
     public class RecycleBinItem : ListedItem
@@ -306,20 +314,5 @@ namespace Files.Filesystem
 
         // For recycle bin elements (path)
         public string ItemOriginalFolder => Path.IsPathRooted(ItemOriginalPath) ? Path.GetDirectoryName(ItemOriginalPath) : ItemOriginalPath;
-    }
-
-    public class ShortcutItem : ListedItem
-    {
-        public ShortcutItem(string folderRelativeId, string returnFormat) : base(folderRelativeId, returnFormat)
-        {
-        }
-
-        // For shortcut elements (.lnk and .url)
-        public string TargetPath { get; set; }
-
-        public string Arguments { get; set; }
-        public string WorkingDirectory { get; set; }
-        public bool RunAsAdmin { get; set; }
-        public bool IsUrl { get; set; }
     }
 }

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -133,7 +133,7 @@ namespace Files.Interacts
             var items = AssociatedInstance.ContentPage.SelectedItems;
             foreach (ListedItem listedItem in items)
             {
-                var selectedItemPath = (listedItem as ShortcutItem)?.TargetPath ?? listedItem.ItemPath;
+                var selectedItemPath = listedItem.TargetPath ?? listedItem.ItemPath;
                 var folderUri = new Uri($"files-uwp:?folder={@selectedItemPath}");
                 await Launcher.LaunchUriAsync(folderUri);
             }
@@ -144,7 +144,7 @@ namespace Files.Interacts
             var listedItem = AssociatedInstance.ContentPage.SelectedItems.FirstOrDefault();
             if (listedItem != null)
             {
-                AssociatedInstance.PaneHolder?.OpenPathInNewPane((listedItem as ShortcutItem)?.TargetPath ?? listedItem.ItemPath);
+                AssociatedInstance.PaneHolder?.OpenPathInNewPane(listedItem.TargetPath ?? listedItem.ItemPath);
             }
         }
 
@@ -161,7 +161,7 @@ namespace Files.Interacts
             {
                 await CoreWindow.GetForCurrentThread().Dispatcher.RunAsync(CoreDispatcherPriority.Low, async () =>
                 {
-                    await MainPage.AddNewTabByPathAsync(typeof(PaneHolderPage), (listedItem as ShortcutItem)?.TargetPath ?? listedItem.ItemPath);
+                    await MainPage.AddNewTabByPathAsync(typeof(PaneHolderPage), listedItem.TargetPath ?? listedItem.ItemPath);
                 });
             }
         }
@@ -174,7 +174,7 @@ namespace Files.Interacts
                 {
                     if (Item.IsShortcutItem)
                     {
-                        OpenPathInNewTab(((e.OriginalSource as FrameworkElement)?.DataContext as ShortcutItem)?.TargetPath ?? Item.ItemPath);
+                        OpenPathInNewTab(((e.OriginalSource as FrameworkElement)?.DataContext as ListedItem)?.TargetPath ?? Item.ItemPath);
                     }
                     else
                     {
@@ -393,7 +393,7 @@ namespace Files.Interacts
 
         public async void OpenFileLocation_Click(object sender, RoutedEventArgs e)
         {
-            var item = AssociatedInstance.ContentPage.SelectedItem as ShortcutItem;
+            var item = AssociatedInstance.ContentPage.SelectedItem;
             var folderPath = Path.GetDirectoryName(item.TargetPath);
             // Check if destination path exists
             var destFolder = await AssociatedInstance.FilesystemViewModel.GetFolderWithPathFromPathAsync(folderPath);
@@ -813,7 +813,7 @@ namespace Files.Interacts
                     {
                         dataRequest.Data.Properties.Title = string.Format("ShareDialogTitle".GetLocalized(), items.First().Name);
                         dataRequest.Data.Properties.Description = "ShareDialogSingleItemDescription".GetLocalized();
-                        dataRequest.Data.SetWebLink(new Uri(((ShortcutItem)item).TargetPath));
+                        dataRequest.Data.SetWebLink(new Uri(item.TargetPath));
                         dataRequestDeferral.Complete();
                         return;
                     }
@@ -1302,7 +1302,7 @@ namespace Files.Interacts
         public async Task<string> GetHashForFileAsync(ListedItem fileItem, string nameOfAlg, CancellationToken token, Microsoft.UI.Xaml.Controls.ProgressBar progress)
         {
             HashAlgorithmProvider algorithmProvider = HashAlgorithmProvider.OpenAlgorithm(nameOfAlg);
-            StorageFile itemFromPath = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync((fileItem as ShortcutItem)?.TargetPath ?? fileItem.ItemPath);
+            StorageFile itemFromPath = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(fileItem.TargetPath ?? fileItem.ItemPath);
             if (itemFromPath == null)
             {
                 return "";

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -2051,7 +2051,7 @@ namespace Files.ViewModels
                             opacity = 0.4;
                         }
 
-                        return new ShortcutItem(null, dateReturnFormat)
+                        return new ListedItem(null, dateReturnFormat)
                         {
                             PrimaryItemAttribute = (bool)response.Message["IsFolder"] ? StorageItemTypes.Folder : StorageItemTypes.File,
                             FileExtension = itemFileExtension,
@@ -2075,6 +2075,7 @@ namespace Files.ViewModels
                             RunAsAdmin = (bool)response.Message["RunAsAdmin"],
                             IsUrl = isUrl,
                             ContainsFilesOrFolders = containsFilesOrFolders,
+                            IsShortcutItem = true,
                         };
                     }
                 }

--- a/Files/ViewModels/Properties/FileProperties.cs
+++ b/Files/ViewModels/Properties/FileProperties.cs
@@ -59,27 +59,25 @@ namespace Files.ViewModels.Properties
 
                 if (Item.IsShortcutItem)
                 {
-                    var shortcutItem = (ShortcutItem)Item;
 
-                    var isApplication = !string.IsNullOrWhiteSpace(shortcutItem.TargetPath) &&
-                        (shortcutItem.TargetPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
-                            || shortcutItem.TargetPath.EndsWith(".msi", StringComparison.OrdinalIgnoreCase)
-                            || shortcutItem.TargetPath.EndsWith(".bat", StringComparison.OrdinalIgnoreCase));
+                    var isApplication = !string.IsNullOrWhiteSpace(Item.TargetPath) &&
+                        (Item.TargetPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                            || Item.TargetPath.EndsWith(".msi", StringComparison.OrdinalIgnoreCase)
+                            || Item.TargetPath.EndsWith(".bat", StringComparison.OrdinalIgnoreCase));
 
-                    ViewModel.ShortcutItemType = isApplication ? "PropertiesShortcutTypeApplication".GetLocalized() :
+                    ViewModel.ItemType = isApplication ? "PropertiesShortcutTypeApplication".GetLocalized() :
                         Item.IsLinkItem ? "PropertiesShortcutTypeLink".GetLocalized() : "PropertiesShortcutTypeFile".GetLocalized();
-                    ViewModel.ShortcutItemPath = shortcutItem.TargetPath;
-                    ViewModel.ShortcutItemWorkingDir = shortcutItem.WorkingDirectory;
+                    ViewModel.ShortcutItemPath = Item.TargetPath;
+                    ViewModel.ShortcutItemWorkingDir = Item.WorkingDirectory;
                     ViewModel.ShortcutItemWorkingDirVisibility = Item.IsLinkItem ? Visibility.Collapsed : Visibility.Visible;
-                    ViewModel.ShortcutItemArguments = shortcutItem.Arguments;
+                    ViewModel.ShortcutItemArguments = Item.Arguments;
                     ViewModel.ShortcutItemArgumentsVisibility = Item.IsLinkItem ? Visibility.Collapsed : Visibility.Visible;
                     ViewModel.IsSelectedItemShortcut = Item.FileExtension.Equals(".lnk", StringComparison.OrdinalIgnoreCase);
                     ViewModel.ShortcutItemOpenLinkCommand = new RelayCommand(async () =>
                     {
                         if (Item.IsLinkItem)
                         {
-                            var tmpItem = (ShortcutItem)Item;
-                            await AppInstance.InteractionOperations.InvokeWin32ComponentAsync(ViewModel.ShortcutItemPath, ViewModel.ShortcutItemArguments, tmpItem.RunAsAdmin, ViewModel.ShortcutItemWorkingDir);
+                            await AppInstance.InteractionOperations.InvokeWin32ComponentAsync(ViewModel.ShortcutItemPath, ViewModel.ShortcutItemArguments, Item.RunAsAdmin, ViewModel.ShortcutItemWorkingDir);
                         }
                         else
                         {
@@ -115,14 +113,14 @@ namespace Files.ViewModels.Properties
                 ViewModel.ItemCreatedTimestamp = Item.ItemDateCreated;
                 ViewModel.ItemAccessedTimestamp = Item.ItemDateAccessed;
                 ViewModel.LoadLinkIcon = Item.IsLinkItem;
-                if (Item.IsLinkItem || string.IsNullOrWhiteSpace(((ShortcutItem)Item).TargetPath))
+                if (Item.IsLinkItem || string.IsNullOrWhiteSpace(Item.TargetPath))
                 {
                     // Can't show any other property
                     return;
                 }
             }
 
-            StorageFile file = await AppInstance.FilesystemViewModel.GetFileFromPathAsync((Item as ShortcutItem)?.TargetPath ?? Item.ItemPath);
+            StorageFile file = await AppInstance.FilesystemViewModel.GetFileFromPathAsync(Item.TargetPath ?? Item.ItemPath);
             if (file == null)
             {
                 // Could not access file, can't show any other property
@@ -316,7 +314,6 @@ namespace Files.ViewModels.Properties
                 case "ShortcutItemPath":
                 case "ShortcutItemWorkingDir":
                 case "ShortcutItemArguments":
-                    var tmpItem = (ShortcutItem)Item;
                     if (string.IsNullOrWhiteSpace(ViewModel.ShortcutItemPath))
                         return;
                     if (AppInstance.FilesystemViewModel.Connection != null)
@@ -329,7 +326,7 @@ namespace Files.ViewModels.Properties
                             { "targetpath", ViewModel.ShortcutItemPath },
                             { "arguments", ViewModel.ShortcutItemArguments },
                             { "workingdir", ViewModel.ShortcutItemWorkingDir },
-                            { "runasadmin", tmpItem.RunAsAdmin },
+                            { "runasadmin", Item.RunAsAdmin },
                         };
                         await AppInstance.FilesystemViewModel.Connection.SendMessageAsync(value);
                     }

--- a/Files/ViewModels/Properties/FolderProperties.cs
+++ b/Files/ViewModels/Properties/FolderProperties.cs
@@ -50,12 +50,11 @@ namespace Files.ViewModels.Properties
 
                 if (Item.IsShortcutItem)
                 {
-                    var shortcutItem = (ShortcutItem)Item;
                     ViewModel.ShortcutItemType = "PropertiesShortcutTypeFolder".GetLocalized();
-                    ViewModel.ShortcutItemPath = shortcutItem.TargetPath;
-                    ViewModel.ShortcutItemWorkingDir = shortcutItem.WorkingDirectory;
+                    ViewModel.ShortcutItemPath = Item.TargetPath;
+                    ViewModel.ShortcutItemWorkingDir = Item.WorkingDirectory;
                     ViewModel.ShortcutItemWorkingDirVisibility = Visibility.Collapsed;
-                    ViewModel.ShortcutItemArguments = shortcutItem.Arguments;
+                    ViewModel.ShortcutItemArguments = Item.Arguments;
                     ViewModel.ShortcutItemArgumentsVisibility = Visibility.Collapsed;
                     ViewModel.ShortcutItemOpenLinkCommand = new RelayCommand(async () =>
                     {
@@ -86,7 +85,7 @@ namespace Files.ViewModels.Properties
                 ViewModel.ItemSize = $"{ByteSize.FromBytes(Item.FileSizeBytes).ToBinaryString().ConvertSizeAbbreviation()} ({ByteSize.FromBytes(Item.FileSizeBytes).Bytes:#,##0} {"ItemSizeBytes".GetLocalized()})";
                 ViewModel.ItemCreatedTimestamp = Item.ItemDateCreated;
                 ViewModel.ItemAccessedTimestamp = Item.ItemDateAccessed;
-                if (Item.IsLinkItem || string.IsNullOrWhiteSpace(((ShortcutItem)Item).TargetPath))
+                if (Item.IsLinkItem || string.IsNullOrWhiteSpace(Item.TargetPath))
                 {
                     // Can't show any other property
                     return;
@@ -96,7 +95,7 @@ namespace Files.ViewModels.Properties
             StorageFolder storageFolder;
             try
             {
-                storageFolder = await AppInstance.FilesystemViewModel.GetFolderFromPathAsync((Item as ShortcutItem)?.TargetPath ?? Item.ItemPath);
+                storageFolder = await AppInstance.FilesystemViewModel.GetFolderFromPathAsync(Item.TargetPath ?? Item.ItemPath);
             }
             catch (Exception ex)
             {
@@ -207,7 +206,6 @@ namespace Files.ViewModels.Properties
                 case "ShortcutItemPath":
                 case "ShortcutItemWorkingDir":
                 case "ShortcutItemArguments":
-                    var tmpItem = (ShortcutItem)Item;
                     if (string.IsNullOrWhiteSpace(ViewModel.ShortcutItemPath))
                     {
                         return;
@@ -223,7 +221,7 @@ namespace Files.ViewModels.Properties
                             { "targetpath", ViewModel.ShortcutItemPath },
                             { "arguments", ViewModel.ShortcutItemArguments },
                             { "workingdir", ViewModel.ShortcutItemWorkingDir },
-                            { "runasadmin", tmpItem.RunAsAdmin },
+                            { "runasadmin", Item.RunAsAdmin },
                         };
                         await AppInstance.FilesystemViewModel.Connection.SendMessageAsync(value);
                     }

--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -51,7 +51,7 @@ namespace Files.Views
             var args = e.Parameter as PropertiesPageNavigationArguments;
             AppInstance = args.AppInstanceArgument;
             navParameterItem = args.Item;
-            TabShorcut.Visibility = args.Item is ShortcutItem ? Visibility.Visible : Visibility.Collapsed;
+            TabShorcut.Visibility = (args.Item as ListedItem).IsShortcutItem ? Visibility.Visible : Visibility.Collapsed;
             listedItem = args.Item as ListedItem;
             TabDetails.Visibility = listedItem != null && listedItem.FileExtension != null && !listedItem.IsShortcutItem ? Visibility.Visible : Visibility.Collapsed;
             SetBackground();


### PR DESCRIPTION
This pr fixes an issue where Shortcut items would not be cached properly.

The issue was caused by the Json converter serializing and de-serializing the shortcut as a ```ListedItem```, not as a ```ShortcutItem```. When the cache was then read, Files would treat the shortcut like a normal file, instead of as a shortcut. 

This would cause the details page instead of the shortcut page to be shown in the properties window when a shortcut was selected, and also caused a minor issue with #3349. 

<img src="https://user-images.githubusercontent.com/59544401/106401444-fcc84080-63d8-11eb-9ec3-ce9619b5a8fc.png" Width="300"/>

Attempting to navigate to the details page would then cause a crash, since StorageFile doesn't work with shortcuts.

This PR fixes that issue by removing the ```ShortcutItem``` child class, and moving all of it's properties into the ```ListedItem``` parent class. ```ListedItem.IsShortcutItem``` is now set to true when a shortcut is initialized. This way, all of the shortcut-specific properties can be serialized and de-serialized, therefore allowing the shortcut's information to be cached.

I have tested these changes with creating, deleting, opening, and changing the settings of shortcuts, with and without file caching enabled, and have not noticed any issues thus far.