### PR TITLE
Fixes an issue for which the UAC prompt was shown when opening .url shortcuts

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -866,7 +866,6 @@ namespace FilesFullTrust
             {
                 using Process process = new Process();
                 process.StartInfo.UseShellExecute = true;
-                process.StartInfo.Verb = "runas";
                 process.StartInfo.FileName = application;
                 process.StartInfo.CreateNoWindow = true;
                 process.StartInfo.Arguments = arguments;

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -241,7 +241,7 @@ namespace Files
                     { "Arguments", "LoadContextMenu" },
                     { "FilePath", IsItemSelected ?
                         string.Join('|', selectedItems.Select(x => x.ItemPath)) :
-                        ParentShellPageInstance.FilesystemViewModel.CurrentFolder.ItemPath},
+                        ParentShellPageInstance.FilesystemViewModel.WorkingDirectory },
                     { "ExtendedMenu", shiftPressed },
                     { "ShowOpenMenu", showOpenMenu }
                 })).Result;


### PR DESCRIPTION
**Resolved / Related Issues**

Fixes #4114

**Details of Changes**

Fixes an issue for which the UAC prompt was shown when opening .url shortcuts.
Does not seem to be breaking anything else (e.g opening exe files)

**Validation**

How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility
