### PR TITLE
feat: Switch GridViewBrowser to use StyleSelector

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -717,9 +717,13 @@ namespace Files
             deferral.Complete();
         }
 
-        protected void InitializeDrag(UIElement element)
+        protected void InitializeDrag(UIElement element, ListedItem item = null)
         {
-            ListedItem item = GetItemFromElement(element);
+            if (item == null)
+            {
+                item = GetItemFromElement(element);
+            }
+
             if (item != null)
             {
                 element.AllowDrop = false;

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -15,8 +15,8 @@
     xmlns:local3="using:Files.Filesystem.Cloud"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:tui="using:Microsoft.Toolkit.Uwp.UI"
-    x:Name="PageRoot"
+    xmlns:tui="using:Microsoft.Toolkit.Uwp.UI" xmlns:layoutmodes="using:Files.Views.LayoutModes"
+	x:Name="PageRoot"
     NavigationCacheMode="Enabled"
     mc:Ignorable="d">
     <i:Interaction.Behaviors>
@@ -27,8 +27,8 @@
             <icore:InvokeCommandAction Command="{x:Bind CommandsViewModel.ItemPointerPressedCommand}" />
         </icore:EventTriggerBehavior>
     </i:Interaction.Behaviors>
-    <local:BaseLayout.Resources>
-        <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
+	<local:BaseLayout.Resources>
+		<converters:BoolNegationConverter x:Key="BoolNegationConverter" />
         <converters:BoolToVisibilityConverter
             x:Key="NegatedBoolToVisibilityConverter"
             FalseValue="Visible"
@@ -320,22 +320,22 @@
             </Grid>
         </DataTemplate>
 
-        <Style TargetType="GridViewHeaderItem">
-            <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
-            <Setter Property="FontSize" Value="{ThemeResource GridViewHeaderItemThemeFontSize}" />
-            <Setter Property="Background" Value="{ThemeResource GridViewHeaderItemBackground}" />
-            <Setter Property="Margin" Value="0,0,0,4" />
-            <Setter Property="Padding" Value="12,8,12,0" />
-            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-            <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
-            <Setter Property="VerticalContentAlignment" Value="Stretch" />
-            <Setter Property="MinHeight" Value="{ThemeResource GridViewHeaderItemMinHeight}" />
-            <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="GridViewHeaderItem">
-                        <Grid
+		<Style TargetType="GridViewHeaderItem">
+			<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+			<Setter Property="FontSize" Value="{ThemeResource GridViewHeaderItemThemeFontSize}" />
+			<Setter Property="Background" Value="{ThemeResource GridViewHeaderItemBackground}" />
+			<Setter Property="Margin" Value="0,0,0,4" />
+			<Setter Property="Padding" Value="12,8,12,0" />
+			<Setter Property="HorizontalContentAlignment" Value="Stretch" />
+			<Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+			<Setter Property="VerticalContentAlignment" Value="Stretch" />
+			<Setter Property="MinHeight" Value="{ThemeResource GridViewHeaderItemMinHeight}" />
+			<Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+			<Setter Property="HorizontalAlignment" Value="Stretch" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="GridViewHeaderItem">
+						<Grid
                             x:Name="HeaderItemRootGrid"
                             Margin="0,0,4,0"
                             HorizontalAlignment="Stretch"
@@ -348,11 +348,11 @@
                             PointerExited="StackPanel_PointerCanceled"
                             PointerPressed="RootPanel_PointerPressed"
                             PointerReleased="StackPanel_PointerCanceled">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <ContentPresenter
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
+							<ContentPresenter
                                 x:Name="ContentPresenter"
                                 Grid.Column="0"
                                 Margin="{TemplateBinding Padding}"
@@ -361,7 +361,7 @@
                                 Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                 ContentTransitions="{TemplateBinding ContentTransitions}" />
-                            <Rectangle
+							<Rectangle
                                 Grid.Column="1"
                                 Height="1"
                                 HorizontalAlignment="Stretch"
@@ -370,46 +370,46 @@
                                 StrokeThickness="0.5" />
 
 
-                            <VisualStateManager.VisualStateGroups>
-                                <VisualStateGroup x:Name="CommonStates">
-                                    <VisualState x:Name="Normal" />
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
 
-                                    <VisualState x:Name="PointerOver">
-                                        <Storyboard>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderItemRootGrid" Storyboard.TargetProperty="Background">
-                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPointerOver}" />
-                                            </ObjectAnimationUsingKeyFrames>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderItemRootGrid" Storyboard.TargetProperty="BorderBrush">
-                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushPointerOver}" />
-                                            </ObjectAnimationUsingKeyFrames>
-                                        </Storyboard>
-                                        <VisualState.Setters>
-                                            <!--<Setter Target="ContentPresenter.(local:AnimatedIcon.State)" Value="PointerOver" />-->
-                                        </VisualState.Setters>
-                                    </VisualState>
+									<VisualState x:Name="PointerOver">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderItemRootGrid" Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPointerOver}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderItemRootGrid" Storyboard.TargetProperty="BorderBrush">
+												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushPointerOver}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+										<VisualState.Setters>
+											<!--<Setter Target="ContentPresenter.(local:AnimatedIcon.State)" Value="PointerOver" />-->
+										</VisualState.Setters>
+									</VisualState>
 
-                                    <VisualState x:Name="Pressed">
-                                        <Storyboard>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderItemRootGrid" Storyboard.TargetProperty="Background">
-                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPressed}" />
-                                            </ObjectAnimationUsingKeyFrames>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderItemRootGrid" Storyboard.TargetProperty="BorderBrush">
-                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushPressed}" />
-                                            </ObjectAnimationUsingKeyFrames>
-                                        </Storyboard>
-                                        <VisualState.Setters>
-                                            <!--<Setter Target="ContentPresenter.(local:AnimatedIcon.State)" Value="Pressed" />-->
-                                        </VisualState.Setters>
-                                    </VisualState>
-                                </VisualStateGroup>
-                            </VisualStateManager.VisualStateGroups>
-                        </Grid>
+									<VisualState x:Name="Pressed">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderItemRootGrid" Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPressed}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderItemRootGrid" Storyboard.TargetProperty="BorderBrush">
+												<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushPressed}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+										<VisualState.Setters>
+											<!--<Setter Target="ContentPresenter.(local:AnimatedIcon.State)" Value="Pressed" />-->
+										</VisualState.Setters>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+						</Grid>
 
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-    </local:BaseLayout.Resources>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</local:BaseLayout.Resources>
 
     <Grid
         x:Name="RootGrid"
@@ -586,12 +586,16 @@
                                 Content="Search unindexed items." />
                         </StackPanel>
                     </GridView.Footer>
-                    <GridView.ItemContainerStyle>
-                        <Style BasedOn="{StaticResource DefaultGridViewItemStyle}" TargetType="GridViewItem">
-                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                            <Setter Property="HorizontalAlignment" Value="Stretch" />
-                        </Style>
-                    </GridView.ItemContainerStyle>
+                    <GridView.ItemContainerStyleSelector>
+						<layoutmodes:GridViewStyleSelector LoadExtendedPropertiesCommand="{x:Bind LoadExtendedPropsCommand}" ThumbnailSize="{x:Bind CurrentIconSize, Mode=OneWay}">
+							<layoutmodes:GridViewStyleSelector.ContainerStyle>
+								<Style BasedOn="{StaticResource DefaultGridViewItemStyle}" TargetType="GridViewItem">
+									<Setter Property="HorizontalContentAlignment" Value="Stretch" />
+									<Setter Property="HorizontalAlignment" Value="Stretch" />
+								</Style>
+							</layoutmodes:GridViewStyleSelector.ContainerStyle>
+						</layoutmodes:GridViewStyleSelector>
+					</GridView.ItemContainerStyleSelector>
                 </GridView>
             </SemanticZoom.ZoomedInView>
 


### PR DESCRIPTION
I think we are somewhat misusing the ChoosingItemContainer event

We almost always do a `GridViewItem item = new GridViewItem();` inside that handler, when it should be done by the control itself and it defeats the purpose of virtualization unless we stored the containers needed like the [example](https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/optimize-gridview-and-listview#:~:text=%20Container%20caching%20is%20something%20that%20can%20be,number%20of%20elements%20cached%20and%20available%20for%20recycling.) suggests. The problem is we rely on that event to setup drag and drop and other events subscribed when an item is scrolled into view.

Instead of doing this, (because the benefits are nonexistent for our scenario) I changed GridViewBrowser only [for now] to only subscribe to the events without having to manually create a new ItemContainer each time. I basically use another type of feature called StyleSelector so we don't have to intercept the process of creating the item container. 

**I am still investigating whether this change actually reduces memory usage and if it allows events for item drag and drop to continue working. Code is not final, but your testing would be great here.**