### PR TITLE
Fix crash when the network drives section on the sidebar is shown

### DIFF
--- a/Files/Filesystem/CloudDrivesManager.cs
+++ b/Files/Filesystem/CloudDrivesManager.cs
@@ -115,10 +115,10 @@ namespace Files.Filesystem
                             Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/CloudDrive.png")),
                             ChildItems = new ObservableCollection<INavigationControlItem>()
                         };
-                        var index = 1 +
-                                    Convert.ToInt32(App.AppSettings.ShowLibrarySection) + 
-                                    Convert.ToInt32(App.AppSettings.ShowDrivesSection); // After drives section
-                        SidebarControl.SideBarItems.Insert(index, section);
+                        var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
+                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
+                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0); // After drives section
+                        SidebarControl.SideBarItems.Insert(Math.Min(index, SidebarControl.SideBarItems.Count), section);
                     }
 
                     if (section != null)

--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -143,9 +143,9 @@ namespace Files.Filesystem
                             Icon = UIHelpers.GetImageForIconOrNull(SidebarPinnedModel.IconResources?.FirstOrDefault(x => x.Index == Constants.ImageRes.ThisPC).Image),
                             ChildItems = new ObservableCollection<INavigationControlItem>()
                         };
-                        var index = 1 +
-                                    Convert.ToInt32(App.AppSettings.ShowLibrarySection); // After libraries section
-                        SidebarControl.SideBarItems.Insert(index, section);
+                        var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
+                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0); // After libraries section
+                        SidebarControl.SideBarItems.Insert(Math.Min(index, SidebarControl.SideBarItems.Count), section);
                     }
 
                     // Sync drives to sidebar

--- a/Files/Filesystem/LibraryManager.cs
+++ b/Files/Filesystem/LibraryManager.cs
@@ -201,8 +201,8 @@ namespace Files.Filesystem
                             Icon = UIHelpers.GetImageForIconOrNull(SidebarPinnedModel.IconResources?.FirstOrDefault(x => x.Index == Constants.ImageRes.Libraries).Image),
                             ChildItems = new ObservableCollection<INavigationControlItem>()
                         };
-                        var index = 1; // After favorites section
-                        SidebarControl.SideBarItems.Insert(index, librarySection);
+                        var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0); // After favorites section
+                        SidebarControl.SideBarItems.Insert(Math.Min(index, SidebarControl.SideBarItems.Count), librarySection);
                     }
                 }
                 finally

--- a/Files/Filesystem/NetworkDrivesManager.cs
+++ b/Files/Filesystem/NetworkDrivesManager.cs
@@ -128,10 +128,13 @@ namespace Files.Filesystem
                             Icon = UIHelpers.GetImageForIconOrNull(SidebarPinnedModel.IconResources?.FirstOrDefault(x => x.Index == Constants.ImageRes.NetworkDrives).Image),
                             ChildItems = new ObservableCollection<INavigationControlItem>()
                         };
-                        var index = 1 +
-                                    Convert.ToInt32(App.AppSettings.ShowLibrarySection) +
+                        var index = Convert.ToInt32(App.AppSettings.ShowLibrarySection) +
                                     Convert.ToInt32(App.AppSettings.ShowDrivesSection) +
                                     Convert.ToInt32(App.AppSettings.ShowCloudDrivesSection); // After cloud section
+                        if(index + 1 == SidebarControl.SideBarItems.Count)
+                        {
+                            index++; // Put after the last item instead of before it
+                        }
                         SidebarControl.SideBarItems.Insert(index, section);
                     }
 

--- a/Files/Filesystem/NetworkDrivesManager.cs
+++ b/Files/Filesystem/NetworkDrivesManager.cs
@@ -128,14 +128,11 @@ namespace Files.Filesystem
                             Icon = UIHelpers.GetImageForIconOrNull(SidebarPinnedModel.IconResources?.FirstOrDefault(x => x.Index == Constants.ImageRes.NetworkDrives).Image),
                             ChildItems = new ObservableCollection<INavigationControlItem>()
                         };
-                        var index = Convert.ToInt32(App.AppSettings.ShowLibrarySection) +
-                                    Convert.ToInt32(App.AppSettings.ShowDrivesSection) +
-                                    Convert.ToInt32(App.AppSettings.ShowCloudDrivesSection); // After cloud section
-                        if(index + 1 == SidebarControl.SideBarItems.Count)
-                        {
-                            index++; // Put after the last item instead of before it
-                        }
-                        SidebarControl.SideBarItems.Insert(index, section);
+                        var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
+                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
+                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0) +
+                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.CloudDrives) ? 1 : 0); // After cloud section
+                        SidebarControl.SideBarItems.Insert(Math.Min(index, SidebarControl.SideBarItems.Count), section);
                     }
 
                     if (section != null)

--- a/Files/Filesystem/WSLDistroManager.cs
+++ b/Files/Filesystem/WSLDistroManager.cs
@@ -59,12 +59,12 @@ namespace Files.Filesystem
                                 Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/WSL/genericpng.png")),
                                 ChildItems = new ObservableCollection<INavigationControlItem>()
                             };
-                            var index = 1 +
-                                    Convert.ToInt32(App.AppSettings.ShowLibrarySection) +
-                                    Convert.ToInt32(App.AppSettings.ShowDrivesSection) +
-                                    Convert.ToInt32(App.AppSettings.ShowCloudDrivesSection) +
-                                    Convert.ToInt32(App.AppSettings.ShowNetworkDrivesSection); // After network section
-                            SidebarControl.SideBarItems.Insert(index, section);
+                            var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
+                                        (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
+                                        (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0) +
+                                        (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.CloudDrives) ? 1 : 0) +
+                                        (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Network) ? 1 : 0); // After network section
+                            SidebarControl.SideBarItems.Insert(Math.Min(index, SidebarControl.SideBarItems.Count), section);
                         }
 
                         if (section != null)


### PR DESCRIPTION
Just cloned the repo for the first time and got the ArgumentOutOfRangeException on startup.

Caused by yesterday's merged PR: https://github.com/files-community/Files/pull/5328

To reproduce just need to enable the "_Show network drives section on the sidebar_" option.

![image](https://user-images.githubusercontent.com/37713088/123700962-de704f00-d869-11eb-8744-46def33082f2.png)
![image](https://user-images.githubusercontent.com/37713088/123701168-298a6200-d86a-11eb-9e65-57a28b4093d3.png)
