### PR TITLE
Fix potential crash when initial shortcut or folder preview loading fails

### DIFF
--- a/Files/ViewModels/PreviewPaneViewModel.cs
+++ b/Files/ViewModels/PreviewPaneViewModel.cs
@@ -251,21 +251,26 @@ namespace Files.ViewModels
                     Debug.WriteLine(e);
                     loadCancellationTokenSource?.Cancel();
                     // If initial loading fails, attempt to load a basic preivew (thumbnail and details only)
-                    // If that fails, revert to no preview/details available
-                    try
+                    // If that fails, revert to no preview/details available as long as the item is not a shortcut or folder
+                    if(!SelectedItem.IsShortcutItem && SelectedItem.PrimaryItemAttribute != StorageItemTypes.Folder)
                     {
-                        var basicModel = new BasicPreviewViewModel(SelectedItem);
-                        await basicModel.LoadAsync();
-                        PreviewPaneContent = new BasicPreview(basicModel);
+                        try
+                        {
+                            var basicModel = new BasicPreviewViewModel(SelectedItem);
+                            await basicModel.LoadAsync();
+                            PreviewPaneContent = new BasicPreview(basicModel);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.WriteLine(ex);
+                        }
                     }
-                    catch (Exception ex)
-                    {
-                        Debug.WriteLine(ex);
-                        PreviewPaneContent = null;
-                        DetailsListVisibility = Visibility.Collapsed;
-                        DetailsErrorText = "PreviewPaneDetailsNotAvailableText".GetLocalized();
-                        PreviewErrorText = "DetailsPanePreviewNotAvaliableText".GetLocalized();
-                    }
+
+                    PreviewPaneContent = null;
+                    DetailsListVisibility = Visibility.Collapsed;
+                    DetailsErrorText = "PreviewPaneDetailsNotAvailableText".GetLocalized();
+                    PreviewErrorText = "DetailsPanePreviewNotAvaliableText".GetLocalized();
                 }
             }
             else if (SelectedItem != null)

--- a/Files/ViewModels/Previews/ShortcutPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/ShortcutPreviewViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Files.Filesystem;
+using Files.Helpers;
 using Files.ViewModels.Properties;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,7 +45,7 @@ namespace Files.ViewModels.Previews
                 }
             };
 
-            _ = await base.LoadPreviewAndDetails();
+            await LoadItemThumbnail();
 
             return details;
         }
@@ -54,6 +55,16 @@ namespace Files.ViewModels.Previews
             var details = await LoadPreviewAndDetails();
             Item.FileDetails?.Clear();
             Item.FileDetails = new System.Collections.ObjectModel.ObservableCollection<FileProperty>(details.Where(i => i.Value != null));
+        }
+
+        private async Task LoadItemThumbnail()
+        {
+            var (IconData, OverlayData, IsCustom) = await FileThumbnailHelper.LoadIconOverlayAsync(Item.ItemPath, 400);
+
+            if (IconData != null)
+            {
+                Item.FileImage = await IconData.ToBitmapAsync();
+            }
         }
     }
 }


### PR DESCRIPTION

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
N/A

**Details of Changes**
Add details of changes here.
- Don't try and use backup item preview if the item is a shortcut or folder, as it can cause an unhandled exception 
- Only use FTP to load shortcut thumbnails (since trying to use the StorageFile one would blow up for obvious reasons)

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility (not applicable)

**Screenshots (optional)**
Add screenshots here.
