### PR TITLE
Fix null reference exception in Bundles

### DIFF
--- a/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
@@ -458,7 +458,6 @@ namespace Files.ViewModels.Widgets.Bundles
             }
 
             Items.CollectionChanged -= Items_CollectionChanged;
-            Items = null;
         }
 
         #endregion IDisposable


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Closes #5258

**Details of Changes**
Fixes NullReferenceException caused by setting `Items = null;` in Dispose() method. After the change tested it multiple times and it never crashed unlike before.

**Validation**
How did you test these changes?
- [x] Built and ran the app
