### PR TITLE
Use correct quick access icon for non-Dev channel builds

### DIFF
--- a/Files/Constants.cs
+++ b/Files/Constants.cs
@@ -40,6 +40,12 @@
             public const int Folder = 3;
         }
 
+        public static class Shell32
+        {
+            // See shell32.dll for more icon indexes to add
+            public const int QuickAccess = 51380;
+        }
+
         public static class UI
         {
             public const float DimItemOpacity = 0.4f;

--- a/Files/DataModels/SidebarPinnedModel.cs
+++ b/Files/DataModels/SidebarPinnedModel.cs
@@ -308,7 +308,7 @@ namespace Files.DataModels
 
             if (IconResources is null)
             {
-                IconResources = await SidebarViewModel.LoadSidebarIconResources();
+                IconResources = (await SidebarViewModel.LoadSidebarIconResources()).ToList();
             }
 
             homeSection = new LocationItem()
@@ -326,7 +326,7 @@ namespace Files.DataModels
                 Text = "SidebarFavorites".GetLocalized(),
                 Section = SectionType.Favorites,
                 SelectsOnInvoked = false,
-                Icon = UIHelpers.GetImageForIconOrNull(IconResources?.FirstOrDefault(x => x.Index == Constants.ImageRes.QuickAccess).Image),
+                Icon = UIHelpers.GetImageForIconOrNull(IconResources?.FirstOrDefault(x => x.Index == Constants.Shell32.QuickAccess).Image),
                 Font = MainViewModel.FontName,
                 ChildItems = new ObservableCollection<INavigationControlItem>()
             };

--- a/Files/DataModels/SidebarPinnedModel.cs
+++ b/Files/DataModels/SidebarPinnedModel.cs
@@ -308,7 +308,7 @@ namespace Files.DataModels
 
             if (IconResources is null)
             {
-                IconResources = (await SidebarViewModel.LoadSidebarIconResources()).ToList();
+                IconResources = (await SidebarViewModel.LoadSidebarIconResources())?.ToList();
             }
 
             homeSection = new LocationItem()

--- a/Files/ViewModels/SidebarViewModel.cs
+++ b/Files/ViewModels/SidebarViewModel.cs
@@ -20,11 +20,10 @@ namespace Files.ViewModels
 {
     public class SidebarViewModel : ObservableObject, IDisposable
     {
-        public static async System.Threading.Tasks.Task<IList<IconFileInfo>> LoadSidebarIconResources()
+        public static async System.Threading.Tasks.Task<IEnumerable<IconFileInfo>> LoadSidebarIconResources()
         {
             const string imageres = @"C:\Windows\System32\imageres.dll";
-            return await UIHelpers.LoadSelectedIconsAsync(imageres, new List<int>() {
-                    Constants.ImageRes.QuickAccess,
+            var imageResList = await UIHelpers.LoadSelectedIconsAsync(imageres, new List<int>() {
                     Constants.ImageRes.RecycleBin,
                     Constants.ImageRes.NetworkDrives,
                     Constants.ImageRes.Libraries,
@@ -32,6 +31,28 @@ namespace Files.ViewModels
                     Constants.ImageRes.CloudDrives,
                     Constants.ImageRes.Folder
                 }, 32, false);
+
+            const string shell32 = @"C:\Windows\System32\shell32.dll";
+            var shell32List = await UIHelpers.LoadSelectedIconsAsync(shell32, new List<int>() {
+                    Constants.Shell32.QuickAccess
+                }, 32, false);
+
+            if (shell32List != null && imageResList != null)
+            {
+                return imageResList.Concat(shell32List);
+            }
+            else if (shell32List != null && imageResList == null)
+            {
+                return shell32List;
+            }
+            else if (shell32List == null && imageResList != null)
+            {
+                return imageResList;
+            }
+            else
+            {
+                return null;
+            }
         }
 
         public ICommand EmptyRecycleBinCommand { get; private set; }


### PR DESCRIPTION
- Supports extraction from shell32.dll
(Testing required)