### PR TITLE
Overhaul for widgets codebase

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -290,11 +290,14 @@
     <Compile Include="UserControls\Widgets\Bundles.xaml.cs">
       <DependentUpon>Bundles.xaml</DependentUpon>
     </Compile>
+    <Compile Include="UserControls\Widgets\WidgetsListControl.xaml.cs">
+      <DependentUpon>WidgetsListControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ViewModels\AdaptiveSidebarViewModel.cs" />
     <Compile Include="ViewModels\BaseJsonSettingsViewModel.cs" />
-    <Compile Include="ViewModels\Bundles\BundleContainerViewModel.cs" />
-    <Compile Include="ViewModels\Bundles\BundleItemViewModel.cs" />
-    <Compile Include="ViewModels\Bundles\BundlesViewModel.cs" />
+    <Compile Include="ViewModels\Widgets\Bundles\BundleContainerViewModel.cs" />
+    <Compile Include="ViewModels\Widgets\Bundles\BundleItemViewModel.cs" />
+    <Compile Include="ViewModels\Widgets\Bundles\BundlesViewModel.cs" />
     <Compile Include="ViewModels\Dialogs\DynamicDialogViewModel.cs" />
     <Compile Include="ViewModels\FolderSettingsViewModel.cs" />
     <Compile Include="ViewModels\MainPageViewModel.cs" />
@@ -455,6 +458,8 @@
     <Compile Include="ViewModels\SettingsViewModels\OnStartupViewModel.cs" />
     <Compile Include="ViewModels\SettingsViewModels\PreferencesViewModel.cs" />
     <Compile Include="ViewModels\SettingsViewModels\WidgetsViewModel.cs" />
+    <Compile Include="ViewModels\Widgets\IWidgetItemModel.cs" />
+    <Compile Include="ViewModels\Widgets\WidgetsListControlViewModel.cs" />
     <Compile Include="Views\ColumnParam.cs" />
     <Compile Include="Views\ColumnShellPage.xaml.cs">
       <DependentUpon>ColumnShellPage.xaml</DependentUpon>
@@ -915,6 +920,10 @@
     <Page Include="UserControls\Widgets\RecentFiles.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UserControls\Widgets\WidgetsListControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\ColumnShellPage.xaml">
       <SubType>Designer</SubType>

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Helpers\NavigationHelpers.cs" />
     <Compile Include="Helpers\UIHelpers.cs" />
     <Compile Include="Helpers\WallpaperHelpers.cs" />
+    <Compile Include="Helpers\WidgetsHelpers.cs" />
     <Compile Include="Helpers\Win32Helpers.cs" />
     <Compile Include="UserControls\RestartControl.xaml.cs">
       <DependentUpon>RestartControl.xaml</DependentUpon>

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -459,6 +459,7 @@
     <Compile Include="ViewModels\SettingsViewModels\OnStartupViewModel.cs" />
     <Compile Include="ViewModels\SettingsViewModels\PreferencesViewModel.cs" />
     <Compile Include="ViewModels\SettingsViewModels\WidgetsViewModel.cs" />
+    <Compile Include="ViewModels\Widgets\ICustomWidgetItemModel.cs" />
     <Compile Include="ViewModels\Widgets\IWidgetItemModel.cs" />
     <Compile Include="ViewModels\Widgets\WidgetsListControlViewModel.cs" />
     <Compile Include="Views\ColumnParam.cs" />

--- a/Files/Helpers/WidgetsHelpers.cs
+++ b/Files/Helpers/WidgetsHelpers.cs
@@ -1,0 +1,60 @@
+﻿using Files.UserControls.Widgets;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.Helpers
+{
+    public static class WidgetsHelpers
+    {
+        public static LibraryCards GetLibraryCards()
+        {
+            if (App.AppSettings.ShowLibraryCardsWidget)
+            {
+                return new LibraryCards();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static DrivesWidget GetDrivesWidget()
+        {
+            if (App.AppSettings.ShowDrivesWidget)
+            {
+                return new DrivesWidget();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static Bundles GetBundles()
+        {
+            if (App.AppSettings.ShowBundlesWidget)
+            {
+                return new Bundles();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public static RecentFiles GetRecentFiles()
+        {
+            if (App.AppSettings.ShowBundlesWidget)
+            {
+                return new RecentFiles();
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Files/Helpers/WidgetsHelpers.cs
+++ b/Files/Helpers/WidgetsHelpers.cs
@@ -18,6 +18,7 @@ namespace Files.Helpers
             {
                 // Remove the widget
                 widgetsViewModel.RemoveWidget<TWidget>();
+                return default(TWidget);
             }
 
             return defaultValue;

--- a/Files/Helpers/WidgetsHelpers.cs
+++ b/Files/Helpers/WidgetsHelpers.cs
@@ -7,9 +7,17 @@ namespace Files.Helpers
     {
         public static TWidget TryGetWidget<TWidget>(WidgetsListControlViewModel widgetsViewModel) where TWidget : IWidgetItemModel, new()
         {
-            if (widgetsViewModel.CanAddWidget(typeof(TWidget).Name) && TryGetIsWidgetSettingEnabled<TWidget>())
+            bool canAddWidget = widgetsViewModel.CanAddWidget(typeof(TWidget).Name);
+            bool isWidgetSettingEnabled = TryGetIsWidgetSettingEnabled<TWidget>();
+
+            if (canAddWidget && isWidgetSettingEnabled)
             {
                 return new TWidget();
+            }
+            else if (!canAddWidget && !isWidgetSettingEnabled) // The widgets exists but the setting has been disabled for it
+            {
+                // Remove the widget
+                widgetsViewModel.RemoveWidget<TWidget>();
             }
 
             return default(TWidget);

--- a/Files/Helpers/WidgetsHelpers.cs
+++ b/Files/Helpers/WidgetsHelpers.cs
@@ -1,60 +1,46 @@
 ﻿using Files.UserControls.Widgets;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Files.ViewModels.Widgets;
 
 namespace Files.Helpers
 {
     public static class WidgetsHelpers
     {
-        public static LibraryCards GetLibraryCards()
+        public static TWidget TryGetWidget<TWidget>(WidgetsListControlViewModel widgetsViewModel) where TWidget : IWidgetItemModel, new()
         {
-            if (App.AppSettings.ShowLibraryCardsWidget)
+            if (widgetsViewModel.CanAddWidget(nameof(TWidget)) && TryGetIsWidgetSettingEnabled<TWidget>())
             {
-                return new LibraryCards();
+                return new TWidget();
             }
-            else
-            {
-                return null;
-            }
+
+            return default(TWidget);
         }
 
-        public static DrivesWidget GetDrivesWidget()
+        public static bool TryGetIsWidgetSettingEnabled<TWidget>() where TWidget : IWidgetItemModel, new()
         {
-            if (App.AppSettings.ShowDrivesWidget)
+            if (typeof(TWidget) == typeof(LibraryCards))
             {
-                return new DrivesWidget();
+                return App.AppSettings.ShowLibraryCardsWidget;
             }
-            else
+            if (typeof(TWidget) == typeof(DrivesWidget))
             {
-                return null;
+                return App.AppSettings.ShowDrivesWidget;
             }
-        }
+            if (typeof(TWidget) == typeof(Bundles))
+            {
+                return App.AppSettings.ShowBundlesWidget;
+            }
+            if (typeof(TWidget) == typeof(RecentFiles))
+            {
+                return App.AppSettings.ShowRecentFilesWidget;
+            }
+            // A custom widget it is - TWidget implements ICustomWidgetItemModel
+            if (typeof(ICustomWidgetItemModel).IsAssignableFrom(typeof(TWidget)))
+            {
+                // Return true for custom widgets - they're always enabled
+                return true;
+            }
 
-        public static Bundles GetBundles()
-        {
-            if (App.AppSettings.ShowBundlesWidget)
-            {
-                return new Bundles();
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        public static RecentFiles GetRecentFiles()
-        {
-            if (App.AppSettings.ShowBundlesWidget)
-            {
-                return new RecentFiles();
-            }
-            else
-            {
-                return null;
-            }
+            return false;
         }
     }
 }

--- a/Files/Helpers/WidgetsHelpers.cs
+++ b/Files/Helpers/WidgetsHelpers.cs
@@ -7,7 +7,7 @@ namespace Files.Helpers
     {
         public static TWidget TryGetWidget<TWidget>(WidgetsListControlViewModel widgetsViewModel) where TWidget : IWidgetItemModel, new()
         {
-            if (widgetsViewModel.CanAddWidget(nameof(TWidget)) && TryGetIsWidgetSettingEnabled<TWidget>())
+            if (widgetsViewModel.CanAddWidget(typeof(TWidget).Name) && TryGetIsWidgetSettingEnabled<TWidget>())
             {
                 return new TWidget();
             }
@@ -15,7 +15,7 @@ namespace Files.Helpers
             return default(TWidget);
         }
 
-        public static bool TryGetIsWidgetSettingEnabled<TWidget>() where TWidget : IWidgetItemModel, new()
+        public static bool TryGetIsWidgetSettingEnabled<TWidget>() where TWidget : IWidgetItemModel
         {
             if (typeof(TWidget) == typeof(LibraryCards))
             {

--- a/Files/Helpers/WidgetsHelpers.cs
+++ b/Files/Helpers/WidgetsHelpers.cs
@@ -5,7 +5,7 @@ namespace Files.Helpers
 {
     public static class WidgetsHelpers
     {
-        public static TWidget TryGetWidget<TWidget>(WidgetsListControlViewModel widgetsViewModel) where TWidget : IWidgetItemModel, new()
+        public static TWidget TryGetWidget<TWidget>(WidgetsListControlViewModel widgetsViewModel, TWidget defaultValue = default(TWidget)) where TWidget : IWidgetItemModel, new()
         {
             bool canAddWidget = widgetsViewModel.CanAddWidget(typeof(TWidget).Name);
             bool isWidgetSettingEnabled = TryGetIsWidgetSettingEnabled<TWidget>();
@@ -20,7 +20,7 @@ namespace Files.Helpers
                 widgetsViewModel.RemoveWidget<TWidget>();
             }
 
-            return default(TWidget);
+            return defaultValue;
         }
 
         public static bool TryGetIsWidgetSettingEnabled<TWidget>() where TWidget : IWidgetItemModel

--- a/Files/UserControls/Widgets/Bundles.xaml.cs
+++ b/Files/UserControls/Widgets/Bundles.xaml.cs
@@ -1,9 +1,7 @@
-﻿using Files.ViewModels.Widgets;
-using Files.ViewModels.Widgets.Bundles;
-using System;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
+﻿using System;
 using Windows.UI.Xaml.Controls;
+using Files.ViewModels.Widgets.Bundles;
+using Files.ViewModels.Widgets;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
@@ -17,7 +15,7 @@ namespace Files.UserControls.Widgets
             private set => DataContext = value;
         }
 
-        public Control WidgetContent => this;
+        public string WidgetName => nameof(Bundles);
 
         public Bundles()
         {

--- a/Files/UserControls/Widgets/Bundles.xaml.cs
+++ b/Files/UserControls/Widgets/Bundles.xaml.cs
@@ -1,18 +1,23 @@
-﻿using Files.ViewModels.Bundles;
+﻿using Files.ViewModels.Widgets;
+using Files.ViewModels.Widgets.Bundles;
 using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using Windows.UI.Xaml.Controls;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace Files.UserControls.Widgets
 {
-    public sealed partial class Bundles : UserControl, IDisposable
+    public sealed partial class Bundles : UserControl, IWidgetItemModel, IDisposable
     {
         public BundlesViewModel ViewModel
         {
             get => (BundlesViewModel)DataContext;
             private set => DataContext = value;
         }
+
+        public Control WidgetContent => this;
 
         public Bundles()
         {

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -118,19 +118,9 @@ namespace Files.UserControls.Widgets
             visual.Scale = new Vector3(1);
         }
 
-        private bool showMultiPaneControls;
-
         public bool ShowMultiPaneControls
         {
-            get => showMultiPaneControls;
-            set
-            {
-                if (value != showMultiPaneControls)
-                {
-                    showMultiPaneControls = value;
-                    NotifyPropertyChanged(nameof(ShowMultiPaneControls));
-                }
-            }
+            get => AppInstance.IsMultiPaneEnabled && AppInstance.IsPageMainPane;
         }
 
         private void OpenInNewPane_Click(object sender, RoutedEventArgs e)

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -6,6 +6,7 @@ using Files.ViewModels.Widgets;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -171,7 +172,7 @@ namespace Files.UserControls.Widgets
 
         public void Dispose()
         {
-            throw new NotImplementedException();
+            Debugger.Break();
         }
     }
 }

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -2,6 +2,7 @@
 using Files.Helpers;
 using Files.Interacts;
 using Files.ViewModels;
+using Files.ViewModels.Widgets;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -32,6 +33,7 @@ namespace Files.UserControls.Widgets
 
         public static ObservableCollection<INavigationControlItem> ItemsAdded = new ObservableCollection<INavigationControlItem>();
 
+
         private IShellPage associatedInstance;
 
         public IShellPage AppInstance
@@ -42,7 +44,6 @@ namespace Files.UserControls.Widgets
                 if (value != associatedInstance)
                 {
                     associatedInstance = value;
-                    NotifyPropertyChanged(nameof(AppInstance));
                 }
             }
         }

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -33,7 +33,6 @@ namespace Files.UserControls.Widgets
 
         public static ObservableCollection<INavigationControlItem> ItemsAdded = new ObservableCollection<INavigationControlItem>();
 
-
         private IShellPage associatedInstance;
 
         public IShellPage AppInstance
@@ -44,6 +43,7 @@ namespace Files.UserControls.Widgets
                 if (value != associatedInstance)
                 {
                     associatedInstance = value;
+                    NotifyPropertyChanged(nameof(AppInstance));
                 }
             }
         }

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -17,7 +17,7 @@ using Windows.UI.Xaml.Hosting;
 
 namespace Files.UserControls.Widgets
 {
-    public sealed partial class DrivesWidget : UserControl, INotifyPropertyChanged
+    public sealed partial class DrivesWidget : UserControl, IWidgetItemModel, INotifyPropertyChanged
     {
         public SettingsViewModel AppSettings => App.AppSettings;
 
@@ -47,6 +47,8 @@ namespace Files.UserControls.Widgets
                 }
             }
         }
+
+        public string WidgetName => nameof(DrivesWidget);
 
         public DrivesWidget()
         {

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -168,5 +168,10 @@ namespace Files.UserControls.Widgets
         {
             await Launcher.LaunchUriAsync(new Uri("ms-settings:storagesense"));
         }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Files/UserControls/Widgets/LibraryCards.xaml.cs
+++ b/Files/UserControls/Widgets/LibraryCards.xaml.cs
@@ -11,6 +11,7 @@ using Microsoft.Toolkit.Uwp;
 using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -309,7 +310,7 @@ namespace Files.UserControls.Widgets
 
         public void Dispose()
         {
-            throw new NotImplementedException();
+            Debugger.Break();
         }
     }
 

--- a/Files/UserControls/Widgets/LibraryCards.xaml.cs
+++ b/Files/UserControls/Widgets/LibraryCards.xaml.cs
@@ -306,6 +306,11 @@ namespace Files.UserControls.Widgets
                 await dialog.ShowAsync();
             }
         }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class LibraryCardInvokedEventArgs : EventArgs

--- a/Files/UserControls/Widgets/LibraryCards.xaml.cs
+++ b/Files/UserControls/Widgets/LibraryCards.xaml.cs
@@ -42,6 +42,8 @@ namespace Files.UserControls.Widgets
 
         public event LibraryCardDeleteInvokedEventHandler LibraryCardDeleteInvoked;
 
+        public event EventHandler LibraryCardShowMultiPaneControlsInvoked;
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         public BulkConcurrentObservableCollection<LibraryCardItem> ItemsAdded = new BulkConcurrentObservableCollection<LibraryCardItem>();
@@ -157,7 +159,12 @@ namespace Files.UserControls.Widgets
 
         public bool ShowMultiPaneControls
         {
-            get => showMultiPaneControls;
+            get
+            {
+                LibraryCardShowMultiPaneControlsInvoked?.Invoke(this, EventArgs.Empty);
+
+                return showMultiPaneControls;
+            }
             set
             {
                 if (value != showMultiPaneControls)

--- a/Files/UserControls/Widgets/LibraryCards.xaml.cs
+++ b/Files/UserControls/Widgets/LibraryCards.xaml.cs
@@ -5,6 +5,7 @@ using Files.Helpers;
 using Files.Interacts;
 using Files.ViewModels;
 using Files.ViewModels.Dialogs;
+using Files.ViewModels.Widgets;
 using Microsoft.Toolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp;
 using System;
@@ -21,7 +22,7 @@ using Windows.UI.Xaml.Media.Imaging;
 
 namespace Files.UserControls.Widgets
 {
-    public sealed partial class LibraryCards : UserControl, INotifyPropertyChanged
+    public sealed partial class LibraryCards : UserControl, IWidgetItemModel, INotifyPropertyChanged
     {
         public SettingsViewModel AppSettings => App.AppSettings;
 
@@ -44,6 +45,8 @@ namespace Files.UserControls.Widgets
         public event PropertyChangedEventHandler PropertyChanged;
 
         public BulkConcurrentObservableCollection<LibraryCardItem> ItemsAdded = new BulkConcurrentObservableCollection<LibraryCardItem>();
+
+        public string WidgetName => nameof(LibraryCards);
 
         public RelayCommand<LibraryCardItem> LibraryCardClicked => new RelayCommand<LibraryCardItem>(item =>
         {

--- a/Files/UserControls/Widgets/RecentFiles.xaml.cs
+++ b/Files/UserControls/Widgets/RecentFiles.xaml.cs
@@ -5,6 +5,7 @@ using Files.ViewModels.Widgets;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -212,7 +213,7 @@ namespace Files.UserControls.Widgets
 
         public void Dispose()
         {
-            throw new NotImplementedException();
+            Debugger.Break();
         }
     }
 

--- a/Files/UserControls/Widgets/RecentFiles.xaml.cs
+++ b/Files/UserControls/Widgets/RecentFiles.xaml.cs
@@ -209,6 +209,11 @@ namespace Files.UserControls.Widgets
             mru.Clear();
             Empty.Visibility = Visibility.Visible;
         }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public class RecentItem

--- a/Files/UserControls/Widgets/RecentFiles.xaml.cs
+++ b/Files/UserControls/Widgets/RecentFiles.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Files.Enums;
 using Files.Filesystem;
 using Files.ViewModels;
+using Files.ViewModels.Widgets;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -15,7 +16,7 @@ using Windows.UI.Xaml.Media.Imaging;
 
 namespace Files.UserControls.Widgets
 {
-    public sealed partial class RecentFiles : UserControl
+    public sealed partial class RecentFiles : UserControl, IWidgetItemModel
     {
         public delegate void RecentFilesOpenLocationInvokedEventHandler(object sender, PathNavigationEventArgs e);
 
@@ -28,6 +29,8 @@ namespace Files.UserControls.Widgets
         private ObservableCollection<RecentItem> recentItemsCollection = new ObservableCollection<RecentItem>();
         private EmptyRecentsText Empty { get; set; } = new EmptyRecentsText();
         public SettingsViewModel AppSettings => App.AppSettings;
+
+        public string WidgetName => nameof(RecentFiles);
 
         public RecentFiles()
         {

--- a/Files/UserControls/Widgets/WidgetsListControl.xaml
+++ b/Files/UserControls/Widgets/WidgetsListControl.xaml
@@ -14,11 +14,13 @@
         <Grid>
             <GridView
                 SelectionMode="None"
-                ItemsSource="{Binding Widgets, Mode=OneWay}">
+                ItemsSource="{x:Bind ViewModel.Widgets, Mode=OneWay}">
 
                 <!--  Remove Reveal Highlight Effect  -->
                 <GridView.ItemContainerStyle>
                     <Style TargetType="GridViewItem">
+                        <!--  Spacing  -->
+                        <Setter Property="Margin" Value="0,0,0,24" />
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate TargetType="GridViewItem">
@@ -32,12 +34,6 @@
                         </Setter>
                     </Style>
                 </GridView.ItemContainerStyle>
-
-                <GridView.ItemTemplate>
-                    <DataTemplate>
-                        <ContentControl Content="{Binding WidgetContent, Mode=OneWay}"/>
-                    </DataTemplate>
-                </GridView.ItemTemplate>
             </GridView>
         </Grid>
     </Border>

--- a/Files/UserControls/Widgets/WidgetsListControl.xaml
+++ b/Files/UserControls/Widgets/WidgetsListControl.xaml
@@ -35,9 +35,7 @@
 
                 <GridView.ItemTemplate>
                     <DataTemplate>
-                        <Grid>
-                            <ContentControl Content="{Binding WidgetContent, Mode=OneWay}"/>
-                        </Grid>
+                        <ContentControl Content="{Binding WidgetContent, Mode=OneWay}"/>
                     </DataTemplate>
                 </GridView.ItemTemplate>
             </GridView>

--- a/Files/UserControls/Widgets/WidgetsListControl.xaml
+++ b/Files/UserControls/Widgets/WidgetsListControl.xaml
@@ -26,6 +26,8 @@
                                 <ControlTemplate TargetType="GridViewItem">
                                     <ListViewItemPresenter
                                         x:Name="Root"
+                                        HorizontalContentAlignment="Stretch"
+                                        VerticalContentAlignment="Stretch"
                                         RevealBackground="{ThemeResource GridViewItemRevealBackground}"
                                         RevealBorderBrush="{ThemeResource GridViewItemRevealBorderBrush}"
                                         RevealBorderThickness="0" />

--- a/Files/UserControls/Widgets/WidgetsListControl.xaml
+++ b/Files/UserControls/Widgets/WidgetsListControl.xaml
@@ -12,18 +12,18 @@
 
     <Border>
         <Grid>
-            <GridView
+            <ListView
                 SelectionMode="None"
                 ItemsSource="{x:Bind ViewModel.Widgets, Mode=OneWay}">
 
                 <!--  Remove Reveal Highlight Effect  -->
-                <GridView.ItemContainerStyle>
-                    <Style TargetType="GridViewItem">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
                         <!--  Spacing  -->
                         <Setter Property="Margin" Value="0,0,0,24" />
                         <Setter Property="Template">
                             <Setter.Value>
-                                <ControlTemplate TargetType="GridViewItem">
+                                <ControlTemplate TargetType="ListViewItem">
                                     <ListViewItemPresenter
                                         x:Name="Root"
                                         HorizontalContentAlignment="Stretch"
@@ -35,8 +35,8 @@
                             </Setter.Value>
                         </Setter>
                     </Style>
-                </GridView.ItemContainerStyle>
-            </GridView>
+                </ListView.ItemContainerStyle>
+            </ListView>
         </Grid>
     </Border>
 </UserControl>

--- a/Files/UserControls/Widgets/WidgetsListControl.xaml
+++ b/Files/UserControls/Widgets/WidgetsListControl.xaml
@@ -1,0 +1,46 @@
+﻿<UserControl
+    x:Class="Files.UserControls.Widgets.WidgetsListControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Files.UserControls.Widgets"
+    xmlns:vm="using:Files.ViewModels.Widgets"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Border>
+        <Grid>
+            <GridView
+                SelectionMode="None"
+                ItemsSource="{Binding Widgets, Mode=OneWay}">
+
+                <!--  Remove Reveal Highlight Effect  -->
+                <GridView.ItemContainerStyle>
+                    <Style TargetType="GridViewItem">
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="GridViewItem">
+                                    <ListViewItemPresenter
+                                        x:Name="Root"
+                                        RevealBackground="{ThemeResource GridViewItemRevealBackground}"
+                                        RevealBorderBrush="{ThemeResource GridViewItemRevealBorderBrush}"
+                                        RevealBorderThickness="0" />
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </GridView.ItemContainerStyle>
+
+                <GridView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <ContentControl Content="{Binding WidgetContent, Mode=OneWay}"/>
+                        </Grid>
+                    </DataTemplate>
+                </GridView.ItemTemplate>
+            </GridView>
+        </Grid>
+    </Border>
+</UserControl>

--- a/Files/UserControls/Widgets/WidgetsListControl.xaml.cs
+++ b/Files/UserControls/Widgets/WidgetsListControl.xaml.cs
@@ -1,0 +1,23 @@
+﻿using Windows.UI.Xaml.Controls;
+using Files.ViewModels.Widgets;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Files.UserControls.Widgets
+{
+    public sealed partial class WidgetsListControl : UserControl
+    {
+        public WidgetsListControlViewModel ViewModel
+        {
+            get => (WidgetsListControlViewModel)DataContext;
+            set => DataContext = value;
+        }
+
+        public WidgetsListControl()
+        {
+            this.InitializeComponent();
+
+            this.ViewModel = new WidgetsListControlViewModel();
+        }
+    }
+}

--- a/Files/UserControls/Widgets/WidgetsListControl.xaml.cs
+++ b/Files/UserControls/Widgets/WidgetsListControl.xaml.cs
@@ -1,11 +1,12 @@
 ﻿using Windows.UI.Xaml.Controls;
 using Files.ViewModels.Widgets;
+using System;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace Files.UserControls.Widgets
 {
-    public sealed partial class WidgetsListControl : UserControl
+    public sealed partial class WidgetsListControl : UserControl, IDisposable
     {
         public WidgetsListControlViewModel ViewModel
         {
@@ -18,6 +19,11 @@ namespace Files.UserControls.Widgets
             this.InitializeComponent();
 
             this.ViewModel = new WidgetsListControlViewModel();
+        }
+
+        public void Dispose()
+        {
+            ViewModel?.Dispose();
         }
     }
 }

--- a/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
@@ -19,7 +19,7 @@ using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Files.ViewModels.Bundles
+namespace Files.ViewModels.Widgets.Bundles
 {
     /// <summary>
     /// Bundle's contents view model

--- a/Files/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
@@ -16,7 +16,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 
-namespace Files.ViewModels.Bundles
+namespace Files.ViewModels.Widgets.Bundles
 {
     public class BundleItemViewModel : ObservableObject, IDisposable
     {

--- a/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
@@ -21,7 +21,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 
-namespace Files.ViewModels.Bundles
+namespace Files.ViewModels.Widgets.Bundles
 {
     /// <summary>
     /// Bundles list View Model

--- a/Files/ViewModels/Widgets/ICustomWidgetItemModel.cs
+++ b/Files/ViewModels/Widgets/ICustomWidgetItemModel.cs
@@ -1,0 +1,9 @@
+﻿namespace Files.ViewModels.Widgets
+{
+    /// <summary>
+    /// This interface is used to mark widgets that are not standard to Files
+    /// </summary>
+    public interface ICustomWidgetItemModel : IWidgetItemModel
+    {
+    }
+}

--- a/Files/ViewModels/Widgets/ICustomWidgetItemModel.cs
+++ b/Files/ViewModels/Widgets/ICustomWidgetItemModel.cs
@@ -1,7 +1,7 @@
 ﻿namespace Files.ViewModels.Widgets
 {
     /// <summary>
-    /// This interface is used to mark widgets that are not standard to Files
+    /// This interface is used to mark widgets that are not standard to Files i.e. custom widgets
     /// </summary>
     public interface ICustomWidgetItemModel : IWidgetItemModel
     {

--- a/Files/ViewModels/Widgets/IWidgetItemModel.cs
+++ b/Files/ViewModels/Widgets/IWidgetItemModel.cs
@@ -1,9 +1,13 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Files.ViewModels.Widgets
 {
     public interface IWidgetItemModel
     {
-        Control WidgetContent { get; }
+        string WidgetName { get; }
     }
 }

--- a/Files/ViewModels/Widgets/IWidgetItemModel.cs
+++ b/Files/ViewModels/Widgets/IWidgetItemModel.cs
@@ -1,0 +1,9 @@
+﻿using Windows.UI.Xaml.Controls;
+
+namespace Files.ViewModels.Widgets
+{
+    public interface IWidgetItemModel
+    {
+        Control WidgetContent { get; }
+    }
+}

--- a/Files/ViewModels/Widgets/IWidgetItemModel.cs
+++ b/Files/ViewModels/Widgets/IWidgetItemModel.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Files.ViewModels.Widgets
 {
-    public interface IWidgetItemModel
+    public interface IWidgetItemModel : IDisposable
     {
         string WidgetName { get; }
     }

--- a/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
+++ b/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
@@ -12,6 +12,11 @@ namespace Files.ViewModels.Widgets
 
         public bool AddWidget(Control widgetModel)
         {
+            return InsertWidget(widgetModel, Widgets.Count + 1);
+        }
+
+        public bool InsertWidget(Control widgetModel, int atIndex)
+        {
             // The widget must not be null and must implement IWidgetItemModel
             if (!(widgetModel is IWidgetItemModel widgetItemModel))
             {
@@ -24,7 +29,15 @@ namespace Files.ViewModels.Widgets
                 return false;
             }
 
-            Widgets.Add(widgetModel);
+            if (atIndex > Widgets.Count)
+            {
+                Widgets.Add(widgetModel);
+            }
+            else
+            {
+                Widgets.Insert(atIndex, widgetModel);
+            }
+
             return true;
         }
 

--- a/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
+++ b/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
@@ -19,13 +19,18 @@ namespace Files.ViewModels.Widgets
             }
 
             // Don't add existing ones!
-            if (Widgets.Any((item) => (item as IWidgetItemModel).WidgetName == widgetItemModel.WidgetName))
+            if (!CanAddWidget(widgetItemModel.WidgetName))
             {
                 return false;
             }
 
             Widgets.Add(widgetModel);
             return true;
+        }
+
+        public bool CanAddWidget(string widgetName)
+        {
+            return !(Widgets.Any((item) => (item as IWidgetItemModel).WidgetName == widgetName));
         }
 
         public void RemoveWidget(Control widgetModel)

--- a/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
+++ b/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
@@ -1,21 +1,24 @@
 ﻿using Microsoft.Toolkit.Mvvm.ComponentModel;
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.UI.Xaml.Controls;
 
 namespace Files.ViewModels.Widgets
 {
     public class WidgetsListControlViewModel : ObservableObject
     {
-        public ObservableCollection<IWidgetItemModel> Widgets { get; private set; } = new ObservableCollection<IWidgetItemModel>();
+        public ObservableCollection<Control> Widgets { get; private set; } = new ObservableCollection<Control>();
 
-        public bool AddWidget(IWidgetItemModel widgetModel)
+        public bool AddWidget(Control widgetModel)
         {
-            if (widgetModel == null)
+            // The widget must not be null and must implement IWidgetItemModel
+            if (!(widgetModel is IWidgetItemModel widgetItemModel))
+            {
+                return false;
+            }
+
+            if (Widgets.Any((item) => (item as IWidgetItemModel).WidgetName == widgetItemModel.WidgetName))
             {
                 return false;
             }
@@ -24,12 +27,14 @@ namespace Files.ViewModels.Widgets
             return true;
         }
 
-        public bool RemoveWidget(IWidgetItemModel widgetModel)
+        public void RemoveWidget(Control widgetModel)
         {
-            return Widgets.Remove(widgetModel);
+            int indexToRemove = Widgets.IndexOf(widgetModel);
+            (Widgets[indexToRemove] as IDisposable)?.Dispose();
+            Widgets.RemoveAt(indexToRemove);
         }
 
-        public void ReorderWidget(IWidgetItemModel widgetModel, int place)
+        public void ReorderWidget(Control widgetModel, int place)
         {
             int widgetIndex = Widgets.IndexOf(widgetModel);
             Widgets.Move(widgetIndex, place);

--- a/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
+++ b/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Toolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+
+namespace Files.ViewModels.Widgets
+{
+    public class WidgetsListControlViewModel : ObservableObject
+    {
+        public ObservableCollection<IWidgetItemModel> Widgets { get; private set; } = new ObservableCollection<IWidgetItemModel>();
+
+        public bool AddWidget(IWidgetItemModel widgetModel)
+        {
+            if (widgetModel == null)
+            {
+                return false;
+            }
+
+            Widgets.Add(widgetModel);
+            return true;
+        }
+
+        public bool RemoveWidget(IWidgetItemModel widgetModel)
+        {
+            return Widgets.Remove(widgetModel);
+        }
+
+        public void ReorderWidget(IWidgetItemModel widgetModel, int place)
+        {
+            int widgetIndex = Widgets.IndexOf(widgetModel);
+            Widgets.Move(widgetIndex, place);
+        }
+    }
+}

--- a/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
+++ b/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
@@ -40,6 +40,28 @@ namespace Files.ViewModels.Widgets
             Widgets.RemoveAt(indexToRemove);
         }
 
+        public void RemoveWidget<TWidget>() where TWidget : IWidgetItemModel
+        {
+            int indexToRemove = -1;
+
+            for (int i = 0; i < Widgets.Count; i++)
+            {
+                if (typeof(TWidget).IsAssignableFrom(Widgets[i].GetType()))
+                {
+                    // Found matching types
+                    indexToRemove = i;
+                    break;
+                }
+            }
+
+            if (indexToRemove == -1)
+            {
+                return;
+            }
+
+            RemoveWidget(Widgets[indexToRemove]);
+        }
+
         public void ReorderWidget(Control widgetModel, int place)
         {
             int widgetIndex = Widgets.IndexOf(widgetModel);

--- a/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
+++ b/Files/ViewModels/Widgets/WidgetsListControlViewModel.cs
@@ -6,7 +6,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Files.ViewModels.Widgets
 {
-    public class WidgetsListControlViewModel : ObservableObject
+    public class WidgetsListControlViewModel : ObservableObject, IDisposable
     {
         public ObservableCollection<Control> Widgets { get; private set; } = new ObservableCollection<Control>();
 
@@ -18,6 +18,7 @@ namespace Files.ViewModels.Widgets
                 return false;
             }
 
+            // Don't add existing ones!
             if (Widgets.Any((item) => (item as IWidgetItemModel).WidgetName == widgetItemModel.WidgetName))
             {
                 return false;
@@ -38,6 +39,17 @@ namespace Files.ViewModels.Widgets
         {
             int widgetIndex = Widgets.IndexOf(widgetModel);
             Widgets.Move(widgetIndex, place);
+        }
+
+        public void Dispose()
+        {
+            for (int i = 0; i < Widgets.Count; i++)
+            {
+                (Widgets[i] as IDisposable)?.Dispose();
+            }
+
+            Widgets.Clear();
+            Widgets = null;
         }
     }
 }

--- a/Files/Views/YourHome.xaml
+++ b/Files/Views/YourHome.xaml
@@ -9,11 +9,10 @@
     mc:Ignorable="d">
 
     <ScrollViewer>
-        <Border Padding="14">
-            <widgets:WidgetsListControl 
-                x:Name="Widgets" 
-                VerticalAlignment="Stretch"
-                HorizontalAlignment="Stretch"/>
-        </Border>
+        <widgets:WidgetsListControl
+            x:Name="Widgets"
+            Margin="24"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch" />
     </ScrollViewer>
 </Page>

--- a/Files/Views/YourHome.xaml
+++ b/Files/Views/YourHome.xaml
@@ -2,7 +2,6 @@
     x:Class="Files.Views.YourHome"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:converters="using:Files.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:widgets="using:Files.UserControls.Widgets"
@@ -10,17 +9,11 @@
     mc:Ignorable="d">
 
     <ScrollViewer>
-        <StackPanel Margin="14,14,14,14" Spacing="24">
-            <StackPanel.ChildrenTransitions>
-                <TransitionCollection>
-                    <EntranceThemeTransition />
-                </TransitionCollection>
-            </StackPanel.ChildrenTransitions>
-
+        <Border Padding="14">
             <widgets:WidgetsListControl 
                 x:Name="Widgets" 
                 VerticalAlignment="Stretch"
                 HorizontalAlignment="Stretch"/>
-        </StackPanel>
+        </Border>
     </ScrollViewer>
 </Page>

--- a/Files/Views/YourHome.xaml
+++ b/Files/Views/YourHome.xaml
@@ -19,24 +19,8 @@
 
             <widgets:WidgetsListControl 
                 x:Name="Widgets" 
-                Background="Red"
                 VerticalAlignment="Stretch"
                 HorizontalAlignment="Stretch"/>
-
-            <widgets:LibraryCards
-                x:Name="LibraryWidget"
-                x:Load="{x:Bind AppSettings.ShowLibraryCardsWidget, Mode=OneWay}"
-                ShowMultiPaneControls="{x:Bind converters:MultiBooleanConverter.AndConvert(AppInstance.IsMultiPaneEnabled, AppInstance.IsPageMainPane), Mode=OneWay}" />
-
-            <widgets:DrivesWidget
-                x:Name="DrivesWidget"
-                x:Load="{x:Bind AppSettings.ShowDrivesWidget, Mode=OneWay}"
-                AppInstance="{x:Bind AppInstance, Mode=OneWay}"
-                ShowMultiPaneControls="{x:Bind converters:MultiBooleanConverter.AndConvert(AppInstance.IsMultiPaneEnabled, AppInstance.IsPageMainPane), Mode=OneWay}" />
-
-            <widgets:Bundles x:Name="BundlesWidget" x:Load="{x:Bind AppSettings.ShowBundlesWidget, Mode=OneWay}" />
-
-            <widgets:RecentFiles x:Name="RecentFilesWidget" x:Load="{x:Bind AppSettings.ShowRecentFilesWidget, Mode=OneWay}" />
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Files/Views/YourHome.xaml
+++ b/Files/Views/YourHome.xaml
@@ -11,7 +11,7 @@
     <ScrollViewer>
         <widgets:WidgetsListControl
             x:Name="Widgets"
-            Margin="24"
+            Margin="14"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch" />
     </ScrollViewer>

--- a/Files/Views/YourHome.xaml
+++ b/Files/Views/YourHome.xaml
@@ -16,6 +16,13 @@
                     <EntranceThemeTransition />
                 </TransitionCollection>
             </StackPanel.ChildrenTransitions>
+
+            <widgets:WidgetsListControl 
+                x:Name="Widgets" 
+                Background="Red"
+                VerticalAlignment="Stretch"
+                HorizontalAlignment="Stretch"/>
+
             <widgets:LibraryCards
                 x:Name="LibraryWidget"
                 x:Load="{x:Bind AppSettings.ShowLibraryCardsWidget, Mode=OneWay}"

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -62,11 +62,14 @@ namespace Files.Views
                 libraryCards.LibraryCardPropertiesInvoked += LibraryWidget_LibraryCardPropertiesInvoked;
                 libraryCards.LibraryCardDeleteInvoked -= LibraryWidget_LibraryCardDeleteInvoked;
                 libraryCards.LibraryCardDeleteInvoked += LibraryWidget_LibraryCardDeleteInvoked;
+                libraryCards.LibraryCardShowMultiPaneControlsInvoked -= LibraryCards_LibraryCardShowMultiPaneControlsInvoked;
+                libraryCards.LibraryCardShowMultiPaneControlsInvoked += LibraryCards_LibraryCardShowMultiPaneControlsInvoked;
 
                 Widgets.ViewModel.AddWidget(libraryCards);
             }
             if (drivesWidget != null)
             {
+                drivesWidget.AppInstance = AppInstance;
                 drivesWidget.DrivesWidgetInvoked -= DrivesWidget_DrivesWidgetInvoked;
                 drivesWidget.DrivesWidgetNewPaneInvoked -= DrivesWidget_DrivesWidgetNewPaneInvoked;
                 drivesWidget.DrivesWidgetInvoked += DrivesWidget_DrivesWidgetInvoked;
@@ -90,6 +93,13 @@ namespace Files.Views
 
                 Widgets.ViewModel.AddWidget(recentFiles);
             }
+        }
+
+        private void LibraryCards_LibraryCardShowMultiPaneControlsInvoked(object sender, EventArgs e)
+        {
+            LibraryCards libraryCards = sender as LibraryCards;
+
+            libraryCards.ShowMultiPaneControls = AppInstance.IsMultiPaneEnabled && AppInstance.IsPageMainPane;
         }
 
         private async void RecentFilesWidget_RecentFileInvoked(object sender, UserControls.PathNavigationEventArgs e)

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -3,13 +3,11 @@ using Files.Filesystem;
 using Files.Helpers;
 using Files.UserControls.Widgets;
 using Files.ViewModels;
-using Files.ViewModels.Widgets.Bundles;
 using Microsoft.Toolkit.Uwp;
 using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Windows.ApplicationModel.AppService;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -30,41 +30,48 @@ namespace Files.Views
 
         private async void YourHome_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            Bundles bundlesWidget = new Bundles();
-            bundlesWidget.ViewModel.Initialize(AppInstance);
-            await bundlesWidget.ViewModel.Load();
+            var libraryCards = WidgetsHelpers.GetLibraryCards();
+            var drivesWidget = WidgetsHelpers.GetDrivesWidget();
+            var bundles = WidgetsHelpers.GetBundles();
+            var recentFiles = WidgetsHelpers.GetRecentFiles();
 
-            Widgets.ViewModel.AddWidget(bundlesWidget);
+            if (libraryCards != null)
+            {
+                libraryCards.LibraryCardInvoked -= LibraryWidget_LibraryCardInvoked;
+                libraryCards.LibraryCardNewPaneInvoked -= LibraryWidget_LibraryCardNewPaneInvoked;
+                libraryCards.LibraryCardInvoked += LibraryWidget_LibraryCardInvoked;
+                libraryCards.LibraryCardNewPaneInvoked += LibraryWidget_LibraryCardNewPaneInvoked;
+                libraryCards.LibraryCardPropertiesInvoked -= LibraryWidget_LibraryCardPropertiesInvoked;
+                libraryCards.LibraryCardPropertiesInvoked += LibraryWidget_LibraryCardPropertiesInvoked;
+                libraryCards.LibraryCardDeleteInvoked -= LibraryWidget_LibraryCardDeleteInvoked;
+                libraryCards.LibraryCardDeleteInvoked += LibraryWidget_LibraryCardDeleteInvoked;
 
-            if (DrivesWidget != null)
-            {
-                DrivesWidget.DrivesWidgetInvoked -= DrivesWidget_DrivesWidgetInvoked;
-                DrivesWidget.DrivesWidgetNewPaneInvoked -= DrivesWidget_DrivesWidgetNewPaneInvoked;
-                DrivesWidget.DrivesWidgetInvoked += DrivesWidget_DrivesWidgetInvoked;
-                DrivesWidget.DrivesWidgetNewPaneInvoked += DrivesWidget_DrivesWidgetNewPaneInvoked;
+                Widgets.ViewModel.AddWidget(libraryCards);
             }
-            if (LibraryWidget != null)
+            if (drivesWidget != null)
             {
-                LibraryWidget.LibraryCardInvoked -= LibraryWidget_LibraryCardInvoked;
-                LibraryWidget.LibraryCardNewPaneInvoked -= LibraryWidget_LibraryCardNewPaneInvoked;
-                LibraryWidget.LibraryCardInvoked += LibraryWidget_LibraryCardInvoked;
-                LibraryWidget.LibraryCardNewPaneInvoked += LibraryWidget_LibraryCardNewPaneInvoked;
-                LibraryWidget.LibraryCardPropertiesInvoked -= LibraryWidget_LibraryCardPropertiesInvoked;
-                LibraryWidget.LibraryCardPropertiesInvoked += LibraryWidget_LibraryCardPropertiesInvoked;
-                LibraryWidget.LibraryCardDeleteInvoked -= LibraryWidget_LibraryCardDeleteInvoked;
-                LibraryWidget.LibraryCardDeleteInvoked += LibraryWidget_LibraryCardDeleteInvoked;
+                drivesWidget.DrivesWidgetInvoked -= DrivesWidget_DrivesWidgetInvoked;
+                drivesWidget.DrivesWidgetNewPaneInvoked -= DrivesWidget_DrivesWidgetNewPaneInvoked;
+                drivesWidget.DrivesWidgetInvoked += DrivesWidget_DrivesWidgetInvoked;
+                drivesWidget.DrivesWidgetNewPaneInvoked += DrivesWidget_DrivesWidgetNewPaneInvoked;
+
+                Widgets.ViewModel.AddWidget(drivesWidget);
             }
-            if (RecentFilesWidget != null)
+            if (bundles != null)
             {
-                RecentFilesWidget.RecentFilesOpenLocationInvoked -= RecentFilesWidget_RecentFilesOpenLocationInvoked;
-                RecentFilesWidget.RecentFileInvoked -= RecentFilesWidget_RecentFileInvoked;
-                RecentFilesWidget.RecentFilesOpenLocationInvoked += RecentFilesWidget_RecentFilesOpenLocationInvoked;
-                RecentFilesWidget.RecentFileInvoked += RecentFilesWidget_RecentFileInvoked;
+                Widgets.ViewModel.AddWidget(bundles);
+
+                bundles.ViewModel.Initialize(AppInstance);
+                await bundles.ViewModel.Load();
             }
-            if (BundlesWidget != null)
+            if (recentFiles != null)
             {
-                (BundlesWidget?.DataContext as BundlesViewModel)?.Initialize(AppInstance);
-                (BundlesWidget?.DataContext as BundlesViewModel)?.Load();
+                recentFiles.RecentFilesOpenLocationInvoked -= RecentFilesWidget_RecentFilesOpenLocationInvoked;
+                recentFiles.RecentFileInvoked -= RecentFilesWidget_RecentFileInvoked;
+                recentFiles.RecentFilesOpenLocationInvoked += RecentFilesWidget_RecentFilesOpenLocationInvoked;
+                recentFiles.RecentFileInvoked += RecentFilesWidget_RecentFileInvoked;
+
+                Widgets.ViewModel.AddWidget(recentFiles);
             }
         }
 
@@ -194,7 +201,7 @@ namespace Files.Views
         //       This IDisposable.Dispose() needs to be called to unhook events in BundlesWidget to avoid memory leaks.
         public void Dispose()
         {
-            BundlesWidget?.Dispose();
+            //BundlesWidget?.Dispose();
         }
 
         #endregion IDisposable

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -201,7 +201,7 @@ namespace Files.Views
         //       This IDisposable.Dispose() needs to be called to unhook events in BundlesWidget to avoid memory leaks.
         public void Dispose()
         {
-            //BundlesWidget?.Dispose();
+            Widgets?.Dispose();
         }
 
         #endregion IDisposable

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -30,28 +30,12 @@ namespace Files.Views
 
         private async void YourHome_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            LibraryCards libraryCards = null;
-            DrivesWidget drivesWidget = null;
-            Bundles bundles = null;
-            RecentFiles recentFiles = null;
+            var libraryCards = WidgetsHelpers.TryGetWidget<LibraryCards>(Widgets.ViewModel);
+            var drivesWidget = WidgetsHelpers.TryGetWidget<DrivesWidget>(Widgets.ViewModel);
+            var bundles = WidgetsHelpers.TryGetWidget<Bundles>(Widgets.ViewModel);
+            var recentFiles = WidgetsHelpers.TryGetWidget<RecentFiles>(Widgets.ViewModel);
 
-            if (Widgets.ViewModel.CanAddWidget(nameof(LibraryCards)))
-            {
-                libraryCards = WidgetsHelpers.GetLibraryCards();
-            }
-            if (Widgets.ViewModel.CanAddWidget(nameof(DrivesWidget)))
-            {
-                drivesWidget = WidgetsHelpers.GetDrivesWidget();
-            }
-            if (Widgets.ViewModel.CanAddWidget(nameof(Bundles)))
-            {
-                bundles = WidgetsHelpers.GetBundles();
-            }
-            if (Widgets.ViewModel.CanAddWidget(nameof(RecentFiles)))
-            {
-                recentFiles = WidgetsHelpers.GetRecentFiles();
-            }
-
+            // Now prepare widgets
             if (libraryCards != null)
             {
                 libraryCards.LibraryCardInvoked -= LibraryWidget_LibraryCardInvoked;

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -20,6 +20,11 @@ namespace Files.Views
         public FolderSettingsViewModel FolderSettings => AppInstance?.InstanceViewModel.FolderSettings;
         public NamedPipeAsAppServiceConnection Connection => AppInstance?.ServiceConnection;
 
+        LibraryCards libraryCards;
+        DrivesWidget drivesWidget;
+        Bundles bundles;
+        RecentFiles recentFiles;
+
         public YourHome()
         {
             InitializeComponent();
@@ -28,10 +33,10 @@ namespace Files.Views
 
         private async void YourHome_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            var libraryCards = WidgetsHelpers.TryGetWidget<LibraryCards>(Widgets.ViewModel);
-            var drivesWidget = WidgetsHelpers.TryGetWidget<DrivesWidget>(Widgets.ViewModel);
-            var bundles = WidgetsHelpers.TryGetWidget<Bundles>(Widgets.ViewModel);
-            var recentFiles = WidgetsHelpers.TryGetWidget<RecentFiles>(Widgets.ViewModel);
+            libraryCards = WidgetsHelpers.TryGetWidget<LibraryCards>(Widgets.ViewModel, libraryCards);
+            drivesWidget = WidgetsHelpers.TryGetWidget<DrivesWidget>(Widgets.ViewModel, drivesWidget);
+            bundles = WidgetsHelpers.TryGetWidget<Bundles>(Widgets.ViewModel, bundles);
+            recentFiles = WidgetsHelpers.TryGetWidget<RecentFiles>(Widgets.ViewModel, recentFiles);
 
             // Now prepare widgets
             if (libraryCards != null)
@@ -47,7 +52,7 @@ namespace Files.Views
                 libraryCards.LibraryCardShowMultiPaneControlsInvoked -= LibraryCards_LibraryCardShowMultiPaneControlsInvoked;
                 libraryCards.LibraryCardShowMultiPaneControlsInvoked += LibraryCards_LibraryCardShowMultiPaneControlsInvoked;
 
-                Widgets.ViewModel.AddWidget(libraryCards);
+                Widgets.ViewModel.InsertWidget(libraryCards, 0);
             }
             if (drivesWidget != null)
             {
@@ -57,11 +62,11 @@ namespace Files.Views
                 drivesWidget.DrivesWidgetInvoked += DrivesWidget_DrivesWidgetInvoked;
                 drivesWidget.DrivesWidgetNewPaneInvoked += DrivesWidget_DrivesWidgetNewPaneInvoked;
 
-                Widgets.ViewModel.AddWidget(drivesWidget);
+                Widgets.ViewModel.InsertWidget(drivesWidget, 1);
             }
             if (bundles != null)
             {
-                Widgets.ViewModel.AddWidget(bundles);
+                Widgets.ViewModel.InsertWidget(bundles, 2);
 
                 bundles.ViewModel.Initialize(AppInstance);
                 await bundles.ViewModel.Load();
@@ -73,7 +78,7 @@ namespace Files.Views
                 recentFiles.RecentFilesOpenLocationInvoked += RecentFilesWidget_RecentFilesOpenLocationInvoked;
                 recentFiles.RecentFileInvoked += RecentFilesWidget_RecentFileInvoked;
 
-                Widgets.ViewModel.AddWidget(recentFiles);
+                Widgets.ViewModel.InsertWidget(recentFiles, 3);
             }
         }
 

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -30,10 +30,27 @@ namespace Files.Views
 
         private async void YourHome_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            var libraryCards = WidgetsHelpers.GetLibraryCards();
-            var drivesWidget = WidgetsHelpers.GetDrivesWidget();
-            var bundles = WidgetsHelpers.GetBundles();
-            var recentFiles = WidgetsHelpers.GetRecentFiles();
+            LibraryCards libraryCards = null;
+            DrivesWidget drivesWidget = null;
+            Bundles bundles = null;
+            RecentFiles recentFiles = null;
+
+            if (Widgets.ViewModel.CanAddWidget(nameof(LibraryCards)))
+            {
+                libraryCards = WidgetsHelpers.GetLibraryCards();
+            }
+            if (Widgets.ViewModel.CanAddWidget(nameof(DrivesWidget)))
+            {
+                drivesWidget = WidgetsHelpers.GetDrivesWidget();
+            }
+            if (Widgets.ViewModel.CanAddWidget(nameof(Bundles)))
+            {
+                bundles = WidgetsHelpers.GetBundles();
+            }
+            if (Widgets.ViewModel.CanAddWidget(nameof(RecentFiles)))
+            {
+                recentFiles = WidgetsHelpers.GetRecentFiles();
+            }
 
             if (libraryCards != null)
             {

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -30,12 +30,11 @@ namespace Files.Views
 
         private async void YourHome_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            Bundles b_widget = new Bundles();
-            b_widget.ViewModel.Initialize(AppInstance);
-            await b_widget.ViewModel.Load();
+            Bundles bundlesWidget = new Bundles();
+            bundlesWidget.ViewModel.Initialize(AppInstance);
+            await bundlesWidget.ViewModel.Load();
 
-
-            Widgets.ViewModel.AddWidget(b_widget);
+            Widgets.ViewModel.AddWidget(bundlesWidget);
 
             if (DrivesWidget != null)
             {

--- a/Files/Views/YourHome.xaml.cs
+++ b/Files/Views/YourHome.xaml.cs
@@ -3,7 +3,7 @@ using Files.Filesystem;
 using Files.Helpers;
 using Files.UserControls.Widgets;
 using Files.ViewModels;
-using Files.ViewModels.Bundles;
+using Files.ViewModels.Widgets.Bundles;
 using Microsoft.Toolkit.Uwp;
 using System;
 using System.IO;
@@ -28,8 +28,15 @@ namespace Files.Views
             this.Loaded += YourHome_Loaded;
         }
 
-        private void YourHome_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        private async void YourHome_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
+            Bundles b_widget = new Bundles();
+            b_widget.ViewModel.Initialize(AppInstance);
+            await b_widget.ViewModel.Load();
+
+
+            Widgets.ViewModel.AddWidget(b_widget);
+
             if (DrivesWidget != null)
             {
                 DrivesWidget.DrivesWidgetInvoked -= DrivesWidget_DrivesWidgetInvoked;


### PR DESCRIPTION
**Resolved / Related Issues**
- For #2263, #4180

**Details of Changes**
- Widgets can now be "cached" meaning you don't have to load new ones when existing ones are loaded (It's not implemented though).
- Widgets will no longer be re-loaded when opening settings (from homepage) and going back.
- (It looks like) widgets loading performance also has improved :thinking: 
- It is now possible to implement reordering.
- Widgets are no longer limited to hardcoded controls. Any control that implements `IWidgetItemModel` or `ICustomWidgetItemModel` can be a widget now.
- IDisposable control - Dispose() will be called for all widgets on their removal
- @winston-de @yair100 This PR makes displaying custom widgets possible :tada:

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility
