### PR TITLE
Fixed crashes when opening properties dialog

### DIFF
--- a/Files/DataModels/SidebarPinnedModel.cs
+++ b/Files/DataModels/SidebarPinnedModel.cs
@@ -265,7 +265,8 @@ namespace Files.DataModels
                     Font = InteractionViewModel.FontName,
                     Path = path,
                     Section = SectionType.Favorites,
-                    Icon = GlyphHelper.GetIconUri(path),
+                    Icon = new Windows.UI.Xaml.Media.Imaging.SvgImageSource(GlyphHelper.GetIconUri(path)),
+                    IconSource = GlyphHelper.GetIconUri(path),
                     IsDefaultLocation = false,
                     Text = res.Result?.DisplayName ?? Path.GetFileName(path.TrimEnd('\\'))
                 };

--- a/Files/Extensions/ImageSourceExtensions.cs
+++ b/Files/Extensions/ImageSourceExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage.FileProperties;
+using Windows.Storage.Streams;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace Files.Extensions
+{
+    internal static class ImageSourceExtensions
+    {
+        internal static async Task<byte[]> ToByteArrayAsync(this IInputStream stream)
+        {
+            var readStream = stream.AsStreamForRead();
+            var byteArray = new byte[readStream.Length];
+            await readStream.ReadAsync(byteArray, 0, byteArray.Length);
+            return byteArray;
+        }
+    }
+}

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -194,6 +194,7 @@
     <Compile Include="EventArguments\Bundles\BundlesOpenPathEventArgs.cs" />
     <Compile Include="EventArguments\LayoutPreferenceEventArgs.cs" />
     <Compile Include="Extensions\EnumExtensions.cs" />
+    <Compile Include="Extensions\ImageSourceExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
     <Compile Include="Filesystem\FolderHelpers.cs" />
     <Compile Include="Filesystem\LibraryLocationItem.cs" />

--- a/Files/Filesystem/DriveItem.cs
+++ b/Files/Filesystem/DriveItem.cs
@@ -16,6 +16,7 @@ namespace Files.Filesystem
     public class DriveItem : ObservableObject, INavigationControlItem
     {
         public SvgImageSource Icon { get; set; }
+        public Uri IconSource { get; set; }
 
         private string path;
 
@@ -194,47 +195,48 @@ namespace Files.Filesystem
                 switch (type)
                 {
                     case DriveType.Fixed:
-                        Icon = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Drive.svg"));
+                        IconSource = new Uri("ms-appx:///Assets/FluentIcons/Drive.svg");
                         break;
 
                     case DriveType.Removable:
-                        Icon = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Folder.svg")); // TODO
+                        IconSource = new Uri("ms-appx:///Assets/FluentIcons/Folder.svg");
                         break;
 
                     case DriveType.Network:
-                        Icon = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Drive_Network.svg"));
+                        IconSource = new Uri("ms-appx:///Assets/FluentIcons/Drive_Network.svg");
                         break;
 
                     case DriveType.Ram:
-                        Icon = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Folder.svg")); // TODO
+                        IconSource = new Uri("ms-appx:///Assets/FluentIcons/Folder.svg");
                         break;
 
                     case DriveType.CDRom:
-                        Icon = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Folder.svg")); // TODO
+                        IconSource = new Uri("ms-appx:///Assets/FluentIcons/Folder.svg");
                         break;
 
                     case DriveType.Unknown:
                         break;
 
                     case DriveType.NoRootDirectory:
-                        Icon = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Folder.svg")); // TODO
+                        IconSource = new Uri("ms-appx:///Assets/FluentIcons/Folder.svg"); // TODO
                         break;
 
                     case DriveType.VirtualDrive:
-                        Icon = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Folder.svg")); // TODO
+                        IconSource = new Uri("ms-appx:///Assets/FluentIcons/Folder.svg"); // TODO
                         break;
 
                     case DriveType.CloudDrive:
-                        Icon = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Folder.svg")); // TODO
+                        IconSource = new Uri("ms-appx:///Assets/FluentIcons/Folder.svg"); // TODO
                         break;
 
                     case DriveType.FloppyDisk:
-                        Icon = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Folder.svg")); // TODO
+                        IconSource = new Uri("ms-appx:///Assets/FluentIcons/Folder.svg");
                         break;
 
                     default:
                         throw new ArgumentOutOfRangeException(nameof(type), type, null);
                 }
+                Icon = new SvgImageSource(IconSource);
             });
         }
 

--- a/Files/Filesystem/LibraryLocationItem.cs
+++ b/Files/Filesystem/LibraryLocationItem.cs
@@ -18,7 +18,8 @@ namespace Files.Filesystem
             Section = SectionType.Library;
             Text = shellLibrary.DisplayName;
             Path = shellLibrary.FullPath;
-            Icon = GlyphHelper.GetIconUri(shellLibrary.DefaultSaveFolder);
+            Icon = new Windows.UI.Xaml.Media.Imaging.SvgImageSource(GlyphHelper.GetIconUri(shellLibrary.DefaultSaveFolder));
+            IconSource = GlyphHelper.GetIconUri(shellLibrary.DefaultSaveFolder);
             DefaultSaveFolder = shellLibrary.DefaultSaveFolder;
             Folders = shellLibrary.Folders == null ? null : new ReadOnlyCollection<string>(shellLibrary.Folders);
             IsDefaultLocation = shellLibrary.IsPinned;

--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -97,6 +97,7 @@ namespace Files.Filesystem
             set => SetProperty(ref customIconSource, value);
         }
 
+        [JsonIgnore]
         private byte[] customIconData;
         public byte[] CustomIconData
         {

--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -76,6 +76,8 @@ namespace Files.Filesystem
             set => SetProperty(ref loadCustomIcon, value);
         }
 
+        // Note: Never attempt to call this from a secondary window or another thread, create a new instance from CustomIconSource instead
+        // TODO: eventually we should remove this b/c it's not thread safe
         private SvgImageSource customIcon;
 
         public SvgImageSource CustomIcon
@@ -86,6 +88,20 @@ namespace Files.Filesystem
                 LoadCustomIcon = true;
                 SetProperty(ref customIcon, value);
             }
+        }
+
+        private Uri customIconSource;
+        public Uri CustomIconSource
+        {
+            get => customIconSource;
+            set => SetProperty(ref customIconSource, value);
+        }
+
+        private byte[] customIconData;
+        public byte[] CustomIconData
+        {
+            get => customIconData;
+            set => SetProperty(ref customIconData, value);
         }
 
         private double opacity;
@@ -404,6 +420,9 @@ namespace Files.Filesystem
             ItemType = "ItemTypeLibrary".GetLocalized();
             LoadCustomIcon = true;
             CustomIcon = lib.Icon;
+            //CustomIconSource = lib.IconSource;
+            CustomIconData = lib.IconData;
+            LoadFileIcon = CustomIconData != null;
 
             IsEmpty = lib.IsEmpty;
             DefaultSaveFolder = lib.DefaultSaveFolder;

--- a/Files/Filesystem/LocationItem.cs
+++ b/Files/Filesystem/LocationItem.cs
@@ -1,6 +1,7 @@
 ﻿using Files.Common;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Uwp;
+using System;
 using System.Collections.ObjectModel;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
@@ -10,6 +11,8 @@ namespace Files.Filesystem
     public class LocationItem : ObservableObject, INavigationControlItem
     {
         public SvgImageSource Icon { get; set; }
+        public Uri IconSource { get; set; }
+        public byte[] IconData { get; set; }
 
         public string Text { get; set; }
 

--- a/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
@@ -205,6 +205,7 @@ namespace Files.Filesystem.StorageEnumerators
             var itemFileExtension = file.FileType;
 
             BitmapImage icon = new BitmapImage();
+            byte[] iconData = null;
             bool itemThumbnailImgVis;
             bool itemEmptyImgVis;
 
@@ -221,6 +222,7 @@ namespace Files.Filesystem.StorageEnumerators
                         icon.DecodePixelWidth = 40;
                         icon.DecodePixelHeight = 40;
                         await icon.SetSourceAsync(itemThumbnailImg);
+                        iconData = await itemThumbnailImg.ToByteArrayAsync();
                     }
                     else
                     {
@@ -248,6 +250,7 @@ namespace Files.Filesystem.StorageEnumerators
                         icon.DecodePixelWidth = 80;
                         icon.DecodePixelHeight = 80;
                         await icon.SetSourceAsync(itemThumbnailImg);
+                        iconData = await itemThumbnailImg.ToByteArrayAsync();
                     }
                     else
                     {
@@ -290,6 +293,7 @@ namespace Files.Filesystem.StorageEnumerators
                     Opacity = 1,
                     LoadUnknownTypeGlyph = itemEmptyImgVis,
                     FileImage = icon,
+                    CustomIconData = iconData,
                     LoadFileIcon = itemThumbnailImgVis,
                     LoadFolderGlyph = itemFolderImgVis,
                     ItemName = itemName,

--- a/Files/Helpers/GlyphHelper.cs
+++ b/Files/Helpers/GlyphHelper.cs
@@ -58,44 +58,44 @@ namespace Files.Helpers
             return iconCode;
         }
 
-        public static SvgImageSource GetIconUri(string path)
+        public static Uri GetIconUri(string path)
         {
-            SvgImageSource iconCode = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Folder.svg"));
+            Uri iconCode = new Uri("ms-appx:///Assets/FluentIcons/Folder.svg");
             if (path != null)
             {
                 // TODO: do library check based on the library file path?
                 var udp = UserDataPaths.GetDefault();
                 if (path.Equals(AppSettings.DesktopPath, StringComparison.OrdinalIgnoreCase))
                 {
-                    iconCode = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Desktop.svg"));
+                    iconCode = new Uri("ms-appx:///Assets/FluentIcons/Desktop.svg");
                 }
                 else if (path.Equals(AppSettings.DownloadsPath, StringComparison.OrdinalIgnoreCase))
                 {
-                    iconCode = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Downloads.svg"));
+                    iconCode = new Uri("ms-appx:///Assets/FluentIcons/Downloads.svg");
                 }
                 else if (path.Equals(udp.Documents, StringComparison.OrdinalIgnoreCase))
                 {
-                    iconCode = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Documents.svg"));
+                    iconCode = new Uri("ms-appx:///Assets/FluentIcons/Documents.svg");
                 }
                 else if (path.Equals(udp.Pictures, StringComparison.OrdinalIgnoreCase))
                 {
-                    iconCode = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Pictures.svg"));
+                    iconCode = new Uri("ms-appx:///Assets/FluentIcons/Pictures.svg");
                 }
                 else if (path.Equals(udp.Music, StringComparison.OrdinalIgnoreCase))
                 {
-                    iconCode = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Music.svg"));
+                    iconCode = new Uri("ms-appx:///Assets/FluentIcons/Music.svg");
                 }
                 else if (path.Equals(udp.Videos, StringComparison.OrdinalIgnoreCase))
                 {
-                    iconCode = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Videos.svg"));
+                    iconCode = new Uri("ms-appx:///Assets/FluentIcons/Videos.svg");
                 }
                 else if (path.Equals(AppSettings.NetworkFolderPath, StringComparison.OrdinalIgnoreCase))
                 {
-                    iconCode = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Drive_Network.svg"));
+                    iconCode = new Uri("ms-appx:///Assets/FluentIcons/Drive_Network.svg");
                 }
                 else if (Path.GetPathRoot(path).Equals(path, StringComparison.OrdinalIgnoreCase))
                 {
-                    iconCode = new SvgImageSource(new Uri("ms-appx:///Assets/FluentIcons/Drive_USB.svg"));
+                    iconCode = new Uri("ms-appx:///Assets/FluentIcons/Drive_USB.svg");
                 }
             }
             return iconCode;

--- a/Files/UserControls/FileIcon.xaml
+++ b/Files/UserControls/FileIcon.xaml
@@ -45,7 +45,7 @@
             HorizontalAlignment="Center"
             VerticalAlignment="Stretch"
             x:Load="{x:Bind ViewModel.LoadCustomIcon, Mode=OneWay}"
-            Source="{x:Bind ViewModel.CustomIcon, Mode=OneWay}" />
+            Source="{x:Bind CustomIconImageSource, Mode=OneWay}" />
         <FontIcon
             x:Name="WebShortcutGlyph"
             HorizontalAlignment="Left"
@@ -59,6 +59,6 @@
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
             x:Load="{x:Bind ViewModel.LoadFileIcon, Mode=OneWay}"
-            Source="{x:Bind ViewModel.FileIconSource, Mode=OneWay}" />
+            Source="{x:Bind FileIconImageSource, Mode=OneWay}" />
     </StackPanel>
 </UserControl>

--- a/Files/UserControls/FileIcon.xaml.cs
+++ b/Files/UserControls/FileIcon.xaml.cs
@@ -28,7 +28,6 @@ namespace Files.UserControls
                 {
                     CustomIconImageSource = new SvgImageSource(ViewModel.CustomIconSource);
                 }
-                InitStuff();
             }
         }
 
@@ -52,6 +51,19 @@ namespace Files.UserControls
             get => GetValue(FileIconImageSourceProperty) as BitmapImage;
             set => SetValue(FileIconImageSourceProperty, value);
         }
+        public static DependencyProperty FileIconImageDataProperty { get; } = DependencyProperty.Register(nameof(FileIconImageData), typeof(byte[]), typeof(FileIcon), null);
+        public byte[] FileIconImageData
+        {
+            get => GetValue(FileIconImageDataProperty) as byte[];
+            set 
+            { 
+                SetValue(FileIconImageDataProperty, value);
+                if(value != null)
+                {
+                    UpdateImageSourceAsync();
+                }
+            }
+        }
         private SvgImageSource CustomIconImageSource { get; set; }
 
         public FileIcon()
@@ -59,13 +71,13 @@ namespace Files.UserControls
             this.InitializeComponent();
         }
 
-        public async void InitStuff()
+        public async void UpdateImageSourceAsync()
         {
-            if(ViewModel.IconData != null)
+            if(FileIconImageData != null)
             {
                 FileIconImageSource = new BitmapImage();
                 using InMemoryRandomAccessStream stream = new InMemoryRandomAccessStream();
-                await stream.WriteAsync(ViewModel.IconData.AsBuffer());
+                await stream.WriteAsync(FileIconImageData.AsBuffer());
                 stream.Seek(0);
                 await FileIconImageSource.SetSourceAsync(stream);
             }

--- a/Files/UserControls/FileIcon.xaml.cs
+++ b/Files/UserControls/FileIcon.xaml.cs
@@ -1,11 +1,36 @@
-﻿using Files.ViewModels;
+﻿using Files.Helpers;
+using Files.ViewModels;
+using System;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Storage.Streams;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
 
 namespace Files.UserControls
 {
     public sealed partial class FileIcon : UserControl
     {
-        public SelectedItemsPropertiesViewModel ViewModel { get; set; }
+        private SelectedItemsPropertiesViewModel viewModel;
+        public SelectedItemsPropertiesViewModel ViewModel 
+        {
+            get => viewModel; 
+            set {
+                viewModel = value;
+
+                if(value == null)
+                {
+                    return;
+                }
+
+                if (ViewModel?.CustomIconSource != null)
+                {
+                    CustomIconImageSource = new SvgImageSource(ViewModel.CustomIconSource);
+                }
+                InitStuff();
+            }
+        }
 
         private double itemSize;
 
@@ -21,9 +46,29 @@ namespace Files.UserControls
 
         private double LargerItemSize { get; set; }
 
+        private static DependencyProperty FileIconImageSourceProperty { get; } = DependencyProperty.Register(nameof(FileIconImageSource), typeof(BitmapImage), typeof(FileIcon), null);
+        private BitmapImage FileIconImageSource 
+        {
+            get => GetValue(FileIconImageSourceProperty) as BitmapImage;
+            set => SetValue(FileIconImageSourceProperty, value);
+        }
+        private SvgImageSource CustomIconImageSource { get; set; }
+
         public FileIcon()
         {
             this.InitializeComponent();
+        }
+
+        public async void InitStuff()
+        {
+            if(ViewModel.IconData != null)
+            {
+                FileIconImageSource = new BitmapImage();
+                using InMemoryRandomAccessStream stream = new InMemoryRandomAccessStream();
+                await stream.WriteAsync(ViewModel.IconData.AsBuffer());
+                stream.Seek(0);
+                await FileIconImageSource.SetSourceAsync(stream);
+            }
         }
     }
 }

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -703,8 +703,10 @@ namespace Files.ViewModels
                             if (fileIconInfo.IconData != null)
                             {
                                 item.FileImage = await fileIconInfo.IconData.ToBitmapAsync();
+                                item.CustomIconData = fileIconInfo.IconData;
                                 item.LoadUnknownTypeGlyph = false;
                                 item.LoadWebShortcutGlyph = false;
+                                item.CustomIconData = fileIconInfo.IconData;
                                 item.LoadFileIcon = true;
                             }
                             item.IconOverlay = await fileIconInfo.OverlayData.ToBitmapAsync();
@@ -723,6 +725,7 @@ namespace Files.ViewModels
                                             await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
                                             {
                                                 item.FileImage = new BitmapImage();
+                                                item.CustomIconData = await Thumbnail.ToByteArrayAsync();
                                                 await item.FileImage.SetSourceAsync(Thumbnail);
                                                 item.LoadUnknownTypeGlyph = false;
                                                 item.LoadFileIcon = true;
@@ -751,6 +754,7 @@ namespace Files.ViewModels
                             if (fileIconInfo.IconData != null && fileIconInfo.IsCustom) // Only set folder icon if it's a custom icon
                             {
                                 item.FileImage = await fileIconInfo.IconData.ToBitmapAsync();
+                                item.CustomIconData = fileIconInfo.IconData;
                                 item.LoadUnknownTypeGlyph = false;
                                 item.LoadFolderGlyph = false;
                                 item.LoadFileIcon = true;

--- a/Files/ViewModels/Properties/DriveProperties.cs
+++ b/Files/ViewModels/Properties/DriveProperties.cs
@@ -23,7 +23,7 @@ namespace Files.ViewModels.Properties
         {
             if (Drive != null)
             {
-                ViewModel.CustomIcon = Drive.Icon;
+                ViewModel.CustomIconSource = Drive.IconSource;
                 ViewModel.LoadCustomIcon = true;
                 ViewModel.ItemName = Drive.Text;
                 ViewModel.OriginalItemName = Drive.Text;

--- a/Files/ViewModels/Properties/FileProperties.cs
+++ b/Files/ViewModels/Properties/FileProperties.cs
@@ -60,6 +60,7 @@ namespace Files.ViewModels.Properties
                 ViewModel.LoadUnknownTypeGlyph = Item.LoadUnknownTypeGlyph;
                 ViewModel.LoadCustomIcon = Item.LoadCustomIcon;
                 ViewModel.CustomIcon = Item.CustomIcon;
+                ViewModel.CustomIconSource = Item.CustomIconSource;
                 ViewModel.LoadFileIcon = Item.LoadFileIcon;
 
                 if (Item.IsShortcutItem)
@@ -112,7 +113,7 @@ namespace Files.ViewModels.Properties
             var fileIconInfo = await AppInstance.FilesystemViewModel.LoadIconOverlayAsync(Item.ItemPath, 80);
             if (fileIconInfo.IconData != null)
             {
-                ViewModel.FileIconSource = await fileIconInfo.IconData.ToBitmapAsync();
+                ViewModel.IconData = fileIconInfo.IconData;
             }
 
             if (Item.IsShortcutItem)

--- a/Files/ViewModels/Properties/FileProperties.cs
+++ b/Files/ViewModels/Properties/FileProperties.cs
@@ -57,6 +57,7 @@ namespace Files.ViewModels.Properties
                 ViewModel.ItemCreatedTimestamp = Item.ItemDateCreated;
                 //ViewModel.FileIconSource = Item.FileImage;
                 ViewModel.LoadFolderGlyph = Item.LoadFolderGlyph;
+                ViewModel.IconData = Item.CustomIconData;
                 ViewModel.LoadUnknownTypeGlyph = Item.LoadUnknownTypeGlyph;
                 ViewModel.LoadCustomIcon = Item.LoadCustomIcon;
                 ViewModel.CustomIcon = Item.CustomIcon;

--- a/Files/ViewModels/Properties/FolderProperties.cs
+++ b/Files/ViewModels/Properties/FolderProperties.cs
@@ -79,6 +79,7 @@ namespace Files.ViewModels.Properties
             if (fileIconInfo.IconData != null && fileIconInfo.IsCustom)
             {
                 ViewModel.FileIconSource = await fileIconInfo.IconData.ToBitmapAsync();
+                ViewModel.IconData = fileIconInfo.IconData;
             }
 
             if (Item.IsShortcutItem)

--- a/Files/ViewModels/Properties/LibraryProperties.cs
+++ b/Files/ViewModels/Properties/LibraryProperties.cs
@@ -46,7 +46,8 @@ namespace Files.ViewModels.Properties
                 ViewModel.ItemType = Library.ItemType;
                 //ViewModel.FileIconSource = Library.FileImage;
                 ViewModel.LoadCustomIcon = Library.LoadCustomIcon;
-                ViewModel.CustomIcon = Library.CustomIcon;
+                ViewModel.CustomIconSource = Library.CustomIconSource;
+                ViewModel.IconData = Library.CustomIconData;
                 ViewModel.LoadFolderGlyph = Library.LoadFolderGlyph;
                 ViewModel.LoadUnknownTypeGlyph = Library.LoadUnknownTypeGlyph;
                 ViewModel.LoadFileIcon = Library.LoadFileIcon;

--- a/Files/ViewModels/SelectedItemsPropertiesViewModel.cs
+++ b/Files/ViewModels/SelectedItemsPropertiesViewModel.cs
@@ -46,6 +46,14 @@ namespace Files.ViewModels
             set => SetProperty(ref customIcon, value);
         }
 
+        private Uri customIconSource;
+
+        public Uri CustomIconSource
+        {
+            get => customIconSource;
+            set => SetProperty(ref customIconSource, value);
+        }
+
         private bool loadCustomIcon;
 
         public bool LoadCustomIcon
@@ -60,6 +68,13 @@ namespace Files.ViewModels
         {
             get => loadFileIcon;
             set => SetProperty(ref loadFileIcon, value);
+        }
+
+        private byte[] iconData;
+        public byte[] IconData
+        {
+            get => iconData;
+            set => SetProperty(ref iconData, value);
         }
 
         private ImageSource fileIconSource;

--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -70,6 +70,7 @@
                 VerticalAlignment="Stretch">
                 <usercontrols:FileIcon
                     AutomationProperties.AccessibilityView="Raw"
+                    FileIconImageData="{x:Bind ViewModel.IconData, Mode=OneWay}"
                     ItemSize="80"
                     ViewModel="{x:Bind ViewModel}" />
             </Grid>

--- a/Files/Views/Pages/PropertiesShortcut.xaml
+++ b/Files/Views/Pages/PropertiesShortcut.xaml
@@ -42,7 +42,10 @@
                 Margin="{StaticResource PropertyNameMargin}"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch">
-                <usercontrols:FileIcon ItemSize="70" ViewModel="{x:Bind ViewModel}" />
+                <usercontrols:FileIcon
+                    FileIconImageData="{x:Bind ViewModel.IconData, Mode=OneWay}"
+                    ItemSize="70"
+                    ViewModel="{x:Bind ViewModel}" />
             </Grid>
             <TextBox
                 x:Name="itemFileName2"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Closes #4639 
- closes #4628 
- closes #4591

**Details of Changes**
Add details of changes here.
- Remove all calls to ImageSource properties in the properties dialog as they are not thread safe and would cause a crash
- obtain images from uri source or byte array

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility (Not applicable) 

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/59544401/115130303-9ef0d100-9fa3-11eb-8d2b-598a1dca6a01.png)
