### PR TITLE
Fixed MultiSelect DoubleTap (#4437)

### DIFF
--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -476,7 +476,10 @@ namespace Files.Views.LayoutModes
             // Skip opening selected items if the double tap doesn't capture an item
             if ((e.OriginalSource as FrameworkElement)?.DataContext is ListedItem && !AppSettings.OpenItemsWithOneclick)
             {
-                NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                if (!InteractionViewModel.MultiselectEnabled)
+                {
+                    NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                }
             }
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
In MultiSelect mode, a double tap/click on a item opens the item.
The expected behavior is to click twice on the selection checkbox.
#4437

**Details of Changes**
Add a test in the DoubleTap event for to do nothing in multiselect mode.
