### PR TITLE
Lowered PDF preview page limit 

### DIFF
--- a/Files/Constants.cs
+++ b/Files/Constants.cs
@@ -53,7 +53,7 @@
             /// <summary>
             /// The maximum number of pages loaded into the PDF preview.
             /// </summary>
-            public const int PDFPageLimit = 50;
+            public const int PDFPageLimit = 10;
 
             /// <summary>
             /// The maximum file size, in bytes, that will attempted to be loaded as text if the extension is unknown.


### PR DESCRIPTION
Having it so high can cause an out of memory exception on lower end devices and takes up a lot of resources in general.
Likely fixes this:
https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/3565178931u/overview