### PR TITLE
Possible fix for crash when moving folders

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -446,8 +446,46 @@ namespace Files
 
         private static void AppUnhandledException(Exception ex)
         {
+            string formattedException = string.Empty;
+
+            formattedException += "--------- UNHANDLED EXCEPTION ---------";
+            if (ex != null)
+            {
+                formattedException += $"\n>>>> HRESULT: {ex.HResult}\n";
+                if (ex.Message != null)
+                {
+                    formattedException += "\n--- MESSAGE ---";
+                    formattedException += ex.Message;
+                }
+                if (ex.StackTrace != null)
+                {
+                    formattedException += "\n--- STACKTRACE ---";
+                    formattedException += ex.StackTrace;
+                }
+                if (ex.Source != null)
+                {
+                    formattedException += "\n--- SOURCE ---";
+                    formattedException += ex.Source;
+                }
+                if (ex.InnerException != null)
+                {
+                    formattedException += "\n--- INNER ---";
+                    formattedException += ex.InnerException;
+                }
+            }
+            else
+            {
+                formattedException += "\nException is null!\n";
+            }
+
+            formattedException += "---------------------------------------";
+
+            Debug.WriteLine(formattedException);
+
+            Debugger.Break(); // Please check "Output Window" for exception details (View -> Output Window) (CTRL + ALT + O)
+
             SaveSessionTabs();
-            Logger.Error(ex, ex.Message);
+            Logger.Error(ex, formattedException);
             if (ShowErrorNotification)
             {
                 var toastContent = new ToastContent()


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Itemize resolved / related issues by this PR.
- Related: [2833388839u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/2833388839u/overview)

**Details of Changes**
Add details of changes here.
- The crash seems to have resulted from using ```NativeFileOperationsHelper.MoveFileFromApp``` native function. This pr changes the behavior of ```MoveAsync``` to always use ```MoveDirectoryAsync``` instead of ```MoveFileFromApp```.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**


```MoveDirectoryAsync``` seems to be a bit slow, so I would appreciate any feedback or alternative solutions. 
