### PR TITLE
Fix crash when resizing the sidebar too quickly

### DIFF
--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -643,7 +643,8 @@ namespace Files.UserControls
 
         private void IncrementSize(double val)
         {
-            AppSettings.SidebarWidth = new GridLength(AppSettings.SidebarWidth.Value + val);
+            var newSize = AppSettings.SidebarWidth.Value + val;
+            AppSettings.SidebarWidth = new GridLength(newSize >= 0 ? newSize : 0); // passing a negative value will cause an exception
         }
 
         private void Border_PointerEntered(object sender, PointerRoutedEventArgs e)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.

**Details of Changes**
Add details of changes here.
- Fixed a crash when resizing the sidebar too quickly to the left. The crash was caused by passing a negative pixel value to the ``GridLength`` constructor, which in turn would throw an invalid argument exception. 

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**