### PR TITLE
Fix unexpected behavior when toggling preview pane in dual pane mode

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -352,7 +352,7 @@ namespace Files
             }
 
             ParentShellPageInstance.InstanceViewModel.IsPageTypeNotHome = true; // show controls that were hidden on the home page
-
+            ParentShellPageInstance.LoadPreviewPaneChanged();
             FolderSettings.IsLayoutModeChanging = false;
 
             ItemManipulationModel.FocusFileList(); // Set focus on layout specific file list control

--- a/Files/IShellPage.cs
+++ b/Files/IShellPage.cs
@@ -44,6 +44,8 @@ namespace Files
         void RemoveLastPageFromBackStack();
 
         void SubmitSearch(string query, bool searchUnindexedItems);
+
+        void LoadPreviewPaneChanged();
     }
 
     public interface IPaneHolder : IDisposable

--- a/Files/Views/ColumnShellPage.xaml
+++ b/Files/Views/ColumnShellPage.xaml
@@ -191,10 +191,12 @@
 
         <Frame
             x:Name="ItemDisplayFrame"
-            Grid.RowSpan="5" Canvas.ZIndex="30" Grid.ColumnSpan="3"
+            Grid.RowSpan="5"
+            Grid.ColumnSpan="3"
             HorizontalAlignment="Stretch"
             x:FieldModifier="public"
             Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
+            Canvas.ZIndex="30"
             Navigated="ItemDisplayFrame_Navigated" />
 
         <Custom:DropShadowPanel
@@ -202,6 +204,7 @@
             Grid.Row="1"
             Grid.Column="2"
             HorizontalContentAlignment="Stretch"
+            x:Load="{x:Bind LoadPreviewPane, Mode=OneWay}"
             BlurRadius="16"
             Canvas.ZIndex="10"
             OffsetX="-4"
@@ -209,8 +212,8 @@
             <controls:PreviewPane
                 x:Name="PreviewPane"
                 x:Uid="SelectedFilePreviewPane"
-                x:Load="{x:Bind AppSettings.PreviewPaneEnabled, Mode=OneWay}"
                 AutomationProperties.Name="Selected file preview pane"
+                Loading="PreviewPane_Loading"
                 SelectedItems="{x:Bind ContentPage.SelectedItems, Mode=OneWay}" />
         </Custom:DropShadowPanel>
 
@@ -218,59 +221,52 @@
             x:Name="PreviewPaneGridSplitter"
             Grid.Row="1"
             Grid.Column="1"
-            x:Load="{x:Bind AppSettings.PreviewPaneEnabled, Mode=OneWay}"
+            x:Load="{x:Bind LoadPreviewPane, Mode=OneWay}"
             ManipulationCompleted="PreviewPaneGridSplitter_ManipulationCompleted"
             ResizeBehavior="BasedOnAlignment"
             Style="{StaticResource DefaultGridSplitterStyle}" />
 
         <controls:StatusBarControl
             x:Name="StatusBarControl"
-            Grid.Row="5" Height="0" Visibility="Collapsed"
+            Grid.Row="5"
             Grid.ColumnSpan="3"
+            Height="0"
             x:Load="{x:Bind InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
             DirectoryPropertiesViewModel="{x:Bind ContentPage.DirectoryPropertiesViewModel, Mode=OneWay}"
             SelectedItemsPropertiesViewModel="{x:Bind ContentPage.SelectedItemsPropertiesViewModel, Mode=OneWay}"
-            ShowStatusCenter="{x:Bind IsPageSecondaryPane, Mode=OneWay}" 
-            StatusCenterViewModel="{x:Bind StatusCenterViewModel}"/>
+            ShowStatusCenter="{x:Bind IsPageSecondaryPane, Mode=OneWay}"
+            StatusCenterViewModel="{x:Bind StatusCenterViewModel}"
+            Visibility="Collapsed" />
 
         <Custom:DropShadowPanel
             Grid.Row="1"
-            Grid.ColumnSpan="3" Visibility="Collapsed"
+            Grid.ColumnSpan="3"
             HorizontalAlignment="Stretch"
             HorizontalContentAlignment="Stretch"
             BlurRadius="8"
             Canvas.ZIndex="100"
             OffsetY="2"
-            ShadowOpacity="0.04">
+            ShadowOpacity="0.04"
+            Visibility="Collapsed">
 
             <controls:NavigationToolbar
                 x:Name="NavToolbar"
                 HorizontalAlignment="Stretch"
                 x:FieldModifier="public"
-
-                MultiselectEnabled="{x:Bind InteractionViewModel.MultiselectEnabled, Mode=TwoWay}"
-                SelectAllInvokedCommand="{x:Bind SelectAllContentPageItemsCommand, Mode=OneWay}"
-                InvertSelectionInvokedCommand="{x:Bind InvertContentPageSelctionCommand, Mode=OneWay}"
-                ClearSelectionInvokedCommand="{x:Bind ClearContentPageSelectionCommand, Mode=OneWay}"
-
-                LayoutModeInformation="{x:Bind FolderSettings.LayoutModeInformation, Mode=OneWay}"
-                ToggleLayoutModeDetailsView="{x:Bind FolderSettings.ToggleLayoutModeDetailsView}"
-                ToggleLayoutModeTiles="{x:Bind FolderSettings.ToggleLayoutModeTiles}"
-                ToggleLayoutModeGridViewSmall="{x:Bind FolderSettings.ToggleLayoutModeGridViewSmall}"
-                ToggleLayoutModeGridViewMedium="{x:Bind FolderSettings.ToggleLayoutModeGridViewMedium}"
-                ToggleLayoutModeGridViewLarge="{x:Bind FolderSettings.ToggleLayoutModeGridViewLarge}"
-                ToggleLayoutModeColumnView="{x:Bind FolderSettings.ToggleLayoutModeColumnView}"
-
                 AreKeyboardAcceleratorsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
                 CanCopyPathInPage="{x:Bind InstanceViewModel.CanCopyPathInPage, Mode=OneWay}"
                 CanCreateFileInPage="{x:Bind InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
                 CanOpenTerminalInPage="{x:Bind InstanceViewModel.CanOpenTerminalInPage, Mode=OneWay}"
                 CanPasteInPage="{x:Bind InstanceViewModel.CanPasteInPage, Mode=OneWay}"
+                ClearSelectionInvokedCommand="{x:Bind ClearContentPageSelectionCommand, Mode=OneWay}"
                 CopyPathInvokedCommand="{x:Bind CopyPathOfWorkingDirectoryCommand}"
+                InvertSelectionInvokedCommand="{x:Bind InvertContentPageSelctionCommand, Mode=OneWay}"
                 IsCreateButtonEnabledInPage="{x:Bind InstanceViewModel.IsCreateButtonEnabledInPage, Mode=OneWay}"
                 IsMultiPaneActive="{x:Bind IsMultiPaneActive, Mode=OneWay}"
                 IsPageMainPane="{x:Bind IsPageMainPane, Mode=OneWay}"
                 IsPageTypeNotHome="{x:Bind InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+                LayoutModeInformation="{x:Bind FolderSettings.LayoutModeInformation, Mode=OneWay}"
+                MultiselectEnabled="{x:Bind InteractionViewModel.MultiselectEnabled, Mode=TwoWay}"
                 NewFileInvokedCommand="{x:Bind CreateNewFileCommand, Mode=OneWay}"
                 NewFolderInvokedCommand="{x:Bind CreateNewFolderCommand, Mode=OneWay}"
                 NewPaneInvokedCommand="{x:Bind OpenNewPaneCommand, Mode=OneWay}"
@@ -279,7 +275,14 @@
                 OpenInTerminalInvokedCommand="{x:Bind OpenDirectoryInDefaultTerminalCommand, Mode=OneWay}"
                 PasteInvokedCommand="{x:Bind PasteItemsFromClipboardCommand, Mode=OneWay}"
                 PreviewPaneEnabled="{x:Bind PreviewPaneEnabled, Mode=TwoWay}"
-                ShowMultiPaneControls="{x:Bind converters1:MultiBooleanConverter.AndConvert(IsMultiPaneEnabled, IsPageMainPane), Mode=OneWay}" />
+                SelectAllInvokedCommand="{x:Bind SelectAllContentPageItemsCommand, Mode=OneWay}"
+                ShowMultiPaneControls="{x:Bind converters1:MultiBooleanConverter.AndConvert(IsMultiPaneEnabled, IsPageMainPane), Mode=OneWay}"
+                ToggleLayoutModeColumnView="{x:Bind FolderSettings.ToggleLayoutModeColumnView}"
+                ToggleLayoutModeDetailsView="{x:Bind FolderSettings.ToggleLayoutModeDetailsView}"
+                ToggleLayoutModeGridViewLarge="{x:Bind FolderSettings.ToggleLayoutModeGridViewLarge}"
+                ToggleLayoutModeGridViewMedium="{x:Bind FolderSettings.ToggleLayoutModeGridViewMedium}"
+                ToggleLayoutModeGridViewSmall="{x:Bind FolderSettings.ToggleLayoutModeGridViewSmall}"
+                ToggleLayoutModeTiles="{x:Bind FolderSettings.ToggleLayoutModeTiles}" />
         </Custom:DropShadowPanel>
     </Grid>
 </Page>

--- a/Files/Views/ColumnShellPage.xaml.cs
+++ b/Files/Views/ColumnShellPage.xaml.cs
@@ -901,15 +901,6 @@ namespace Files.Views
                 InitialPageType = typeof(ColumnShellPage),
                 NavigationArg = parameters.IsSearchResultPage ? parameters.SearchPathParam : parameters.NavPathParam
             };
-
-            if (ItemDisplayFrame.CurrentSourcePageType == typeof(WidgetsPage))
-            {
-                UpdatePositioning(true);
-            }
-            else
-            {
-                UpdatePositioning();
-            }
         }
 
         private async void KeyboardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
@@ -1217,45 +1208,21 @@ namespace Files.Views
             return DataPackageOperation.None;
         }
 
-        // This is needed so the layout can be updated when the preview pane is opened
-        public bool PreviewPaneEnabled
-        {
-            get => AppSettings.PreviewPaneEnabled;
-            set
-            {
-                AppSettings.PreviewPaneEnabled = value;
-                NotifyPropertyChanged(nameof(PreviewPaneEnabled));
-                UpdatePositioning();
-            }
-        }
-
         private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            UpdatePositioning(!InstanceViewModel.IsPageTypeNotHome);
+            UpdatePositioning();
         }
 
         /// <summary>
         /// Call this function to update the positioning of the preview pane.
         /// This is a workaround as the VisualStateManager causes problems.
         /// </summary>
-        private void UpdatePositioning(bool IsHome = false)
+        private void UpdatePositioning()
         {
-            if (!AppSettings.PreviewPaneEnabled || IsHome)
+            if (!LoadPreviewPane || PreviewPaneDropShadowPanel is null || PreviewPane is null)
             {
                 PreviewPaneRow.Height = new GridLength(0);
                 PreviewPaneColumn.Width = new GridLength(0);
-                if (PreviewPaneGridSplitter != null)
-                {
-                    PreviewPaneGridSplitter.Visibility = Visibility.Collapsed;
-                }
-
-                if (PreviewPane != null)
-                {
-                    PreviewPane.Visibility = Visibility.Collapsed;
-                    PreviewPaneDropShadowPanel.Visibility = Visibility.Collapsed;
-                }
-
-                PreviewPaneDropShadowPanel.ShadowOpacity = 0.00;
             }
             else if (RootGrid.ActualWidth > 800)
             {
@@ -1274,10 +1241,6 @@ namespace Files.Views
                 PreviewPaneRow.Height = new GridLength(0);
                 PreviewPaneColumn.Width = AppSettings.PreviewPaneSizeVertical;
                 PreviewPane.IsHorizontal = false;
-
-                PreviewPane.Visibility = Visibility.Visible;
-                PreviewPaneGridSplitter.Visibility = Visibility.Visible;
-                PreviewPaneDropShadowPanel.Visibility = Visibility.Visible;
             }
             else if (RootGrid.ActualWidth <= 800)
             {
@@ -1296,10 +1259,6 @@ namespace Files.Views
                 PreviewPaneGridSplitter.Height = 2;
                 PreviewPaneGridSplitter.Width = RootGrid.Width;
                 PreviewPane.IsHorizontal = true;
-
-                PreviewPane.Visibility = Visibility.Visible;
-                PreviewPaneGridSplitter.Visibility = Visibility.Visible;
-                PreviewPaneDropShadowPanel.Visibility = Visibility.Visible;
             }
         }
 
@@ -1376,6 +1335,37 @@ namespace Files.Views
                     InstanceViewModel.FolderSettings.GetIconSize())
             });
             FilesystemViewModel.IsLoadingIndicatorActive = false;
+        }
+
+        public bool LoadPreviewPane => AppSettings.PreviewPaneEnabled && InstanceViewModel.IsPageTypeNotHome;
+
+        public void LoadPreviewPaneChanged()
+        {
+            NotifyPropertyChanged(nameof(LoadPreviewPane));
+            UpdatePositioning();
+        }
+
+        private void PreviewPane_Loading(FrameworkElement sender, object args)
+        {
+            UpdatePositioning();
+        }
+
+        private bool previewPaneEnabled = App.AppSettings.PreviewPaneEnabled;
+
+        // This is needed so the layout can be updated when the preview pane is opened
+        public bool PreviewPaneEnabled
+        {
+            get => previewPaneEnabled;
+            set
+            {
+                if (value != previewPaneEnabled)
+                {
+                    AppSettings.PreviewPaneEnabled = value;
+                    NotifyPropertyChanged(nameof(PreviewPaneEnabled));
+                    NotifyPropertyChanged(nameof(LoadPreviewPane));
+                    UpdatePositioning();
+                }
+            }
         }
     }
 }

--- a/Files/Views/ModernShellPage.xaml
+++ b/Files/Views/ModernShellPage.xaml
@@ -202,6 +202,7 @@
             Grid.Row="1"
             Grid.Column="2"
             HorizontalContentAlignment="Stretch"
+            x:Load="{x:Bind LoadPreviewPane, Mode=OneWay}"
             BlurRadius="16"
             Canvas.ZIndex="10"
             OffsetX="-4"
@@ -209,8 +210,8 @@
             <controls:PreviewPane
                 x:Name="PreviewPane"
                 x:Uid="SelectedFilePreviewPane"
-                x:Load="{x:Bind AppSettings.PreviewPaneEnabled, Mode=OneWay}"
                 AutomationProperties.Name="Selected file preview pane"
+                Loading="PreviewPane_Loading"
                 SelectedItems="{x:Bind ContentPage.SelectedItems, Mode=OneWay}" />
         </Custom:DropShadowPanel>
 
@@ -218,7 +219,7 @@
             x:Name="PreviewPaneGridSplitter"
             Grid.Row="1"
             Grid.Column="1"
-            x:Load="{x:Bind AppSettings.PreviewPaneEnabled, Mode=OneWay}"
+            x:Load="{x:Bind LoadPreviewPane, Mode=OneWay}"
             ManipulationCompleted="PreviewPaneGridSplitter_ManipulationCompleted"
             ResizeBehavior="BasedOnAlignment"
             Style="{StaticResource DefaultGridSplitterStyle}" />

--- a/Files/Views/WidgetsPage.xaml.cs
+++ b/Files/Views/WidgetsPage.xaml.cs
@@ -216,6 +216,8 @@ namespace Files.Views
             AppInstance.NavigationToolbar.CanGoForward = AppInstance.CanNavigateForward;
             AppInstance.NavigationToolbar.CanNavigateToParent = false;
 
+            AppInstance.LoadPreviewPaneChanged();
+
             // Set path of working directory empty
             await AppInstance.FilesystemViewModel.SetWorkingDirectoryAsync("Home");
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Closes #4752 

**Details of Changes**
Add details of changes here.
- Add local field for preview pane enabled so that the state can vary across panes 
- Don't load preview pane on the home page instead of collapsing it (may improve startup speed slightly)
- Move x:load to the preview pane drop shadow from the preview pane itself

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
