### PR TITLE
Fix preview pane content alignment

### DIFF
--- a/Files/UserControls/PreviewPane.xaml
+++ b/Files/UserControls/PreviewPane.xaml
@@ -59,8 +59,8 @@
                 VerticalAlignment="Center"
                 Text="{x:Bind Model.PreviewErrorText, Mode=OneWay}" />
             <ContentControl
-                HorizontalContentAlignment="Center"
-                VerticalContentAlignment="Center"
+                HorizontalContentAlignment="Stretch"
+                VerticalContentAlignment="Stretch"
                 Content="{x:Bind Model.PreviewPaneContent, Mode=OneWay}" />
         </Grid>
 


### PR DESCRIPTION
This changes the preview pane content alignment from center to stretch.
Having it center aligned looks bad with text.