### PR TITLE
Add necessary UIA name binding for datagrid header control

### DIFF
--- a/Files/UserControls/DataGridHeader.xaml
+++ b/Files/UserControls/DataGridHeader.xaml
@@ -32,6 +32,7 @@
             Command="{x:Bind Command}"
             CommandParameter="{x:Bind CommandParameter}"
             IsEnabled="{x:Bind CanBeSorted, Mode=OneWay}"
+            AutomationProperties.Name="{x:Bind Header, Mode=OneWay}"
             Style="{StaticResource HeaderButtonStyle}">
             <Grid>
                 <Grid.ColumnDefinitions>


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5078

**Details of Changes**
Add details of changes here.
- Added missing binding for AutomationProperties.Name property on button inside datagrid header control

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
