### PR TITLE
Display correctly (Un)Pin To Start in the context menu

### DIFF
--- a/Files/Helpers/ContextFlyoutItemHelper.cs
+++ b/Files/Helpers/ContextFlyoutItemHelper.cs
@@ -308,7 +308,6 @@ namespace Files.Helpers
                     Text = "PinItemToStart/Text".GetLocalized(),
                     Glyph = "\uE840",
                     Command = commandsViewModel.PinItemToStartCommand,
-                    ShowOnShift = true,
                     ShowItem = !itemViewModel.CurrentFolder.IsItemPinnedToStart,
                 },
                 new ContextMenuFlyoutItemViewModel()
@@ -316,7 +315,6 @@ namespace Files.Helpers
                     Text = "UnpinItemFromStart/Text".GetLocalized(),
                     Glyph = "\uE77A",
                     Command = commandsViewModel.UnpinItemFromStartCommand,
-                    ShowOnShift = true,
                     ShowItem = itemViewModel.CurrentFolder.IsItemPinnedToStart,
                 },
                 new ContextMenuFlyoutItemViewModel()
@@ -536,7 +534,6 @@ namespace Files.Helpers
                     Text = "PinItemToStart/Text".GetLocalized(),
                     Glyph = "\uE840",
                     Command = commandsViewModel.PinItemToStartCommand,
-                    ShowOnShift = true,
                     ShowItem = selectedItems.All(x => x.PrimaryItemAttribute == StorageItemTypes.Folder && !x.IsItemPinnedToStart),
                     SingleItemOnly = true,
                 },
@@ -545,7 +542,6 @@ namespace Files.Helpers
                     Text = "UnpinItemFromStart/Text".GetLocalized(),
                     Glyph = "\uE77A",
                     Command = commandsViewModel.UnpinItemFromStartCommand,
-                    ShowOnShift = true,
                     ShowItem = selectedItems.All(x => x.PrimaryItemAttribute == StorageItemTypes.Folder && x.IsItemPinnedToStart),
                     SingleItemOnly = true,
                 },

--- a/Files/Helpers/ContextFlyoutItemHelper.cs
+++ b/Files/Helpers/ContextFlyoutItemHelper.cs
@@ -51,7 +51,9 @@ namespace Files.Helpers
             var overflow = items.Where(x => x.ID == "ItemOverflow").FirstOrDefault();
             if (overflow != null && !shiftPressed)
             {
-                var overflowItems = items.Where(x => x.ShowOnShift).ToList();
+                var overflowItems = App.AppSettings.MoveOverflowMenuItemsToSubMenu
+                    ? items.Where(x => x.ShowInMoreMenu).ToList()
+                    : new List<ContextMenuFlyoutItemViewModel>(0);
 
                 // Adds a separator between items already there and the new ones
                 if (overflow.Items.Count != 0 && overflow.Items.Last().ItemType != ItemType.Separator && overflowItems.Count > 0)
@@ -307,6 +309,7 @@ namespace Files.Helpers
                 {
                     Text = "PinItemToStart/Text".GetLocalized(),
                     Glyph = "\uE840",
+                    ShowInMoreMenu = true,
                     Command = commandsViewModel.PinItemToStartCommand,
                     ShowItem = !itemViewModel.CurrentFolder.IsItemPinnedToStart,
                 },
@@ -314,6 +317,7 @@ namespace Files.Helpers
                 {
                     Text = "UnpinItemFromStart/Text".GetLocalized(),
                     Glyph = "\uE77A",
+                    ShowInMoreMenu = true,
                     Command = commandsViewModel.UnpinItemFromStartCommand,
                     ShowItem = itemViewModel.CurrentFolder.IsItemPinnedToStart,
                 },
@@ -533,6 +537,7 @@ namespace Files.Helpers
                 {
                     Text = "PinItemToStart/Text".GetLocalized(),
                     Glyph = "\uE840",
+                    ShowInMoreMenu = true,
                     Command = commandsViewModel.PinItemToStartCommand,
                     ShowItem = selectedItems.All(x => x.PrimaryItemAttribute == StorageItemTypes.Folder && !x.IsItemPinnedToStart),
                     SingleItemOnly = true,
@@ -541,6 +546,7 @@ namespace Files.Helpers
                 {
                     Text = "UnpinItemFromStart/Text".GetLocalized(),
                     Glyph = "\uE77A",
+                    ShowInMoreMenu = true,
                     Command = commandsViewModel.UnpinItemFromStartCommand,
                     ShowItem = selectedItems.All(x => x.PrimaryItemAttribute == StorageItemTypes.Folder && x.IsItemPinnedToStart),
                     SingleItemOnly = true,

--- a/Files/ViewModels/ContextMenuFlyoutItemViewModel.cs
+++ b/Files/ViewModels/ContextMenuFlyoutItemViewModel.cs
@@ -20,9 +20,9 @@ namespace Files.ViewModels
         public BitmapImage BitmapIcon { get; set; }
 
         /// <summary>
-        /// Only show the item when the shift key is held
+        /// Show item in more menu where setting MoveOverflowMenuItemsToSubMenu is active and shift is not held
         /// </summary>
-        public bool ShowOnShift { get; set; }
+        public bool ShowInMoreMenu { get; set; }
 
         /// <summary>
         /// Only show when one item is selected


### PR DESCRIPTION
**Resolved / Related Issues**
Pin to start menu is in a sub menu even when "move overflow items to sub menu" is off.
Should be out with the rest of them.
Fixes #4850

**Details of Changes**
This command uses ShowOnShift. This property is bugged.
The expected behavior of ShowOnShift is to show the command only if shift is pressed.
The real behavior of ShowOnShift is to show the command in More when Shift is not pressed.
ShowOnShift is only used for PinItemToStart and UnpinItemFromStart.

However, this command should not use it to always be visible (PinItemToStart and UnpinItemFromStart).
This PR disables ShowOnShift for these commands.

The bug with ShowOnShift is not fixed but it would no longer be used and would not have any impact.
We can decide to fix the bug or remove the unused functionality.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility