### PR TITLE
New tab in background

### DIFF
--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
@@ -27,15 +27,9 @@ namespace Files.UserControls.MultitaskingControl
 
         private void HorizontalTabView_TabItemsChanged(TabView sender, Windows.Foundation.Collections.IVectorChangedEventArgs args)
         {
-            switch (args.CollectionChange)
+            if (args.CollectionChange == Windows.Foundation.Collections.CollectionChange.ItemRemoved)
             {
-                case Windows.Foundation.Collections.CollectionChange.ItemRemoved:
-                    App.InteractionViewModel.TabStripSelectedIndex = Items.IndexOf(HorizontalTabView.SelectedItem as TabItem);
-                    break;
-
-                case Windows.Foundation.Collections.CollectionChange.ItemInserted:
-                    App.InteractionViewModel.TabStripSelectedIndex = (int)args.Index;
-                    break;
+                App.InteractionViewModel.TabStripSelectedIndex = Items.IndexOf(HorizontalTabView.SelectedItem as TabItem);
             }
 
             if (App.InteractionViewModel.TabStripSelectedIndex >= 0 && App.InteractionViewModel.TabStripSelectedIndex < Items.Count)

--- a/Files/UserControls/MultitaskingControl/VerticalTabViewControl.xaml.cs
+++ b/Files/UserControls/MultitaskingControl/VerticalTabViewControl.xaml.cs
@@ -23,15 +23,9 @@ namespace Files.UserControls.MultitaskingControl
 
         private void VerticalTabView_TabItemsChanged(TabView sender, Windows.Foundation.Collections.IVectorChangedEventArgs args)
         {
-            switch (args.CollectionChange)
+            if (args.CollectionChange == Windows.Foundation.Collections.CollectionChange.ItemRemoved)
             {
-                case Windows.Foundation.Collections.CollectionChange.ItemRemoved:
-                    App.InteractionViewModel.TabStripSelectedIndex = Items.IndexOf(VerticalTabView.SelectedItem as TabItem);
-                    break;
-
-                case Windows.Foundation.Collections.CollectionChange.ItemInserted:
-                    App.InteractionViewModel.TabStripSelectedIndex = (int)args.Index;
-                    break;
+                App.InteractionViewModel.TabStripSelectedIndex = Items.IndexOf(VerticalTabView.SelectedItem as TabItem);
             }
 
             if (App.InteractionViewModel.TabStripSelectedIndex >= 0 && App.InteractionViewModel.TabStripSelectedIndex < Items.Count)


### PR DESCRIPTION
**Resolved / Related Issues**
Opening a new tab keeps you on the current tab.
https://github.com/files-community/Files/issues/4506 and https://github.com/files-community/Files/issues/2512

**Details of Changes**
Disable open new tabitem in events HorizontalTabView_TabItemsChanged and VerticalTabView_TabItemsChanged.
The switch has become useless and is replaced by an if. 

The new tab is loaded only when it becomes visible. We can change this later, probably managed by a user parameter. 