### PR TITLE
Keep last pathbox item visible and add padding

### DIFF
--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -552,7 +552,8 @@
                                     FontFamily="{StaticResource FluentUIGlyphs}"
                                     FontSize="10"
                                     Glyph="&#xE9A8;"
-                                    Loaded="PathItemSeparator_Loaded">
+                                    Loaded="PathItemSeparator_Loaded"
+                                    DataContextChanged="PathItemSeparator_DataContextChanged">
                                     <Interactivity:Interaction.Behaviors>
                                         <Core:EventTriggerBehavior EventName="PointerEntered">
                                             <Core:ChangePropertyAction PropertyName="Opacity">
@@ -830,6 +831,7 @@
                     VerticalAlignment="Stretch"
                     HorizontalContentAlignment="Stretch"
                     VerticalContentAlignment="Stretch"
+                    Padding="0,0,12,0"
                     Background="Transparent"
                     CanReorderItems="False"
                     CornerRadius="4"
@@ -844,7 +846,9 @@
                     Style="{StaticResource ListViewStyleNoAnimation}">
                     <ListView.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <StackPanel Background="Transparent" Orientation="Horizontal" />
+                            <ItemsStackPanel ItemsUpdatingScrollMode="KeepLastItemInView"
+                                             Background="Transparent"
+                                             Orientation="Horizontal" />
                         </ItemsPanelTemplate>
                     </ListView.ItemsPanel>
                     <ListView.ItemTemplateSelector>

--- a/Files/UserControls/NavigationToolbar.xaml.cs
+++ b/Files/UserControls/NavigationToolbar.xaml.cs
@@ -871,15 +871,23 @@ namespace Files.UserControls
         private void PathItemSeparator_Loaded(object sender, RoutedEventArgs e)
         {
             var pathSeparatorIcon = sender as FontIcon;
+            pathSeparatorIcon.Tapped += (s, e) => pathSeparatorIcon.ContextFlyout.ShowAt(pathSeparatorIcon);
+            pathSeparatorIcon.ContextFlyout.Opened += (s, e) => { pathSeparatorIcon.Glyph = "\uE9A5"; };
+            pathSeparatorIcon.ContextFlyout.Closed += (s, e) => { pathSeparatorIcon.Glyph = "\uE9A8"; };
+        }
+
+        private void PathItemSeparator_DataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+        {
+            var pathSeparatorIcon = sender as FontIcon;
+            if (pathSeparatorIcon.DataContext == null)
+            {
+                return;
+            }
             ToolbarPathItemLoaded?.Invoke(pathSeparatorIcon, new ToolbarPathItemLoadedEventArgs()
             {
                 Item = pathSeparatorIcon.DataContext as PathBoxItem,
                 OpenedFlyout = pathSeparatorIcon.ContextFlyout as MenuFlyout
             });
-
-            pathSeparatorIcon.Tapped += (s, e) => pathSeparatorIcon.ContextFlyout.ShowAt(pathSeparatorIcon);
-            pathSeparatorIcon.ContextFlyout.Opened += (s, e) => { pathSeparatorIcon.Glyph = "\uE9A5"; };
-            pathSeparatorIcon.ContextFlyout.Closed += (s, e) => { pathSeparatorIcon.Glyph = "\uE9A8"; };
         }
 
         private void PathboxItemFlyout_Opened(object sender, object e)

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -207,18 +207,24 @@ namespace Files.Views
          */
         public void UpdatePathUIToWorkingDirectory(string newWorkingDir, string singleItemOverride = null)
         {
-            // Clear the path UI
-            NavigationToolbar.PathComponents.Clear();
-
             if (string.IsNullOrWhiteSpace(singleItemOverride))
             {
-                foreach (var component in StorageFileExtensions.GetDirectoryPathComponents(newWorkingDir))
+                var components = StorageFileExtensions.GetDirectoryPathComponents(newWorkingDir);
+                var lastCommonItemIndex = NavigationToolbar.PathComponents
+                    .Select((value, index) => new { value, index })
+                    .LastOrDefault(x => x.index < components.Count && x.value.Path == components[x.index].Path)?.index ?? 0;
+                while (NavigationToolbar.PathComponents.Count > lastCommonItemIndex)
+                {
+                    NavigationToolbar.PathComponents.RemoveAt(lastCommonItemIndex);
+                }
+                foreach (var component in components.Skip(lastCommonItemIndex))
                 {
                     NavigationToolbar.PathComponents.Add(component);
                 }
             }
             else
             {
+                NavigationToolbar.PathComponents.Clear(); // Clear the path UI
                 NavigationToolbar.PathComponents.Add(new Views.PathBoxItem() { Path = null, Title = singleItemOverride });
             }
         }


### PR DESCRIPTION
@yair100 regarding the navigationbar getting cramped with the added buttons, I realized that what bugs me the most is actually the behavior of the navigationbar:
1. When the path is too long it shows the beginning of the path instead of the end
2. When the navigationbar is "full" you can't click on it to go into edit mode

This PR:
1. Makes so the pathbox items list scrolls automatically to show the last item
2. Adds a small padding at the end of the list to allow for going into edit mode

Old:
![image](https://user-images.githubusercontent.com/9673091/109418486-e78b0580-79c8-11eb-994a-6c34d0a353d1.png)

New:
![image](https://user-images.githubusercontent.com/9673091/109418500-f5d92180-79c8-11eb-87ca-45aa9d33ad37.png)
