### PR TITLE
Allow user to right click text in item name box without ending rename

### DIFF
--- a/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -275,8 +275,12 @@ namespace Files.Views.LayoutModes
 
         private void RenameTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            TextBox textBox = e.OriginalSource as TextBox;
-            CommitRename(textBox);
+            // This check allows the user to use the text box context menu without ending the rename
+            if (!(FocusManager.GetFocusedElement() is AppBarButton))
+            {
+                TextBox textBox = e.OriginalSource as TextBox;
+                CommitRename(textBox);
+            }
         }
 
         private async void CommitRename(TextBox textBox)

--- a/Files/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -336,8 +336,12 @@ namespace Files.Views.LayoutModes
 
         private void RenameTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            TextBox textBox = e.OriginalSource as TextBox;
-            CommitRename(textBox);
+            // This check allows the user to use the text box context menu without ending the rename
+            if (!(FocusManager.GetFocusedElement() is AppBarButton))
+            {
+                TextBox textBox = e.OriginalSource as TextBox;
+                CommitRename(textBox);
+            }
         }
 
         private async void CommitRename(TextBox textBox)

--- a/Files/Views/LayoutModes/GenericFileBrowser2.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser2.xaml.cs
@@ -11,6 +11,7 @@ using Microsoft.Toolkit.Uwp.UI;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.System;
@@ -353,8 +354,12 @@ namespace Files.Views.LayoutModes
 
         private void RenameTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            TextBox textBox = e.OriginalSource as TextBox;
-            CommitRename(textBox);
+            // This check allows the user to use the text box context menu without ending the rename
+            if (!(FocusManager.GetFocusedElement() is AppBarButton))
+            {
+                TextBox textBox = e.OriginalSource as TextBox;
+                CommitRename(textBox);
+            }
         }
 
         private async void CommitRename(TextBox textBox)

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -313,8 +313,12 @@ namespace Files.Views.LayoutModes
 
         private void RenameTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            TextBox textBox = e.OriginalSource as TextBox;
-            CommitRename(textBox);
+            // This check allows the user to use the text box context menu without ending the rename
+            if (!(FocusManager.GetFocusedElement() is AppBarButton))
+            {
+                TextBox textBox = e.OriginalSource as TextBox;
+                CommitRename(textBox);
+            }
         }
 
         private async void CommitRename(TextBox textBox)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
- There was an issue for this at some point, however I can't seem to find it. 

**Details of Changes**
Add details of changes here.
- Changed behavior to not end rename if the focused element is an ```AppBarButton``` (the type used for the text box context flyout). Before, rename would end if the user right clicked the text inside the name text box.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

I have tested this by accessing the menu via mouse, keyboard, and touchscreen.

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/59544401/116294439-d3575080-a74c-11eb-914b-334f735772f8.png)

Note: a more elegant solution would be to check if the element has a parent of type ```FlyoutBase```, however I couldn't get this to work. ```DependencyObjectHelpers.FindParent<FlyoutBase>``` would always return null. 