### PR TITLE
Exit fulltrust process on UWP crash

### DIFF
--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -218,6 +218,7 @@ namespace Files.Filesystem
             }
         }
 
+        // Parameterless constructor for JsonConvert
         public ListedItem()
         { }
 
@@ -309,6 +310,10 @@ namespace Files.Filesystem
         {
         }
 
+        // Parameterless constructor for JsonConvert
+        public RecycleBinItem() : base()
+        { }
+
         public string ItemDateDeleted { get; private set; }
 
         public DateTimeOffset ItemDateDeletedReal
@@ -335,6 +340,10 @@ namespace Files.Filesystem
         public ShortcutItem(string folderRelativeId, string returnFormat) : base(folderRelativeId, returnFormat)
         {
         }
+
+        // Parameterless constructor for JsonConvert
+        public ShortcutItem() : base()
+        { }
 
         // For shortcut elements (.lnk and .url)
         public string TargetPath { get; set; }

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -181,7 +181,10 @@ namespace Files.Views.LayoutModes
 
         protected override void AddSelectedItem(ListedItem item)
         {
-            AllView.SelectedItems.Add(item);
+            if (((IList<ListedItem>)AllView.ItemsSource).Contains(item))
+            {
+                AllView.SelectedItems.Add(item);
+            }
         }
 
         protected override IEnumerable GetAllItems()
@@ -232,7 +235,10 @@ namespace Files.Views.LayoutModes
 
         public override void FocusSelectedItems()
         {
-            AllView.ScrollIntoView(AllView.ItemsSource.Cast<ListedItem>().Last(), null);
+            if (SelectedItems.Any())
+            {
+                AllView.ScrollIntoView(SelectedItems.Last(), null);
+            }
         }
 
         public override void StartRenameItem()

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -122,7 +122,10 @@ namespace Files.Views.LayoutModes
 
         protected override void AddSelectedItem(ListedItem item)
         {
-            FileList.SelectedItems.Add(item);
+            if (FileList.Items.Contains(item))
+            {
+                FileList.SelectedItems.Add(item);
+            }
         }
 
         protected override IEnumerable GetAllItems()
@@ -161,7 +164,10 @@ namespace Files.Views.LayoutModes
 
         public override void FocusSelectedItems()
         {
-            FileList.ScrollIntoView(FileList.Items.Last());
+            if (SelectedItems.Any())
+            {
+                FileList.ScrollIntoView(SelectedItems.Last());
+            }
         }
 
         private void StackPanel_RightTapped(object sender, RightTappedRoutedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Fixes an issue for which the FTP remains open when the UWP app terminates.
- Fixes an issue that causes a lot of warnings to be written to the log files ("No parameterless constructor for object..")
- Fixes an issue that sometimes causes a crash when switching folder

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility
