### PR TITLE
Stretch GridView items to fit page width

### DIFF
--- a/Files/Behaviors/StretchedGridViewItems.cs
+++ b/Files/Behaviors/StretchedGridViewItems.cs
@@ -98,7 +98,7 @@ namespace Files.Behaviors
             if (itemsControl.ItemsPanelRoot is ItemsWrapGrid itemsPanel)
             {
                 //Get total size
-                var total = e?.NewSize.Width ?? itemsControl.ActualWidth;
+                var total = (e?.NewSize.Width ?? itemsControl.ActualWidth) - (itemsPanel.Margin.Left + itemsPanel.Margin.Right + itemsControl.Padding.Left + itemsControl.Padding.Right);
 
                 //Minimum item size.
                 var itemMinSize = Math.Min(total, (double)itemsControl.GetValue(MinItemWidthProperty));

--- a/Files/Behaviors/StretchedGridViewItems.cs
+++ b/Files/Behaviors/StretchedGridViewItems.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Files.Behaviors
+{
+    // Adapted from https://gist.github.com/WamWooWam/6b19b8355e3e3a8d605ac015c67f6093
+    public class StretchedGridViewItems
+    {
+        /// <summary>
+        /// This property specifies the minium width for child items in an items wrap grid panel. 
+        /// Setting this property o an non zero value will enable dynamic sizing of items so that
+        /// when items are wrapped the items control is always filled out horizontally
+        /// i.e. the width of items are increased to fill the empty space.
+        /// </summary>
+        public static readonly DependencyProperty MinItemWidthProperty =
+            DependencyProperty.RegisterAttached("MinItemWidth", typeof(double),
+            typeof(StretchedGridViewItems), new PropertyMetadata(0.0d, OnMinItemWidthChanged));
+
+        /// <summary>
+        /// Only applicable when MinItemWidth is non zero. Typically the logic behind 
+        /// MinItemWidth will only trigger if the number of items is more than or equal to 
+        /// what a single row will accomodate. This property specifies that the layout logic
+        /// is also performed when there are less items than what a single row will accomodate.
+        /// </summary>
+        public static readonly DependencyProperty FillBeforeWrapProperty =
+           DependencyProperty.RegisterAttached("FillBeforeWrap", typeof(bool),
+           typeof(StretchedGridViewItems), new PropertyMetadata(false));
+
+        /// <summary>
+        /// Returns the value of the FillBeforeWrap
+        /// </summary>
+        /// <param name="obj">The dependency-object whichs value should be returned</param> 
+        /// <returns>The value of the property</returns>
+        public static bool GetFillBeforeWrap(DependencyObject obj)
+        {
+            return (bool)obj.GetValue(FillBeforeWrapProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the FillBeforeWrap
+        /// </summary>
+        /// <param name="obj">The dependency-object whichs value should be set</param>
+        /// <param name="value">The value which should be assigned to the property.</param>
+        public static void SetFillBeforeWrap(DependencyObject obj, bool value)
+        {
+            obj.SetValue(FillBeforeWrapProperty, value);
+        }
+
+        /// <summary>
+        /// Returns the value of the MinItemWidthProperty
+        /// </summary>
+        /// <param name="obj">The dependency-object whichs value should be returned</param> 
+        /// <returns>The value of the property</returns>
+        public static double GetMinItemWidth(DependencyObject obj)
+        {
+            return (double)obj.GetValue(MinItemWidthProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the MinItemWidthProperty
+        /// </summary>
+        /// <param name="obj">The dependency-object whichs value should be set</param>
+        /// <param name="value">The value which should be assigned to the property.</param>
+        public static void SetMinItemWidth(DependencyObject obj, double value)
+        {
+            obj.SetValue(MinItemWidthProperty, value);
+        }
+
+        private static void OnMinItemWidthChanged(DependencyObject s, DependencyPropertyChangedEventArgs e)
+        {
+            if (s is ListViewBase f)
+            {
+                f.SizeChanged -= OnListViewSizeChanged;
+
+                if (((double)e.NewValue) > 0)
+                {
+                    f.SizeChanged += OnListViewSizeChanged;
+                }
+            }
+        }
+
+        public static void ResizeItems(DependencyObject obj)
+        {
+            OnListViewSizeChanged(obj, null);
+        }
+
+        private static void OnListViewSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            //Unbox the sender.
+            var itemsControl = sender as ListViewBase;
+
+            //If the items panel is a wrap grid.
+            if (itemsControl.ItemsPanelRoot is ItemsWrapGrid itemsPanel)
+            {
+                //Get total size
+                var total = e?.NewSize.Width ?? itemsControl.ActualWidth;
+
+                //Minimum item size.
+                var itemMinSize = Math.Min(total, (double)itemsControl.GetValue(MinItemWidthProperty));
+
+                //How many items can be fit whole.
+                var canBeFit = Math.Floor(total / itemMinSize);
+
+                //I could add logic that if the total items 
+                //are less then the number of items that 
+                //would fit then devide the total size by
+                //the number of items rather than the number
+                //of items that would actually fit.
+                if ((bool)itemsControl.GetValue(FillBeforeWrapProperty) &&
+                    itemsControl.Items.Count > 0 &&
+                    itemsControl.Items.Count < canBeFit)
+                {
+                    canBeFit = itemsControl.Items.Count;
+                }
+
+                // Set the items Panel item width appropriately.
+                // Note you will need your container to stretch
+                // along with the items panel or it will look 
+                // strange. 
+                // <GridView.ItemContainerStyle>
+                //     <Style TargetType="GridViewItem">
+                //         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                //         <Setter Property="HorizontalAlignment" Value="Stretch" />
+                //     </Style>
+                // </GridView.ItemContainerStyle>
+                itemsPanel.ItemWidth = total / canBeFit;
+            }
+        }
+    }
+}

--- a/Files/Constants.cs
+++ b/Files/Constants.cs
@@ -20,6 +20,8 @@
                 public const int GridViewSizeMedium = 160;
 
                 public const int GridViewSizeSmall = 100;
+
+                public const int TilesView = 260;
             }
 
             public static class GenericFileBrowser

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -153,6 +153,7 @@
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="BaseLayout.cs" />
+    <Compile Include="Behaviors\StretchedGridViewItems.cs" />
     <Compile Include="CommandLine\CommandLineParser.cs" />
     <Compile Include="CommandLine\ParsedCommand.cs" />
     <Compile Include="CommandLine\ParsedCommands.cs" />

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -187,7 +187,7 @@
                 Height="100"
                 Margin="0,0,0,0"
                 Padding="0"
-                HorizontalAlignment="Stretch"
+                HorizontalAlignment="Left"
                 VerticalAlignment="Stretch"
                 Background="Transparent"
                 IsRightTapEnabled="True"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:animations="using:Microsoft.Toolkit.Uwp.UI.Animations"
+    xmlns:behaviors="using:Files.Behaviors"
     xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     xmlns:converters1="using:Files.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -488,6 +489,8 @@
                     x:Name="FileList"
                     VerticalContentAlignment="Stretch"
                     animations:ItemsReorderAnimation.Duration="0:0:0.350"
+                    behaviors:StretchedGridViewItems.FillBeforeWrap="True"
+                    behaviors:StretchedGridViewItems.MinItemWidth="{x:Bind GridViewItemMinWidth, Mode=OneWay}"
                     x:FieldModifier="public"
                     AllowDrop="{x:Bind InstanceViewModel.IsPageTypeSearchResults, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
                     CanDragItems="{x:Bind InstanceViewModel.IsPageTypeSearchResults, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
@@ -589,6 +592,12 @@
                                 Content="Search unindexed items." />
                         </StackPanel>
                     </GridView.Footer>
+                    <GridView.ItemContainerStyle>
+                        <Style TargetType="GridViewItem">
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            <Setter Property="HorizontalAlignment" Value="Stretch" />
+                        </Style>
+                    </GridView.ItemContainerStyle>
                 </GridView>
             </SemanticZoom.ZoomedInView>
 

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -561,7 +561,10 @@
 
                     <GridView.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <ItemsWrapGrid AreStickyGroupHeadersEnabled="True" Orientation="Horizontal" />
+                            <ItemsWrapGrid
+                                Margin="0,0,8,0"
+                                AreStickyGroupHeadersEnabled="True"
+                                Orientation="Horizontal" />
                         </ItemsPanelTemplate>
                     </GridView.ItemsPanel>
 

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -28,6 +28,11 @@ namespace Files.Views.LayoutModes
     {
         public string oldItemName;
 
+        /// <summary>
+        /// The minimum item width for items. Used in the StretchedGridViewItems behavior.
+        /// </summary>
+        public int GridViewItemMinWidth => FolderSettings.LayoutMode == FolderLayoutModes.TilesView ? Constants.Browser.GridViewBrowser.TilesView : FolderSettings.GridViewSize;
+
         public GridViewBrowser()
             : base()
         {
@@ -215,6 +220,8 @@ namespace Files.Views.LayoutModes
         private void SetItemTemplate()
         {
             FileList.ItemTemplate = (FolderSettings.LayoutMode == FolderLayoutModes.TilesView) ? TilesBrowserTemplate : GridViewBrowserTemplate; // Choose Template
+            SetItemMinWidth();
+            itemTemplateChanging = true;
 
             // Set GridViewSize event handlers
             if (FolderSettings.LayoutMode == FolderLayoutModes.TilesView)
@@ -227,6 +234,17 @@ namespace Files.Views.LayoutModes
                 FolderSettings.GridViewSizeChangeRequested += FolderSettings_GridViewSizeChangeRequested;
             }
         }
+
+        /// <summary>
+        /// Updates the min size for the item containers
+        /// </summary>
+        private void SetItemMinWidth()
+        {
+            NotifyPropertyChanged(nameof(GridViewItemMinWidth));
+            Behaviors.StretchedGridViewItems.ResizeItems(FileList);
+        }
+
+        private bool itemTemplateChanging = false;
 
         protected override IEnumerable GetAllItems()
         {
@@ -474,6 +492,7 @@ namespace Files.Views.LayoutModes
 
         private void FolderSettings_GridViewSizeChangeRequested(object sender, EventArgs e)
         {
+            SetItemMinWidth();
             var requestedIconSize = FolderSettings.GetIconSize(); // Get new icon size
 
             // Prevents reloading icons when the icon size hasn't changed
@@ -519,6 +538,13 @@ namespace Files.Views.LayoutModes
 
         private async void FileList_ChoosingItemContainer(ListViewBase sender, ChoosingItemContainerEventArgs args)
         {
+            // This resizes the items after the item template has been changed and reloaded
+            if(itemTemplateChanging)
+            {
+                itemTemplateChanging = false;
+                Behaviors.StretchedGridViewItems.ResizeItems(FileList);
+            }
+
             if (args.ItemContainer == null)
             {
                 GridViewItem gvi = new GridViewItem();


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #4940 

**Details of Changes**
Add details of changes here.
- Added and implemented behavior to change item size so that the entire page with is filled

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**

https://user-images.githubusercontent.com/59544401/118571291-93bfcb00-b732-11eb-809d-30464ff418e1.mp4


Note: while resizing, the reordering animation seems to be slowed down. Not sure why. 