### PR TITLE
Fix new context menu

### DIFF
--- a/Files/Helpers/RegistryHelper.cs
+++ b/Files/Helpers/RegistryHelper.cs
@@ -115,8 +115,6 @@ namespace Files.Helpers
                 Data = data
             };
 
-            thumbnail?.Result?.Dispose();
-
             return entry;
         }
 

--- a/Files/UserControls/Selection/ExtendPreviousItemSelectionStrategy.cs
+++ b/Files/UserControls/Selection/ExtendPreviousItemSelectionStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Files.UserControls.Selection
 {
@@ -13,18 +14,30 @@ namespace Files.UserControls.Selection
 
         public override void HandleIntersectionWithItem(object item)
         {
-            if (!selectedItems.Contains(item))
+            try
             {
-                selectedItems.Add(item);
+                if (!selectedItems.Contains(item))
+                {
+                    selectedItems.Add(item);
+                }
+            }
+            catch (COMException) // List is being modified
+            {
             }
         }
 
         public override void HandleNoIntersectionWithItem(object item)
         {
-            // Restore selection on items not intersecting with the rectangle
-            if (!prevSelectedItems.Contains(item))
+            try
             {
-                selectedItems.Remove(item);
+                // Restore selection on items not intersecting with the rectangle
+                if (!prevSelectedItems.Contains(item))
+                {
+                    selectedItems.Remove(item);
+                }
+            }
+            catch (COMException) // List is being modified
+            {
             }
         }
     }

--- a/Files/UserControls/Selection/IgnorePreviousItemSelectionStrategy.cs
+++ b/Files/UserControls/Selection/IgnorePreviousItemSelectionStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Files.UserControls.Selection
 {
@@ -10,16 +11,28 @@ namespace Files.UserControls.Selection
 
         public override void HandleIntersectionWithItem(object item)
         {
-            // Select item intersection with the rectangle
-            if (!selectedItems.Contains(item))
+            try
             {
-                selectedItems.Add(item);
+                // Select item intersection with the rectangle
+                if (!selectedItems.Contains(item))
+                {
+                    selectedItems.Add(item);
+                }
+            }
+            catch (COMException) // List is being modified
+            {
             }
         }
 
         public override void HandleNoIntersectionWithItem(object item)
         {
-            selectedItems.Remove(item);
+            try
+            {
+                selectedItems.Remove(item);
+            }
+            catch (COMException) // List is being modified
+            {
+            }
         }
 
         public override void StartSelection()

--- a/Files/UserControls/Selection/InvertPreviousItemSelectionStrategy.cs
+++ b/Files/UserControls/Selection/InvertPreviousItemSelectionStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace Files.UserControls.Selection
 {
@@ -13,29 +14,41 @@ namespace Files.UserControls.Selection
 
         public override void HandleIntersectionWithItem(object item)
         {
-            if (prevSelectedItems.Contains(item))
+            try
             {
-                selectedItems.Remove(item);
+                if (prevSelectedItems.Contains(item))
+                {
+                    selectedItems.Remove(item);
+                }
+                else if (!selectedItems.Contains(item))
+                {
+                    selectedItems.Add(item);
+                }
             }
-            else if (!selectedItems.Contains(item))
+            catch (COMException) // List is being modified
             {
-                selectedItems.Add(item);
             }
         }
 
         public override void HandleNoIntersectionWithItem(object item)
         {
-            // Restore selection on items not intersecting with the rectangle
-            if (prevSelectedItems.Contains(item))
+            try
             {
-                if (!selectedItems.Contains(item))
+                // Restore selection on items not intersecting with the rectangle
+                if (prevSelectedItems.Contains(item))
                 {
-                    selectedItems.Add(item);
+                    if (!selectedItems.Contains(item))
+                    {
+                        selectedItems.Add(item);
+                    }
+                }
+                else
+                {
+                    selectedItems.Remove(item);
                 }
             }
-            else
+            catch (COMException) // List is being modified
             {
-                selectedItems.Remove(item);
             }
         }
     }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes #5332

**Changes**
- Fixes an issue introduced in #5242 which affects the "new" menu and folder empty-space menu
- Fixes an issue with the filewatcher for which a crash can occur when temp files are quickly created/deleted
- Fixes an issue with the selection rectangle for which a crash can occur when temp files are quickly created/deleted

**Validation**
How did you test these changes?
- [x] Built and ran the app
