### PR TITLE
Fix crash due to wrong thread exception

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -150,10 +150,6 @@ namespace Files
 
         private List<ShellNewEntry> cachedNewContextMenuEntries { get; set; }
 
-        private DispatcherQueueController timerQueueController;
-
-        private DispatcherQueue timerQueue;
-
         private DispatcherQueueTimer dragOverTimer;
 
         public BaseLayout()
@@ -170,9 +166,7 @@ namespace Files
                 IsQuickLookEnabled = true;
             }
 
-            timerQueueController = DispatcherQueueController.CreateOnDedicatedThread();
-            timerQueue = timerQueueController.DispatcherQueue;
-            dragOverTimer = timerQueue.CreateTimer();
+            dragOverTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
         }
 
         protected abstract void InitializeCommandsViewModel();

--- a/Files/UserControls/NavigationToolbar.xaml.cs
+++ b/Files/UserControls/NavigationToolbar.xaml.cs
@@ -555,10 +555,6 @@ namespace Files.UserControls
 
         private List<ShellNewEntry> cachedNewContextMenuEntries { get; set; }
 
-        private DispatcherQueueController timerQueueController;
-
-        private DispatcherQueue timerQueue;
-
         private DispatcherQueueTimer dragOverTimer;
 
         public NavigationToolbar()
@@ -566,9 +562,7 @@ namespace Files.UserControls
             this.InitializeComponent();
             this.Loading += NavigationToolbar_Loading;
 
-            timerQueueController = DispatcherQueueController.CreateOnDedicatedThread();
-            timerQueue = timerQueueController.DispatcherQueue;
-            dragOverTimer = timerQueue.CreateTimer();
+            dragOverTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
         }
 
         private async void NavigationToolbar_Loading(FrameworkElement sender, object args)

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -73,10 +73,6 @@ namespace Files.UserControls
             set => SetValue(EmptyRecycleBinCommandProperty, value);
         }
 
-        private DispatcherQueueController timerQueueController;
-
-        private DispatcherQueue timerQueue;
-
         private DispatcherQueueTimer dragOverTimer;
 
         public SidebarControl()
@@ -84,9 +80,7 @@ namespace Files.UserControls
             this.InitializeComponent();
             SidebarNavView.Loaded += SidebarNavView_Loaded;
 
-            timerQueueController = DispatcherQueueController.CreateOnDedicatedThread();
-            timerQueue = timerQueueController.DispatcherQueue;
-            dragOverTimer = timerQueue.CreateTimer();
+            dragOverTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
         }
 
         private INavigationControlItem selectedSidebarItem;

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -93,10 +93,6 @@ namespace Files.Views.LayoutModes
             }
         }
 
-        private DispatcherQueueController timerQueueController;
-
-        private DispatcherQueue timerQueue;
-
         private DispatcherQueueTimer tapDebounceTimer;
 
         public GenericFileBrowser()
@@ -111,9 +107,7 @@ namespace Files.Views.LayoutModes
             selectionRectangle.SelectionEnded += SelectionRectangle_SelectionEnded;
             AllView.PointerCaptureLost += AllView_ItemPress;
 
-            timerQueueController = DispatcherQueueController.CreateOnDedicatedThread();
-            timerQueue = timerQueueController.DispatcherQueue;
-            tapDebounceTimer = timerQueue.CreateTimer();
+            tapDebounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
         }
 
         protected override void InitializeCommandsViewModel()
@@ -307,7 +301,7 @@ namespace Files.Views.LayoutModes
 
         private TextBox renamingTextBox;
 
-        private async void AllView_BeginningEdit(object sender, DataGridBeginningEditEventArgs e)
+        private void AllView_BeginningEdit(object sender, DataGridBeginningEditEventArgs e)
         {
             if (ParentShellPageInstance.FilesystemViewModel.WorkingDirectory.StartsWith(AppSettings.RecycleBinPath))
             {
@@ -333,16 +327,12 @@ namespace Files.Views.LayoutModes
                     // We have an edit due to the first tap in the double-click mode
                     // Let's wait to see if there is another tap (double click).
 
-                    tapDebounceTimer.Debounce(async () =>
+                    tapDebounceTimer.Debounce(() =>
                     {
-                        await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
-                        {
-                            tapDebounceTimer.Stop();
+                        tapDebounceTimer.Stop();
 
-                            AllView.BeginEdit();
-                        });
+                        AllView.BeginEdit();
                     }, TimeSpan.FromMilliseconds(700), false);
-                    
                 }
             }
             else


### PR DESCRIPTION
**Resolved / Related Issues**

Dragging and hovering on a folder / sidebar item is currently broken since timers actions are not invoked on the UI thread.
This caused, among others, #4158.

**Details of Changes**

Properly create timers so they invoke the action on the UI thread.

**Validation**

How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility
