### PR TITLE
Fix null exception in AddItemToSidebarAsync when item StorageFolder is null

### DIFF
--- a/Files/DataModels/SidebarPinnedModel.cs
+++ b/Files/DataModels/SidebarPinnedModel.cs
@@ -270,10 +270,16 @@ namespace Files.DataModels
                     IsDefaultLocation = false,
                     Text = res.Result?.DisplayName ?? Path.GetFileName(path.TrimEnd('\\'))
                 };
-                await locationItem.SetBitmapImage(await res.Result?.GetThumbnailAsync(
-                    Windows.Storage.FileProperties.ThumbnailMode.ListView, 
-                    24, 
-                    Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail));
+
+                var getImage = res.Result?.GetThumbnailAsync(
+                    Windows.Storage.FileProperties.ThumbnailMode.ListView,
+                    24,
+                    Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
+
+                if(getImage != null)
+                {
+                    await locationItem.SetBitmapImage(await getImage);
+                }
 
                 if (!favoriteSection.ChildItems.Contains(locationItem))
                 {


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fix issue discussed in Discord server caused by awaiting a null task

**Details of Changes**
Add details of changes here.
- Added a null check for the thumbnail task before awaiting it

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
