### PR TITLE
Fix ObjectDisposedException in CancellationTokenSource

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -170,7 +170,6 @@
     <Compile Include="Converters\UInt32ToString.cs" />
     <Compile Include="Converters\VisiblityInvertConverter.cs" />
     <Compile Include="Converters\LayoutModeToBoolConverter.cs" />
-    <Compile Include="Converters\LayoutModeToBoolConverter.cs" />
     <Compile Include="DataModels\ShellNewEntry.cs" />
     <Compile Include="Dialogs\DynamicDialog.xaml.cs">
       <DependentUpon>DynamicDialog.xaml</DependentUpon>

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -752,7 +752,7 @@ namespace Files.ViewModels
                 {
                     await loadExtendedPropsSemaphore.WaitAsync(loadPropsCTS.Token);
                 }
-                catch (Exception ex) when (ex is OperationCanceledException || ex is ObjectDisposedException)
+                catch (OperationCanceledException)
                 {
                     return;
                 }
@@ -911,7 +911,7 @@ namespace Files.ViewModels
                 // simply drop this instance
                 await enumFolderSemaphore.WaitAsync(semaphoreCTS.Token);
             }
-            catch (Exception ex) when (ex is OperationCanceledException || ex is ObjectDisposedException)
+            catch (OperationCanceledException)
             {
                 return;
             }
@@ -1076,10 +1076,6 @@ namespace Files.ViewModels
                         }
                     }
                 }
-            }
-            catch (ObjectDisposedException ex)
-            {
-                NLog.LogManager.GetCurrentClassLogger().Warn(ex, ex.Message);
             }
             finally
             {
@@ -1831,7 +1827,7 @@ namespace Files.ViewModels
             {
                 await enumFolderSemaphore.WaitAsync(semaphoreCTS.Token);
             }
-            catch (Exception ex) when (ex is OperationCanceledException || ex is ObjectDisposedException)
+            catch (OperationCanceledException)
             {
                 return;
             }
@@ -1876,7 +1872,7 @@ namespace Files.ViewModels
             {
                 await enumFolderSemaphore.WaitAsync(semaphoreCTS.Token);
             }
-            catch (Exception ex) when (ex is OperationCanceledException || ex is ObjectDisposedException)
+            catch (OperationCanceledException)
             {
                 return;
             }

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -476,7 +476,6 @@ namespace Files.ViewModels
         public void CancelExtendedPropertiesLoading()
         {
             loadPropsCTS.Cancel();
-            loadPropsCTS.Dispose();
             loadPropsCTS = new CancellationTokenSource();
         }
 
@@ -921,7 +920,6 @@ namespace Files.ViewModels
             {
                 // Drop all the other waiting instances
                 semaphoreCTS.Cancel();
-                semaphoreCTS.Dispose();
                 semaphoreCTS = new CancellationTokenSource();
 
                 IsLoadingItems = true;
@@ -1028,7 +1026,6 @@ namespace Files.ViewModels
 
                 if (addFilesCTS.IsCancellationRequested)
                 {
-                    addFilesCTS.Dispose();
                     addFilesCTS = new CancellationTokenSource();
                     IsLoadingItems = false;
                     return;
@@ -1605,7 +1602,6 @@ namespace Files.ViewModels
                 CloseHandle(overlapped.hEvent);
                 operationQueue.Clear();
                 cts.Cancel();
-                cts.Dispose();
                 Debug.WriteLine("aWatcherAction done: {0}", rand);
             });
 
@@ -1924,9 +1920,6 @@ namespace Files.ViewModels
         public void Dispose()
         {
             CancelLoadAndClearFiles();
-            addFilesCTS?.Dispose();
-            semaphoreCTS?.Dispose();
-            loadPropsCTS?.Dispose();
         }
     }
 

--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -128,7 +128,6 @@ namespace Files.Views
             if (tokenSource != null && !tokenSource.IsCancellationRequested)
             {
                 tokenSource.Cancel();
-                tokenSource.Dispose();
                 tokenSource = null;
             }
         }
@@ -141,7 +140,6 @@ namespace Files.Views
             if (tokenSource != null && !tokenSource.IsCancellationRequested)
             {
                 tokenSource.Cancel();
-                tokenSource.Dispose();
                 tokenSource = null;
             }
             propertiesDialog.Hide();


### PR DESCRIPTION
After some investigation, there's no need to dispose CancellationTokenSource manually if `LinkedTokenSource` was not used, so just let GC dispose CancellationTokenSource to prevent ObjectDisposedException.