### PR TITLE
Fixes an issue for which opening a folder in ColumnView did not add a new column

### DIFF
--- a/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -439,7 +439,7 @@ namespace Files.Views.LayoutModes
                     listViewItem.Style = (Style)this.Resources["NormalStyle"];
                 }
                 var item = (e.OriginalSource as FrameworkElement).DataContext as ListedItem;
-                if (item.ItemType == "File folder")
+                if (item.PrimaryItemAttribute == Windows.Storage.StorageItemTypes.Folder)
                 {
                     if (item.ContainsFilesOrFolders)
                     {
@@ -508,7 +508,7 @@ namespace Files.Views.LayoutModes
             {
                 tapDebounceTimer.Stop();
                 await Task.Delay(200);
-                if (item.ItemType == "File folder")
+                if (item.PrimaryItemAttribute == Windows.Storage.StorageItemTypes.Folder)
                 {
                     if (item.ContainsFilesOrFolders)
                     {

--- a/Files/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -492,7 +492,7 @@ namespace Files.Views.LayoutModes
                     listViewItem.Style = (Style)this.Resources["NormalStyle"];
                 }
                 var item = (e.OriginalSource as FrameworkElement).DataContext as ListedItem;
-                if (item.ItemType == "File folder")
+                if (item.PrimaryItemAttribute == Windows.Storage.StorageItemTypes.Folder)
                 {
                     //var pane = new ModernShellPage();
                     //pane.FilesystemViewModel = new ItemViewModel(InstanceViewModel?.FolderSettings);
@@ -624,7 +624,7 @@ namespace Files.Views.LayoutModes
             {
                 tapDebounceTimer.Stop();
                 await Task.Delay(200);
-                if (item.ItemType == "File folder")
+                if (item.PrimaryItemAttribute == Windows.Storage.StorageItemTypes.Folder)
                 {
                     //var pane = new ModernShellPage();
                     //pane.FilesystemViewModel = new ItemViewModel(InstanceViewModel?.FolderSettings);


### PR DESCRIPTION
**Resolved / Related Issues**
Fixes an issue for which double clicking on a folder in columnview does not add a new column.

**Details of Changes**
Changes the check to test if an item is a folder to use the PrimaryItemAttribute property instead of ItemType which only works if windows language is set as English.

**Validation**
How did you test these changes?
- [x] Built and ran the app
