### PR TITLE
fix(CodeQL): remove conditional for restore step

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,6 @@ jobs:
 
       - name: "NuGet Caching"
         uses: actions/cache@v2
-        id: cache
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/Files.Package/Package.appxmanifest') }}
@@ -57,7 +56,6 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: "Restore NuGets for Solution"
-        if: steps.cache.outputs.cache-hit != 'true'
         run: nuget restore -LockedMode Files.sln
 
       - name: "Perform Project Build"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: windows-latest
+    if: github.repository == 'files-community/Files'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Description

Since I feared this yesterday already I monitored the `CodeQL` Action, and low and behold the conditional `NuGet restore` step caused issues.
Here is me fixing this with this PR to run that step regardless of `cache-hit=true`, sorry for the inconvenience. 

### Changes

* change to run `NuGet restore` even on cache hit
* CodeQL workflow now ignores fork repos and only runs on the main repo and its PRs

### Issue

* n/a