### PR TITLE
Close the search bar with the search button

### DIFF
--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -912,7 +912,7 @@
                 IsEnabled="{x:Bind IsPageTypeNotHome, Mode=OneWay}"
                 Style="{StaticResource ToolBarButtonStyle}"
                 ToolTipService.ToolTip="Search">
-                <FontIcon x:Name="SearchButtonIcon" FontSize="14" Glyph="&#xE721;" />
+                <FontIcon FontSize="14" Glyph="{x:Bind SearchButtonGlyph, Mode=OneWay}" />
             </Button>
         </Grid>
 

--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -912,7 +912,7 @@
                 IsEnabled="{x:Bind IsPageTypeNotHome, Mode=OneWay}"
                 Style="{StaticResource ToolBarButtonStyle}"
                 ToolTipService.ToolTip="Search">
-                <FontIcon FontSize="14" Glyph="&#xE721;" />
+                <FontIcon x:Name="SearchButtonIcon" FontSize="14" Glyph="&#xE721;" />
             </Button>
         </Grid>
 

--- a/Files/UserControls/NavigationToolbar.xaml.cs
+++ b/Files/UserControls/NavigationToolbar.xaml.cs
@@ -1241,6 +1241,7 @@ namespace Files.UserControls
             {
                 SearchRegion.Text = "";
                 IsSearchRegionVisible = false;
+                SearchButtonIcon.Glyph = "\uE721";
             }
             else
             {
@@ -1251,6 +1252,7 @@ namespace Files.UserControls
                 SearchRegion.UpdateLayout();
 
                 SearchRegion.Focus(FocusState.Programmatic);
+                SearchButtonIcon.Glyph = "\uE711";
             }
         }
 
@@ -1264,6 +1266,7 @@ namespace Files.UserControls
 
             SearchRegion.Text = "";
             IsSearchRegionVisible = false;
+            SearchButtonIcon.Glyph = "\uE721";
         }
 
         public void ClearSearchBoxQueryText(bool collapseSearchRegion = false)

--- a/Files/UserControls/NavigationToolbar.xaml.cs
+++ b/Files/UserControls/NavigationToolbar.xaml.cs
@@ -787,6 +787,24 @@ namespace Files.UserControls
             }
         }
 
+        private string searchButtonGlyph = "\uE721";
+
+        public string SearchButtonGlyph
+        {
+            get
+            {
+                return searchButtonGlyph;
+            }
+            set
+            {
+                if (value != searchButtonGlyph)
+                {
+                    searchButtonGlyph = value;
+                    NotifyPropertyChanged(nameof(SearchButtonGlyph));
+                }
+            }
+        }
+
         bool INavigationToolbar.IsEditModeEnabled
         {
             get
@@ -1241,7 +1259,7 @@ namespace Files.UserControls
             {
                 SearchRegion.Text = "";
                 IsSearchRegionVisible = false;
-                SearchButtonIcon.Glyph = "\uE721";
+                SearchButtonGlyph = "\uE721";
             }
             else
             {
@@ -1252,7 +1270,7 @@ namespace Files.UserControls
                 SearchRegion.UpdateLayout();
 
                 SearchRegion.Focus(FocusState.Programmatic);
-                SearchButtonIcon.Glyph = "\uE711";
+                SearchButtonGlyph = "\uE711";
             }
         }
 
@@ -1266,7 +1284,7 @@ namespace Files.UserControls
 
             SearchRegion.Text = "";
             IsSearchRegionVisible = false;
-            SearchButtonIcon.Glyph = "\uE721";
+            SearchButtonGlyph = "\uE721";
         }
 
         public void ClearSearchBoxQueryText(bool collapseSearchRegion = false)

--- a/Files/UserControls/NavigationToolbar.xaml.cs
+++ b/Files/UserControls/NavigationToolbar.xaml.cs
@@ -1237,19 +1237,27 @@ namespace Files.UserControls
 
         private void SearchButton_Click(object sender, RoutedEventArgs e)
         {
-            IsSearchRegionVisible = true;
+            if (IsSearchRegionVisible)
+            {
+                SearchRegion.Text = "";
+                IsSearchRegionVisible = false;
+            }
+            else
+            {
+                IsSearchRegionVisible = true;
 
-            // Given that binding and layouting might take a few cycles, when calling UpdateLayout
-            // we can guarantee that the focus call will be able to find an open ASB
-            SearchRegion.UpdateLayout();
+                // Given that binding and layouting might take a few cycles, when calling UpdateLayout
+                // we can guarantee that the focus call will be able to find an open ASB
+                SearchRegion.UpdateLayout();
 
-            SearchRegion.Focus(FocusState.Programmatic);
+                SearchRegion.Focus(FocusState.Programmatic);
+            }
         }
 
         private void SearchRegion_LostFocus(object sender, RoutedEventArgs e)
         {
             var focusedElement = FocusManager.GetFocusedElement();
-            if (focusedElement is FlyoutBase || focusedElement is AppBarButton)
+            if (focusedElement == SearchButton || focusedElement is FlyoutBase || focusedElement is AppBarButton)
             {
                 return;
             }


### PR DESCRIPTION
**Resolved / Related Issues**
When the search bar is open, the search button close and reopen the search bar.
The expected behavior is to close the search bar. 

**Details of Changes**
When the search bar is open, the search button close close the search bar.