### PR TITLE
Added the option to open Storage Sense on drives widget

### DIFF
--- a/Files/Constants.cs
+++ b/Files/Constants.cs
@@ -29,6 +29,11 @@
             {
                 public const int MaxAmountOfItemsPerBundle = 8;
             }
+
+            public static class Drives
+            {
+                public const float LowStorageSpacePercentageThreshold = 90.0f;
+            }
         }
 
         public static class LocalSettings

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -1950,10 +1950,10 @@
   <data name="PinItemToStart.Text" xml:space="preserve">
     <value>Pin to the Start Menu</value>
   </data>
-    <data name="UnpinItemFromStart.Text" xml:space="preserve">
+  <data name="UnpinItemFromStart.Text" xml:space="preserve">
     <value>Unpin from the Start Menu</value>
   </data>
-    <data name="BaseLayoutContextFlyoutColumn.Text" xml:space="preserve">
+  <data name="BaseLayoutContextFlyoutColumn.Text" xml:space="preserve">
     <value>Column View</value>
   </data>
   <data name="ItemTypeLibrary" xml:space="preserve">
@@ -2030,5 +2030,8 @@
   </data>
   <data name="DialogDeleteLibraryButtonText" xml:space="preserve">
     <value>Delete</value>
+  </data>
+  <data name="DrivesWidgetOpenStorageSenseButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Open Storage Sense</value>
   </data>
 </root>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2034,4 +2034,7 @@
   <data name="DrivesWidgetOpenStorageSenseButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Open Storage Sense</value>
   </data>
+  <data name="DrivesWidgetOpenStorageSenseButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Open Storage Sense</value>
+  </data>
 </root>

--- a/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -196,14 +196,44 @@
                                     Margin="12,0,0,0"
                                     VerticalAlignment="Center"
                                     Orientation="Vertical">
-                                    <TextBlock
-                                        x:Name="ItemLocationName"
-                                        Margin="0,0,0,8"
-                                        VerticalAlignment="Center"
-                                        FontSize="14"
-                                        FontWeight="Medium"
-                                        Text="{x:Bind Text, Mode=OneWay}"
-                                        TextWrapping="NoWrap" />
+                                    <Grid Margin="0,0,0,8" HorizontalAlignment="Stretch">
+                                        
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition/>
+                                        </Grid.ColumnDefinitions>
+                                        
+                                        <TextBlock
+                                            x:Name="ItemLocationName"
+                                            VerticalAlignment="Center"
+                                            FontSize="14"
+                                            FontWeight="Medium"
+                                            Text="{x:Bind Text, Mode=OneWay}"
+                                            TextWrapping="NoWrap" />
+                                        
+                                        <Button 
+                                            x:Uid="DrivesWidgetOpenStorageSenseButton"
+                                            Grid.Column="1" 
+                                            HorizontalAlignment="Right"
+                                            x:Name="GoToStorageSense"
+                                            x:Load="{x:Bind ShowStorageSense}"
+                                            Click="GoToStorageSense_Click"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            Width="30"
+                                            Height="30"
+                                            ToolTipService.ToolTip="Open Storage Sense"
+                                            VerticalContentAlignment="Center"
+                                            HorizontalContentAlignment="Center"
+                                            Padding="0">
+                                            <FontIcon
+                                                Glyph="&#xEA41;"
+                                                FontSize="18"
+                                                FontFamily="{StaticResource OldFluentUIGlyphs}"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"/>
+                                        </Button>
+                                    </Grid>
                                     <muxc:ProgressBar
                                         Margin="0,0,0,8"
                                         AutomationProperties.AccessibilityView="Raw"

--- a/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -220,7 +220,7 @@
                                             HorizontalAlignment="Right"
                                             Click="GoToStorageSense_Click"
                                             Background="Transparent"
-                                            BorderThickness="0"
+                                            BorderBrush="Transparent"
                                             Width="30"
                                             Height="30"
                                             ToolTipService.ToolTip="Open Storage Sense"

--- a/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -213,10 +213,11 @@
                                         
                                         <Button 
                                             x:Uid="DrivesWidgetOpenStorageSenseButton"
-                                            Grid.Column="1" 
-                                            HorizontalAlignment="Right"
                                             x:Name="GoToStorageSense"
                                             x:Load="{x:Bind ShowStorageSense}"
+                                            AutomationProperties.Name="Open Storage Sense"
+                                            Grid.Column="1" 
+                                            HorizontalAlignment="Right"
                                             Click="GoToStorageSense_Click"
                                             Background="Transparent"
                                             BorderThickness="0"
@@ -227,9 +228,8 @@
                                             HorizontalContentAlignment="Center"
                                             Padding="0">
                                             <FontIcon
-                                                Glyph="&#xEA41;"
+                                                Glyph="&#xE7BA;"
                                                 FontSize="18"
-                                                FontFamily="{StaticResource OldFluentUIGlyphs}"
                                                 HorizontalAlignment="Center"
                                                 VerticalAlignment="Center"/>
                                         </Button>

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Windows.Foundation.Collections;
+using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
@@ -168,6 +169,11 @@ namespace Files.UserControls.Widgets
                         { "drive", item.Path }
                     });
             }
+        }
+
+        private async void GoToStorageSense_Click(object sender, RoutedEventArgs e)
+        {
+            await Launcher.LaunchUriAsync(new Uri("ms-settings:storagesense"));
         }
     }
 }


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #3540 

**Details of Changes**
This PR adds a button to a drive that's nearly full (<10%) that opens Storage Sense

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/53011783/113272635-1d7b1c80-92dc-11eb-9b9a-f7b7cd635e78.png)

