### PR TITLE
best close in debug

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -412,6 +412,10 @@ namespace Files
             LibraryManager?.Dispose();
             DrivesManager?.Dispose();
             deferral.Complete();
+
+            #if DEBUG
+            Current.Exit();
+            #endif
         }
 
         public static void SaveSessionTabs() // Enumerates through all tabs and gets the Path property and saves it to AppSettings.LastSessionPages


### PR DESCRIPTION
In Visual Studio, the application may stop compiling after being closed, because of a lock.
This fix, only in Debug mode, cleanly closes the application instead of suspending it, so that it can be recompiled after a modification.

I don't know if this fix is useful or if I am the only one having the problem.