### PR TITLE
Fixes an issue for which drives are not removed from sidebar when disconnected

### DIFF
--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -154,6 +154,15 @@ namespace Files.Filesystem
                         }
                     }
 
+                    foreach (DriveItem drive in section.ChildItems.ToList())
+                    {
+                        if (!Drives.Contains(drive))
+                        {
+                            section.ChildItems.Remove(drive);
+                            DrivesWidget.ItemsAdded.Remove(drive);
+                        }
+                    }
+
                     MainPage.SideBarItems.EndBulkOperation();
                 }
                 finally


### PR DESCRIPTION
**Resolved / Related Issues**

Fixes #4152
Fixes #4088

**Details of Changes**

Fixes an issue for which drives are not removed from sidebar / homepage when disconnected.
Adds a check in `SyncSideBarItemsUI` to remove drives when syncing `MainPage.SideBarItems` to the `Drives` list.

**Validation**

How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility
