### PR TITLE
Added button to open themes folder below theme selector

### DIFF
--- a/Files/Helpers/ExternalResourcesHelper.cs
+++ b/Files/Helpers/ExternalResourcesHelper.cs
@@ -17,7 +17,7 @@ namespace Files.Helpers
             "DefaultScheme".GetLocalized()
         };
 
-        private StorageFolder ThemeFolder { get; set; }
+        public StorageFolder ThemeFolder { get; set; }
 
         public string CurrentThemeResources { get; set; }
 

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2091,4 +2091,7 @@
   <data name="SearchUnindexedItemsButton.Content" xml:space="preserve">
     <value>Search unindexed items.</value>
   </data>
+    <data name="SettingsAppearanceOpenThemesFolderButton.Content" xml:space="preserve">
+    <value>Open themes folder</value>
+  </data>
 </root>

--- a/Files/ViewModels/SettingsViewModel.cs
+++ b/Files/ViewModels/SettingsViewModel.cs
@@ -4,6 +4,7 @@ using Files.DataModels;
 using Files.Enums;
 using Files.Filesystem;
 using Files.Helpers;
+using Files.Views;
 using Microsoft.AppCenter.Analytics;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
@@ -21,6 +22,7 @@ using Windows.Globalization;
 using Windows.Storage;
 using Windows.System;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 
 namespace Files.ViewModels
 {
@@ -88,6 +90,16 @@ namespace Files.ViewModels
         public static async void OpenLogLocation()
         {
             await Launcher.LaunchFolderAsync(ApplicationData.Current.LocalFolder);
+        }
+        public static void OpenThemesFolder()
+        {
+            Frame rootFrame = Window.Current.Content as Frame;
+            // This works (tm)
+            if (rootFrame.CanGoBack)
+            {
+                rootFrame.GoBack();
+            }
+            NavigationHelpers.OpenPathInNewTab(App.ExternalResourcesHelper.ThemeFolder.Path);
         }
 
         public static async void ReportIssueOnGitHub()

--- a/Files/ViewModels/SettingsViewModel.cs
+++ b/Files/ViewModels/SettingsViewModel.cs
@@ -94,7 +94,7 @@ namespace Files.ViewModels
         public static void OpenThemesFolder()
         {
             Frame rootFrame = Window.Current.Content as Frame;
-            // This works (tm)
+            // Go back to main page
             if (rootFrame.CanGoBack)
             {
                 rootFrame.GoBack();

--- a/Files/ViewModels/SettingsViewModels/AppearanceViewModel.cs
+++ b/Files/ViewModels/SettingsViewModels/AppearanceViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using Files.Enums;
 using Files.Helpers;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
+using Microsoft.Toolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp;
 using System;
 using System.Collections.Generic;
@@ -16,6 +17,7 @@ namespace Files.ViewModels.SettingsViewModels
         private bool moveOverflowMenuItemsToSubMenu = App.AppSettings.MoveOverflowMenuItemsToSubMenu;
         private string selectedThemeName = App.AppSettings.PathToThemeFile;
         private bool showRestartControl = false;
+        public RelayCommand OpenThemesFolderCommand => new RelayCommand(() => SettingsViewModel.OpenThemesFolder());
 
         public AppearanceViewModel()
         {

--- a/Files/Views/SettingsPages/Appearance.xaml
+++ b/Files/Views/SettingsPages/Appearance.xaml
@@ -56,7 +56,7 @@
                     SelectedItem="{Binding SelectedThemeName, Mode=TwoWay}" 
                     x:Load="{x:Bind ShowColorSchemeSelector}"/>
 
-                <Button
+                <HyperlinkButton
                     x:Name="OpenThemesFolderButton"
                     x:Uid="SettingsAppearanceOpenThemesFolderButton"
                     Command="{Binding OpenThemesFolderCommand}"

--- a/Files/Views/SettingsPages/Appearance.xaml
+++ b/Files/Views/SettingsPages/Appearance.xaml
@@ -50,11 +50,18 @@
                     Width="Auto"
                     MinWidth="200"
                     MaxWidth="250"
-                    x:Load="{x:Bind ShowColorSchemeSelector}"
                     Header="Color scheme"
                     HeaderTemplate="{StaticResource CustomHeaderStyle}"
                     ItemsSource="{Binding ColorSchemes}"
-                    SelectedItem="{Binding SelectedThemeName, Mode=TwoWay}" />
+                    SelectedItem="{Binding SelectedThemeName, Mode=TwoWay}" 
+                    x:Load="{x:Bind ShowColorSchemeSelector}"/>
+
+                <Button
+                    x:Name="OpenThemesFolderButton"
+                    x:Uid="SettingsAppearanceOpenThemesFolderButton"
+                    Command="{Binding OpenThemesFolderCommand}"
+                    Content="Open themes folder" 
+                    x:Load="{x:Bind ShowColorSchemeSelector}"/>
 
                 <StackPanel
                     Width="Auto"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Closes #4492

**Details of Changes**
- Added button to open themes folder below theme selector, which opens the theme folder in a new tab

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
![image](https://user-images.githubusercontent.com/59544401/113915478-b35aef80-9793-11eb-9669-606ed38d5df0.png)

Note: I know the tab isn't selected after opening, however I don't know how to fix it.