### PR TITLE
Display SharePoint folder in sidebar for each Tenant

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Enums\FolderLayoutModes.cs" />
     <Compile Include="Enums\FileSystemStatusCode.cs" />
     <Compile Include="Filesystem\CloudDrivesManager.cs" />
+    <Compile Include="Filesystem\Cloud\Providers\OneDriveSharePointCloudProvider.cs" />
     <Compile Include="Helpers\AppServiceConnectionHelper.cs" />
     <Compile Include="Filesystem\Cloud\Providers\AmazonDriveProvider.cs" />
     <Compile Include="Helpers\AppUpdater.cs" />

--- a/Files/Filesystem/Cloud/CloudProviderController.cs
+++ b/Files/Filesystem/Cloud/CloudProviderController.cs
@@ -16,6 +16,7 @@ namespace Files.Filesystem.Cloud
                 new BoxCloudProvider(),
                 new AppleCloudProvider(),
                 new AmazonDriveProvider(),
+                new OneDriveSharePointCloudProvider(),
             };
 
         public async Task<List<CloudProvider>> DetectInstalledCloudProvidersAsync()

--- a/Files/Filesystem/Cloud/Providers/OneDriveSharePointCloudProvider.cs
+++ b/Files/Filesystem/Cloud/Providers/OneDriveSharePointCloudProvider.cs
@@ -1,0 +1,51 @@
+﻿using Files.Enums;
+using Files.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.AppService;
+using Windows.Foundation.Collections;
+
+namespace Files.Filesystem.Cloud.Providers
+{
+    public class OneDriveSharePointCloudProvider : ICloudProviderDetector
+    {
+        public async Task<IList<CloudProvider>> DetectAsync()
+        {
+            try
+            {
+                var connection = await AppServiceConnectionHelper.Instance;
+                if (connection != null)
+                {
+                    var (status, response) = await connection.SendMessageWithRetryAsync(new ValueSet()
+                    {
+                        { "Arguments", "GetSharePointSyncLocationsFromOneDrive" }
+                    }, TimeSpan.FromSeconds(10));
+                    if (status == AppServiceResponseStatus.Success)
+                    {
+                        var results = new List<CloudProvider>();
+                        foreach (var key in response.Message.Keys
+                            .OrderBy(o => o))
+                        {
+                            results.Add(new CloudProvider()
+                            {
+                                ID = CloudProviders.OneDrive,
+                                Name = key,
+                                SyncFolder = (string)response.Message[key]
+                            });
+                        }
+
+                        return results;
+                    }
+                }
+                return Array.Empty<CloudProvider>();
+            }
+            catch
+            {
+                // Not detected
+                return Array.Empty<CloudProvider>();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1310 

Because it is possible to sync an unlimited number of SharePoint libraries for any number of tenants, I have followed Explorer and add a single sidebar entry for each tenant. This maps to the a folder that contains the folders representing each document library/sync point.

![image](https://user-images.githubusercontent.com/307719/107877812-80e4f280-6ec6-11eb-96db-97aed25da391.png)
