### PR TITLE
Added type setting for de-serializer

### DIFF
--- a/Files/Helpers/FileListCache/PersistentSQLiteCacheAdapter.cs
+++ b/Files/Helpers/FileListCache/PersistentSQLiteCacheAdapter.cs
@@ -111,7 +111,11 @@ namespace Files.Helpers.FileListCache
                 }
                 var timestamp = reader.GetInt64(0);
                 var entryAsJson = reader.GetString(1);
-                var entry = JsonConvert.DeserializeObject<CacheEntry>(entryAsJson);
+                var settings = new JsonSerializerSettings
+                {
+                    TypeNameHandling = TypeNameHandling.Auto
+                };
+                var entry = JsonConvert.DeserializeObject<CacheEntry>(entryAsJson, settings);
                 entry.CurrentFolder.ItemPropertiesInitialized = false;
                 entry.FileList.ForEach((item) => item.ItemPropertiesInitialized = false);
                 return entry;


### PR DESCRIPTION
It turns out I was very wrong, the de-serializer does need a type setting specified in order for the shortcuts to be read from cache properly.

I apologize for this mistake.