### PR TITLE
Always use Windows.Storage to load thumbnails

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -399,7 +399,7 @@ namespace FilesFullTrust
                 case "GetIconOverlay":
                     var fileIconPath = (string)message["filePath"];
                     var thumbnailSize = (int)(long)message["thumbnailSize"];
-                    var isOverlayOnly = Convert.ToBoolean(message["isOverlayOnly"]);
+                    var isOverlayOnly = (bool)message["isOverlayOnly"];
                     var iconOverlay = Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(fileIconPath, thumbnailSize, true, isOverlayOnly)).Result;
                     await Win32API.SendMessageAsync(connection, new ValueSet()
                     {

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -399,7 +399,8 @@ namespace FilesFullTrust
                 case "GetIconOverlay":
                     var fileIconPath = (string)message["filePath"];
                     var thumbnailSize = (int)(long)message["thumbnailSize"];
-                    var iconOverlay = Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(fileIconPath, thumbnailSize)).Result;
+                    var isOverlayOnly = Convert.ToBoolean(message["isOverlayOnly"]);
+                    var iconOverlay = Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(fileIconPath, thumbnailSize, true, isOverlayOnly)).Result;
                     await Win32API.SendMessageAsync(connection, new ValueSet()
                     {
                         { "Icon", iconOverlay.icon },

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -404,8 +404,7 @@ namespace FilesFullTrust
                     await Win32API.SendMessageAsync(connection, new ValueSet()
                     {
                         { "Icon", iconOverlay.icon },
-                        { "Overlay", iconOverlay.overlay },
-                        { "HasCustomIcon", iconOverlay.isCustom }
+                        { "Overlay", iconOverlay.overlay }
                     }, message.Get("RequestID", (string)null));
                     break;
 

--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -102,26 +102,28 @@ namespace FilesFullTrust
             }
         }
 
-        public static (string icon, string overlay, bool isCustom) GetFileIconAndOverlay(string path, int thumbnailSize, bool getOverlay = true)
+        public static (string icon, string overlay, bool isCustom) GetFileIconAndOverlay(string path, int thumbnailSize, bool getOverlay = true, bool onlyGetOverlay = false)
         {
             string iconStr = null, overlayStr = null;
-
-            using var shellItem = new Vanara.Windows.Shell.ShellItem(path);
-            if (shellItem.IShellItem is Shell32.IShellItemImageFactory fctry)
+            if (!onlyGetOverlay)
             {
-                var flags = Shell32.SIIGBF.SIIGBF_BIGGERSIZEOK;
-                if (thumbnailSize < 80) flags |= Shell32.SIIGBF.SIIGBF_ICONONLY;
-                var hres = fctry.GetImage(new SIZE(thumbnailSize, thumbnailSize), flags, out var hbitmap);
-                if (hres == HRESULT.S_OK)
+                using var shellItem = new Vanara.Windows.Shell.ShellItem(path);
+                if (shellItem.IShellItem is Shell32.IShellItemImageFactory fctry)
                 {
-                    using var image = GetBitmapFromHBitmap(hbitmap);
-                    if (image != null)
+                    var flags = Shell32.SIIGBF.SIIGBF_BIGGERSIZEOK;
+                    if (thumbnailSize < 80) flags |= Shell32.SIIGBF.SIIGBF_ICONONLY;
+                    var hres = fctry.GetImage(new SIZE(thumbnailSize, thumbnailSize), flags, out var hbitmap);
+                    if (hres == HRESULT.S_OK)
                     {
-                        byte[] bitmapData = (byte[])new ImageConverter().ConvertTo(image, typeof(byte[]));
-                        iconStr = Convert.ToBase64String(bitmapData, 0, bitmapData.Length);
+                        using var image = GetBitmapFromHBitmap(hbitmap);
+                        if (image != null)
+                        {
+                            byte[] bitmapData = (byte[])new ImageConverter().ConvertTo(image, typeof(byte[]));
+                            iconStr = Convert.ToBase64String(bitmapData, 0, bitmapData.Length);
+                        }
                     }
+                    //Marshal.ReleaseComObject(fctry);
                 }
-                //Marshal.ReleaseComObject(fctry);
             }
 
             if (getOverlay)

--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -102,10 +102,9 @@ namespace FilesFullTrust
             }
         }
 
-        public static (string icon, string overlay, bool isCustom) GetFileIconAndOverlay(string path, int thumbnailSize, bool getOverlay = true, bool onlyGetOverlay = false)
+        public static (string icon, string overlay) GetFileIconAndOverlay(string path, int thumbnailSize, bool getOverlay = true, bool onlyGetOverlay = false)
         {
             string iconStr = null, overlayStr = null;
-            bool isCustom = true;
 
             if (!onlyGetOverlay)
             {
@@ -139,7 +138,7 @@ namespace FilesFullTrust
                     Shell32.SHGFI.SHGFI_OVERLAYINDEX | Shell32.SHGFI.SHGFI_ICON | Shell32.SHGFI.SHGFI_SYSICONINDEX | Shell32.SHGFI.SHGFI_ICONLOCATION);
                 if (ret == IntPtr.Zero)
                 {
-                    return (iconStr, null, isCustom);
+                    return (iconStr, null);
                 }
 
                 User32.DestroyIcon(shfi.hIcon);
@@ -147,7 +146,7 @@ namespace FilesFullTrust
                 using var imageList = ComCtl32.SafeHIMAGELIST.FromIImageList(tmp);
                 if (imageList.IsNull || imageList.IsInvalid)
                 {
-                    return (iconStr, null, isCustom);
+                    return (iconStr, null);
                 }
 
                 var overlayIdx = shfi.iIcon >> 24;
@@ -163,13 +162,12 @@ namespace FilesFullTrust
                     }
                 }
 
-                return (iconStr, overlayStr, isCustom);
+                return (iconStr, overlayStr);
             }
             else
             {
-                return (iconStr, null, isCustom);
+                return (iconStr, null);
             }
-
         }
 
         public static bool RunPowershellCommand(string command, bool runAsAdmin)

--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -105,6 +105,8 @@ namespace FilesFullTrust
         public static (string icon, string overlay, bool isCustom) GetFileIconAndOverlay(string path, int thumbnailSize, bool getOverlay = true, bool onlyGetOverlay = false)
         {
             string iconStr = null, overlayStr = null;
+            bool isCustom = true;
+
             if (!onlyGetOverlay)
             {
                 using var shellItem = new Vanara.Windows.Shell.ShellItem(path);
@@ -137,10 +139,9 @@ namespace FilesFullTrust
                     Shell32.SHGFI.SHGFI_OVERLAYINDEX | Shell32.SHGFI.SHGFI_ICON | Shell32.SHGFI.SHGFI_SYSICONINDEX | Shell32.SHGFI.SHGFI_ICONLOCATION);
                 if (ret == IntPtr.Zero)
                 {
-                    return (iconStr, null, false);
+                    return (iconStr, null, isCustom);
                 }
 
-                bool isCustom = true;
                 User32.DestroyIcon(shfi.hIcon);
                 Shell32.SHGetImageList(Shell32.SHIL.SHIL_LARGE, typeof(ComCtl32.IImageList).GUID, out var tmp);
                 using var imageList = ComCtl32.SafeHIMAGELIST.FromIImageList(tmp);
@@ -166,7 +167,7 @@ namespace FilesFullTrust
             }
             else
             {
-                return (iconStr, null, false);
+                return (iconStr, null, isCustom);
             }
 
         }

--- a/Files/DataModels/SidebarPinnedModel.cs
+++ b/Files/DataModels/SidebarPinnedModel.cs
@@ -260,7 +260,7 @@ namespace Files.DataModels
 
                 if (res)
                 {
-                    var thumbnail = await res.Result.GetThumbnailAsync(
+                    using var thumbnail = await res.Result.GetThumbnailAsync(
                         Windows.Storage.FileProperties.ThumbnailMode.ListView,
                         24,
                         Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);

--- a/Files/Extensions/ImageSourceExtensions.cs
+++ b/Files/Extensions/ImageSourceExtensions.cs
@@ -8,6 +8,10 @@ namespace Files.Extensions
     {
         internal static async Task<byte[]> ToByteArrayAsync(this IInputStream stream)
         {
+            if (stream == null)
+            {
+                return null;
+            }
             var readStream = stream.AsStreamForRead();
             var byteArray = new byte[readStream.Length];
             await readStream.ReadAsync(byteArray, 0, byteArray.Length);

--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -211,7 +211,7 @@ namespace Files.Filesystem
                 type = DriveType.Removable;
             }
 
-            var thumbnail = await root.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale);
+            using var thumbnail = await root.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale);
             lock (drivesList)
             {
                 // If drive already in list, skip.
@@ -254,8 +254,6 @@ namespace Files.Filesystem
 
             foreach (var drive in drives)
             {
-                StorageItemThumbnail thumbnail;
-
                 var res = await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(drive.Name).AsTask());
                 if (res == FileSystemStatusCode.Unauthorized)
                 {
@@ -268,10 +266,8 @@ namespace Files.Filesystem
                     Logger.Warn($"{res.ErrorCode}: Attempting to add the device, {drive.Name}, failed at the StorageFolder initialization step. This device will be ignored.");
                     continue;
                 }
-                else
-                {
-                    thumbnail = await res.Result.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale);
-                }
+
+                using var thumbnail = await res.Result.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale);
 
                 lock (drivesList)
                 {
@@ -404,8 +400,6 @@ namespace Files.Filesystem
                         return;
                     }
 
-                    var thumbnail = await rootAdded.Result.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale);
-
                     lock (drivesList)
                     {
                         // If drive already in list, skip.
@@ -419,14 +413,18 @@ namespace Files.Filesystem
                         }
                     }
 
-                    var type = GetDriveType(driveAdded);
-                    var driveItem = await DriveItem.CreateFromPropertiesAsync(rootAdded, deviceId, type, thumbnail);
-
-                    lock (drivesList)
+                    using (var thumbnail = await rootAdded.Result.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale))
                     {
-                        Logger.Info($"Drive added from fulltrust process: {driveItem.Path}, {driveItem.Type}");
-                        drivesList.Add(driveItem);
+                        var type = GetDriveType(driveAdded);
+                        var driveItem = await DriveItem.CreateFromPropertiesAsync(rootAdded, deviceId, type, thumbnail);
+
+                        lock (drivesList)
+                        {
+                            Logger.Info($"Drive added from fulltrust process: {driveItem.Path}, {driveItem.Type}");
+                            drivesList.Add(driveItem);
+                        }
                     }
+
                     DeviceWatcher_EnumerationCompleted(null, null);
                     break;
 

--- a/Files/Filesystem/Search/FolderSearch.cs
+++ b/Files/Filesystem/Search/FolderSearch.cs
@@ -208,7 +208,7 @@ namespace Files.Filesystem.Search
             {
                 var file = (StorageFile)item;
                 var bitmapIcon = new BitmapImage();
-                var thumbnail = await file.GetThumbnailAsync(ThumbnailMode.ListView, ThumbnailSize, ThumbnailOptions.UseCurrentScale);
+                using var thumbnail = await file.GetThumbnailAsync(ThumbnailMode.ListView, ThumbnailSize, ThumbnailOptions.UseCurrentScale);
 
                 string itemFileExtension = null;
                 string itemType = null;

--- a/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
@@ -198,7 +198,7 @@ namespace Files.Filesystem.StorageEnumerators
             {
                 try
                 {
-                    var itemThumbnailImg = suppressThumbnailLoading ? null :
+                    using var itemThumbnailImg = suppressThumbnailLoading ? null :
                         await file.GetThumbnailAsync(ThumbnailMode.ListView, 40, ThumbnailOptions.UseCurrentScale);
                     if (itemThumbnailImg != null)
                     {
@@ -226,7 +226,7 @@ namespace Files.Filesystem.StorageEnumerators
             {
                 try
                 {
-                    var itemThumbnailImg = suppressThumbnailLoading ? null :
+                    using var itemThumbnailImg = suppressThumbnailLoading ? null :
                         await file.GetThumbnailAsync(ThumbnailMode.ListView, 80, ThumbnailOptions.UseCurrentScale);
                     if (itemThumbnailImg != null)
                     {

--- a/Files/Helpers/ExternalResourcesHelper.cs
+++ b/Files/Helpers/ExternalResourcesHelper.cs
@@ -37,12 +37,10 @@ namespace Files.Helpers
             {
                 // ToDo this is for backwards compatability, remove after a couple updates
                 var themeFolder = await StorageFolder.GetFolderFromPathAsync(ApplicationData.Current.LocalFolder.Path + "\\Themes");
-
                 await themeFolder.RenameAsync("Skins", NameCollisionOption.FailIfExists);
             }
             catch (Exception)
             {
-
             }
 
             SkinFolder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("Skins", CreationCollisionOption.OpenIfExists);

--- a/Files/Helpers/FileThumbnailHelper.cs
+++ b/Files/Helpers/FileThumbnailHelper.cs
@@ -17,7 +17,8 @@ namespace Files.Helpers
                 {
                     { "Arguments", "GetIconOverlay" },
                     { "filePath", filePath },
-                    { "thumbnailSize", (int)thumbnailSize }
+                    { "thumbnailSize", (int)thumbnailSize },
+                    { "isOverlayOnly", false }
                 };
                 var (status, response) = await connection.SendMessageForResponseAsync(value);
                 if (status == AppServiceResponseStatus.Success)

--- a/Files/Helpers/FileThumbnailHelper.cs
+++ b/Files/Helpers/FileThumbnailHelper.cs
@@ -1,17 +1,14 @@
 ﻿using Files.Common;
-using Microsoft.Toolkit.Uwp;
 using System;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.AppService;
-using Windows.ApplicationModel.Core;
 using Windows.Foundation.Collections;
-using Windows.UI.Xaml.Media.Imaging;
 
 namespace Files.Helpers
 {
     public static class FileThumbnailHelper
     {
-        public static async Task<(byte[] IconData, byte[] OverlayData, bool IsCustom)> LoadIconAndOverlayAsync(string filePath, uint thumbnailSize)
+        public static async Task<(byte[] IconData, byte[] OverlayData)> LoadIconAndOverlayAsync(string filePath, uint thumbnailSize)
         {
             var connection = await AppServiceConnectionHelper.Instance;
             if (connection != null)
@@ -25,18 +22,16 @@ namespace Files.Helpers
                 var (status, response) = await connection.SendMessageForResponseAsync(value);
                 if (status == AppServiceResponseStatus.Success)
                 {
-                    var hasCustomIcon = response.Get("HasCustomIcon", false);
                     var icon = response.Get("Icon", (string)null);
                     var overlay = response.Get("Overlay", (string)null);
 
                     // BitmapImage can only be created on UI thread, so return raw data and create
                     // BitmapImage later to prevent exceptions once SynchorizationContext lost
                     return (icon == null ? null : Convert.FromBase64String(icon),
-                        overlay == null ? null : Convert.FromBase64String(overlay),
-                        hasCustomIcon);
+                        overlay == null ? null : Convert.FromBase64String(overlay));
                 }
             }
-            return (null, null, false);
+            return (null, null);
         }
 
         public static async Task<byte[]> LoadOverlayAsync(string filePath)

--- a/Files/Helpers/RegistryHelper.cs
+++ b/Files/Helpers/RegistryHelper.cs
@@ -115,6 +115,8 @@ namespace Files.Helpers
                 Data = data
             };
 
+            thumbnail?.Result?.Dispose();
+
             return entry;
         }
 

--- a/Files/UserControls/Widgets/FolderWidget.xaml.cs
+++ b/Files/UserControls/Widgets/FolderWidget.xaml.cs
@@ -253,13 +253,19 @@ namespace Files.UserControls.Widgets
             }
             else
             {
-                StorageFolder folder = await StorageFolder.GetFolderFromPathAsync(item.Path);
-                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
+                StorageFolder folder = await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(item.Path).AsTask());
+                if (folder != null)
                 {
-                    item.Icon = new BitmapImage();
-                    Windows.Storage.FileProperties.StorageItemThumbnail thumbnail = await folder.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.ListView, 48, Windows.Storage.FileProperties.ThumbnailOptions.ReturnOnlyIfCached);
-                    await item.Icon.SetSourceAsync(thumbnail);
-                });
+                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
+                    {
+                        item.Icon = new BitmapImage();
+                        using var thumbnail = await folder.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.ListView, 48, Windows.Storage.FileProperties.ThumbnailOptions.ReturnOnlyIfCached);
+                        if (thumbnail != null)
+                        {
+                            await item.Icon.SetSourceAsync(thumbnail);
+                        }
+                    });
+                }
             }
         }
     }

--- a/Files/UserControls/Widgets/FolderWidget.xaml.cs
+++ b/Files/UserControls/Widgets/FolderWidget.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Files.Filesystem;
+﻿using Files.Extensions;
+using Files.Filesystem;
 using Files.Helpers;
 using Files.ViewModels;
 using Files.ViewModels.Widgets;
@@ -8,6 +9,7 @@ using Microsoft.Toolkit.Uwp;
 using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -152,7 +154,7 @@ namespace Files.UserControls.Widgets
             ItemsAdded.Add(new LibraryCardItem
             {
                 Text = "SidebarDesktop".GetLocalized(),
-                Path = UserDataPaths.GetDefault().Desktop,
+                Path = UserDataPaths.GetDefault().Desktop
             });
             ItemsAdded.Add(new LibraryCardItem
             {
@@ -179,9 +181,10 @@ namespace Files.UserControls.Widgets
                 Text = "SidebarVideos".GetLocalized(),
                 Path = UserDataPaths.GetDefault().Videos,
             });
-            await GetItemsAddedIcon();
-            ItemsAdded.EndBulkOperation();
 
+            await GetItemsAddedIcon();
+
+            ItemsAdded.EndBulkOperation();
             Loaded -= FolderWidget_Loaded;
         }
 
@@ -243,10 +246,20 @@ namespace Files.UserControls.Widgets
 
         private async Task LoadLibraryIcon(LibraryCardItem item)
         {
-            var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(item.Path, 48u);
+            byte[] iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(item.Path, 48u);
             if (iconData != null)
             {
                 item.Icon = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => iconData.ToBitmapAsync());
+            }
+            else
+            {
+                StorageFolder folder = await StorageFolder.GetFolderFromPathAsync(item.Path);
+                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
+                {
+                    item.Icon = new BitmapImage();
+                    Windows.Storage.FileProperties.StorageItemThumbnail thumbnail = await folder.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.ListView, 48, Windows.Storage.FileProperties.ThumbnailOptions.ReturnOnlyIfCached);
+                    await item.Icon.SetSourceAsync(thumbnail);
+                });
             }
         }
     }

--- a/Files/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -135,7 +135,7 @@ namespace Files.UserControls.Widgets
                 ItemType = StorageItemTypes.File;
                 ItemImage = new BitmapImage();
                 StorageFile file = (StorageFile)item;
-                var thumbnail = await file.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.ListView, 24, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale);
+                using var thumbnail = await file.GetThumbnailAsync(Windows.Storage.FileProperties.ThumbnailMode.ListView, 24, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale);
                 if (thumbnail == null)
                 {
                     ItemEmptyImgVis = true;

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -748,38 +748,15 @@ namespace Files.ViewModels
                                         item.LoadWebShortcutGlyph = false;
                                         item.LoadFileIcon = true;
                                     }, Windows.System.DispatcherQueuePriority.Low);
-
-                                    var overlayInfo = await FileThumbnailHelper.LoadOverlayAsync(item.ItemPath);
-                                    if (overlayInfo != null)
-                                    {
-                                        await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                                        {
-                                            item.IconOverlay = await overlayInfo.ToBitmapAsync();
-                                        }, Windows.System.DispatcherQueuePriority.Low);
-                                    }
                                 }
-                                else
-                                {
-                                    var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize);
-                                    if (iconInfo.IconData != null)
-                                    {
-                                        await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                                        {
-                                            item.FileImage = await iconInfo.IconData.ToBitmapAsync();
-                                            item.CustomIconData = iconInfo.IconData;
-                                            item.LoadFileIcon = true;
-                                            item.LoadUnknownTypeGlyph = false;
-                                            item.LoadWebShortcutGlyph = false;
-                                        }, Windows.System.DispatcherQueuePriority.Low);
-                                    }
 
-                                    if (iconInfo.OverlayData != null)
+                                var overlayInfo = await FileThumbnailHelper.LoadOverlayAsync(item.ItemPath);
+                                if (overlayInfo != null)
+                                {
+                                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
                                     {
-                                        await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                                        {
-                                            item.IconOverlay = await iconInfo.OverlayData.ToBitmapAsync();
-                                        }, Windows.System.DispatcherQueuePriority.Low);
-                                    }
+                                        item.IconOverlay = await overlayInfo.ToBitmapAsync();
+                                    }, Windows.System.DispatcherQueuePriority.Low);
                                 }
 
                                 var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageFile);
@@ -791,28 +768,28 @@ namespace Files.ViewModels
                                 }, Windows.System.DispatcherQueuePriority.Low);
                                 wasSyncStatusLoaded = true;
                             }
-                            else
+                        }
+                        if (!item.LoadFileIcon)
+                        {
+                            var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize);
+                            if (iconInfo.IconData != null)
                             {
-                                var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize);
-                                if (iconInfo.IconData != null)
+                                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
                                 {
-                                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                                    {
-                                        item.FileImage = await iconInfo.IconData.ToBitmapAsync();
-                                        item.CustomIconData = iconInfo.IconData;
-                                        item.LoadFileIcon = true;
-                                        item.LoadUnknownTypeGlyph = false;
-                                        item.LoadWebShortcutGlyph = false;
-                                    }, Windows.System.DispatcherQueuePriority.Low);
-                                }
+                                    item.FileImage = await iconInfo.IconData.ToBitmapAsync();
+                                    item.CustomIconData = iconInfo.IconData;
+                                    item.LoadFileIcon = true;
+                                    item.LoadUnknownTypeGlyph = false;
+                                    item.LoadWebShortcutGlyph = false;
+                                }, Windows.System.DispatcherQueuePriority.Low);
+                            }
 
-                                if (iconInfo.OverlayData != null)
+                            if (iconInfo.OverlayData != null)
+                            {
+                                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
                                 {
-                                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                                    {
-                                        item.IconOverlay = await iconInfo.OverlayData.ToBitmapAsync();
-                                    }, Windows.System.DispatcherQueuePriority.Low);
-                                }
+                                    item.IconOverlay = await iconInfo.OverlayData.ToBitmapAsync();
+                                }, Windows.System.DispatcherQueuePriority.Low);
                             }
                         }
                     }
@@ -823,15 +800,6 @@ namespace Files.ViewModels
                             StorageFolder matchingStorageItem = await GetFolderFromPathAsync(item.ItemPath);
                             if (matchingStorageItem != null)
                             {
-                                var overlayInfo = await FileThumbnailHelper.LoadOverlayAsync(item.ItemPath);
-                                if (overlayInfo != null)
-                                {
-                                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                                    {
-                                        item.IconOverlay = await overlayInfo.ToBitmapAsync();
-                                    }, Windows.System.DispatcherQueuePriority.Low);
-                                }
-
                                 using var Thumbnail = await matchingStorageItem.GetThumbnailAsync(ThumbnailMode.ListView, thumbnailSize, ThumbnailOptions.ReturnOnlyIfCached);
                                 if (!(Thumbnail == null || Thumbnail.Size == 0 || Thumbnail.OriginalHeight == 0 || Thumbnail.OriginalWidth == 0))
                                 {
@@ -843,6 +811,15 @@ namespace Files.ViewModels
                                         item.LoadWebShortcutGlyph = false;
                                         item.LoadFolderGlyph = false;
                                         item.LoadFileIcon = true;
+                                    }, Windows.System.DispatcherQueuePriority.Low);
+                                }
+
+                                var overlayInfo = await FileThumbnailHelper.LoadOverlayAsync(item.ItemPath);
+                                if (overlayInfo != null)
+                                {
+                                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
+                                    {
+                                        item.IconOverlay = await overlayInfo.ToBitmapAsync();
                                     }, Windows.System.DispatcherQueuePriority.Low);
                                 }
 
@@ -859,6 +836,7 @@ namespace Files.ViewModels
                                         await ApplySingleFileChangeAsync(item);
                                     }
                                 }
+
                                 var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageItem);
                                 await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
                                 {
@@ -868,30 +846,30 @@ namespace Files.ViewModels
                                     wasSyncStatusLoaded = true;
                                 }, Windows.System.DispatcherQueuePriority.Low);
                             }
-                            else
+                        }
+                        if (!item.LoadFileIcon)
+                        {
+                            var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize);
+
+                            if (iconInfo.IconData != null)
                             {
-                                var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize);
-
-                                if (iconInfo.IconData != null)
+                                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
                                 {
-                                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                                    {
-                                        item.FileImage = await iconInfo.IconData.ToBitmapAsync();
-                                        item.CustomIconData = iconInfo.IconData;
-                                        item.LoadFileIcon = true;
-                                        item.LoadFolderGlyph = false;
-                                        item.LoadUnknownTypeGlyph = false;
-                                        item.LoadWebShortcutGlyph = false;
-                                    }, Windows.System.DispatcherQueuePriority.Low);
-                                }
+                                    item.FileImage = await iconInfo.IconData.ToBitmapAsync();
+                                    item.CustomIconData = iconInfo.IconData;
+                                    item.LoadFileIcon = true;
+                                    item.LoadFolderGlyph = false;
+                                    item.LoadUnknownTypeGlyph = false;
+                                    item.LoadWebShortcutGlyph = false;
+                                }, Windows.System.DispatcherQueuePriority.Low);
+                            }
 
-                                if (iconInfo.OverlayData != null)
+                            if (iconInfo.OverlayData != null)
+                            {
+                                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
                                 {
-                                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                                    {
-                                        item.IconOverlay = await iconInfo.OverlayData.ToBitmapAsync();
-                                    }, Windows.System.DispatcherQueuePriority.Low);
-                                }
+                                    item.IconOverlay = await iconInfo.OverlayData.ToBitmapAsync();
+                                }, Windows.System.DispatcherQueuePriority.Low);
                             }
                         }
                     }
@@ -908,19 +886,19 @@ namespace Files.ViewModels
                 {
                     if (!wasSyncStatusLoaded)
                     {
-                        await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
+                        await FilesystemTasks.Wrap(() => CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
                         {
                             item.SyncStatusUI = new CloudDriveSyncStatusUI() { LoadSyncStatus = false }; // Reset cloud sync status icon
-                        }, Windows.System.DispatcherQueuePriority.Low);
+                        }, Windows.System.DispatcherQueuePriority.Low));
                     }
 
                     if (loadGroupHeaderInfo)
                     {
-                        await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
+                        await FilesystemTasks.Wrap(() => CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
                         {
                             gp.Model.ImageSource = groupImage;
                             gp.InitializeExtendedGroupHeaderInfoAsync();
-                        });
+                        }));
                     }
 
                     loadExtendedPropsSemaphore.Release();

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -701,24 +701,24 @@ namespace Files.ViewModels
 
             await Task.Run(async () =>
             {
-            if (item == null)
-            {
-                return;
-            }
+                if (item == null)
+                {
+                    return;
+                }
 
-            try
-            {
-                await loadExtendedPropsSemaphore.WaitAsync(loadPropsCTS.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
+                try
+                {
+                    await loadExtendedPropsSemaphore.WaitAsync(loadPropsCTS.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
 
-            var wasSyncStatusLoaded = false;
-            ImageSource groupImage = null;
-            bool loadGroupHeaderInfo = false;
-            GroupedCollection<ListedItem> gp = null;
+                var wasSyncStatusLoaded = false;
+                ImageSource groupImage = null;
+                bool loadGroupHeaderInfo = false;
+                GroupedCollection<ListedItem> gp = null;
                 try
                 {
                     bool isFileTypeGroupMode = folderSettings.DirectoryGroupOption == GroupOption.FileType;
@@ -780,7 +780,6 @@ namespace Files.ViewModels
                                             item.IconOverlay = await iconInfo.OverlayData.ToBitmapAsync();
                                         }, Windows.System.DispatcherQueuePriority.Low);
                                     }
-
                                 }
 
                                 var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageFile);
@@ -934,7 +933,7 @@ namespace Files.ViewModels
             ImageSource groupImage = null;
             if (item.PrimaryItemAttribute != StorageItemTypes.Folder)
             {
-                (byte[] iconData, byte[] overlayData, bool isCustom) headerIconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, 76);
+                (byte[] iconData, byte[] overlayData) headerIconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, 76);
 
                 await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
                 {

--- a/Files/ViewModels/Previews/BasePreviewModel.cs
+++ b/Files/ViewModels/Previews/BasePreviewModel.cs
@@ -48,11 +48,11 @@ namespace Files.ViewModels.Previews
         /// <returns>A list of details</returns>
         public async virtual Task<List<FileProperty>> LoadPreviewAndDetails()
         {
-            var (IconData, OverlayData, IsCustom) = await FileThumbnailHelper.LoadIconAndOverlayAsync(Item.ItemPath, 400);
+            var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 400);
 
-            if (IconData != null)
+            if (iconData != null)
             {
-                Item.FileImage = await IconData.ToBitmapAsync();
+                Item.FileImage = await iconData.ToBitmapAsync();
             }
             else
             {

--- a/Files/ViewModels/Previews/BasePreviewModel.cs
+++ b/Files/ViewModels/Previews/BasePreviewModel.cs
@@ -48,7 +48,7 @@ namespace Files.ViewModels.Previews
         /// <returns>A list of details</returns>
         public async virtual Task<List<FileProperty>> LoadPreviewAndDetails()
         {
-            var (IconData, OverlayData, IsCustom) = await FileThumbnailHelper.LoadIconOverlayAsync(Item.ItemPath, 400);
+            var (IconData, OverlayData, IsCustom) = await FileThumbnailHelper.LoadIconAndOverlayAsync(Item.ItemPath, 400);
 
             if (IconData != null)
             {

--- a/Files/ViewModels/Previews/ShortcutPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/ShortcutPreviewViewModel.cs
@@ -59,7 +59,7 @@ namespace Files.ViewModels.Previews
 
         private async Task LoadItemThumbnail()
         {
-            var (IconData, OverlayData, IsCustom) = await FileThumbnailHelper.LoadIconOverlayAsync(Item.ItemPath, 400);
+            var (IconData, OverlayData, IsCustom) = await FileThumbnailHelper.LoadIconAndOverlayAsync(Item.ItemPath, 400);
 
             if (IconData != null)
             {

--- a/Files/ViewModels/Previews/ShortcutPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/ShortcutPreviewViewModel.cs
@@ -59,11 +59,11 @@ namespace Files.ViewModels.Previews
 
         private async Task LoadItemThumbnail()
         {
-            var (IconData, OverlayData, IsCustom) = await FileThumbnailHelper.LoadIconAndOverlayAsync(Item.ItemPath, 400);
+            var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 400);
 
-            if (IconData != null)
+            if (iconData != null)
             {
-                Item.FileImage = await IconData.ToBitmapAsync();
+                Item.FileImage = await iconData.ToBitmapAsync();
             }
         }
     }

--- a/Files/ViewModels/Properties/DriveProperties.cs
+++ b/Files/ViewModels/Properties/DriveProperties.cs
@@ -52,7 +52,7 @@ namespace Files.ViewModels.Properties
             {
                 if (ViewModel.LoadFileIcon)
                 {
-                    var thumbnail = await diskRoot.GetThumbnailAsync(ThumbnailMode.SingleItem, 80, ThumbnailOptions.UseCurrentScale);
+                    using var thumbnail = await diskRoot.GetThumbnailAsync(ThumbnailMode.SingleItem, 80, ThumbnailOptions.UseCurrentScale);
                     ViewModel.IconData = await thumbnail.ToByteArrayAsync();
                 }
 

--- a/Files/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
@@ -166,12 +166,11 @@ namespace Files.ViewModels.Widgets.Bundles
                     }
 
                     BitmapImage icon = new BitmapImage();
-                    StorageItemThumbnail thumbnail = await file.GetThumbnailAsync(ThumbnailMode.ListView, 24u, ThumbnailOptions.UseCurrentScale);
+                    using var thumbnail = await file.GetThumbnailAsync(ThumbnailMode.ListView, 24u, ThumbnailOptions.UseCurrentScale);
 
                     if (thumbnail != null)
                     {
                         await icon.SetSourceAsync(thumbnail);
-
                         Icon = icon;
                         OnPropertyChanged(nameof(Icon));
                     }


### PR DESCRIPTION
**Details of Changes**
- Always load thumbnails for folders widget except if FullTrustProcess is available
- Use Windows.Storage for thumbnails unless unavailable
- Provide a simplified way to get icon overlays only when needed

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility
