### PR TITLE
Fixes an issue for which "close tab to the right" was sometimes improperly enabled 

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -141,20 +141,6 @@ namespace Files
             DrivesManager?.ResumeDeviceWatcher();
         }
 
-        public static INavigationControlItem RightClickedItem;
-
-        public static void UnpinItem_Click(object sender, RoutedEventArgs e)
-        {
-            if (RightClickedItem.Path.Equals(AppSettings.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
-            {
-                AppSettings.PinRecycleBinToSideBar = false;
-            }
-            else if (RightClickedItem.Section == SectionType.Favorites)
-            {
-                SidebarPinnedController.Model.RemoveItem(RightClickedItem.Path.ToString());
-            }
-        }
-
         public static Windows.UI.Xaml.UnhandledExceptionEventArgs ExceptionInfo { get; set; }
         public static string ExceptionStackTrace { get; set; }
         public static List<string> pathsToDeleteAfterPaste = new List<string>();

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -49,10 +49,11 @@
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
                         <MenuFlyoutItem
+                            x:Name="MenuItemCloseTabsToTheRight"
                             x:Uid="HorizontalMultitaskingControlCloseTabsToTheRight"
                             Click="{x:Bind views:MainPage.CloseTabsToTheRight}"
                             Text="Close tabs to the right"
-                            IsEnabled="{x:Bind CloseTabsToTheRightEnabled, Mode=OneWay}"/>
+                            DataContextChanged="MenuItemCloseTabsToTheRight_DataContextChanged" />
                     </MenuFlyout>
                 </ResourceDictionary>
                 <ResourceDictionary>

--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
@@ -21,20 +21,6 @@ namespace Files.UserControls.MultitaskingControl
 
         private SettingsViewModel AppSettings => App.AppSettings;
 
-        private bool closeTabsToTheRightEnabled = true;
-        public bool CloseTabsToTheRightEnabled
-        {
-            get => closeTabsToTheRightEnabled;
-            private set
-            {
-                if (value != closeTabsToTheRightEnabled)
-                {
-                    closeTabsToTheRightEnabled = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
-
         public HorizontalMultitaskingControl()
         {
             InitializeComponent();
@@ -187,17 +173,6 @@ namespace Files.UserControls.MultitaskingControl
 
         private void TabItemContextMenu_Opening(object sender, object e)
         {
-            TabItem tabItem = (((MenuFlyout)sender).Items.First()).DataContext as TabItem;
-
-            if (MainPage.AppInstances.IndexOf(tabItem) == MainPage.AppInstances.Count - 1)
-            {
-                CloseTabsToTheRightEnabled = false;
-            }
-            else
-            {
-                CloseTabsToTheRightEnabled = true;
-            }
-
             if (MainPage.MultitaskingControl.Items.Count == 1)
             {
                 MenuItemMoveTabToNewWindow.IsEnabled = false;
@@ -205,6 +180,20 @@ namespace Files.UserControls.MultitaskingControl
             else
             {
                 MenuItemMoveTabToNewWindow.IsEnabled = true;
+            }
+        }
+
+        private void MenuItemCloseTabsToTheRight_DataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+        {
+            TabItem tabItem = args.NewValue as TabItem;
+
+            if (MainPage.AppInstances.IndexOf(tabItem) == MainPage.AppInstances.Count - 1)
+            {
+                MenuItemCloseTabsToTheRight.IsEnabled = false;
+            }
+            else
+            {
+                MenuItemCloseTabsToTheRight.IsEnabled = true;
             }
         }
     }

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -186,7 +186,7 @@
                                 x:Name="UnpinItem"
                                 x:Uid="SideBarUnpinFromSideBar"
                                 x:Load="{x:Bind ShowUnpinItem, Mode=OneWay}"
-                                Click="{x:Bind local1:App.UnpinItem_Click}"
+                                Click="{x:Bind UnpinItem_Click}"
                                 Text="Unpin from Sidebar">
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xE77A;" />

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -200,11 +200,25 @@ namespace Files.UserControls
             }
         }
 
+        public INavigationControlItem RightClickedItem;
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public void UnpinItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (RightClickedItem.Path.Equals(AppSettings.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
+            {
+                AppSettings.PinRecycleBinToSideBar = false;
+            }
+            else if (RightClickedItem.Section == SectionType.Favorites)
+            {
+                App.SidebarPinnedController.Model.RemoveItem(RightClickedItem.Path.ToString());
+            }
         }
 
         private void Sidebar_ItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
@@ -251,8 +265,8 @@ namespace Files.UserControls
                     }
                 }
 
+                RightClickedItem = item;
                 SideBarItemContextFlyout.ShowAt(sidebarItem, e.GetPosition(sidebarItem));
-                App.RightClickedItem = item;
             }
 
             e.Handled = true;
@@ -270,7 +284,7 @@ namespace Files.UserControls
 
             SideBarItemContextFlyout.ShowAt(sidebarItem, e.GetPosition(sidebarItem));
 
-            App.RightClickedItem = item;
+            RightClickedItem = item;
 
             e.Handled = true;
         }
@@ -287,19 +301,19 @@ namespace Files.UserControls
 
             SideBarItemContextFlyout.ShowAt(sidebarItem, e.GetPosition(sidebarItem));
 
-            App.RightClickedItem = item;
+            RightClickedItem = item;
 
             e.Handled = true;
         }
 
         private void OpenInNewTab_Click(object sender, RoutedEventArgs e)
         {
-            Interaction.OpenPathInNewTab(App.RightClickedItem.Path);
+            Interaction.OpenPathInNewTab(RightClickedItem.Path);
         }
 
         private async void OpenInNewWindow_Click(object sender, RoutedEventArgs e)
         {
-            await Interaction.OpenPathInNewWindowAsync(App.RightClickedItem.Path);
+            await Interaction.OpenPathInNewWindowAsync(RightClickedItem.Path);
         }
 
         private void NavigationViewItem_DragStarting(UIElement sender, DragStartingEventArgs args)
@@ -561,7 +575,7 @@ namespace Files.UserControls
 
         private async void EjectDevice_Click(object sender, RoutedEventArgs e)
         {
-            await DeviceHelpers.EjectDeviceAsync(App.RightClickedItem.Path);
+            await DeviceHelpers.EjectDeviceAsync(RightClickedItem.Path);
         }
 
         private void SidebarNavView_Loaded(object sender, RoutedEventArgs e)

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -189,7 +189,7 @@ namespace Files.Views
             }
         }
 
-        public static async void CloseTabsToTheRight(object sender, RoutedEventArgs e)
+        public static void CloseTabsToTheRight(object sender, RoutedEventArgs e)
         {
             TabItem tabItem = ((FrameworkElement)sender).DataContext as TabItem;
             int index = AppInstances.IndexOf(tabItem);


### PR DESCRIPTION
**Resolved / Related Issues**

Fixes #4062

**Details of Changes**

Fixes an issue for which "close tab to the right" was sometimes improperly enabled by moving the enable logic from the `Opening` to the `DataContextChanged` event.
This PR also moves the `RightClickedItem` from App to SidebarControl (RightClickedItem does not need to be global/static).

**Validation**

How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility
