### PR TITLE
Experimental list view based details view

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -305,6 +305,7 @@
     </Compile>
     <Compile Include="ViewModels\AdaptiveSidebarViewModel.cs" />
     <Compile Include="ViewModels\BaseJsonSettingsViewModel.cs" />
+    <Compile Include="ViewModels\ColumnsViewModel.cs" />
     <Compile Include="ViewModels\Pages\YourHomeViewModel.cs" />
     <Compile Include="ViewModels\Widgets\Bundles\BundleContainerViewModel.cs" />
     <Compile Include="ViewModels\Widgets\Bundles\BundleItemViewModel.cs" />
@@ -483,6 +484,9 @@
     </Compile>
     <Compile Include="Views\LayoutModes\ColumnViewBrowser.xaml.cs">
       <DependentUpon>ColumnViewBrowser.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\LayoutModes\GenericFileBrowser2.xaml.cs">
+      <DependentUpon>GenericFileBrowser2.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\Pages\PropertiesLibrary.xaml.cs">
       <DependentUpon>PropertiesLibrary.xaml</DependentUpon>
@@ -947,6 +951,10 @@
     <Page Include="Views\LayoutModes\ColumnViewBrowser.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\LayoutModes\GenericFileBrowser2.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\Pages\PropertiesLibrary.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Enums;
 using Files.Filesystem.Cloud;
+using Files.ViewModels;
 using Files.ViewModels.Properties;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Uwp;
@@ -326,6 +327,20 @@ namespace Files.Filesystem
         {
             get => itemFile;
             set => SetProperty(ref itemFile, value);
+        }
+
+        [JsonIgnore]
+        private ColumnsViewModel columnsViewModel;
+        public ColumnsViewModel ColumnsViewModel
+        {
+            get => columnsViewModel;
+            set
+            {
+                if (value != columnsViewModel)
+                {
+                    SetProperty(ref columnsViewModel, value);
+                }
+            }
         }
     }
 

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2097,4 +2097,16 @@
     <data name="SettingsAppearanceOpenThemesFolderButton.Content" xml:space="preserve">
     <value>Open themes folder</value>
   </data>
+  <data name="SettingsUseNewDetailsView.Header" xml:space="preserve">
+    <value>Use new details view</value>
+  </data>
+  <data name="FileBrowserSortOption_Name.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="FileBrowserSortOption_DateModified.Text" xml:space="preserve">
+    <value>Date modified</value>
+  </data>
+  <data name="FileBrowserSortOption_FileType.Text" xml:space="preserve">
+    <value>Type</value>
+  </data>
 </root>

--- a/Files/ViewModels/ColumnsViewModel.cs
+++ b/Files/ViewModels/ColumnsViewModel.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Toolkit.Mvvm.ComponentModel;
+using Microsoft.Toolkit.Uwp.UI.Controls;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Input;
+
+namespace Files.ViewModels
+{
+    public class ColumnsViewModel : ObservableObject
+    {
+        private GridLength row1Width = new GridLength(30, GridUnitType.Pixel);
+        public GridLength Row1Width
+        {
+            get => row1Width;
+            set => SetProperty(ref row1Width, value);
+        }
+        private GridLength row2Width = new GridLength(1, GridUnitType.Star);
+        public GridLength Row2Width
+        {
+            get => row2Width;
+            set => SetProperty(ref row2Width, value);
+        }
+        private GridLength row3Width = new GridLength(40, GridUnitType.Pixel);
+        public GridLength Row3Width
+        {
+            get => row3Width;
+            set => SetProperty(ref row3Width, value);
+        }
+
+        private GridLength row4Width = new GridLength(1, GridUnitType.Star);
+        public GridLength Row4Width
+        {
+            get => row4Width;
+            set => SetProperty(ref row4Width, value);
+        }
+        private GridLength row5Width = new GridLength(1, GridUnitType.Star);
+        public GridLength Row5Width
+        {
+            get => row5Width;
+            set => SetProperty(ref row5Width, value);
+        }
+    }
+}

--- a/Files/ViewModels/FolderSettingsViewModel.cs
+++ b/Files/ViewModels/FolderSettingsViewModel.cs
@@ -110,7 +110,7 @@ namespace Files.ViewModels
             switch (prefsForPath.LayoutMode)
             {
                 case FolderLayoutModes.DetailsView:
-                    type = typeof(GenericFileBrowser);
+                    type = App.AppSettings.UseNewDetailsView ? typeof(GenericFileBrowser2) : typeof(GenericFileBrowser);
                     break;
 
                 case FolderLayoutModes.TilesView:
@@ -126,7 +126,7 @@ namespace Files.ViewModels
                     break;
 
                 default:
-                    type = typeof(GenericFileBrowser);
+                    type = App.AppSettings.UseNewDetailsView ? typeof(GenericFileBrowser2) : typeof(GenericFileBrowser);
                     break;
             }
             return type;

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -51,7 +51,7 @@ namespace Files.ViewModels
         public BulkConcurrentObservableCollection<ListedItem> FilesAndFolders { get; }
 
         public SettingsViewModel AppSettings => App.AppSettings;
-        private FolderSettingsViewModel folderSettings = null;
+        public FolderSettingsViewModel folderSettings = null;
         private bool shouldDisplayFileExtensions = false;
         public ListedItem CurrentFolder { get; private set; }
         public CollectionViewSource viewSource;

--- a/Files/ViewModels/SettingsViewModel.cs
+++ b/Files/ViewModels/SettingsViewModel.cs
@@ -597,6 +597,15 @@ namespace Files.ViewModels
             set => Set(value);
         }
 
+        /// <summary>
+        /// Gets or sets a value whether or not to enable the new list view based details view.
+        /// </summary>
+        public bool UseNewDetailsView
+        {
+            get => Get(false);
+            set => Set(value);
+        }
+
         #endregion Experimental
 
         #region Startup

--- a/Files/ViewModels/SettingsViewModels/ExperimentalViewModel.cs
+++ b/Files/ViewModels/SettingsViewModels/ExperimentalViewModel.cs
@@ -88,5 +88,22 @@ namespace Files.ViewModels.SettingsViewModels
                 }
             }
         }
+
+        private bool useNewDetailsView = App.AppSettings.UseNewDetailsView;
+
+        public bool UseNewDetailsView
+        {
+            get
+            {
+                return useNewDetailsView;
+            }
+            set
+            {
+                if (SetProperty(ref useNewDetailsView, value))
+                {
+                    App.AppSettings.UseNewDetailsView = value;
+                }
+            }
+        }
     }
 }

--- a/Files/Views/ColumnShellPage.xaml.cs
+++ b/Files/Views/ColumnShellPage.xaml.cs
@@ -916,7 +916,7 @@ namespace Files.Views
             var ctrl = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Control);
             var alt = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Menu);
             var shift = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
-            var tabInstance = CurrentPageType == typeof(GenericFileBrowser)
+            var tabInstance = CurrentPageType == (App.AppSettings.UseNewDetailsView ? typeof(GenericFileBrowser2) : typeof(GenericFileBrowser))
                 || CurrentPageType == typeof(GridViewBrowser) || CurrentPageType == typeof(ColumnViewBrowser) || CurrentPageType == typeof(ColumnViewBase);
 
             switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.KeyboardAccelerator.Key)
@@ -1040,7 +1040,7 @@ namespace Files.Views
             switch (args.KeyboardAccelerator.Key)
             {
                 case VirtualKey.F2: //F2, rename
-                    if (CurrentPageType == typeof(GenericFileBrowser) || CurrentPageType == typeof(GridViewBrowser) || CurrentPageType == typeof(ColumnViewBrowser) || CurrentPageType == typeof(ColumnViewBase))
+                    if (CurrentPageType == (App.AppSettings.UseNewDetailsView ? typeof(GenericFileBrowser2) : typeof(GenericFileBrowser)) || CurrentPageType == typeof(GridViewBrowser) || CurrentPageType == typeof(ColumnViewBrowser) || CurrentPageType == typeof(ColumnViewBase))
 
                     {
                         if (ContentPage.IsItemSelected)

--- a/Files/Views/LayoutModes/GenericFileBrowser2.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser2.xaml
@@ -1,0 +1,306 @@
+<local:BaseLayout
+    x:Class="Files.Views.LayoutModes.GenericFileBrowser2"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="using:Files"
+    xmlns:converters1="using:Files.Converters"
+    xmlns:local2="using:Files.Filesystem"
+    xmlns:local3="using:Files.Filesystem.Cloud"
+    xmlns:animations="using:Microsoft.Toolkit.Uwp.UI.Animations"
+    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:icore="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:i="using:Microsoft.Xaml.Interactivity" xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    x:Name="PageRoot"
+    NavigationCacheMode="Enabled"
+    mc:Ignorable="d">
+    <i:Interaction.Behaviors>
+        <icore:EventTriggerBehavior EventName="PointerWheelChanged">
+            <icore:InvokeCommandAction Command="{x:Bind CommandsViewModel.PointerWheelChangedCommand}" />
+        </icore:EventTriggerBehavior>
+        <icore:EventTriggerBehavior EventName="PointerPressed">
+            <icore:InvokeCommandAction Command="{x:Bind CommandsViewModel.ItemPointerPressedCommand}" />
+        </icore:EventTriggerBehavior>
+    </i:Interaction.Behaviors>
+    <local:BaseLayout.Resources>
+        <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
+        <converters:BoolToVisibilityConverter
+            x:Key="NegatedBoolToVisibilityConverter"
+            FalseValue="Visible"
+            TrueValue="Collapsed" />
+
+        <converters1:BoolToSelectionMode x:Key="BoolToSelectionModeConverter" />
+
+    </local:BaseLayout.Resources>
+
+    <Grid
+        x:Name="RootGrid"
+        Padding="0,0,0,0"
+        VerticalAlignment="Stretch"
+        ContextFlyout="{x:Bind BaseContextMenuFlyout}">
+        <Grid.KeyboardAccelerators>
+            <KeyboardAccelerator
+                Key="{x:Bind PlusKey}"
+                Modifiers="Control">
+                <i:Interaction.Behaviors>
+                    <icore:EventTriggerBehavior EventName="Invoked">
+                        <icore:InvokeCommandAction Command="{x:Bind CommandsViewModel.GridViewSizeIncreaseCommand}" />
+                    </icore:EventTriggerBehavior>
+                </i:Interaction.Behaviors>
+            </KeyboardAccelerator>
+            <KeyboardAccelerator
+                Key="{x:Bind MinusKey}"
+                Modifiers="Control">
+                <i:Interaction.Behaviors>
+                    <icore:EventTriggerBehavior EventName="Invoked">
+                        <icore:InvokeCommandAction Command="{x:Bind CommandsViewModel.GridViewSizeDecreaseCommand}" />
+                    </icore:EventTriggerBehavior>
+                </i:Interaction.Behaviors>
+            </KeyboardAccelerator>
+            <KeyboardAccelerator
+                Key="Add"
+                Modifiers="Control">
+                <i:Interaction.Behaviors>
+                    <icore:EventTriggerBehavior EventName="Invoked">
+                        <icore:InvokeCommandAction Command="{x:Bind CommandsViewModel.GridViewSizeIncreaseCommand}" />
+                    </icore:EventTriggerBehavior>
+                </i:Interaction.Behaviors>
+            </KeyboardAccelerator>
+            <KeyboardAccelerator
+                Key="Subtract"
+                Modifiers="Control">
+                <i:Interaction.Behaviors>
+                    <icore:EventTriggerBehavior EventName="Invoked">
+                        <icore:InvokeCommandAction Command="{x:Bind CommandsViewModel.GridViewSizeDecreaseCommand}" />
+                    </icore:EventTriggerBehavior>
+                </i:Interaction.Behaviors>
+            </KeyboardAccelerator>
+        </Grid.KeyboardAccelerators>
+        <muxc:ProgressBar
+            x:Name="progBar"
+            VerticalAlignment="Top"
+            x:Load="{x:Bind ParentShellPageInstance.FilesystemViewModel.IsLoadingIndicatorActive, Mode=OneWay}"
+            Background="Transparent"
+            IsIndeterminate="True" />
+        <TextBlock
+            x:Name="EmptyText"
+            x:Uid="EmptyFolder"
+            Grid.Row="3"
+            Margin="0,125,0,0"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Top"
+            x:Load="{x:Bind ParentShellPageInstance.FilesystemViewModel.IsFolderEmptyTextDisplayed, Mode=OneWay}"
+            Canvas.ZIndex="0"
+            Text="This folder is empty."
+            TextWrapping="Wrap" />
+
+        <muxc:TeachingTip
+            x:Name="FileNameTeachingTip"
+            x:Uid="FileNameTeachingTip"
+            CloseButtonContent="OK"
+            PreferredPlacement="Auto"
+            Subtitle="The file name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |"
+            Visibility="Collapsed" />
+
+        <ListView
+            x:Name="FileList"
+            Padding="12,4,4,0"
+            VerticalContentAlignment="Stretch"
+            animations:ItemsReorderAnimation.Duration="0:0:0.350"
+            x:FieldModifier="public"
+            AllowDrop="{x:Bind InstanceViewModel.IsPageTypeSearchResults, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
+            DoubleTapped="FileList_DoubleTapped"
+            IsDoubleTapEnabled="True"
+            IsItemClickEnabled="True"
+            ItemClick="FileList_ItemClick"
+            PreviewKeyDown="FileList_PreviewKeyDown"
+            SelectionChanged="FileList_SelectionChanged"
+            SelectionMode="{x:Bind InteractionViewModel.MultiselectEnabled, Mode=OneWay, Converter={StaticResource BoolToSelectionModeConverter}}"
+            Visibility="{x:Bind FolderSettings.IsLayoutModeChanging, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
+            <ListView.Header>
+                <Grid Padding="0" Margin="0" BorderBrush="{ThemeResource SystemChromeHighColor}" BorderThickness="0, 0, 0, 1" PointerPressed="Grid_PointerPressed">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="{x:Bind ColumnsViewModel.Row1Width, Mode=TwoWay}" x:Name="Column1" />
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="{x:Bind ColumnsViewModel.Row2Width, Mode=TwoWay}" x:Name="Column2"/>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="{x:Bind ColumnsViewModel.Row3Width, Mode=TwoWay}" x:Name="Column3"/>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="{x:Bind ColumnsViewModel.Row4Width, Mode=TwoWay}" x:Name="Column4" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="{x:Bind ColumnsViewModel.Row5Width, Mode=TwoWay}" x:Name="Column5" />
+                    </Grid.ColumnDefinitions>
+
+                    <Button HorizontalAlignment="Stretch" Grid.Column="2" Command="{x:Bind UpdateSortOptionsCommand, Mode=OneWay}" CommandParameter="Name">
+                        <TextBlock Text="Name" TextWrapping="Wrap" Style="{ThemeResource NavigationViewItemHeaderTextStyle}" TextAlignment="Center" x:Uid="FileBrowserSortOption_Name"/>
+                    </Button>
+
+                    <controls:GridSplitter Grid.Column="3" Background="Transparent" Width="1"/>
+
+                    <TextBlock Text="Status" TextWrapping="Wrap" Style="{ThemeResource NavigationViewItemHeaderTextStyle}" TextAlignment="Center" HorizontalAlignment="Stretch" Grid.Column="4" VerticalAlignment="Center"/>
+
+                    <controls:GridSplitter Grid.Column="5" Background="Transparent" Width="1"/>
+
+                    <Button HorizontalAlignment="Stretch" Grid.Column="6"  Command="{x:Bind UpdateSortOptionsCommand, Mode=OneWay}" CommandParameter="DateModified">
+                        <TextBlock Text="Date modified" TextWrapping="Wrap" Style="{ThemeResource NavigationViewItemHeaderTextStyle}" TextAlignment="Center" x:Uid="FileBrowserSortOption_DateModified"/>
+                    </Button>
+
+                    <controls:GridSplitter Grid.Column="7" Background="Transparent" Width="1"/>
+                    <Button HorizontalAlignment="Stretch" Grid.Column="8"  Command="{x:Bind UpdateSortOptionsCommand, Mode=OneWay}" CommandParameter="FileType">
+                        <TextBlock Text="Type" TextWrapping="Wrap" Style="{ThemeResource NavigationViewItemHeaderTextStyle}" TextAlignment="Center" x:Uid="FileBrowserSortOption_FileType"/>
+                    </Button>
+                </Grid>
+            </ListView.Header>
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="local2:ListedItem">
+                    <Grid HorizontalAlignment="Stretch" IsRightTapEnabled="True"
+                        RightTapped="StackPanel_RightTapped"
+                        ToolTipService.ToolTip="{x:Bind ItemName, Mode=OneWay}"
+                        Loaded="Grid_Loaded">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="{x:Bind ColumnsViewModel.Row1Width, Mode=OneWay}"/>
+                            <ColumnDefinition Width="{x:Bind ColumnsViewModel.Row2Width, Mode=OneWay}"/>
+                            <ColumnDefinition Width="{x:Bind ColumnsViewModel.Row3Width, Mode=OneWay}"/>
+                            <ColumnDefinition Width="{x:Bind ColumnsViewModel.Row4Width, Mode=OneWay}"/>
+                            <ColumnDefinition Width="{x:Bind ColumnsViewModel.Row5Width, Mode=OneWay}"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid
+                            Grid.Column="0"
+                            Height="Auto"
+                            Opacity="{x:Bind Opacity, Mode=OneWay}"
+                            Tag="ItemImage">
+                            <Image
+                                x:Name="Picture"
+                                Width="25"
+                                Margin="0,12,0,12"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                x:Load="{x:Bind LoadFileIcon, Mode=OneWay}"
+                                x:Phase="1"
+                                Source="{x:Bind FileImage, Mode=OneWay}"
+                                Stretch="Uniform" />
+                            <Image
+                                x:Name="FolderGlyph"
+                                Width="25"
+                                Height="25"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                x:Load="{x:Bind LoadFolderGlyph, Mode=OneWay}"
+                                x:Phase="1"
+                                Stretch="Uniform">
+                                <Image.Source>
+                                    <SvgImageSource
+                                RasterizePixelHeight="128"
+                                RasterizePixelWidth="128"
+                                UriSource="{x:Bind FolderIconSource}" />
+                                </Image.Source>
+                            </Image>
+                            <FontIcon
+                                x:Name="TypeUnknownGlyph"
+                                Width="25"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                x:Load="{x:Bind LoadUnknownTypeGlyph, Mode=OneWay}"
+                                x:Phase="1"
+                        
+                                FontSize="25"
+                                Glyph="&#xE7C3;" />
+                            <Image
+                                x:Name="IconOverlay"
+                                Width="5"
+                                Height="5"
+                                Margin="1"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Bottom"
+                                x:Load="True"
+                                x:Phase="1"
+                                Source="{x:Bind IconOverlay, Mode=OneWay}"
+                                Stretch="Uniform" />
+                            <Viewbox
+                                x:Name="WebShortcutGlyph"
+                                MaxWidth="25"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                x:Load="{x:Bind LoadWebShortcutGlyph, Mode=OneWay}"
+                                x:Phase="1">
+                                <FontIcon
+                            
+                                    FontSize="28"
+                                    Glyph="&#xE71B;" />
+                            </Viewbox>
+                            <Border
+                                x:Name="ShortcutGlyphElement"
+                                Margin="1"
+                                Padding="0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Bottom"
+                                x:Load="{x:Bind IsShortcutItem}"
+                                x:Phase="1"
+                                Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+                                BorderBrush="{ThemeResource ApplicationForegroundThemeBrush}"
+                                BorderThickness="1">
+                                <FontIcon
+                                            FontFamily="{StaticResource CustomGlyph}"
+                                            FontSize="7"
+                                            Glyph="&#xF10A;" />
+                            </Border>
+                        </Grid>
+
+                        <Grid Grid.Column="1" DoubleTapped="ItemNameGrid_DoubleTapped">
+                            <TextBlock Text="{x:Bind ItemName, Mode=OneWay}" x:Name="ItemName"/>
+                            <TextBox x:Name="ItemNameTextBox" Visibility="Collapsed"/>
+                        </Grid>
+                        <FontIcon
+                            x:Name="CloudDriveSyncStatusGlyph"
+                            Grid.Column="2"
+                            Margin="10,0,0,0"
+                            x:Load="{x:Bind ((local3:CloudDriveSyncStatusUI)SyncStatusUI).LoadSyncStatus, Mode=OneWay}"
+                            x:Phase="2"
+                            Foreground="{x:Bind ((local3:CloudDriveSyncStatusUI)SyncStatusUI).Foreground, Mode=OneWay}"
+                            Glyph="{x:Bind ((local3:CloudDriveSyncStatusUI)SyncStatusUI).Glyph, Mode=OneWay}"
+                            HorizontalAlignment="Stretch"/>
+
+                        <TextBlock Text="{x:Bind ItemDateModified, Mode=OneWay}" Grid.Column="3"/>
+                        <TextBlock Text="{x:Bind ItemType, Mode=OneWay}" Grid.Column="4"/>
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+            <ListView.Resources>
+                <ResourceDictionary>
+                    <ResourceDictionary.ThemeDictionaries>
+                        <ResourceDictionary x:Key="Default">
+                            <SolidColorBrush x:Key="GridViewItemCheckBoxBrush" Color="{ThemeResource SystemChromeMediumLowColor}" />
+                        </ResourceDictionary>
+                    </ResourceDictionary.ThemeDictionaries>
+                </ResourceDictionary>
+            </ListView.Resources>
+
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.Footer>
+                <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" x:Load="{x:Bind InstanceViewModel.ShowSearchUnindexedItemsMessage, Mode=OneWay}" x:Name="SearchUnindexedItemsPanel">
+                    <TextBlock Text="Didn't find what you're looking for?" HorizontalTextAlignment="Center" x:Uid="SearchUnindexedItemsLabel" />
+                    <HyperlinkButton Content="Search unindexed items." HorizontalAlignment="Center" Command="{x:Bind CommandsViewModel.SearchUnindexedItems}" x:Name="SearchUnindexedItemsButton" x:Uid="SearchUnindexedItemsButton" />
+                </StackPanel>
+            </ListView.Footer>
+        </ListView>
+
+        <Canvas HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+            <Rectangle
+                Name="SelectionRectangle"
+                Canvas.Left="0"
+                Canvas.Top="0"
+                Width="0"
+                Height="0"
+                Fill="{ThemeResource SystemAccentColor}"
+                Opacity=".5"
+                Stroke="{ThemeResource SystemAccentColorLight1}"
+                StrokeThickness="1" />
+        </Canvas>
+    </Grid>
+</local:BaseLayout>

--- a/Files/Views/LayoutModes/GenericFileBrowser2.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser2.xaml.cs
@@ -1,0 +1,564 @@
+﻿using Files.Enums;
+using Files.EventArguments;
+using Files.Filesystem;
+using Files.Helpers;
+using Files.Helpers.XamlHelpers;
+using Files.Interacts;
+using Files.UserControls.Selection;
+using Files.ViewModels;
+using Microsoft.Toolkit.Mvvm.Input;
+using Microsoft.Toolkit.Uwp.UI;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.System;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Files.Views.LayoutModes
+{
+    public sealed partial class GenericFileBrowser2 : BaseLayout
+    {
+        public string oldItemName;
+        public ColumnsViewModel ColumnsViewModel { get; set; } = new ColumnsViewModel();
+
+        RelayCommand<string> UpdateSortOptionsCommand { get; set; }
+
+        public GenericFileBrowser2()
+            : base()
+        {
+            InitializeComponent();
+            this.DataContext = this;
+
+            var selectionRectangle = RectangleSelection.Create(FileList, SelectionRectangle, FileList_SelectionChanged);
+            selectionRectangle.SelectionEnded += SelectionRectangle_SelectionEnded;
+        }
+
+        protected override void HookEvents()
+        {
+            UnhookEvents();
+            ItemManipulationModel.FocusFileListInvoked += ItemManipulationModel_FocusFileListInvoked;
+            ItemManipulationModel.SelectAllItemsInvoked += ItemManipulationModel_SelectAllItemsInvoked;
+            ItemManipulationModel.ClearSelectionInvoked += ItemManipulationModel_ClearSelectionInvoked;
+            ItemManipulationModel.InvertSelectionInvoked += ItemManipulationModel_InvertSelectionInvoked;
+            ItemManipulationModel.AddSelectedItemInvoked += ItemManipulationModel_AddSelectedItemInvoked;
+            ItemManipulationModel.FocusSelectedItemsInvoked += ItemManipulationModel_FocusSelectedItemsInvoked;
+            ItemManipulationModel.StartRenameItemInvoked += ItemManipulationModel_StartRenameItemInvoked;
+            ItemManipulationModel.ScrollIntoViewInvoked += ItemManipulationModel_ScrollIntoViewInvoked;
+            ItemManipulationModel.SetDragModeForItemsInvoked += ItemManipulationModel_SetDragModeForItemsInvoked;
+            ItemManipulationModel.RefreshItemsOpacityInvoked += ItemManipulationModel_RefreshItemsOpacityInvoked;
+        }
+
+        private void ItemManipulationModel_RefreshItemsOpacityInvoked(object sender, EventArgs e)
+        {
+            foreach (ListedItem listedItem in (IEnumerable)FileList.ItemsSource)
+            {
+                if (listedItem.IsHiddenItem)
+                {
+                    listedItem.Opacity = Constants.UI.DimItemOpacity;
+                }
+                else
+                {
+                    listedItem.Opacity = 1;
+                }
+            }
+        }
+
+        private void ItemManipulationModel_SetDragModeForItemsInvoked(object sender, EventArgs e)
+        {
+            if (!InstanceViewModel.IsPageTypeSearchResults)
+            {
+                foreach (ListedItem listedItem in FileList.Items.ToList())
+                {
+                    if (FileList.ContainerFromItem(listedItem) is GridViewItem gridViewItem)
+                    {
+                        gridViewItem.CanDrag = gridViewItem.IsSelected;
+                    }
+                }
+            }
+        }
+
+        private void FilesAndFolders_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            UpdateItemColumnViewModels();
+        }
+
+        private void UpdateItemColumnViewModels()
+        {
+            // Make sure every new item has the column view model
+            ParentShellPageInstance.FilesystemViewModel.FilesAndFolders?.ToList().ForEach(x => x.ColumnsViewModel = ColumnsViewModel);
+        }
+
+        private void ItemManipulationModel_ScrollIntoViewInvoked(object sender, ListedItem e)
+        {
+            FileList.ScrollIntoView(e);
+        }
+
+        private void ItemManipulationModel_StartRenameItemInvoked(object sender, EventArgs e)
+        {
+            StartRenameItem();
+        }
+
+        private void ItemManipulationModel_FocusSelectedItemsInvoked(object sender, EventArgs e)
+        {
+            if (SelectedItems.Any())
+            {
+                FileList.ScrollIntoView(SelectedItems.Last());
+            }
+        }
+
+        private void ItemManipulationModel_AddSelectedItemInvoked(object sender, ListedItem e)
+        {
+            if (FileList?.Items.Contains(e) ?? false)
+            {
+                FileList.SelectedItems.Add(e);
+            }
+        }
+
+        private void ItemManipulationModel_InvertSelectionInvoked(object sender, EventArgs e)
+        {
+            List<ListedItem> newSelectedItems = GetAllItems()
+                .Cast<ListedItem>()
+                .Except(SelectedItems)
+                .ToList();
+
+            ItemManipulationModel.SetSelectedItems(newSelectedItems);
+        }
+
+        private void ItemManipulationModel_ClearSelectionInvoked(object sender, EventArgs e)
+        {
+            FileList.SelectedItems.Clear();
+        }
+
+        private void ItemManipulationModel_SelectAllItemsInvoked(object sender, EventArgs e)
+        {
+            FileList.SelectAll();
+        }
+
+        private void ItemManipulationModel_FocusFileListInvoked(object sender, EventArgs e)
+        {
+            FileList.Focus(FocusState.Programmatic);
+        }
+
+        protected override void UnhookEvents()
+        {
+            if (ItemManipulationModel != null)
+            {
+                ItemManipulationModel.FocusFileListInvoked -= ItemManipulationModel_FocusFileListInvoked;
+                ItemManipulationModel.SelectAllItemsInvoked -= ItemManipulationModel_SelectAllItemsInvoked;
+                ItemManipulationModel.ClearSelectionInvoked -= ItemManipulationModel_ClearSelectionInvoked;
+                ItemManipulationModel.InvertSelectionInvoked -= ItemManipulationModel_InvertSelectionInvoked;
+                ItemManipulationModel.AddSelectedItemInvoked -= ItemManipulationModel_AddSelectedItemInvoked;
+                ItemManipulationModel.FocusSelectedItemsInvoked -= ItemManipulationModel_FocusSelectedItemsInvoked;
+                ItemManipulationModel.StartRenameItemInvoked -= ItemManipulationModel_StartRenameItemInvoked;
+                ItemManipulationModel.ScrollIntoViewInvoked -= ItemManipulationModel_ScrollIntoViewInvoked;
+                ItemManipulationModel.SetDragModeForItemsInvoked -= ItemManipulationModel_SetDragModeForItemsInvoked;
+                ItemManipulationModel.RefreshItemsOpacityInvoked -= ItemManipulationModel_RefreshItemsOpacityInvoked;
+            }
+        }
+
+        protected override void InitializeCommandsViewModel()
+        {
+            CommandsViewModel = new BaseLayoutCommandsViewModel(new BaseLayoutCommandImplementationModel(ParentShellPageInstance, ItemManipulationModel));
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
+        {
+            base.OnNavigatedTo(eventArgs);
+            currentIconSize = FolderSettings.GetIconSize();
+            FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
+            FolderSettings.LayoutModeChangeRequested += FolderSettings_LayoutModeChangeRequested;
+            ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.CollectionChanged += FilesAndFolders_CollectionChanged;
+
+            if (FileList.ItemsSource == null)
+            {
+                FileList.ItemsSource = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders;
+            }
+            var parameters = (NavigationArguments)eventArgs.Parameter;
+            if (parameters.IsLayoutSwitch)
+            {
+                ReloadItemIcons();
+            }
+
+            UpdateSortOptionsCommand = new RelayCommand<string>(x => {
+                var val = Enum.Parse<SortOption>(x);
+                if (ParentShellPageInstance.FilesystemViewModel.folderSettings.DirectorySortOption == val)
+                {
+                    ParentShellPageInstance.FilesystemViewModel.folderSettings.DirectorySortDirection = (SortDirection)(((int)ParentShellPageInstance.FilesystemViewModel.folderSettings.DirectorySortDirection + 1) % 2);
+                }
+                else
+                {
+                    ParentShellPageInstance.FilesystemViewModel.folderSettings.DirectorySortOption = val;
+                    ParentShellPageInstance.FilesystemViewModel.folderSettings.DirectorySortDirection = SortDirection.Ascending;
+                }
+            });
+        }
+
+        protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+        {
+            var selectorItems = new List<SelectorItem>();
+            DependencyObjectHelpers.FindChildren<SelectorItem>(selectorItems, FileList);
+            foreach (SelectorItem gvi in selectorItems)
+            {
+                base.UninitializeDrag(gvi);
+                gvi.PointerPressed -= FileListGridItem_PointerPressed;
+            }
+            selectorItems.Clear();
+            base.OnNavigatingFrom(e);
+            FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
+            FolderSettings.GridViewSizeChangeRequested -= FolderSettings_GridViewSizeChangeRequested;
+            if (e.SourcePageType != typeof(GridViewBrowser))
+            {
+                FileList.ItemsSource = null;
+            }
+        }
+
+        private async void SelectionRectangle_SelectionEnded(object sender, EventArgs e)
+        {
+            await Task.Delay(200);
+            FileList.Focus(FocusState.Programmatic);
+        }
+
+        private void FolderSettings_LayoutModeChangeRequested(object sender, LayoutModeEventArgs e)
+        {
+
+        }
+
+        protected override IEnumerable GetAllItems()
+        {
+            return FileList.Items;
+        }
+
+        private void StackPanel_RightTapped(object sender, RightTappedRoutedEventArgs e)
+        {
+            var parentContainer = DependencyObjectHelpers.FindParent<ListViewItem>(e.OriginalSource as DependencyObject);
+            if (!parentContainer.IsSelected)
+            {
+                ItemManipulationModel.SetSelectedItem(FileList.ItemFromContainer(parentContainer) as ListedItem);
+            }
+        }
+
+        private void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            SelectedItems = FileList.SelectedItems.Cast<ListedItem>().Where(x => x != null).ToList();
+        }
+
+        private ListedItem renamingItem;
+
+        private void StartRenameItem()
+        {
+            renamingItem = SelectedItem;
+            int extensionLength = renamingItem.FileExtension?.Length ?? 0;
+            ListViewItem gridViewItem = FileList.ContainerFromItem(renamingItem) as ListViewItem;
+            TextBox textBox = null;
+
+            TextBlock textBlock = gridViewItem.FindDescendant("ItemName") as TextBlock;
+            textBox = gridViewItem.FindDescendant("ItemNameTextBox") as TextBox;
+            //TextBlock textBlock = (gridViewItem.ContentTemplateRoot as Grid).FindName("ItemName") as TextBlock;
+            //textBox = (gridViewItem.ContentTemplateRoot as Grid).FindName("TileViewTextBoxItemName") as TextBox;
+            textBox.Text = textBlock.Text;
+            oldItemName = textBlock.Text;
+            textBlock.Visibility = Visibility.Collapsed;
+            textBox.Visibility = Visibility.Visible;
+
+            textBox.Focus(FocusState.Pointer);
+            textBox.LostFocus += RenameTextBox_LostFocus;
+            textBox.KeyDown += RenameTextBox_KeyDown;
+
+            int selectedTextLength = SelectedItem.ItemName.Length;
+            if (!SelectedItem.IsShortcutItem && App.AppSettings.ShowFileExtensions)
+            {
+                selectedTextLength -= extensionLength;
+            }
+            textBox.Select(0, selectedTextLength);
+            IsRenamingItem = true;
+        }
+
+        private void GridViewTextBoxItemName_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            var textBox = sender as TextBox;
+
+            if (FilesystemHelpers.ContainsRestrictedCharacters(textBox.Text))
+            {
+                FileNameTeachingTip.Visibility = Visibility.Visible;
+                FileNameTeachingTip.IsOpen = true;
+            }
+            else
+            {
+                FileNameTeachingTip.IsOpen = false;
+                FileNameTeachingTip.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        private void RenameTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            if (e.Key == VirtualKey.Escape)
+            {
+                TextBox textBox = sender as TextBox;
+                textBox.LostFocus -= RenameTextBox_LostFocus;
+                textBox.Text = oldItemName;
+                EndRename(textBox);
+                e.Handled = true;
+            }
+            else if (e.Key == VirtualKey.Enter)
+            {
+                TextBox textBox = sender as TextBox;
+                textBox.LostFocus -= RenameTextBox_LostFocus;
+                CommitRename(textBox);
+                e.Handled = true;
+            }
+        }
+
+        private void RenameTextBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            TextBox textBox = e.OriginalSource as TextBox;
+            CommitRename(textBox);
+        }
+
+        private async void CommitRename(TextBox textBox)
+        {
+            EndRename(textBox);
+            string newItemName = textBox.Text.Trim().TrimEnd('.');
+
+            bool successful = await UIFilesystemHelpers.RenameFileItemAsync(renamingItem, oldItemName, newItemName, ParentShellPageInstance);
+            if (!successful)
+            {
+                renamingItem.ItemName = oldItemName;
+            }
+        }
+
+        private void EndRename(TextBox textBox)
+        {
+            if (textBox.Parent == null)
+            {
+                // Navigating away, do nothing
+            }
+            else
+            {
+                ListViewItem gridViewItem = FileList.ContainerFromItem(renamingItem) as ListViewItem;
+                TextBlock textBlock = gridViewItem.FindDescendant("ItemName") as TextBlock;
+
+                textBox.Visibility = Visibility.Collapsed;
+                textBlock.Visibility = Visibility.Visible;
+            }
+
+            textBox.LostFocus -= RenameTextBox_LostFocus;
+            textBox.KeyDown -= RenameTextBox_KeyDown;
+            FileNameTeachingTip.IsOpen = false;
+            IsRenamingItem = false;
+        }
+
+        private void FileList_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            var ctrlPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            var shiftPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+
+            if (e.Key == VirtualKey.Enter && !e.KeyStatus.IsMenuKeyDown)
+            {
+                if (!IsRenamingItem)
+                {
+                    NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                    e.Handled = true;
+                }
+            }
+            else if (e.Key == VirtualKey.Enter && e.KeyStatus.IsMenuKeyDown)
+            {
+                FilePropertiesHelpers.ShowProperties(ParentShellPageInstance);
+                e.Handled = true;
+            }
+            else if (e.Key == VirtualKey.Space)
+            {
+                if (!IsRenamingItem && !ParentShellPageInstance.NavigationToolbar.IsEditModeEnabled)
+                {
+                    if (InteractionViewModel.IsQuickLookEnabled)
+                    {
+                        QuickLookHelpers.ToggleQuickLook(ParentShellPageInstance);
+                    }
+                    e.Handled = true;
+                }
+            }
+            else if (e.KeyStatus.IsMenuKeyDown && (e.Key == VirtualKey.Left || e.Key == VirtualKey.Right || e.Key == VirtualKey.Up))
+            {
+                // Unfocus the GridView so keyboard shortcut can be handled
+                (ParentShellPageInstance.NavigationToolbar as Control)?.Focus(FocusState.Pointer);
+            }
+            else if (ctrlPressed && shiftPressed && (e.Key == VirtualKey.Left || e.Key == VirtualKey.Right || e.Key == VirtualKey.W))
+            {
+                // Unfocus the ListView so keyboard shortcut can be handled (ctrl + shift + W/"->"/"<-")
+                (ParentShellPageInstance.NavigationToolbar as Control)?.Focus(FocusState.Pointer);
+            }
+            else if (e.KeyStatus.IsMenuKeyDown && shiftPressed && e.Key == VirtualKey.Add)
+            {
+                // Unfocus the ListView so keyboard shortcut can be handled (alt + shift + "+")
+                (ParentShellPageInstance.NavigationToolbar as Control)?.Focus(FocusState.Pointer);
+            }
+        }
+
+        protected override void Page_CharacterReceived(CoreWindow sender, CharacterReceivedEventArgs args)
+        {
+            if (ParentShellPageInstance != null)
+            {
+                if (ParentShellPageInstance.CurrentPageType == typeof(GridViewBrowser) && !IsRenamingItem)
+                {
+                    // Don't block the various uses of enter key (key 13)
+                    var focusedElement = FocusManager.GetFocusedElement() as FrameworkElement;
+                    if (args.KeyCode == 13
+                        || focusedElement is Button
+                        || focusedElement is TextBox
+                        || focusedElement is PasswordBox
+                        || DependencyObjectHelpers.FindParent<ContentDialog>(focusedElement) != null)
+                    {
+                        return;
+                    }
+
+                    base.Page_CharacterReceived(sender, args);
+                    FileList.Focus(FocusState.Keyboard);
+                }
+            }
+        }
+
+        protected override ListedItem GetItemFromElement(object element)
+        {
+            return (element as GridViewItem).DataContext as ListedItem;
+        }
+
+        private void FileListGridItem_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            if (e.KeyModifiers == VirtualKeyModifiers.Control)
+            {
+                if ((sender as SelectorItem).IsSelected)
+                {
+                    (sender as SelectorItem).IsSelected = false;
+                    // Prevent issues arising caused by the default handlers attempting to select the item that has just been deselected by ctrl + click
+                    e.Handled = true;
+                }
+            }
+            else if (e.GetCurrentPoint(sender as UIElement).Properties.IsLeftButtonPressed)
+            {
+                if (!(sender as SelectorItem).IsSelected)
+                {
+                    (sender as SelectorItem).IsSelected = true;
+                }
+            }
+        }
+
+        private uint currentIconSize;
+
+        private void FolderSettings_GridViewSizeChangeRequested(object sender, EventArgs e)
+        {
+            var requestedIconSize = FolderSettings.GetIconSize(); // Get new icon size
+
+            // Prevents reloading icons when the icon size hasn't changed
+            if (requestedIconSize != currentIconSize)
+            {
+                currentIconSize = requestedIconSize; // Update icon size before refreshing
+                ReloadItemIcons();
+            }
+        }
+
+        private async void ReloadItemIcons()
+        {
+            ParentShellPageInstance.FilesystemViewModel.CancelExtendedPropertiesLoading();
+            foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.ToList())
+            {
+                listedItem.ItemPropertiesInitialized = false;
+                if (FileList.ContainerFromItem(listedItem) != null)
+                {
+                    listedItem.ItemPropertiesInitialized = true;
+                    await ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(listedItem, currentIconSize);
+                }
+            }
+        }
+
+        private async void FileList_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            var ctrlPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            var shiftPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+
+            // Skip code if the control or shift key is pressed or if the user is using multiselect
+            if (ctrlPressed || shiftPressed || InteractionViewModel.MultiselectEnabled)
+            {
+                return;
+            }
+
+            // Check if the setting to open items with a single click is turned on
+            if (AppSettings.OpenItemsWithOneclick)
+            {
+                await Task.Delay(200); // The delay gives time for the item to be selected
+                NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+            }
+        }
+
+        private async void FileList_ChoosingItemContainer(ListViewBase sender, ChoosingItemContainerEventArgs args)
+        {
+            if (args.ItemContainer == null)
+            {
+                GridViewItem gvi = new GridViewItem();
+                args.ItemContainer = gvi;
+            }
+            args.ItemContainer.DataContext = args.Item;
+
+            if (args.Item is ListedItem item && !item.ItemPropertiesInitialized)
+            {
+                args.ItemContainer.PointerPressed += FileListGridItem_PointerPressed;
+                InitializeDrag(args.ItemContainer);
+                args.ItemContainer.CanDrag = args.ItemContainer.IsSelected; // Update CanDrag
+
+                item.ItemPropertiesInitialized = true;
+                await ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(item, currentIconSize);
+            }
+        }
+
+        private void FileList_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+        {
+            // Skip opening selected items if the double tap doesn't capture an item
+            if ((e.OriginalSource as FrameworkElement)?.DataContext is ListedItem && !AppSettings.OpenItemsWithOneclick)
+            {
+                if (!InteractionViewModel.MultiselectEnabled)
+                {
+                    NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                }
+            }
+        }
+
+        #region IDisposable
+
+        public override void Dispose()
+        {
+            UnhookEvents();
+            CommandsViewModel?.Dispose();
+        }
+
+        #endregion IDisposable
+
+        private void Grid_Loaded(object sender, RoutedEventArgs e)
+        {
+            // This is the best way I could find to set the context flyout, as doing it in the styles isn't possible
+            // because you can't use bindings in the setters
+            DependencyObject item = VisualTreeHelper.GetParent(sender as Grid);
+            while (!(item is ListViewItem))
+                item = VisualTreeHelper.GetParent(item);
+            var itemContainer = item as ListViewItem;
+            itemContainer.ContextFlyout = ItemContextMenuFlyout;
+        }
+
+        private void Grid_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            // This prevents the drag selection rectangle from appearing when resizing the columns
+            e.Handled = true;
+        }
+
+        private void ItemNameGrid_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+        {
+            StartRenameItem();
+            e.Handled = true;
+        }
+    }
+}

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -902,7 +902,7 @@ namespace Files.Views
         {
             ContentPage = await GetContentOrNullAsync();
             NavigationToolbar.ClearSearchBoxQueryText(true);
-            if (ItemDisplayFrame.CurrentSourcePageType == typeof(GenericFileBrowser)
+            if (ItemDisplayFrame.CurrentSourcePageType == (App.AppSettings.UseNewDetailsView ? typeof(GenericFileBrowser2) : typeof(GenericFileBrowser))
                 || ItemDisplayFrame.CurrentSourcePageType == typeof(GridViewBrowser))
             {
                 // Reset DataGrid Rows that may be in "cut" command mode

--- a/Files/Views/SettingsPages/Experimental.xaml
+++ b/Files/Views/SettingsPages/Experimental.xaml
@@ -69,6 +69,12 @@
                     Header="Enable multiselect options (currently only available in the tiles and grid view layout modes)"
                     HeaderTemplate="{StaticResource CustomHeaderStyle}"
                     IsOn="{Binding ShowMultiselectOption, Mode=TwoWay}" />
+                
+                <ToggleSwitch
+                    x:Uid="SettingsUseNewDetailsView"
+                    Header="Use new details view"
+                    HeaderTemplate="{StaticResource CustomHeaderStyle}"
+                    IsOn="{Binding UseNewDetailsView, Mode=TwoWay}" />
             </StackPanel>
         </ScrollViewer>
     </Grid>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
This could probably solve some of the Needs-Winui-DataGrid issues.

**Details of Changes**
This PR adds a list view based details view, which can be enabled in the experiments settings page. 
For now I think this should be kept as an experiment until it reaches feature parity with the DataGrid and the bugs are worked out, but I believe it should be ready by 2.0.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

#### What works
- double click name to rename
- click header to sort, click again to toggle direction
- resize columns
- context menus

#### What doesn't work
- Hide status column in non-cloud drive folders
- Recycle bin sort options

#### Advantages of this over the DataGrid
- virtualized
- smooth scrolling
- will be updated with WinUI 2.6 styles
- DataGrid doesn't allow for automation properties
- multiselect

**Screenshots (optional)**

https://user-images.githubusercontent.com/59544401/114475380-04604e80-9bad-11eb-8fa5-76efac41ec95.mp4

