### PR TITLE
Fixed wrong text shown for item arguments

### DIFF
--- a/Files/ViewModels/Previews/ShortcutPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/ShortcutPreviewViewModel.cs
@@ -40,7 +40,7 @@ namespace Files.ViewModels.Previews
                 },
                 new FileProperty()
                 {
-                    NameResource = "PropertyItemName",
+                    NameResource = "PropertyItemArguments",
                     Value = item.Arguments,
                 }
             };


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
The wrong string was being shown in the preview pane for arguments.

![image](https://user-images.githubusercontent.com/59544401/112745430-26c35c80-8f5d-11eb-8d03-6e3c417968ba.png)

**Details of Changes**
Add details of changes here.
Changed referenced resource name.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**

