### PR TITLE
Add support for copy, move, rename as administrator

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -880,6 +880,56 @@ namespace FilesFullTrust
                     }
                     break;
 
+                case "RenameItem":
+                    var fileToRenamePath = (string)message["filepath"];
+                    var newName = (string)message["newName"];
+                    using (var op = new ShellFileOperations())
+                    {
+                        op.Options = ShellFileOperations.OperationFlags.NoUI;
+                        using var shi = new ShellItem(fileToRenamePath);
+                        op.QueueRenameOperation(shi, newName);
+                        var renameTcs = new TaskCompletionSource<bool>();
+                        op.PostRenameItem += (s, e) => renameTcs.TrySetResult(e.Result.Succeeded);
+                        op.PerformOperations();
+                        var result = await renameTcs.Task;
+                        await Win32API.SendMessageAsync(connection, new ValueSet() { { "Success", result } }, message.Get("RequestID", (string)null));
+                    }
+                    break;
+
+                case "MoveItem":
+                    var fileToMovePath = (string)message["filepath"];
+                    var moveDestination = (string)message["destpath"];
+                    using (var op = new ShellFileOperations())
+                    {
+                        op.Options = ShellFileOperations.OperationFlags.NoUI;
+                        using var shi = new ShellItem(fileToMovePath);
+                        using var shd = new ShellFolder(Path.GetDirectoryName(moveDestination));
+                        op.QueueMoveOperation(shi, shd, Path.GetFileName(moveDestination));
+                        var moveTcs = new TaskCompletionSource<bool>();
+                        op.PostMoveItem += (s, e) => moveTcs.TrySetResult(e.Result.Succeeded);
+                        op.PerformOperations();
+                        var result = await moveTcs.Task;
+                        await Win32API.SendMessageAsync(connection, new ValueSet() { { "Success", result } }, message.Get("RequestID", (string)null));
+                    }
+                    break;
+
+                case "CopyItem":
+                    var fileToCopyPath = (string)message["filepath"];
+                    var copyDestination = (string)message["destpath"];
+                    using (var op = new ShellFileOperations())
+                    {
+                        op.Options = ShellFileOperations.OperationFlags.NoUI;
+                        using var shi = new ShellItem(fileToCopyPath);
+                        using var shd = new ShellFolder(Path.GetDirectoryName(copyDestination));
+                        op.QueueCopyOperation(shi, shd, Path.GetFileName(copyDestination));
+                        var copyTcs = new TaskCompletionSource<bool>();
+                        op.PostCopyItem += (s, e) => copyTcs.TrySetResult(e.Result.Succeeded);
+                        op.PerformOperations();
+                        var result = await copyTcs.Task;
+                        await Win32API.SendMessageAsync(connection, new ValueSet() { { "Success", result } }, message.Get("RequestID", (string)null));
+                    }
+                    break;
+
                 case "ParseLink":
                     var linkPath = (string)message["filepath"];
                     try

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -883,9 +883,11 @@ namespace FilesFullTrust
                 case "RenameItem":
                     var fileToRenamePath = (string)message["filepath"];
                     var newName = (string)message["newName"];
+                    var overwriteOnRename = (bool)message["overwrite"];
                     using (var op = new ShellFileOperations())
                     {
                         op.Options = ShellFileOperations.OperationFlags.NoUI;
+                        op.Options |= !overwriteOnRename ? ShellFileOperations.OperationFlags.PreserveFileExtensions | ShellFileOperations.OperationFlags.RenameOnCollision : 0;
                         using var shi = new ShellItem(fileToRenamePath);
                         op.QueueRenameOperation(shi, newName);
                         var renameTcs = new TaskCompletionSource<bool>();
@@ -899,9 +901,11 @@ namespace FilesFullTrust
                 case "MoveItem":
                     var fileToMovePath = (string)message["filepath"];
                     var moveDestination = (string)message["destpath"];
+                    var overwriteOnMove = (bool)message["overwrite"];
                     using (var op = new ShellFileOperations())
                     {
                         op.Options = ShellFileOperations.OperationFlags.NoUI;
+                        op.Options |= !overwriteOnMove ? ShellFileOperations.OperationFlags.PreserveFileExtensions | ShellFileOperations.OperationFlags.RenameOnCollision : 0;
                         using var shi = new ShellItem(fileToMovePath);
                         using var shd = new ShellFolder(Path.GetDirectoryName(moveDestination));
                         op.QueueMoveOperation(shi, shd, Path.GetFileName(moveDestination));
@@ -916,9 +920,11 @@ namespace FilesFullTrust
                 case "CopyItem":
                     var fileToCopyPath = (string)message["filepath"];
                     var copyDestination = (string)message["destpath"];
+                    var overwriteOnCopy = (bool)message["overwrite"];
                     using (var op = new ShellFileOperations())
                     {
                         op.Options = ShellFileOperations.OperationFlags.NoUI;
+                        op.Options |= !overwriteOnCopy ? ShellFileOperations.OperationFlags.PreserveFileExtensions | ShellFileOperations.OperationFlags.RenameOnCollision : 0;
                         using var shi = new ShellItem(fileToCopyPath);
                         using var shd = new ShellFolder(Path.GetDirectoryName(copyDestination));
                         op.QueueCopyOperation(shi, shd, Path.GetFileName(copyDestination));

--- a/Files/Enums/FileSystemStatusCode.cs
+++ b/Files/Enums/FileSystemStatusCode.cs
@@ -14,6 +14,7 @@ namespace Files.Enums
         AlreadyExists = 32,
         NotAFolder = 64,
         NotAFile = 128,
-        InProgress = 256
+        ReadOnly = 256,
+        InProgress = 512
     }
 }

--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -204,7 +204,8 @@ namespace Files.Filesystem
                             { "Arguments", "FileOperation" },
                             { "fileop", "CopyItem" },
                             { "filepath", source.Path },
-                            { "destpath", destination }
+                            { "destpath", destination },
+                            { "overwrite", collision == NameCollisionOption.ReplaceExisting }
                         });
                     }
                     errorCode?.Report(fsResult.ErrorCode);
@@ -251,7 +252,8 @@ namespace Files.Filesystem
                             { "Arguments", "FileOperation" },
                             { "fileop", "CopyItem" },
                             { "filepath", source.Path },
-                            { "destpath", destination }
+                            { "destpath", destination },
+                            { "overwrite", collision == NameCollisionOption.ReplaceExisting }
                         });
                     }
                 }
@@ -414,7 +416,8 @@ namespace Files.Filesystem
                                 { "Arguments", "FileOperation" },
                                 { "fileop", "MoveItem" },
                                 { "filepath", source.Path },
-                                { "destpath", destination }
+                                { "destpath", destination },
+                                { "overwrite", collision == NameCollisionOption.ReplaceExisting }
                             });
                         }
                     }
@@ -436,7 +439,7 @@ namespace Files.Filesystem
                     if (fsResult)
                     {
                         var file = (StorageFile)sourceResult;
-                        var fsResultMove = await FilesystemTasks.Wrap(() => file.MoveAsync(destinationResult.Result, Path.GetFileName(file.Name), NameCollisionOption.FailIfExists).AsTask());
+                        var fsResultMove = await FilesystemTasks.Wrap(() => file.MoveAsync(destinationResult.Result, Path.GetFileName(file.Name), collision).AsTask());
 
                         if (fsResultMove == FileSystemStatusCode.AlreadyExists)
                         {
@@ -458,7 +461,8 @@ namespace Files.Filesystem
                             { "Arguments", "FileOperation" },
                             { "fileop", "MoveItem" },
                             { "filepath", source.Path },
-                            { "destpath", destination }
+                            { "destpath", destination },
+                            { "overwrite", collision == NameCollisionOption.ReplaceExisting }
                         });
                     }
                 }
@@ -679,7 +683,8 @@ namespace Files.Filesystem
                             { "Arguments", "FileOperation" },
                             { "fileop", "RenameItem" },
                             { "filepath", source.Path },
-                            { "newName", newName }
+                            { "newName", newName },
+                            { "overwrite", collision == NameCollisionOption.ReplaceExisting }
                         });
                         if (fsResult)
                         {

--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -199,28 +199,13 @@ namespace Files.Filesystem
                     }
                     if (fsResult == FileSystemStatusCode.Unauthorized)
                     {
-                        var elevateConfirmDialog = new Files.Dialogs.ElevateConfirmDialog();
-                        var elevateConfirmResult = await elevateConfirmDialog.ShowAsync();
-                        if (elevateConfirmResult == ContentDialogResult.Primary)
+                        fsResult = await PerformAdminOperation(new ValueSet()
                         {
-                            if (associatedInstance.ServiceConnection != null &&
-                                await associatedInstance.ServiceConnection.Elevate())
-                            {
-                                // Try again with fulltrust process (admin)
-                                if (associatedInstance.ServiceConnection != null)
-                                {
-                                    var (status, response) = await associatedInstance.ServiceConnection.SendMessageForResponseAsync(new ValueSet()
-                                    {
-                                        { "Arguments", "FileOperation" },
-                                        { "fileop", "CopyItem" },
-                                        { "filepath", source.Path },
-                                        { "destpath", destination }
-                                    });
-                                    fsResult = (FilesystemResult)(status == AppServiceResponseStatus.Success
-                                        && response.Get("Success", false));
-                                }
-                            }
-                        }
+                            { "Arguments", "FileOperation" },
+                            { "fileop", "CopyItem" },
+                            { "filepath", source.Path },
+                            { "destpath", destination }
+                        });
                     }
                     errorCode?.Report(fsResult.ErrorCode);
                     if (!fsResult)
@@ -261,28 +246,13 @@ namespace Files.Filesystem
                     }
                     if (fsResult == FileSystemStatusCode.Unauthorized)
                     {
-                        var elevateConfirmDialog = new Files.Dialogs.ElevateConfirmDialog();
-                        var elevateConfirmResult = await elevateConfirmDialog.ShowAsync();
-                        if (elevateConfirmResult == ContentDialogResult.Primary)
+                        fsResult = await PerformAdminOperation(new ValueSet()
                         {
-                            if (associatedInstance.ServiceConnection != null &&
-                                await associatedInstance.ServiceConnection.Elevate())
-                            {
-                                // Try again with fulltrust process (admin)
-                                if (associatedInstance.ServiceConnection != null)
-                                {
-                                    var (status, response) = await associatedInstance.ServiceConnection.SendMessageForResponseAsync(new ValueSet()
-                                    {
-                                        { "Arguments", "FileOperation" },
-                                        { "fileop", "CopyItem" },
-                                        { "filepath", source.Path },
-                                        { "destpath", destination }
-                                    });
-                                    fsResult = (FilesystemResult)(status == AppServiceResponseStatus.Success
-                                        && response.Get("Success", false));
-                                }
-                            }
-                        }
+                            { "Arguments", "FileOperation" },
+                            { "fileop", "CopyItem" },
+                            { "filepath", source.Path },
+                            { "destpath", destination }
+                        });
                     }
                 }
                 errorCode?.Report(fsResult.ErrorCode);
@@ -439,28 +409,13 @@ namespace Files.Filesystem
                         }
                         if (fsResult == FileSystemStatusCode.Unauthorized || fsResult == FileSystemStatusCode.ReadOnly)
                         {
-                            var elevateConfirmDialog = new Files.Dialogs.ElevateConfirmDialog();
-                            var elevateConfirmResult = await elevateConfirmDialog.ShowAsync();
-                            if (elevateConfirmResult == ContentDialogResult.Primary)
+                            fsResult = await PerformAdminOperation(new ValueSet()
                             {
-                                if (associatedInstance.ServiceConnection != null &&
-                                    await associatedInstance.ServiceConnection.Elevate())
-                                {
-                                    // Try again with fulltrust process (admin)
-                                    if (associatedInstance.ServiceConnection != null)
-                                    {
-                                        var (status, response) = await associatedInstance.ServiceConnection.SendMessageForResponseAsync(new ValueSet()
-                                        {
-                                            { "Arguments", "FileOperation" },
-                                            { "fileop", "MoveItem" },
-                                            { "filepath", source.Path },
-                                            { "destpath", destination }
-                                        });
-                                        fsResult = (FilesystemResult)(status == AppServiceResponseStatus.Success
-                                            && response.Get("Success", false));
-                                    }
-                                }
-                            }
+                                { "Arguments", "FileOperation" },
+                                { "fileop", "MoveItem" },
+                                { "filepath", source.Path },
+                                { "destpath", destination }
+                            });
                         }
                     }
                     errorCode?.Report(fsResult.ErrorCode);
@@ -498,28 +453,13 @@ namespace Files.Filesystem
                     }
                     if (fsResult == FileSystemStatusCode.Unauthorized || fsResult == FileSystemStatusCode.ReadOnly)
                     {
-                        var elevateConfirmDialog = new Files.Dialogs.ElevateConfirmDialog();
-                        var elevateConfirmResult = await elevateConfirmDialog.ShowAsync();
-                        if (elevateConfirmResult == ContentDialogResult.Primary)
+                        fsResult = await PerformAdminOperation(new ValueSet()
                         {
-                            if (associatedInstance.ServiceConnection != null &&
-                                await associatedInstance.ServiceConnection.Elevate())
-                            {
-                                // Try again with fulltrust process (admin)
-                                if (associatedInstance.ServiceConnection != null)
-                                {
-                                    var (status, response) = await associatedInstance.ServiceConnection.SendMessageForResponseAsync(new ValueSet()
-                                        {
-                                            { "Arguments", "FileOperation" },
-                                            { "fileop", "MoveItem" },
-                                            { "filepath", source.Path },
-                                            { "destpath", destination }
-                                        });
-                                    fsResult = (FilesystemResult)(status == AppServiceResponseStatus.Success
-                                        && response.Get("Success", false));
-                                }
-                            }
-                        }
+                            { "Arguments", "FileOperation" },
+                            { "fileop", "MoveItem" },
+                            { "filepath", source.Path },
+                            { "destpath", destination }
+                        });
                     }
                 }
                 errorCode?.Report(fsResult.ErrorCode);
@@ -616,27 +556,13 @@ namespace Files.Filesystem
                 }
                 if (!fsResult)
                 {
-                    var elevateConfirmDialog = new Files.Dialogs.ElevateConfirmDialog();
-                    var elevateConfirmResult = await elevateConfirmDialog.ShowAsync();
-                    if (elevateConfirmResult == ContentDialogResult.Primary)
+                    fsResult = await PerformAdminOperation(new ValueSet()
                     {
-                        if (await associatedInstance.ServiceConnection?.Elevate())
-                        {
-                            // Try again with fulltrust process (admin)
-                            if (associatedInstance.ServiceConnection != null)
-                            {
-                                var (status, response) = await associatedInstance.ServiceConnection.SendMessageForResponseAsync(new ValueSet()
-                                {
-                                    { "Arguments", "FileOperation" },
-                                    { "fileop", "DeleteItem" },
-                                    { "filepath", source.Path },
-                                    { "permanently", permanently }
-                                });
-                                fsResult = (FilesystemResult)(status == AppServiceResponseStatus.Success
-                                    && response.Get("Success", false));
-                            }
-                        }
-                    }
+                        { "Arguments", "FileOperation" },
+                        { "fileop", "DeleteItem" },
+                        { "filepath", source.Path },
+                        { "permanently", permanently }
+                    });
                 }
             }
             else if (fsResult == FileSystemStatusCode.InUse)
@@ -748,32 +674,17 @@ namespace Files.Filesystem
                     }
                     else
                     {
-                        var elevateConfirmDialog = new Files.Dialogs.ElevateConfirmDialog();
-                        var elevateConfirmResult = await elevateConfirmDialog.ShowAsync();
-                        if (elevateConfirmResult == ContentDialogResult.Primary)
+                        var fsResult = await PerformAdminOperation(new ValueSet()
                         {
-                            if (associatedInstance.ServiceConnection != null &&
-                                await associatedInstance.ServiceConnection.Elevate())
-                            {
-                                // Try again with fulltrust process (admin)
-                                if (associatedInstance.ServiceConnection != null)
-                                {
-                                    var (status, response) = await associatedInstance.ServiceConnection.SendMessageForResponseAsync(new ValueSet()
-                                    {
-                                        { "Arguments", "FileOperation" },
-                                        { "fileop", "RenameItem" },
-                                        { "filepath", source.Path },
-                                        { "newName", newName }
-                                    });
-                                    var fsResult = (FilesystemResult)(status == AppServiceResponseStatus.Success
-                                        && response.Get("Success", false));
-                                    if (fsResult)
-                                    {
-                                        errorCode?.Report(FileSystemStatusCode.Success);
-                                        return new StorageHistory(FileOperationType.Rename, source, StorageItemHelpers.FromPathAndType(destination, source.ItemType));
-                                    }
-                                }
-                            }
+                            { "Arguments", "FileOperation" },
+                            { "fileop", "RenameItem" },
+                            { "filepath", source.Path },
+                            { "newName", newName }
+                        });
+                        if (fsResult)
+                        {
+                            errorCode?.Report(FileSystemStatusCode.Success);
+                            return new StorageHistory(FileOperationType.Rename, source, StorageItemHelpers.FromPathAndType(destination, source.ItemType));
                         }
                     }
                 }
@@ -955,6 +866,27 @@ namespace Files.Filesystem
             App.JumpList.RemoveFolder(sourceFolder.Path);
 
             return createdRoot;
+        }
+
+        private async Task<FilesystemResult> PerformAdminOperation(ValueSet operation)
+        {
+            var elevateConfirmDialog = new Files.Dialogs.ElevateConfirmDialog();
+            var elevateConfirmResult = await elevateConfirmDialog.ShowAsync();
+            if (elevateConfirmResult == ContentDialogResult.Primary)
+            {
+                if (associatedInstance.ServiceConnection != null &&
+                    await associatedInstance.ServiceConnection.Elevate())
+                {
+                    // Try again with fulltrust process (admin)
+                    if (associatedInstance.ServiceConnection != null)
+                    {
+                        var (status, response) = await associatedInstance.ServiceConnection.SendMessageForResponseAsync(operation);
+                        return (FilesystemResult)(status == AppServiceResponseStatus.Success
+                            && response.Get("Success", false));
+                    }
+                }
+            }
+            return (FilesystemResult)false;
         }
 
         #endregion Helpers

--- a/Files/Filesystem/StorageFileHelpers/FilesystemResult.cs
+++ b/Files/Filesystem/StorageFileHelpers/FilesystemResult.cs
@@ -77,6 +77,10 @@ namespace Files.Filesystem
             {
                 return FileSystemStatusCode.AlreadyExists;
             }
+            else if ((uint)ex.HResult == 0x80071779)
+            {
+                return FileSystemStatusCode.ReadOnly;
+            }
             else if ((uint)ex.HResult == 0x800700A1 // The specified path is invalid (usually an mtp device was disconnected)
                 || (uint)ex.HResult == 0x8007016A // The cloud file provider is not running
                 || (uint)ex.HResult == 0x8000000A) // The data necessary to complete this operation is not yet available)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes #2513

**Details of Changes**
Add details of changes here.
- Add support for copy, move, rename file operation as admin

TODO:
- [x] Respect chosen collision resolution option (overwrite or rename) when destination exists
- [x] ~When copying multiple files a confirmation dialog will come up for each one~ -> TODO next PR

**Validation**
How did you test these changes?
- [x] Built and ran the app
