### PR TITLE
Revert "Use single instance of AppServiceConnection for preview pane thumbnails"

### DIFF
--- a/Files/Helpers/FileThumbnailHelper.cs
+++ b/Files/Helpers/FileThumbnailHelper.cs
@@ -8,11 +8,10 @@ namespace Files.Helpers
 {
     public static class FileThumbnailHelper
     {
-        private static AppServiceConnection AppServiceConnection { get; set; }
         public static async Task<(byte[] IconData, byte[] OverlayData, bool IsCustom)> LoadIconOverlayAsync(string filePath, uint thumbnailSize)
         {
-            AppServiceConnection ??= await AppServiceConnectionHelper.Instance;
-            if (AppServiceConnection != null)
+            var connection = await AppServiceConnectionHelper.Instance;
+            if (connection != null)
             {
                 var value = new ValueSet
                 {
@@ -20,7 +19,7 @@ namespace Files.Helpers
                     { "filePath", filePath },
                     { "thumbnailSize", (int)thumbnailSize }
                 };
-                var response = await AppServiceConnection.SendMessageAsync(value);
+                var response = await connection.SendMessageAsync(value);
                 var hasCustomIcon = (response.Status == AppServiceResponseStatus.Success)
                     && response.Message.Get("HasCustomIcon", false);
                 var icon = response.Message.Get("Icon", (string)null);


### PR DESCRIPTION
Reverts files-community/Files#4014
As @gave92 pointed out, a new connection was not being created each time, which was the motive for the original pr, and also that the new method would cause more issues when the app is restored from suspension.
I apologize for this mistake.