### PR TITLE
Change "show hidden files" and "hide system files" behavior to match explorer

### DIFF
--- a/Files/Filesystem/Search/FolderSearch.cs
+++ b/Files/Filesystem/Search/FolderSearch.cs
@@ -125,54 +125,56 @@ namespace Files.Filesystem.Search
                             break;
                         }
                         var itemPath = Path.Combine(folder, findData.cFileName);
-                        if (((FileAttributes)findData.dwFileAttributes & FileAttributes.System) != FileAttributes.System
-                            || !App.AppSettings.AreSystemItemsHidden)
-                        {
-                            var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
-                            if ((!isHidden && !hiddenOnly) || (isHidden && App.AppSettings.AreHiddenItemsVisible))
-                            {
-                                if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
-                                {
-                                    string itemFileExtension = null;
-                                    string itemType = null;
-                                    if (findData.cFileName.Contains("."))
-                                    {
-                                        itemFileExtension = Path.GetExtension(itemPath);
-                                        itemType = itemFileExtension.Trim('.') + " " + itemType;
-                                    }
 
+                        var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
+                        var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
+                        bool shouldBeListed = hiddenOnly ?
+                            isHidden && (!isSystem || !App.AppSettings.AreSystemItemsHidden) :
+                            !isHidden || (App.AppSettings.AreHiddenItemsVisible && (!isSystem || !App.AppSettings.AreSystemItemsHidden));
+
+                        if (shouldBeListed)
+                        {
+                            if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
+                            {
+                                string itemFileExtension = null;
+                                string itemType = null;
+                                if (findData.cFileName.Contains("."))
+                                {
+                                    itemFileExtension = Path.GetExtension(itemPath);
+                                    itemType = itemFileExtension.Trim('.') + " " + itemType;
+                                }
+
+                                results.Add(new ListedItem(null)
+                                {
+                                    PrimaryItemAttribute = StorageItemTypes.File,
+                                    ItemName = findData.cFileName,
+                                    ItemPath = itemPath,
+                                    IsHiddenItem = true,
+                                    LoadFileIcon = false,
+                                    LoadUnknownTypeGlyph = true,
+                                    LoadFolderGlyph = false,
+                                    ItemPropertiesInitialized = false, // Load thumbnail
+                                    FileExtension = itemFileExtension,
+                                    ItemType = itemType,
+                                    Opacity = isHidden ? Constants.UI.DimItemOpacity : 1
+                                });
+                            }
+                            else if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
+                            {
+                                if (findData.cFileName != "." && findData.cFileName != "..")
+                                {
                                     results.Add(new ListedItem(null)
                                     {
-                                        PrimaryItemAttribute = StorageItemTypes.File,
+                                        PrimaryItemAttribute = StorageItemTypes.Folder,
                                         ItemName = findData.cFileName,
                                         ItemPath = itemPath,
                                         IsHiddenItem = true,
                                         LoadFileIcon = false,
-                                        LoadUnknownTypeGlyph = true,
-                                        LoadFolderGlyph = false,
-                                        ItemPropertiesInitialized = false, // Load thumbnail
-                                        FileExtension = itemFileExtension,
-                                        ItemType = itemType,
+                                        LoadUnknownTypeGlyph = false,
+                                        LoadFolderGlyph = true,
+                                        ItemPropertiesInitialized = true,
                                         Opacity = isHidden ? Constants.UI.DimItemOpacity : 1
                                     });
-                                }
-                                else if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
-                                {
-                                    if (findData.cFileName != "." && findData.cFileName != "..")
-                                    {
-                                        results.Add(new ListedItem(null)
-                                        {
-                                            PrimaryItemAttribute = StorageItemTypes.Folder,
-                                            ItemName = findData.cFileName,
-                                            ItemPath = itemPath,
-                                            IsHiddenItem = true,
-                                            LoadFileIcon = false,
-                                            LoadUnknownTypeGlyph = false,
-                                            LoadFolderGlyph = true,
-                                            ItemPropertiesInitialized = true,
-                                            Opacity = isHidden ? Constants.UI.DimItemOpacity : 1
-                                        });
-                                    }
                                 }
                             }
                         }

--- a/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -39,29 +39,28 @@ namespace Files.Filesystem.StorageEnumerators
 
             do
             {
-                if (((FileAttributes)findData.dwFileAttributes & FileAttributes.System) != FileAttributes.System || !App.AppSettings.AreSystemItemsHidden)
+                var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
+                var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
+                if (!isHidden || (App.AppSettings.AreHiddenItemsVisible && (!isSystem || !App.AppSettings.AreSystemItemsHidden)))
                 {
-                    if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) != FileAttributes.Hidden || App.AppSettings.AreHiddenItemsVisible)
+                    if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
                     {
-                        if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
+                        var file = await GetFile(findData, path, returnformat, connection, cancellationToken);
+                        if (file != null)
                         {
-                            var file = await GetFile(findData, path, returnformat, connection, cancellationToken);
-                            if (file != null)
-                            {
-                                tempList.Add(file);
-                                ++count;
-                            }
+                            tempList.Add(file);
+                            ++count;
                         }
-                        else if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
+                    }
+                    else if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
+                    {
+                        if (findData.cFileName != "." && findData.cFileName != "..")
                         {
-                            if (findData.cFileName != "." && findData.cFileName != "..")
+                            var folder = await GetFolder(findData, path, returnformat, cancellationToken);
+                            if (folder != null)
                             {
-                                var folder = await GetFolder(findData, path, returnformat, cancellationToken);
-                                if (folder != null)
-                                {
-                                    tempList.Add(folder);
-                                    ++count;
-                                }
+                                tempList.Add(folder);
+                                ++count;
                             }
                         }
                     }

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1761,7 +1761,7 @@ namespace Files.ViewModels
 
             var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
             var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
-            if ((isSystem && !AppSettings.AreSystemItemsHidden) || (isHidden && !AppSettings.AreHiddenItemsVisible))
+            if (isHidden && (!AppSettings.AreHiddenItemsVisible || (isSystem && AppSettings.AreSystemItemsHidden)))
             {
                 // Do not add to file list if hidden/system attribute is set and system/hidden file are not to be shown
                 return;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #1245

**Details of Changes**
Add details of changes here.
- Windows explorer does not hide file/folders which are only marked as "system", to be hidden an item must have the "hidden" attribute set. Currently items marked as system but not hidden (e.g Nextcloud folder) are not shown in Files which is not expected.

**Validation**
How did you test these changes?
- [x] Built and ran the app
