### PR TITLE
Open new tab with ctrl + click in sidebar

### DIFF
--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -238,7 +238,7 @@ namespace Files.UserControls
             }
 
             var ctrlPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            if (ctrlPressed)
+            if (ctrlPressed && !(args.InvokedItemContainer.Tag is null))
             {
                 string navigationPath = args.InvokedItemContainer.Tag.ToString();
                 await NavigationHelpers.OpenPathInNewTab(navigationPath);

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -229,11 +229,19 @@ namespace Files.UserControls
             return new GridLength(200);
         }
 
-        private void Sidebar_ItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
+        private async void Sidebar_ItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
         {
             if (IsInPointerPressed || args.InvokedItem == null || args.InvokedItemContainer == null)
             {
                 IsInPointerPressed = false;
+                return;
+            }
+
+            var ctrlPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            if (ctrlPressed)
+            {
+                string navigationPath = args.InvokedItemContainer.Tag.ToString();
+                await NavigationHelpers.OpenPathInNewTab(navigationPath);
                 return;
             }
 
@@ -621,7 +629,7 @@ namespace Files.UserControls
         }
 
         private void Border_ManipulationDelta(object sender, ManipulationDeltaRoutedEventArgs e)
-        {   
+        {
             if(IsPaneOpen)
             {
                 IncrementSize(e.Delta.Translation.X);


### PR DESCRIPTION
**Resolved / Related Issues**
In the sidebar, ctrl + click opens the items in the current tab instead of a new tab.
#4511

**Details of Changes**
In the sidebar, opens the item in a new tab with ctrl + click.
This version fix the crash with the group headers.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility