### PR TITLE
In sidebar, middle click opens item in new tab

### DIFF
--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -60,6 +60,7 @@
                     MenuItemsSource="{x:Bind ChildItems}"
                     RightTapped="NavigationViewLocationItem_RightTapped"
                     SelectsOnInvoked="{x:Bind SelectsOnInvoked}"
+                    PointerPressed="Sidebar_PointerPressed"
                     Tag="{x:Bind Path}"
                     ToolTipService.ToolTip="{x:Bind HoverDisplayText}">
                     <muxc:NavigationViewItem.Icon>
@@ -81,6 +82,7 @@
                     Drop="NavigationViewDriveItem_Drop"
                     IsRightTapEnabled="True"
                     RightTapped="NavigationViewDriveItem_RightTapped"
+                    PointerPressed="Sidebar_PointerPressed"
                     Tag="{x:Bind Path}"
                     ToolTipService.ToolTip="{x:Bind HoverDisplayText, Mode=OneWay}"
                     Visibility="{x:Bind ItemVisibility}">
@@ -99,6 +101,7 @@
                     DragEnter="NavigationViewItem_DragEnter"
                     DragLeave="NavigationViewItem_DragLeave"
                     RightTapped="NavigationViewWSLItem_RightTapped"
+                    PointerPressed="Sidebar_PointerPressed"
                     Tag="{x:Bind Path}"
                     ToolTipService.ToolTip="{x:Bind HoverDisplayText, Mode=OneWay}">
                     <muxc:NavigationViewItem.Icon>

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -86,6 +86,8 @@ namespace Files.UserControls
             set => SetValue(EmptyRecycleBinCommandProperty, value);
         }
 
+        private bool IsInPointerPressed = false;
+
         private DispatcherQueueTimer dragOverTimer;
 
         public SidebarControl()
@@ -241,11 +243,25 @@ namespace Files.UserControls
 
         private void Sidebar_ItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
         {
-            if (args.InvokedItem == null || args.InvokedItemContainer == null)
+            if (IsInPointerPressed || args.InvokedItem == null || args.InvokedItemContainer == null)
             {
+                IsInPointerPressed = false;
                 return;
             }
+
             SidebarItemInvoked?.Invoke(this, new SidebarItemInvokedEventArgs(args.InvokedItemContainer));
+        }
+
+        private void Sidebar_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            var properties = e.GetCurrentPoint(null).Properties;
+            var context = (sender as Microsoft.UI.Xaml.Controls.NavigationViewItem).DataContext;
+            if (properties.IsMiddleButtonPressed && context is INavigationControlItem item)
+            {
+                IsInPointerPressed = true;
+                NavigationHelpers.OpenPathInNewTab(item.Path);
+                e.Handled = true;
+            }
         }
 
         private void NavigationViewLocationItem_RightTapped(object sender, RightTappedRoutedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
In sidebar, middle click opens item in new tab.
#4510

**Details of Changes**
Ctrl+Left is not active because this was causing unexplained crashes. 
It may be related to #4551, because the crashes always concerned the documents.
