### PR TITLE
Fixed issue where ScrollIntoView could throw argument exception

### DIFF
--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -208,7 +208,14 @@ namespace Files.Views.LayoutModes
 
         public override void ScrollIntoView(ListedItem item)
         {
-            AllView.ScrollIntoView(item, null);
+            try
+            {
+                AllView.ScrollIntoView(item, null);
+            }
+            catch (Exception)
+            {
+                // Catch error where row index could not be found
+            }
         }
 
         public override void FocusFileList()


### PR DESCRIPTION
I noticed that this would, on occasion, throw something like ```Argument Exception: Row index could not be found```, which would cause a crash.

This PR adds a catch for that.