### PR TITLE
Remove unused strings of library restoration status messages

### DIFF
--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2406,21 +2406,6 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Restore Libraries</value>
   </data>
-  <data name="StatusLibraryRestoration" xml:space="preserve">
-    <value>Restoring libraries</value>
-  </data>
-  <data name="StatusLibraryRestorationInProgress" xml:space="preserve">
-    <value>Restoring default libraries in progress...</value>
-  </data>
-  <data name="StatusLibraryRestorationComplete" xml:space="preserve">
-    <value>Libraries restored</value>
-  </data>
-  <data name="StatusLibraryRestorationFailed" xml:space="preserve">
-    <value>Failed to restore libraries</value>
-  </data>
-  <data name="StatusRestoreLibrariesDetails" xml:space="preserve">
-    <value>{0} library files successfully restored</value>
-  </data>
   <data name="PropertyFileOwner" xml:space="preserve">
     <value>Owner</value>
   </data>


### PR DESCRIPTION
Continuation of PR #5122

**Details of Changes**

- Removed accidentally kept strings for restoration status messages
  *These were added with the previously implemented method, but not removed in the end. Should be removed from all language files ASAP to spare work of translators.*

**Validation**
- [x] Built and ran the app