### PR TITLE
Fixed issue where file preview could reload while scrolling

### DIFF
--- a/Files/ViewModels/PreviewPaneViewModel.cs
+++ b/Files/ViewModels/PreviewPaneViewModel.cs
@@ -30,8 +30,11 @@ namespace Files.ViewModels
             get => selectedItems;
             set
             {
-                SetProperty(ref selectedItems, value);
-                SelectedItem = SelectedItems?.FirstOrDefault();
+                if(value != selectedItems)
+                {
+                    SetProperty(ref selectedItems, value);
+                    SelectedItem = SelectedItems?.FirstOrDefault();
+                }
             }
         }
 

--- a/Files/ViewModels/PreviewPaneViewModel.cs
+++ b/Files/ViewModels/PreviewPaneViewModel.cs
@@ -30,9 +30,8 @@ namespace Files.ViewModels
             get => selectedItems;
             set
             {
-                if(value != selectedItems)
+                if (SetProperty(ref selectedItems, value))
                 {
-                    SetProperty(ref selectedItems, value);
                     SelectedItem = SelectedItems?.FirstOrDefault();
                 }
             }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Seemed too minor to make an issue for. 
Basically, the selected items list would register a change when there wasn't one when scrolling, which caused the preview pane to reload.

**Details of Changes**
Prevents the property changed notification for SelectedItems from being raised when the selection is the same.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
