### PR TITLE
Use WinUI shadow border with selected TabViewItems

### DIFF
--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -106,6 +106,15 @@
                             <SolidColorBrush x:Key="ControlStrokeColorOnAccentDisabledBrush" Color="{StaticResource SystemColorWindowTextColor}" />
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
+                    <LinearGradientBrush x:Key="ControlElevationBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
+                        <LinearGradientBrush.RelativeTransform>
+                            <ScaleTransform CenterY="0.5" ScaleY="-1" />
+                        </LinearGradientBrush.RelativeTransform>
+                        <LinearGradientBrush.GradientStops>
+                            <GradientStop Offset="0" Color="{ThemeResource ControlStrokeColorSecondary}" />
+                            <GradientStop Offset="1.0" Color="{ThemeResource ControlStrokeColorDefault}" />
+                        </LinearGradientBrush.GradientStops>
+                    </LinearGradientBrush>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -361,7 +361,7 @@
                                 <ControlTemplate TargetType="muxc:TabViewItem">
                                     <Grid
                                         x:Name="LayoutRoot"
-                                        Height="36"
+                                        Height="{TemplateBinding Height}"
                                         Padding="{TemplateBinding Padding}">
                                         <!--  This item will cover the separator on its left side.  -->
 
@@ -444,26 +444,10 @@
                                                 Style="{StaticResource TabViewCloseButtonStyle}" />
                                         </Grid>
 
-                                        <!--<controls:DropShadowPanel
-                                            x:Name="SelectedTabViewItemShadow"
-                                            Grid.Column="1"
-                                            Margin="0,1,0,0"
-                                            HorizontalContentAlignment="Stretch"
-                                            BlurRadius="5"
-                                            ShadowOpacity="0.5"
-                                            Visibility="Collapsed"
-                                            Color="{ThemeResource SystemRevealBaseHighColor}">
-                                            <Rectangle
-                                                Fill="{ThemeResource SolidBackgroundFillColorQuarternary}"
-                                                RadiusX="4"
-                                                RadiusY="4" />
-                                        </controls:DropShadowPanel>-->
-
                                         <VisualStateManager.VisualStateGroups>
                                             <VisualStateGroup x:Name="CommonStates">
                                                 <VisualState x:Name="Normal">
                                                     <VisualState.Setters>
-                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
                                                         <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorSecondary}" />
                                                         <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundSelected}" />
@@ -476,7 +460,6 @@
 
                                                 <VisualState x:Name="PointerOver">
                                                     <VisualState.Setters>
-                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
                                                         <Setter Target="TabContainer.BorderBrush" Value="{StaticResource SystemBaseLowColor}"/>
                                                         <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="ContentPresenter.FontWeight" Value="Normal" />
@@ -490,7 +473,6 @@
 
                                                 <VisualState x:Name="Pressed">
                                                     <VisualState.Setters>
-                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
                                                         <Setter Target="TabContainer.BorderBrush" Value="{StaticResource ControlElevationBorderBrush}"/>
                                                         <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorQuarternary}" />
@@ -503,7 +485,6 @@
 
                                                 <VisualState x:Name="Selected">
                                                     <VisualState.Setters>
-                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
                                                         <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorQuarternary}"/>
                                                         <Setter Target="TabContainer.BorderBrush" Value="{StaticResource ControlElevationBorderBrush}"/>
                                                         <Setter Target="TabContainer.BorderThickness" Value="1" />
@@ -517,8 +498,6 @@
 
                                                 <VisualState x:Name="PointerOverSelected">
                                                     <VisualState.Setters>
-                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
-                                                        <!--<Setter Target="SelectedTabViewItemShadow.ShadowOpacity" Value=".8" />-->
                                                         <Setter Target="TabContainer.BorderBrush" Value="{StaticResource ControlElevationBorderBrush}"/>
                                                         <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorQuarternary}" />
@@ -533,8 +512,6 @@
 
                                                 <VisualState x:Name="PressedSelected">
                                                     <VisualState.Setters>
-                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />
-                                                        <Setter Target="SelectedTabViewItemShadow.ShadowOpacity" Value=".8" />-->
                                                         <Setter Target="TabContainer.BorderBrush" Value="{StaticResource ControlElevationBorderBrush}"/>
                                                         <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorQuarternary}" />
@@ -835,6 +812,7 @@
                         AllowDrop="{x:Bind AllowStorageItemDrop, Mode=OneWay}"
                         ContextFlyout="{StaticResource TabFlyout}"
                         CornerRadius="4"
+                        Height="36"
                         DragEnter="TabViewItem_DragEnter"
                         DragLeave="TabViewItem_DragLeave"
                         Drop="TabViewItem_Drop"

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -361,7 +361,7 @@
                                 <ControlTemplate TargetType="muxc:TabViewItem">
                                     <Grid
                                         x:Name="LayoutRoot"
-                                        Height="34"
+                                        Height="36"
                                         Padding="{TemplateBinding Padding}">
                                         <!--  This item will cover the separator on its left side.  -->
 
@@ -382,7 +382,7 @@
                                             Margin="{ThemeResource TabViewItemSeparatorMargin}"
                                             HorizontalAlignment="Right"
                                             BorderBrush="{StaticResource SystemBaseLowColor}"
-                                            BorderThickness="1" />
+                                            BorderThickness="0" />
 
 
                                         <Grid
@@ -390,8 +390,6 @@
                                             Grid.Column="1"
                                             Padding="{ThemeResource TabViewItemHeaderPadding}"
                                             Background="Transparent"
-                                            BorderBrush="{ThemeResource SystemBaseLowColor}"
-                                            BorderThickness="0"
                                             Canvas.ZIndex="2"
                                             Control.IsTemplateFocusTarget="True"
                                             CornerRadius="{TemplateBinding CornerRadius}"
@@ -446,7 +444,7 @@
                                                 Style="{StaticResource TabViewCloseButtonStyle}" />
                                         </Grid>
 
-                                        <controls:DropShadowPanel
+                                        <!--<controls:DropShadowPanel
                                             x:Name="SelectedTabViewItemShadow"
                                             Grid.Column="1"
                                             Margin="0,1,0,0"
@@ -459,15 +457,15 @@
                                                 Fill="{ThemeResource SolidBackgroundFillColorQuarternary}"
                                                 RadiusX="4"
                                                 RadiusY="4" />
-                                        </controls:DropShadowPanel>
+                                        </controls:DropShadowPanel>-->
 
                                         <VisualStateManager.VisualStateGroups>
                                             <VisualStateGroup x:Name="CommonStates">
                                                 <VisualState x:Name="Normal">
                                                     <VisualState.Setters>
-                                                        <Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />
+                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
                                                         <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorSecondary}" />
-                                                        <Setter Target="TabContainer.BorderThickness" Value="0" />
+                                                        <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundSelected}" />
                                                         <Setter Target="ContentPresenter.FontWeight" Value="Normal" />
                                                         <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundSelected}" />
@@ -478,7 +476,8 @@
 
                                                 <VisualState x:Name="PointerOver">
                                                     <VisualState.Setters>
-                                                        <Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />
+                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
+                                                        <Setter Target="TabContainer.BorderBrush" Value="{StaticResource SystemBaseLowColor}"/>
                                                         <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="ContentPresenter.FontWeight" Value="Normal" />
                                                         <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorTertiary}" />
@@ -491,8 +490,9 @@
 
                                                 <VisualState x:Name="Pressed">
                                                     <VisualState.Setters>
-                                                        <Setter Target="SelectedTabViewItemShadow.Visibility" Value="Visible" />
-                                                        <Setter Target="TabContainer.BorderThickness" Value="0" />
+                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
+                                                        <Setter Target="TabContainer.BorderBrush" Value="{StaticResource ControlElevationBorderBrush}"/>
+                                                        <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorQuarternary}" />
                                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundPressed}" />
                                                         <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundPressed}" />
@@ -503,9 +503,10 @@
 
                                                 <VisualState x:Name="Selected">
                                                     <VisualState.Setters>
-                                                        <Setter Target="SelectedTabViewItemShadow.Visibility" Value="Visible" />
-                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorQuarternary}" />
-                                                        <Setter Target="TabContainer.BorderThickness" Value="0" />
+                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
+                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource ControlFillColorDefaultBrush}"/>
+                                                        <Setter Target="TabContainer.BorderBrush" Value="{StaticResource ControlElevationBorderBrush}"/>
+                                                        <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundSelected}" />
                                                         <Setter Target="ContentPresenter.FontWeight" Value="SemiBold" />
                                                         <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundSelected}" />
@@ -516,9 +517,10 @@
 
                                                 <VisualState x:Name="PointerOverSelected">
                                                     <VisualState.Setters>
-                                                        <Setter Target="SelectedTabViewItemShadow.Visibility" Value="Visible" />
-                                                        <Setter Target="SelectedTabViewItemShadow.ShadowOpacity" Value=".8" />
-                                                        <Setter Target="TabContainer.BorderThickness" Value="0" />
+                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
+                                                        <!--<Setter Target="SelectedTabViewItemShadow.ShadowOpacity" Value=".8" />-->
+                                                        <Setter Target="TabContainer.BorderBrush" Value="{StaticResource ControlElevationBorderBrush}"/>
+                                                        <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorQuarternary}" />
                                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundPointerOver}" />
                                                         <Setter Target="ContentPresenter.FontWeight" Value="SemiBold" />
@@ -531,9 +533,10 @@
 
                                                 <VisualState x:Name="PressedSelected">
                                                     <VisualState.Setters>
-                                                        <Setter Target="SelectedTabViewItemShadow.Visibility" Value="Visible" />
-                                                        <Setter Target="SelectedTabViewItemShadow.ShadowOpacity" Value=".8" />
-                                                        <Setter Target="TabContainer.BorderThickness" Value="0" />
+                                                        <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />
+                                                        <Setter Target="SelectedTabViewItemShadow.ShadowOpacity" Value=".8" />-->
+                                                        <Setter Target="TabContainer.BorderBrush" Value="{StaticResource ControlElevationBorderBrush}"/>
+                                                        <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorQuarternary}" />
                                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundPressed}" />
                                                         <Setter Target="ContentPresenter.FontWeight" Value="SemiBold" />
@@ -828,7 +831,7 @@
             <muxc:TabView.TabItemTemplate>
                 <DataTemplate x:DataType="local:TabItem">
                     <muxc:TabViewItem
-                        Margin="4,4,4,4"
+                        Margin="4,4"
                         AllowDrop="{x:Bind AllowStorageItemDrop, Mode=OneWay}"
                         ContextFlyout="{StaticResource TabFlyout}"
                         CornerRadius="4"

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -504,7 +504,7 @@
                                                 <VisualState x:Name="Selected">
                                                     <VisualState.Setters>
                                                         <!--<Setter Target="SelectedTabViewItemShadow.Visibility" Value="Collapsed" />-->
-                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource ControlFillColorDefaultBrush}"/>
+                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource SolidBackgroundFillColorQuarternary}"/>
                                                         <Setter Target="TabContainer.BorderBrush" Value="{StaticResource ControlElevationBorderBrush}"/>
                                                         <Setter Target="TabContainer.BorderThickness" Value="1" />
                                                         <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundSelected}" />

--- a/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -13,15 +13,6 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
     <UserControl.Resources>
-        <LinearGradientBrush x:Key="ControlElevationBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
-            <LinearGradientBrush.RelativeTransform>
-                <ScaleTransform CenterY="0.5" ScaleY="-1" />
-            </LinearGradientBrush.RelativeTransform>
-            <LinearGradientBrush.GradientStops>
-                <GradientStop Offset="0" Color="{StaticResource ControlStrokeColorSecondary}" />
-                <GradientStop Offset="1.0" Color="{StaticResource ControlStrokeColorDefault}" />
-            </LinearGradientBrush.GradientStops>
-        </LinearGradientBrush>
         <StaticResource x:Key="ButtonBackground" ResourceKey="ControlFillColorDefaultBrush" />
         <StaticResource x:Key="ButtonBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
         <StaticResource x:Key="ButtonBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />

--- a/Files/UserControls/Widgets/LibraryCards.xaml
+++ b/Files/UserControls/Widgets/LibraryCards.xaml
@@ -12,15 +12,6 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
     <UserControl.Resources>
-        <LinearGradientBrush x:Key="ControlElevationBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
-            <LinearGradientBrush.RelativeTransform>
-                <ScaleTransform CenterY="0.5" ScaleY="-1" />
-            </LinearGradientBrush.RelativeTransform>
-            <LinearGradientBrush.GradientStops>
-                <GradientStop Offset="0" Color="{ThemeResource ControlStrokeColorSecondary}" />
-                <GradientStop Offset="1.0" Color="{ThemeResource ControlStrokeColorDefault}" />
-            </LinearGradientBrush.GradientStops>
-        </LinearGradientBrush>
         <StaticResource x:Key="ButtonBackground" ResourceKey="ControlFillColorDefaultBrush" />
         <StaticResource x:Key="ButtonBackgroundPointerOver" ResourceKey="ControlFillColorSecondaryBrush" />
         <StaticResource x:Key="ButtonBackgroundPressed" ResourceKey="ControlFillColorTertiaryBrush" />


### PR DESCRIPTION
(After vs Before) We switch away from adding a drop shadow panel to every tab and instead use a border which simulates elevation.

Will remove commented markup shortly...
![AFTER](https://user-images.githubusercontent.com/20365014/110545524-3d635a00-80fb-11eb-8eed-5f0f2596303c.png)
![BEFORE](https://user-images.githubusercontent.com/20365014/110545579-4fdd9380-80fb-11eb-9740-ba41682da85d.png)
