### PR TITLE
Fixed Text overlapping on address bar (#4369)

### DIFF
--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -841,6 +841,8 @@
                 PlaceholderText="Search"
                 QuerySubmitted="SearchRegion_QuerySubmitted"
                 SuggestionChosen="SearchRegion_SuggestionChosen"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternary}"
+                BorderBrush="{ThemeResource SystemBaseMediumLowColor}"
                 TextBoxStyle="{StaticResource AutoSuggestBoxTextBoxStyleFixed}"
                 TextChanged="SearchRegion_TextChanged"
                 UpdateTextOnSelect="False"


### PR DESCRIPTION
**Explain the bug**
When the search bar is focused, opening the "More options" menu will cause a strange visual bug where the search text overlaps the address bar.

**To reproduce**
- Click the search button to trigger search.
- With the bar still focused, click on the 3 dots to open the "More options" menu.

#4369