### PR TITLE
Fix binding error in details layout

### DIFF
--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -598,7 +598,7 @@
                                 <Grid
                                     x:Name="ItemStatusGrid"
                                     Grid.Column="4"
-                                    Width="{Binding ColumnsViewModel.StatusColumn.Length, ElementName=PageRoot, Mode=OneWay}"
+                                    Width="{Binding ColumnsViewModel.StatusColumn.Length.Value, ElementName=PageRoot, Mode=OneWay}"
                                     Padding="12,0,0,0"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes invalid cast ``GridLength`` to ``double`` binding error in details layout

**Details of Changes**
Add details of changes here.
- Bind to ``StatusColumn.Length.Value`` instead of ``StatusColumn.Length``

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
