### PR TITLE
Fixed issue where set as options wouldn't show for images

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -474,6 +474,7 @@ namespace Files
 
         private void LoadMenuItemsAsync()
         {
+            SelectedItemsPropertiesViewModel.CheckFileExtension();
             var shiftPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
             var items = ContextFlyoutItemHelper.GetItemContextCommands(connection: Connection, currentInstanceViewModel: InstanceViewModel, workingDir: ParentShellPageInstance.FilesystemViewModel.WorkingDirectory, selectedItems: SelectedItems, selectedItemsPropertiesViewModel: SelectedItemsPropertiesViewModel, commandsViewModel: CommandsViewModel, shiftPressed: shiftPressed, showOpenMenu: false);
             ItemContextMenuFlyout.PrimaryCommands.Clear();

--- a/Files/ViewModels/SelectedItemsPropertiesViewModel.cs
+++ b/Files/ViewModels/SelectedItemsPropertiesViewModel.cs
@@ -539,14 +539,14 @@ namespace Files.ViewModels
             set => SetProperty(ref isSelectedItemShortcut, value);
         }
 
-        public async void CheckFileExtension()
+        public void CheckFileExtension()
         {
             // Set properties to false
             IsSelectedItemImage = false;
             IsSelectedItemShortcut = false;
 
             //check if the selected item is an image file
-            string ItemExtension = await CoreApplication.MainView.ExecuteOnUIThreadAsync(() => contentPage?.SelectedItem?.FileExtension);
+            string ItemExtension = contentPage?.SelectedItem?.FileExtension;
             if (!string.IsNullOrEmpty(ItemExtension) && SelectedItemsCount == 1)
             {
                 if (ItemExtension.Equals(".png", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Fixed issue where set as options wouldn't show for images

**Details of Changes**
The function that updates ```IsItemImage``` in ```SelectedItemsPropertiesViewModel``` wasn't getting called. This PR calls it in the flyout opening function, and also removes the unnecessary await task.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [N/A] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/59544401/113535314-e892f200-9587-11eb-80f5-090eccb03943.png)

