### PR TITLE
Fix Files sometimes freezing after right clicking an item

### DIFF
--- a/Files/Helpers/ShellContextMenuHelper.cs
+++ b/Files/Helpers/ShellContextMenuHelper.cs
@@ -37,15 +37,19 @@ namespace Files.Helpers
                     { "ExtendedMenu", shiftPressed },
                     { "ShowOpenMenu", showOpenMenu }
                 }));
-                task.Wait(10000);
-                var (status, response) = task.Result;
-                if (status == AppServiceResponseStatus.Success
-                    && response.ContainsKey("Handle"))
+                var completed = task.Wait(10000);
+
+                if(completed)
                 {
-                    var contextMenu = JsonConvert.DeserializeObject<Win32ContextMenu>((string)response["ContextMenu"]);
-                    if (contextMenu != null)
+                    var (status, response) = task.Result;
+                    if (status == AppServiceResponseStatus.Success
+                        && response.ContainsKey("Handle"))
                     {
-                        LoadMenuFlyoutItem(menuItemsList, contextMenu.Items, (string)response["Handle"], true, maxItems);
+                        var contextMenu = JsonConvert.DeserializeObject<Win32ContextMenu>((string)response["ContextMenu"]);
+                        if (contextMenu != null)
+                        {
+                            LoadMenuFlyoutItem(menuItemsList, contextMenu.Items, (string)response["Handle"], true, maxItems);
+                        }
                     }
                 }
             }

--- a/Files/Helpers/ShellContextMenuHelper.cs
+++ b/Files/Helpers/ShellContextMenuHelper.cs
@@ -28,7 +28,7 @@ namespace Files.Helpers
 
             if (connection != null)
             {
-                var (status, response) = Task.Run(() => connection.SendMessageForResponseAsync(new ValueSet()
+                var task = Task.Run(() => connection.SendMessageForResponseAsync(new ValueSet()
                 {
                     { "Arguments", "LoadContextMenu" },
                     { "FilePath", IsItemSelected ?
@@ -36,7 +36,9 @@ namespace Files.Helpers
                         workingDirectory},
                     { "ExtendedMenu", shiftPressed },
                     { "ShowOpenMenu", showOpenMenu }
-                })).Result;
+                }));
+                task.Wait(10000);
+                var (status, response) = task.Result;
                 if (status == AppServiceResponseStatus.Success
                     && response.ContainsKey("Handle"))
                 {


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Fixes #3855

**Details of Changes**
Add details of changes here.
- This adds a 10 second timeout to the operation that gets the shell context menu items. This should prevent Files from completely freezing up if the operation hangs

**Validation**
How did you test these changes?
- I have tested this by adding a ```Task.Delay()``` in the ```SendMessageForResponseAsync``` function to make sure it times out properly

**Screenshots (optional)**
Add screenshots here.
