### PR TITLE
Add "paste" to the item menu items

### DIFF
--- a/Files/Helpers/ContextFlyoutItemHelper.cs
+++ b/Files/Helpers/ContextFlyoutItemHelper.cs
@@ -453,7 +453,7 @@ namespace Files.Helpers
                     Command = commandsViewModel.PasteItemsFromClipboardCommand,
                     ShowItem = selectedItems.All(x => x.PrimaryItemAttribute == StorageItemTypes.Folder),
                     SingleItemOnly = true,
-                    IsEnabled = App.InteractionViewModel.IsPasteEnabled && selectedItems.All(x => !x.IsRecycleBinItem),
+                    IsEnabled = App.InteractionViewModel.IsPasteEnabled,
                 },
                 new ContextMenuFlyoutItemViewModel()
                 {

--- a/Files/Helpers/ContextFlyoutItemHelper.cs
+++ b/Files/Helpers/ContextFlyoutItemHelper.cs
@@ -448,6 +448,15 @@ namespace Files.Helpers
                 },
                 new ContextMenuFlyoutItemViewModel()
                 {
+                    Text = "BaseLayoutContextFlyoutPaste/Text".GetLocalized(),
+                    Glyph = "\uE16D",
+                    Command = commandsViewModel.PasteItemsFromClipboardCommand,
+                    ShowItem = selectedItems.All(x => x.PrimaryItemAttribute == StorageItemTypes.Folder),
+                    SingleItemOnly = true,
+                    IsEnabled = App.InteractionViewModel.IsPasteEnabled && selectedItems.All(x => !x.IsRecycleBinItem),
+                },
+                new ContextMenuFlyoutItemViewModel()
+                {
                     Text = "BaseLayoutItemContextFlyoutShortcut/Text".GetLocalized(),
                     Glyph = "\uF10A",
                     GlyphFontFamilyName = "CustomGlyph",

--- a/Files/Helpers/ItemModelListToContextFlyoutHelper.cs
+++ b/Files/Helpers/ItemModelListToContextFlyoutHelper.cs
@@ -186,7 +186,8 @@ namespace Files.Helpers.ContextFlyouts
                     Command = item.Command,
                     CommandParameter = item.CommandParameter,
                     IsChecked = item.IsChecked,
-                    Content = content
+                    Content = content,
+                    IsEnabled = item.IsEnabled
                 };
 
                 if (icon != null)
@@ -209,6 +210,7 @@ namespace Files.Helpers.ContextFlyouts
                     CommandParameter = item.CommandParameter,
                     Flyout = ctxFlyout,
                     Content = content,
+                    IsEnabled = item.IsEnabled
                 };
 
                 if (icon != null)

--- a/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -288,7 +288,14 @@ namespace Files.Interacts
 
         public virtual async void PasteItemsFromClipboard(RoutedEventArgs e)
         {
-            await UIFilesystemHelpers.PasteItemAsync(associatedInstance.FilesystemViewModel.WorkingDirectory, associatedInstance);
+            if (SlimContentPage.SelectedItems.Count == 1 && SlimContentPage.SelectedItems.Single().PrimaryItemAttribute == StorageItemTypes.Folder)
+            {
+                await UIFilesystemHelpers.PasteItemAsync(SlimContentPage.SelectedItems.Single().ItemPath, associatedInstance);
+            }
+            else
+            {
+                await UIFilesystemHelpers.PasteItemAsync(associatedInstance.FilesystemViewModel.WorkingDirectory, associatedInstance);
+            }
         }
 
         public virtual void CopyPathOfSelectedItem(RoutedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Resolves #2952

**Details of Changes**
Added "paste" to the item menu items as described in the mentioned issue.

The option is only displayed if a single folder is selected.
If multiple folders or e.g. a file are selected, then the option is not displayed.
If the clipboard is empty then the option is disabled.

The "Ctrl + V" command is not affected by this change.

**Screenshots (optional)**

https://user-images.githubusercontent.com/56681014/114279764-8da14500-9a36-11eb-9d93-c29a49751678.mp4


