### PR TITLE
Fixed bug where details wouldn't be loaded from extensions in the preview pane

### DIFF
--- a/Files/ViewModels/PreviewPaneViewModel.cs
+++ b/Files/ViewModels/PreviewPaneViewModel.cs
@@ -213,7 +213,7 @@ namespace Files.ViewModels
                 if (result.TryGetValue("details", out object details))
                 {
                     var detailsList = JsonConvert.DeserializeObject<List<FileProperty>>(details as string);
-                    BasePreviewModel.LoadDetailsOnly(item, detailsList);
+                    await BasePreviewModel.LoadDetailsOnly(item, detailsList);
                 }
             }
             catch (Exception e)

--- a/Files/ViewModels/Previews/BasePreviewModel.cs
+++ b/Files/ViewModels/Previews/BasePreviewModel.cs
@@ -73,12 +73,11 @@ namespace Files.ViewModels.Previews
             {
                 var detailsFull = new List<FileProperty>();
                 Item.ItemFile ??= await StorageFile.GetFileFromPathAsync(Item.ItemPath);
-                var detailsFromPreview = await LoadPreviewAndDetails();
+                DetailsFromPreview = await LoadPreviewAndDetails();
                 RaiseLoadedEvent();
                 var props = await GetSystemFileProperties();
 
                 DetailsFromPreview?.ForEach(i => detailsFull.Add(i));
-                detailsFromPreview?.ForEach(i => detailsFull.Add(i));
                 props?.ForEach(i => detailsFull.Add(i));
 
                 Item.FileDetails = new System.Collections.ObjectModel.ObservableCollection<FileProperty>(detailsFull);
@@ -99,15 +98,21 @@ namespace Files.ViewModels.Previews
             LoadedEvent?.Invoke(this, new EventArgs());
         }
 
-        public static void LoadDetailsOnly(ListedItem item, List<FileProperty> details = null)
+        public static async Task LoadDetailsOnly(ListedItem item, List<FileProperty> details = null)
         {
-            _ = new DetailsOnlyPreviewModel(item) { DetailsFromPreview = details };
+            var temp = new DetailsOnlyPreviewModel(item) { DetailsFromPreview = details };
+            await temp.LoadAsync();
         }
 
         internal class DetailsOnlyPreviewModel : BasePreviewModel
         {
             public DetailsOnlyPreviewModel(ListedItem item) : base(item)
             {
+            }
+
+            public override Task<List<FileProperty>> LoadPreviewAndDetails()
+            {
+                return Task.FromResult(DetailsFromPreview);
             }
         }
     }


### PR DESCRIPTION
This bug was introduced in #3639 which changed from fire-and-forget in the constructor to awaiting a load function after initialization. This was not done for extensions, which lead to them not being loaded.