### PR TITLE
Fix crash in release by switching to version 1 WinUI styles

### DIFF
--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -27,7 +27,6 @@
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
                 <ResourceDictionary Source="/ResourceDictionaries/CustomHeaderStyle.xaml" />
-                <controls:XamlControlsResources ControlsResourcesVersion="Version2" />
                 <ResourceDictionary>
                     <ResourceDictionary.ThemeDictionaries>
                         <ResourceDictionary x:Key="Light">


### PR DESCRIPTION


**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Closes nothing, no corresponding issue found
- Related https://github.com/microsoft/microsoft-ui-xaml/issues/4759

**Details of Changes**
Add details of changes here.
- Seems that in our configuration, the Version 2 styles are causing issues, so we are removing them now and as such fix the release build crashing on launch

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
