### PR TITLE
Foreground windows opened when invoking context menu items

### DIFF
--- a/Files.Launcher/Win32API_ContextMenu.cs
+++ b/Files.Launcher/Win32API_ContextMenu.cs
@@ -154,11 +154,13 @@ namespace FilesFullTrust
 
                 try
                 {
+                    var currentWindows = Win32API.GetDesktopWindows();
                     var pici = new Shell32.CMINVOKECOMMANDINFOEX();
                     pici.lpVerb = new SafeResourceId(verb, CharSet.Ansi);
                     pici.nShow = ShowWindowCommand.SW_SHOWNORMAL;
                     pici.cbSize = (uint)Marshal.SizeOf(pici);
                     cMenu.InvokeCommand(pici);
+                    Win32API.BringToForeground(currentWindows);
                 }
                 catch (Exception ex) when (
                     ex is COMException
@@ -177,11 +179,13 @@ namespace FilesFullTrust
 
                 try
                 {
+                    var currentWindows = Win32API.GetDesktopWindows();
                     var pici = new Shell32.CMINVOKECOMMANDINFOEX();
                     pici.lpVerb = Macros.MAKEINTRESOURCE(itemID);
                     pici.nShow = ShowWindowCommand.SW_SHOWNORMAL;
                     pici.cbSize = (uint)Marshal.SizeOf(pici);
                     cMenu.InvokeCommand(pici);
+                    Win32API.BringToForeground(currentWindows);
                 }
                 catch (Exception ex) when (
                     ex is COMException


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes #4554

Integration to #5009 to fix issue #4554 which was merged with #985 but was slightly different since it was related to windows opened when invoking context menu items and not when double clicking on something.
This should be easier to test since (for me at least) right clicking on zip file and selecting "Extract all.." consistently opens the window behind Files (fixed with this PR).

**Details of Changes**
Add details of changes here.
- Foreground windows opened when invoking context menu items

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Right click on zip file and choose "Extract all..." option 
