### PR TITLE
Fix crash that can occur when deleting items

### DIFF
--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -94,103 +94,112 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItemWithPath> source, bool showDialog, bool permanently, bool registerHistory)
         {
-            PostedStatusBanner banner;
-            if (permanently)
+            try
             {
-                banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
-                associatedInstance.FilesystemViewModel.WorkingDirectory,
-                0,
-                ReturnResult.InProgress,
-                FileOperationType.Delete);
-            }
-            else
-            {
-                banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
-                associatedInstance.FilesystemViewModel.WorkingDirectory,
-                0,
-                ReturnResult.InProgress,
-                FileOperationType.Recycle);
-            }
-
-            var returnStatus = ReturnResult.InProgress;
-            banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
-
-            var pathsUnderRecycleBin = GetPathsUnderRecycleBin(source);
-
-            if (App.AppSettings.ShowConfirmDeleteDialog && showDialog) // Check if the setting to show a confirmation dialog is on
-            {
-                var deleteFromRecycleBin = pathsUnderRecycleBin.Count > 0;
-
-                List<FilesystemItemsOperationItemModel> incomingItems = new List<FilesystemItemsOperationItemModel>();
-
-                for (int i = 0; i < source.Count(); i++)
+                PostedStatusBanner banner;
+                if (permanently)
                 {
-                    incomingItems.Add(new FilesystemItemsOperationItemModel(FilesystemOperationType.Delete, source.ElementAt(i).Path ?? source.ElementAt(i).Item.Path, null));
-                }
-
-                FilesystemOperationDialog dialog = FilesystemOperationDialogViewModel.GetDialog(new FilesystemItemsOperationDataModel(
-                    FilesystemOperationType.Delete,
-                    false,
-                    !deleteFromRecycleBin ? permanently : deleteFromRecycleBin,
-                    !deleteFromRecycleBin,
-                    incomingItems,
-                    new List<FilesystemItemsOperationItemModel>()));
-
-                ContentDialogResult result = await dialog.ShowAsync();
-
-                if (result != ContentDialogResult.Primary)
-                {
-                    banner.Remove();
-                    return ReturnResult.Cancelled; // Return if the result isn't delete
-                }
-
-                // Delete selected items if the result is Yes
-                permanently = dialog.ViewModel.PermanentlyDelete;
-            }
-
-            var sw = new Stopwatch();
-            sw.Start();
-
-            IStorageHistory history;
-            var rawStorageHistory = new List<IStorageHistory>();
-
-            bool originalPermanently = permanently;
-            float progress;
-            for (int i = 0; i < source.Count(); i++)
-            {
-                if (pathsUnderRecycleBin.Contains(source.ElementAt(i).Path))
-                {
-                    permanently = true;
+                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    associatedInstance.FilesystemViewModel.WorkingDirectory,
+                    0,
+                    ReturnResult.InProgress,
+                    FileOperationType.Delete);
                 }
                 else
                 {
-                    permanently = originalPermanently;
+                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    associatedInstance.FilesystemViewModel.WorkingDirectory,
+                    0,
+                    ReturnResult.InProgress,
+                    FileOperationType.Recycle);
                 }
 
-                rawStorageHistory.Add(await filesystemOperations.DeleteAsync(source.ElementAt(i), null, banner.ErrorCode, permanently, cancellationToken));
-                progress = ((float)i / (float)source.Count()) * 100.0f;
-                ((IProgress<float>)banner.Progress).Report(progress);
-            }
+                var returnStatus = ReturnResult.InProgress;
+                banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
 
-            if (rawStorageHistory.Any() && rawStorageHistory.TrueForAll((item) => item != null))
-            {
-                history = new StorageHistory(
-                    rawStorageHistory[0].OperationType,
-                    rawStorageHistory.SelectMany((item) => item.Source).ToList(),
-                    rawStorageHistory.SelectMany((item) => item.Destination).ToList());
+                var pathsUnderRecycleBin = GetPathsUnderRecycleBin(source);
 
-                if (!permanently && registerHistory)
+                if (App.AppSettings.ShowConfirmDeleteDialog && showDialog) // Check if the setting to show a confirmation dialog is on
                 {
-                    App.HistoryWrapper.AddHistory(history);
+                    var deleteFromRecycleBin = pathsUnderRecycleBin.Count > 0;
+
+                    List<FilesystemItemsOperationItemModel> incomingItems = new List<FilesystemItemsOperationItemModel>();
+
+                    for (int i = 0; i < source.Count(); i++)
+                    {
+                        incomingItems.Add(new FilesystemItemsOperationItemModel(FilesystemOperationType.Delete, source.ElementAt(i).Path ?? source.ElementAt(i).Item.Path, null));
+                    }
+
+                    FilesystemOperationDialog dialog = FilesystemOperationDialogViewModel.GetDialog(new FilesystemItemsOperationDataModel(
+                        FilesystemOperationType.Delete,
+                        false,
+                        !deleteFromRecycleBin ? permanently : deleteFromRecycleBin,
+                        !deleteFromRecycleBin,
+                        incomingItems,
+                        new List<FilesystemItemsOperationItemModel>()));
+
+                    ContentDialogResult result = await dialog.ShowAsync();
+
+                    if (result != ContentDialogResult.Primary)
+                    {
+                        banner.Remove();
+                        return ReturnResult.Cancelled; // Return if the result isn't delete
+                    }
+
+                    // Delete selected items if the result is Yes
+                    permanently = dialog.ViewModel.PermanentlyDelete;
                 }
+
+                var sw = new Stopwatch();
+                sw.Start();
+
+                IStorageHistory history;
+                var rawStorageHistory = new List<IStorageHistory>();
+
+                bool originalPermanently = permanently;
+                float progress;
+                for (int i = 0; i < source.Count(); i++)
+                {
+                    if (pathsUnderRecycleBin.Contains(source.ElementAt(i).Path))
+                    {
+                        permanently = true;
+                    }
+                    else
+                    {
+                        permanently = originalPermanently;
+                    }
+
+                    rawStorageHistory.Add(await filesystemOperations.DeleteAsync(source.ElementAt(i), null, banner.ErrorCode, permanently, cancellationToken));
+                    progress = ((float)i / (float)source.Count()) * 100.0f;
+                    ((IProgress<float>)banner.Progress).Report(progress);
+                }
+
+                if (rawStorageHistory.Any() && rawStorageHistory.TrueForAll((item) => item != null))
+                {
+                    history = new StorageHistory(
+                        rawStorageHistory[0].OperationType,
+                        rawStorageHistory.SelectMany((item) => item.Source).ToList(),
+                        rawStorageHistory.SelectMany((item) => item.Destination).ToList());
+
+                    if (!permanently && registerHistory)
+                    {
+                        App.HistoryWrapper.AddHistory(history);
+                    }
+                }
+
+                banner.Remove();
+                sw.Stop();
+
+                PostBannerHelpers.PostBanner_Delete(returnStatus, permanently ? FileOperationType.Delete : FileOperationType.Recycle, sw, associatedInstance);
+                return returnStatus;
+
+            }
+            catch (System.Exception ex)
+            {
+                NLog.LogManager.GetCurrentClassLogger().Warn($"Delete items operation failed:\n{ex}");
+                return ReturnResult.Failed;
             }
 
-            banner.Remove();
-            sw.Stop();
-
-            PostBannerHelpers.PostBanner_Delete(returnStatus, permanently ? FileOperationType.Delete : FileOperationType.Recycle, sw, associatedInstance);
-
-            return returnStatus;
         }
 
         private ISet<string> GetPathsUnderRecycleBin(IEnumerable<IStorageItemWithPath> source)
@@ -200,78 +209,87 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> DeleteItemAsync(IStorageItemWithPath source, bool showDialog, bool permanently, bool registerHistory)
         {
-            PostedStatusBanner banner;
-            bool deleteFromRecycleBin = recycleBinHelpers.IsPathUnderRecycleBin(source.Path);
-
-            if (deleteFromRecycleBin)
+            try
             {
-                permanently = true;
-            }
+                PostedStatusBanner banner;
+                bool deleteFromRecycleBin = recycleBinHelpers.IsPathUnderRecycleBin(source.Path);
 
-            if (permanently)
-            {
-                banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
-                associatedInstance.FilesystemViewModel.WorkingDirectory,
-                0,
-                ReturnResult.InProgress,
-                FileOperationType.Delete);
-            }
-            else
-            {
-                banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
-                associatedInstance.FilesystemViewModel.WorkingDirectory,
-                0,
-                ReturnResult.InProgress,
-                FileOperationType.Recycle);
-            }
+                if (deleteFromRecycleBin)
+                {
+                    permanently = true;
+                }
 
-            var returnStatus = ReturnResult.InProgress;
-            banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
+                if (permanently)
+                {
+                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    associatedInstance.FilesystemViewModel.WorkingDirectory,
+                    0,
+                    ReturnResult.InProgress,
+                    FileOperationType.Delete);
+                }
+                else
+                {
+                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    associatedInstance.FilesystemViewModel.WorkingDirectory,
+                    0,
+                    ReturnResult.InProgress,
+                    FileOperationType.Recycle);
+                }
 
-            if (App.AppSettings.ShowConfirmDeleteDialog && showDialog) // Check if the setting to show a confirmation dialog is on
-            {
-                List<FilesystemItemsOperationItemModel> incomingItems = new List<FilesystemItemsOperationItemModel>
+                var returnStatus = ReturnResult.InProgress;
+
+                banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
+
+                if (App.AppSettings.ShowConfirmDeleteDialog && showDialog) // Check if the setting to show a confirmation dialog is on
+                {
+                    List<FilesystemItemsOperationItemModel> incomingItems = new List<FilesystemItemsOperationItemModel>
                 {
                     new FilesystemItemsOperationItemModel(FilesystemOperationType.Delete, source.Path ?? source.Item.Path, null)
                 };
 
-                FilesystemOperationDialog dialog = FilesystemOperationDialogViewModel.GetDialog(new FilesystemItemsOperationDataModel(
-                    FilesystemOperationType.Delete,
-                    false,
-                    !deleteFromRecycleBin ? permanently : deleteFromRecycleBin,
-                    !deleteFromRecycleBin,
-                    incomingItems,
-                    new List<FilesystemItemsOperationItemModel>()));
+                    FilesystemOperationDialog dialog = FilesystemOperationDialogViewModel.GetDialog(new FilesystemItemsOperationDataModel(
+                        FilesystemOperationType.Delete,
+                        false,
+                        !deleteFromRecycleBin ? permanently : deleteFromRecycleBin,
+                        !deleteFromRecycleBin,
+                        incomingItems,
+                        new List<FilesystemItemsOperationItemModel>()));
 
-                ContentDialogResult result = await dialog.ShowAsync();
+                    ContentDialogResult result = await dialog.ShowAsync();
 
-                if (result != ContentDialogResult.Primary)
-                {
-                    banner.Remove();
-                    return ReturnResult.Cancelled; // Return if the result isn't delete
+                    if (result != ContentDialogResult.Primary)
+                    {
+                        banner.Remove();
+                        return ReturnResult.Cancelled; // Return if the result isn't delete
+                    }
+
+                    // Delete selected item if the result is Yes
+                    permanently = dialog.ViewModel.PermanentlyDelete;
                 }
 
-                // Delete selected item if the result is Yes
-                permanently = dialog.ViewModel.PermanentlyDelete;
+                var sw = new Stopwatch();
+                sw.Start();
+
+                IStorageHistory history = await filesystemOperations.DeleteAsync(source, banner.Progress, banner.ErrorCode, permanently, cancellationToken);
+                ((IProgress<float>)banner.Progress).Report(100.0f);
+
+                if (!permanently && registerHistory)
+                {
+                    App.HistoryWrapper.AddHistory(history);
+                }
+
+                banner.Remove();
+                sw.Stop();
+
+                PostBannerHelpers.PostBanner_Delete(returnStatus, permanently ? FileOperationType.Delete : FileOperationType.Recycle, sw, associatedInstance);
+                return returnStatus;
             }
-
-            var sw = new Stopwatch();
-            sw.Start();
-
-            IStorageHistory history = await filesystemOperations.DeleteAsync(source, banner.Progress, banner.ErrorCode, permanently, cancellationToken);
-            ((IProgress<float>)banner.Progress).Report(100.0f);
-
-            if (!permanently && registerHistory)
+            catch (System.Exception ex)
             {
-                App.HistoryWrapper.AddHistory(history);
+                NLog.LogManager.GetCurrentClassLogger().Warn($"Delete item operation failed:\n{ex}");
+                return ReturnResult.Failed;
             }
 
-            banner.Remove();
-            sw.Stop();
-
-            PostBannerHelpers.PostBanner_Delete(returnStatus, permanently ? FileOperationType.Delete : FileOperationType.Recycle, sw, associatedInstance);
-
-            return returnStatus;
         }
 
         public async Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItem> source, bool showDialog, bool permanently, bool registerHistory)
@@ -281,78 +299,86 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> DeleteItemAsync(IStorageItem source, bool showDialog, bool permanently, bool registerHistory)
         {
-            PostedStatusBanner banner;
-            bool deleteFromRecycleBin = recycleBinHelpers.IsPathUnderRecycleBin(source.Path);
-
-            if (deleteFromRecycleBin)
+            try
             {
-                permanently = true;
-            }
+                PostedStatusBanner banner;
+                bool deleteFromRecycleBin = recycleBinHelpers.IsPathUnderRecycleBin(source.Path);
 
-            if (permanently)
-            {
-                banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
-                associatedInstance.FilesystemViewModel.WorkingDirectory,
-                0,
-                ReturnResult.InProgress,
-                FileOperationType.Delete);
-            }
-            else
-            {
-                banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
-                associatedInstance.FilesystemViewModel.WorkingDirectory,
-                0,
-                ReturnResult.InProgress,
-                FileOperationType.Recycle);
-            }
+                if (deleteFromRecycleBin)
+                {
+                    permanently = true;
+                }
 
-            var returnStatus = ReturnResult.InProgress;
-            banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
+                if (permanently)
+                {
+                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    associatedInstance.FilesystemViewModel.WorkingDirectory,
+                    0,
+                    ReturnResult.InProgress,
+                    FileOperationType.Delete);
+                }
+                else
+                {
+                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    associatedInstance.FilesystemViewModel.WorkingDirectory,
+                    0,
+                    ReturnResult.InProgress,
+                    FileOperationType.Recycle);
+                }
 
-            if (App.AppSettings.ShowConfirmDeleteDialog && showDialog) // Check if the setting to show a confirmation dialog is on
-            {
-                List<FilesystemItemsOperationItemModel> incomingItems = new List<FilesystemItemsOperationItemModel>
+                var returnStatus = ReturnResult.InProgress;
+                banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
+
+                if (App.AppSettings.ShowConfirmDeleteDialog && showDialog) // Check if the setting to show a confirmation dialog is on
+                {
+                    List<FilesystemItemsOperationItemModel> incomingItems = new List<FilesystemItemsOperationItemModel>
                 {
                     new FilesystemItemsOperationItemModel(FilesystemOperationType.Delete, source.Path, null)
                 };
 
-                FilesystemOperationDialog dialog = FilesystemOperationDialogViewModel.GetDialog(new FilesystemItemsOperationDataModel(
-                    FilesystemOperationType.Delete,
-                    false,
-                    !deleteFromRecycleBin ? permanently : deleteFromRecycleBin,
-                    !deleteFromRecycleBin,
-                    incomingItems,
-                    new List<FilesystemItemsOperationItemModel>()));
+                    FilesystemOperationDialog dialog = FilesystemOperationDialogViewModel.GetDialog(new FilesystemItemsOperationDataModel(
+                        FilesystemOperationType.Delete,
+                        false,
+                        !deleteFromRecycleBin ? permanently : deleteFromRecycleBin,
+                        !deleteFromRecycleBin,
+                        incomingItems,
+                        new List<FilesystemItemsOperationItemModel>()));
 
-                ContentDialogResult result = await dialog.ShowAsync();
+                    ContentDialogResult result = await dialog.ShowAsync();
 
-                if (result != ContentDialogResult.Primary)
-                {
-                    banner.Remove();
-                    return ReturnResult.Cancelled; // Return if the result isn't delete
+                    if (result != ContentDialogResult.Primary)
+                    {
+                        banner.Remove();
+                        return ReturnResult.Cancelled; // Return if the result isn't delete
+                    }
+
+                    // Delete selected item if the result is Yes
+                    permanently = dialog.ViewModel.PermanentlyDelete;
                 }
 
-                // Delete selected item if the result is Yes
-                permanently = dialog.ViewModel.PermanentlyDelete;
+                var sw = new Stopwatch();
+                sw.Start();
+
+                IStorageHistory history = await filesystemOperations.DeleteAsync(source, banner.Progress, banner.ErrorCode, permanently, cancellationToken);
+                ((IProgress<float>)banner.Progress).Report(100.0f);
+
+                if (!permanently && registerHistory)
+                {
+                    App.HistoryWrapper.AddHistory(history);
+                }
+
+                banner.Remove();
+                sw.Stop();
+
+                PostBannerHelpers.PostBanner_Delete(returnStatus, permanently ? FileOperationType.Delete : FileOperationType.Recycle, sw, associatedInstance);
+
+                return returnStatus;
             }
-
-            var sw = new Stopwatch();
-            sw.Start();
-
-            IStorageHistory history = await filesystemOperations.DeleteAsync(source, banner.Progress, banner.ErrorCode, permanently, cancellationToken);
-            ((IProgress<float>)banner.Progress).Report(100.0f);
-
-            if (!permanently && registerHistory)
+            catch (System.Exception ex)
             {
-                App.HistoryWrapper.AddHistory(history);
+                NLog.LogManager.GetCurrentClassLogger().Warn($"Delete item operation failed:\n{ex}");
+                return ReturnResult.Failed;
             }
-
-            banner.Remove();
-            sw.Stop();
-
-            PostBannerHelpers.PostBanner_Delete(returnStatus, permanently ? FileOperationType.Delete : FileOperationType.Recycle, sw, associatedInstance);
-
-            return returnStatus;
         }
 
         #endregion Delete


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/2619919200u/overview

- I believe this will solve [this](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/2619919200u/overview) crash, and make it easier to figure out the root cause of the issue in the future.

**Details of Changes**
Add details of changes here.
- Added try catch around delete operations, and log any exceptions caught to the app log

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**

