### PR TITLE
Add support for selecting multiple items in the recents widget #3677

### DIFF
--- a/Files/Helpers/NavigationHelpers.cs
+++ b/Files/Helpers/NavigationHelpers.cs
@@ -20,7 +20,7 @@ namespace Files.Helpers
 {
     public static class NavigationHelpers
     {
-        public static async void OpenPathInNewTab(string path)
+        public static async Task OpenPathInNewTab(string path)
         {
             await MainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), path);
         }

--- a/Files/UserControls/Widgets/RecentFiles.xaml
+++ b/Files/UserControls/Widgets/RecentFiles.xaml
@@ -37,11 +37,11 @@
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     IsItemClickEnabled="True"
-                    IsRightTapEnabled="True"
-                    ItemClick="RecentsView_ItemClick"
+                    IsRightTapEnabled="True"                    
+                    DoubleTapped="RecentsView_DoubleTapped"
                     ItemContainerTransitions="{x:Null}"
                     ItemsSource="{x:Bind recentItemsCollection}"
-                    SelectionMode="None">
+                    SelectionMode="Multiple">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="local:RecentItem">
                             <Grid
@@ -55,10 +55,10 @@
                                 <Grid.ContextFlyout>
                                     <MenuFlyout>
                                         <MenuFlyoutItem
-                                            x:Name="RemoveRecentItem"
-                                            x:Uid="RecentItemRemove"
-                                            Click="RemoveRecentItem_Click"
-                                            Text="Remove this item">
+                                            x:Name="RemoveRecentSelectedItems"
+                                            x:Uid="RecentItemsSelectedRemove"
+                                            Click="RemoveRecentSelectedItems_Click"
+                                            Text="Remove selected items">
                                             <MenuFlyoutItem.Icon>
                                                 <FontIcon Glyph="&#xE738;" />
                                             </MenuFlyoutItem.Icon>
@@ -72,9 +72,9 @@
                                             </MenuFlyoutItem.Icon>
                                         </MenuFlyoutItem>
                                         <MenuFlyoutItem
-                                            x:Uid="RecentItemOpenFileLocation"
-                                            Click="OpenFileLocation_Click"
-                                            Text="Open file location"
+                                            x:Uid="RecentItemOpenSelectedFiles"
+                                            Click="OpenSelectedFilesLocation_Click"
+                                            Text="Open selected files locations"
                                             Visibility="{x:Bind IsFile}">
                                             <MenuFlyoutItem.Icon>
                                                 <FontIcon Glyph="&#xED25;" />


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes ([#3677](https://github.com/files-community/Files/issues/3677))

**Details of Changes**
Add details of changes here.
- Added feature to select multiple items on recent opened files (Home). Open multiple folder file location. Clean more than one item from recent opened files.

**Validation**
How did you test these changes?
- [x] Select multiple recent files 
- [x] Clean multiple recent files 
- [x] Open folders location of multiple recent files

**Screenshots (optional)**
![Capture3](https://user-images.githubusercontent.com/72361786/118711210-394c6a80-b817-11eb-80c7-1976ffdb8608.PNG)

