### PR TITLE
Hide This folder is empty text on load

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1808,11 +1808,6 @@ namespace Files.ViewModels
                 {
                     AssociatedInstance.ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{filesAndFolders.Count} {"ItemCount/Text".GetLocalized()}";
                 }
-                else if (filesAndFolders.Count == 0 && !IsFolderEmptyTextDisplayed)
-                {
-                    // Display no text when filesAndFolders cleared at the start of loading
-                    AssociatedInstance.ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = null;
-                }
                 else
                 {
                     AssociatedInstance.ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{filesAndFolders.Count} {"ItemsCount/Text".GetLocalized()}";

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -885,17 +885,10 @@ namespace Files.ViewModels
 
                 IsLoadingItems = true;
 
-                // Clear previous state
                 filesAndFolders.Clear();
                 await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
                 {
                     FilesAndFolders.Clear();
-                    // We don't want the empty text to show up when we're about to
-                    // try loading directory contents, so we set this property to false
-                    // It will be updated later based on the item count of
-                    // filesAndFolders inside ApplyFilesAndFoldersChangesAsync()
-                    IsFolderEmptyTextDisplayed = false;
-                    UpdateDirectoryInfo();
                 });
 
                 Stopwatch stopwatch = new Stopwatch();

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -480,7 +480,7 @@ namespace Files.ViewModels
                     await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
                     {
                         FilesAndFolders.Clear();
-                        IsFolderEmptyTextDisplayed = FilesAndFolders.Count == 0;
+                        IsFolderEmptyTextDisplayed = true;
                         UpdateDirectoryInfo();
                     });
                     return;
@@ -884,8 +884,20 @@ namespace Files.ViewModels
                 semaphoreCTS = new CancellationTokenSource();
 
                 IsLoadingItems = true;
+
+                // Clear previous state
                 filesAndFolders.Clear();
-                await ApplyFilesAndFoldersChangesAsync();
+                await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
+                {
+                    FilesAndFolders.Clear();
+                    // We don't want the empty text to show up when we're about to
+                    // try loading directory contents, so we set this property to false
+                    // It will be updated later based on the item count of
+                    // filesAndFolders inside ApplyFilesAndFoldersChangesAsync()
+                    IsFolderEmptyTextDisplayed = false;
+                    UpdateDirectoryInfo();
+                });
+
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
 

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1808,6 +1808,11 @@ namespace Files.ViewModels
                 {
                     AssociatedInstance.ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{filesAndFolders.Count} {"ItemCount/Text".GetLocalized()}";
                 }
+                else if (filesAndFolders.Count == 0 && !IsFolderEmptyTextDisplayed)
+                {
+                    // Display no text when filesAndFolders cleared at the start of loading
+                    AssociatedInstance.ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = null;
+                }
                 else
                 {
                     AssociatedInstance.ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{filesAndFolders.Count} {"ItemsCount/Text".GetLocalized()}";


### PR DESCRIPTION
This PR is for hiding some texts at the beginning of the loading process of directory contents.

They represent a temprorary state when items are about to load, and can confuse users – maybe make them exit a directory without waiting enough time to load if it was slow for some reason. The loading progress bar is visible on the top, but the "This folder is empty." text around the center is easier to notice.
The second change is about hiding the item counter at the bottom, but this might be not so important.

Affected texts:

- *This folder is empty.* - visible on the main panel, when the actual directory is empty
- *0 items* - item counter on the status bar