### PR TITLE
fix recycle bin case

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -58,7 +58,7 @@ namespace FilesFullTrust
                 var sid = WindowsIdentity.GetCurrent().User.ToString();
                 foreach (var drive in DriveInfo.GetDrives())
                 {
-                    var recyclePath = Path.Combine(drive.Name, "$Recycle.Bin", sid);
+                    var recyclePath = Path.Combine(drive.Name, "$RECYCLE.BIN", sid);
                     if (drive.DriveType == DriveType.Network || !Directory.Exists(recyclePath))
                     {
                         continue;


### PR DESCRIPTION
**Resolved / Related Issues**
The folder Recycle.Bin use the bad case.
This prevents name comparison (in RemoveFileOrFolderAsync)
Recycle bin doesn't refresh when deleting.
#4640 #4733

**Details of Changes**
Change case of folder Recycle.Bin