### PR TITLE
Fix issue where requested theme was not respected in settings dialog

### DIFF
--- a/Files/Dialogs/SettingsDialog.xaml
+++ b/Files/Dialogs/SettingsDialog.xaml
@@ -8,6 +8,7 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     Closing="ContentDialog_Closing"
     CornerRadius="{StaticResource OverlayCornerRadius}"
+    RequestedTheme="{x:Bind RootAppElement.RequestedTheme, Mode=OneWay}"
     Style="{StaticResource DefaultContentDialogStyle}"
     mc:Ignorable="d">
     <ContentDialog.Resources>

--- a/Files/Dialogs/SettingsDialog.xaml.cs
+++ b/Files/Dialogs/SettingsDialog.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Files.SettingsPages;
+﻿using Files.Helpers;
+using Files.SettingsPages;
 using Files.ViewModels;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -9,6 +10,9 @@ namespace Files.Dialogs
     public sealed partial class SettingsDialog : ContentDialog
     {
         public SettingsViewModel AppSettings => App.AppSettings;
+
+        // for some reason the requested theme wasn't being set on the content dialog, so this is used to manually bind to the requested app theme
+        FrameworkElement RootAppElement => Window.Current.Content as FrameworkElement;
 
         public SettingsDialog()
         {

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -186,7 +186,7 @@ namespace Files.Views
             if (invokedItemContainer.DataContext is MainPageViewModel)
             {
                 SettingsDialog settingsDialog = new SettingsDialog();
-                await settingsDialog.ShowAsync();
+                _ = await settingsDialog.ShowAsync();
 
                 return;
             }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5101

**Details of Changes**
Add details of changes here.
- Added oneway binding from the content dialog's ``RequestedTheme`` property to the window root element ``RequestedTheme`` property

I'm not sure why this content dialog in particular is affected and not other ones, however it may turn up again.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/59544401/120548548-55b7dd80-c3a7-11eb-8f8e-7ff3378a533d.png)
