### PR TITLE
Fix rename background #4229

### DIFF
--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -151,6 +151,7 @@
                         Grid.Column="1"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
+                        Visibility="{Binding IsOpen, ElementName=EditPopup, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
                         Text="{x:Bind ItemName, Mode=OneWay}"
                         TextTrimming="CharacterEllipsis"
                         TextWrapping="NoWrap" />


### PR DESCRIPTION
**Resolved / Related Issues**
Fix rename background in grid view. #4229
Before, the original name was visible behind the new name. 

**Details of Changes**
The initial text is collapsed in rename mode.