### PR TITLE
open drive in new tab with middle click

### DIFF
--- a/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -106,6 +106,7 @@
                             VerticalContentAlignment="Stretch"
                             AutomationProperties.Name="{x:Bind Text, Mode=OneWay}"
                             Click="Button_Click"
+                            PointerPressed="Button_PointerPressed"
                             CornerRadius="8"
                             Tag="{x:Bind Path}"
                             ToolTipService.ToolTip="{x:Bind Text, Mode=OneWay}">

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -10,9 +10,11 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using Windows.Foundation.Collections;
 using Windows.System;
+using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
+using Windows.UI.Xaml.Input;
 
 namespace Files.UserControls.Widgets
 {
@@ -92,10 +94,26 @@ namespace Files.UserControls.Widgets
 
             NavigationPath = ClickedCard;
 
+            var ctrlPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            if (ctrlPressed)
+            {
+                NavigationHelpers.OpenPathInNewTab(NavigationPath);
+                return;
+            }
+
             DrivesWidgetInvoked?.Invoke(this, new DrivesWidgetInvokedEventArgs()
             {
                 Path = NavigationPath
             });
+        }
+
+        private void Button_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            if (e.GetCurrentPoint(null).Properties.IsMiddleButtonPressed) // check middle click
+            {
+                string navigationPath = (sender as Button).Tag.ToString();
+                NavigationHelpers.OpenPathInNewTab(navigationPath);
+            }
         }
 
         public class DrivesWidgetInvokedEventArgs : EventArgs


### PR DESCRIPTION
**Resolved / Related Issues**
Middle click opens drives in new tab.
CTRL + Left click opens drives in new tab.
In widget page only

**Details of Changes**
Not yet implemented in the SideBar.
CTRL + Left click is implemented for drives only.