### PR TITLE
Move StatusBarControl to MainPage

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -59,6 +59,8 @@ namespace Files
 
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
+        public static StatusCenterViewModel StatusCenterViewModel { get; } = new StatusCenterViewModel();
+
         public static SecondaryTileHelper SecondaryTileHelper { get; private set; } = new SecondaryTileHelper();
 
         public static class AppData

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -37,19 +37,7 @@ namespace Files
 
         protected NamedPipeAsAppServiceConnection Connection => ParentShellPageInstance?.ServiceConnection;
 
-        private SelectedItemsPropertiesViewModel selectedItemsPropertiesViewModel;
-        public SelectedItemsPropertiesViewModel SelectedItemsPropertiesViewModel 
-        {
-            get => selectedItemsPropertiesViewModel;
-            private set
-            {
-                if (value != selectedItemsPropertiesViewModel)
-                {
-                    selectedItemsPropertiesViewModel = value;
-                    NotifyPropertyChanged(nameof(DirectoryPropertiesViewModel));
-                }
-            }
-        }
+        public SelectedItemsPropertiesViewModel SelectedItemsPropertiesViewModel { get; }
 
         public SettingsViewModel AppSettings => App.AppSettings;
 
@@ -58,20 +46,7 @@ namespace Files
         public CurrentInstanceViewModel InstanceViewModel => ParentShellPageInstance.InstanceViewModel;
 
         public InteractionViewModel InteractionViewModel => App.InteractionViewModel;
-
-        private DirectoryPropertiesViewModel directoryPropertiesViewModel;
-        public DirectoryPropertiesViewModel DirectoryPropertiesViewModel 
-        {
-            get => directoryPropertiesViewModel;
-            private set
-            {
-                if(value != directoryPropertiesViewModel)
-                {
-                    directoryPropertiesViewModel = value;
-                    NotifyPropertyChanged(nameof(DirectoryPropertiesViewModel));
-                }
-            }
-        }
+        public DirectoryPropertiesViewModel DirectoryPropertiesViewModel { get; }
 
         public Microsoft.UI.Xaml.Controls.CommandBarFlyout ItemContextMenuFlyout { get; set; } = new Microsoft.UI.Xaml.Controls.CommandBarFlyout();
         public MenuFlyout BaseContextMenuFlyout { get; set; } = new MenuFlyout();

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -37,7 +37,19 @@ namespace Files
 
         protected NamedPipeAsAppServiceConnection Connection => ParentShellPageInstance?.ServiceConnection;
 
-        public SelectedItemsPropertiesViewModel SelectedItemsPropertiesViewModel { get; }
+        private SelectedItemsPropertiesViewModel selectedItemsPropertiesViewModel;
+        public SelectedItemsPropertiesViewModel SelectedItemsPropertiesViewModel 
+        {
+            get => selectedItemsPropertiesViewModel;
+            private set
+            {
+                if (value != selectedItemsPropertiesViewModel)
+                {
+                    selectedItemsPropertiesViewModel = value;
+                    NotifyPropertyChanged(nameof(DirectoryPropertiesViewModel));
+                }
+            }
+        }
 
         public SettingsViewModel AppSettings => App.AppSettings;
 
@@ -47,7 +59,19 @@ namespace Files
 
         public InteractionViewModel InteractionViewModel => App.InteractionViewModel;
 
-        public DirectoryPropertiesViewModel DirectoryPropertiesViewModel { get; }
+        private DirectoryPropertiesViewModel directoryPropertiesViewModel;
+        public DirectoryPropertiesViewModel DirectoryPropertiesViewModel 
+        {
+            get => directoryPropertiesViewModel;
+            private set
+            {
+                if(value != directoryPropertiesViewModel)
+                {
+                    directoryPropertiesViewModel = value;
+                    NotifyPropertyChanged(nameof(DirectoryPropertiesViewModel));
+                }
+            }
+        }
 
         public Microsoft.UI.Xaml.Controls.CommandBarFlyout ItemContextMenuFlyout { get; set; } = new Microsoft.UI.Xaml.Controls.CommandBarFlyout();
         public MenuFlyout BaseContextMenuFlyout { get; set; } = new MenuFlyout();

--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -100,7 +100,7 @@ namespace Files.Filesystem
                 PostedStatusBanner banner;
                 if (permanently)
                 {
-                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -108,7 +108,7 @@ namespace Files.Filesystem
                 }
                 else
                 {
-                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -220,7 +220,7 @@ namespace Files.Filesystem
 
                 if (permanently)
                 {
-                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -228,7 +228,7 @@ namespace Files.Filesystem
                 }
                 else
                 {
-                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -309,7 +309,7 @@ namespace Files.Filesystem
 
                 if (permanently)
                 {
-                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -317,7 +317,7 @@ namespace Files.Filesystem
                 }
                 else
                 {
-                    banner = associatedInstance.StatusCenterActions.PostBanner(string.Empty,
+                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -459,7 +459,7 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> CopyItemsAsync(IEnumerable<IStorageItemWithPath> source, IEnumerable<string> destination, bool showDialog, bool registerHistory)
         {
-            PostedStatusBanner banner = associatedInstance.StatusCenterActions.PostBanner(
+            PostedStatusBanner banner = App.StatusCenterViewModel.PostBanner(
                 string.Empty,
                 associatedInstance.FilesystemViewModel.WorkingDirectory,
                 0,
@@ -520,7 +520,7 @@ namespace Files.Filesystem
 
             if (sw.Elapsed.TotalSeconds >= 10)
             {
-                associatedInstance.StatusCenterActions.PostBanner(
+                App.StatusCenterViewModel.PostBanner(
                     "StatusCopyComplete".GetLocalized(),
                     "StatusOperationCompleted".GetLocalized(),
                     0,
@@ -533,7 +533,7 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> CopyItemAsync(IStorageItemWithPath source, string destination, bool showDialog, bool registerHistory)
         {
-            PostedStatusBanner banner = associatedInstance.StatusCenterActions.PostBanner(
+            PostedStatusBanner banner = App.StatusCenterViewModel.PostBanner(
                 string.Empty,
                 associatedInstance.FilesystemViewModel.WorkingDirectory,
                 0,
@@ -578,7 +578,7 @@ namespace Files.Filesystem
 
             if (sw.Elapsed.TotalSeconds >= 10)
             {
-                associatedInstance.StatusCenterActions.PostBanner(
+                App.StatusCenterViewModel.PostBanner(
                     "StatusCopyComplete".GetLocalized(),
                     "StatusOperationCompleted".GetLocalized(),
                     0,
@@ -668,7 +668,7 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> MoveItemsAsync(IEnumerable<IStorageItemWithPath> source, IEnumerable<string> destination, bool showDialog, bool registerHistory)
         {
-            PostedStatusBanner banner = associatedInstance.StatusCenterActions.PostBanner(
+            PostedStatusBanner banner = App.StatusCenterViewModel.PostBanner(
                 string.Empty,
                 associatedInstance.FilesystemViewModel.WorkingDirectory,
                 0,
@@ -729,7 +729,7 @@ namespace Files.Filesystem
 
             if (sw.Elapsed.TotalSeconds >= 10)
             {
-                associatedInstance.StatusCenterActions.PostBanner(
+                App.StatusCenterViewModel.PostBanner(
                     "StatusMoveComplete".GetLocalized(),
                     "StatusOperationCompleted".GetLocalized(),
                     0,
@@ -742,7 +742,7 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> MoveItemAsync(IStorageItemWithPath source, string destination, bool showDialog, bool registerHistory)
         {
-            PostedStatusBanner banner = associatedInstance.StatusCenterActions.PostBanner(
+            PostedStatusBanner banner = App.StatusCenterViewModel.PostBanner(
                 string.Empty,
                 associatedInstance.FilesystemViewModel.WorkingDirectory,
                 0,
@@ -794,7 +794,7 @@ namespace Files.Filesystem
 
             if (sw.Elapsed.TotalSeconds >= 10)
             {
-                associatedInstance.StatusCenterActions.PostBanner(
+                App.StatusCenterViewModel.PostBanner(
                     "StatusMoveComplete".GetLocalized(),
                     "StatusOperationCompleted".GetLocalized(),
                     0,

--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -40,6 +40,8 @@ namespace Files.Filesystem
 
         private readonly CancellationToken cancellationToken;
 
+        private StatusCenterViewModel statusCenterViewModel => App.StatusCenterViewModel;
+
         #region Helpers Members
 
         private static readonly List<string> RestrictedFileNames = new List<string>()
@@ -100,7 +102,7 @@ namespace Files.Filesystem
                 PostedStatusBanner banner;
                 if (permanently)
                 {
-                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
+                    banner = statusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -108,7 +110,7 @@ namespace Files.Filesystem
                 }
                 else
                 {
-                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
+                    banner = statusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -220,7 +222,7 @@ namespace Files.Filesystem
 
                 if (permanently)
                 {
-                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
+                    banner = statusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -228,7 +230,7 @@ namespace Files.Filesystem
                 }
                 else
                 {
-                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
+                    banner = statusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -309,7 +311,7 @@ namespace Files.Filesystem
 
                 if (permanently)
                 {
-                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
+                    banner = statusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -317,7 +319,7 @@ namespace Files.Filesystem
                 }
                 else
                 {
-                    banner = App.StatusCenterViewModel.PostBanner(string.Empty,
+                    banner = statusCenterViewModel.PostBanner(string.Empty,
                     associatedInstance.FilesystemViewModel.WorkingDirectory,
                     0,
                     ReturnResult.InProgress,
@@ -459,7 +461,7 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> CopyItemsAsync(IEnumerable<IStorageItemWithPath> source, IEnumerable<string> destination, bool showDialog, bool registerHistory)
         {
-            PostedStatusBanner banner = App.StatusCenterViewModel.PostBanner(
+            PostedStatusBanner banner = statusCenterViewModel.PostBanner(
                 string.Empty,
                 associatedInstance.FilesystemViewModel.WorkingDirectory,
                 0,
@@ -520,7 +522,7 @@ namespace Files.Filesystem
 
             if (sw.Elapsed.TotalSeconds >= 10)
             {
-                App.StatusCenterViewModel.PostBanner(
+                statusCenterViewModel.PostBanner(
                     "StatusCopyComplete".GetLocalized(),
                     "StatusOperationCompleted".GetLocalized(),
                     0,
@@ -533,7 +535,7 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> CopyItemAsync(IStorageItemWithPath source, string destination, bool showDialog, bool registerHistory)
         {
-            PostedStatusBanner banner = App.StatusCenterViewModel.PostBanner(
+            PostedStatusBanner banner = statusCenterViewModel.PostBanner(
                 string.Empty,
                 associatedInstance.FilesystemViewModel.WorkingDirectory,
                 0,
@@ -578,7 +580,7 @@ namespace Files.Filesystem
 
             if (sw.Elapsed.TotalSeconds >= 10)
             {
-                App.StatusCenterViewModel.PostBanner(
+                statusCenterViewModel.PostBanner(
                     "StatusCopyComplete".GetLocalized(),
                     "StatusOperationCompleted".GetLocalized(),
                     0,
@@ -668,7 +670,7 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> MoveItemsAsync(IEnumerable<IStorageItemWithPath> source, IEnumerable<string> destination, bool showDialog, bool registerHistory)
         {
-            PostedStatusBanner banner = App.StatusCenterViewModel.PostBanner(
+            PostedStatusBanner banner = statusCenterViewModel.PostBanner(
                 string.Empty,
                 associatedInstance.FilesystemViewModel.WorkingDirectory,
                 0,
@@ -729,7 +731,7 @@ namespace Files.Filesystem
 
             if (sw.Elapsed.TotalSeconds >= 10)
             {
-                App.StatusCenterViewModel.PostBanner(
+                statusCenterViewModel.PostBanner(
                     "StatusMoveComplete".GetLocalized(),
                     "StatusOperationCompleted".GetLocalized(),
                     0,
@@ -742,7 +744,7 @@ namespace Files.Filesystem
 
         public async Task<ReturnResult> MoveItemAsync(IStorageItemWithPath source, string destination, bool showDialog, bool registerHistory)
         {
-            PostedStatusBanner banner = App.StatusCenterViewModel.PostBanner(
+            PostedStatusBanner banner = statusCenterViewModel.PostBanner(
                 string.Empty,
                 associatedInstance.FilesystemViewModel.WorkingDirectory,
                 0,
@@ -794,7 +796,7 @@ namespace Files.Filesystem
 
             if (sw.Elapsed.TotalSeconds >= 10)
             {
-                App.StatusCenterViewModel.PostBanner(
+                statusCenterViewModel.PostBanner(
                     "StatusMoveComplete".GetLocalized(),
                     "StatusOperationCompleted".GetLocalized(),
                     0,

--- a/Files/Helpers/PostBannerHelpers.cs
+++ b/Files/Helpers/PostBannerHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using Files.Enums;
+using Files.ViewModels;
 using Microsoft.Toolkit.Uwp;
 using System.Diagnostics;
 
@@ -6,6 +7,7 @@ namespace Files.Helpers
 {
     public static class PostBannerHelpers
     {
+        private static StatusCenterViewModel statusCenterViewModel => statusCenterViewModel;
         public static void PostBanner_Delete(ReturnResult status, FileOperationType operation, Stopwatch sw, IShellPage associatedInstance)
         {
             if (status == ReturnResult.Failed ||
@@ -15,7 +17,7 @@ namespace Files.Helpers
             {
                 if (status == ReturnResult.AccessUnauthorized)
                 {
-                    App.StatusCenterViewModel.PostBanner(
+                    statusCenterViewModel.PostBanner(
                         "AccessDeniedDeleteDialog/Title".GetLocalized(),
                         "AccessDeniedDeleteDialog/Text".GetLocalized(),
                         0,
@@ -24,7 +26,7 @@ namespace Files.Helpers
                 }
                 else if (status == ReturnResult.IntegrityCheckFailed)
                 {
-                    App.StatusCenterViewModel.PostBanner(
+                    statusCenterViewModel.PostBanner(
                         "FileNotFoundDialog/Title".GetLocalized(),
                         "FileNotFoundDialog/Text".GetLocalized(),
                         0,
@@ -33,7 +35,7 @@ namespace Files.Helpers
                 }
                 else if (status == ReturnResult.Failed || status == ReturnResult.UnknownException)
                 {
-                    App.StatusCenterViewModel.PostBanner(
+                    statusCenterViewModel.PostBanner(
                         "StatusDeletionFailed".GetLocalized(),
                         "StatusUnknownError".GetLocalized(),
                         0,
@@ -44,7 +46,7 @@ namespace Files.Helpers
                 {
                     if (operation == FileOperationType.Delete)
                     {
-                        App.StatusCenterViewModel.PostBanner(
+                        statusCenterViewModel.PostBanner(
                         "StatusDeletionComplete".GetLocalized(),
                         "StatusOperationCompleted".GetLocalized(),
                         0,
@@ -53,7 +55,7 @@ namespace Files.Helpers
                     }
                     else if (operation == FileOperationType.Recycle)
                     {
-                        App.StatusCenterViewModel.PostBanner(
+                        statusCenterViewModel.PostBanner(
                         "StatusRecycleComplete".GetLocalized(),
                         "StatusOperationCompleted".GetLocalized(),
                         0,

--- a/Files/Helpers/PostBannerHelpers.cs
+++ b/Files/Helpers/PostBannerHelpers.cs
@@ -15,7 +15,7 @@ namespace Files.Helpers
             {
                 if (status == ReturnResult.AccessUnauthorized)
                 {
-                    associatedInstance.StatusCenterActions.PostBanner(
+                    App.StatusCenterViewModel.PostBanner(
                         "AccessDeniedDeleteDialog/Title".GetLocalized(),
                         "AccessDeniedDeleteDialog/Text".GetLocalized(),
                         0,
@@ -24,7 +24,7 @@ namespace Files.Helpers
                 }
                 else if (status == ReturnResult.IntegrityCheckFailed)
                 {
-                    associatedInstance.StatusCenterActions.PostBanner(
+                    App.StatusCenterViewModel.PostBanner(
                         "FileNotFoundDialog/Title".GetLocalized(),
                         "FileNotFoundDialog/Text".GetLocalized(),
                         0,
@@ -33,7 +33,7 @@ namespace Files.Helpers
                 }
                 else if (status == ReturnResult.Failed || status == ReturnResult.UnknownException)
                 {
-                    associatedInstance.StatusCenterActions.PostBanner(
+                    App.StatusCenterViewModel.PostBanner(
                         "StatusDeletionFailed".GetLocalized(),
                         "StatusUnknownError".GetLocalized(),
                         0,
@@ -44,7 +44,7 @@ namespace Files.Helpers
                 {
                     if (operation == FileOperationType.Delete)
                     {
-                        associatedInstance.StatusCenterActions.PostBanner(
+                        App.StatusCenterViewModel.PostBanner(
                         "StatusDeletionComplete".GetLocalized(),
                         "StatusOperationCompleted".GetLocalized(),
                         0,
@@ -53,7 +53,7 @@ namespace Files.Helpers
                     }
                     else if (operation == FileOperationType.Recycle)
                     {
-                        associatedInstance.StatusCenterActions.PostBanner(
+                        App.StatusCenterViewModel.PostBanner(
                         "StatusRecycleComplete".GetLocalized(),
                         "StatusOperationCompleted".GetLocalized(),
                         0,

--- a/Files/IBaseLayout.cs
+++ b/Files/IBaseLayout.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Filesystem;
 using Files.Interacts;
+using Files.ViewModels;
 using System;
 using System.Collections.Generic;
 
@@ -16,5 +17,8 @@ namespace Files
         public ListedItem SelectedItem { get; }
 
         ItemManipulationModel ItemManipulationModel { get; }
+
+        public SelectedItemsPropertiesViewModel SelectedItemsPropertiesViewModel { get; }
+        public DirectoryPropertiesViewModel DirectoryPropertiesViewModel { get; }
     }
 }

--- a/Files/IShellPage.cs
+++ b/Files/IShellPage.cs
@@ -11,8 +11,6 @@ namespace Files
 {
     public interface IShellPage : ITabItemContent, IMultiPaneInfo, IDisposable
     {
-        //IStatusCenterActions StatusCenterActions { get; }
-
         //Interaction InteractionOperations { get; }
 
         ItemViewModel FilesystemViewModel { get; }

--- a/Files/IShellPage.cs
+++ b/Files/IShellPage.cs
@@ -11,7 +11,7 @@ namespace Files
 {
     public interface IShellPage : ITabItemContent, IMultiPaneInfo, IDisposable
     {
-        IStatusCenterActions StatusCenterActions { get; }
+        //IStatusCenterActions StatusCenterActions { get; }
 
         //Interaction InteractionOperations { get; }
 

--- a/Files/UserControls/StatusBarControl.xaml
+++ b/Files/UserControls/StatusBarControl.xaml
@@ -36,8 +36,10 @@
         </Grid.ColumnDefinitions>
 
         <StackPanel
+            x:Name="SelectionDirectoryInformationPanel"
             Margin="8,0"
             VerticalAlignment="Center"
+            x:Load="{x:Bind ShowInfoText, Mode=OneWay}"
             Orientation="Horizontal"
             Spacing="12">
             <TextBlock Text="{x:Bind DirectoryPropertiesViewModel.DirectoryItemCount, Mode=OneWay}" />

--- a/Files/UserControls/StatusBarControl.xaml
+++ b/Files/UserControls/StatusBarControl.xaml
@@ -27,7 +27,7 @@
     </UserControl.Resources>
 
     <Grid
-        Height="38"
+        Height="42"
         HorizontalAlignment="Stretch"
         Background="{ThemeResource SolidBackgroundFillColorBaseBrush}">
         <Grid.ColumnDefinitions>
@@ -65,7 +65,7 @@
 
         <StackPanel
             Grid.Column="1"
-            Padding="0,2,8,2"
+            Padding="0,2,8,8"
             HorizontalAlignment="Right"
             Orientation="Horizontal"
             Spacing="4">

--- a/Files/UserControls/StatusBarControl.xaml.cs
+++ b/Files/UserControls/StatusBarControl.xaml.cs
@@ -2,6 +2,7 @@
 using Files.ViewModels;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace Files.UserControls
@@ -24,35 +25,42 @@ namespace Files.UserControls
 
         #region Public Properties
 
-        private DirectoryPropertiesViewModel directoryPropertiesViewModel;
+
 
         public DirectoryPropertiesViewModel DirectoryPropertiesViewModel
         {
-            get => directoryPropertiesViewModel;
-            set
-            {
-                if (value != directoryPropertiesViewModel)
-                {
-                    directoryPropertiesViewModel = value;
-                    NotifyPropertyChanged(nameof(DirectoryPropertiesViewModel));
-                }
-            }
+            get => (DirectoryPropertiesViewModel)GetValue(DirectoryPropertiesViewModelProperty);
+            set => SetValue(DirectoryPropertiesViewModelProperty, value);
         }
 
-        private SelectedItemsPropertiesViewModel selectedItemsPropertiesViewModel;
+        // Using a DependencyProperty as the backing store for DirectoryPropertiesViewModel.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty DirectoryPropertiesViewModelProperty =
+            DependencyProperty.Register(nameof(DirectoryPropertiesViewModel), typeof(DirectoryPropertiesViewModel), typeof(StatusBarControl), new PropertyMetadata(null));
+
 
         public SelectedItemsPropertiesViewModel SelectedItemsPropertiesViewModel
         {
-            get => selectedItemsPropertiesViewModel;
-            set
-            {
-                if (value != selectedItemsPropertiesViewModel)
-                {
-                    selectedItemsPropertiesViewModel = value;
-                    NotifyPropertyChanged(nameof(SelectedItemsPropertiesViewModel));
-                }
-            }
+            get => (SelectedItemsPropertiesViewModel)GetValue(SelectedItemsPropertiesViewModelProperty);
+            set => SetValue(SelectedItemsPropertiesViewModelProperty, value);
         }
+
+        public static readonly DependencyProperty SelectedItemsPropertiesViewModelProperty =
+            DependencyProperty.Register(nameof(SelectedItemsPropertiesViewModel), typeof(SelectedItemsPropertiesViewModel), typeof(StatusBarControl), new PropertyMetadata(null));
+
+
+
+        public bool ShowInfoText
+        {
+            get => (bool)GetValue(ShowInfoTextProperty);
+            set => SetValue(ShowInfoTextProperty, value);
+        }
+
+        // Using a DependencyProperty as the backing store for HideInfoText.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty ShowInfoTextProperty =
+            DependencyProperty.Register(nameof(ShowInfoText), typeof(bool), typeof(StatusBarControl), new PropertyMetadata(null));
+
+
+
 
         private bool showStatusCenter;
 

--- a/Files/UserControls/StatusCenter.xaml
+++ b/Files/UserControls/StatusCenter.xaml
@@ -4,8 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Files.UserControls"
-    xmlns:models="using:Files.ViewModels"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Files.ViewModels"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     d:DesignHeight="300"
     d:DesignWidth="300"
@@ -131,7 +131,7 @@
             Grid.Row="1"
             VerticalAlignment="Stretch"
             ItemContainerStyle="{StaticResource ListViewItemStyleFixed}"
-            ItemsSource="{x:Bind models:StatusCenterViewModel.StatusBannersSource, Mode=OneWay}"
+            ItemsSource="{x:Bind StatusCenterViewModel.StatusBannersSource, Mode=OneWay}"
             SelectionMode="None">
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:StatusBanner">

--- a/Files/ViewModels/AdaptiveSidebarViewModel.cs
+++ b/Files/ViewModels/AdaptiveSidebarViewModel.cs
@@ -21,7 +21,14 @@ namespace Files.ViewModels
     public class AdaptiveSidebarViewModel : ObservableObject, IDisposable
     {
         public ICommand EmptyRecycleBinCommand { get; private set; }
-        public IPaneHolder PaneHolder { get; set; }
+
+        private IPaneHolder paneHolder;
+        public IPaneHolder PaneHolder
+        {
+            get => paneHolder;
+            set => SetProperty(ref paneHolder, value);
+        }
+
         public IFilesystemHelpers FilesystemHelpers => PaneHolder?.FilesystemHelpers;
 
         public static readonly GridLength CompactSidebarWidth = SidebarControl.GetSidebarCompactSize();

--- a/Files/ViewModels/AdaptiveSidebarViewModel.cs
+++ b/Files/ViewModels/AdaptiveSidebarViewModel.cs
@@ -21,13 +21,7 @@ namespace Files.ViewModels
     public class AdaptiveSidebarViewModel : ObservableObject, IDisposable
     {
         public ICommand EmptyRecycleBinCommand { get; private set; }
-
-        private IPaneHolder paneHolder;
-        public IPaneHolder PaneHolder
-        {
-            get => paneHolder;
-            set => SetProperty(ref paneHolder, value);
-        }
+        public IPaneHolder PaneHolder { get; set; }
 
         public IFilesystemHelpers FilesystemHelpers => PaneHolder?.FilesystemHelpers;
 

--- a/Files/ViewModels/StatusCenterViewModel.cs
+++ b/Files/ViewModels/StatusCenterViewModel.cs
@@ -23,7 +23,7 @@ namespace Files.ViewModels
     {
         #region Public Properties
 
-        public static ObservableCollection<StatusBanner> StatusBannersSource { get; private set; } = new ObservableCollection<StatusBanner>();
+        public ObservableCollection<StatusBanner> StatusBannersSource { get; private set; } = new ObservableCollection<StatusBanner>();
 
         private float medianOperationProgressValue = 0.0f;
         public float MedianOperationProgressValue

--- a/Files/Views/ColumnShellPage.xaml
+++ b/Files/Views/ColumnShellPage.xaml
@@ -226,18 +226,6 @@
             ResizeBehavior="BasedOnAlignment"
             Style="{StaticResource DefaultGridSplitterStyle}" />
 
-        <controls:StatusBarControl
-            x:Name="StatusBarControl"
-            Grid.Row="5"
-            Grid.ColumnSpan="3"
-            Height="0"
-            x:Load="{x:Bind InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-            DirectoryPropertiesViewModel="{x:Bind ContentPage.DirectoryPropertiesViewModel, Mode=OneWay}"
-            SelectedItemsPropertiesViewModel="{x:Bind ContentPage.SelectedItemsPropertiesViewModel, Mode=OneWay}"
-            ShowStatusCenter="{x:Bind IsPageSecondaryPane, Mode=OneWay}"
-            StatusCenterViewModel="{x:Bind StatusCenterViewModel}"
-            Visibility="Collapsed" />
-
         <Custom:DropShadowPanel
             Grid.Row="1"
             Grid.ColumnSpan="3"

--- a/Files/Views/ColumnShellPage.xaml.cs
+++ b/Files/Views/ColumnShellPage.xaml.cs
@@ -50,8 +50,7 @@ namespace Files.Views
         public IFilesystemHelpers FilesystemHelpers { get; private set; }
         private CancellationTokenSource cancellationTokenSource;
         public SettingsViewModel AppSettings => App.AppSettings;
-        public IStatusCenterActions StatusCenterActions => StatusCenterViewModel;
-        public StatusCenterViewModel StatusCenterViewModel { get; set; } = new StatusCenterViewModel();
+
         public bool CanNavigateBackward => ItemDisplayFrame.CanGoBack;
         public bool CanNavigateForward => ItemDisplayFrame.CanGoForward;
 
@@ -101,6 +100,7 @@ namespace Files.Views
                 {
                     contentPage = value;
                     NotifyPropertyChanged(nameof(ContentPage));
+                    NotifyPropertyChanged(nameof(SlimContentPage));
                 }
             }
         }

--- a/Files/Views/MainPage.xaml
+++ b/Files/Views/MainPage.xaml
@@ -205,8 +205,6 @@
                 Grid.Row="2"
                 Grid.ColumnSpan="3"
                 x:Load="False"
-                DirectoryPropertiesViewModel="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePane.SlimContentPage.DirectoryPropertiesViewModel, Mode=OneWay}"
-                SelectedItemsPropertiesViewModel="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePane.SlimContentPage.SelectedItemsPropertiesViewModel, Mode=OneWay}"
                 ShowInfoText="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePane.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
                 ShowStatusCenter="True"
                 StatusCenterViewModel="{x:Bind StatusCenterViewModel}" />

--- a/Files/Views/MainPage.xaml
+++ b/Files/Views/MainPage.xaml
@@ -15,6 +15,7 @@
     xmlns:viewmodels="using:Files.ViewModels"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     KeyboardAcceleratorPlacementMode="Hidden"
+    Loaded="Page_Loaded"
     NavigationCacheMode="Required"
     mc:Ignorable="d">
     <Page.DataContext>
@@ -192,7 +193,24 @@
         IsCompact="{x:Bind SidebarAdaptiveViewModel.IsWindowCompactSize, Mode=OneWay}"
         IsPaneOpen="{x:Bind SidebarAdaptiveViewModel.IsSidebarOpen, Mode=TwoWay}"
         SelectedSidebarItem="{x:Bind SidebarAdaptiveViewModel.SidebarSelectedItem, Mode=TwoWay}">
-        <ContentPresenter HorizontalAlignment="Stretch" Content="{x:Bind ((viewmodels:MainPageViewModel)DataContext).SelectedTabItem.Control, Mode=OneWay}" />
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <ContentPresenter HorizontalAlignment="Stretch" Content="{x:Bind ((viewmodels:MainPageViewModel)DataContext).SelectedTabItem.Control, Mode=OneWay}" />
+
+            <controls:StatusBarControl
+                x:Name="StatusBarControl"
+                Grid.Row="2"
+                Grid.ColumnSpan="3"
+                x:Load="False"
+                DirectoryPropertiesViewModel="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePane.SlimContentPage.DirectoryPropertiesViewModel, Mode=OneWay}"
+                SelectedItemsPropertiesViewModel="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePane.SlimContentPage.SelectedItemsPropertiesViewModel, Mode=OneWay}"
+                ShowInfoText="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePane.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+                ShowStatusCenter="True"
+                StatusCenterViewModel="{x:Bind StatusCenterViewModel}" />
+        </Grid>
 
         <controls:SidebarControl.TabContent>
             <Grid

--- a/Files/Views/MainPage.xaml
+++ b/Files/Views/MainPage.xaml
@@ -203,7 +203,6 @@
             <controls:StatusBarControl
                 x:Name="StatusBarControl"
                 Grid.Row="2"
-                Grid.ColumnSpan="3"
                 x:Load="False"
                 ShowInfoText="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePane.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
                 ShowStatusCenter="True"

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -76,7 +76,7 @@ namespace Files.Views
             if (SidebarAdaptiveViewModel.PaneHolder != null)
             {
                 SidebarAdaptiveViewModel.UpdateSidebarSelectedItemFromArgs((e.NavigationArg as PaneNavigationArguments).LeftPaneNavPathParam);
-                UpdateStatusBarStuff();
+                UpdateStatusBarProperties();
             }
         }
 
@@ -89,7 +89,7 @@ namespace Files.Views
             SidebarAdaptiveViewModel.PaneHolder = e.CurrentInstance as IPaneHolder;
             SidebarAdaptiveViewModel.PaneHolder.ActivePaneChanged += PaneHolder_ActivePaneChanged;
             SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged((e.CurrentInstance.TabItemArguments?.NavigationArg as PaneNavigationArguments).LeftPaneNavPathParam);
-            UpdateStatusBarStuff();
+            UpdateStatusBarProperties();
             e.CurrentInstance.ContentChanged -= TabItemContent_ContentChanged;
             e.CurrentInstance.ContentChanged += TabItemContent_ContentChanged;
         }
@@ -97,10 +97,10 @@ namespace Files.Views
         private void PaneHolder_ActivePaneChanged(object sender, EventArgs e)
         {
             SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged(SidebarAdaptiveViewModel.PaneHolder.ActivePane.TabItemArguments.NavigationArg.ToString());
-            UpdateStatusBarStuff();
+            UpdateStatusBarProperties();
         }
         
-        private void UpdateStatusBarStuff()
+        private void UpdateStatusBarProperties()
         {
             if(StatusBarControl != null)
             {

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -76,6 +76,7 @@ namespace Files.Views
             if (SidebarAdaptiveViewModel.PaneHolder != null)
             {
                 SidebarAdaptiveViewModel.UpdateSidebarSelectedItemFromArgs((e.NavigationArg as PaneNavigationArguments).LeftPaneNavPathParam);
+                UpdateStatusBarStuff();
             }
         }
 
@@ -88,6 +89,7 @@ namespace Files.Views
             SidebarAdaptiveViewModel.PaneHolder = e.CurrentInstance as IPaneHolder;
             SidebarAdaptiveViewModel.PaneHolder.ActivePaneChanged += PaneHolder_ActivePaneChanged;
             SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged((e.CurrentInstance.TabItemArguments?.NavigationArg as PaneNavigationArguments).LeftPaneNavPathParam);
+            UpdateStatusBarStuff();
             e.CurrentInstance.ContentChanged -= TabItemContent_ContentChanged;
             e.CurrentInstance.ContentChanged += TabItemContent_ContentChanged;
         }
@@ -95,6 +97,16 @@ namespace Files.Views
         private void PaneHolder_ActivePaneChanged(object sender, EventArgs e)
         {
             SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged(SidebarAdaptiveViewModel.PaneHolder.ActivePane.TabItemArguments.NavigationArg.ToString());
+            UpdateStatusBarStuff();
+        }
+        
+        private void UpdateStatusBarStuff()
+        {
+            if(StatusBarControl != null)
+            {
+                StatusBarControl.DirectoryPropertiesViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePane.SlimContentPage?.DirectoryPropertiesViewModel;
+                StatusBarControl.SelectedItemsPropertiesViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePane.SlimContentPage?.SelectedItemsPropertiesViewModel;
+            }
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -33,6 +33,8 @@ namespace Files.Views
 
         public AdaptiveSidebarViewModel SidebarAdaptiveViewModel = new AdaptiveSidebarViewModel();
 
+        public StatusCenterViewModel StatusCenterViewModel => App.StatusCenterViewModel;
+
         public MainPage()
         {
             this.InitializeComponent();
@@ -226,6 +228,12 @@ namespace Files.Views
                 SidebarControl.RecycleBinItemRightTapped -= SidebarControl_RecycleBinItemRightTapped;
                 SidebarControl.SidebarItemNewPaneInvoked -= SidebarControl_SidebarItemNewPaneInvoked;
             }
+        }
+
+        private void Page_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Defers the status bar loading until after the page has loaded to improve startup perf
+            FindName(nameof(StatusBarControl));
         }
     }
 }

--- a/Files/Views/ModernShellPage.xaml
+++ b/Files/Views/ModernShellPage.xaml
@@ -166,7 +166,7 @@
     <Grid
         x:Name="RootGrid"
         BorderBrush="{x:Bind CurrentInstanceBorderBrush, Mode=OneWay}"
-        BorderThickness="0,0,0,2"
+        BorderThickness="{x:Bind CurrentInstanceBorderThickness, Mode=OneWay}"
         SizeChanged="RootGrid_SizeChanged">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/Files/Views/ModernShellPage.xaml
+++ b/Files/Views/ModernShellPage.xaml
@@ -177,7 +177,6 @@
                 x:Name="PreviewPaneRow"
                 Height="2*"
                 MaxHeight="400" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Grid.ColumnDefinitions>
@@ -223,16 +222,6 @@
             ManipulationCompleted="PreviewPaneGridSplitter_ManipulationCompleted"
             ResizeBehavior="BasedOnAlignment"
             Style="{StaticResource DefaultGridSplitterStyle}" />
-
-        <controls:StatusBarControl
-            x:Name="StatusBarControl"
-            Grid.Row="5"
-            Grid.ColumnSpan="3"
-            x:Load="{x:Bind InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-            DirectoryPropertiesViewModel="{x:Bind ContentPage.DirectoryPropertiesViewModel, Mode=OneWay}"
-            SelectedItemsPropertiesViewModel="{x:Bind ContentPage.SelectedItemsPropertiesViewModel, Mode=OneWay}"
-            ShowStatusCenter="{x:Bind IsPageSecondaryPane, Mode=OneWay}"
-            StatusCenterViewModel="{x:Bind StatusCenterViewModel}" />
 
         <Custom:DropShadowPanel
             Grid.Row="1"

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -47,16 +47,10 @@ namespace Files.Views
         public IFilesystemHelpers FilesystemHelpers { get; private set; }
         private CancellationTokenSource cancellationTokenSource;
         public SettingsViewModel AppSettings => App.AppSettings;
-        //public IStatusCenterActions StatusCenterActions => StatusCenterViewModel;
         public bool CanNavigateBackward => ItemDisplayFrame.CanGoBack;
         public bool CanNavigateForward => ItemDisplayFrame.CanGoForward;
-
         public FolderSettingsViewModel FolderSettings => InstanceViewModel?.FolderSettings;
-
         public InteractionViewModel InteractionViewModel => App.InteractionViewModel;
-
-        //public StatusCenterViewModel StatusCenterViewModel { get; } = new StatusCenterViewModel();
-
         private bool isCurrentInstance { get; set; } = false;
 
         public bool IsCurrentInstance

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -47,7 +47,7 @@ namespace Files.Views
         public IFilesystemHelpers FilesystemHelpers { get; private set; }
         private CancellationTokenSource cancellationTokenSource;
         public SettingsViewModel AppSettings => App.AppSettings;
-        public IStatusCenterActions StatusCenterActions => StatusCenterViewModel;
+        //public IStatusCenterActions StatusCenterActions => StatusCenterViewModel;
         public bool CanNavigateBackward => ItemDisplayFrame.CanGoBack;
         public bool CanNavigateForward => ItemDisplayFrame.CanGoForward;
 
@@ -55,7 +55,7 @@ namespace Files.Views
 
         public InteractionViewModel InteractionViewModel => App.InteractionViewModel;
 
-        public StatusCenterViewModel StatusCenterViewModel { get; } = new StatusCenterViewModel();
+        //public StatusCenterViewModel StatusCenterViewModel { get; } = new StatusCenterViewModel();
 
         private bool isCurrentInstance { get; set; } = false;
 
@@ -99,6 +99,7 @@ namespace Files.Views
                 {
                     contentPage = value;
                     NotifyPropertyChanged(nameof(ContentPage));
+                    NotifyPropertyChanged(nameof(SlimContentPage));
                 }
             }
         }

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -145,6 +145,18 @@ namespace Files.Views
             set { SetValue(CurrentInstanceBorderBrushProperty, value); }
         }
 
+        public Thickness CurrentInstanceBorderThickness
+        {
+            get { return (Thickness)GetValue(CurrentInstanceBorderThicknessProperty); }
+            set { SetValue(CurrentInstanceBorderThicknessProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for CurrentInstanceBorderThickness.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty CurrentInstanceBorderThicknessProperty =
+            DependencyProperty.Register("CurrentInstanceBorderThickness", typeof(Thickness), typeof(ModernShellPage), new PropertyMetadata(null));
+
+
+
         public static readonly DependencyProperty CurrentInstanceBorderBrushProperty =
             DependencyProperty.Register("CurrentInstanceBorderBrush", typeof(SolidColorBrush), typeof(ModernShellPage), new PropertyMetadata(null));
 

--- a/Files/Views/PaneHolderPage.xaml
+++ b/Files/Views/PaneHolderPage.xaml
@@ -12,8 +12,8 @@
     xmlns:local="using:Files.Views"
     xmlns:local1="using:Files"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:multitaskingcontrol="using:Files.UserControls.MultitaskingControl"
     xmlns:mconv="using:Microsoft.Toolkit.Uwp.UI.Converters"
+    xmlns:multitaskingcontrol="using:Files.UserControls.MultitaskingControl"
     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
     mc:Ignorable="d">
 
@@ -121,6 +121,7 @@
                     <local:ModernShellPage
                         x:Name="PaneLeft"
                         ContentChanged="Pane_ContentChanged"
+                        CurrentInstanceBorderThickness="0,0,2,0"
                         IsMultiPaneActive="{x:Bind IsRightPaneVisible, Mode=OneWay}"
                         IsMultiPaneEnabled="{x:Bind IsMultiPaneEnabled, Mode=OneWay}"
                         IsPageMainPane="True"
@@ -139,6 +140,7 @@
                     <local:ModernShellPage
                         x:Name="PaneRight"
                         ContentChanged="Pane_ContentChanged"
+                        CurrentInstanceBorderThickness="2,0,0,0"
                         IsMultiPaneActive="{x:Bind IsRightPaneVisible, Mode=OneWay}"
                         IsMultiPaneEnabled="{x:Bind IsMultiPaneEnabled, Mode=OneWay}"
                         IsPageMainPane="False"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #4600

**Details of Changes**
Add details of changes here.
- Move StatusBarControl to MainPage.xaml
- Move StatusCenterViewModel to App.xaml.cs from IShellPage so that it's accessible throughout the app
- Make StatusCenterViewModel.StatusBannersSource not static since it's now the same instance across the app
- Defer status bar loading until after the page has loaded

~~All that's left for this PR is to fix an issue where bindings aren't updated when navigating and switching the active pane (currently it's only updated after switching tabs)~~

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested in dual pane mode
- [x] Tested in column view
- [x] Tested in all other layout modes
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
