### PR TITLE
Add more space to some strings in Settings

### DIFF
--- a/Files/Dialogs/SettingsDialog.xaml
+++ b/Files/Dialogs/SettingsDialog.xaml
@@ -47,7 +47,7 @@
         <muxc:NavigationView
             x:Name="SettingsPane"
             Grid.Column="0"
-            Width="180"
+            Width="190"
             Margin="12,12,0,12"
             IsBackButtonVisible="Collapsed"
             IsBackEnabled="False"
@@ -55,7 +55,7 @@
             IsPaneToggleButtonVisible="False"
             IsSettingsVisible="False"
             IsTitleBarAutoPaddingEnabled="False"
-            OpenPaneLength="180"
+            OpenPaneLength="190"
             PaneDisplayMode="Left"
             SelectionChanged="SettingsPane_SelectionChanged">
 

--- a/Files/Views/SettingsPages/About.xaml
+++ b/Files/Views/SettingsPages/About.xaml
@@ -71,6 +71,7 @@
                                 x:Name="FeedbackForm"
                                 x:Uid="SettingsAboutSubmitFeedbackListViewItem"
                                 Padding="8,2"
+                                Width="200"
                                 HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
                                 AutomationProperties.Name="Send the developers an issue report with more information"

--- a/Files/Views/SettingsPages/Preferences.xaml
+++ b/Files/Views/SettingsPages/Preferences.xaml
@@ -45,7 +45,7 @@
                         <FontIcon Glyph="&#xF2B7;" />
                     </local:SettingsBlockControl.Icon>
                     <ComboBox
-                        Width="200"
+                        Width="230"
                         HorizontalAlignment="Left"
                         ItemsSource="{Binding DefaultLanguages}"
                         SelectedIndex="{Binding SelectedLanguageIndex, Mode=TwoWay}">


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related #5376 

**Details of Changes**
I divided the changes on 3 commits to easily check what does each commit. Check screenshots for visual explanation.
- Added more space on preferences to language selector. 
- Added more space on About to all useful links
- Add more space on settings left pane

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
- Added more space on preferences to language selector (check "Idioma" menu, on the right side.)
- - Before: 
![Preferences](https://user-images.githubusercontent.com/11770760/125688319-56516d4d-3a66-4dfd-88e0-63b3d0d08eb4.png)
- - After:
![image](https://user-images.githubusercontent.com/11770760/125688381-792b987c-a907-45ab-87d7-9195a7a4b090.png)

- Added more space on About to all useful links (check the useful link of "Política de privacidad"
- - Before:
![About](https://user-images.githubusercontent.com/11770760/125688694-dca88918-81c8-4cc7-92ec-89cb8cc92e0c.png)
- - After:
![image](https://user-images.githubusercontent.com/11770760/125688804-ae4f4e53-afef-41fe-94a1-d7194ed08e86.png)

- Add more space on settings left pane (check "Archivos y carpetas" on the left pane)
- - Before: 
![Preferences](https://user-images.githubusercontent.com/11770760/125688319-56516d4d-3a66-4dfd-88e0-63b3d0d08eb4.png)
- - After:
![image](https://user-images.githubusercontent.com/11770760/125688381-792b987c-a907-45ab-87d7-9195a7a4b090.png)
