### PR TITLE
Fixes for version 1.3

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -333,6 +333,10 @@ namespace Files.Interacts
         public static T FindParent<T>(DependencyObject child) where T : DependencyObject
         {
             T parent = null;
+            if (child == null)
+            {
+                return parent;
+            }
             DependencyObject CurrentParent = VisualTreeHelper.GetParent(child);
             while (CurrentParent != null)
             {

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -832,7 +832,7 @@ namespace Files.ViewModels
                             StorageFolder matchingStorageItem = await GetFolderFromPathAsync(item.ItemPath);
                             if (matchingStorageItem != null)
                             {
-                                if (matchingStorageItem.DisplayName != item.ItemName)
+                                if (matchingStorageItem.DisplayName != item.ItemName && !matchingStorageItem.DisplayName.StartsWith("$R"))
                                 {
                                     await CoreApplication.MainView.ExecuteOnUIThreadAsync(() =>
                                     {

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -142,7 +142,7 @@ namespace Files.Views.LayoutModes
             var rows = new List<DataGridRow>();
             Interaction.FindChildren<DataGridRow>(rows, AllView);
             ParentShellPageInstance.FilesystemViewModel.CancelExtendedPropertiesLoading();
-            foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders)
+            foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.ToList())
             {
                 listedItem.ItemPropertiesInitialized = false;
                 if (rows.Any(x => x.DataContext == listedItem))

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -425,7 +425,7 @@ namespace Files.Views.LayoutModes
         {
             AllView.CommitEdit();
             tapDebounceTimer.Stop();
-            SelectedItems = AllView.SelectedItems.Cast<ListedItem>().ToList();
+            SelectedItems = AllView.SelectedItems.Cast<ListedItem>().Where(x => x != null).ToList();
         }
 
         private void AllView_Sorting(object sender, DataGridColumnEventArgs e)

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -429,7 +429,7 @@ namespace Files.Views.LayoutModes
         private async void ReloadItemIcons()
         {
             ParentShellPageInstance.FilesystemViewModel.CancelExtendedPropertiesLoading();
-            foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders)
+            foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.ToList())
             {
                 listedItem.ItemPropertiesInitialized = false;
                 if (FileList.ContainerFromItem(listedItem) != null)

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -175,7 +175,7 @@ namespace Files.Views.LayoutModes
 
         private void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            SelectedItems = FileList.SelectedItems.Cast<ListedItem>().ToList();
+            SelectedItems = FileList.SelectedItems.Cast<ListedItem>().Where(x => x != null).ToList();
         }
 
         private ListedItem renamingItem;


### PR DESCRIPTION
Fixes #3623

Grrr this one keeps eluding me -> #3531
Is anyone able to reproduce it consistently? @XPoppyX I've seen you are getting the stacktrace below?
```cs
2021-02-10 16:23:36.7113|ERROR|.ctor|Index larger than max value.
Parameter name: index|System.ArgumentOutOfRangeException: Index larger than max value.
Parameter name: index
   at System.Runtime.InteropServices.WindowsRuntime.IVector_CCWAdapter.EnsureIndexInt32(UInt32, Int32) + 0x74
   at System.Runtime.InteropServices.WindowsRuntime.IBindableVector_CCWAdapter.GetAt(IList, UInt32) + 0x26
   at System.Collections.IList__Impl.Vtbl.GetAt__n(IntPtr, UInt32, Void**) + 0x3e
   at System.Runtime.InteropServices.McgMarshal.ThrowOnExternalCallFailed(Int32, RuntimeTypeHandle) + 0x21
   at __Interop.ComCallHelpers.Call(__ComObject, RuntimeTypeHandle, Int32) + 0xb8
   at __Interop.ForwardComStubs.Stub_19[TThis](__ComObject, Int32) + 0x24
   at Microsoft.AppCenter.Utils.ApplicationLifecycleHelper.<.ctor>b__17_1(Object, UnhandledErrorDetectedEventArgs) + 0x3d
```