### PR TITLE
Use new ContentDialog style in DynamicDialog

### DIFF
--- a/Files/Dialogs/DynamicDialog.xaml
+++ b/Files/Dialogs/DynamicDialog.xaml
@@ -8,17 +8,15 @@
     xmlns:icore="using:Microsoft.Xaml.Interactions.Core"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Title="{Binding TitleText, Mode=OneWay}"
-    CloseButtonStyle="{StaticResource DefaultButtonStyle}"
     CloseButtonText="{Binding CloseButtonText, Mode=OneWay}"
     CornerRadius="{StaticResource OverlayCornerRadius}"
     DefaultButton="Primary"
     IsPrimaryButtonEnabled="{Binding IsPrimaryButtonEnabled, Mode=OneWay}"
     IsSecondaryButtonEnabled="{Binding IsSecondaryButtonEnabled, Mode=OneWay}"
-    PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
     PrimaryButtonText="{Binding PrimaryButtonText, Mode=OneWay}"
     RequestedTheme="{x:Bind helpers:ThemeHelper.RootTheme}"
-    SecondaryButtonStyle="{StaticResource DefaultButtonStyle}"
     SecondaryButtonText="{Binding SecondaryButtonText, Mode=OneWay}"
+    Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
     <i:Interaction.Behaviors>
         <!--  No need to specify CommandParameter - `e` is passed by default  -->


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.

**Details of Changes**
Add details of changes here.
- Use ``DefaultContentDialogStyle`` for the ``DynamicDialog`` control so that it has WinUI 2.6 styles

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
After:
![image](https://user-images.githubusercontent.com/59544401/119283679-9d45a900-bbf2-11eb-8abf-e6b1723baddc.png)

Before:
![image](https://user-images.githubusercontent.com/59544401/119283697-aafb2e80-bbf2-11eb-9131-1d1877485e44.png)