### PR TITLE
Fix issue where images wouldn't always be saved with the right encoding

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -196,6 +196,7 @@
     <Compile Include="Extensions\EnumExtensions.cs" />
     <Compile Include="Extensions\ImageSourceExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
+    <Compile Include="Helpers\SaveImageToFile.cs" />
     <Compile Include="Filesystem\FolderHelpers.cs" />
     <Compile Include="Filesystem\LibraryLocationItem.cs" />
     <Compile Include="Filesystem\LibraryManager.cs" />

--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -5,7 +5,6 @@ using Files.Extensions;
 using Files.Filesystem.FilesystemHistory;
 using Files.Helpers;
 using Files.Interacts;
-using Files.UserControls;
 using Files.ViewModels;
 using Files.ViewModels.Dialogs;
 using Microsoft.Toolkit.Uwp;
@@ -19,6 +18,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation.Collections;
+using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.UI.Xaml.Controls;
 using static Files.Helpers.NativeFindStorageItemHelper;
@@ -625,8 +625,15 @@ namespace Files.Filesystem
                     // Set the name of the file to be the current time and date
                     var file = await folder.CreateFileAsync($"{DateTime.Now:mm-dd-yy-HHmmss}.png", CreationCollisionOption.GenerateUniqueName);
 
-                    using var stream = await file.OpenAsync(FileAccessMode.ReadWrite);
-                    await imageStream.AsStreamForRead().CopyToAsync(stream.AsStreamForWrite());
+                    SoftwareBitmap softwareBitmap;
+
+                    // Create the decoder from the stream
+                    BitmapDecoder decoder = await BitmapDecoder.CreateAsync(imageStream);
+
+                    // Get the SoftwareBitmap representation of the file
+                    softwareBitmap = await decoder.GetSoftwareBitmapAsync();
+
+                    await Helpers.SaveImageToFile.SaveSoftwareBitmapToFile(softwareBitmap, file, BitmapEncoder.PngEncoderId);
                     return ReturnResult.Success;
                 }
                 catch (Exception)

--- a/Files/Helpers/SaveImageToFile.cs
+++ b/Files/Helpers/SaveImageToFile.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Graphics.Imaging;
+using Windows.Storage;
+using Windows.Storage.Streams;
+
+namespace Files.Helpers
+{
+    static class SaveImageToFile
+    {
+        /// <summary>
+        /// This function encodes a software bitmap with the specified encoder and saves it to a file
+        /// </summary>
+        /// <param name="softwareBitmap"></param>
+        /// <param name="outputFile"></param>
+        /// <param name="encoderId">The guid of the image encoder type</param>
+        /// <returns></returns>
+        public static async Task SaveSoftwareBitmapToFile(SoftwareBitmap softwareBitmap, StorageFile outputFile, Guid encoderId)
+        {
+            using IRandomAccessStream stream = await outputFile.OpenAsync(FileAccessMode.ReadWrite);
+            // Create an encoder with the desired format
+            BitmapEncoder encoder = await BitmapEncoder.CreateAsync(encoderId, stream);
+
+            // Set the software bitmap
+            encoder.SetSoftwareBitmap(softwareBitmap);
+
+            try
+            {
+                await encoder.FlushAsync();
+            }
+            catch (Exception err)
+            {
+                const int WINCODEC_ERR_UNSUPPORTEDOPERATION = unchecked((int)0x88982F81);
+                switch (err.HResult)
+                {
+                    case WINCODEC_ERR_UNSUPPORTEDOPERATION:
+                        // If the encoder does not support writing a thumbnail, then try again
+                        // but disable thumbnail generation.
+                        encoder.IsThumbnailGenerated = false;
+                        break;
+                    default:
+                        throw;
+                }
+            }
+
+            if (encoder.IsThumbnailGenerated == false)
+            {
+                await encoder.FlushAsync();
+            }
+        }
+
+    }
+}

--- a/Files/Helpers/SaveImageToFile.cs
+++ b/Files/Helpers/SaveImageToFile.cs
@@ -51,6 +51,5 @@ namespace Files.Helpers
                 await encoder.FlushAsync();
             }
         }
-
     }
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Closes #4609

**Details of Changes**
Add details of changes here.
- Encode images as pngs before saving them as png files

**Validation**
How did you test these changes?
- [ ] Built and ran the app (I wasn't able to reproduce the issue in the first place, so I can't be certain that it's fixed)
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
