### PR TITLE
Fix icon size in new details view

### DIFF
--- a/Files/Views/LayoutModes/ColumnViewBase.xaml
+++ b/Files/Views/LayoutModes/ColumnViewBase.xaml
@@ -1290,6 +1290,16 @@
                     ScrollViewer.IsScrollInertiaEnabled="True"
                     SelectionChanged="FileList_SelectionChanged"
                     SelectionMode="{x:Bind InteractionViewModel.MultiselectEnabled, Mode=OneWay, Converter={StaticResource BoolToSelectionModeConverter}}">
+
+                    <ListView.ItemContainerTransitions>
+                        <TransitionCollection>
+                            <AddDeleteThemeTransition />
+                            <!--<ContentThemeTransition />-->
+                            <ReorderThemeTransition />
+                            <EntranceThemeTransition IsStaggeringEnabled="False" />
+                        </TransitionCollection>
+                    </ListView.ItemContainerTransitions>
+
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="local2:ListedItem">
                             <Grid

--- a/Files/Views/LayoutModes/ColumnViewBrowser.xaml
+++ b/Files/Views/LayoutModes/ColumnViewBrowser.xaml
@@ -1294,6 +1294,16 @@
                                 ScrollViewer.IsScrollInertiaEnabled="True"
                                 SelectionChanged="FileList_SelectionChanged"
                                 SelectionMode="{x:Bind InteractionViewModel.MultiselectEnabled, Mode=OneWay, Converter={StaticResource BoolToSelectionModeConverter}}">
+
+                                <ListView.ItemContainerTransitions>
+                                    <TransitionCollection>
+                                        <AddDeleteThemeTransition />
+                                        <!--<ContentThemeTransition />-->
+                                        <ReorderThemeTransition />
+                                        <EntranceThemeTransition IsStaggeringEnabled="False" />
+                                    </TransitionCollection>
+                                </ListView.ItemContainerTransitions>
+
                                 <ListView.ItemTemplate>
 
                                     <DataTemplate x:DataType="local2:ListedItem">

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -193,11 +193,6 @@
                                 AutomationProperties.Name="Thumbnail column"
                                 Opacity="{x:Bind Opacity, Mode=OneWay}"
                                 ToolTipService.ToolTip="{x:Bind ItemTooltipText}">
-                                <Rectangle
-                                    x:Name="CutIndicator"
-                                    Fill="LightGray"
-                                    Opacity="0.1"
-                                    Visibility="Collapsed" />
                                 <Image
                                     x:Name="FolderGlyphElement"
                                     Width="24"

--- a/Files/Views/LayoutModes/GenericFileBrowser2.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser2.xaml
@@ -53,6 +53,7 @@
                 <Setter Property="CornerRadius" Value="0" />
                 <Setter Property="BorderBrush" Value="Transparent" />
                 <Setter Property="HorizontalAlignment" Value="Stretch" />
+                <Setter Property="HorizontalContentAlignment" Value="Left" />
                 <Setter Property="Background">
                     <Setter.Value>
                         <SolidColorBrush Opacity="0" />
@@ -233,6 +234,14 @@
                     <i:Interaction.Behaviors>
                         <behaviors:StickyHeaderBehavior />
                     </i:Interaction.Behaviors>
+                    <ListView.ItemContainerTransitions>
+                        <TransitionCollection>
+                            <AddDeleteThemeTransition />
+                            <!--<ContentThemeTransition />-->
+                            <ReorderThemeTransition />
+                            <EntranceThemeTransition IsStaggeringEnabled="False" />
+                        </TransitionCollection>
+                    </ListView.ItemContainerTransitions>
                     <ListView.Header>
                         <Grid
                             x:Name="HeaderGrid"
@@ -306,6 +315,10 @@
                                     x:Name="Column7"
                                     Width="{x:Bind ColumnsViewModel.ItemTypeColumn.Length, Mode=OneWay}"
                                     MaxWidth="{x:Bind ColumnsViewModel.ItemTypeColumn.MaxLength, Mode=OneWay}" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition
+                                    x:Name="Column8"
+                                    Width="0" />
                             </Grid.ColumnDefinitions>
 
                             <Button
@@ -317,7 +330,6 @@
                                     x:Uid="FileBrowserSortOption_Name"
                                     Style="{ThemeResource NavigationViewItemHeaderTextStyle}"
                                     Text="Name"
-                                    TextAlignment="Center"
                                     TextWrapping="Wrap" />
                             </Button>
 
@@ -329,7 +341,6 @@
 
                             <Button
                                 Grid.Column="4"
-                                HorizontalAlignment="Stretch"
                                 Command="{x:Bind UpdateSortOptionsCommand, Mode=OneWay}"
                                 CommandParameter="OriginalPath"
                                 Style="{StaticResource HeaderButtonStyle}"
@@ -337,9 +348,9 @@
                                 <TextBlock
                                     Style="{ThemeResource NavigationViewItemHeaderTextStyle}"
                                     Text="Original path"
-                                    TextAlignment="Center"
                                     TextWrapping="Wrap" />
                             </Button>
+
                             <controls:GridSplitter
                                 Grid.Column="5"
                                 ManipulationCompleted="GridSplitter_ManipulationCompleted"
@@ -356,9 +367,9 @@
                                 <TextBlock
                                     Style="{ThemeResource NavigationViewItemHeaderTextStyle}"
                                     Text="Date deleted"
-                                    TextAlignment="Center"
                                     TextWrapping="Wrap" />
                             </Button>
+
                             <controls:GridSplitter
                                 Grid.Column="7"
                                 ManipulationCompleted="GridSplitter_ManipulationCompleted"
@@ -369,7 +380,6 @@
                             <TextBlock
                                 Grid.Column="8"
                                 Width="{x:Bind ColumnsViewModel.StatusColumn.Length.Value, Mode=OneWay}"
-                                HorizontalAlignment="Stretch"
                                 VerticalAlignment="Center"
                                 Style="{ThemeResource NavigationViewItemHeaderTextStyle}"
                                 Text="Status"
@@ -386,7 +396,6 @@
 
                             <Button
                                 Grid.Column="10"
-                                HorizontalAlignment="Stretch"
                                 Command="{x:Bind UpdateSortOptionsCommand, Mode=OneWay}"
                                 CommandParameter="DateModified"
                                 Style="{StaticResource HeaderButtonStyle}"
@@ -395,7 +404,6 @@
                                     x:Uid="FileBrowserSortOption_DateModified"
                                     Style="{ThemeResource NavigationViewItemHeaderTextStyle}"
                                     Text="Date modified"
-                                    TextAlignment="Center"
                                     TextWrapping="Wrap" />
                             </Button>
 
@@ -416,9 +424,15 @@
                                     x:Uid="FileBrowserSortOption_FileType"
                                     Style="{ThemeResource NavigationViewItemHeaderTextStyle}"
                                     Text="Type"
-                                    TextAlignment="Center"
                                     TextWrapping="Wrap" />
                             </Button>
+
+                            <controls:GridSplitter
+                                Grid.Column="13"
+                                ManipulationCompleted="GridSplitter_ManipulationCompleted"
+                                ManipulationDelta="GridSplitter_ManipulationDelta"
+                                Style="{StaticResource HeaderGridSplitterStyle}"
+                                Visibility="{x:Bind ColumnsViewModel.ItemTypeColumn.Visibility, Mode=OneWay}" />
                         </Grid>
                     </ListView.Header>
                     <ListView.ItemTemplate>
@@ -449,21 +463,9 @@
                                     TabFocusNavigation="Local"
                                     Tag="ItemImage">
                                     <Image
-                                        x:Name="Picture"
-                                        Width="25"
-                                        Margin="0,12,0,12"
-                                        HorizontalAlignment="Stretch"
-                                        VerticalAlignment="Stretch"
-                                        x:Load="{x:Bind LoadFileIcon, Mode=OneWay}"
-                                        x:Phase="1"
-                                        Source="{x:Bind FileImage, Mode=OneWay}"
-                                        Stretch="Uniform" />
-                                    <Image
                                         x:Name="FolderGlyph"
-                                        Width="25"
-                                        Height="25"
-                                        HorizontalAlignment="Stretch"
-                                        VerticalAlignment="Stretch"
+                                        Width="24"
+                                        Height="24"
                                         x:Load="{x:Bind LoadFolderGlyph, Mode=OneWay}"
                                         x:Phase="1"
                                         Stretch="Uniform">
@@ -476,39 +478,39 @@
                                     </Image>
                                     <FontIcon
                                         x:Name="TypeUnknownGlyph"
-                                        Width="25"
-                                        HorizontalAlignment="Stretch"
-                                        VerticalAlignment="Stretch"
                                         x:Load="{x:Bind LoadUnknownTypeGlyph, Mode=OneWay}"
                                         x:Phase="1"
-                                        FontSize="25"
                                         Glyph="&#xE7C3;" />
+                                    <FontIcon
+                                        x:Name="WebShortcutGlyph"
+                                        x:Load="{x:Bind LoadWebShortcutGlyph, Mode=OneWay}"
+                                        x:Phase="1"
+                                        Glyph="&#xE71B;" />
+                                    <Image
+                                        x:Name="Picture"
+                                        Width="20"
+                                        Height="20"
+                                        x:Load="{x:Bind LoadFileIcon, Mode=OneWay}"
+                                        x:Phase="1"
+                                        Source="{x:Bind FileImage, Mode=OneWay}"
+                                        Stretch="Uniform" />
                                     <Image
                                         x:Name="IconOverlay"
-                                        Width="5"
-                                        Height="5"
-                                        Margin="1"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Bottom"
+                                        Width="22"
+                                        Height="22"
+                                        Margin="2,8,8,2"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
                                         x:Load="True"
                                         x:Phase="1"
                                         Source="{x:Bind IconOverlay, Mode=OneWay}"
                                         Stretch="Uniform" />
-                                    <Viewbox
-                                        x:Name="WebShortcutGlyph"
-                                        MaxWidth="25"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        x:Load="{x:Bind LoadWebShortcutGlyph, Mode=OneWay}"
-                                        x:Phase="1">
-                                        <FontIcon FontSize="28" Glyph="&#xE71B;" />
-                                    </Viewbox>
                                     <Border
                                         x:Name="ShortcutGlyphElement"
-                                        Margin="1"
-                                        Padding="0"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Bottom"
+                                        Margin="2,18,18,2"
+                                        Padding="1"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
                                         x:Load="{x:Bind IsShortcutItem}"
                                         x:Phase="1"
                                         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
@@ -516,7 +518,7 @@
                                         BorderThickness="1">
                                         <FontIcon
                                             FontFamily="{StaticResource CustomGlyph}"
-                                            FontSize="7"
+                                            FontSize="10"
                                             Glyph="&#xF10A;" />
                                     </Border>
                                 </Grid>
@@ -558,7 +560,7 @@
                                 <FontIcon
                                     x:Name="CloudDriveSyncStatusGlyph"
                                     Grid.Column="4"
-                                    HorizontalAlignment="Left"
+                                    HorizontalAlignment="Center"
                                     AutomationProperties.Name="{x:Bind SyncStatusString, Mode=OneWay}"
                                     Foreground="{x:Bind SyncStatusUI.Foreground, Mode=OneWay}"
                                     Glyph="{x:Bind SyncStatusUI.Glyph, Mode=OneWay}"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -547,6 +547,15 @@
                         </GroupStyle>
                     </GridView.GroupStyle>
 
+                    <GridView.ItemContainerTransitions>
+                        <TransitionCollection>
+                            <AddDeleteThemeTransition />
+                            <!--<ContentThemeTransition />-->
+                            <ReorderThemeTransition />
+                            <EntranceThemeTransition IsStaggeringEnabled="False" />
+                        </TransitionCollection>
+                    </GridView.ItemContainerTransitions>
+
                     <GridView.ItemsPanel>
                         <ItemsPanelTemplate>
                             <ItemsWrapGrid AreStickyGroupHeadersEnabled="True" Orientation="Horizontal" />


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- For #4643

**Details of Changes**
Add details of changes here.
- Fixed too small file icons and overlays (now same size as "old" details view)
- Removed content animation when the list is reset to avoid flickering when loading directories larger than 32 elements
- Left aligned the headers except for the cloud drive status column

**Validation**
How did you test these changes?
- [x] Built and ran the app
