### PR TITLE
Now preview dates uses getfriendlydate format / Fixed a bug with files and folders without creation or modification date

### DIFF
--- a/Files/Converters/DateTimeOffsetToString.cs
+++ b/Files/Converters/DateTimeOffsetToString.cs
@@ -13,7 +13,7 @@ namespace Files.Converters
             {
                 ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
                 string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[Constants.LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
-                return (Extensions.DateTimeExtensions.GetFriendlyDateFromFormat((DateTimeOffset)value, returnformat));
+                return (Extensions.DateTimeExtensions.GetFriendlyDateFromFormat((DateTimeOffset)value, returnformat, true));
             }
 
             return "";

--- a/Files/Converters/DateTimeOffsetToString.cs
+++ b/Files/Converters/DateTimeOffsetToString.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Files.Enums;
+using System;
+using Windows.Storage;
 using Windows.UI.Xaml.Data;
 
 namespace Files.Converters
@@ -9,7 +11,9 @@ namespace Files.Converters
         {
             if (value != null)
             {
-                return (Extensions.DateTimeExtensions.GetFriendlyDateFromFormat((DateTimeOffset)value, "D"));
+                ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+                string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[Constants.LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
+                return (Extensions.DateTimeExtensions.GetFriendlyDateFromFormat((DateTimeOffset)value, returnformat));
             }
 
             return "";

--- a/Files/Converters/DateTimeOffsetToString.cs
+++ b/Files/Converters/DateTimeOffsetToString.cs
@@ -9,7 +9,7 @@ namespace Files.Converters
         {
             if (value != null)
             {
-                return ((DateTimeOffset)value).ToLocalTime().ToString("D");
+                return (Extensions.DateTimeExtensions.GetFriendlyDateFromFormat((DateTimeOffset)value, "D"));
             }
 
             return "";

--- a/Files/Extensions/DateTimeExtensions.cs
+++ b/Files/Extensions/DateTimeExtensions.cs
@@ -10,7 +10,11 @@ namespace Files.Extensions
         {
             var elapsed = DateTimeOffset.Now - d;
 
-            if (elapsed.TotalDays > 7 || returnFormat == "g")
+            if (d.Year == 1601)
+            {
+                return " ";
+            }
+            else if (elapsed.TotalDays > 7 || returnFormat == "g")
             {
                 return d.ToLocalTime().ToString(returnFormat);
             }

--- a/Files/Extensions/DateTimeExtensions.cs
+++ b/Files/Extensions/DateTimeExtensions.cs
@@ -6,7 +6,7 @@ namespace Files.Extensions
 {
     public static class DateTimeExtensions
     {
-        public static string GetFriendlyDateFromFormat(this DateTimeOffset d, string returnFormat)
+        public static string GetFriendlyDateFromFormat(this DateTimeOffset d, string returnFormat, bool isDetailed = false)
         {
             var elapsed = DateTimeOffset.Now - d;
 
@@ -14,33 +14,37 @@ namespace Files.Extensions
             {
                 return " ";
             }
-            else if (elapsed.TotalDays > 7 || returnFormat == "g")
+            else if (isDetailed && returnFormat != "g" && elapsed.TotalDays < 7)
+            {
+                return d.ToLocalTime().ToString(returnFormat) + " (" + GetFriendlyDateFromFormat(d, returnFormat) + ")";
+            }
+            else if (elapsed.TotalDays >= 7 || returnFormat == "g")
             {
                 return d.ToLocalTime().ToString(returnFormat);
             }
-            else if (elapsed.TotalDays > 2)
+            else if (elapsed.TotalDays >= 2)
             {
                 return string.Format("DaysAgo".GetLocalized(), elapsed.Days);
             }
-            else if (elapsed.TotalDays > 1)
+            else if (elapsed.TotalDays >= 1)
             {
                 return string.Format("DayAgo".GetLocalized(), elapsed.Days);
             }
-            else if (elapsed.TotalHours > 2)
+            else if (elapsed.TotalHours >= 2)
             {
                 return string.Format("HoursAgo".GetLocalized(), elapsed.Hours);
             }
-            else if (elapsed.TotalHours > 1)
+            else if (elapsed.TotalHours >= 1)
             {
-                return string.Format("HoursAgo".GetLocalized(), elapsed.Hours);
+                return string.Format("HourAgo".GetLocalized(), elapsed.Hours);
             }
-            else if (elapsed.TotalMinutes > 2)
+            else if (elapsed.TotalMinutes >= 2)
             {
                 return string.Format("MinutesAgo".GetLocalized(), elapsed.Minutes);
             }
-            else if (elapsed.TotalMinutes > 1)
+            else if (elapsed.TotalMinutes >= 1)
             {
-                return string.Format("MinutesAgo".GetLocalized(), elapsed.Minutes);
+                return string.Format("MinuteAgo".GetLocalized(), elapsed.Minutes);
             }
             else
             {

--- a/Files/ViewModels/Previews/FolderPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/FolderPreviewViewModel.cs
@@ -50,12 +50,12 @@ namespace Files.ViewModels.Previews
                 new FileProperty()
                 {
                     NameResource = "PropertyDateModified",
-                    Value = Extensions.DateTimeExtensions.GetFriendlyDateFromFormat(info.DateModified, returnformat)
+                    Value = Extensions.DateTimeExtensions.GetFriendlyDateFromFormat(info.DateModified, returnformat, true)
                 },
                 new FileProperty()
                 {
                     NameResource = "PropertyDateCreated",
-                    Value = Extensions.DateTimeExtensions.GetFriendlyDateFromFormat(info.ItemDate, returnformat)
+                    Value = Extensions.DateTimeExtensions.GetFriendlyDateFromFormat(info.ItemDate, returnformat, true)
                 },
                 new FileProperty()
                 {

--- a/Files/ViewModels/Previews/FolderPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/FolderPreviewViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Files.Filesystem;
+﻿using Files.Enums;
+using Files.Filesystem;
 using Files.ViewModels.Properties;
 using System;
 using System.Collections.ObjectModel;
@@ -46,12 +47,12 @@ namespace Files.ViewModels.Previews
                 new FileProperty()
                 {
                     NameResource = "PropertyDateModified",
-                    Value = info.DateModified,
+                    Value = Extensions.DateTimeExtensions.GetFriendlyDateFromFormat(info.DateModified, "D")
                 },
                 new FileProperty()
                 {
                     NameResource = "PropertyDateCreated",
-                    Value = info.ItemDate,
+                    Value = Extensions.DateTimeExtensions.GetFriendlyDateFromFormat(info.ItemDate, "D")
                 },
                 new FileProperty()
                 {

--- a/Files/ViewModels/Previews/FolderPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/FolderPreviewViewModel.cs
@@ -30,6 +30,9 @@ namespace Files.ViewModels.Previews
 
         private async Task LoadPreviewAndDetailsAsync()
         {
+            ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+            string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[Constants.LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
+
             Folder = await StorageFolder.GetFolderFromPathAsync(Item.ItemPath);
             var items = await Folder.GetItemsAsync();
 
@@ -47,12 +50,12 @@ namespace Files.ViewModels.Previews
                 new FileProperty()
                 {
                     NameResource = "PropertyDateModified",
-                    Value = Extensions.DateTimeExtensions.GetFriendlyDateFromFormat(info.DateModified, "D")
+                    Value = Extensions.DateTimeExtensions.GetFriendlyDateFromFormat(info.DateModified, returnformat)
                 },
                 new FileProperty()
                 {
                     NameResource = "PropertyDateCreated",
-                    Value = Extensions.DateTimeExtensions.GetFriendlyDateFromFormat(info.ItemDate, "D")
+                    Value = Extensions.DateTimeExtensions.GetFriendlyDateFromFormat(info.ItemDate, returnformat)
                 },
                 new FileProperty()
                 {


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5269

**Details of Changes**

- Fixed a bug that caused files or folders without creation or modification date to show "01/01/1601". For this, I added a new if case to check if the year is 1601 return an empty string, as Windows explorer does:
![image](https://user-images.githubusercontent.com/11770760/122912681-e2c3d600-d358-11eb-8e1d-85308cc9f5ea.png)

- Now preview files and folder uses getfriendlydate format, to fix that bug and to keep consistency while showing dates also.

- Also files and folders properties and details uses getfriendlydate format.

- Fixed a bug that causes that "1 hour" was showed as "1 hours" and "1 minute" as "1 minutes".

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
- Before:
- - File properties of #5269 :
![image](https://user-images.githubusercontent.com/11770760/122912227-629d7080-d358-11eb-860b-e2a97ef7d072.png)

- -  Preview pane:

- - - Bug #5269:
![image](https://user-images.githubusercontent.com/11770760/122912369-8d87c480-d358-11eb-80c0-c17449052ebd.png)

- - - Friendly date on preview:
![image](https://user-images.githubusercontent.com/11770760/122912400-97112c80-d358-11eb-8f8a-727dfa829e61.png)

- After:

- - File properties of #5269 :
![image](https://user-images.githubusercontent.com/11770760/122912039-34b82c00-d358-11eb-9804-9fe7f529f15b.png)

- - Preview pane:

- - - Bug #5269:
![image](https://user-images.githubusercontent.com/11770760/122911649-cc694a80-d357-11eb-9cf0-d8393ee8b9c2.png)

- - - Friendly date on preview:
![image](https://user-images.githubusercontent.com/11770760/122911735-e60a9200-d357-11eb-87cb-568836e2eed9.png)

