### PR TITLE
Fix issue where preview pane content would be loaded even if the preview pane is closed

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -180,6 +180,27 @@ namespace Files
             {
                 if (value != selectedItems)
                 {
+                    if(value?.FirstOrDefault() != selectedItems?.FirstOrDefault())
+                    {
+                        // update preview pane properties
+                        if (value?.Count == 1)
+                        {
+                            PreviewPaneViewModel.IsItemSelected = true;
+                            PreviewPaneViewModel.SelectedItem = value.First();
+                        }
+                        else
+                        {
+                            PreviewPaneViewModel.IsItemSelected = value?.Count > 0;
+                            PreviewPaneViewModel.SelectedItem = null;
+                        }
+
+                        // check if the preview pane is open before updating the model
+                        if (((Window.Current.Content as Frame)?.Content as MainPage)?.LoadPreviewPane ?? false)
+                        {
+                            PreviewPaneViewModel.UpdateSelectedItemPreview();
+                        }
+                    }
+
                     selectedItems = value;
                     if (selectedItems.Count == 0 || selectedItems[0] == null)
                     {
@@ -221,17 +242,6 @@ namespace Files
                                 SelectedItemsPropertiesViewModel.ItemSize = string.Empty;
                             }
                         }
-                    }
-
-                    if (value?.Count == 1)
-                    {
-                        PreviewPaneViewModel.IsItemSelected = true;
-                        PreviewPaneViewModel.SelectedItem = SelectedItems.First();
-                    }
-                    else
-                    {
-                        PreviewPaneViewModel.IsItemSelected = value?.Count > 0;
-                        PreviewPaneViewModel.SelectedItem = null;
                     }
 
                     NotifyPropertyChanged(nameof(SelectedItems));

--- a/Files/Filesystem/NetworkDrivesManager.cs
+++ b/Files/Filesystem/NetworkDrivesManager.cs
@@ -128,7 +128,7 @@ namespace Files.Filesystem
                             Icon = UIHelpers.GetImageForIconOrNull(SidebarPinnedModel.IconResources?.FirstOrDefault(x => x.Index == Constants.ImageRes.NetworkDrives).Image),
                             ChildItems = new ObservableCollection<INavigationControlItem>()
                         };
-                        var index =
+                        var index = 1 +
                                     Convert.ToInt32(App.AppSettings.ShowLibrarySection) +
                                     Convert.ToInt32(App.AppSettings.ShowDrivesSection) +
                                     Convert.ToInt32(App.AppSettings.ShowCloudDrivesSection); // After cloud section

--- a/Files/Filesystem/NetworkDrivesManager.cs
+++ b/Files/Filesystem/NetworkDrivesManager.cs
@@ -128,7 +128,7 @@ namespace Files.Filesystem
                             Icon = UIHelpers.GetImageForIconOrNull(SidebarPinnedModel.IconResources?.FirstOrDefault(x => x.Index == Constants.ImageRes.NetworkDrives).Image),
                             ChildItems = new ObservableCollection<INavigationControlItem>()
                         };
-                        var index = 1 +
+                        var index =
                                     Convert.ToInt32(App.AppSettings.ShowLibrarySection) +
                                     Convert.ToInt32(App.AppSettings.ShowDrivesSection) +
                                     Convert.ToInt32(App.AppSettings.ShowCloudDrivesSection); // After cloud section

--- a/Files/ViewModels/PreviewPaneViewModel.cs
+++ b/Files/ViewModels/PreviewPaneViewModel.cs
@@ -36,14 +36,7 @@ namespace Files.ViewModels
         public ListedItem SelectedItem
         {
             get => selectedItem;
-            set
-            {
-                if (SetProperty(ref selectedItem, value))
-                {
-                    SelectedItem?.FileDetails?.Clear();
-                    UpdateSelectedItemPreview();
-                }
-            }
+            set => SetProperty(ref selectedItem, value);
         }
 
 
@@ -248,6 +241,8 @@ namespace Files.ViewModels
             loadCancellationTokenSource?.Cancel();
             if (SelectedItem != null && IsItemSelected)
             {
+                SelectedItem?.FileDetails?.Clear();
+
                 try
                 {
                     PreviewPaneState = PreviewPaneStates.LoadingPreview;

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -433,6 +433,7 @@ namespace Files.Views
         {
             UpdatePreviewPaneProperties();
             UpdatePositioning();
+            PreviewPane.Model.UpdateSelectedItemPreview();
         }
 
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related #issue...

**Details of Changes**
Add details of changes here.
- Added check that the preview pane is loaded before loading the content
**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
