### PR TITLE
Added ability to launch Files with relative path from command line

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -18,6 +18,7 @@ using NLog;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -339,7 +340,21 @@ namespace Files
                                     break;
 
                                 case ParsedCommandType.Unknown:
-                                    rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+                                    if (command.Payload.Equals("."))
+                                    {
+                                        rootFrame.Navigate(typeof(MainPage), activationPath, new SuppressNavigationTransitionInfo());
+                                    } else
+                                    {
+                                        var target = Path.GetFullPath(Path.Combine(activationPath, command.Payload));
+                                        if(!string.IsNullOrEmpty(command.Payload))
+                                        {
+                                            rootFrame.Navigate(typeof(MainPage), target, new SuppressNavigationTransitionInfo());
+                                        } else
+                                        {
+                                            rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+                                        }
+                                    }
+                                    
                                     // Ensure the current window is active.
                                     Window.Current.Activate();
                                     Window.Current.CoreWindow.Activated += CoreWindow_Activated;


### PR DESCRIPTION
Closes #1751

This change allows Files to be launched from the command line with a relative path, like this:
```PS C:\Users\user2> files onedrive/documents/test```

The current directory can be opened the same way it can with windows explorer:
```PS C:\Users\user2> files .``

This change also works with forward slash paths (for convenience when launching from WSL).