### PR TITLE
Fix search region visual (#4369)

### DIFF
--- a/Files/Converters/VisiblityInvertConverter.cs
+++ b/Files/Converters/VisiblityInvertConverter.cs
@@ -8,6 +8,10 @@ namespace Files.Converters
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
+            if (value is bool isVisible)
+            {
+                return isVisible ? Visibility.Collapsed : Visibility.Visible;
+            }
             return (Visibility)value == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
         }
 

--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -21,6 +21,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <converters:LayoutModeToBoolConverter x:Key="LayoutModeConverter" />
+            <converters:VisiblityInvertConverter x:Key="VisiblityInvertConverter" />
             <converters1:BoolNegationConverter x:Key="BoolNegationConverter" />
 
             <ResourceDictionary.MergedDictionaries>
@@ -781,7 +782,8 @@
                 ScrollViewer.VerticalScrollBarVisibility="Hidden"
                 Text="{x:Bind PathText, Mode=OneWay}"
                 TextChanged="VisiblePath_TextChanged"
-                TextMemberPath="ItemPath" />
+                TextMemberPath="ItemPath"
+                Visibility="{x:Bind IsSearchRegionVisible, Mode=OneWay, Converter={StaticResource VisiblityInvertConverter}}" />
 
             <Grid
                 x:Name="ClickablePath"
@@ -795,7 +797,8 @@
                 BorderBrush="{ThemeResource ControlElevationBorderBrush}"
                 BorderThickness="1"
                 CornerRadius="4"
-                PointerPressed="ManualPathEntryItem_Click">
+                PointerPressed="ManualPathEntryItem_Click"
+                Visibility="{x:Bind IsSearchRegionVisible, Mode=OneWay, Converter={StaticResource VisiblityInvertConverter}}">
 
                 <ListView
                     x:Name="PathViewInteract"

--- a/Files/UserControls/NavigationToolbar.xaml.cs
+++ b/Files/UserControls/NavigationToolbar.xaml.cs
@@ -1246,9 +1246,8 @@ namespace Files.UserControls
 
         private void SearchRegion_LostFocus(object sender, RoutedEventArgs e)
         {
-            if (FocusManager.GetFocusedElement() is FlyoutBase ||
-                FocusManager.GetFocusedElement() is AppBarButton ||
-                FocusManager.GetFocusedElement() is Popup)
+            var focusedElement = FocusManager.GetFocusedElement();
+            if (focusedElement is FlyoutBase || focusedElement is AppBarButton)
             {
                 return;
             }


### PR DESCRIPTION
**Resolved / Related Issues**
Fix Text overlapping on search bar. 
Fixes #4369

**Details of Changes**
When a popup is open, the search bar is close.
When the searchbar is visible, the adressbar is collapsed.