### PR TITLE
Improved the code and speed of ToStorageItem<TOut>()

### DIFF
--- a/Files/Helpers/StorageItemHelpers.cs
+++ b/Files/Helpers/StorageItemHelpers.cs
@@ -27,6 +27,8 @@ namespace Files.Helpers
                 // TODO: In the future, when IStorageItemWithPath will inherit from IStorageItem,
                 //      we could implement this code here for getting .lnk files
                 //      for now, we can't
+                
+                return default(TOut);
 
                 if (false) // Prevent unnecessary exceptions
                 {

--- a/Files/Helpers/StorageItemHelpers.cs
+++ b/Files/Helpers/StorageItemHelpers.cs
@@ -22,7 +22,7 @@ namespace Files.Helpers
             FilesystemResult<StorageFile> file = null;
             FilesystemResult<StorageFolder> folder = null;
 
-            if (path.EndsWith(".lnk") || path.EndsWith(".url"))
+            if (path.ToLower().EndsWith(".lnk") || path.ToLower().EndsWith(".url"))
             {
                 // TODO: In the future, when IStorageItemWithPath will inherit from IStorageItem,
                 //      we could implement this code here for getting .lnk files

--- a/Files/Helpers/StorageItemHelpers.cs
+++ b/Files/Helpers/StorageItemHelpers.cs
@@ -47,18 +47,15 @@ namespace Files.Helpers
             }
             else if (typeof(IStorageItem).IsAssignableFrom(typeof(TOut)))
             {
-                bool fileChecked = false;
-
                 if (System.IO.Path.HasExtension(path)) // Probably a file
                 {
                     await GetFile();
-                    fileChecked = true;
                 }
                 else // Possibly a folder
                 {
                     await GetFolder();
 
-                    if (!folder && !fileChecked)
+                    if (!folder)
                     {
                         // It wasn't a folder, so check file then because it wasn't checked
                         await GetFile();

--- a/Files/Helpers/StorageItemHelpers.cs
+++ b/Files/Helpers/StorageItemHelpers.cs
@@ -20,30 +20,55 @@ namespace Files.Helpers
             FilesystemResult<StorageFile> file = null;
             FilesystemResult<StorageFolder> folder = null;
 
-            if (associatedInstance == null)
+            if (typeof(IStorageFile).IsAssignableFrom(typeof(TOut)))
             {
-                file = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFileFromPathAsync(path));
-
-                if (!file)
+                if (associatedInstance == null)
+                {
+                    file = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFileFromPathAsync(path));
+                }
+                else
+                {
+                    file = await associatedInstance?.FilesystemViewModel?.GetFileFromPathAsync(path);
+                }
+            }
+            else if (typeof(IStorageFolder).IsAssignableFrom(typeof(TOut)))
+            {
+                if (associatedInstance == null)
                 {
                     folder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(path));
                 }
-            }
-            else
-            {
-                file = await associatedInstance?.FilesystemViewModel?.GetFileFromPathAsync(path);
-
-                if (!file)
+                else
                 {
                     folder = await associatedInstance?.FilesystemViewModel?.GetFolderFromPathAsync(path);
                 }
             }
+            else if (typeof(IStorageItem).IsAssignableFrom(typeof(TOut)))
+            {
+                if (associatedInstance == null)
+                {
+                    file = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFileFromPathAsync(path));
 
-            if (file)
+                    if (!file)
+                    {
+                        folder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(path));
+                    }
+                }
+                else
+                {
+                    file = await associatedInstance?.FilesystemViewModel?.GetFileFromPathAsync(path);
+
+                    if (!file)
+                    {
+                        folder = await associatedInstance?.FilesystemViewModel?.GetFolderFromPathAsync(path);
+                    }
+                }
+            }
+
+            if (file != null && file)
             {
                 return (TOut)(IStorageItem)file.Result;
             }
-            else if (folder)
+            else if (folder != null && folder)
             {
                 return (TOut)(IStorageItem)folder.Result;
             }

--- a/Files/Helpers/StorageItemHelpers.cs
+++ b/Files/Helpers/StorageItemHelpers.cs
@@ -58,7 +58,7 @@ namespace Files.Helpers
                 {
                     await GetFolder();
 
-                    if (!folder && !fileChecked && !file)
+                    if (!folder && !fileChecked)
                     {
                         // It wasn't a folder, so check file then because it wasn't checked
                         await GetFile();


### PR DESCRIPTION
**Details of Changes**
This PR improves the code and speed of `ToStorageItem<TOut>()`.
Since getting instances of `StorageFile` and `StorageFolder` is resource heavy and slow, this PR mitigates the performance hole as much as possible.
Bundles widget heavily relies on this function and the performance increase is ***very*** noticeable (It's "you could test debug app against release app" noticeable)

For #4180

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility
