### PR TITLE
DrivesWidget: Remove hardcoded row size values

### DIFF
--- a/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -167,18 +167,19 @@
                                 VerticalAlignment="Stretch"
                                 ColumnSpacing="12">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="44" />
+                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
+                                    <RowDefinition Height="*" />
                                     <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="28" />
-                                    <RowDefinition Height="16" />
+                                    <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
                                 <Image
                                     Grid.RowSpan="3"
                                     Grid.Column="0"
                                     Height="40"
+									Width="40"
                                     HorizontalAlignment="Center"
                                     x:Phase="1"
                                     Source="{x:Bind Icon, Mode=OneWay}" />
@@ -187,7 +188,7 @@
                                     x:Name="ItemLocationName"
                                     Grid.Row="0"
                                     Grid.Column="1"
-                                    VerticalAlignment="Center"
+                                    VerticalAlignment="Stretch"
                                     FontSize="14"
                                     FontWeight="Medium"
                                     Text="{x:Bind Text, Mode=OneWay}"
@@ -195,6 +196,7 @@
                                     TextWrapping="NoWrap" />
 
                                 <Grid
+									VerticalAlignment="Stretch"
                                     Grid.Row="1"
                                     Grid.Column="1"
                                     Grid.ColumnSpan="8">
@@ -238,6 +240,7 @@
                                     Grid.Column="1"
                                     x:Phase="1"
                                     FontSize="12"
+									VerticalAlignment="Bottom"
                                     Text="{x:Bind SpaceText, Mode=OneWay}"
                                     TextTrimming="CharacterEllipsis"
                                     TextWrapping="NoWrap"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Closes #5216

**Details of Changes**
Remove hardcoded row and column size values to properly support text scaling.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
At 130% text scaling
![image](https://user-images.githubusercontent.com/20365014/122647726-a2175300-d0f3-11eb-83fb-0068a8084c9b.png)
