### PR TITLE
Auto hide cloud section when no cloud drives are detected

### DIFF
--- a/Files/Filesystem/CloudDrivesManager.cs
+++ b/Files/Filesystem/CloudDrivesManager.cs
@@ -98,7 +98,7 @@ namespace Files.Filesystem
                     SidebarControl.SideBarItems.BeginBulkOperation();
 
                     var section = SidebarControl.SideBarItems.FirstOrDefault(x => x.Text == "SidebarCloudDrives".GetLocalized()) as LocationItem;
-                    if (section == null)
+                    if (section == null && Drives.Any())
                     {
                         section = new LocationItem()
                         {
@@ -111,11 +111,14 @@ namespace Files.Filesystem
                         SidebarControl.SideBarItems.Add(section);
                     }
 
-                    foreach (DriveItem drive in Drives.ToList())
+                    if (section != null)
                     {
-                        if (!section.ChildItems.Contains(drive))
+                        foreach (DriveItem drive in Drives.ToList())
                         {
-                            section.ChildItems.Add(drive);
+                            if (!section.ChildItems.Contains(drive))
+                            {
+                                section.ChildItems.Add(drive);
+                            }
                         }
                     }
 

--- a/Files/Filesystem/NetworkDrivesManager.cs
+++ b/Files/Filesystem/NetworkDrivesManager.cs
@@ -114,7 +114,7 @@ namespace Files.Filesystem
                     SidebarControl.SideBarItems.BeginBulkOperation();
 
                     var section = SidebarControl.SideBarItems.FirstOrDefault(x => x.Text == "SidebarNetworkDrives".GetLocalized()) as LocationItem;
-                    if (section == null && this.drivesList.Any(d => d.DeviceID != "network-folder"))
+                    if (section == null)
                     {
                         section = new LocationItem()
                         {


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #4247
- Closes #3912

**Details of Changes**
Add details of changes here.
- Auto hide cloud section when no cloud drives are detected
- Show sidebar network item

**Validation**
How did you test these changes?
- [x] Built and ran the app
