### PR TITLE
Switch to muxc navigation view for properties dialog

### DIFF
--- a/Files/Views/Pages/Properties.xaml
+++ b/Files/Views/Pages/Properties.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Media"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     d:DesignHeight="700"
     d:DesignWidth="400"
     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
@@ -26,10 +26,11 @@
             VerticalAlignment="Center"
             Text="Properties" />
 
-        <NavigationView
+        <muxc:NavigationView
             x:Name="NavigationView"
             Grid.Row="1"
             AllowDrop="False"
+            Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
             IsBackButtonVisible="Collapsed"
             IsPaneOpen="False"
             IsPaneToggleButtonVisible="False"
@@ -38,72 +39,72 @@
             SelectedItem="{x:Bind TabGeneral}"
             SelectionChanged="NavigationView_SelectionChanged"
             SelectionFollowsFocus="Enabled">
-            <NavigationView.Resources>
+            <!--<muxc:NavigationView.Resources>
                 <SolidColorBrush x:Key="TransparentBackdropColor" Color="Transparent" />
                 <StaticResource x:Key="NavigationViewTopPaneBackground" ResourceKey="TransparentBackdropColor" />
-            </NavigationView.Resources>
+            </muxc:NavigationView.Resources>-->
 
             <!--  Tabs  -->
-            <NavigationView.MenuItems>
-                <NavigationViewItem
+            <muxc:NavigationView.MenuItems>
+                <muxc:NavigationViewItem
                     x:Name="TabGeneral"
                     x:Uid="PropertiesDialogTabGeneral"
                     AccessKey="G"
                     Content="General"
                     Tag="General">
-                    <NavigationViewItem.Icon>
+                    <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE7C3;" />
-                    </NavigationViewItem.Icon>
-                </NavigationViewItem>
-                <NavigationViewItem
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
+                <muxc:NavigationViewItem
                     x:Name="TabSecurity"
                     x:Uid="PropertiesDialogTabSecurity"
                     Content="Security"
                     Tag="Security">
-                    <NavigationViewItem.Icon>
+                    <muxc:NavigationViewItem.Icon>
                         <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE730;" />
-                    </NavigationViewItem.Icon>
-                </NavigationViewItem>
-                <NavigationViewItem
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
+                <muxc:NavigationViewItem
                     x:Name="TabShorcut"
                     x:Uid="PropertiesDialogTabShortcut"
                     AccessKey="S"
                     Content="Shortcut"
                     Tag="Shortcut"
                     Visibility="Collapsed">
-                    <NavigationViewItem.Icon>
+                    <muxc:NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF10A;" />
-                    </NavigationViewItem.Icon>
-                </NavigationViewItem>
-                <NavigationViewItem
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
+                <muxc:NavigationViewItem
                     x:Name="TabLibrary"
                     x:Uid="PropertiesDialogTabLibrary"
                     AccessKey="L"
                     Content="Library"
                     Tag="Library"
                     Visibility="Collapsed">
-                    <NavigationViewItem.Icon>
+                    <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE1D3;" />
-                    </NavigationViewItem.Icon>
-                </NavigationViewItem>
-                <NavigationViewItem
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
+                <muxc:NavigationViewItem
                     x:Name="TabDetails"
                     x:Uid="PropertiesDialogTabDetails"
                     AccessKey="D"
                     Content="Details"
                     Tag="Details"
                     Visibility="Collapsed">
-                    <NavigationViewItem.Icon>
+                    <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE946;" />
-                    </NavigationViewItem.Icon>
-                </NavigationViewItem>
-            </NavigationView.MenuItems>
+                    </muxc:NavigationViewItem.Icon>
+                </muxc:NavigationViewItem>
+            </muxc:NavigationView.MenuItems>
 
             <Frame
                 x:Name="contentFrame"
                 Grid.Row="1"
                 IsNavigationStackEnabled="False" />
-        </NavigationView>
+        </muxc:NavigationView>
 
         <Grid Grid.Row="2" Padding="8">
             <Grid.ColumnDefinitions>

--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -192,7 +192,7 @@ namespace Files.Views
             }
         }
 
-        private void NavigationView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
+        private void NavigationView_SelectionChanged(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs args)
         {
             var navParam = new PropertyNavParam()
             {


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related #issue...

**Details of Changes**
Now that https://github.com/microsoft/microsoft-ui-xaml/issues/3822 has been resolved, the muxc nav view can now be used again in the properties dialog. This PR switches back to the muxc nav view.

Switching to the muxc navview changes the design, so feedback on that would be appreciated.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
<img src="https://user-images.githubusercontent.com/59544401/123529372-5856db80-d6a4-11eb-9bbb-5416b45a1aa9.png" Width="500"/>