### PR TITLE
Moved clear all properties button to bottom of page

### DIFF
--- a/Files/Views/Pages/PropertiesDetails.xaml
+++ b/Files/Views/Pages/PropertiesDetails.xaml
@@ -28,79 +28,82 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Page.Resources>
-    <ListView
-        x:Name="MainList"
-        ItemsSource="{x:Bind PropertiesSource.View, Mode=OneWay}"
-        SelectionMode="None">
-        <ListView.ItemTemplate>
-            <DataTemplate x:DataType="properties:FileProperty">
-                <Grid HorizontalAlignment="Stretch">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <ListView
+            x:Name="MainList"
+            ItemsSource="{x:Bind PropertiesSource.View, Mode=OneWay}"
+            SelectionMode="None">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="properties:FileProperty">
+                    <Grid HorizontalAlignment="Stretch">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
 
-                    <TextBlock
-                        Grid.Row="0"
-                        HorizontalAlignment="Stretch"
-                        Style="{StaticResource PropertyName}"
-                        Text="{x:Bind Name, Mode=OneWay}" />
-                    <TextBox
-                        x:Name="PropertyValueTemplateTextBox"
-                        Grid.Row="0"
-                        Grid.Column="1"
-                        HorizontalAlignment="Stretch"
-                        IsReadOnly="{x:Bind IsReadOnly, Mode=OneWay}"
-                        Style="{StaticResource PropertyValueTextBox}"
-                        Text="{x:Bind ValueText, Mode=TwoWay}" />
-                </Grid>
-            </DataTemplate>
-        </ListView.ItemTemplate>
-        <ListView.GroupStyle>
-            <GroupStyle>
-                <GroupStyle.HeaderTemplate>
-                    <DataTemplate x:DataType="properties:FilePropertySection">
-                        <Border AutomationProperties.Name="{x:Bind Title}">
-                            <TextBlock Style="{ThemeResource SeparatorText}" Text="{x:Bind Title}" />
-                        </Border>
-                    </DataTemplate>
-                </GroupStyle.HeaderTemplate>
-            </GroupStyle>
-        </ListView.GroupStyle>
-        <ListView.ItemContainerStyle>
-            <Style TargetType="ListViewItem">
-                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-            </Style>
-        </ListView.ItemContainerStyle>
-        <ListView.ItemsPanel>
-            <ItemsPanelTemplate>
-                <ItemsStackPanel AreStickyGroupHeadersEnabled="False" />
-            </ItemsPanelTemplate>
-        </ListView.ItemsPanel>
-
-        <ListView.Footer>
-            <StackPanel Margin="10,5,10,5" Spacing="5">
-                <Button
+                        <TextBlock
+                            Grid.Row="0"
+                            HorizontalAlignment="Stretch"
+                            Style="{StaticResource PropertyName}"
+                            Text="{x:Bind Name, Mode=OneWay}" />
+                        <TextBox
+                            x:Name="PropertyValueTemplateTextBox"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            HorizontalAlignment="Stretch"
+                            IsReadOnly="{x:Bind IsReadOnly, Mode=OneWay}"
+                            Style="{StaticResource PropertyValueTextBox}"
+                            Text="{x:Bind ValueText, Mode=TwoWay}" />
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+            <ListView.GroupStyle>
+                <GroupStyle>
+                    <GroupStyle.HeaderTemplate>
+                        <DataTemplate x:DataType="properties:FilePropertySection">
+                            <Border AutomationProperties.Name="{x:Bind Title}">
+                                <TextBlock Style="{ThemeResource SeparatorText}" Text="{x:Bind Title}" />
+                            </Border>
+                        </DataTemplate>
+                    </GroupStyle.HeaderTemplate>
+                </GroupStyle>
+            </ListView.GroupStyle>
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <ItemsStackPanel AreStickyGroupHeadersEnabled="False" />
+                </ItemsPanelTemplate>
+            </ListView.ItemsPanel>
+        </ListView>
+        <StackPanel Margin="10,5,10,5" Spacing="5" Grid.Row="1">
+            <Button
                     x:Name="ClearPropertiesButton"
                     x:Uid="ClearPropertiesButton"
                     Margin="0,10,0,0"
                     HorizontalAlignment="Stretch">
-                    <Button.Flyout>
-                        <Flyout x:Name="ClearPropertiesFlyout">
-                            <StackPanel Orientation="Vertical" Spacing="5">
-                                <TextBlock x:Uid="ClearPropertiesFlyoutText" Text="Confirm?" />
-                                <StackPanel Orientation="Horizontal" Spacing="10">
-                                    <Button
+                <Button.Flyout>
+                    <Flyout x:Name="ClearPropertiesFlyout">
+                        <StackPanel Orientation="Vertical" Spacing="5">
+                            <TextBlock x:Uid="ClearPropertiesFlyoutText" Text="Confirm?" />
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <Button
                                         x:Uid="ClearPropertiesFlyoutConfirmation"
                                         Click="ClearPropertiesConfirmation_Click"
                                         Content="Clear" />
-                                </StackPanel>
                             </StackPanel>
-                        </Flyout>
-                    </Button.Flyout>
-                </Button>
-            </StackPanel>
-        </ListView.Footer>
-    </ListView>
+                        </StackPanel>
+                    </Flyout>
+                </Button.Flyout>
+            </Button>
+        </StackPanel>
+    </Grid>
 </local:PropertiesTab>


### PR DESCRIPTION
**Resolved / Related Issues**

Itemize resolved / related issues by this PR.
Closes #3444 

**Details of Changes**
Moved the clear properties button from the bottom of the list to the bottom of the page.

**Validation**

How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/59544401/111892454-e7bf6500-89b8-11eb-820d-af28599d06e2.png)
