### PR TITLE
Auto refresh network folders on change

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -26,6 +26,7 @@ using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
+using Windows.Storage.Search;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
@@ -1087,13 +1088,26 @@ namespace Files.ViewModels
                         storageFolder = res.Result;
                     }
                 }
-                if (await EnumerateItemsFromStandardFolderAsync(path, storageFolder, folderSettings.GetLayoutType(path, false), addFilesCTS.Token, cacheResult, cacheOnly: false, library))
+                var enumerated = await EnumerateItemsFromStandardFolderAsync(path, storageFolder, folderSettings.GetLayoutType(path, false), addFilesCTS.Token, cacheResult, cacheOnly: false, library);
+                switch (enumerated)
                 {
-                    // Is folder synced to cloud storage?
-                    var syncStatus = await CheckCloudDriveSyncStatusAsync(currentStorageFolder?.Item);
-                    PageTypeUpdated?.Invoke(this, new PageTypeUpdatedEventArgs() { IsTypeCloudDrive = syncStatus != CloudDriveSyncStatus.NotSynced && syncStatus != CloudDriveSyncStatus.Unknown });
+                    case 0: // Enumerated with FindFirstFileExFromApp
+                        // Is folder synced to cloud storage?
+                        var syncStatus = await CheckCloudDriveSyncStatusAsync(currentStorageFolder?.Item);
+                        PageTypeUpdated?.Invoke(this, new PageTypeUpdatedEventArgs() { IsTypeCloudDrive = syncStatus != CloudDriveSyncStatus.NotSynced && syncStatus != CloudDriveSyncStatus.Unknown });
 
-                    WatchForDirectoryChanges(path, syncStatus);
+                        WatchForDirectoryChanges(path, syncStatus);
+                        break;
+
+                    case 1: // Enumerated with StorageFolder
+                        PageTypeUpdated?.Invoke(this, new PageTypeUpdatedEventArgs() { IsTypeCloudDrive = false });
+                        currentStorageFolder ??= await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderWithPathFromPathAsync(path));
+                        WatchForStorageFolderChanges(currentStorageFolder.Folder);
+                        break;
+
+                    case -1: // Enumeration failed
+                    default:
+                        break;
                 }
 
                 var parallelLimit = App.AppSettings.PreemptiveCacheParallelLimit;
@@ -1171,6 +1185,12 @@ namespace Files.ViewModels
                     CloseHandle(hWatchDir);
                 }
             }
+            if (watchedItemsOperation != null)
+            {
+                itemQueryResult.ContentsChanged -= ItemQueryResult_ContentsChanged;
+                watchedItemsOperation?.Cancel();
+                watchedItemsOperation = null;
+            }
         }
 
         public async Task EnumerateItemsFromSpecialFolderAsync(string path)
@@ -1234,7 +1254,7 @@ namespace Files.ViewModels
             }
         }
 
-        public async Task<bool> EnumerateItemsFromStandardFolderAsync(string path, StorageFolderWithPath storageFolderForGivenPath, Type sourcePageType, CancellationToken cancellationToken, List<string> skipItems, bool cacheOnly = false, LibraryItem library = null)
+        public async Task<int> EnumerateItemsFromStandardFolderAsync(string path, StorageFolderWithPath storageFolderForGivenPath, Type sourcePageType, CancellationToken cancellationToken, List<string> skipItems, bool cacheOnly = false, LibraryItem library = null)
         {
             // Flag to use FindFirstFileExFromApp or StorageFolder enumeration
             bool enumFromStorageFolder =
@@ -1250,7 +1270,7 @@ namespace Files.ViewModels
             {
                 if (storageFolderForGivenPath == null)
                 {
-                    return false;
+                    return -1;
                 }
                 rootFolder = storageFolderForGivenPath.Folder;
                 enumFromStorageFolder = true;
@@ -1259,7 +1279,7 @@ namespace Files.ViewModels
             {
                 if (cacheOnly)
                 {
-                    return false;
+                    return -1;
                 }
 
                 if (res == FileSystemStatusCode.Unauthorized)
@@ -1268,19 +1288,19 @@ namespace Files.ViewModels
                     await DialogDisplayHelper.ShowDialogAsync(
                         "AccessDeniedDeleteDialog/Title".GetLocalized(),
                         "SubDirectoryAccessDenied".GetLocalized());
-                    return false;
+                    return -1;
                 }
                 else if (res == FileSystemStatusCode.NotFound)
                 {
                     await DialogDisplayHelper.ShowDialogAsync(
                         "FolderNotFoundDialog/Title".GetLocalized(),
                         "FolderNotFoundDialog/Text".GetLocalized());
-                    return false;
+                    return -1;
                 }
                 else
                 {
                     await DialogDisplayHelper.ShowDialogAsync("DriveUnpluggedDialog/Title".GetLocalized(), res.ErrorCode.ToString());
-                    return false;
+                    return -1;
                 }
             }
 
@@ -1343,7 +1363,7 @@ namespace Files.ViewModels
                     CurrentFolder = currentFolder;
                 }
                 await EnumFromStorageFolderAsync(path, currentFolder, rootFolder, storageFolderForGivenPath, sourcePageType, cancellationToken, skipItems, cacheOnly);
-                return true;
+                return 1;
             }
             else
             {
@@ -1411,12 +1431,12 @@ namespace Files.ViewModels
                     {
                         await DialogDisplayHelper.ShowDialogAsync("DriveUnpluggedDialog/Title".GetLocalized(), "");
                     }
-                    return false;
+                    return -1;
                 }
                 else if (hFile.ToInt64() == -1)
                 {
                     await EnumFromStorageFolderAsync(path, currentFolder, rootFolder, storageFolderForGivenPath, sourcePageType, cancellationToken, skipItems, cacheOnly);
-                    return false;
+                    return 1;
                 }
                 else
                 {
@@ -1461,7 +1481,7 @@ namespace Files.ViewModels
                             await fileListCache.SaveFileListToCache(path, null);
                         }
                     }
-                    return true;
+                    return 0;
                 }
             }
         }
@@ -1553,6 +1573,50 @@ namespace Files.ViewModels
                 return CloudDriveSyncStatus.Unknown;
             }
             return (CloudDriveSyncStatus)syncStatus;
+        }
+
+        private StorageItemQueryResult itemQueryResult;
+
+        private IAsyncOperation<IReadOnlyList<IStorageItem>> watchedItemsOperation;
+
+        private async void WatchForStorageFolderChanges(StorageFolder rootFolder)
+        {
+            if (rootFolder == null)
+            {
+                return;
+            }
+            await Task.Run(() =>
+            {
+                var options = new QueryOptions()
+                {
+                    FolderDepth = FolderDepth.Shallow,
+                    IndexerOption = IndexerOption.OnlyUseIndexerAndOptimizeForIndexedProperties
+                };
+                options.SetPropertyPrefetch(PropertyPrefetchOptions.None, null);
+                options.SetThumbnailPrefetch(ThumbnailMode.ListView, 0, ThumbnailOptions.ReturnOnlyIfCached);
+                itemQueryResult = rootFolder.CreateItemQueryWithOptions(options);
+                itemQueryResult.ContentsChanged += ItemQueryResult_ContentsChanged;
+                watchedItemsOperation = itemQueryResult.GetItemsAsync();
+            });
+        }
+
+        private async void ItemQueryResult_ContentsChanged(IStorageQueryResultBase sender, object args)
+        {
+            //query options have to be reapplied otherwise old results are returned
+            var options = new QueryOptions()
+            {
+                FolderDepth = FolderDepth.Shallow,
+                IndexerOption = IndexerOption.OnlyUseIndexerAndOptimizeForIndexedProperties
+            };
+            options.SetPropertyPrefetch(PropertyPrefetchOptions.None, null);
+            options.SetThumbnailPrefetch(ThumbnailMode.ListView, 0, ThumbnailOptions.ReturnOnlyIfCached);
+
+            sender.ApplyNewQueryOptions(options);
+
+            await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
+            {
+                RefreshItems(null);
+            });
         }
 
         private void WatchForDirectoryChanges(string path, CloudDriveSyncStatus syncStatus)

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1102,7 +1102,7 @@ namespace Files.ViewModels
                     case 1: // Enumerated with StorageFolder
                         PageTypeUpdated?.Invoke(this, new PageTypeUpdatedEventArgs() { IsTypeCloudDrive = false });
                         currentStorageFolder ??= await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderWithPathFromPathAsync(path));
-                        WatchForStorageFolderChanges(currentStorageFolder.Folder);
+                        WatchForStorageFolderChanges(currentStorageFolder?.Folder);
                         break;
 
                     case -1: // Enumeration failed
@@ -1596,7 +1596,7 @@ namespace Files.ViewModels
                 options.SetThumbnailPrefetch(ThumbnailMode.ListView, 0, ThumbnailOptions.ReturnOnlyIfCached);
                 itemQueryResult = rootFolder.CreateItemQueryWithOptions(options);
                 itemQueryResult.ContentsChanged += ItemQueryResult_ContentsChanged;
-                watchedItemsOperation = itemQueryResult.GetItemsAsync();
+                watchedItemsOperation = itemQueryResult.GetItemsAsync(0, 1); // Just get one item to start getting notifications
             });
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes #2042

**Details of Changes**
Add details of changes here.
- Adds support for automatically refresh a network folder when a file is created/deleted/renamed..
Done using the "old" method of watching for folder changes (code taken from 0.9.2) only in case of network folders
Note: triggers a full refresh of the folder on any change <- @duke7553 there's no way to get what's changed is there?
- Fixes some issues with recycle bin updating:
    - Crash when the recycle bin is open in one tab and multiple files are deleted from another tab
    - "Folder empty" text sometimes not appearing/disappearing
    - Contents not updated when emptying the recycle bin

**Validation**
How did you test these changes?
- [x] Built and ran the app
