### PR TITLE
Fix for NullReferenceException in AddSelectedItem that could occur when quickly switching directories

### DIFF
--- a/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -135,7 +135,7 @@ namespace Files.Views.LayoutModes
 
         protected override void AddSelectedItem(ListedItem item)
         {
-            FileList.SelectedItems.Add(item);
+            FileList?.SelectedItems.Add(item);
         }
 
         public override void InvertSelection()

--- a/Files/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -182,7 +182,7 @@ namespace Files.Views.LayoutModes
 
         protected override void AddSelectedItem(ListedItem item)
         {
-            FileList.SelectedItems.Add(item);
+            FileList?.SelectedItems.Add(item);
         }
 
         public override void InvertSelection()

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -179,7 +179,7 @@ namespace Files.Views.LayoutModes
 
         protected override void AddSelectedItem(ListedItem item)
         {
-            if (((IList<ListedItem>)AllView.ItemsSource).Contains(item))
+            if (((IList<ListedItem>)AllView?.ItemsSource)?.Contains(item) ?? false)
             {
                 AllView.SelectedItems.Add(item);
             }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -123,7 +123,7 @@ namespace Files.Views.LayoutModes
 
         protected override void AddSelectedItem(ListedItem item)
         {
-            if (FileList.Items.Contains(item))
+            if (FileList?.Items.Contains(item) ?? false)
             {
                 FileList.SelectedItems.Add(item);
             }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Resolves a NullReferenceException that could be thrown when quickly switching through several directories.

```
2021-04-02 21:02:42.8482|ERROR|.ctor|Object reference not set to an instance of an object.|System.NullReferenceException: Object reference not set to an instance of an object.
   at Files.Views.LayoutModes.GenericFileBrowser.AddSelectedItem(ListedItem) + 0x5a
   at Files.BaseLayout.SetSelectedItemOnUi(ListedItem) + 0x25
   at Files.Views.ModernShellPage.FilesystemViewModel_ItemLoadStatusChanged(Object, ItemLoadStatusChangedEventArgs) + 0x403
   at Microsoft.Toolkit.Uwp.UI.Controls.InAppNotificationOpeningEventHandler.Invoke(Object, InAppNotificationOpeningEventArgs) + 0x2e
   at Files.ViewModels.ItemViewModel.<RapidAddItemsToCollectionAsync>d__104.MoveNext() + 0x3eb
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x21
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.<>c.<ThrowAsync>b__7_0(Object) + 0x1e
   at System.Action`1.Invoke(T) + 0x28
   at System.Threading.WinRTSynchronizationContext.Invoker.InvokeCore() + 0x33
   at System.Runtime.InteropServices.McgMarshal.ThrowOnExternalCallFailed(Int32, RuntimeTypeHandle) + 0x21
   at __Interop.ComCallHelpers.Call(__ComObject, RuntimeTypeHandle, Int32) + 0xb8
   at __Interop.ForwardComStubs.Stub_19[TThis](__ComObject, Int32) + 0x24
   at Microsoft.AppCenter.Utils.ApplicationLifecycleHelper.<.ctor>b__17_1(Object, UnhandledErrorDetectedEventArgs) + 0x3d
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x21
   at Microsoft.AppCenter.Utils.ApplicationLifecycleHelper.<.ctor>b__17_1(Object, UnhandledErrorDetectedEventArgs) + 0x75
   at System.EventHandler`1.Invoke(Object, TEventArgs) + 0x2e
   at __Interop.Intrinsics.HasThisCall__24[TArg0](Object, IntPtr, Object, TArg0) + 0x36
   at Files!<BaseAddress>+0x15b56a0
```

**Details of Changes**
Add details of changes here.
- Added null checks for the file lists in ```AddSelectedItem```

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
