### PR TITLE
Added search unindexed items option at bottom of search results

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -665,9 +665,5 @@ namespace Files
         {
             ParentShellPageInstance.Refresh_Click();
         }
-        protected void SearchUnindexedItemsButton_Click(object sender, RoutedEventArgs e)
-        {
-            ParentShellPageInstance.SubmitSearch(InstanceViewModel.CurrentSearchQuery, true);
-        }
     }
 }

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -665,5 +665,9 @@ namespace Files
         {
             ParentShellPageInstance.Refresh_Click();
         }
+        protected void SearchUnindexedItemsButton_Click(object sender, RoutedEventArgs e)
+        {
+            ParentShellPageInstance.SubmitSearch(InstanceViewModel.CurrentSearchQuery, true);
+        }
     }
 }

--- a/Files/Filesystem/Search/FolderSearch.cs
+++ b/Files/Filesystem/Search/FolderSearch.cs
@@ -14,7 +14,7 @@ namespace Files.Filesystem.Search
 {
     internal class FolderSearch
     {
-        public static async Task<ObservableCollection<ListedItem>> SearchForUserQueryTextAsync(string userText, string WorkingDirectory, IShellPage associatedInstance, int maxItemCount = 10, uint thumbnailSize = 24)
+        public static async Task<ObservableCollection<ListedItem>> SearchForUserQueryTextAsync(string userText, string WorkingDirectory, IShellPage associatedInstance, bool searchUnindexedItems, int maxItemCount = 10, uint thumbnailSize = 24)
         {
             var returnedItems = new ObservableCollection<ListedItem>();
             maxItemCount = maxItemCount < 0 ? int.MaxValue : maxItemCount;
@@ -23,7 +23,7 @@ namespace Files.Filesystem.Search
             var workingDir = await associatedInstance.FilesystemViewModel.GetFolderFromPathAsync(WorkingDirectory);
             if (workingDir)
             {
-                foreach (var item in await SearchWithStorageFolder(userText, workingDir, maxItemCount, thumbnailSize))
+                foreach (var item in await SearchWithStorageFolder(userText, workingDir, searchUnindexedItems, maxItemCount, thumbnailSize))
                 {
                     returnedItems.Add(item);
                 }
@@ -125,7 +125,7 @@ namespace Files.Filesystem.Search
             return returnedItems;
         }
 
-        private static async Task<IList<ListedItem>> SearchWithStorageFolder(string userText, StorageFolder workingDir, int maxItemCount = 10, uint thumbnailSize = 24)
+        private static async Task<IList<ListedItem>> SearchWithStorageFolder(string userText, StorageFolder workingDir, bool searchUnindexedItems, int maxItemCount = 10, uint thumbnailSize = 24)
         {
             QueryOptions options = new QueryOptions()
             {
@@ -133,7 +133,7 @@ namespace Files.Filesystem.Search
                 UserSearchFilter = string.IsNullOrWhiteSpace(userText) ? null : userText,
             };
 
-            if (App.AppSettings.SearchUnindexedItems)
+            if (searchUnindexedItems)
             {
                 options.IndexerOption = IndexerOption.DoNotUseIndexer;
             }

--- a/Files/IShellPage.cs
+++ b/Files/IShellPage.cs
@@ -42,6 +42,8 @@ namespace Files
         void NavigateWithArguments(Type sourcePageType, NavigationArguments navArgs);
 
         void RemoveLastPageFromBackStack();
+
+        void SubmitSearch(string query, bool searchUnindexedItems);
     }
 
     public interface IPaneHolder : IDisposable

--- a/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -535,6 +535,11 @@ namespace Files.Interacts
             SlimContentPage.RefreshItems();
         }
 
+        public void SearchUnindexedItems(RoutedEventArgs e)
+        {
+            associatedInstance.SubmitSearch(associatedInstance.InstanceViewModel.CurrentSearchQuery, true);
+        }
+
         #endregion Command Implementation
     }
 }

--- a/Files/Interacts/BaseLayoutCommandsViewModel.cs
+++ b/Files/Interacts/BaseLayoutCommandsViewModel.cs
@@ -69,6 +69,7 @@ namespace Files.Interacts
             DragEnterCommand = new RelayCommand<DragEventArgs>(commandsModel.DragEnter);
             DropCommand = new RelayCommand<DragEventArgs>(commandsModel.Drop);
             RefreshCommand = new RelayCommand<RoutedEventArgs>(commandsModel.RefreshItems);
+            SearchUnindexedItems = new RelayCommand<RoutedEventArgs>(commandsModel.SearchUnindexedItems);
         }
 
         #endregion Command Initialization
@@ -152,6 +153,7 @@ namespace Files.Interacts
         public ICommand DropCommand { get; private set; }
 
         public ICommand RefreshCommand { get; private set; }
+        public ICommand SearchUnindexedItems { get; private set; }
 
         #endregion Commands
 

--- a/Files/Interacts/IBaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/IBaseLayoutCommandImplementationModel.cs
@@ -84,5 +84,7 @@ namespace Files.Interacts
         void Drop(DragEventArgs e);
 
         void RefreshItems(RoutedEventArgs e);
+
+        void SearchUnindexedItems(RoutedEventArgs e);
     }
 }

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2037,4 +2037,10 @@
   <data name="PropertyISO" xml:space="preserve">
     <value>ISO speed</value>
   </data>
+  <data name="SearchUnindexedItemsLabel.Text" xml:space="preserve">
+    <value>Didn't find what you're looking for?</value>
+  </data>
+  <data name="SearchUnindexedItemsButton.Content" xml:space="preserve">
+    <value>Search unindexed items.</value>
+  </data>
 </root>

--- a/Files/ViewModels/CurrentInstanceViewModel.cs
+++ b/Files/ViewModels/CurrentInstanceViewModel.cs
@@ -31,7 +31,33 @@ namespace Files.ViewModels
                 OnPropertyChanged(nameof(CanPasteInPage));
                 OnPropertyChanged(nameof(CanOpenTerminalInPage));
                 OnPropertyChanged(nameof(CanCopyPathInPage));
+                OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
             }
+        }
+
+        private string currentSearchQuery;
+        public string CurrentSearchQuery
+        {
+            get => currentSearchQuery;
+            set => SetProperty(ref currentSearchQuery, value);
+        }
+
+        private bool searchedUnindexedItems;
+        public bool SearchedUnindexedItems
+        {
+            get => searchedUnindexedItems;
+            set
+            {
+                if(SetProperty(ref searchedUnindexedItems, value))
+                {
+                    OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
+                }
+            }
+        }
+
+        public bool ShowSearchUnindexedItemsMessage
+        {
+            get => !SearchedUnindexedItems && IsPageTypeSearchResults;
         }
 
         private bool isPageTypeNotHome = false;

--- a/Files/Views/ColumnShellPage.xaml.cs
+++ b/Files/Views/ColumnShellPage.xaml.cs
@@ -310,7 +310,7 @@ namespace Files.Views
             {
                 if (!string.IsNullOrWhiteSpace(sender.Text))
                 {
-                    sender.ItemsSource = await FolderSearch.SearchForUserQueryTextAsync(sender.Text, FilesystemViewModel.WorkingDirectory, this);
+                    sender.ItemsSource = await FolderSearch.SearchForUserQueryTextAsync(sender.Text, FilesystemViewModel.WorkingDirectory, this, App.AppSettings.SearchUnindexedItems);
                 }
                 else
                 {
@@ -323,16 +323,7 @@ namespace Files.Views
         {
             if (args.ChosenSuggestion == null && !string.IsNullOrWhiteSpace(args.QueryText))
             {
-                FilesystemViewModel.IsLoadingIndicatorActive = true;
-                ItemDisplayFrame.Navigate(typeof(ColumnViewBase), new NavigationArguments()
-                {
-                    AssociatedTabInstance = this,
-                    IsSearchResultPage = true,
-                    SearchPathParam = FilesystemViewModel.WorkingDirectory,
-                    SearchResults = await FolderSearch.SearchForUserQueryTextAsync(args.QueryText, FilesystemViewModel.WorkingDirectory, this, -1,
-                        InstanceViewModel.FolderSettings.GetIconSize())
-                });
-                FilesystemViewModel.IsLoadingIndicatorActive = false;
+                SubmitSearch(args.QueryText, App.AppSettings.SearchUnindexedItems);
             }
         }
 
@@ -1372,6 +1363,21 @@ namespace Files.Views
         {
             ItemDisplayFrame.BackStack.Remove(ItemDisplayFrame.BackStack.Last());
         }
-    }
 
+        public async void SubmitSearch(string query, bool searchUnindexedItems)
+        {
+            InstanceViewModel.CurrentSearchQuery = query;
+            FilesystemViewModel.IsLoadingIndicatorActive = true;
+            InstanceViewModel.SearchedUnindexedItems = !searchUnindexedItems;
+            ItemDisplayFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(FilesystemViewModel.WorkingDirectory), new NavigationArguments()
+            {
+                AssociatedTabInstance = this,
+                IsSearchResultPage = true,
+                SearchPathParam = FilesystemViewModel.WorkingDirectory,
+                SearchResults = await FolderSearch.SearchForUserQueryTextAsync(query, FilesystemViewModel.WorkingDirectory, this, searchUnindexedItems, -1,
+                    InstanceViewModel.FolderSettings.GetIconSize())
+            });
+            FilesystemViewModel.IsLoadingIndicatorActive = false;
+        }
+    }
 }

--- a/Files/Views/LayoutModes/ColumnViewBrowser.xaml
+++ b/Files/Views/LayoutModes/ColumnViewBrowser.xaml
@@ -190,7 +190,7 @@
                         <ListView.Footer>
                             <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" x:Load="{x:Bind InstanceViewModel.ShowSearchUnindexedItemsMessage, Mode=OneWay}" x:Name="SearchUnindexedItemsPanel">
                                 <TextBlock Text="Didn't find what you're looking for?" HorizontalTextAlignment="Center" x:Uid="SearchUnindexedItemsLabel"/>
-                                <HyperlinkButton Content="Search unindexed items." HorizontalAlignment="Center" Click="SearchUnindexedItemsButton_Click" x:Name="SearchUnindexedItemsButton" x:Uid="SearchUnindexedItemsButton"/>
+                                <HyperlinkButton Content="Search unindexed items." HorizontalAlignment="Center" Command="{x:Bind CommandsViewModel.SearchUnindexedItems}" x:Name="SearchUnindexedItemsButton" x:Uid="SearchUnindexedItemsButton"/>
                             </StackPanel>
                         </ListView.Footer>
                     </ListView>

--- a/Files/Views/LayoutModes/ColumnViewBrowser.xaml
+++ b/Files/Views/LayoutModes/ColumnViewBrowser.xaml
@@ -187,6 +187,12 @@
                                 </Grid>
                             </DataTemplate>
                         </ListView.ItemTemplate>
+                        <ListView.Footer>
+                            <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" x:Load="{x:Bind InstanceViewModel.ShowSearchUnindexedItemsMessage, Mode=OneWay}" x:Name="SearchUnindexedItemsPanel">
+                                <TextBlock Text="Didn't find what you're looking for?" HorizontalTextAlignment="Center" x:Uid="SearchUnindexedItemsLabel"/>
+                                <HyperlinkButton Content="Search unindexed items." HorizontalAlignment="Center" Click="SearchUnindexedItemsButton_Click" x:Name="SearchUnindexedItemsButton" x:Uid="SearchUnindexedItemsButton"/>
+                            </StackPanel>
+                        </ListView.Footer>
                     </ListView>
                     <Canvas>
                         <Rectangle

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -423,7 +423,7 @@
 
         <StackPanel Grid.Row="1" Orientation="Vertical" HorizontalAlignment="Stretch" x:Load="{x:Bind InstanceViewModel.ShowSearchUnindexedItemsMessage, Mode=OneWay}" x:Name="SearchUnindexedItemsPanel">
             <TextBlock Text="Didn't find what you're looking for?" HorizontalTextAlignment="Center" x:Uid="SearchUnindexedItemsLabel"/>
-            <HyperlinkButton Content="Search unindexed items." HorizontalAlignment="Center" Click="SearchUnindexedItemsButton_Click" x:Name="SearchUnindexedItemsButton" x:Uid="SearchUnindexedItemsButton"/>
+            <HyperlinkButton Content="Search unindexed items." HorizontalAlignment="Center" Command="{x:Bind CommandsViewModel.SearchUnindexedItems}" x:Name="SearchUnindexedItemsButton" x:Uid="SearchUnindexedItemsButton"/>
         </StackPanel>
 
         <Canvas Grid.RowSpan="2" Margin="12,12,12,0">

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -64,6 +64,10 @@
                 </i:Interaction.Behaviors>
             </KeyboardAccelerator>
         </Grid.KeyboardAccelerators>
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
         <muxc:ProgressBar
             x:Name="progBar"
             VerticalAlignment="Top"
@@ -416,6 +420,11 @@
                 </controls:DataGridTextColumn>
             </controls:DataGrid.Columns>
         </controls:DataGrid>
+
+        <StackPanel Grid.Row="1" Orientation="Vertical" HorizontalAlignment="Stretch" x:Load="{x:Bind InstanceViewModel.ShowSearchUnindexedItemsMessage, Mode=OneWay}" x:Name="SearchUnindexedItemsPanel">
+            <TextBlock Text="Didn't find what you're looking for?" HorizontalTextAlignment="Center" x:Uid="SearchUnindexedItemsLabel"/>
+            <HyperlinkButton Content="Search unindexed items." HorizontalAlignment="Center" Click="SearchUnindexedItemsButton_Click" x:Name="SearchUnindexedItemsButton" x:Uid="SearchUnindexedItemsButton"/>
+        </StackPanel>
 
         <Canvas Grid.RowSpan="2" Margin="12,12,12,0">
             <Rectangle

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -415,6 +415,12 @@
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>
             </GridView.Resources>
+            <GridView.Footer>
+                <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" x:Load="{x:Bind InstanceViewModel.ShowSearchUnindexedItemsMessage, Mode=OneWay}" x:Name="SearchUnindexedItemsPanel">
+                    <TextBlock Text="Didn't find what you're looking for?" HorizontalTextAlignment="Center" x:Uid="SearchUnindexedItemsLabel"/>
+                    <HyperlinkButton Content="Search unindexed items." HorizontalAlignment="Center" Click="SearchUnindexedItemsButton_Click" x:Name="SearchUnindexedItemsButton" x:Uid="SearchUnindexedItemsButton"/>
+                </StackPanel>
+            </GridView.Footer>
         </GridView>
 
         <Canvas HorizontalAlignment="Stretch" VerticalAlignment="Stretch">

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -418,7 +418,7 @@
             <GridView.Footer>
                 <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" x:Load="{x:Bind InstanceViewModel.ShowSearchUnindexedItemsMessage, Mode=OneWay}" x:Name="SearchUnindexedItemsPanel">
                     <TextBlock Text="Didn't find what you're looking for?" HorizontalTextAlignment="Center" x:Uid="SearchUnindexedItemsLabel"/>
-                    <HyperlinkButton Content="Search unindexed items." HorizontalAlignment="Center" Click="SearchUnindexedItemsButton_Click" x:Name="SearchUnindexedItemsButton" x:Uid="SearchUnindexedItemsButton"/>
+                    <HyperlinkButton Content="Search unindexed items." HorizontalAlignment="Center" Command="{x:Bind CommandsViewModel.SearchUnindexedItems}" x:Name="SearchUnindexedItemsButton" x:Uid="SearchUnindexedItemsButton"/>
                 </StackPanel>
             </GridView.Footer>
         </GridView>

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -304,7 +304,7 @@ namespace Files.Views
             }
         }
 
-        private async void ModernShellPage_SearchQuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+        private void ModernShellPage_SearchQuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
         {
             if (args.ChosenSuggestion == null && !string.IsNullOrWhiteSpace(args.QueryText))
             {
@@ -314,15 +314,18 @@ namespace Files.Views
 
         public async void SubmitSearch(string query, bool searchUnindexedItems)
         {
+            InstanceViewModel.CurrentSearchQuery = query;
             FilesystemViewModel.IsLoadingIndicatorActive = true;
+            InstanceViewModel.SearchedUnindexedItems = searchUnindexedItems;
             ItemDisplayFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(FilesystemViewModel.WorkingDirectory), new NavigationArguments()
             {
                 AssociatedTabInstance = this,
                 IsSearchResultPage = true,
                 SearchPathParam = FilesystemViewModel.WorkingDirectory,
-                SearchResults = await FolderSearch.SearchForUserQueryTextAsync(query, FilesystemViewModel.WorkingDirectory, this, App.AppSettings.SearchUnindexedItems, -1,
+                SearchResults = await FolderSearch.SearchForUserQueryTextAsync(query, FilesystemViewModel.WorkingDirectory, this, searchUnindexedItems, -1,
                     InstanceViewModel.FolderSettings.GetIconSize())
             });
+
             FilesystemViewModel.IsLoadingIndicatorActive = false;
         }
 

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -295,7 +295,7 @@ namespace Files.Views
             {
                 if (!string.IsNullOrWhiteSpace(sender.Text))
                 {
-                    sender.ItemsSource = await FolderSearch.SearchForUserQueryTextAsync(sender.Text, FilesystemViewModel.WorkingDirectory, this);
+                    sender.ItemsSource = await FolderSearch.SearchForUserQueryTextAsync(sender.Text, FilesystemViewModel.WorkingDirectory, this, App.AppSettings.SearchUnindexedItems);
                 }
                 else
                 {
@@ -308,17 +308,22 @@ namespace Files.Views
         {
             if (args.ChosenSuggestion == null && !string.IsNullOrWhiteSpace(args.QueryText))
             {
-                FilesystemViewModel.IsLoadingIndicatorActive = true;
-                ItemDisplayFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(FilesystemViewModel.WorkingDirectory), new NavigationArguments()
-                {
-                    AssociatedTabInstance = this,
-                    IsSearchResultPage = true,
-                    SearchPathParam = FilesystemViewModel.WorkingDirectory,
-                    SearchResults = await FolderSearch.SearchForUserQueryTextAsync(args.QueryText, FilesystemViewModel.WorkingDirectory, this, -1,
-                        InstanceViewModel.FolderSettings.GetIconSize())
-                });
-                FilesystemViewModel.IsLoadingIndicatorActive = false;
+                SubmitSearch(args.QueryText, AppSettings.SearchUnindexedItems);
             }
+        }
+
+        public async void SubmitSearch(string query, bool searchUnindexedItems)
+        {
+            FilesystemViewModel.IsLoadingIndicatorActive = true;
+            ItemDisplayFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(FilesystemViewModel.WorkingDirectory), new NavigationArguments()
+            {
+                AssociatedTabInstance = this,
+                IsSearchResultPage = true,
+                SearchPathParam = FilesystemViewModel.WorkingDirectory,
+                SearchResults = await FolderSearch.SearchForUserQueryTextAsync(query, FilesystemViewModel.WorkingDirectory, this, App.AppSettings.SearchUnindexedItems, -1,
+                    InstanceViewModel.FolderSettings.GetIconSize())
+            });
+            FilesystemViewModel.IsLoadingIndicatorActive = false;
         }
 
         private void ModernShellPage_RefreshRequested(object sender, EventArgs e)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Closes #4278 

**Details of Changes**
Add details of changes here.
- Added parameter for searching unindexed items to folder search helper
- Moved search navigation code to a single function to invoke a search
- Added button to bottom of search results to search unindexed items, that is shown when the previous search was not unindexed

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**

https://user-images.githubusercontent.com/59544401/113669666-ed7ba280-9668-11eb-8072-62d9a4b26bf4.mp4

