### PR TITLE
Fix issue where hamburger button could overlay tabs

### DIFF
--- a/Files/ViewModels/SidebarViewModel.cs
+++ b/Files/ViewModels/SidebarViewModel.cs
@@ -200,7 +200,7 @@ namespace Files.ViewModels
         }
 
 
-        private void UpdateTabControlMargin()
+        public void UpdateTabControlMargin()
         {
             TabControlMargin = SidebarDisplayMode switch
             {

--- a/Files/Views/MainPage.xaml
+++ b/Files/Views/MainPage.xaml
@@ -207,6 +207,7 @@
         DisplayModeChanged="{x:Bind SidebarAdaptiveViewModel.SidebarControl_DisplayModeChanged}"
         EmptyRecycleBinCommand="{x:Bind SidebarAdaptiveViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
         IsPaneOpen="{x:Bind SidebarAdaptiveViewModel.IsSidebarOpen, Mode=TwoWay}"
+        Loaded="SidebarControl_Loaded"
         SelectedSidebarItem="{x:Bind SidebarAdaptiveViewModel.SidebarSelectedItem, Mode=TwoWay}">
         <Grid>
             <Grid.RowDefinitions>

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -278,5 +278,10 @@ namespace Files.Views
 
             e.Handled = true;
         }
+
+        private void SidebarControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            SidebarAdaptiveViewModel.UpdateTabControlMargin(); // Set the correct tab margin on startup
+        }
     }
 }


### PR DESCRIPTION

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fix issue where hamburger button would overlay tabs when window was opened with the sidebar in minimal mode

**Details of Changes**
Add details of changes here.
- Check pane display mode when sidebar is loaded and update tab margin accordingly

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before:
![image](https://user-images.githubusercontent.com/59544401/121817064-f756ee80-cc33-11eb-9e96-07dc76b84199.png)

After:
![image](https://user-images.githubusercontent.com/59544401/121817074-0473dd80-cc34-11eb-8b86-3a86ee0bd451.png)
