### PR TITLE
Fixed text overlapping in library card

### DIFF
--- a/Files/UserControls/Widgets/LibraryCards.xaml
+++ b/Files/UserControls/Widgets/LibraryCards.xaml
@@ -199,7 +199,8 @@
                                     FontWeight="Medium"
                                     HorizontalTextAlignment="Center"
                                     Text="{x:Bind Text}"
-                                    TextWrapping="WrapWholeWords" />
+                                    TextTrimming="WordEllipsis"
+                                    TextWrapping="NoWrap" />
                             </Grid>
                         </Button>
                     </Grid>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
The library card text was overlapping its item image

**Details of Changes**
Changed whole word wrapping to text truncating in library card text.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
![lib_card_bug](https://user-images.githubusercontent.com/52413473/114190931-899cf680-9954-11eb-9267-149c29d9608f.png)
![изображение](https://user-images.githubusercontent.com/52413473/114199573-18157600-995d-11eb-8586-f84a4c6fc423.png)

