### PR TITLE
[Testing only] - Load icons from FTP only for hidden and shortcut files

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -356,7 +356,8 @@ namespace FilesFullTrust
                 case "GetIconOverlay":
                     var fileIconPath = (string)message["filePath"];
                     var thumbnailSize = (int)(long)message["thumbnailSize"];
-                    var iconOverlay = Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(fileIconPath, thumbnailSize)).Result;
+                    var shouldLoadIcon = (bool)message["loadIcon"];
+                    var iconOverlay = Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(fileIconPath, shouldLoadIcon, thumbnailSize)).Result;
                     await Win32API.SendMessageAsync(connection, new ValueSet()
                     {
                         { "Icon", iconOverlay.icon },

--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -100,12 +100,12 @@ namespace FilesFullTrust
             }
         }
 
-        public static (string icon, string overlay, bool isCustom) GetFileIconAndOverlay(string path, int thumbnailSize)
+        public static (string icon, string overlay, bool isCustom) GetFileIconAndOverlay(string path, bool shouldLoadIcon, int thumbnailSize)
         {
             string iconStr = null, overlayStr = null;
 
             using var shellItem = new Vanara.Windows.Shell.ShellItem(path);
-            if (shellItem.IShellItem is Shell32.IShellItemImageFactory fctry)
+            if (shouldLoadIcon && shellItem.IShellItem is Shell32.IShellItemImageFactory fctry)
             {
                 var flags = Shell32.SIIGBF.SIIGBF_BIGGERSIZEOK;
                 if (thumbnailSize < 80) flags |= Shell32.SIIGBF.SIIGBF_ICONONLY;

--- a/Files/Helpers/FileThumbnailHelper.cs
+++ b/Files/Helpers/FileThumbnailHelper.cs
@@ -8,7 +8,7 @@ namespace Files.Helpers
 {
     public static class FileThumbnailHelper
     {
-        public static async Task<(byte[] IconData, byte[] OverlayData, bool IsCustom)> LoadIconOverlayAsync(string filePath, uint thumbnailSize)
+        public static async Task<(byte[] IconData, byte[] OverlayData, bool IsCustom)> LoadIconOverlayAsync(string filePath, bool shouldLoadIcon, uint thumbnailSize)
         {
             var connection = await AppServiceConnectionHelper.Instance;
             if (connection != null)
@@ -17,6 +17,7 @@ namespace Files.Helpers
                 {
                     { "Arguments", "GetIconOverlay" },
                     { "filePath", filePath },
+                    { "loadIcon", shouldLoadIcon },
                     { "thumbnailSize", (int)thumbnailSize }
                 };
                 var (status, response) = await connection.SendMessageForResponseAsync(value);

--- a/Files/ViewModels/Bundles/BundleItemViewModel.cs
+++ b/Files/ViewModels/Bundles/BundleItemViewModel.cs
@@ -155,7 +155,7 @@ namespace Files.ViewModels.Bundles
                 {
                     if (Path.EndsWith(".lnk"))
                     {
-                        var (IconData, OverlayData, IsCustom) = await associatedInstance.FilesystemViewModel.LoadIconOverlayAsync(Path, 24u);
+                        var (IconData, OverlayData, IsCustom) = await associatedInstance.FilesystemViewModel.LoadIconOverlayAsync(Path, true, 24u);
 
                         await CoreApplication.MainView.ExecuteOnUIThreadAsync(async () =>
                         {

--- a/Files/ViewModels/Previews/BasePreviewModel.cs
+++ b/Files/ViewModels/Previews/BasePreviewModel.cs
@@ -34,7 +34,7 @@ namespace Files.ViewModels.Previews
 
         public async virtual Task<List<FileProperty>> LoadPreviewAndDetails()
         {
-            var (IconData, OverlayData, IsCustom) = await FileThumbnailHelper.LoadIconOverlayAsync(Item.ItemPath, 400);
+            var (IconData, OverlayData, IsCustom) = await FileThumbnailHelper.LoadIconOverlayAsync(Item.ItemPath, Item.IsHiddenItem || Item.IsShortcutItem, 400);
 
             if (IconData != null)
             {


### PR DESCRIPTION
**Resolved / Related Issues**

Fixes #3163

@XPoppyX since you can "easily" reproduce the issue (comment in #4199), I'm curious if you could test this PR and see if the issue is fixed.
[The effect of the issue is: after opening different folders, eventually the shortcuts and the extra options of the contextual menu are no longer shown]
Note: this is based on main so maybe you have to turn off file caching in order to repro the issue.

**Details of Changes**

Only use FTP for loading hidden and shortcut files icons.

**Validation**

How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility
