### PR TITLE
Implement preview load cancellation

### DIFF
--- a/Files/ViewModels/PreviewPaneViewModel.cs
+++ b/Files/ViewModels/PreviewPaneViewModel.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation.Collections;
@@ -35,6 +36,8 @@ namespace Files.ViewModels
         }
 
         private ListedItem selectedItem;
+
+        private CancellationTokenSource loadCancellationTokenSource;
 
         public ListedItem SelectedItem
         {
@@ -83,7 +86,7 @@ namespace Files.ViewModels
         {
         }
 
-        private async Task LoadPreviewControlAsync()
+        private async Task LoadPreviewControlAsync(CancellationToken token)
         {
             DetailsErrorText = "";
             PreviewErrorText = "";
@@ -100,12 +103,23 @@ namespace Files.ViewModels
             {
                 if (extension.FileExtensions.Contains(SelectedItem.FileExtension))
                 {
-                    await LoadPreviewControlFromExtension(SelectedItem, extension);
+                    var extControl = await LoadPreviewControlFromExtension(SelectedItem, extension);
+                    if (!token.IsCancellationRequested && extControl != null)
+                    {
+                        PreviewPaneContent = extControl;
+                    }
+
                     return;
                 }
             }
 
             var control = await GetBuiltInPreviewControlAsync(SelectedItem);
+
+            if(token.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (control != null)
             {
                 PreviewPaneContent = control;
@@ -197,17 +211,18 @@ namespace Files.ViewModels
             return null;
         }
 
-        private async Task LoadPreviewControlFromExtension(ListedItem item, Extension extension)
+        private async Task<UIElement> LoadPreviewControlFromExtension(ListedItem item, Extension extension)
         {
             try
             {
+                UIElement control = null;
                 var file = await StorageFile.GetFileFromPathAsync(item.ItemPath);
                 string sharingToken = SharedStorageAccessManager.AddFile(file);
                 var result = await extension.Invoke(new ValueSet() { { "token", sharingToken } });
 
                 if (result.TryGetValue("preview", out object preview))
                 {
-                    PreviewPaneContent = XamlReader.Load(preview as string) as UIElement;
+                    control = XamlReader.Load(preview as string) as UIElement;
                 }
 
                 if (result.TryGetValue("details", out object details))
@@ -215,19 +230,24 @@ namespace Files.ViewModels
                     var detailsList = JsonConvert.DeserializeObject<List<FileProperty>>(details as string);
                     await BasePreviewModel.LoadDetailsOnly(item, detailsList);
                 }
+
+                return control;
             }
             catch (Exception e)
             {
                 Debug.WriteLine(e.ToString());
             }
+            return null;
         }
 
         private async void SelectedItemChanged()
         {
+            loadCancellationTokenSource?.Cancel();
             if (SelectedItem != null && SelectedItems.Count == 1)
             {
                 DetailsListVisibility = Visibility.Visible;
-                await LoadPreviewControlAsync();
+                loadCancellationTokenSource = new CancellationTokenSource();
+                await LoadPreviewControlAsync(loadCancellationTokenSource.Token);
             }
             else if (SelectedItem != null)
             {


### PR DESCRIPTION
This fixes an issue where wrong content would be shown if the user selected another item before the current item finished loading.