### PR TITLE
Fix issue where the preview pane wouldn't show the proper visual state when no item is selected

### DIFF
--- a/Files/ViewModels/PreviewPaneViewModel.cs
+++ b/Files/ViewModels/PreviewPaneViewModel.cs
@@ -272,7 +272,7 @@ namespace Files.ViewModels
                     PreviewPaneState = PreviewPaneStates.NoPreviewOrDetailsAvailable;
                 }
             }
-            else if (!IsItemSelected)
+            else if (IsItemSelected)
             {
                 PreviewPaneContent = null;
                 PreviewPaneState = PreviewPaneStates.NoPreviewOrDetailsAvailable;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related #issue...

**Details of Changes**
Add details of changes here.
- Changed ``IsItemSelected`` to ``!IsItemSelected`` for no item selected state check

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
