### PR TITLE
Cleanups to Interaction

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Common;
 using Files.DataModels;
+using Files.Enums;
 using Files.EventArguments;
 using Files.Extensions;
 using Files.Filesystem;

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Dialogs\RestartDialog.xaml.cs">
       <DependentUpon>RestartDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\DeviceHelpers.cs" />
     <Compile Include="Helpers\ExternalResourcesHelper.cs" />
     <Compile Include="Helpers\GlyphHelper.cs" />
     <Compile Include="Helpers\FileThumbnailHelper.cs" />
@@ -224,6 +225,7 @@
     <Compile Include="Helpers\ExtensionManager.cs" />
     <Compile Include="Helpers\IntervalSampler.cs" />
     <Compile Include="Helpers\RegistryHelper.cs" />
+    <Compile Include="Helpers\XamlHelpers\DependencyObjectHelpers.cs" />
     <Compile Include="Helpers\XamlHelpers\SystemTypeToXaml.cs" />
     <Compile Include="Interacts\IStatusCenterActions.cs" />
     <Compile Include="UserControls\FilePreviews\BasicPreview.xaml.cs">

--- a/Files/Helpers/DeviceHelpers.cs
+++ b/Files/Helpers/DeviceHelpers.cs
@@ -1,0 +1,62 @@
+﻿using Files.Interacts;
+using Microsoft.Toolkit.Uwp.Extensions;
+using Microsoft.Toolkit.Uwp.Notifications;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Windows.UI.Notifications;
+
+namespace Files.Helpers
+{
+    public static class DeviceHelpers
+    {
+        public static async Task EjectDeviceAsync(string path)
+        {
+            var removableDevice = new RemovableDevice(path);
+            bool result = await removableDevice.EjectAsync();
+            if (result)
+            {
+                Debug.WriteLine("Device successfully ejected");
+
+                var toastContent = new ToastContent()
+                {
+                    Visual = new ToastVisual()
+                    {
+                        BindingGeneric = new ToastBindingGeneric()
+                        {
+                            Children =
+                            {
+                                new AdaptiveText()
+                                {
+                                    Text = "EjectNotificationHeader".GetLocalized()
+                                },
+                                new AdaptiveText()
+                                {
+                                    Text = "EjectNotificationBody".GetLocalized()
+                                }
+                            },
+                            Attribution = new ToastGenericAttributionText()
+                            {
+                                Text = "SettingsAboutAppName".GetLocalized()
+                            }
+                        }
+                    },
+                    ActivationType = ToastActivationType.Protocol
+                };
+
+                // Create the toast notification
+                var toastNotif = new ToastNotification(toastContent.GetXml());
+
+                // And send the notification
+                ToastNotificationManager.CreateToastNotifier().Show(toastNotif);
+            }
+            else
+            {
+                Debug.WriteLine("Can't eject device");
+
+                await DialogDisplayHelper.ShowDialogAsync(
+                    "EjectNotificationErrorDialogHeader".GetLocalized(),
+                    "EjectNotificationErrorDialogBody".GetLocalized());
+            }
+        }
+    }
+}

--- a/Files/Helpers/XamlHelpers/DependencyObjectHelpers.cs
+++ b/Files/Helpers/XamlHelpers/DependencyObjectHelpers.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+
+namespace Files.Helpers.XamlHelpers
+{
+    public static class DependencyObjectHelpers
+    {
+        public static T FindChild<T>(DependencyObject startNode) where T : DependencyObject
+        {
+            int count = VisualTreeHelper.GetChildrenCount(startNode);
+            for (int i = 0; i < count; i++)
+            {
+                DependencyObject current = VisualTreeHelper.GetChild(startNode, i);
+                if (current.GetType().Equals(typeof(T)) || current.GetType().GetTypeInfo().IsSubclassOf(typeof(T)))
+                {
+                    T asType = (T)current;
+                    return asType;
+                }
+                var retVal = FindChild<T>(current);
+                if (retVal != null)
+                {
+                    return retVal;
+                }
+            }
+            return null;
+        }
+
+        public static void FindChildren<T>(IList<T> results, DependencyObject startNode) where T : DependencyObject
+        {
+            int count = VisualTreeHelper.GetChildrenCount(startNode);
+            for (int i = 0; i < count; i++)
+            {
+                DependencyObject current = VisualTreeHelper.GetChild(startNode, i);
+                if (current.GetType().Equals(typeof(T)) || (current.GetType().GetTypeInfo().IsSubclassOf(typeof(T))))
+                {
+                    T asType = (T)current;
+                    results.Add(asType);
+                }
+                FindChildren<T>(results, current);
+            }
+        }
+
+        public static T FindParent<T>(DependencyObject child) where T : DependencyObject
+        {
+            T parent = null;
+            if (child == null)
+            {
+                return parent;
+            }
+            DependencyObject CurrentParent = VisualTreeHelper.GetParent(child);
+            while (CurrentParent != null)
+            {
+                if (CurrentParent is T)
+                {
+                    parent = (T)CurrentParent;
+                    break;
+                }
+                CurrentParent = VisualTreeHelper.GetParent(CurrentParent);
+            }
+            return parent;
+        }
+    }
+}

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -115,12 +115,12 @@ namespace Files.Interacts
 
         public void SetAsDesktopBackgroundItem_Click(object sender, RoutedEventArgs e)
         {
-            SetAsBackground(WallpaperType.Desktop, AssociatedInstance.ContentPage.SelectedItem.ItemPath);
+            SetAsBackground(WallpaperType.Desktop, ((sender as MenuFlyoutItem).DataContext as ListedItem).ItemPath);
         }
 
         public void SetAsLockscreenBackgroundItem_Click(object sender, RoutedEventArgs e)
         {
-            SetAsBackground(WallpaperType.LockScreen, AssociatedInstance.ContentPage.SelectedItem.ItemPath);
+            SetAsBackground(WallpaperType.LockScreen, ((sender as MenuFlyoutItem).DataContext as ListedItem).ItemPath);
         }
 
         public async void SetAsBackground(WallpaperType type, string filePath)
@@ -1278,13 +1278,13 @@ namespace Files.Interacts
 
         public void ClearAllItems(BaseLayout contentPage) => contentPage.ClearSelection();
 
-        public async void ToggleQuickLook(IShellPage associatedInstance)
+        public async void ToggleQuickLook()
         {
             try
             {
-                if (associatedInstance.ContentPage.IsItemSelected && !associatedInstance.ContentPage.IsRenamingItem)
+                if (AssociatedInstance.ContentPage.IsItemSelected && !AssociatedInstance.ContentPage.IsRenamingItem)
                 {
-                    var clickedOnItem = associatedInstance.ContentPage.SelectedItem;
+                    var clickedOnItem = AssociatedInstance.ContentPage.SelectedItem;
 
                     Logger.Info("Toggle QuickLook");
                     Debug.WriteLine("Toggle QuickLook");
@@ -1300,10 +1300,10 @@ namespace Files.Interacts
             catch (FileNotFoundException)
             {
                 await DialogDisplayHelper.ShowDialogAsync("FileNotFoundDialog/Title".GetLocalized(), "FileNotFoundPreviewDialog/Text".GetLocalized());
-                associatedInstance.NavigationToolbar.CanRefresh = false;
+                AssociatedInstance.NavigationToolbar.CanRefresh = false;
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    var ContentOwnedViewModelInstance = associatedInstance.FilesystemViewModel;
+                    var ContentOwnedViewModelInstance = AssociatedInstance.FilesystemViewModel;
                     ContentOwnedViewModelInstance?.RefreshItems(null);
                 });
             }

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -128,7 +128,7 @@ namespace Files.Interacts
             if (UserProfilePersonalizationSettings.IsSupported())
             {
                 // Get the path of the selected file
-                StorageFile sourceFile = await StorageItemHelpers.ToStorageItem<StorageFile>(filePath);
+                StorageFile sourceFile = await StorageItemHelpers.ToStorageItem<StorageFile>(filePath, AssociatedInstance);
                 if (sourceFile == null)
                 {
                     return;
@@ -830,14 +830,14 @@ namespace Files.Interacts
                 }
                 else if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    if (await StorageItemHelpers.ToStorageItem<StorageFolder>(item.ItemPath) is StorageFolder folder)
+                    if (await StorageItemHelpers.ToStorageItem<StorageFolder>(item.ItemPath, AssociatedInstance) is StorageFolder folder)
                     {
                         items.Add(folder);
                     }
                 }
                 else
                 {
-                    if (await StorageItemHelpers.ToStorageItem<StorageFile>(item.ItemPath) is StorageFile file)
+                    if (await StorageItemHelpers.ToStorageItem<StorageFile>(item.ItemPath, AssociatedInstance) is StorageFile file)
                     {
                         items.Add(file);
                     }
@@ -1323,7 +1323,7 @@ namespace Files.Interacts
         public async Task<string> GetHashForFileAsync(ListedItem fileItem, string nameOfAlg, CancellationToken token, Microsoft.UI.Xaml.Controls.ProgressBar progress)
         {
             HashAlgorithmProvider algorithmProvider = HashAlgorithmProvider.OpenAlgorithm(nameOfAlg);
-            StorageFile file = await StorageItemHelpers.ToStorageItem<StorageFile>((fileItem as ShortcutItem)?.TargetPath ?? fileItem.ItemPath);
+            StorageFile file = await StorageItemHelpers.ToStorageItem<StorageFile>((fileItem as ShortcutItem)?.TargetPath ?? fileItem.ItemPath, AssociatedInstance);
             if (file == null)
             {
                 return "";

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -113,31 +113,22 @@ namespace Files.Interacts
             }
         }
 
-        public void List_ItemDoubleClick(object sender, DoubleTappedRoutedEventArgs e)
-        {
-            // Skip opening selected items if the double tap doesn't capture an item
-            if ((e.OriginalSource as FrameworkElement)?.DataContext is ListedItem && !AppSettings.OpenItemsWithOneclick)
-            {
-                OpenSelectedItems(false);
-            }
-        }
-
         public void SetAsDesktopBackgroundItem_Click(object sender, RoutedEventArgs e)
         {
-            SetAsBackground(WallpaperType.Desktop);
+            SetAsBackground(WallpaperType.Desktop, AssociatedInstance.ContentPage.SelectedItem.ItemPath);
         }
 
         public void SetAsLockscreenBackgroundItem_Click(object sender, RoutedEventArgs e)
         {
-            SetAsBackground(WallpaperType.LockScreen);
+            SetAsBackground(WallpaperType.LockScreen, AssociatedInstance.ContentPage.SelectedItem.ItemPath);
         }
 
-        public async void SetAsBackground(WallpaperType type)
+        public async void SetAsBackground(WallpaperType type, string filePath)
         {
             if (UserProfilePersonalizationSettings.IsSupported())
             {
                 // Get the path of the selected file
-                var sourceFile = (StorageFile)await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(AssociatedInstance.ContentPage.SelectedItem.ItemPath);
+                StorageFile sourceFile = await StorageItemHelpers.ToStorageItem<StorageFile>(filePath);
                 if (sourceFile == null)
                 {
                     return;
@@ -250,9 +241,9 @@ namespace Files.Interacts
             return await Launcher.LaunchUriAsync(folderUri);
         }
 
-        public RelayCommand OpenDirectoryInDefaultTerminal => new RelayCommand(() => OpenDirectoryInTerminal());
+        public RelayCommand OpenDirectoryInDefaultTerminal => new RelayCommand(() => OpenDirectoryInTerminal(AssociatedInstance.FilesystemViewModel.WorkingDirectory));
 
-        private async void OpenDirectoryInTerminal()
+        private async void OpenDirectoryInTerminal(string workingDir)
         {
             var terminal = AppSettings.TerminalController.Model.GetDefaultTerminal();
 
@@ -260,10 +251,10 @@ namespace Files.Interacts
             {
                 var value = new ValueSet
                 {
-                    { "WorkingDirectory", AssociatedInstance.FilesystemViewModel.WorkingDirectory },
+                    { "WorkingDirectory", workingDir },
                     { "Application", terminal.Path },
                     { "Arguments", string.Format(terminal.Arguments,
-                       Helpers.PathNormalization.NormalizePath(AssociatedInstance.FilesystemViewModel.WorkingDirectory)) }
+                       Helpers.PathNormalization.NormalizePath(workingDir)) }
                 };
                 await Connection.SendMessageSafeAsync(value);
             }
@@ -344,61 +335,6 @@ namespace Files.Interacts
             return openedPopups.Any(popup => popup.Child is ContentDialog);
         }
 
-        public static T FindChild<T>(DependencyObject startNode) where T : DependencyObject
-        {
-            int count = VisualTreeHelper.GetChildrenCount(startNode);
-            for (int i = 0; i < count; i++)
-            {
-                DependencyObject current = VisualTreeHelper.GetChild(startNode, i);
-                if (current.GetType().Equals(typeof(T)) || current.GetType().GetTypeInfo().IsSubclassOf(typeof(T)))
-                {
-                    T asType = (T)current;
-                    return asType;
-                }
-                var retVal = FindChild<T>(current);
-                if (retVal != null)
-                {
-                    return retVal;
-                }
-            }
-            return null;
-        }
-
-        public static void FindChildren<T>(IList<T> results, DependencyObject startNode) where T : DependencyObject
-        {
-            int count = VisualTreeHelper.GetChildrenCount(startNode);
-            for (int i = 0; i < count; i++)
-            {
-                DependencyObject current = VisualTreeHelper.GetChild(startNode, i);
-                if (current.GetType().Equals(typeof(T)) || (current.GetType().GetTypeInfo().IsSubclassOf(typeof(T))))
-                {
-                    T asType = (T)current;
-                    results.Add(asType);
-                }
-                FindChildren<T>(results, current);
-            }
-        }
-
-        public static T FindParent<T>(DependencyObject child) where T : DependencyObject
-        {
-            T parent = null;
-            if (child == null)
-            {
-                return parent;
-            }
-            DependencyObject CurrentParent = VisualTreeHelper.GetParent(child);
-            while (CurrentParent != null)
-            {
-                if (CurrentParent is T)
-                {
-                    parent = (T)CurrentParent;
-                    break;
-                }
-                CurrentParent = VisualTreeHelper.GetParent(CurrentParent);
-            }
-            return parent;
-        }
-
         public static TEnum GetEnum<TEnum>(string text) where TEnum : struct
         {
             if (!typeof(TEnum).GetTypeInfo().IsEnum)
@@ -446,7 +382,7 @@ namespace Files.Interacts
 
         public async void OpenFileLocation_Click(object sender, RoutedEventArgs e)
         {
-            var item = AssociatedInstance.ContentPage.SelectedItem as ShortcutItem;
+            var item = ((sender as MenuFlyoutItem).DataContext as ShortcutItem);
             if (string.IsNullOrEmpty(item?.TargetPath))
             {
                 return;
@@ -528,7 +464,7 @@ namespace Files.Interacts
                 }
                 else
                 {
-                    itemType = await StorageItemHelpers.GetTypeFromPath(path, AssociatedInstance);
+                    itemType = await StorageItemHelpers.GetTypeFromPath(path);
                 }
             }
 
@@ -738,7 +674,7 @@ namespace Files.Interacts
             return opened;
         }
 
-        private async void OpenSelectedItems(bool openViaApplicationPicker = false)
+        public async void OpenSelectedItems(bool openViaApplicationPicker = false)
         {
             if (AssociatedInstance.FilesystemViewModel.WorkingDirectory.StartsWith(AppSettings.RecycleBinPath))
             {
@@ -894,13 +830,17 @@ namespace Files.Interacts
                 }
                 else if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    await AssociatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.ItemPath)
-                        .OnSuccess(folderAsItem => items.Add(folderAsItem));
+                    if (await StorageItemHelpers.ToStorageItem<StorageFolder>(item.ItemPath) is StorageFolder folder)
+                    {
+                        items.Add(folder);
+                    }
                 }
                 else
                 {
-                    await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.ItemPath)
-                        .OnSuccess(fileAsItem => items.Add(fileAsItem));
+                    if (await StorageItemHelpers.ToStorageItem<StorageFile>(item.ItemPath) is StorageFile file)
+                    {
+                        items.Add(file);
+                    }
                 }
             }
 
@@ -1186,7 +1126,6 @@ namespace Files.Interacts
             {
                 if (AssociatedInstance.ContentPage != null)
                 {
-                    Clipboard.Clear();
                     DataPackage data = new DataPackage();
                     data.SetText(AssociatedInstance.ContentPage.SelectedItem.ItemPath);
                     Clipboard.SetContent(data);
@@ -1206,7 +1145,6 @@ namespace Files.Interacts
             {
                 if (AssociatedInstance.ContentPage != null)
                 {
-                    Clipboard.Clear();
                     DataPackage data = new DataPackage();
                     data.SetText(AssociatedInstance.FilesystemViewModel.WorkingDirectory);
                     Clipboard.SetContent(data);
@@ -1251,14 +1189,13 @@ namespace Files.Interacts
             }
         }
 
-        public RelayCommand PasteItemsFromClipboard => new RelayCommand(async () => await PasteItemAsync());
+        public RelayCommand PasteItemsFromClipboard => new RelayCommand(async () => await PasteItemAsync(AssociatedInstance.FilesystemViewModel.WorkingDirectory));
 
-        public async Task PasteItemAsync()
+        public async Task PasteItemAsync(string destinationPath)
         {
             DataPackageView packageView = await FilesystemTasks.Wrap(() => Task.FromResult(Clipboard.GetContent()));
             if (packageView != null)
             {
-                string destinationPath = AssociatedInstance.FilesystemViewModel.WorkingDirectory;
                 await FilesystemHelpers.PerformOperationTypeAsync(packageView.RequestedOperation, packageView, destinationPath, true);
                 AssociatedInstance.ContentPage.ResetItemOpacity();
             }
@@ -1329,25 +1266,25 @@ namespace Files.Interacts
             CreateFileFromDialogResultType(AddItemType.File, itemType);
         }
 
-        public RelayCommand SelectAllContentPageItems => new RelayCommand(() => SelectAllItems());
+        public RelayCommand SelectAllContentPageItems => new RelayCommand(() => SelectAllItems(AssociatedInstance.ContentPage));
 
-        public void SelectAllItems() => AssociatedInstance.ContentPage.SelectAllItems();
+        public void SelectAllItems(BaseLayout contentPage) => contentPage.SelectAllItems();
 
-        public RelayCommand InvertContentPageSelction => new RelayCommand(() => InvertAllItems());
+        public RelayCommand InvertContentPageSelction => new RelayCommand(() => InvertAllItems(AssociatedInstance.ContentPage));
 
-        public void InvertAllItems() => AssociatedInstance.ContentPage.InvertSelection();
+        public void InvertAllItems(BaseLayout contentPage) => contentPage.InvertSelection();
 
-        public RelayCommand ClearContentPageSelection => new RelayCommand(() => ClearAllItems());
+        public RelayCommand ClearContentPageSelection => new RelayCommand(() => ClearAllItems(AssociatedInstance.ContentPage));
 
-        public void ClearAllItems() => AssociatedInstance.ContentPage.ClearSelection();
+        public void ClearAllItems(BaseLayout contentPage) => contentPage.ClearSelection();
 
-        public async void ToggleQuickLook()
+        public async void ToggleQuickLook(IShellPage associatedInstance)
         {
             try
             {
-                if (AssociatedInstance.ContentPage.IsItemSelected && !AssociatedInstance.ContentPage.IsRenamingItem)
+                if (associatedInstance.ContentPage.IsItemSelected && !associatedInstance.ContentPage.IsRenamingItem)
                 {
-                    var clickedOnItem = AssociatedInstance.ContentPage.SelectedItem;
+                    var clickedOnItem = associatedInstance.ContentPage.SelectedItem;
 
                     Logger.Info("Toggle QuickLook");
                     Debug.WriteLine("Toggle QuickLook");
@@ -1363,10 +1300,10 @@ namespace Files.Interacts
             catch (FileNotFoundException)
             {
                 await DialogDisplayHelper.ShowDialogAsync("FileNotFoundDialog/Title".GetLocalized(), "FileNotFoundPreviewDialog/Text".GetLocalized());
-                AssociatedInstance.NavigationToolbar.CanRefresh = false;
+                associatedInstance.NavigationToolbar.CanRefresh = false;
                 await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    var ContentOwnedViewModelInstance = AssociatedInstance.FilesystemViewModel;
+                    var ContentOwnedViewModelInstance = associatedInstance.FilesystemViewModel;
                     ContentOwnedViewModelInstance?.RefreshItems(null);
                 });
             }
@@ -1386,13 +1323,13 @@ namespace Files.Interacts
         public async Task<string> GetHashForFileAsync(ListedItem fileItem, string nameOfAlg, CancellationToken token, Microsoft.UI.Xaml.Controls.ProgressBar progress)
         {
             HashAlgorithmProvider algorithmProvider = HashAlgorithmProvider.OpenAlgorithm(nameOfAlg);
-            StorageFile itemFromPath = await AssociatedInstance.FilesystemViewModel.GetFileFromPathAsync((fileItem as ShortcutItem)?.TargetPath ?? fileItem.ItemPath);
-            if (itemFromPath == null)
+            StorageFile file = await StorageItemHelpers.ToStorageItem<StorageFile>((fileItem as ShortcutItem)?.TargetPath ?? fileItem.ItemPath);
+            if (file == null)
             {
                 return "";
             }
 
-            Stream stream = await FilesystemTasks.Wrap(() => itemFromPath.OpenStreamForReadAsync());
+            Stream stream = await FilesystemTasks.Wrap(() => file.OpenStreamForReadAsync());
             if (stream == null)
             {
                 return "";
@@ -1436,56 +1373,6 @@ namespace Files.Interacts
                 return "";
             }
             return CryptographicBuffer.EncodeToHexString(hash.GetValueAndReset()).ToLower();
-        }
-
-        public static async Task EjectDeviceAsync(string path)
-        {
-            var removableDevice = new RemovableDevice(path);
-            bool result = await removableDevice.EjectAsync();
-            if (result)
-            {
-                Debug.WriteLine("Device successfully ejected");
-
-                var toastContent = new ToastContent()
-                {
-                    Visual = new ToastVisual()
-                    {
-                        BindingGeneric = new ToastBindingGeneric()
-                        {
-                            Children =
-                            {
-                                new AdaptiveText()
-                                {
-                                    Text = "EjectNotificationHeader".GetLocalized()
-                                },
-                                new AdaptiveText()
-                                {
-                                    Text = "EjectNotificationBody".GetLocalized()
-                                }
-                            },
-                            Attribution = new ToastGenericAttributionText()
-                            {
-                                Text = "SettingsAboutAppName".GetLocalized()
-                            }
-                        }
-                    },
-                    ActivationType = ToastActivationType.Protocol
-                };
-
-                // Create the toast notification
-                var toastNotif = new ToastNotification(toastContent.GetXml());
-
-                // And send the notification
-                ToastNotificationManager.CreateToastNotifier().Show(toastNotif);
-            }
-            else
-            {
-                Debug.WriteLine("Can't eject device");
-
-                await DialogDisplayHelper.ShowDialogAsync(
-                    "EjectNotificationErrorDialogHeader".GetLocalized(),
-                    "EjectNotificationErrorDialogBody".GetLocalized());
-            }
         }
     }
 }

--- a/Files/UserControls/NavigationToolbar.xaml.cs
+++ b/Files/UserControls/NavigationToolbar.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Files.DataModels;
 using Files.Filesystem;
 using Files.Helpers;
+using Files.Helpers.XamlHelpers;
 using Files.Interacts;
 using Files.UserControls.MultitaskingControl;
 using Files.ViewModels;
@@ -511,7 +512,7 @@ namespace Files.UserControls
                 {
                     EditModeEnabled?.Invoke(this, new EventArgs());
                     VisiblePath.Focus(FocusState.Programmatic);
-                    Interaction.FindChild<TextBox>(VisiblePath)?.SelectAll();
+                    DependencyObjectHelpers.FindChild<TextBox>(VisiblePath)?.SelectAll();
                 }
                 else
                 {
@@ -527,7 +528,7 @@ namespace Files.UserControls
         {
             // AutoSuggestBox won't receive focus unless it's fully loaded
             VisiblePath.Focus(FocusState.Programmatic);
-            Interaction.FindChild<TextBox>(VisiblePath)?.SelectAll();
+            DependencyObjectHelpers.FindChild<TextBox>(VisiblePath)?.SelectAll();
         }
 
         public bool CanRefresh

--- a/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
+++ b/Files/UserControls/Selection/RectangleSelection_DataGrid.cs
@@ -1,4 +1,5 @@
-﻿using Files.Interacts;
+﻿using Files.Helpers.XamlHelpers;
+using Files.Interacts;
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using System;
 using System.Collections.Generic;
@@ -84,7 +85,7 @@ namespace Files.UserControls.Selection
                     if (actualWidth < 0)
                     {
                         var temp = new List<DataGridCell>();
-                        Interaction.FindChildren<DataGridCell>(temp, row); // Find cells inside row
+                        DependencyObjectHelpers.FindChildren<DataGridCell>(temp, row); // Find cells inside row
                         actualWidth = temp.Sum(x => x.ActualWidth); // row.ActualWidth reports incorrect width
                     }
 
@@ -161,7 +162,7 @@ namespace Files.UserControls.Selection
         {
             itemsPosition.Clear();
             dataGridRows.Clear();
-            Interaction.FindChildren<DataGridRow>(dataGridRows, uiElement); // Find visible/loaded rows
+            DependencyObjectHelpers.FindChildren<DataGridRow>(dataGridRows, uiElement); // Find visible/loaded rows
             prevSelectedItems = uiElement.SelectedItems.Cast<object>().ToList(); // Save current selected items
             originDragPoint = new Point(e.GetCurrentPoint(uiElement).Position.X, e.GetCurrentPoint(uiElement).Position.Y); // Initial drag point relative to the topleft corner
             var verticalOffset = (scrollBar?.Value ?? 0) - uiElement.ColumnHeaderHeight;
@@ -172,7 +173,7 @@ namespace Files.UserControls.Selection
                 return;
             }
 
-            var clickedRow = Interaction.FindParent<DataGridRow>(e.OriginalSource as DependencyObject);
+            var clickedRow = DependencyObjectHelpers.FindParent<DataGridRow>(e.OriginalSource as DependencyObject);
             if (clickedRow != null && uiElement.SelectedItems.Contains(clickedRow.DataContext))
             {
                 // If the item under the pointer is selected do not trigger selection rectangle
@@ -256,7 +257,7 @@ namespace Files.UserControls.Selection
                 uiElement.PointerCanceled += RectangleSelection_PointerReleased;
                 uiElement.LoadingRow += RectangleSelection_LoadingRow;
                 uiElement.UnloadingRow += RectangleSelection_UnloadingRow;
-                scrollBar = Interaction.FindChild<ScrollBar>(uiElement);
+                scrollBar = DependencyObjectHelpers.FindChild<ScrollBar>(uiElement);
             }
         }
 

--- a/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
+++ b/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
@@ -1,4 +1,5 @@
-﻿using Files.Interacts;
+﻿using Files.Helpers.XamlHelpers;
+using Files.Interacts;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -170,7 +171,7 @@ namespace Files.UserControls.Selection
         {
             if (scrollViewer == null)
             {
-                scrollViewer = Interaction.FindChild<ScrollViewer>(uiElement);
+                scrollViewer = DependencyObjectHelpers.FindChild<ScrollViewer>(uiElement);
             }
 
             if (scrollViewer != null)
@@ -193,7 +194,7 @@ namespace Files.UserControls.Selection
                 uiElement.PointerCaptureLost += RectangleSelection_PointerReleased;
                 uiElement.PointerCanceled += RectangleSelection_PointerReleased;
 
-                scrollViewer = Interaction.FindChild<ScrollViewer>(uiElement);
+                scrollViewer = DependencyObjectHelpers.FindChild<ScrollViewer>(uiElement);
                 if (scrollViewer == null)
                 {
                     uiElement.LayoutUpdated += RectangleSelection_LayoutUpdated;

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Files.DataModels;
 using Files.Filesystem;
+using Files.Helpers;
 using Files.Interacts;
 using Files.ViewModels;
 using Files.Views;
@@ -569,7 +570,7 @@ namespace Files.UserControls
 
         private async void EjectDevice_Click(object sender, RoutedEventArgs e)
         {
-            await Interaction.EjectDeviceAsync(App.RightClickedItem.Path);
+            await DeviceHelpers.EjectDeviceAsync(App.RightClickedItem.Path);
         }
 
         private void SidebarNavView_Loaded(object sender, RoutedEventArgs e)

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -59,7 +59,7 @@ namespace Files.UserControls.Widgets
         private async void EjectDevice_Click(object sender, RoutedEventArgs e)
         {
             var item = ((MenuFlyoutItem)sender).DataContext as DriveItem;
-            await Interaction.EjectDeviceAsync(item.Path);
+            await DeviceHelpers.EjectDeviceAsync(item.Path);
         }
 
         private void OpenInNewTab_Click(object sender, RoutedEventArgs e)

--- a/Files/ViewModels/Dialogs/DynamicDialogViewModel.cs
+++ b/Files/ViewModels/Dialogs/DynamicDialogViewModel.cs
@@ -1,5 +1,5 @@
 ﻿using Files.Enums;
-using Files.Interacts;
+using Files.Helpers.XamlHelpers;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
 using System;
@@ -424,7 +424,7 @@ namespace Files.ViewModels.Dialogs
 
                 if (control == null)
                 {
-                    control = Interaction.FindChild<Control>(vm.DisplayControl as DependencyObject);
+                    control = DependencyObjectHelpers.FindChild<Control>(vm.DisplayControl as DependencyObject);
                 }
 
                 control?.Focus(FocusState.Programmatic);

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -1,6 +1,7 @@
 using Files.Enums;
 using Files.Filesystem;
 using Files.Helpers;
+using Files.Helpers.XamlHelpers;
 using Files.Interacts;
 using Files.UserControls.Selection;
 using Microsoft.Toolkit.Uwp.UI;
@@ -140,7 +141,7 @@ namespace Files.Views.LayoutModes
         private async void ReloadItemIcons()
         {
             var rows = new List<DataGridRow>();
-            Interaction.FindChildren<DataGridRow>(rows, AllView);
+            DependencyObjectHelpers.FindChildren<DataGridRow>(rows, AllView);
             ParentShellPageInstance.FilesystemViewModel.CancelExtendedPropertiesLoading();
             foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.ToList())
             {
@@ -196,7 +197,7 @@ namespace Files.Views.LayoutModes
             if (IsItemSelected && !InstanceViewModel.IsPageTypeSearchResults)
             {
                 var rows = new List<DataGridRow>();
-                Interaction.FindChildren<DataGridRow>(rows, AllView);
+                DependencyObjectHelpers.FindChildren<DataGridRow>(rows, AllView);
 
                 foreach (DataGridRow row in rows)
                 {
@@ -505,7 +506,7 @@ namespace Files.Views.LayoutModes
 
         private void HandleRightClick(object sender, RoutedEventArgs e)
         {
-            var rowPressed = Interaction.FindParent<DataGridRow>(e.OriginalSource as DependencyObject);
+            var rowPressed = DependencyObjectHelpers.FindParent<DataGridRow>(e.OriginalSource as DependencyObject);
             if (rowPressed != null)
             {
                 var objectPressed = ((IList<ListedItem>)AllView.ItemsSource).ElementAtOrDefault(rowPressed.GetIndex());
@@ -537,7 +538,7 @@ namespace Files.Views.LayoutModes
                     // Don't block the various uses of enter key (key 13)
                     var focusedElement = FocusManager.GetFocusedElement() as FrameworkElement;
                     if (args.KeyCode == 13 || focusedElement is Button || focusedElement is TextBox || focusedElement is PasswordBox ||
-                        Interaction.FindParent<ContentDialog>(focusedElement) != null)
+                        DependencyObjectHelpers.FindParent<ContentDialog>(focusedElement) != null)
                     {
                         return;
                     }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -968,7 +968,7 @@
             x:FieldModifier="public"
             AllowDrop="{x:Bind InstanceViewModel.IsPageTypeSearchResults, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
             ChoosingItemContainer="FileList_ChoosingItemContainer"
-            DoubleTapped="{x:Bind ParentShellPageInstance.InteractionOperations.List_ItemDoubleClick}"
+            DoubleTapped="FileList_DoubleTapped"
             DragEnter="List_DragEnter"
             Drop="List_Drop"
             IsDoubleTapEnabled="True"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Files.Enums;
 using Files.EventArguments;
 using Files.Filesystem;
+using Files.Helpers.XamlHelpers;
 using Files.UserControls.Selection;
 using System;
 using System.Collections;
@@ -55,7 +56,7 @@ namespace Files.Views.LayoutModes
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
             var selectorItems = new List<SelectorItem>();
-            Interaction.FindChildren<SelectorItem>(selectorItems, FileList);
+            DependencyObjectHelpers.FindChildren<SelectorItem>(selectorItems, FileList);
             foreach (SelectorItem gvi in selectorItems)
             {
                 base.UninitializeDrag(gvi);
@@ -158,7 +159,7 @@ namespace Files.Views.LayoutModes
 
         private void StackPanel_RightTapped(object sender, RightTappedRoutedEventArgs e)
         {
-            var parentContainer = Interaction.FindParent<GridViewItem>(e.OriginalSource as DependencyObject);
+            var parentContainer = DependencyObjectHelpers.FindParent<GridViewItem>(e.OriginalSource as DependencyObject);
             if (parentContainer.IsSelected)
             {
                 return;
@@ -325,7 +326,7 @@ namespace Files.Views.LayoutModes
                 {
                     if (IsQuickLookEnabled)
                     {
-                        ParentShellPageInstance.InteractionOperations.ToggleQuickLook();
+                        ParentShellPageInstance.InteractionOperations.ToggleQuickLook(ParentShellPageInstance);
                     }
                     e.Handled = true;
                 }
@@ -359,7 +360,7 @@ namespace Files.Views.LayoutModes
                         || focusedElement is Button
                         || focusedElement is TextBox
                         || focusedElement is PasswordBox
-                        || Interaction.FindParent<ContentDialog>(focusedElement) != null)
+                        || DependencyObjectHelpers.FindParent<ContentDialog>(focusedElement) != null)
                     {
                         return;
                     }
@@ -459,6 +460,15 @@ namespace Files.Views.LayoutModes
 
                 item.ItemPropertiesInitialized = true;
                 await ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(item, currentIconSize);
+            }
+        }
+
+        private void FileList_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+        {
+            // Skip opening selected items if the double tap doesn't capture an item
+            if ((e.OriginalSource as FrameworkElement)?.DataContext is ListedItem && !AppSettings.OpenItemsWithOneclick)
+            {
+                ParentShellPageInstance.InteractionOperations.OpenSelectedItems(false);
             }
         }
     }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -326,7 +326,7 @@ namespace Files.Views.LayoutModes
                 {
                     if (IsQuickLookEnabled)
                     {
-                        ParentShellPageInstance.InteractionOperations.ToggleQuickLook(ParentShellPageInstance);
+                        ParentShellPageInstance.InteractionOperations.ToggleQuickLook();
                     }
                     e.Handled = true;
                 }

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -956,7 +956,7 @@ namespace Files.Views
                 case (true, false, false, true, VirtualKey.A): // ctrl + a, select all
                     if (!NavigationToolbar.IsEditModeEnabled && !ContentPage.IsRenamingItem)
                     {
-                        InteractionOperations.SelectAllItems();
+                        InteractionOperations.SelectAllItems(this.ContentPage);
                     }
 
                     break;
@@ -978,7 +978,7 @@ namespace Files.Views
                     {
                         if (ContentPage.IsQuickLookEnabled)
                         {
-                            InteractionOperations.ToggleQuickLook(this);
+                            InteractionOperations.ToggleQuickLook();
                         }
                     }
                     break;

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -940,7 +940,7 @@ namespace Files.Views
                 case (true, false, false, true, VirtualKey.V): // ctrl + v, paste
                     if (!NavigationToolbar.IsEditModeEnabled && !ContentPage.IsRenamingItem && !InstanceViewModel.IsPageTypeSearchResults)
                     {
-                        await InteractionOperations.PasteItemAsync();
+                        await InteractionOperations.PasteItemAsync(FilesystemViewModel.WorkingDirectory);
                     }
 
                     break;
@@ -978,7 +978,7 @@ namespace Files.Views
                     {
                         if (ContentPage.IsQuickLookEnabled)
                         {
-                            InteractionOperations.ToggleQuickLook();
+                            InteractionOperations.ToggleQuickLook(this);
                         }
                     }
                     break;

--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Filesystem;
 using Files.Helpers;
+using Files.Helpers.XamlHelpers;
 using Files.Interacts;
 using Files.ViewModels;
 using Microsoft.Toolkit.Uwp.Helpers;
@@ -75,7 +76,7 @@ namespace Files.Views
             }
             else
             {
-                propertiesDialog = Interaction.FindParent<ContentDialog>(this);
+                propertiesDialog = DependencyObjectHelpers.FindParent<ContentDialog>(this);
                 propertiesDialog.Closed += PropertiesDialog_Closed;
             }
         }


### PR DESCRIPTION
This PR aims to reduce `IShellPage` references in `Interaction` and also moves some stuff around

Motivation:
Since `IShellPage` contains a reference to `Interaction` and `Interaction` contains `IShellPage` field it creates circular references which causes memory leaks. To solve such problem we must get rid of that reference in `Interaction` completely. Ideally, we'd have `Interaction` class completely removed and all handlers moved to respective View Models.
In my next PR I'll try to move as many functions out of `Interaction` as possible.