### PR TITLE
Improved behavior when opening new tabs

### DIFF
--- a/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
+++ b/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
@@ -27,15 +27,9 @@ namespace Files.UserControls.MultitaskingControl
 
         private void HorizontalTabView_TabItemsChanged(TabView sender, Windows.Foundation.Collections.IVectorChangedEventArgs args)
         {
-            switch (args.CollectionChange)
+            if (args.CollectionChange == Windows.Foundation.Collections.CollectionChange.ItemRemoved)
             {
-                case Windows.Foundation.Collections.CollectionChange.ItemRemoved:
-                    App.InteractionViewModel.TabStripSelectedIndex = Items.IndexOf(HorizontalTabView.SelectedItem as TabItem);
-                    break;
-
-                case Windows.Foundation.Collections.CollectionChange.ItemInserted:
-                    App.InteractionViewModel.TabStripSelectedIndex = (int)args.Index;
-                    break;
+                App.InteractionViewModel.TabStripSelectedIndex = Items.IndexOf(HorizontalTabView.SelectedItem as TabItem);
             }
 
             if (App.InteractionViewModel.TabStripSelectedIndex >= 0 && App.InteractionViewModel.TabStripSelectedIndex < Items.Count)

--- a/Files/UserControls/MultitaskingControl/VerticalTabViewControl.xaml.cs
+++ b/Files/UserControls/MultitaskingControl/VerticalTabViewControl.xaml.cs
@@ -23,15 +23,9 @@ namespace Files.UserControls.MultitaskingControl
 
         private void VerticalTabView_TabItemsChanged(TabView sender, Windows.Foundation.Collections.IVectorChangedEventArgs args)
         {
-            switch (args.CollectionChange)
+            if (args.CollectionChange == Windows.Foundation.Collections.CollectionChange.ItemRemoved)
             {
-                case Windows.Foundation.Collections.CollectionChange.ItemRemoved:
-                    App.InteractionViewModel.TabStripSelectedIndex = Items.IndexOf(VerticalTabView.SelectedItem as TabItem);
-                    break;
-
-                case Windows.Foundation.Collections.CollectionChange.ItemInserted:
-                    App.InteractionViewModel.TabStripSelectedIndex = (int)args.Index;
-                    break;
+                App.InteractionViewModel.TabStripSelectedIndex = Items.IndexOf(VerticalTabView.SelectedItem as TabItem);
             }
 
             if (App.InteractionViewModel.TabStripSelectedIndex >= 0 && App.InteractionViewModel.TabStripSelectedIndex < Items.Count)

--- a/Files/ViewModels/InteractionViewModel.cs
+++ b/Files/ViewModels/InteractionViewModel.cs
@@ -63,6 +63,10 @@ namespace Files.ViewModels
                     {
                         SetProperty(ref tabStripSelectedIndex, value);
                     }
+                    if (MainPageViewModel.MultitaskingControl is null)
+                    {
+                        return;
+                    }
                     if (value < MainPageViewModel.MultitaskingControl.Items.Count)
                     {
                         Frame rootFrame = Window.Current.Content as Frame;

--- a/Files/ViewModels/MainPageViewModel.cs
+++ b/Files/ViewModels/MainPageViewModel.cs
@@ -140,7 +140,7 @@ namespace Files.ViewModels
 
             if (!shift)
             {
-                await AddNewTabByPathAsync(typeof(PaneHolderPage), "NewTab".GetLocalized());
+                await AddNewTabAsync();
             }
             else // ctrl + shift + t, restore recently closed tab
             {
@@ -427,11 +427,12 @@ namespace Files.ViewModels
         public static async Task AddNewTabAsync()
         {
             await AddNewTabByPathAsync(typeof(PaneHolderPage), "NewTab".GetLocalized());
+            App.InteractionViewModel.TabStripSelectedIndex = AppInstances.Count - 1;
         }
 
         public static async void AddNewTabAtIndex(object sender, RoutedEventArgs e)
         {
-            await AddNewTabByPathAsync(typeof(PaneHolderPage), "NewTab".GetLocalized());
+            await AddNewTabAsync();
         }
 
         public static async void DuplicateTabAtIndex(object sender, RoutedEventArgs e)

--- a/Files/Views/ColumnShellPage.xaml.cs
+++ b/Files/Views/ColumnShellPage.xaml.cs
@@ -136,7 +136,7 @@ namespace Files.Views
 
         public ICommand OpenDirectoryInDefaultTerminalCommand => new RelayCommand(() => NavigationHelpers.OpenDirectoryInTerminal(this.FilesystemViewModel.WorkingDirectory, this));
 
-        public ICommand AddNewTabToMultitaskingControlCommand => new RelayCommand(async () => await MainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), "NewTab".GetLocalized()));
+        public ICommand AddNewTabToMultitaskingControlCommand => new RelayCommand(async () => await MainPageViewModel.AddNewTabAsync());
 
         public ICommand CreateNewFileCommand => new RelayCommand(() => UIFilesystemHelpers.CreateFileFromDialogResultType(AddItemType.File, null, this));
 

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -133,7 +133,7 @@ namespace Files.Views
 
         public ICommand OpenDirectoryInDefaultTerminalCommand => new RelayCommand(() => NavigationHelpers.OpenDirectoryInTerminal(this.FilesystemViewModel.WorkingDirectory, this));
 
-        public ICommand AddNewTabToMultitaskingControlCommand => new RelayCommand(async () => await MainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), "NewTab".GetLocalized()));
+        public ICommand AddNewTabToMultitaskingControlCommand => new RelayCommand(async () => await MainPageViewModel.AddNewTabAsync());
 
         public ICommand CreateNewFileCommand => new RelayCommand<ShellNewEntry>(x => UIFilesystemHelpers.CreateFileFromDialogResultType(AddItemType.File, x, this));
 


### PR DESCRIPTION
**Resolved / Related Issues**
Opening a new tab keeps you on the current tab.
Opening a standard new tab (button add new tab, ctrl+t) active the new tab immediately.
#4506 and closes #2512

**Details of Changes**
The new tab is loaded only when it becomes visible. We can change this later, probably managed by a user parameter.