### PR TITLE
Fix network drive dialog opening behind Files

### DIFF
--- a/Files.Launcher/NetworkDrivesAPI.cs
+++ b/Files.Launcher/NetworkDrivesAPI.cs
@@ -107,11 +107,20 @@ namespace FilesFullTrust
             }
         }
 
-        public static bool OpenMapNetworkDriveDialog()
+        private class Win32Window : IWin32Window
+        {
+            public IntPtr Handle { get; set; }
+            public static Win32Window FromLong(long hwnd)
+            {
+                return new Win32Window() { Handle = new IntPtr(hwnd) };
+            }
+        }
+
+        public static bool OpenMapNetworkDriveDialog(long hwnd)
         {
             using var ncd = new NetworkConnectionDialog { UseMostRecentPath = true };
             ncd.HideRestoreConnectionCheckBox = false;
-            return ncd.ShowDialog() == DialogResult.OK;
+            return ncd.ShowDialog(Win32Window.FromLong(hwnd)) == DialogResult.OK;
         }
 
         public static bool DisconnectNetworkDrive(string drive)

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -377,6 +377,7 @@ namespace FilesFullTrust
                     var driveName = (string)message["drivename"];
                     var newLabel = (string)message["newlabel"];
                     Win32API.SetVolumeLabel(driveName, newLabel);
+                    await Win32API.SendMessageAsync(connection, new ValueSet() { { "SetVolumeLabel", driveName } }, message.Get("RequestID", (string)null));
                     break;
 
                 case "FileOperation":
@@ -739,7 +740,8 @@ namespace FilesFullTrust
                     break;
 
                 case "OpenMapNetworkDriveDialog":
-                    NetworkDrivesAPI.OpenMapNetworkDriveDialog();
+                    var hwnd = (long)message["HWND"];
+                    NetworkDrivesAPI.OpenMapNetworkDriveDialog(hwnd);
                     break;
 
                 case "DisconnectNetworkDrive":

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -165,7 +165,8 @@ namespace Files.UserControls.Widgets
                 await AppInstance.ServiceConnection.SendMessageAsync(new ValueSet()
                     {
                         { "Arguments", "NetworkDriveOperation" },
-                        { "netdriveop", "OpenMapNetworkDriveDialog" }
+                        { "netdriveop", "OpenMapNetworkDriveDialog" },
+                        { "HWND", NativeWinApiHelper.CoreWindowHandle.ToInt64() }
                     });
             }
         }

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1206,7 +1206,7 @@ namespace Files.ViewModels
                         value.Add("action", "Unlock");
                         value.Add("drive", Path.GetPathRoot(path));
                         value.Add("password", userInput);
-                        await Connection.SendMessageAsync(value);
+                        _ = await Connection.SendMessageForResponseAsync(value);
 
                         if (await FolderHelpers.CheckBitlockerStatusAsync(rootFolder, WorkingDirectory))
                         {

--- a/Files/Views/Pages/PropertiesGeneral.xaml.cs
+++ b/Files/Views/Pages/PropertiesGeneral.xaml.cs
@@ -31,11 +31,12 @@ namespace Files.Views
             if (BaseProperties is DriveProperties driveProps)
             {
                 var drive = driveProps.Drive;
+                ViewModel.ItemName = ItemFileName.Text; // Make sure ItemName is updated
                 if (!string.IsNullOrWhiteSpace(ViewModel.ItemName) && ViewModel.OriginalItemName != ViewModel.ItemName)
                 {
                     if (AppInstance.FilesystemViewModel != null)
                     {
-                        await AppInstance.ServiceConnection?.SendMessageAsync(new ValueSet()
+                        _ = await AppInstance.ServiceConnection?.SendMessageForResponseAsync(new ValueSet()
                         {
                             { "Arguments", "SetVolumeLabel" },
                             { "drivename", drive.Path },
@@ -53,6 +54,7 @@ namespace Files.Views
             else if (BaseProperties is LibraryProperties libProps)
             {
                 var library = libProps.Library;
+                ViewModel.ItemName = ItemFileName.Text; // Make sure ItemName is updated
                 var newName = ViewModel.ItemName;
                 if (!string.IsNullOrWhiteSpace(newName) && ViewModel.OriginalItemName != newName)
                 {
@@ -74,6 +76,7 @@ namespace Files.Views
             }
             else
             {
+                ViewModel.ItemName = ItemFileName.Text; // Make sure ItemName is updated
                 if (!string.IsNullOrWhiteSpace(ViewModel.ItemName) && ViewModel.OriginalItemName != ViewModel.ItemName)
                 {
                     return await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => UIFilesystemHelpers.RenameFileItemAsync(item,


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes #4912
- Fixes #4911

**Details of Changes**
Add details of changes here.
- Fixes an issue for which files were not renamed from Properties if the user did not click outside the textbox before clicking "OK":
Forces the `ViewModel.ItemName` to update when clicking "OK"
- Fixes an issue for which the Map  Network Drive dialog opened behind Files:
Pass the HWND of Files when creating the dialog
- Fixes an issue for which unlocking a Bitlocker drive did not wait for password input

Note: with this the Files window goes one level back when the dialog is closed, arguably this is still a little better then the current behavior.

**Validation**
How did you test these changes?
- [x] Built and ran the app
