### PR TITLE
Smb files will show their date creation on properties properly

### DIFF
--- a/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
@@ -181,7 +181,7 @@ namespace Files.Filesystem.StorageEnumerators
             var itemName = string.IsNullOrEmpty(file.DisplayName) || App.AppSettings.ShowFileExtensions ?
                 file.Name : file.DisplayName;
             var itemModifiedDate = basicProperties.DateModified;
-            DateTimeOffset.TryParse(extraProperties["System.DateCreated"] as string, out var itemCreatedDate);
+            var itemCreatedDate = file.DateCreated;
             var itemPath = string.IsNullOrEmpty(file.Path) ? Path.Combine(currentStorageFolder.Path, file.Name) : file.Path;
             var itemSize = ByteSize.FromBytes(basicProperties.Size).ToBinaryString().ConvertSizeAbbreviation();
             var itemSizeBytes = basicProperties.Size;

--- a/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
@@ -141,8 +141,6 @@ namespace Files.Filesystem.StorageEnumerators
         private static async Task<ListedItem> AddFolderAsync(StorageFolder folder, StorageFolderWithPath currentStorageFolder, string dateReturnFormat, CancellationToken cancellationToken)
         {
             var basicProperties = await folder.GetBasicPropertiesAsync();
-            var extraProps = await basicProperties.RetrievePropertiesAsync(new[] { "System.DateCreated" });
-            DateTimeOffset.TryParse(extraProps["System.DateCreated"] as string, out var dateCreated);
             if (!cancellationToken.IsCancellationRequested)
             {
                 return new ListedItem(folder.FolderRelativeId, dateReturnFormat)
@@ -150,7 +148,7 @@ namespace Files.Filesystem.StorageEnumerators
                     PrimaryItemAttribute = StorageItemTypes.Folder,
                     ItemName = folder.DisplayName,
                     ItemDateModifiedReal = basicProperties.DateModified,
-                    ItemDateCreatedReal = dateCreated,
+                    ItemDateCreatedReal = folder.DateCreated,
                     ItemType = folder.DisplayType,
                     IsHiddenItem = false,
                     Opacity = 1,
@@ -176,7 +174,6 @@ namespace Files.Filesystem.StorageEnumerators
         )
         {
             var basicProperties = await file.GetBasicPropertiesAsync();
-            var extraProperties = await basicProperties.RetrievePropertiesAsync(new[] { "System.DateCreated" });
             // Display name does not include extension
             var itemName = string.IsNullOrEmpty(file.DisplayName) || App.AppSettings.ShowFileExtensions ?
                 file.Name : file.DisplayName;

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1279,11 +1279,7 @@ namespace Files.ViewModels
                 };
                 if (library == null)
                 {
-                    var extraProps = await basicProps.RetrievePropertiesAsync(new[] { "System.DateCreated" });
-                    if (DateTimeOffset.TryParse(extraProps["System.DateCreated"] as string, out var dateCreated))
-                    {
-                        currentFolder.ItemDateCreatedReal = dateCreated;
-                    }
+                    currentFolder.ItemDateCreatedReal = rootFolder.DateCreated;
                 }
                 CurrentFolder = currentFolder;
                 await EnumFromStorageFolderAsync(path, currentFolder, rootFolder, currentStorageFolder, sourcePageType, cancellationToken);


### PR DESCRIPTION
Fixed a bug that caused that creation dates were showed on properties as "01/01/0001"

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Closes #5277

**Details of Changes**
- Change the way of getting the creation date on UniversalStorageEnumerator. I don't see any change on creation date of any other files than smb files, which now show their properly date.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**

Before:
![image](https://user-images.githubusercontent.com/11770760/122658538-c7957280-d16e-11eb-991c-009376199288.png)

After: 
![image](https://user-images.githubusercontent.com/11770760/124380421-cf036280-dcbc-11eb-9f44-41e34da927ed.png)
