### PR TITLE
Focus text input when dialog opened.

### DIFF
--- a/Files/Helpers/DynamicDialogFactory.cs
+++ b/Files/Helpers/DynamicDialogFactory.cs
@@ -5,6 +5,7 @@ using Files.ViewModels.Dialogs;
 using Microsoft.Toolkit.Uwp.Extensions;
 using System;
 using Windows.System;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace Files.Helpers
@@ -108,6 +109,11 @@ namespace Files.Helpers
                 DynamicButtonsEnabled = DynamicDialogButtons.Cancel,
                 DynamicButtons = DynamicDialogButtons.Primary | DynamicDialogButtons.Cancel
             });
+
+            dialog.Opened += (sender, args) =>
+            {
+                inputText.Focus(FocusState.Keyboard);
+            };
 
             return dialog;
         }

--- a/Files/Helpers/DynamicDialogFactory.cs
+++ b/Files/Helpers/DynamicDialogFactory.cs
@@ -112,7 +112,7 @@ namespace Files.Helpers
 
             dialog.Opened += (sender, args) =>
             {
-                inputText.Focus(FocusState.Keyboard);
+                inputText.Focus(FocusState.Programmatic);
             };
 
             return dialog;


### PR DESCRIPTION
### Steps:
1. Open a folder in Files.
2. Right click and select `New -> anything` in context menu.
3. The dialog that request the item name is pop up.

### Actual behavior (before this patch):
We have to click the text box or press `Tab` key to move the focus.

### Excepted behavior (after this patch):
The text input is auto focused.