### PR TITLE
Execute copy/move on background thread

### DIFF
--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -224,7 +224,7 @@ namespace Files.Filesystem
             }
             else if (source.ItemType == FilesystemItemType.File)
             {
-                var fsResult = (FilesystemResult)NativeFileOperationsHelper.CopyFileFromApp(source.Path, destination, true);
+                var fsResult = (FilesystemResult) await Task.Run(() => NativeFileOperationsHelper.CopyFileFromApp(source.Path, destination, true));
 
                 if (!fsResult)
                 {
@@ -387,7 +387,7 @@ namespace Files.Filesystem
                 }
                 else
                 {
-                    var fsResult = (FilesystemResult)NativeFileOperationsHelper.MoveFileFromApp(source.Path, destination);
+                    var fsResult = (FilesystemResult) await Task.Run(() => NativeFileOperationsHelper.MoveFileFromApp(source.Path, destination));
 
                     if (!fsResult)
                     {
@@ -449,7 +449,7 @@ namespace Files.Filesystem
             }
             else if (source.ItemType == FilesystemItemType.File)
             {
-                var fsResult = (FilesystemResult)NativeFileOperationsHelper.MoveFileFromApp(source.Path, destination);
+                var fsResult = (FilesystemResult) await Task.Run(() => NativeFileOperationsHelper.MoveFileFromApp(source.Path, destination));
 
                 if (!fsResult)
                 {


### PR DESCRIPTION
Fixes #3355 
Fixes (maybe) #3530

Avoid freezing app when copying/moving big files.