### PR TITLE
Do not reload sidebar library items

### DIFF
--- a/Files/Filesystem/LibraryManager.cs
+++ b/Files/Filesystem/LibraryManager.cs
@@ -197,15 +197,24 @@ namespace Files.Filesystem
                     }
                 }
 
-                Libraries.BeginBulkOperation();
-                Libraries.Clear();
                 var libs = await LibraryHelper.ListUserLibraries();
                 if (libs != null)
                 {
-                    libs.Sort();
-                    Libraries.AddRange(libs);
+                    foreach (var lib in libs)
+                    {
+                        if (!Libraries.Any(x => x.Path == lib.Path))
+                        {
+                            Libraries.AddSorted(lib);
+                        }
+                    }
+                    foreach (var lib in Libraries.ToList())
+                    {
+                        if (!libs.Any(x => x.Path == lib.Path))
+                        {
+                            Libraries.Remove(lib);
+                        }
+                    }
                 }
-                Libraries.EndBulkOperation();
             });
         }
 

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -69,10 +69,10 @@ namespace Files.UserControls.Widgets
             await DriveHelpers.EjectDeviceAsync(item.Path);
         }
 
-        private void OpenInNewTab_Click(object sender, RoutedEventArgs e)
+        private async void OpenInNewTab_Click(object sender, RoutedEventArgs e)
         {
             var item = ((MenuFlyoutItem)sender).DataContext as DriveItem;
-            NavigationHelpers.OpenPathInNewTab(item.Path);
+            await NavigationHelpers.OpenPathInNewTab(item.Path);
         }
 
         private async void OpenInNewWindow_Click(object sender, RoutedEventArgs e)
@@ -87,7 +87,7 @@ namespace Files.UserControls.Widgets
             await FilePropertiesHelpers.OpenPropertiesWindowAsync(item, associatedInstance);
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+        private async void Button_Click(object sender, RoutedEventArgs e)
         {
             string NavigationPath = ""; // path to navigate
             string ClickedCard = (sender as Button).Tag.ToString();
@@ -97,7 +97,7 @@ namespace Files.UserControls.Widgets
             var ctrlPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
             if (ctrlPressed)
             {
-                NavigationHelpers.OpenPathInNewTab(NavigationPath);
+                await NavigationHelpers.OpenPathInNewTab(NavigationPath);
                 return;
             }
 
@@ -107,12 +107,12 @@ namespace Files.UserControls.Widgets
             });
         }
 
-        private void Button_PointerPressed(object sender, PointerRoutedEventArgs e)
+        private async void Button_PointerPressed(object sender, PointerRoutedEventArgs e)
         {
             if (e.GetCurrentPoint(null).Properties.IsMiddleButtonPressed) // check middle click
             {
                 string navigationPath = (sender as Button).Tag.ToString();
-                NavigationHelpers.OpenPathInNewTab(navigationPath);
+                await NavigationHelpers.OpenPathInNewTab(navigationPath);
             }
         }
 

--- a/Files/UserControls/Widgets/LibraryCards.xaml.cs
+++ b/Files/UserControls/Widgets/LibraryCards.xaml.cs
@@ -89,7 +89,7 @@ namespace Files.UserControls.Widgets
 
         public bool IsWidgetSettingEnabled => App.AppSettings.ShowLibraryCardsWidget;
 
-        public RelayCommand<LibraryCardItem> LibraryCardClicked => new RelayCommand<LibraryCardItem>(item =>
+        public RelayCommand<LibraryCardItem> LibraryCardClicked => new RelayCommand<LibraryCardItem>(async (item) =>
         {
             if (string.IsNullOrEmpty(item.Path))
             {
@@ -104,7 +104,7 @@ namespace Files.UserControls.Widgets
             var ctrlPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
             if (ctrlPressed)
             {
-                NavigationHelpers.OpenPathInNewTab(item.Path);
+                await NavigationHelpers.OpenPathInNewTab(item.Path);
                 return;
             }
 
@@ -328,18 +328,18 @@ namespace Files.UserControls.Widgets
             LibraryCardNewPaneInvoked?.Invoke(this, new LibraryCardInvokedEventArgs { Path = item.Path });
         }
 
-        private void OpenInNewTab_Click(object sender, RoutedEventArgs e)
+        private async void OpenInNewTab_Click(object sender, RoutedEventArgs e)
         {
             var item = ((MenuFlyoutItem)sender).DataContext as LibraryCardItem;
-            NavigationHelpers.OpenPathInNewTab(item.Path);
+            await NavigationHelpers.OpenPathInNewTab(item.Path);
         }
 
-        private void Button_PointerPressed (object sender, PointerRoutedEventArgs e)
+        private async void Button_PointerPressed (object sender, PointerRoutedEventArgs e)
         {
             if (e.GetCurrentPoint(null).Properties.IsMiddleButtonPressed) // check middle click
             {
                 string navigationPath = (sender as Button).Tag.ToString();
-                NavigationHelpers.OpenPathInNewTab(navigationPath);
+                await NavigationHelpers.OpenPathInNewTab(navigationPath);
             }
         }
 
@@ -381,7 +381,7 @@ namespace Files.UserControls.Widgets
                     SelectCommand = LibraryCardClicked,
                     AutomationProperties = lib.Text,
                     Library = lib,
-                }) ;
+                });
             }
             ItemsAdded.EndBulkOperation();
         }


### PR DESCRIPTION
**Resolved / Related Issues**
Fixes #4800

**Details of Changes**
Does not reset the Libraries collection when syncing sidebar items
Fixes a few warnings related to async methods not being awaited

**Validation**
How did you test these changes?
- [x] Built and ran the app
