### PR TITLE
Correct wrong translation for QuickLook in German (Closes #3839)

### DIFF
--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -272,7 +272,7 @@
         </trans-unit>
         <trans-unit id="BaseLayoutItemContextFlyoutQuickLook.Text" translate="yes" xml:space="preserve">
           <source>QuickLook</source>
-          <target state="translated">Links</target>
+          <target state="translated">QuickLook</target>
         </trans-unit>
         <trans-unit id="NavigationToolbarNewWindow.Text" translate="yes" xml:space="preserve">
           <source>New Window</source>


### PR DESCRIPTION
This PR corrects a wrong translation in German ("QuickLook" was translated as "Links") in the context menu.

---

Closes #3839 