### PR TITLE
Fix issue where preview pane row/column would not be collapsed after navigating to the home page

### DIFF
--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -1418,6 +1418,7 @@ namespace Files.Views
         public void LoadPreviewPaneChanged()
         {
             NotifyPropertyChanged(nameof(LoadPreviewPane));
+            UpdatePositioning();
         }
 
         private void PreviewPane_Loading(FrameworkElement sender, object args)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Only post one request per one feature request
3. Try not to make duplicates. Do a quick search before posting
4. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.

**Details of Changes**
Add details of changes here.
- Update the layout when ```LoadPreviewPaneChanged()``` is called

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**


After:
![image](https://user-images.githubusercontent.com/59544401/116729780-718d2580-a99c-11eb-92a0-d114627be1a2.png)

Before:
![image](https://user-images.githubusercontent.com/59544401/116729825-81a50500-a99c-11eb-961b-db6c73e70503.png)
