### PR TITLE
Fix crash due to missing resource key

### DIFF
--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -2,14 +2,9 @@
     x:Class="Files.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
     xmlns:contract13NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,13)"
     xmlns:contract13Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,13)"
-    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:fsvm="using:Files.ViewModels"
-    xmlns:local="using:Microsoft.UI.Xaml.Controls"
-    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives">
+    xmlns:fsvm="using:Files.ViewModels">
 
     <Application.Resources>
         <ResourceDictionary>
@@ -67,7 +62,7 @@
                             <SolidColorBrush x:Key="PreviewPaneBackgroundBrush" Color="#21000000" />
 
                             <contract13Present:SolidColorBrush x:Key="RootBackgroundBrush" Color="Transparent" />
-                            <contract13NotPresent:ThemeResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                            <contract13NotPresent:StaticResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
                             <StaticResource x:Key="PropertiesDialogRootBackgroundBrush" ResourceKey="RootBackgroundBrush" />
 
@@ -110,7 +105,7 @@
                             <SolidColorBrush x:Key="PreviewPaneBackgroundBrush" Color="#31000000" />
 
                             <contract13Present:SolidColorBrush x:Key="RootBackgroundBrush" Color="Transparent" />
-                            <contract13NotPresent:ThemeResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                            <contract13NotPresent:StaticResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
                             <StaticResource x:Key="PropertiesDialogRootBackgroundBrush" ResourceKey="RootBackgroundBrush" />
 
@@ -162,7 +157,7 @@
                             <SolidColorBrush x:Key="PreviewPaneBackgroundBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
 
                             <contract13Present:SolidColorBrush x:Key="RootBackgroundBrush" Color="Transparent" />
-                            <contract13NotPresent:ThemeResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                            <contract13NotPresent:StaticResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
                             <StaticResource x:Key="PropertiesDialogRootBackgroundBrush" ResourceKey="RootBackgroundBrush" />
 


### PR DESCRIPTION
App on main currently crashes on startup due to missing resource key.

**Details of Changes**
Add details of changes here.
- Changed `RootBackgroundBrush` from ThemeResource to StaticResource

**Validation**
How did you test these changes?
- [x] Built and ran the app
