### PR TITLE
Add Ctrl + Shift + Tab to select previous tab

### DIFF
--- a/Files/ViewModels/MainPageViewModel.cs
+++ b/Files/ViewModels/MainPageViewModel.cs
@@ -103,15 +103,31 @@ namespace Files.ViewModels
                     break;
 
                 case VirtualKey.Tab:
-                    // Select the next tab
-                    if ((App.MainViewModel.TabStripSelectedIndex + 1) < AppInstances.Count)
+                    bool shift = e.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
+
+                    if (!shift) // ctrl + tab, select next tab
                     {
-                        indexToSelect = App.MainViewModel.TabStripSelectedIndex + 1;
+                        if ((App.MainViewModel.TabStripSelectedIndex + 1) < AppInstances.Count)
+                        {
+                            indexToSelect = App.MainViewModel.TabStripSelectedIndex + 1;
+                        }
+                        else
+                        {
+                            indexToSelect = 0;
+                        }
                     }
-                    else
+                    else // ctrl + shift + tab, select previous tab
                     {
-                        indexToSelect = 0;
+                        if ((App.MainViewModel.TabStripSelectedIndex - 1) >= 0)
+                        {
+                            indexToSelect = App.MainViewModel.TabStripSelectedIndex - 1;
+                        }
+                        else
+                        {
+                            indexToSelect = AppInstances.Count - 1;
+                        }
                     }
+                    
                     break;
             }
 

--- a/Files/Views/MainPage.xaml
+++ b/Files/Views/MainPage.xaml
@@ -145,6 +145,13 @@
                 </icore:EventTriggerBehavior>
             </i:Interaction.Behaviors>
         </KeyboardAccelerator>
+        <KeyboardAccelerator Key="Tab" Modifiers="Control,Shift">
+            <i:Interaction.Behaviors>
+                <icore:EventTriggerBehavior EventName="Invoked">
+                    <icore:InvokeCommandAction Command="{x:Bind ViewModel.NavigateToNumberedTabKeyboardAcceleratorCommand}" />
+                </icore:EventTriggerBehavior>
+            </i:Interaction.Behaviors>
+        </KeyboardAccelerator>
         <KeyboardAccelerator Key="Tab" Modifiers="Control">
             <i:Interaction.Behaviors>
                 <icore:EventTriggerBehavior EventName="Invoked">


### PR DESCRIPTION
Now you can select previous tab as easy as select next tab.

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Closes #5235

**Details of Changes**
Added the Ctrl + Shift + Tab keybinding to select previous tab, similar to Ctrl + Tab to select next tab.

I copied and adapted the code used to handle new tabs (Ctrl + T and Ctrl + Shift + T).

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [ ] Tested the changes for accessibility -> I don't know how I can do this.

**Screenshots (optional)**
![GIF 17-06-2021 15-44-51](https://user-images.githubusercontent.com/11770760/122408888-ff3fc700-cf82-11eb-83c9-66033e8e31aa.gif)

