### PR TITLE
Fixes an issue for which duplicate WSL sections appeared on sidebar

### DIFF
--- a/Files/Filesystem/WSLDistroManager.cs
+++ b/Files/Filesystem/WSLDistroManager.cs
@@ -51,16 +51,18 @@ namespace Files.Filesystem
                         if ((await distroFolder.GetFoldersAsync()).Count != 0)
                         {
                             var section = MainPage.SideBarItems.FirstOrDefault(x => x.Text == "WSL") as LocationItem;
-
-                            section = new LocationItem()
+                            if (section == null)
                             {
-                                Text = "WSL",
-                                Section = SectionType.WSL,
-                                Glyph = "\uEC7A",
-                                SelectsOnInvoked = false,
-                                ChildItems = new ObservableCollection<INavigationControlItem>()
-                            };
-                            MainPage.SideBarItems.Add(section);
+                                section = new LocationItem()
+                                {
+                                    Text = "WSL",
+                                    Section = SectionType.WSL,
+                                    Glyph = "\uEC7A",
+                                    SelectsOnInvoked = false,
+                                    ChildItems = new ObservableCollection<INavigationControlItem>()
+                                };
+                                MainPage.SideBarItems.Add(section);
+                            }
 
                             foreach (StorageFolder folder in await distroFolder.GetFoldersAsync())
                             {
@@ -90,12 +92,15 @@ namespace Files.Filesystem
                                     logoURI = new Uri("ms-appx:///Assets/WSL/genericpng.png");
                                 }
 
-                                section.ChildItems.Add(new WSLDistroItem()
+                                if (!section.ChildItems.Any(x => x.Path == folder.Path))
                                 {
-                                    Text = folder.DisplayName,
-                                    Path = folder.Path,
-                                    Logo = logoURI
-                                });
+                                    section.ChildItems.Add(new WSLDistroItem()
+                                    {
+                                        Text = folder.DisplayName,
+                                        Path = folder.Path,
+                                        Logo = logoURI
+                                    });
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
**Resolved / Related Issues**

Fixes #4164

**Details of Changes**

Fixes an issue for which duplicate WSL sections appeared on sidebar.
Adds a check in `WSLDistroManager\SyncSideBarItemsUI()` to skip adding WSL section if already exists.
To reproduce the bug: open Files and then launch a folder from the taskbar,

**Validation**

How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility
