### PR TITLE
Hide network section in sidebar when no drives are detected

### DIFF
--- a/Files/Filesystem/NetworkDrivesManager.cs
+++ b/Files/Filesystem/NetworkDrivesManager.cs
@@ -35,6 +35,7 @@ namespace Files.Filesystem
         {
             var networkItem = new DriveItem()
             {
+                DeviceID = "network-folder",
                 Text = "Network".GetLocalized(),
                 Path = App.AppSettings.NetworkFolderPath,
                 Type = DriveType.Network,
@@ -112,7 +113,7 @@ namespace Files.Filesystem
                     MainPage.SideBarItems.BeginBulkOperation();
 
                     var section = MainPage.SideBarItems.FirstOrDefault(x => x.Text == "SidebarNetworkDrives".GetLocalized()) as LocationItem;
-                    if (section == null && this.drivesList.Count > 0)
+                    if (section == null && this.drivesList.Any(d => d.DeviceID != "network-folder"))
                     {
                         section = new LocationItem()
                         {
@@ -125,13 +126,16 @@ namespace Files.Filesystem
                         MainPage.SideBarItems.Add(section);
                     }
 
-                    foreach (var drive in Drives.ToList()
+                    if (section != null)
+                    {
+                        foreach (var drive in Drives.ToList()
                         .OrderByDescending(o => string.Equals(o.Text, "Network".GetLocalized(), StringComparison.OrdinalIgnoreCase))
                         .ThenBy(o => o.Text))
-                    {
-                        if (!section.ChildItems.Contains(drive))
                         {
-                            section.ChildItems.Add(drive);
+                            if (!section.ChildItems.Contains(drive))
+                            {
+                                section.ChildItems.Add(drive);
+                            }
                         }
                     }
 

--- a/Files/Filesystem/NetworkDrivesManager.cs
+++ b/Files/Filesystem/NetworkDrivesManager.cs
@@ -112,7 +112,7 @@ namespace Files.Filesystem
                     MainPage.SideBarItems.BeginBulkOperation();
 
                     var section = MainPage.SideBarItems.FirstOrDefault(x => x.Text == "SidebarNetworkDrives".GetLocalized()) as LocationItem;
-                    if (section == null)
+                    if (section == null && this.drivesList.Count > 0)
                     {
                         section = new LocationItem()
                         {


### PR DESCRIPTION
Closes #3924 

I just added an additional check before creating the network drive LocationItem.

This is my first PR, feedback is appreciated 🙂