### PR TITLE
Allow libraries to be pinned to Start

### DIFF
--- a/Files/Helpers/ContextFlyoutItemHelper.cs
+++ b/Files/Helpers/ContextFlyoutItemHelper.cs
@@ -304,6 +304,22 @@ namespace Files.Helpers
                 },
                 new ContextMenuFlyoutItemViewModel()
                 {
+                    Text = "PinItemToStart/Text".GetLocalized(),
+                    Glyph = "\uE840",
+                    Command = commandsViewModel.PinItemToStartCommand,
+                    ShowOnShift = true,
+                    ShowItem = !itemViewModel.CurrentFolder.IsItemPinnedToStart,
+                },
+                new ContextMenuFlyoutItemViewModel()
+                {
+                    Text = "UnpinItemFromStart/Text".GetLocalized(),
+                    Glyph = "\uE77A",
+                    Command = commandsViewModel.UnpinItemFromStartCommand,
+                    ShowOnShift = true,
+                    ShowItem = itemViewModel.CurrentFolder.IsItemPinnedToStart,
+                },
+                new ContextMenuFlyoutItemViewModel()
+                {
                     Text = "BaseLayoutContextFlyoutPropertiesFolder/Text".GetLocalized(),
                     Glyph = "\uE946",
                     Command = commandsViewModel.ShowFolderPropertiesCommand,

--- a/Files/Helpers/SecondaryTileHelper.cs
+++ b/Files/Helpers/SecondaryTileHelper.cs
@@ -15,14 +15,20 @@ namespace Files.Helpers
         }
 
         /// <summary>
-        /// Gets a tile-id to be used from a folder path
+        /// Gets a unique tile-id to be used from a folder path
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
         private string GetTileID(string path)
         {
             // Remove symbols because windows doesn't like them in the ID, and will blow up
-            return $"folder-{new string(path.Where(c => char.IsLetterOrDigit(c)).ToArray())}";
+            var str = $"folder-{new string(path.Where(c => char.IsLetterOrDigit(c)).ToArray())}";
+            if(str.Length > 64)
+            {
+                // if the id string is too long, Windows will throw an error, so remove every other character
+                str = new string(str.Where((x, i) => i % 2 == 0).ToArray());
+            }
+            return str;
         }
 
         public async Task<bool> TryPinFolderAsync(string path, string name)

--- a/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -411,17 +411,30 @@ namespace Files.Interacts
 
         public virtual async void UnpinItemFromStart(RoutedEventArgs e)
         {
-            foreach (ListedItem listedItem in associatedInstance.SlimContentPage.SelectedItems)
+            if(associatedInstance.SlimContentPage.SelectedItems.Count > 0)
             {
-                await App.SecondaryTileHelper.UnpinFromStartAsync(listedItem.ItemPath);
+                foreach (ListedItem listedItem in associatedInstance.SlimContentPage.SelectedItems)
+                {
+                    await App.SecondaryTileHelper.UnpinFromStartAsync(listedItem.ItemPath);
+                }
+            } else
+            {
+                await App.SecondaryTileHelper.UnpinFromStartAsync(associatedInstance.FilesystemViewModel.WorkingDirectory);
             }
         }
 
         public async void PinItemToStart(RoutedEventArgs e)
         {
-            foreach (ListedItem listedItem in associatedInstance.SlimContentPage.SelectedItems)
+            if (associatedInstance.SlimContentPage.SelectedItems.Count > 0)
             {
-                await App.SecondaryTileHelper.TryPinFolderAsync(listedItem.ItemPath, listedItem.ItemName);
+                foreach (ListedItem listedItem in associatedInstance.SlimContentPage.SelectedItems)
+                {
+                    await App.SecondaryTileHelper.TryPinFolderAsync(listedItem.ItemPath, listedItem.ItemName);
+                }
+            }
+            else
+            {
+                await App.SecondaryTileHelper.TryPinFolderAsync(associatedInstance.FilesystemViewModel.CurrentFolder.ItemPath, associatedInstance.FilesystemViewModel.CurrentFolder.ItemName);
             }
         }
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Closes #4567 

**Details of Changes**
Add details of changes here.
- Windows will throw an error if the tile id is too long, so if the tile ID is too long, split it in half.
- Also resolves an issue where you couldn't pin folders with very long paths
- Added the pin to start option to the base menu items

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/59544401/114445087-7d977b80-9b84-11eb-8e5a-20aa1521adbe.png)

In the future we may want to show the colored icon, but that should get it's own PR later. 