### PR TITLE
Added time to preview and detailed properties

### DIFF
--- a/Files/Extensions/DateTimeExtensions.cs
+++ b/Files/Extensions/DateTimeExtensions.cs
@@ -16,7 +16,11 @@ namespace Files.Extensions
             }
             else if (isDetailed && returnFormat != "g" && elapsed.TotalDays < 7)
             {
-                return d.ToLocalTime().ToString(returnFormat) + " (" + GetFriendlyDateFromFormat(d, returnFormat) + ")";
+                return d.ToLocalTime().ToString(returnFormat) + " " + d.ToLocalTime().ToString("t") + " (" + GetFriendlyDateFromFormat(d, returnFormat) + ")";
+            }
+            else if (isDetailed && returnFormat != "g")
+            {
+                return d.ToLocalTime().ToString(returnFormat) + " " + d.ToLocalTime().ToString("t");
             }
             else if (elapsed.TotalDays >= 7 || returnFormat == "g")
             {


### PR DESCRIPTION
Now when you check the creation or modification date on preview or on detailed properties, you will see also the time of creation / modification.

I realized the other day that when you want to know the exactly time when you did something it's very difficult right now, so added this little change to make things easier.

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**

**Details of Changes**
- Added creation and modification time on preview and detailed properties, so you can know exactly when you made something.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**

![image](https://user-images.githubusercontent.com/11770760/125161243-7ed74500-e181-11eb-8c5b-9464b2e54a84.png)

![image](https://user-images.githubusercontent.com/11770760/125161248-85fe5300-e181-11eb-8356-398287db0ec7.png)
