### PR TITLE
Update some icons

### DIFF
--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -936,7 +936,7 @@
                     AutomationProperties.Name="Toggle preview pane"
                     Background="Transparent"
                     Click="PreviewPane_Click"
-                    Content="&#xE946;"
+                    Content="&#xE146;"
                     FontFamily="{StaticResource FluentGlyphs}"
                     IsEnabled="{x:Bind IsPageTypeNotHome, Mode=OneWay}"
                     Style="{StaticResource ToolBarButtonStyle}"

--- a/Files/UserControls/StatusBarControl.xaml
+++ b/Files/UserControls/StatusBarControl.xaml
@@ -100,7 +100,7 @@
                             Command="{x:Bind InvertSelectionInvokedCommand}"
                             Text="Invert Selection">
                             <MenuFlyoutItem.Icon>
-                                <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xf102;" />
+                                <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE746;" />
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
                         <MenuFlyoutItem
@@ -160,9 +160,10 @@
                                     Style="{StaticResource ToggleButtonRevealStyle}"
                                     ToolTipService.ToolTip="Details View">
                                     <FontIcon
-                                        FontFamily="{StaticResource CustomGlyph}"
+                                        Margin="0,2,0,0"
+                                        FontFamily="{StaticResource FluentGlyphs}"
                                         FontSize="16"
-                                        Glyph="&#xF101;" />
+                                        Glyph="&#xE179;" />
                                 </RadioButton>
                                 <RadioButton
                                     x:Uid="StatusBarControlTilesView"
@@ -174,9 +175,10 @@
                                     Style="{StaticResource ToggleButtonRevealStyle}"
                                     ToolTipService.ToolTip="Tiles View">
                                     <FontIcon
-                                        FontFamily="{StaticResource CustomGlyph}"
+                                        Margin="0,2,0,0"
+                                        FontFamily="{StaticResource FluentGlyphs}"
                                         FontSize="16"
-                                        Glyph="&#xF100;" />
+                                        Glyph="&#xE15C;" />
                                 </RadioButton>
                                 <RadioButton
                                     x:Uid="StatusBarControlGridViewSmall"
@@ -190,10 +192,10 @@
                                     Style="{StaticResource ToggleButtonRevealStyle}"
                                     ToolTipService.ToolTip="Grid View (Small)">
                                     <FontIcon
-                                        Margin="0,1,0,0"
-                                        FontFamily="{StaticResource OldFluentUIGlyphs}"
+                                        Margin="0,2,0,0"
+                                        FontFamily="{StaticResource FluentGlyphs}"
                                         FontSize="16"
-                                        Glyph="&#xEBA1;" />
+                                        Glyph="&#xE80A;" />
                                 </RadioButton>
                                 <RadioButton
                                     x:Uid="StatusBarControlGridViewMedium"
@@ -206,7 +208,7 @@
                                     Style="{StaticResource ToggleButtonRevealStyle}"
                                     ToolTipService.ToolTip="Grid View (Medium)">
                                     <FontIcon
-                                        Margin="0,1,0,0"
+                                        Margin="0,2,0,0"
                                         FontFamily="{StaticResource FluentGlyphs}"
                                         FontSize="16"
                                         Glyph="&#xF0E2;" />
@@ -221,10 +223,10 @@
                                     Style="{StaticResource ToggleButtonRevealStyle}"
                                     ToolTipService.ToolTip="Grid View (Large)">
                                     <FontIcon
-                                        Margin="0,1,0,0"
-                                        FontFamily="{StaticResource OldFluentUIGlyphs}"
+                                        Margin="0,2,0,0"
+                                        FontFamily="{StaticResource FluentGlyphs}"
                                         FontSize="16"
-                                        Glyph="&#xE9A0;" />
+                                        Glyph="&#xE739;" />
                                 </RadioButton>
                             </StackPanel>
                         </StackPanel>

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -104,7 +104,7 @@
                         Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewLarge}"
                         Text="Grid View (Large)">
                         <MenuFlyoutItem.Icon>
-                            <FontIcon FontFamily="{StaticResource OldFluentUIGlyphs}" Glyph="&#xE9A0;" />
+                            <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE739;" />
                         </MenuFlyoutItem.Icon>
                     </MenuFlyoutItem>
                     <MenuFlyoutItem
@@ -120,7 +120,7 @@
                         Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewSmall}"
                         Text="Grid View (Small)">
                         <MenuFlyoutItem.Icon>
-                            <FontIcon FontFamily="{StaticResource OldFluentUIGlyphs}" Glyph="&#xEBA1;" />
+                            <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE80A;" />
                         </MenuFlyoutItem.Icon>
                     </MenuFlyoutItem>
                     <MenuFlyoutItem
@@ -128,7 +128,7 @@
                         Command="{x:Bind FolderSettings.ToggleLayoutModeTiles}"
                         Text="Tiles View">
                         <MenuFlyoutItem.Icon>
-                            <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF100;" />
+                            <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE15C;" />
                         </MenuFlyoutItem.Icon>
                     </MenuFlyoutItem>
                     <MenuFlyoutItem
@@ -136,7 +136,7 @@
                         Command="{x:Bind FolderSettings.ToggleLayoutModeDetailsView}"
                         Text="Details View">
                         <MenuFlyoutItem.Icon>
-                            <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF101;" />
+                            <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE179;" />
                         </MenuFlyoutItem.Icon>
                     </MenuFlyoutItem>
                 </MenuFlyoutSubItem>
@@ -177,7 +177,7 @@
                     IsEnabled="{x:Bind InstanceViewModel.CanOpenTerminalInPage, Mode=OneWay}"
                     Text="Open in Terminal...">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Glyph="&#xE756;" />
+                        <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE756;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator />
@@ -370,7 +370,7 @@
                     Tag="OpenWith"
                     Text="Open With">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF108;" />
+                        <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE17D;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutItem

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -85,7 +85,7 @@
                         Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewLarge}"
                         Text="Grid View (Large)">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon FontFamily="{StaticResource OldFluentUIGlyphs}" Glyph="&#xE9A0;" />
+                        <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE739;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
@@ -101,7 +101,7 @@
                         Command="{x:Bind FolderSettings.ToggleLayoutModeGridViewSmall}"
                         Text="Grid View (Small)">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon FontFamily="{StaticResource OldFluentUIGlyphs}" Glyph="&#xEBA1;" />
+                        <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE80A;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
@@ -109,7 +109,7 @@
                         Command="{x:Bind FolderSettings.ToggleLayoutModeTiles}"
                         Text="Tiles View">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF100;" />
+                        <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE15C;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
                 <MenuFlyoutItem
@@ -117,7 +117,7 @@
                         Command="{x:Bind FolderSettings.ToggleLayoutModeDetailsView}"
                         Text="Details View">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF101;" />
+                        <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE179;" />
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
             </MenuFlyoutSubItem>
@@ -158,7 +158,7 @@
                     IsEnabled="{x:Bind InstanceViewModel.CanOpenTerminalInPage, Mode=OneWay}"
                     Text="Open in Terminal...">
                 <MenuFlyoutItem.Icon>
-                    <FontIcon Glyph="&#xE756;" />
+                    <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE756;" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
             <MenuFlyoutSeparator />
@@ -333,7 +333,7 @@
                     Tag="OpenWith"
                     Text="Open With">
                 <MenuFlyoutItem.Icon>
-                    <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF108;" />
+                    <FontIcon FontFamily="{StaticResource FluentGlyphs}" Glyph="&#xE17D;" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
             <MenuFlyoutItem


### PR DESCRIPTION
Closes #3870

**Changes:**

- New icons for layout modes (Status bar + Context menu)
- New icon for Preview / Details button (Navigation bar)
- New icon for "Open in Terminal..." in context menu
- New icon for "Open with" in context menu
- New icon for "Invert selection" (Status Bar)
- Fixed alignment of layout mode icons
-----------------------

### **Before:**
 
Preview/Details pane
![before3](https://user-images.githubusercontent.com/61259627/110246662-3dbaf400-7f47-11eb-801d-6acae50c37e6.png)

Context menu/ Open in Terminal...
![before4](https://user-images.githubusercontent.com/61259627/110246674-4f9c9700-7f47-11eb-9d66-4e307971ccbd.png)

Layout mode icons
![before](https://user-images.githubusercontent.com/61259627/110246715-78249100-7f47-11eb-8a91-a869489e901f.png)

Layout mode icons alignment
![before-alig](https://user-images.githubusercontent.com/61259627/110247105-3a286c80-7f49-11eb-8cf6-76ed13a69cfb.png)

Invert selection
![before2](https://user-images.githubusercontent.com/61259627/110247880-2e3ea980-7f4d-11eb-9c48-fabfa63cafd4.png)

Context menu/Open with
![Captura de pantalla 2021-03-07 143958](https://user-images.githubusercontent.com/61259627/110249078-005c6380-7f53-11eb-8042-0e894f51273c.png)


---------------

### **After:**

Preview/Details pane
![after](https://user-images.githubusercontent.com/61259627/110247136-722faf80-7f49-11eb-9f02-302709694fde.png)

Context menu/ Open in Terminal...
![after3](https://user-images.githubusercontent.com/61259627/110247142-7b208100-7f49-11eb-8624-c44b1f101298.png)

Layout mode icons
![after2](https://user-images.githubusercontent.com/61259627/110247143-81166200-7f49-11eb-94c4-dc6ae7b2103e.png)

Layout mode icons alignment
![after-align](https://user-images.githubusercontent.com/61259627/110247332-845e1d80-7f4a-11eb-9885-c017b90632c0.png)

Invert selection
![after4](https://user-images.githubusercontent.com/61259627/110247886-34cd2100-7f4d-11eb-8a47-0a3e67a33012.png)

Context menu/Open with
![Captura de pantalla 2021-03-07 143450](https://user-images.githubusercontent.com/61259627/110249069-f33f7480-7f52-11eb-9739-707e111c4aa7.png)


---------
All icons are from **"Segoe fluent icons"**

-----------------


_I would like to update other icons such as "open in new tab / window" and others that I customized because they look blurry, but I did not find the right icons in "Segoe Fluent icons", is there a website or repository where I can see these new icons from "Segoe Fluent icons"? maybe there are more_