### PR TITLE
Fix LibraryNoLocations Visibility

### DIFF
--- a/Files/Views/Pages/PropertiesLibrary.xaml
+++ b/Files/Views/Pages/PropertiesLibrary.xaml
@@ -105,7 +105,7 @@
                     <StackPanel Margin="14,5,14,5" Spacing="5">
                         <TextBlock
                             x:Uid="LibraryNoLocations"
-                            Visibility="{x:Bind IsLibraryEmpty}"
+                            Visibility="{x:Bind IsLibraryEmpty, Mode=OneWay}"
                             Text="No locations"
                             TextWrapping="WrapWholeWords" />
                     </StackPanel>


### PR DESCRIPTION
**Resolved / Related Issues**
In the menu Library Properties, the  label "No locations" is always visible.
It should only be visible if the library is empty.

**Details of Changes**
Change mode of binding of the property IsLibraryEmpty.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
before
![before](https://i.ibb.co/yhqP01r/before.png[/img][/url])
after
![after](https://i.ibb.co/72QNNPC/after.png)
