### PR TITLE
Fix broken sticky header in details view

### DIFF
--- a/Files/UserControls/DataGridHeader.xaml
+++ b/Files/UserControls/DataGridHeader.xaml
@@ -10,7 +10,10 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
     <UserControl.Resources>
-        <Style x:Name="HeaderButtonStyle" TargetType="Button">
+        <Style
+            x:Name="HeaderButtonStyle"
+            BasedOn="{StaticResource DefaultButtonStyle}"
+            TargetType="Button">
             <Setter Property="CornerRadius" Value="0" />
             <Setter Property="BorderBrush" Value="Transparent" />
             <Setter Property="HorizontalContentAlignment" Value="Stretch" />

--- a/Files/ViewModels/ColumnsViewModel.cs
+++ b/Files/ViewModels/ColumnsViewModel.cs
@@ -97,11 +97,32 @@ namespace Files.ViewModels
             set => SetProperty(ref sizeColumn, value);
         }
 
-        private double totalWidth = 600;
-        public double TotalWidth
+        public double TotalWidth => IconColumn.Length.Value + NameColumn.Length.Value + StatusColumn.Length.Value + DateModifiedColumn.Length.Value + OriginalPathColumn.Length.Value 
+            + ItemTypeColumn.Length.Value + DateDeletedColumn.Length.Value + DateCreatedColumn.Length.Value + SizeColumn.Length.Value;
+
+        public void SetDesiredSize(double width)
         {
-            get => totalWidth;
-            set => SetProperty(ref totalWidth, value);
+            if(TotalWidth > width || TotalWidth < width) 
+            {
+                var proportion = width / TotalWidth;
+                SetColumnSizeProportionally(proportion);
+            }
+        }
+
+        /// <summary>
+        /// Multiplies every column's length by the given amount if it is within the size
+        /// </summary>
+        /// <param name="factor"></param>
+        private void SetColumnSizeProportionally(double factor)
+        {
+            NameColumn.TryMultiplySize(factor);
+            StatusColumn.TryMultiplySize(factor);
+            DateModifiedColumn.TryMultiplySize(factor);
+            OriginalPathColumn.TryMultiplySize(factor);
+            ItemTypeColumn.TryMultiplySize(factor);
+            DateDeletedColumn.TryMultiplySize(factor);
+            DateCreatedColumn.TryMultiplySize(factor);
+            SizeColumn.TryMultiplySize(factor);
         }
     }
 
@@ -204,6 +225,27 @@ namespace Files.ViewModels
             OnPropertyChanged(nameof(MaxLength));
             OnPropertyChanged(nameof(Visibility));
             OnPropertyChanged(nameof(MinLength));
+        }
+
+
+        public void TryMultiplySize(double factor)
+        {
+            var newSize = Length.Value * factor;
+            if(newSize == 0)
+            {
+                return;
+            }
+
+            double setLength = newSize;
+            if (newSize < MinLength)
+            {
+                setLength = MinLength;
+            } else if(newSize >= MaxLength)
+            {
+                setLength = MaxLength;
+            }
+
+            UserLength = new GridLength(setLength);
         }
     }
 }

--- a/Files/ViewModels/ColumnsViewModel.cs
+++ b/Files/ViewModels/ColumnsViewModel.cs
@@ -227,7 +227,6 @@ namespace Files.ViewModels
             OnPropertyChanged(nameof(MinLength));
         }
 
-
         public void TryMultiplySize(double factor)
         {
             var newSize = Length.Value * factor;

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -310,7 +310,6 @@
                     <ListView.Header>
                         <Grid
                             x:Name="HeaderGrid"
-                            Width="{x:Bind ColumnsViewModel.TotalWidth, Mode=OneWay}"
                             Height="38"
                             Padding="0"
                             Background="{ThemeResource FileBrowserBackgroundBrush}"
@@ -538,7 +537,6 @@
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="local2:ListedItem">
                             <Grid
-                                Width="{Binding ColumnsViewModel.TotalWidth, ElementName=PageRoot, Mode=OneWay}"
                                 HorizontalAlignment="Stretch"
                                 IsRightTapEnabled="True"
                                 Loaded="Grid_Loaded"

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -308,7 +308,7 @@
                         <Grid
                             x:Name="HeaderGrid"
                             Height="38"
-                            Margin="26,0,0,0"
+                            Margin="16,0,0,0"
                             Padding="0"
                             Background="{ThemeResource FileBrowserBackgroundBrush}"
                             BorderBrush="{ThemeResource SystemChromeHighColor}"
@@ -620,7 +620,7 @@
                                 <Grid
                                     Grid.Column="1"
                                     Width="{Binding ColumnsViewModel.NameColumn.Length.Value, ElementName=PageRoot, Mode=OneWay}"
-                                    Padding="8,0,0,0"
+                                    Padding="12,0,0,0"
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     Tapped="ItemNameGrid_Tapped">
@@ -911,7 +911,7 @@
                         <triggers:IsEqualStateTrigger Value="{x:Bind MainViewModel.MultiselectEnabled, Mode=OneWay}" To="True" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="HeaderGrid.Margin" Value="56,0,0,0" />
+                        <Setter Target="HeaderGrid.Margin" Value="44,0,0,0" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -308,7 +308,7 @@
                         <Grid
                             x:Name="HeaderGrid"
                             Height="38"
-                            Margin="24,0,0,0"
+                            Margin="20,0,0,0"
                             Padding="0"
                             Background="{ThemeResource FileBrowserBackgroundBrush}"
                             BorderBrush="{ThemeResource SystemChromeHighColor}"
@@ -911,7 +911,7 @@
                         <triggers:IsEqualStateTrigger Value="{x:Bind MainViewModel.MultiselectEnabled, Mode=OneWay}" To="True" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="HeaderGrid.Margin" Value="56,0,0,0" />
+                        <Setter Target="HeaderGrid.Margin" Value="52,0,0,0" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -51,6 +51,88 @@
                 <Setter Property="Width" Value="1" />
                 <Setter Property="Opacity" Value="0.8" />
             </Style>
+            <Style TargetType="ListView">
+                <Setter Property="IsTabStop" Value="False" />
+                <Setter Property="TabNavigation" Value="Once" />
+                <Setter Property="IsSwipeEnabled" Value="True" />
+                <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+                <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+                <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Enabled" />
+                <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="True" />
+                <Setter Property="ScrollViewer.VerticalScrollMode" Value="Enabled" />
+                <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="True" />
+                <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
+                <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+                <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
+                <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                <Setter Property="ItemContainerTransitions">
+                    <Setter.Value>
+                        <TransitionCollection>
+                            <AddDeleteThemeTransition />
+                            <ContentThemeTransition />
+                            <ReorderThemeTransition />
+                            <EntranceThemeTransition IsStaggeringEnabled="False" />
+                        </TransitionCollection>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <ItemsStackPanel Orientation="Vertical" />
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ListView">
+                            <Border
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                                <ScrollViewer
+                                    HorizontalScrollBarVisibility="Auto"
+                                    HorizontalScrollMode="Auto"
+                                    VerticalScrollBarVisibility="Disabled"
+                                    VerticalScrollMode="Disabled">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="*" />
+                                        </Grid.RowDefinitions>
+                                        <ContentPresenter Content="{TemplateBinding Header}" />
+                                        <ScrollViewer
+                                            x:Name="ScrollViewer"
+                                            Grid.Row="1"
+                                            AutomationProperties.AccessibilityView="Raw"
+                                            BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+                                            HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                            HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                                            IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                                            IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                                            IsHorizontalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsHorizontalScrollChainingEnabled}"
+                                            IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                                            IsVerticalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsVerticalScrollChainingEnabled}"
+                                            TabNavigation="{TemplateBinding TabNavigation}"
+                                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                                            VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                                            ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}">
+                                            <ItemsPresenter
+                                                Padding="{TemplateBinding Padding}"
+                                                Footer="{TemplateBinding Footer}"
+                                                FooterTemplate="{TemplateBinding FooterTemplate}"
+                                                FooterTransitions="{TemplateBinding FooterTransitions}"
+                                                HeaderTemplate="{TemplateBinding HeaderTemplate}"
+                                                HeaderTransitions="{TemplateBinding HeaderTransitions}" />
+                                        </ScrollViewer>
+                                    </Grid>
+                                </ScrollViewer>
+                            </Border>
+
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
 
             <Style TargetType="ListViewHeaderItem">
                 <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -308,7 +308,7 @@
                         <Grid
                             x:Name="HeaderGrid"
                             Height="38"
-                            Margin="20,0,0,0"
+                            Margin="26,0,0,0"
                             Padding="0"
                             Background="{ThemeResource FileBrowserBackgroundBrush}"
                             BorderBrush="{ThemeResource SystemChromeHighColor}"
@@ -911,7 +911,7 @@
                         <triggers:IsEqualStateTrigger Value="{x:Bind MainViewModel.MultiselectEnabled, Mode=OneWay}" To="True" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="HeaderGrid.Margin" Value="52,0,0,0" />
+                        <Setter Target="HeaderGrid.Margin" Value="56,0,0,0" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -15,6 +15,7 @@
     xmlns:local2="using:Files.Filesystem"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:triggers="using:Microsoft.Toolkit.Uwp.UI.Triggers"
     xmlns:tui="using:Microsoft.Toolkit.Uwp.UI"
     xmlns:uc="using:Files.UserControls"
     x:Name="PageRoot"
@@ -100,7 +101,7 @@
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="*" />
                                         </Grid.RowDefinitions>
-                                        <ContentPresenter Content="{TemplateBinding Header}" />
+                                        <ContentPresenter Padding="{TemplateBinding Padding}" Content="{TemplateBinding Header}" />
                                         <ScrollViewer
                                             x:Name="ScrollViewer"
                                             Grid.Row="1"
@@ -232,7 +233,6 @@
         VerticalAlignment="Stretch"
         ContextFlyout="{x:Bind BaseContextMenuFlyout}"
         SizeChanged="RootGrid_SizeChanged">
-
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Key="{x:Bind PlusKey}" Modifiers="Control">
                 <i:Interaction.Behaviors>
@@ -311,6 +311,7 @@
                         <Grid
                             x:Name="HeaderGrid"
                             Height="38"
+                            Margin="24,0,0,0"
                             Padding="0"
                             Background="{ThemeResource FileBrowserBackgroundBrush}"
                             BorderBrush="{ThemeResource SystemChromeHighColor}"
@@ -904,5 +905,19 @@
                 Stroke="{ThemeResource SystemAccentColorLight1}"
                 StrokeThickness="1" />
         </Canvas>
+
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState x:Name="MultiselectDisabled" />
+                <VisualState x:Name="MultiselectEnabled">
+                    <VisualState.StateTriggers>
+                        <triggers:IsEqualStateTrigger Value="{x:Bind MainViewModel.MultiselectEnabled, Mode=OneWay}" To="True" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="HeaderGrid.Margin" Value="56,0,0,0" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
     </Grid>
 </local:BaseLayout>

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -101,7 +101,7 @@
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="*" />
                                         </Grid.RowDefinitions>
-                                        <ContentPresenter Padding="{TemplateBinding Padding}" Content="{TemplateBinding Header}" />
+                                        <ContentPresenter Padding="8,0,8,8" Content="{TemplateBinding Header}" />
                                         <ScrollViewer
                                             x:Name="ScrollViewer"
                                             Grid.Row="1"
@@ -274,7 +274,7 @@
                 <ListView
                     x:Name="FileList"
                     Margin="0,4,0,0"
-                    Padding="8,0,8,8"
+                    Padding="8,0,8,12"
                     HorizontalAlignment="Stretch"
                     VerticalContentAlignment="Stretch"
                     tui:ScrollViewerExtensions.EnableMiddleClickScrolling="{x:Bind IsMiddleClickToScrollEnabled, Mode=OneWay}"
@@ -296,9 +296,6 @@
                     SelectionChanged="FileList_SelectionChanged"
                     SelectionMode="{x:Bind MainViewModel.MultiselectEnabled, Mode=OneWay, Converter={StaticResource BoolToSelectionModeConverter}}"
                     Visibility="{x:Bind FolderSettings.IsLayoutModeChanging, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
-                    <i:Interaction.Behaviors>
-                        <behaviors:StickyHeaderBehavior />
-                    </i:Interaction.Behaviors>
                     <ListView.ItemContainerTransitions>
                         <TransitionCollection>
                             <AddDeleteThemeTransition />

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -258,9 +258,6 @@ namespace Files.Views.LayoutModes
                 ColumnsViewModel.StatusColumn.Show();
             }
 
-            //ColumnsViewModel.TotalWidth = Math.Max(RootGrid.ActualWidth, Column1.ActualWidth + Column2.ActualWidth + Column3.ActualWidth + Column4.ActualWidth + Column5.ActualWidth
-            //        + Column6.ActualWidth + Column7.ActualWidth + Column8.ActualWidth + Column9.ActualWidth + Column10.ActualWidth);
-
             UpdateSortIndicator();
         }
 

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -205,6 +205,7 @@ namespace Files.Views.LayoutModes
                 }
             });
 
+            ColumnsViewModel.SetDesiredSize(RootGrid.ActualWidth - 50);
             FilesystemViewModel_PageTypeUpdated(null, new PageTypeUpdatedEventArgs()
             {
                 IsTypeCloudDrive = InstanceViewModel.IsPageTypeCloudDrive,
@@ -257,8 +258,8 @@ namespace Files.Views.LayoutModes
                 ColumnsViewModel.StatusColumn.Show();
             }
 
-            ColumnsViewModel.TotalWidth = Math.Max(RootGrid.ActualWidth, Column1.ActualWidth + Column2.ActualWidth + Column3.ActualWidth + Column4.ActualWidth + Column5.ActualWidth
-                    + Column6.ActualWidth + Column7.ActualWidth + Column8.ActualWidth + Column9.ActualWidth + Column10.ActualWidth);
+            //ColumnsViewModel.TotalWidth = Math.Max(RootGrid.ActualWidth, Column1.ActualWidth + Column2.ActualWidth + Column3.ActualWidth + Column4.ActualWidth + Column5.ActualWidth
+            //        + Column6.ActualWidth + Column7.ActualWidth + Column8.ActualWidth + Column9.ActualWidth + Column10.ActualWidth);
 
             UpdateSortIndicator();
         }
@@ -653,13 +654,11 @@ namespace Files.Views.LayoutModes
             ColumnsViewModel.DateCreatedColumn.UserLength = new GridLength(Column7.ActualWidth, GridUnitType.Pixel);
             ColumnsViewModel.ItemTypeColumn.UserLength = new GridLength(Column8.ActualWidth, GridUnitType.Pixel);
             ColumnsViewModel.SizeColumn.UserLength = new GridLength(Column9.ActualWidth, GridUnitType.Pixel);
-            ColumnsViewModel.TotalWidth = Math.Max(RootGrid.ActualWidth, Column1.ActualWidth + Column2.ActualWidth + Column3.ActualWidth + Column4.ActualWidth + Column5.ActualWidth
-                    + Column6.ActualWidth + Column7.ActualWidth + Column8.ActualWidth + Column9.ActualWidth + Column10.ActualWidth);
         }
 
         private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            UpdateColumnLayout();
+            ColumnsViewModel.SetDesiredSize(RootGrid.ActualWidth - 50);
         }
 
         private void GridSplitter_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related #4643
- Closes #5360 (scrollbar now hidden until hovered over or horizontal scrolling is invoked)

**Details of Changes**
Add details of changes here.
- Fix issue where the header wouldn't always show when scrolling vertically
- Update header buttons to use winui 2.6 styling
- Update column sizes when the view area is resized

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**