### PR TITLE
Get smaller size icons (48 vs 128), never look for overlays

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -395,6 +395,16 @@ namespace FilesFullTrust
                     }, message.Get("RequestID", (string)null));
                     break;
 
+                case "GetIconWithoutOverlay":
+                    var fileIconPath2 = (string)message["filePath"];
+                    var thumbnailSize2 = (int)(long)message["thumbnailSize"];
+                    var icon2 = Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(fileIconPath2, thumbnailSize2, false)).Result;
+                    await Win32API.SendMessageAsync(connection, new ValueSet()
+                    {
+                        { "Icon", icon2.icon },
+                    }, message.Get("RequestID", (string)null));
+                    break;
+
                 case "NetworkDriveOperation":
                     await ParseNetworkDriveOperationAsync(message);
                     break;

--- a/Files/UserControls/Widgets/LibraryCards.xaml.cs
+++ b/Files/UserControls/Widgets/LibraryCards.xaml.cs
@@ -83,7 +83,7 @@ namespace Files.UserControls.Widgets
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public Func<string, uint, Task<(byte[] IconData, byte[] OverlayData, bool IsCustom)>> LoadIconOverlay;
+        public Func<string, uint, Task<byte[]>> LoadIconOverlay;
 
         public SettingsViewModel AppSettings => App.AppSettings;
 
@@ -167,13 +167,9 @@ namespace Files.UserControls.Widgets
             }
         }
 
-        private async System.Threading.Tasks.Task<byte[]> GetIcon(string path)
+        private async Task<byte[]> GetIcon(string path)
         {
-            BitmapImage icon = new BitmapImage();
-
-            var (IconData, OverlayData, IsCustom) = await LoadIconOverlay(path, 128u);
-
-            return IconData;
+            return await LoadIconOverlay(path, 48u);
         }
 
         private async Task GetItemsAddedIcon()

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -832,6 +832,27 @@ namespace Files.ViewModels
             return (null, null, false);
         }
 
+        public async Task<byte[]> LoadIconWithoutOverlayAsync(string filePath, uint thumbnailSize)
+        {
+            if (Connection != null)
+            {
+                var value = new ValueSet();
+                value.Add("Arguments", "GetIconWithoutOverlay");
+                value.Add("filePath", filePath);
+                value.Add("thumbnailSize", (int)thumbnailSize);
+                var (status, response) = await Connection.SendMessageForResponseAsync(value);
+                if (status == AppServiceResponseStatus.Success)
+                {
+                    var icon = response.Get("Icon", (string)null);
+
+                    // BitmapImage can only be created on UI thread, so return raw data and create
+                    // BitmapImage later to prevent exceptions once SynchorizationContext lost
+                    return (icon == null ? null : Convert.FromBase64String(icon));
+                }
+            }
+            return null;
+        }
+
         public void RefreshItems(string previousDir, bool useCache = true)
         {
             RapidAddItemsToCollectionAsync(WorkingDirectory, previousDir, useCache);

--- a/Files/Views/WidgetsPage.xaml.cs
+++ b/Files/Views/WidgetsPage.xaml.cs
@@ -58,7 +58,7 @@ namespace Files.Views
             if (shouldReloadLibraryCards && libraryCards != null)
             {
                 Widgets.ViewModel.InsertWidget(libraryCards, 0);
-                libraryCards.LoadIconOverlay = AppInstance.FilesystemViewModel.LoadIconOverlayAsync;
+                libraryCards.LoadIconOverlay = AppInstance.FilesystemViewModel.LoadIconWithoutOverlayAsync;
 
                 libraryCards.LibraryCardInvoked -= LibraryWidget_LibraryCardInvoked;
                 libraryCards.LibraryCardNewPaneInvoked -= LibraryWidget_LibraryCardNewPaneInvoked;


### PR DESCRIPTION
Loads library icons from the shell faster by getting them in a smaller size without much difference in quality. Also, never look for overlays for the library widget.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility