### PR TITLE
Preview pane improvements & fixes

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -213,6 +213,7 @@
       <DependentUpon>ConfirmDeleteDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="Helpers\ContextFlyoutItemHelper.cs" />
+    <Compile Include="Helpers\Fractions.cs" />
     <Compile Include="Helpers\ItemModelListToContextFlyoutHelper.cs" />
     <Compile Include="Helpers\FilePropertiesHelpers.cs" />
     <Compile Include="Helpers\ShellContextMenuHelper.cs" />

--- a/Files/Helpers/Fractions.cs
+++ b/Files/Helpers/Fractions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.Helpers
+{
+    /// <summary>
+    /// Some simple helper methods to convert doubles to fractions
+    /// </summary>
+    public static class Fractions
+    {
+        public static string ToFractions(this double number, int precision = 4)
+        {
+            int w, n, d;
+            RoundToMixedFraction(number, precision, out w, out n, out d);
+            var ret = $"{w}";
+            if (w > 0)
+            {
+                if (n > 0)
+                    ret = $"{w} {n}/{d}";
+            }
+            else
+            {
+                if (n > 0)
+                    ret = $"{n}/{d}";
+            }
+            return ret;
+        }
+
+        static void RoundToMixedFraction(double input, int accuracy, out int whole, out int numerator, out int denominator)
+        {
+            double dblAccuracy = (double)accuracy;
+            whole = (int)(Math.Truncate(input));
+            var fraction = Math.Abs(input - whole);
+            if (fraction == 0)
+            {
+                numerator = 0;
+                denominator = 1;
+                return;
+            }
+            var n = Enumerable.Range(0, accuracy + 1).SkipWhile(e => (e / dblAccuracy) < fraction).First();
+            var hi = n / dblAccuracy;
+            var lo = (n - 1) / dblAccuracy;
+            if ((fraction - lo) < (hi - fraction)) n--;
+            if (n == accuracy)
+            {
+                whole++;
+                numerator = 0;
+                denominator = 1;
+                return;
+            }
+            var gcd = GCD(n, accuracy);
+            numerator = n / gcd;
+            denominator = accuracy / gcd;
+        }
+
+        static int GCD(int a, int b)
+        {
+            if (b == 0) return a;
+            else return GCD(b, a % b);
+        }
+    }
+}

--- a/Files/Resources/PreviewPanePropertiesInformation.json
+++ b/Files/Resources/PreviewPanePropertiesInformation.json
@@ -100,7 +100,8 @@
     "SectionResource": "PropertySectionPhoto",
     "Property": "System.Photo.Aperture",
     "IsReadOnly": true,
-    "ID": null
+    "ID": null,
+    "DisplayFunctionName":  "AddF",
   },
   {
     "NameResource": "PropertyPeopleNames",

--- a/Files/Resources/PreviewPanePropertiesInformation.json
+++ b/Files/Resources/PreviewPanePropertiesInformation.json
@@ -85,7 +85,8 @@
     "SectionResource": "PropertySectionPhoto",
     "Property": "System.Photo.ExposureTime",
     "IsReadOnly": true,
-    "ID": null
+    "ID": null,
+    "DisplayFunctionName": "Fraction"
   },
   {
     "NameResource": "PropertyFocalLength",

--- a/Files/Resources/PreviewPanePropertiesInformation.json
+++ b/Files/Resources/PreviewPanePropertiesInformation.json
@@ -101,7 +101,15 @@
     "Property": "System.Photo.Aperture",
     "IsReadOnly": true,
     "ID": null,
-    "DisplayFunctionName":  "AddF",
+    "DisplayFunctionName": "AddF"
+  },
+  {
+    "NameResource": "PropertyISO",
+    "SectionResource": "PropertySectionPhoto",
+    "Property": "System.Photo.ISOSpeed",
+    "IsReadOnly": true,
+    "ID": null,
+    "DisplayFunctionName": "AddISO"
   },
   {
     "NameResource": "PropertyPeopleNames",

--- a/Files/Resources/PreviewPanePropertiesInformation.json
+++ b/Files/Resources/PreviewPanePropertiesInformation.json
@@ -95,6 +95,7 @@
     "SectionResource": "PropertySectionPhoto",
     "Property": "System.Photo.FocalLength",
     "IsReadOnly": true,
+    "DisplayFunctionName": "UnitMM",
     "ID": null
   },
   {

--- a/Files/Resources/PreviewPanePropertiesInformation.json
+++ b/Files/Resources/PreviewPanePropertiesInformation.json
@@ -25,12 +25,14 @@
     "SectionResource": "PropertySectionImage",
     "Property": "System.Image.HorizontalResolution",
     "IsReadOnly": true,
+    "DisplayFunctionName": "RoundDouble",
     "ID": null
   },
   {
     "NameResource": "PropertyVerticalResolution",
     "SectionResource": "PropertySectionImage",
     "Property": "System.Image.VerticalResolution",
+    "DisplayFunctionName": "RoundDouble",
     "IsReadOnly": true,
     "ID": null
   },

--- a/Files/Resources/PreviewPanePropertiesInformation.json
+++ b/Files/Resources/PreviewPanePropertiesInformation.json
@@ -67,13 +67,6 @@
     "ID": null
   },
   {
-    "NameResource": "PropertyDateTaken",
-    "SectionResource": "PropertySectionPhoto",
-    "Property": "System.Photo.DateTaken",
-    "IsReadOnly": true,
-    "ID": null
-  },
-  {
     "NameResource": "PropertyCameraManufacturer",
     "SectionResource": "PropertySectionPhoto",
     "Property": "System.Photo.CameraManufacturer",
@@ -401,6 +394,13 @@
     "NameResource": "PropertyDateModified",
     "SectionResource": "PropertySectionCore",
     "Property": "System.DateModified",
+    "IsReadOnly": true,
+    "ID": null
+  },
+  {
+    "NameResource": "PropertyDateTaken",
+    "SectionResource": "PropertySectionPhoto",
+    "Property": "System.Photo.DateTaken",
     "IsReadOnly": true,
     "ID": null
   }

--- a/Files/Resources/PropertiesInformation.json
+++ b/Files/Resources/PropertiesInformation.json
@@ -127,7 +127,16 @@
     "SectionResource": "PropertySectionPhoto",
     "Property": "System.Photo.Aperture",
     "IsReadOnly": true,
-    "ID": null
+    "ID": null,
+    "DisplayFunctionName": "AddF"
+  },
+  {
+    "NameResource": "PropertyISO",
+    "SectionResource": "PropertySectionPhoto",
+    "Property": "System.Photo.ISOSpeed",
+    "IsReadOnly": true,
+    "ID": null,
+    "DisplayFunctionName": "AddISO"
   },
   {
     "NameResource": "PropertyPeopleNames",

--- a/Files/Resources/PropertiesInformation.json
+++ b/Files/Resources/PropertiesInformation.json
@@ -122,6 +122,7 @@
     "SectionResource": "PropertySectionPhoto",
     "Property": "System.Photo.FocalLength",
     "IsReadOnly": true,
+    "DisplayFunctionName": "UnitMM",
     "ID": null
   },
   {

--- a/Files/Resources/PropertiesInformation.json
+++ b/Files/Resources/PropertiesInformation.json
@@ -39,13 +39,15 @@
     "SectionResource": "PropertySectionImage",
     "Property": "System.Image.HorizontalResolution",
     "IsReadOnly": true,
-    "ID": null
+    "ID": null,
+    "DisplayFunctionName":  "RoundDouble"
   },
   {
     "NameResource": "PropertyVerticalResolution",
     "SectionResource": "PropertySectionImage",
     "Property": "System.Image.VerticalResolution",
     "IsReadOnly": true,
+    "DisplayFunctionName": "RoundDouble",
     "ID": null
   },
   {

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2035,6 +2035,6 @@
     <value>Open Storage Sense</value>
   </data>
   <data name="PropertyISO" xml:space="preserve">
-    <value>ISO</value>
+    <value>ISO speed</value>
   </data>
 </root>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2034,4 +2034,7 @@
   <data name="DrivesWidgetOpenStorageSenseButton.AutomationProperties.Name" xml:space="preserve">
     <value>Open Storage Sense</value>
   </data>
+  <data name="PropertyISO" xml:space="preserve">
+    <value>ISO</value>
+  </data>
 </root>

--- a/Files/UserControls/PreviewPane.xaml
+++ b/Files/UserControls/PreviewPane.xaml
@@ -73,7 +73,7 @@
                 <Grid>
                     <FontIcon
                         x:Name="GripperGlyph"
-                        Margin="-1,0,0,-1"
+                        Margin="-1.5,0,0,-1"
                         HorizontalAlignment="Center"
                         Foreground="{StaticResource SystemChromeHighColor}"
                         Glyph="&#xE76F;"

--- a/Files/ViewModels/Previews/TextPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/TextPreviewViewModel.cs
@@ -37,7 +37,7 @@ namespace Files.ViewModels.Previews
 
         public static async Task<TextPreview> TryLoadAsTextAsync(ListedItem item)
         {
-            if (ExcludedExtensions.Contains(item.FileExtension?.ToLower()) || item.FileSizeBytes > Constants.PreviewPane.TryLoadAsTextSizeLimit)
+            if (ExcludedExtensions.Contains(item.FileExtension?.ToLower()) || item.FileSizeBytes > Constants.PreviewPane.TryLoadAsTextSizeLimit || item.FileSizeBytes == 0)
             {
                 return null;
             }

--- a/Files/ViewModels/Properties/FileProperty.cs
+++ b/Files/ViewModels/Properties/FileProperty.cs
@@ -288,6 +288,7 @@ namespace Files.ViewModels.Properties
             { "Fraction" , input => ((double)input).ToFractions(2000)},
             { "AddF" , input => $"f/{(double)input}"},
             { "AddISO" , input => $"ISO-{(UInt16)input}"},
+            { "RoundDouble" , input => $"{Math.Round((double)input)}"},
         };
     }
 }

--- a/Files/ViewModels/Properties/FileProperty.cs
+++ b/Files/ViewModels/Properties/FileProperty.cs
@@ -1,4 +1,5 @@
 ﻿using Files.Converters;
+using Files.Helpers;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Uwp;
 using Newtonsoft.Json;
@@ -284,6 +285,7 @@ namespace Files.ViewModels.Properties
         {
             { "DivideBy1000", input => (((uint) input)/1000).ToString() },
             { "FormatDuration", input => new TimeSpan(Convert.ToInt64(input)).ToString("mm':'ss")},
+            { "Fraction" , input => ((double)input).ToFractions(2000)}
         };
     }
 }

--- a/Files/ViewModels/Properties/FileProperty.cs
+++ b/Files/ViewModels/Properties/FileProperty.cs
@@ -284,7 +284,7 @@ namespace Files.ViewModels.Properties
         private static readonly Dictionary<string, Func<object, string>> DisplayFuncs = new Dictionary<string, Func<object, string>>()
         {
             { "DivideBy1000", input => (((uint) input)/1000).ToString() },
-            { "FormatDuration", input => new TimeSpan(Convert.ToInt64(input)).ToString("mm':'ss")},
+            { "FormatDuration", input => new TimeSpan(Convert.ToInt64(input)).ToString("hh':'mm':'ss")},
             { "Fraction" , input => ((double)input).ToFractions(2000)}
         };
     }

--- a/Files/ViewModels/Properties/FileProperty.cs
+++ b/Files/ViewModels/Properties/FileProperty.cs
@@ -287,6 +287,7 @@ namespace Files.ViewModels.Properties
             { "FormatDuration", input => new TimeSpan(Convert.ToInt64(input)).ToString("hh':'mm':'ss")},
             { "Fraction" , input => ((double)input).ToFractions(2000)},
             { "AddF" , input => $"f/{(double)input}"},
+            { "AddISO" , input => $"ISO-{(UInt16)input}"},
         };
     }
 }

--- a/Files/ViewModels/Properties/FileProperty.cs
+++ b/Files/ViewModels/Properties/FileProperty.cs
@@ -289,6 +289,7 @@ namespace Files.ViewModels.Properties
             { "AddF" , input => $"f/{(double)input}"},
             { "AddISO" , input => $"ISO-{(UInt16)input}"},
             { "RoundDouble" , input => $"{Math.Round((double)input)}"},
+            { "UnitMM" , input => $"{(double)input} mm"},
         };
     }
 }

--- a/Files/ViewModels/Properties/FileProperty.cs
+++ b/Files/ViewModels/Properties/FileProperty.cs
@@ -285,7 +285,8 @@ namespace Files.ViewModels.Properties
         {
             { "DivideBy1000", input => (((uint) input)/1000).ToString() },
             { "FormatDuration", input => new TimeSpan(Convert.ToInt64(input)).ToString("hh':'mm':'ss")},
-            { "Fraction" , input => ((double)input).ToFractions(2000)}
+            { "Fraction" , input => ((double)input).ToFractions(2000)},
+            { "AddF" , input => $"f/{(double)input}"},
         };
     }
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
- Fixes an issue I noticed where empty files would be loaded as text files, even if they were not text files. 
- Moves the date taken property down with the date modified and date created property.
- Displays the exposure property as a fraction
- Fix alignment of gripper icon in horizontal layout
- Show exposure time as fraction instead of as a decimal 
- Closes #4444

**Details of Changes**
- Don't run ```TryLoadAsText``` on empty files, as it will always think the file is a text file, instead just show the thumbnail.
- Move "date taken" below date modified and date created
- Show exposure time as a fraction instead of as a decimal, and add helper extensions to convert doubles to a fraction (the fractions are inaccurate, I think the storage file properties API is giving inaccurate values, for example I keep seeing 59 fps when it should be 60)
- Added hours to duration prop format
- Fix gripper alignment being off when in horizontal layout
- Round image resolution

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Empty pptx files before and after: 
![image](https://user-images.githubusercontent.com/59544401/113451860-b7fc5e00-93b7-11eb-9d46-c8bd6bc24914.png)
![image](https://user-images.githubusercontent.com/59544401/113452237-75875100-93b8-11eb-8fb0-f884ecba27b0.png)

Duration format:
![image](https://user-images.githubusercontent.com/59544401/113458497-4b895b00-93c7-11eb-8582-271f4ed685c1.png)
