### PR TITLE
Library widgets new tab button

### DIFF
--- a/Files/UserControls/Widgets/LibraryCards.xaml
+++ b/Files/UserControls/Widgets/LibraryCards.xaml
@@ -109,6 +109,8 @@
                             AutomationProperties.Name="{x:Bind AutomationProperties}"
                             Command="{x:Bind SelectCommand}"
                             CommandParameter="{x:Bind}"
+                            Tag="{x:Bind Path}"
+                            PointerPressed="Button_PointerPressed"
                             CornerRadius="8">
                             <Button.ContextFlyout>
                                 <MenuFlyout Opening="MenuFlyout_Opening">

--- a/Files/UserControls/Widgets/LibraryCards.xaml.cs
+++ b/Files/UserControls/Widgets/LibraryCards.xaml.cs
@@ -14,9 +14,11 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Windows.System;
+using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media.Imaging;
 
 namespace Files.UserControls.Widgets
@@ -62,6 +64,14 @@ namespace Files.UserControls.Widgets
                 // TODO: show message?
                 return;
             }
+
+            var ctrlPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            if (ctrlPressed)
+            {
+                NavigationHelpers.OpenPathInNewTab(item.Path);
+                return;
+            }
+
             LibraryCardInvoked?.Invoke(this, new LibraryCardInvokedEventArgs { Path = item.Path });
         });
 
@@ -305,6 +315,15 @@ namespace Files.UserControls.Widgets
                     DynamicButtons = DynamicDialogButtons.Primary | DynamicDialogButtons.Cancel
                 });
                 await dialog.ShowAsync();
+            }
+        }
+
+        private void Button_PointerPressed (object sender, PointerRoutedEventArgs e)
+        {
+            if (e.GetCurrentPoint(null).Properties.IsMiddleButtonPressed) // check middle click
+            {
+                string navigationPath = (sender as Button).Tag.ToString();
+                NavigationHelpers.OpenPathInNewTab(navigationPath);
             }
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Middle click opens libraries in new tab.
CTRL + Left click opens libraries in new tab.
In widget page only.

**Details of Changes**
Not yet implemented in the SideBar.
CTRL + Left click is implemented for libraries only.