### PR TITLE
Fixes an issue for which only the first file was shown in Box Drive folder

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1143,7 +1143,8 @@ namespace Files.ViewModels
         public async Task<bool> EnumerateItemsFromStandardFolderAsync(string path, StorageFolderWithPath storageFolderForGivenPath, Type sourcePageType, CancellationToken cancellationToken, List<string> skipItems, bool cacheOnly = false, LibraryItem library = null)
         {
             // Flag to use FindFirstFileExFromApp or StorageFolder enumeration
-            bool enumFromStorageFolder = false;
+            bool enumFromStorageFolder =
+                path == App.CloudDrivesManager.Drives.FirstOrDefault(x => x.Text == "Box")?.Path?.TrimEnd('\\'); // Use storage folder for Box Drive (#4629)
 
             StorageFolder rootFolder = null;
             var res = await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(path).AsTask());


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes #4629

**Details of Changes**
For mysterious reasons `FindFirstFileExFromApp/FindNextFile` only returns the first file in the Box Drive folder, enumerating using StorageFolder methods instead works ok.

**Validation**
How did you test these changes?
- [x] Built and ran the app
