### PR TITLE
color progressbar red if free diskspace low

### DIFF
--- a/Files/Filesystem/DriveItem.cs
+++ b/Files/Filesystem/DriveItem.cs
@@ -8,6 +8,7 @@ using System;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.Storage;
+using Windows.UI;
 using Windows.UI.Xaml;
 
 namespace Files.Filesystem
@@ -92,6 +93,14 @@ namespace Files.Filesystem
             set => SetProperty(ref spaceText, value);
         }
 
+        private Color progressColor = Color.FromArgb(255, 41, 132, 204);
+
+        public Color ProgressColor
+        {
+	        get => progressColor;
+	        set => SetProperty(ref progressColor, value);
+        }
+
         public DriveItem()
         {
             ItemType = NavigationControlItemType.CloudDrive;
@@ -130,14 +139,22 @@ namespace Files.Filesystem
 
                 if (properties["System.Capacity"] != null && properties["System.FreeSpace"] != null)
                 {
-                    MaxSpace = ByteSize.FromBytes((ulong)properties["System.Capacity"]);
-                    FreeSpace = ByteSize.FromBytes((ulong)properties["System.FreeSpace"]);
+	                ulong maxSpace = (ulong) properties["System.Capacity"];
+	                ulong freeSpace = (ulong) properties["System.FreeSpace"];
+
+                    MaxSpace = ByteSize.FromBytes(maxSpace);
+                    FreeSpace = ByteSize.FromBytes(freeSpace);
                     SpaceUsed = MaxSpace - FreeSpace;
 
                     SpaceText = string.Format(
                         "DriveFreeSpaceAndCapacity".GetLocalized(),
                         FreeSpace.ToBinaryString().ConvertSizeAbbreviation(),
                         MaxSpace.ToBinaryString().ConvertSizeAbbreviation());
+
+                    if (freeSpace < maxSpace * 0.1)
+                    {
+	                    ProgressColor = Colors.Red;
+                    }
                 }
             }
             catch (Exception)

--- a/Files/Filesystem/DriveItem.cs
+++ b/Files/Filesystem/DriveItem.cs
@@ -93,7 +93,7 @@ namespace Files.Filesystem
             set => SetProperty(ref spaceText, value);
         }
 
-        private Color progressColor = Color.FromArgb(255, 41, 132, 204);
+        private Color progressColor;
 
         public Color ProgressColor
         {
@@ -113,6 +113,8 @@ namespace Files.Filesystem
             Path = string.IsNullOrEmpty(root.Path) ? $"\\\\?\\{root.Name}\\" : root.Path;
             DeviceID = deviceId;
             Root = root;
+
+            ProgressColor = new Windows.UI.ViewManagement.UISettings().GetColorValue(Windows.UI.ViewManagement.UIColorType.Accent);
 
             CoreApplication.MainView.ExecuteOnUIThreadAsync(() => UpdatePropertiesAsync());
         }

--- a/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -220,7 +220,11 @@
                                         AutomationProperties.AccessibilityView="Raw"
                                         Maximum="{x:Bind MaxSpace.GigaBytes, Mode=OneWay}"
                                         Visibility="{x:Bind ShowDriveDetails, Mode=OneWay}"
-                                        Value="{x:Bind SpaceUsed.GigaBytes, Mode=OneWay}" />
+                                        Value="{x:Bind SpaceUsed.GigaBytes, Mode=OneWay}">
+                                        <muxc:ProgressBar.Foreground>
+                                            <SolidColorBrush Color="{x:Bind ProgressColor, Mode=OneWay}"/>
+                                        </muxc:ProgressBar.Foreground>
+                                    </muxc:ProgressBar>
                                     <TextBlock
                                         x:Phase="1"
                                         FontSize="12"


### PR DESCRIPTION
color the progressbar red if disk space is low.

__Open Questions__

1. Currently the threshold is to 10%. So, if more than 90% is used, the progress bar is red.


Because the changes are so small, i didn't open an issue before.