### PR TITLE
Fix easy warnings

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -369,7 +369,7 @@ namespace Files
                     ItemManipulationModel.SetSelectedItems(liItemsToSelect);
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
             }
 

--- a/Files/Converters/DateTimeOffsetToString.cs
+++ b/Files/Converters/DateTimeOffsetToString.cs
@@ -21,7 +21,7 @@ namespace Files.Converters
             {
                 return DateTimeOffset.Parse(value as string);
             }
-            catch (FormatException e)
+            catch (FormatException)
             {
                 return null;
             }

--- a/Files/Converters/DoubleToString.cs
+++ b/Files/Converters/DoubleToString.cs
@@ -21,7 +21,7 @@ namespace Files.Converters
             {
                 return Double.Parse(value as string);
             }
-            catch (FormatException e)
+            catch (FormatException)
             {
                 return null;
             }

--- a/Files/Converters/UInt32ToString.cs
+++ b/Files/Converters/UInt32ToString.cs
@@ -21,7 +21,7 @@ namespace Files.Converters
             {
                 return UInt32.Parse(value as string);
             }
-            catch (FormatException e)
+            catch (FormatException)
             {
                 return null;
             }

--- a/Files/Dialogs/BitlockerDialog.xaml
+++ b/Files/Dialogs/BitlockerDialog.xaml
@@ -38,7 +38,6 @@
                 x:Name="PasswordInput"
                 x:Uid="BitlockerDialogInputText"
                 Height="35"
-                IsPasswordRevealButtonEnabled="True"
                 PasswordChanged="BitlockerInput_TextChanged"
                 PasswordRevealMode="Peek"
                 PlaceholderText="Password" />

--- a/Files/Helpers/StorageItemHelpers.cs
+++ b/Files/Helpers/StorageItemHelpers.cs
@@ -28,7 +28,7 @@ namespace Files.Helpers
                 //      we could implement this code here for getting .lnk files
                 //      for now, we can't
 
-                return default(TOut);
+                return default;
 
                 if (false) // Prevent unnecessary exceptions
                 {
@@ -72,7 +72,7 @@ namespace Files.Helpers
                 return (TOut)(IStorageItem)folder.Result;
             }
 
-            return default(TOut);
+            return default;
 
             // Extensions
 

--- a/Files/Helpers/WidgetsHelpers.cs
+++ b/Files/Helpers/WidgetsHelpers.cs
@@ -6,7 +6,7 @@ namespace Files.Helpers
 {
     public static class WidgetsHelpers
     {
-        public static TWidget TryGetWidget<TWidget>(WidgetsListControlViewModel widgetsViewModel, out bool shouldReload, TWidget defaultValue = default(TWidget)) where TWidget : IWidgetItemModel, new()
+        public static TWidget TryGetWidget<TWidget>(WidgetsListControlViewModel widgetsViewModel, out bool shouldReload, TWidget defaultValue = default) where TWidget : IWidgetItemModel, new()
         {
             bool canAddWidget = widgetsViewModel.CanAddWidget(typeof(TWidget).Name);
             bool isWidgetSettingEnabled = TryGetIsWidgetSettingEnabled<TWidget>();
@@ -21,15 +21,15 @@ namespace Files.Helpers
                 // Remove the widget
                 widgetsViewModel.RemoveWidget<TWidget>();
                 shouldReload = false;
-                return default(TWidget);
+                return default;
             }
             else if (!isWidgetSettingEnabled)
             {
                 shouldReload = false;
-                return default(TWidget);
+                return default;
             }
 
-            shouldReload = EqualityComparer<TWidget>.Default.Equals(defaultValue, default(TWidget));
+            shouldReload = EqualityComparer<TWidget>.Default.Equals(defaultValue, default);
 
             return (defaultValue);
         }

--- a/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -311,7 +311,7 @@ namespace Files.Interacts
                     Clipboard.Flush();
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Debugger.Break();
             }

--- a/Files/UserControls/FileIcon.xaml
+++ b/Files/UserControls/FileIcon.xaml
@@ -45,7 +45,7 @@
             HorizontalAlignment="Center"
             VerticalAlignment="Stretch"
             x:Load="{x:Bind ViewModel.LoadCustomIcon, Mode=OneWay}"
-            Source="{x:Bind CustomIconImageSource, Mode=OneWay}" />
+            Source="{x:Bind CustomIconImageSource}" />
         <FontIcon
             x:Name="WebShortcutGlyph"
             HorizontalAlignment="Left"

--- a/Files/UserControls/FilePreviews/FolderPreview.xaml
+++ b/Files/UserControls/FilePreviews/FolderPreview.xaml
@@ -10,6 +10,6 @@
     mc:Ignorable="d">
 
     <Grid>
-        <Image Source="{x:Bind Model.Thumbnail, Mode=OneWay}" />
+        <Image Source="{x:Bind Model.Thumbnail}" />
     </Grid>
 </UserControl>

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -112,7 +112,7 @@
                     PointerPressed="Sidebar_PointerPressed"
                     RightTapped="NavigationViewWSLItem_RightTapped"
                     Tag="{x:Bind Path}"
-                    ToolTipService.ToolTip="{x:Bind HoverDisplayText, Mode=OneWay}">
+                    ToolTipService.ToolTip="{x:Bind HoverDisplayText}">
                     <muxc:NavigationViewItem.Icon>
 						<muxc:ImageIcon>
 							<muxc:ImageIcon.Source>

--- a/Files/UserControls/Widgets/LibraryCards.xaml
+++ b/Files/UserControls/Widgets/LibraryCards.xaml
@@ -108,7 +108,7 @@
                                         <MenuFlyoutItem
                                             x:Name="OpenInNewPane"
                                             x:Uid="SideBarOpenInNewPane"
-                                            x:Load="{x:Bind HasPath, Mode=OneWay}"
+                                            x:Load="{x:Bind HasPath}"
                                             Click="OpenInNewPane_Click"
                                             DataContext="{x:Bind}"
                                             Text="Open in new pane"
@@ -120,7 +120,7 @@
                                         <MenuFlyoutItem
                                             x:Name="OpenInNewTab"
                                             x:Uid="SideBarOpenInNewTab"
-                                            x:Load="{x:Bind HasPath, Mode=OneWay}"
+                                            x:Load="{x:Bind HasPath}"
                                             Click="OpenInNewTab_Click"
                                             DataContext="{x:Bind}"
                                             Text="Open in new tab">
@@ -131,7 +131,7 @@
                                         <MenuFlyoutItem
                                             x:Name="OpenInNewWindow"
                                             x:Uid="SideBarOpenInNewWindow"
-                                            x:Load="{x:Bind HasPath, Mode=OneWay}"
+                                            x:Load="{x:Bind HasPath}"
                                             Click="OpenInNewWindow_Click"
                                             DataContext="{x:Bind}"
                                             Text="Open in new window">
@@ -142,7 +142,7 @@
                                         <MenuFlyoutItem
                                             x:Name="Properties"
                                             x:Uid="BaseLayoutContextFlyoutPropertiesFolder"
-                                            x:Load="{x:Bind IsLibrary, Mode=OneWay}"
+                                            x:Load="{x:Bind IsLibrary}"
                                             Click="OpenLibraryProperties_Click"
                                             DataContext="{x:Bind}"
                                             Text="Properties">
@@ -150,11 +150,11 @@
                                                 <FontIcon Glyph="&#xE946;" />
                                             </MenuFlyoutItem.Icon>
                                         </MenuFlyoutItem>
-                                        <MenuFlyoutSeparator x:Name="DeleteLibrarySeparator" x:Load="{x:Bind IsUserCreatedLibrary, Mode=OneWay}" />
+                                        <MenuFlyoutSeparator x:Name="DeleteLibrarySeparator" x:Load="{x:Bind IsUserCreatedLibrary}" />
                                         <MenuFlyoutItem
                                             x:Name="DeleteLibrary"
                                             x:Uid="BaseLayoutContextFlyoutDeleteLibrary"
-                                            x:Load="{x:Bind IsUserCreatedLibrary, Mode=OneWay}"
+                                            x:Load="{x:Bind IsUserCreatedLibrary}"
                                             Click="DeleteLibrary_Click"
                                             DataContext="{x:Bind}"
                                             Foreground="OrangeRed"

--- a/Files/ViewModels/BaseJsonSettingsViewModel.cs
+++ b/Files/ViewModels/BaseJsonSettingsViewModel.cs
@@ -68,7 +68,7 @@ namespace Files.ViewModels
                 // Serialize
                 NativeFileOperationsHelper.WriteStringToFile(settingsPath, JsonConvert.SerializeObject(serializableSettings, Formatting.Indented));
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Debugger.Break();
                 return false;
@@ -110,10 +110,10 @@ namespace Files.ViewModels
 
                 return (TValue)serializableSettings[propertyName];
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Debugger.Break();
-                return default(TValue);
+                return default;
             }
         }
 

--- a/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
@@ -355,7 +355,7 @@ namespace Files.ViewModels.Widgets.Bundles
                     SaveBundle();
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
             }
             finally

--- a/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
@@ -38,8 +38,6 @@ namespace Files.ViewModels.Widgets.Bundles
 
         #region Private Members
 
-        private bool isInitialized;
-
         private bool itemAddedInternally;
 
         private int internalCollectionCount;
@@ -438,7 +436,6 @@ namespace Files.ViewModels.Widgets.Bundles
         public async Task Initialize()
         {
             await Load();
-            isInitialized = true;
         }
 
         public (bool result, string reason) CanAddBundle(string name)

--- a/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -33,8 +33,6 @@ namespace Files.Views.LayoutModes
         private ListedItem renamingItem;
         private string oldItemName;
         private TextBlock textBlock;
-        private ListViewItem navigatedfolder;
-        private Grid gridindicatior;
 
         public ColumnViewBase() : base()
         {

--- a/Files/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -31,16 +31,12 @@ namespace Files.Views.LayoutModes
     /// </summary>
     public sealed partial class ColumnViewBrowser : BaseLayout
     {
-        private List<Frame> Frames;
-        private string NavParam;
         private DispatcherQueueTimer tapDebounceTimer;
         private ListedItem renamingItem;
         private string oldItemName;
         private TextBlock textBlock;
         public static IShellPage columnparent;
         private NavigationArguments parameters;
-        private ListViewItem navigatedfolder;
-        private Grid gridindicatior;
         private ListViewItem listViewItem;
         public static ColumnViewBrowser ColumnViewBrowser1;
 


### PR DESCRIPTION
**Resolved / Related Issues**
Fix easy warnings

**Details of Changes**
Fix warnings:
- Unused variables
- Unused exceptions
- Unused binding mode OneWay
- Obsolete property IsPasswordRevealButtonEnabled is contained in PasswordRevealMode
- default(type) -> default
