### PR TITLE
Properly load libraries and add support for library management

### DIFF
--- a/Common/ShellLibraryItem.cs
+++ b/Common/ShellLibraryItem.cs
@@ -1,0 +1,20 @@
+﻿namespace Files.Common
+{
+    public class ShellLibraryItem
+    {
+        public string Path;
+        public string Name;
+        public bool IsPinned;
+        public string DefaultSaveFolder;
+        public string[] Folders;
+
+        public ShellLibraryItem() { }
+
+        public ShellLibraryItem(string path, string name, bool isPinned)
+        {
+            this.Path = path;
+            this.Name = name;
+            this.IsPinned = isPinned;
+        }
+    }
+}

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -186,6 +186,7 @@
     <Compile Include="EventArguments\LayoutPreferenceEventArgs.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Filesystem\FolderHelpers.cs" />
+    <Compile Include="Filesystem\LibraryItem.cs" />
     <Compile Include="Filesystem\LibraryManager.cs" />
     <Compile Include="Filesystem\WSLDistroManager.cs" />
     <Compile Include="Filesystem\StorageEnumerators\UniversalStorageEnumerator.cs" />
@@ -217,6 +218,7 @@
     <Compile Include="Helpers\ExternalResourcesHelper.cs" />
     <Compile Include="Helpers\GlyphHelper.cs" />
     <Compile Include="Helpers\FileThumbnailHelper.cs" />
+    <Compile Include="Helpers\LibraryHelper.cs" />
     <Compile Include="Helpers\MenuFlyoutHelper.cs" />
     <Compile Include="Helpers\BitmapHelper.cs" />
     <Compile Include="Helpers\CollectionDebugView.cs" />

--- a/Files/Filesystem/LibraryItem.cs
+++ b/Files/Filesystem/LibraryItem.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Files.Filesystem
+{
+    public class LibraryItem : LocationItem
+    {
+        public string LibraryPath { get; }
+
+        public ReadOnlyCollection<string> Paths { get; }
+
+        public LibraryItem(string path, string name, string defaultSaveFolder, string[] folders, bool isPinned)
+        {
+            Section = SectionType.Library;
+            LibraryPath = path;
+            Text = name;
+            Path = defaultSaveFolder;
+            Paths = folders == null ? null : new ReadOnlyCollection<string>(folders);
+            IsDefaultLocation = isPinned;
+        }
+    }
+}

--- a/Files/Filesystem/LocationItem.cs
+++ b/Files/Filesystem/LocationItem.cs
@@ -18,7 +18,7 @@ namespace Files.Filesystem
             set
             {
                 path = value;
-                HoverDisplayText = Path.Contains("?") || Path.StartsWith("Shell:") || Path == "Home" ? Text : Path;
+                HoverDisplayText = Path == null || Path.Contains("?") || Path.StartsWith("Shell:") || Path == "Home" ? Text : Path;
             }
         }
 

--- a/Files/Helpers/GlyphHelper.cs
+++ b/Files/Helpers/GlyphHelper.cs
@@ -15,41 +15,38 @@ namespace Files.Helpers
         /// <returns>The icon code</returns>
         public static string GetItemIcon(string path)
         {
-            string iconCode;
-
-            if (path.Equals(AppSettings.DesktopPath, StringComparison.OrdinalIgnoreCase))
+            string iconCode = "\uE8B7";
+            if (path != null)
             {
-                iconCode = "\uE8FC";
+                if (path.Equals(AppSettings.DesktopPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    iconCode = "\uE8FC";
+                }
+                else if (path.Equals(AppSettings.DownloadsPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    iconCode = "\uE896";
+                }
+                else if (path.Equals(AppSettings.DocumentsPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    iconCode = "\uE8A5";
+                }
+                else if (path.Equals(AppSettings.PicturesPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    iconCode = "\uEB9F";
+                }
+                else if (path.Equals(AppSettings.MusicPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    iconCode = "\uEC4F";
+                }
+                else if (path.Equals(AppSettings.VideosPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    iconCode = "\uE8B2";
+                }
+                else if (Path.GetPathRoot(path).Equals(path, StringComparison.OrdinalIgnoreCase))
+                {
+                    iconCode = "\uEDA2";
+                }
             }
-            else if (path.Equals(AppSettings.DownloadsPath, StringComparison.OrdinalIgnoreCase))
-            {
-                iconCode = "\uE896";
-            }
-            else if (path.Equals(AppSettings.DocumentsPath, StringComparison.OrdinalIgnoreCase))
-            {
-                iconCode = "\uE8A5";
-            }
-            else if (path.Equals(AppSettings.PicturesPath, StringComparison.OrdinalIgnoreCase))
-            {
-                iconCode = "\uEB9F";
-            }
-            else if (path.Equals(AppSettings.MusicPath, StringComparison.OrdinalIgnoreCase))
-            {
-                iconCode = "\uEC4F";
-            }
-            else if (path.Equals(AppSettings.VideosPath, StringComparison.OrdinalIgnoreCase))
-            {
-                iconCode = "\uE8B2";
-            }
-            else if (Path.GetPathRoot(path).Equals(path, StringComparison.OrdinalIgnoreCase))
-            {
-                iconCode = "\uEDA2";
-            }
-            else
-            {
-                iconCode = "\uE8B7";
-            }
-
             return iconCode;
         }
     }

--- a/Files/Helpers/LibraryHelper.cs
+++ b/Files/Helpers/LibraryHelper.cs
@@ -1,0 +1,154 @@
+﻿using Files.Common;
+using Files.Filesystem;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.AppService;
+using Windows.Foundation.Collections;
+
+namespace Files.Helpers
+{
+    /// <summary>
+    /// Helper class for listing and managing Shell libraries.
+    /// </summary>
+    public class LibraryHelper
+    {
+        // https://docs.microsoft.com/en-us/windows/win32/shell/library-ovw
+
+        /// TODO:
+        /// - Create UI part of CreateLibrary method and test it
+        /// - Watch library updates: https://docs.microsoft.com/windows/win32/shell/library-be-library-aware#keeping-in-sync-with-a-library 
+        /// - Implement library rename
+        /// - Implement library deletion
+        /// - 
+
+        public static LibraryHelper Instance => new LibraryHelper();
+
+        /// <summary>
+        /// LibraryItem cache. Access with <see cref="ListUserLibraries"/>.
+        /// </summary>
+        private readonly List<LibraryItem> libraryItems = new List<LibraryItem>();
+
+        /// <summary>
+        /// Get libraries of the current user with the help of the FullTrust process in case there are no cached items or the 2nd parameter is true.
+        /// </summary>
+        /// <param name="allowEmpty">Keep empty libraries in result (where Path == null)</param>
+        /// <param name="refresh">Re-enumerate libraries in case <see cref="libraryItems"/> is empty</param>
+        /// <returns>List of library items</returns>
+        public async Task<List<LibraryItem>> ListUserLibraries(bool allowEmpty, bool refresh = false)
+        {
+            if (libraryItems.Count == 0 || refresh)
+            {
+                var connection = await AppServiceConnectionHelper.Instance;
+                if (connection != null)
+                {
+                    var request = new ValueSet
+                    {
+                        { "Arguments", "ShellLibrary" },
+                        { "action", "Enumerate" }
+                    };
+                    var (status, response) = await connection.SendMessageForResponseAsync(request);
+
+                    if (status == AppServiceResponseStatus.Success && response.ContainsKey("Enumerate"))
+                    {
+                        libraryItems.Clear();
+                        foreach (var lib in JsonConvert.DeserializeObject<List<ShellLibraryItem>>((string)response["Enumerate"]))
+                        {
+                            libraryItems.Add(new LibraryItem(lib.Path, lib.Name, lib.DefaultSaveFolder, lib.Folders, lib.IsPinned));
+                        }
+                        libraryItems.Sort((a, b) => a.Text.CompareTo(b.Text));
+                    }
+                }
+            }
+            if (!allowEmpty)
+            {
+                return libraryItems.Where(l => l.Path != null).ToList();
+            }
+            return libraryItems;
+        }
+
+        /// <summary>
+        /// Get additional library folder paths from the library default save path.
+        /// </summary>
+        /// <param name="defaultSavePath">The default save path of the library</param>
+        /// <returns>The additional library folder paths. Empty array returned in case of a single directory library or null if the path is not a default save path of any library.</returns>
+        public async Task<string[]> GetExtraLibraryPaths(string defaultSavePath)
+        {
+            if (defaultSavePath == null)
+            {
+                return null;
+            }
+            var libs = await ListUserLibraries(false);
+            var lib = libs.FirstOrDefault(l => string.Equals(l.Path, defaultSavePath, StringComparison.InvariantCultureIgnoreCase));
+            if (lib == null)
+            {
+                return null;
+            }
+            return lib.Paths?.Where(p => p != defaultSavePath)?.ToArray();
+        }
+
+        /// <summary>
+        /// Opens the Shell library management dialog for the specified library.
+        /// </summary>
+        /// <param name="lib">The library to manage</param>
+        public async void OpenLibraryManagerDialog(LibraryItem lib)
+        {
+            if (lib == null)
+            {
+                return;
+            }
+            var connection = await AppServiceConnectionHelper.Instance;
+            if (connection == null)
+            {
+                return;
+            }
+            var libs = await ListUserLibraries(true);
+            if (!libs.Any(l => l.LibraryPath == lib.LibraryPath))
+            {
+                return;
+            }
+            await connection.SendMessageForResponseAsync(new ValueSet
+            {
+                { "Arguments", "ShellLibrary" },
+                { "action", "Manage" },
+                { "library", lib.LibraryPath }
+            });
+        }
+
+        /// <summary>
+        /// Create new library with the specified name.
+        /// </summary>
+        /// <param name="name">The name of the new library (must be unique)</param>
+        /// <returns>True if the new library successfully created</returns>
+        public async Task<bool> CreateLibrary(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return false;
+            }
+            var connection = await AppServiceConnectionHelper.Instance;
+            if (connection == null)
+            {
+                return false;
+            }
+            var libs = await ListUserLibraries(true);
+            if (libs.Any(l => string.Equals(l.Text, name, StringComparison.InvariantCultureIgnoreCase)))
+            {
+                return false;
+            }
+            var (status, response) = await connection.SendMessageForResponseAsync(new ValueSet
+            {
+                { "Arguments", "ShellLibrary" },
+                { "action", "Create" },
+                { "library", name }
+            });
+            if (status == AppServiceResponseStatus.Success && response.ContainsKey("ShellLibrary"))
+            {
+                return response["ShellLibrary"] as string == "Create";
+            }
+            return false;
+        }
+    }
+}

--- a/Files/UserControls/Widgets/LibraryCards.xaml
+++ b/Files/UserControls/Widgets/LibraryCards.xaml
@@ -3,7 +3,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:animations="using:Microsoft.Toolkit.Uwp.UI.Animations"
-    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:extensions="using:Microsoft.Toolkit.Uwp.UI.Extensions"
     xmlns:local="using:Files.UserControls.Widgets"
@@ -25,7 +24,7 @@
             x:Name="CardsList"
             Grid.Row="0"
             HorizontalAlignment="Stretch"
-            ItemsSource="{x:Bind local:LibraryCards.itemsAdded}">
+            ItemsSource="{x:Bind local:LibraryCards.ItemsAdded}">
             <muxc:ItemsRepeater.Layout>
                 <muxc:UniformGridLayout
                     ItemsStretch="Fill"
@@ -37,7 +36,7 @@
                     Orientation="Horizontal" />
             </muxc:ItemsRepeater.Layout>
             <muxc:ItemsRepeater.ItemTemplate>
-                <DataTemplate x:DataType="local:FavoriteLocationItem">
+                <DataTemplate x:DataType="local:LibraryCardItem">
                     <Grid
                         extensions:VisualExtensions.CenterPoint="80,45,0"
                         PointerEntered="GridScaleUp"
@@ -52,9 +51,60 @@
                             HorizontalContentAlignment="Stretch"
                             VerticalContentAlignment="Stretch"
                             AutomationProperties.Name="{x:Bind AutomationProperties}"
-                            Click="Button_Click"
-                            CornerRadius="8"
-                            Tag="{x:Bind Tag}">
+                            Command="{x:Bind SelectCommand}"
+                            CommandParameter="{x:Bind}"
+                            CornerRadius="8">
+                            <Button.ContextFlyout>
+                                <MenuFlyout Opening="MenuFlyout_Opening">
+                                    <MenuFlyout.Items>
+                                        <MenuFlyoutItem
+                                            x:Name="OpenInNewPane"
+                                            x:Uid="SideBarOpenInNewPane"
+                                            x:Load="{x:Bind HasPath, Mode=OneWay}"
+                                            Click="OpenInNewPane_Click"
+                                            DataContext="{x:Bind}"
+                                            Text="Open in new pane"
+                                            Visibility="Collapsed">
+                                            <MenuFlyoutItem.Icon>
+                                                <FontIcon FontFamily="{StaticResource OldFluentUIGlyphs}" Glyph="&#xEA2F;" />
+                                            </MenuFlyoutItem.Icon>
+                                        </MenuFlyoutItem>
+                                        <MenuFlyoutItem
+                                            x:Name="OpenInNewTab"
+                                            x:Uid="SideBarOpenInNewTab"
+                                            x:Load="{x:Bind HasPath, Mode=OneWay}"
+                                            Click="OpenInNewTab_Click"
+                                            DataContext="{x:Bind}"
+                                            Text="Open in new tab">
+                                            <MenuFlyoutItem.Icon>
+                                                <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF106;" />
+                                            </MenuFlyoutItem.Icon>
+                                        </MenuFlyoutItem>
+                                        <MenuFlyoutItem
+                                            x:Name="OpenInNewWindow"
+                                            x:Uid="SideBarOpenInNewWindow"
+                                            x:Load="{x:Bind HasPath, Mode=OneWay}"
+                                            Click="OpenInNewWindow_Click"
+                                            DataContext="{x:Bind}"
+                                            Text="Open in new window">
+                                            <MenuFlyoutItem.Icon>
+                                                <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF107;" />
+                                            </MenuFlyoutItem.Icon>
+                                        </MenuFlyoutItem>
+                                        <MenuFlyoutItem
+                                            x:Name="ManageLibrary"
+                                            x:Uid="SidebarManageLibrary"
+                                            x:Load="{x:Bind IsLibrary, Mode=OneWay}"
+                                            Text="Manage library"
+                                            Click="ManageLibrary_Click"
+                                            DataContext="{x:Bind}">
+                                            <MenuFlyoutItem.Icon>
+                                                <FontIcon Glyph="&#xE1D3;" />
+                                            </MenuFlyoutItem.Icon>
+                                        </MenuFlyoutItem>
+                                    </MenuFlyout.Items>
+                                </MenuFlyout>
+                            </Button.ContextFlyout>
 
                             <Grid
                                 Margin="8,14"

--- a/Files/Views/YourHome.xaml
+++ b/Files/Views/YourHome.xaml
@@ -16,7 +16,10 @@
                     <EntranceThemeTransition />
                 </TransitionCollection>
             </StackPanel.ChildrenTransitions>
-            <widgets:LibraryCards x:Name="LibraryWidget" x:Load="{x:Bind AppSettings.ShowLibraryCardsWidget, Mode=OneWay}" />
+            <widgets:LibraryCards
+                x:Name="LibraryWidget"
+                x:Load="{x:Bind AppSettings.ShowLibraryCardsWidget, Mode=OneWay}"
+                ShowMultiPaneControls="{x:Bind converters:MultiBooleanConverter.AndConvert(AppInstance.IsMultiPaneEnabled, AppInstance.IsPageMainPane), Mode=OneWay}" />
 
             <widgets:DrivesWidget
                 x:Name="DrivesWidget"

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -9,7 +9,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Windows.ApplicationModel.AppService;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
@@ -40,7 +39,9 @@ namespace Files.Views
             if (LibraryWidget != null)
             {
                 LibraryWidget.LibraryCardInvoked -= LibraryLocationCardsWidget_LibraryCardInvoked;
+                LibraryWidget.LibraryCardNewPaneInvoked -= LibraryLocationCardsWidget_LibraryCardNewPaneInvoked;
                 LibraryWidget.LibraryCardInvoked += LibraryLocationCardsWidget_LibraryCardInvoked;
+                LibraryWidget.LibraryCardNewPaneInvoked += LibraryLocationCardsWidget_LibraryCardNewPaneInvoked;
             }
             if (RecentFilesWidget != null)
             {
@@ -106,6 +107,11 @@ namespace Files.Views
             {
                 NavPathParam = e.ItemPath
             });
+        }
+
+        private void LibraryLocationCardsWidget_LibraryCardNewPaneInvoked(object sender, LibraryCardInvokedEventArgs e)
+        {
+            AppInstance.PaneHolder?.OpenPathInNewPane(e.Path);
         }
 
         private void LibraryLocationCardsWidget_LibraryCardInvoked(object sender, LibraryCardInvokedEventArgs e)


### PR DESCRIPTION
Current status of this PR:

- [x] load libraries with the FullTrust process
- [x] create libraries with the FullTrust process *- implemented but not tested yet*
- [ ] rename libraries with the FullTrust process
- [ ] remove libraries with the FullTrust process
- [x] add possibility to invoke library folders management dialog
- [x] show pinned libraries on the sidebar
- [ ] add library specific context menu items to sidebar library entries
  - [ ] manage folders
  - [ ] rename
  - [ ] remove
- [x] show all libraries on the Home page
- [ ] add library specific context menu items to Home page cards
  - [x] manage folders
  - [ ] rename
  - [ ] remove
- [ ] add possibility to create new library and show button for it on the Home page
- [x] load folders and files from all folders of the library when navigating to a default save location of one *- currently works with some issues*
- [ ] watch library changes and update sidebar & Home page entries