### PR TITLE
Fix NullReferenceException in Files.Helpers.NavigationHelpers.OpenSelectedItems

### DIFF
--- a/Files/Helpers/NavigationHelpers.cs
+++ b/Files/Helpers/NavigationHelpers.cs
@@ -82,7 +82,15 @@ namespace Files.Helpers
                 }
                 else
                 {
-                    await OpenPath(item.ItemPath, associatedInstance, type, false, openViaApplicationPicker);
+                    try
+                    {
+                        await OpenPath(item.ItemPath, associatedInstance, type, false, openViaApplicationPicker);
+                    }
+                    catch (Exception e)
+                    {
+                        // This is to try and figure out the root cause of AppCenter error #985932119u
+                        NLog.LogManager.GetCurrentClassLogger().Warn(e, e.Message);
+                    }
                 }
             }
         }
@@ -115,7 +123,7 @@ namespace Files.Helpers
             {
                 if (isShortcutItem)
                 {
-                    var (status, response) = await associatedInstance.ServiceConnection.SendMessageForResponseAsync(new ValueSet()
+                    var (status, response) = await associatedInstance.ServiceConnection?.SendMessageForResponseAsync(new ValueSet()
                     {
                         { "Arguments", "FileOperation" },
                         { "fileop", "ParseLink" },


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/985932119u/overview

**Details of Changes**
Add details of changes here.
- Added try catch around OpenPath, and log the exception to the logger to make it easier to debug in the future
- Added null check to app service connection when opening shortcuts (I doubt this caused the crash, however I believe it's a good change anyway)

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [N/A] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
