### PR TITLE
Switched icon for preview pane gripper

### DIFF
--- a/Files/UserControls/PreviewPane.xaml
+++ b/Files/UserControls/PreviewPane.xaml
@@ -72,13 +72,13 @@
             <controls:GridSplitter.Element>
                 <Grid>
                     <FontIcon
-                        x:Name="GripperGlyphTextBlock"
+                        x:Name="GripperGlyph"
                         HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        FontSize="36"
                         Foreground="{StaticResource SystemChromeHighColor}"
-                        Glyph="&#xE738;"
-                        IsHitTestVisible="False" />
+                        Glyph="&#xE76F;"
+                        Margin="-1, 0, 0, -1"
+                        IsHitTestVisible="False">
+                    </FontIcon>
                 </Grid>
             </controls:GridSplitter.Element>
         </controls:GridSplitter>
@@ -174,7 +174,7 @@
                         <Setter Target="HorizontalGridSplitter.Width" Value="2" />
 
                         <Setter Target="PropertiesRow.Height" Value="0" />
-                        <Setter Target="GripperGlyphTextBlock.Text" Value="&#xE9FC;" />
+                        <Setter Target="GripperGlyph.Glyph" Value="&#xE784;" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState>


### PR DESCRIPTION
One of the icons currently is not present in the new Segoe Fluent Icons. 
This switches the icon to the fluent gripper icons.

New icons:

![image](https://user-images.githubusercontent.com/59544401/110844558-66503000-825e-11eb-9d00-055a2024d442.png)
![image](https://user-images.githubusercontent.com/59544401/110844607-71a35b80-825e-11eb-8102-c956c033f752.png)
