### PR TITLE
Assorted sidebar icons work

### DIFF
--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -138,7 +138,9 @@
                         </LinearGradientBrush.GradientStops>
                     </LinearGradientBrush>
 
-                    <!--  WinUI style is breaking us, overriding with a modified version solves crashes in release  -->
+					<Thickness x:Key="NavigationViewContentPresenterMargin">0,0,0,0</Thickness>
+
+					<!--  WinUI style is breaking us, overriding with a modified version solves crashes in release  -->
                     <Style x:Key="MUX_NavigationViewItemPresenterStyleWhenOnLeftPane" TargetType="primitives:NavigationViewItemPresenter">
                         <Setter Property="Foreground" Value="{ThemeResource NavigationViewItemForeground}" />
                         <Setter Property="Background" Value="{ThemeResource NavigationViewItemBackground}" />

--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -138,6 +138,7 @@
                         </LinearGradientBrush.GradientStops>
                     </LinearGradientBrush>
 
+					<x:Double x:Key="SidebarIconSize">20</x:Double>
 					<Thickness x:Key="NavigationViewContentPresenterMargin">0,0,0,0</Thickness>
 
 					<!--  WinUI style is breaking us, overriding with a modified version solves crashes in release  -->
@@ -205,7 +206,7 @@
                                                 <Border x:Name="IconColumn" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.SmallerIconWidth}">
                                                     <Viewbox
                                                         x:Name="IconBox"
-                                                        Height="16"
+                                                        Height="{StaticResource SidebarIconSize}"
                                                         Margin="{ThemeResource NavigationViewItemOnLeftIconBoxMargin}">
                                                         <ContentPresenter
                                                             x:Name="Icon"

--- a/Files/DataModels/NavigationControlItems/LocationItem.cs
+++ b/Files/DataModels/NavigationControlItems/LocationItem.cs
@@ -4,6 +4,8 @@ using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Uwp;
 using System;
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Windows.Storage.Streams;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 
@@ -11,7 +13,7 @@ namespace Files.DataModels.NavigationControlItems
 {
     public class LocationItem : ObservableObject, INavigationControlItem
     {
-        public SvgImageSource Icon { get; set; }
+        public BitmapImage Icon { get; set; }
         public Uri IconSource { get; set; }
         public byte[] IconData { get; set; }
 
@@ -50,5 +52,15 @@ namespace Files.DataModels.NavigationControlItems
         public SectionType Section { get; set; }
 
         public int CompareTo(INavigationControlItem other) => Text.CompareTo(other.Text);
+
+        public async Task SetBitmapImage(IRandomAccessStream imageStream)
+        {
+            if (imageStream != null)
+            {
+                var image = new BitmapImage();
+                await image.SetSourceAsync(imageStream);
+                Icon = image;
+            }
+        }
     }
 }

--- a/Files/DataModels/SidebarPinnedModel.cs
+++ b/Files/DataModels/SidebarPinnedModel.cs
@@ -266,11 +266,13 @@ namespace Files.DataModels
                     Font = InteractionViewModel.FontName,
                     Path = path,
                     Section = SectionType.Favorites,
-                    Icon = new Windows.UI.Xaml.Media.Imaging.SvgImageSource(GlyphHelper.GetIconUri(path)),
-                    IconSource = GlyphHelper.GetIconUri(path),
                     IsDefaultLocation = false,
                     Text = res.Result?.DisplayName ?? Path.GetFileName(path.TrimEnd('\\'))
                 };
+                await locationItem.SetBitmapImage(await res.Result?.GetThumbnailAsync(
+                    Windows.Storage.FileProperties.ThumbnailMode.ListView, 
+                    24, 
+                    Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail));
 
                 if (!favoriteSection.ChildItems.Contains(locationItem))
                 {

--- a/Files/Filesystem/CloudDrivesManager.cs
+++ b/Files/Filesystem/CloudDrivesManager.cs
@@ -1,5 +1,6 @@
 using Files.DataModels.NavigationControlItems;
 using Files.Filesystem.Cloud;
+using Files.Helpers;
 using Files.UserControls;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Uwp;
@@ -48,6 +49,12 @@ namespace Files.Filesystem
                     Path = provider.SyncFolder,
                     Type = DriveType.CloudDrive,
                 };
+
+                await CoreApplication.MainView.CoreWindow.DispatcherQueue.EnqueueAsync(async () =>
+                {
+                    cloudProviderItem.Icon = await (await FileThumbnailHelper.LoadIconWithoutOverlayAsync(provider.SyncFolder, 24)).ToBitmapAsync();
+                });
+
                 lock (drivesList)
                 {
                     if (!drivesList.Any(x => x.Path == cloudProviderItem.Path))

--- a/Files/Filesystem/LibraryLocationItem.cs
+++ b/Files/Filesystem/LibraryLocationItem.cs
@@ -19,8 +19,6 @@ namespace Files.Filesystem
             Section = SectionType.Library;
             Text = shellLibrary.DisplayName;
             Path = shellLibrary.FullPath;
-            Icon = new Windows.UI.Xaml.Media.Imaging.SvgImageSource(GlyphHelper.GetIconUri(shellLibrary.DefaultSaveFolder));
-            IconSource = GlyphHelper.GetIconUri(shellLibrary.DefaultSaveFolder);
             DefaultSaveFolder = shellLibrary.DefaultSaveFolder;
             Folders = shellLibrary.Folders == null ? null : new ReadOnlyCollection<string>(shellLibrary.Folders);
             IsDefaultLocation = shellLibrary.IsPinned;

--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -88,9 +88,9 @@ namespace Files.Filesystem
 
         // Note: Never attempt to call this from a secondary window or another thread, create a new instance from CustomIconSource instead
         // TODO: eventually we should remove this b/c it's not thread safe
-        private SvgImageSource customIcon;
+        private BitmapImage customIcon;
 
-        public SvgImageSource CustomIcon
+        public BitmapImage CustomIcon
         {
             get => customIcon;
             set

--- a/Files/Filesystem/WSLDistroManager.cs
+++ b/Files/Filesystem/WSLDistroManager.cs
@@ -59,6 +59,7 @@ namespace Files.Filesystem
                                     Text = "WSL",
                                     Section = SectionType.WSL,
                                     SelectsOnInvoked = false,
+                                    Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/WSL/genericpng.png")),
                                     ChildItems = new ObservableCollection<INavigationControlItem>()
                                 };
                                 SidebarControl.SideBarItems.Add(section);

--- a/Files/Helpers/FileThumbnailHelper.cs
+++ b/Files/Helpers/FileThumbnailHelper.cs
@@ -35,5 +35,27 @@ namespace Files.Helpers
             }
             return (null, null, false);
         }
+
+        public static async Task<byte[]> LoadIconWithoutOverlayAsync(string filePath, uint thumbnailSize)
+        {
+            var Connection = await AppServiceConnectionHelper.Instance;
+            if (Connection != null)
+            {
+                var value = new ValueSet();
+                value.Add("Arguments", "GetIconWithoutOverlay");
+                value.Add("filePath", filePath);
+                value.Add("thumbnailSize", (int)thumbnailSize);
+                var (status, response) = await Connection.SendMessageForResponseAsync(value);
+                if (status == AppServiceResponseStatus.Success)
+                {
+                    var icon = response.Get("Icon", (string)null);
+
+                    // BitmapImage can only be created on UI thread, so return raw data and create
+                    // BitmapImage later to prevent exceptions once SynchorizationContext lost
+                    return (icon == null ? null : Convert.FromBase64String(icon));
+                }
+            }
+            return null;
+        }
     }
 }

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -42,7 +42,6 @@
             <DataTemplate x:Key="LocationNavItem" x:DataType="navigationcontrolitems:LocationItem">
                 <muxc:NavigationViewItem
                     AllowDrop="True"
-                    BorderThickness="0.8"
                     CanDrag="False"
                     Content="{x:Bind Text}"
                     DataContext="{x:Bind}"
@@ -69,7 +68,6 @@
                 <muxc:NavigationViewItem
                     Padding="0"
                     AllowDrop="True"
-                    BorderThickness="0.8"
                     Content="{x:Bind Text, Mode=OneWay}"
                     DataContext="{x:Bind}"
                     DragEnter="NavigationViewItem_DragEnter"
@@ -91,7 +89,6 @@
             <DataTemplate x:Key="LinuxNavItem" x:DataType="navigationcontrolitems:WslDistroItem">
                 <muxc:NavigationViewItem
                     Padding="0"
-                    BorderThickness="0.8"
                     Content="{x:Bind Text}"
                     DataContext="{x:Bind}"
                     DragEnter="NavigationViewItem_DragEnter"
@@ -101,19 +98,17 @@
                     Tag="{x:Bind Path}"
                     ToolTipService.ToolTip="{x:Bind HoverDisplayText}">
                     <muxc:NavigationViewItem.Icon>
-                        <muxc:ImageIcon>
-                            <muxc:ImageIcon.Source>
-                                <BitmapImage UriSource="{x:Bind Logo}" />
-                            </muxc:ImageIcon.Source>
-                        </muxc:ImageIcon>
-                    </muxc:NavigationViewItem.Icon>
+						<muxc:ImageIcon>
+							<muxc:ImageIcon.Source>
+								<BitmapImage UriSource="{x:Bind Logo}"/>
+							</muxc:ImageIcon.Source>
+						</muxc:ImageIcon>
+					</muxc:NavigationViewItem.Icon>
                 </muxc:NavigationViewItem>
             </DataTemplate>
 
             <mconv:BoolNegationConverter x:Key="BoolNegationConverter" />
             <conv:NavigationViewCompactConverter x:Key="DisplayModeConverter" />
-
-            <x:Double x:Key="NavigationViewItemExpandedGlyphFontSize">8.0</x:Double>
 
             <MenuFlyout x:Name="SideBarItemContextFlyout" x:FieldModifier="public">
                 <MenuFlyout.Items>
@@ -197,11 +192,11 @@
                 <Setter Property="OpenPaneLength" Value="{ThemeResource SplitViewOpenPaneThemeLength}" />
                 <Setter Property="CompactPaneLength" Value="{ThemeResource SplitViewCompactPaneThemeLength}" />
                 <Setter Property="PaneBackground" Value="{ThemeResource SystemControlPageBackgroundChromeLowBrush}" />
-                <!--<contract7Present:Setter Property="CornerRadius" Value="{ThemeResource SplitViewPaneRootCornerRadius}" />-->
+                <Setter Property="CornerRadius" Value="0" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="SplitView">
-                            <Grid Background="{TemplateBinding Background}">
+                            <Grid CornerRadius="0" Background="{TemplateBinding Background}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition x:Name="ColumnDefinition1" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.OpenPaneGridLength, FallbackValue=0}" />
                                     <ColumnDefinition x:Name="ColumnDefinition2" Width="*" />
@@ -214,7 +209,7 @@
                                     Grid.ColumnSpan="2"
                                     Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.OpenPaneLength}"
                                     HorizontalAlignment="Left"
-                                    contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
+									CornerRadius="0"
                                     Background="{TemplateBinding PaneBackground}"
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
@@ -995,7 +990,7 @@
             Margin="10,6"
             VerticalAlignment="Center"
             FontSize="16"
-            FontWeight="Medium"
+            FontWeight="SemiBold"
             Text="Files" />
     </muxc:NavigationView.PaneHeader>
 

--- a/Files/ViewModels/SelectedItemsPropertiesViewModel.cs
+++ b/Files/ViewModels/SelectedItemsPropertiesViewModel.cs
@@ -38,9 +38,9 @@ namespace Files.ViewModels
             set => SetProperty(ref loadCombinedItemsGlyph, value);
         }
 
-        private SvgImageSource customIcon;
+        private BitmapImage customIcon;
 
-        public SvgImageSource CustomIcon
+        public BitmapImage CustomIcon
         {
             get => customIcon;
             set => SetProperty(ref customIcon, value);


### PR DESCRIPTION
**Details of Changes**
- Fixed issue with NavigationView having a large margin set for its ContentPresenter
- Get filesystem thumbnails for pinned items
- Increases icon size to 20px for navigation surfaces like the sidebar
- Get custom icons for SyncFolder of cloud-based storage providers

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/20365014/118230570-e1e77c80-b45b-11eb-8cda-f722ea1de848.png)