### PR TITLE
Don't scale image previews over their size

### DIFF
--- a/Files/UserControls/FilePreviews/ImagePreview.xaml
+++ b/Files/UserControls/FilePreviews/ImagePreview.xaml
@@ -10,6 +10,8 @@
     mc:Ignorable="d">
 
     <Grid>
-        <Image Source="{x:Bind ViewModel.ImageSource, Mode=OneWay}" />
+        <Viewbox StretchDirection="DownOnly">
+            <Image Source="{x:Bind ViewModel.ImageSource, Mode=OneWay}" />
+        </Viewbox>
     </Grid>
 </UserControl>


### PR DESCRIPTION
This PR is about to wrap Image in a Viewbox with `StretchDirection="DownOnly"` in the image preview control to allow images stretch just until their size is downscaled.

Scaling an image over the size degrades recognizability of its content.