### PR TITLE
Reduce scrolling stutters

### DIFF
--- a/Files/Helpers/BulkConcurrentObservableCollection.cs
+++ b/Files/Helpers/BulkConcurrentObservableCollection.cs
@@ -10,106 +10,19 @@ namespace Files.Helpers
 {
     public class BulkConcurrentObservableCollection<T> : INotifyCollectionChanged, INotifyPropertyChanged, ICollection<T>, IList<T>, ICollection, IList
     {
-        private volatile bool isBulkOperationStarted;
-        private volatile int readerCount;
-        private volatile bool needSnapshot;
-        private readonly SemaphoreSlim writerLock = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim mutex = new SemaphoreSlim(1, 1);
-        private readonly SemaphoreSlim snapshotLock = new SemaphoreSlim(1, 1);
+        private bool isBulkOperationStarted;
+        private readonly object syncRoot = new object();
         private readonly List<T> collection = new List<T>();
-        private List<T> snapshot = new List<T>();
 
-        private void Write(Action writeFunc)
-        {
-            writerLock.Wait();
-            try
-            {
-                writeFunc();
-            }
-            finally
-            {
-                writerLock.Release();
-                snapshotLock.Wait();
-                needSnapshot = true;
-                snapshotLock.Release();
-            }
-        }
-
-        private U Write<U>(Func<U> writeFunc)
-        {
-            writerLock.Wait();
-            try
-            {
-                return writeFunc();
-            }
-            finally
-            {
-                writerLock.Release();
-                snapshotLock.Wait();
-                needSnapshot = true;
-                snapshotLock.Release();
-            }
-        }
-
-        private void Read(Action readFunc)
-        {
-            mutex.Wait();
-            readerCount++;
-            if (readerCount == 1)
-            {
-                writerLock.Wait();
-            }
-            mutex.Release();
-            try
-            {
-                readFunc();
-            }
-            finally
-            {
-                mutex.Wait();
-                readerCount--;
-                if (readerCount == 0)
-                {
-                    writerLock.Release();
-                }
-                mutex.Release();
-            }
-        }
-
-        private U Read<U>(Func<U> readFunc)
-        {
-            mutex.Wait();
-            readerCount++;
-            if (readerCount == 1)
-            {
-                writerLock.Wait();
-            }
-            mutex.Release();
-            try
-            {
-                return readFunc();
-            }
-            finally
-            {
-                mutex.Wait();
-                readerCount--;
-                if (readerCount == 0)
-                {
-                    writerLock.Release();
-                }
-                mutex.Release();
-            }
-        }
-
-        public int Count => Read(() => collection.Count);
+        public int Count => collection.Count;
 
         public bool IsReadOnly => false;
 
         public bool IsFixedSize => false;
 
-        public bool IsSynchronized => false;
+        public bool IsSynchronized => true;
 
-        public object SyncRoot => throw new NotImplementedException();
+        public object SyncRoot => syncRoot;
 
         object IList.this[int index]
         {
@@ -125,15 +38,11 @@ namespace Files.Helpers
 
         public T this[int index]
         {
-            get => Read(() => collection[index]);
+            get => collection[index];
             set
             {
-                var item = Write(() =>
-                {
-                    var item = collection[index];
-                    collection[index] = value;
-                    return item;
-                });
+                var item = collection[index];
+                collection[index] = value;
                 OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, value, item));
             }
         }
@@ -163,43 +72,50 @@ namespace Files.Helpers
 
         public void Add(T item)
         {
-            Write(() => collection.Add(item));
+            lock (syncRoot)
+            {
+                collection.Add(item);
+            }
+
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
         }
 
         public void Clear()
         {
-            Write(() => collection.Clear());
+            lock (syncRoot)
+            {
+                collection.Clear();
+            }
+
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
         public bool Contains(T item)
         {
-            return Read(() => collection.Contains(item));
+            return collection.Contains(item);
         }
 
         public void CopyTo(T[] array, int arrayIndex)
         {
-            Read(() => collection.CopyTo(array, arrayIndex));
+            collection.CopyTo(array, arrayIndex);
         }
 
         public bool Remove(T item)
         {
-            var result = Write(() => collection.Remove(item));
+            bool result;
+
+            lock (syncRoot)
+            {
+                result = collection.Remove(item);
+            }
+
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item));
             return result;
         }
 
         public IEnumerator<T> GetEnumerator()
         {
-            snapshotLock.Wait();
-            if (needSnapshot)
-            {
-                snapshot = Read(() => collection.ToList());
-                needSnapshot = false;
-            }
-            snapshotLock.Release();
-            return snapshot.GetEnumerator();
+            return collection.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -209,23 +125,28 @@ namespace Files.Helpers
 
         public int IndexOf(T item)
         {
-            return Read(() => collection.IndexOf(item));
+            return collection.IndexOf(item);
         }
 
         public void Insert(int index, T item)
         {
-            Write(() => collection.Insert(index, item));
+            lock (syncRoot)
+            {
+                collection.Insert(index, item);
+            }
+
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
         }
 
         public void RemoveAt(int index)
         {
-            var item = Write(() =>
+            var item = collection[index];
+
+            lock (syncRoot)
             {
-                var item = collection[index];
                 collection.RemoveAt(index);
-                return item;
-            });
+            }
+
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item));
         }
 
@@ -235,7 +156,12 @@ namespace Files.Helpers
             {
                 return;
             }
-            Write(() => collection.AddRange(items));
+
+            lock (syncRoot)
+            {
+                collection.AddRange(items);
+            }
+
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, items.ToList()));
         }
 
@@ -245,50 +171,62 @@ namespace Files.Helpers
             {
                 return;
             }
-            Write(() => collection.InsertRange(index, items));
+
+            lock (syncRoot)
+            {
+                collection.InsertRange(index, items);
+            }
+
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, items.ToList(), index));
         }
 
         public void RemoveRange(int index, int count)
         {
-            if (count == 0)
+            if (count <= 0)
             {
                 return;
             }
-            var items = Write(() =>
+
+            var items = collection.Skip(index).Take(count).ToList();
+
+            lock (syncRoot)
             {
-                var items = collection.Skip(index).Take(count).ToList();
                 collection.RemoveRange(index, count);
-                return items;
-            });
+            }
+
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, items));
         }
 
         public void ReplaceRange(int index, IEnumerable<T> items)
         {
             var count = items.Count();
+
             if (count == 0)
             {
                 return;
             }
-            var (newItems, oldItems) = Write(() =>
+
+            var oldItems = collection.Skip(index).Take(count).ToList();
+            var newItems = items.ToList();
+
+            lock (syncRoot)
             {
-                var oldItems = collection.Skip(index).Take(count).ToList();
-                var newItems = items.ToList();
                 collection.InsertRange(index, newItems);
                 collection.RemoveRange(index + count, count);
-                return (newItems, oldItems);
-            });
+            }
+
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newItems, oldItems));
         }
 
         int IList.Add(object value)
         {
-            var index = Write(() =>
+            int index;
+
+            lock (syncRoot)
             {
-                collection.Add((T)value);
-                return collection.Count;
-            });
+                index = ((IList)collection).Add((T)value);
+            }
+
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, value));
             return index;
         }

--- a/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
+++ b/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
@@ -58,7 +58,7 @@ namespace Files.UserControls.Selection
                 base.DrawRectangle(currentPoint, originDragPointShifted);
                 // Selected area considering scrolled offset
                 var rect = new System.Drawing.Rectangle((int)Canvas.GetLeft(selectionRectangle), (int)Math.Min(originDragPoint.Y, currentPoint.Position.Y + verticalOffset), (int)selectionRectangle.Width, (int)Math.Abs(originDragPoint.Y - (currentPoint.Position.Y + verticalOffset)));
-                foreach (var item in uiElement.Items.Except(itemsPosition.Keys))
+                foreach (var item in uiElement.Items.ToList().Except(itemsPosition.Keys))
                 {
                     var listViewItem = (FrameworkElement)uiElement.ContainerFromItem(item); // Get ListViewItem
                     if (listViewItem == null)

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -129,7 +129,7 @@ namespace Files.Views.LayoutModes
         {
             if (!InstanceViewModel.IsPageTypeSearchResults)
             {
-                foreach (ListedItem listedItem in FileList.Items)
+                foreach (ListedItem listedItem in FileList.Items.ToList())
                 {
                     if (FileList.ContainerFromItem(listedItem) is GridViewItem gridViewItem)
                     {


### PR DESCRIPTION
Make use of SyncRoot to reduce unnecessary semaphores in BulkConcurrentObservableCollection.

I found there's no need to implement lock manually, there's already built-in `SyncRoot` for this (inspired by `SynchronizedCollection<T>`).

Fixes #3371

Note: it's no longer safe if you try to enumerate it without neither `lock (list.SyncRoot)` nor `.ToList()`