### PR TITLE
Use single instance of AppServiceConnection for preview pane thumbnails

### DIFF
--- a/Files/Helpers/FileThumbnailHelper.cs
+++ b/Files/Helpers/FileThumbnailHelper.cs
@@ -8,10 +8,11 @@ namespace Files.Helpers
 {
     public static class FileThumbnailHelper
     {
+        private static AppServiceConnection AppServiceConnection { get; set; }
         public static async Task<(byte[] IconData, byte[] OverlayData, bool IsCustom)> LoadIconOverlayAsync(string filePath, uint thumbnailSize)
         {
-            var connection = await AppServiceConnectionHelper.Instance;
-            if (connection != null)
+            AppServiceConnection ??= await AppServiceConnectionHelper.Instance;
+            if (AppServiceConnection != null)
             {
                 var value = new ValueSet
                 {
@@ -19,7 +20,7 @@ namespace Files.Helpers
                     { "filePath", filePath },
                     { "thumbnailSize", (int)thumbnailSize }
                 };
-                var response = await connection.SendMessageAsync(value);
+                var response = await AppServiceConnection.SendMessageAsync(value);
                 var hasCustomIcon = (response.Status == AppServiceResponseStatus.Success)
                     && response.Message.Get("HasCustomIcon", false);
                 var icon = response.Message.Get("Icon", (string)null);


### PR DESCRIPTION
Before it was loading a new one each time, which I think may have caused other issues after continued use.