### PR TITLE
Prevent FullTitle string from being null in StatusCenter.cs

### DIFF
--- a/Files/UserControls/StatusCenter.xaml.cs
+++ b/Files/UserControls/StatusCenter.xaml.cs
@@ -201,7 +201,7 @@ namespace Files.UserControls
         public string FullTitle
         {
             get => fullTitle;
-            set => SetProperty(ref fullTitle, value);
+            set => SetProperty(ref fullTitle, value ?? string.Empty);
         }
 
         #endregion Public Properties


### PR DESCRIPTION
Fix for https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/3768192674u/overview:
```
StatusCenter_obj17_Bindings.Update_FullTitle (String obj, Int32 phase)
D:\a\1\s\Files\obj\x64\Release\UserControls\StatusCenter.g.cs at 566, line 29
System.ArgumentNullException: Null strings may not be marshaled in Windows Runtime arguments. Parameter name: sourceString
```

I believe the issue was caused by a null value being passed to AutomationProperties.Name, which binds to FullTitle.