### PR TITLE
Fixed issue where shortcut items would not be cached properly

### DIFF
--- a/Files/Helpers/FileListCache/PersistentSQLiteCacheAdapter.cs
+++ b/Files/Helpers/FileListCache/PersistentSQLiteCacheAdapter.cs
@@ -70,7 +70,11 @@ namespace Files.Helpers.FileListCache
                     using var updateCommand = new SqliteCommand("UPDATE FileListCache SET Timestamp = @Timestamp, Entry = @Entry WHERE Id = @Id", connection);
                     updateCommand.Parameters.Add("@Id", SqliteType.Text).Value = path;
                     updateCommand.Parameters.Add("@Timestamp", SqliteType.Integer).Value = GetTimestamp(DateTime.UtcNow);
-                    updateCommand.Parameters.Add("@Entry", SqliteType.Text).Value = JsonConvert.SerializeObject(cacheEntry);
+                    var settings = new JsonSerializerSettings
+                    {
+                        TypeNameHandling = TypeNameHandling.Auto
+                    };
+                    updateCommand.Parameters.Add("@Entry", SqliteType.Text).Value = JsonConvert.SerializeObject(cacheEntry, settings);
                     await updateCommand.ExecuteNonQueryAsync();
                 }
                 else
@@ -79,7 +83,11 @@ namespace Files.Helpers.FileListCache
                     using var insertCommand = new SqliteCommand("INSERT INTO FileListCache (Id, Timestamp, Entry) VALUES (@Id, @Timestamp, @Entry)", connection);
                     insertCommand.Parameters.Add("@Id", SqliteType.Text).Value = path;
                     insertCommand.Parameters.Add("@Timestamp", SqliteType.Integer).Value = GetTimestamp(DateTime.UtcNow);
-                    insertCommand.Parameters.Add("@Entry", SqliteType.Text).Value = JsonConvert.SerializeObject(cacheEntry);
+                    var settings = new JsonSerializerSettings
+                    {
+                        TypeNameHandling = TypeNameHandling.Auto
+                    };
+                    insertCommand.Parameters.Add("@Entry", SqliteType.Text).Value = JsonConvert.SerializeObject(cacheEntry, settings);
                     await insertCommand.ExecuteNonQueryAsync();
                 }
             }


### PR DESCRIPTION
New PR for the bug in #3381 with @gave92's suggested alternative changes.

This pr fixes an issue where Shortcut items would not be cached properly.

The issue was caused by the Json converter serializing and de-serializing the shortcut as a ```ListedItem```, not as a ```ShortcutItem```. When the cache was then read, Files would treat the shortcut like a normal file, instead of as a shortcut. 

This would cause the details page instead of the shortcut page to be shown in the properties window when a shortcut was selected, and also caused a minor issue with #3349. 

<img src="https://user-images.githubusercontent.com/59544401/106401444-fcc84080-63d8-11eb-9ec3-ce9619b5a8fc.png" Width="300"/>

Attempting to navigate to the details page would then cause a crash, since StorageFile doesn't work with shortcuts.

This PR fixes that by adding the preserve type setting to the Json serializer.