### PR TITLE
Renamed strings and methods related to Pin to favorites to keep consistency

### DIFF
--- a/Files/Helpers/ContextFlyoutItemHelper.cs
+++ b/Files/Helpers/ContextFlyoutItemHelper.cs
@@ -408,14 +408,14 @@ namespace Files.Helpers
                 {
                     Text = "BaseLayoutItemContextFlyoutPinToFavorites/Text".GetLocalized(),
                     Glyph = "\uE840",
-                    Command = commandsViewModel.PinDirectoryToSidebarCommand,
+                    Command = commandsViewModel.PinDirectoryToFavoritesCommand,
                     ShowItem =!itemViewModel.CurrentFolder.IsPinned
                 },
                 new ContextMenuFlyoutItemViewModel()
                 {
-                    Text = "BaseLayoutContextFlyoutUnpinDirectoryFromSidebar/Text".GetLocalized(),
+                    Text = "BaseLayoutContextFlyoutUnpinFromFavorites/Text".GetLocalized(),
                     Glyph = "\uE77A",
-                    Command = commandsViewModel.UnpinDirectoryFromSidebarCommand,
+                    Command = commandsViewModel.UnpinDirectoryFromFavoritesCommand,
                     ShowItem =itemViewModel.CurrentFolder.IsPinned
                 },
                 new ContextMenuFlyoutItemViewModel()
@@ -697,7 +697,7 @@ namespace Files.Helpers
                 },
                 new ContextMenuFlyoutItemViewModel()
                 {
-                    Text = "BaseLayoutContextFlyoutUnpinDirectoryFromSidebar/Text".GetLocalized(),
+                    Text = "BaseLayoutContextFlyoutUnpinFromFavorites/Text".GetLocalized(),
                     Glyph = "\uE77A",
                     Command = commandsViewModel.SidebarUnpinItemCommand,
                     ShowItem = selectedItems.All(x => x.PrimaryItemAttribute == StorageItemTypes.Folder && x.IsPinned),

--- a/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -155,7 +155,7 @@ namespace Files.Interacts
             NavigationHelpers.OpenSelectedItems(associatedInstance, false);
         }
 
-        public virtual void UnpinDirectoryFromSidebar(RoutedEventArgs e)
+        public virtual void UnpinDirectoryFromFavorites(RoutedEventArgs e)
         {
             App.SidebarPinnedController.Model.RemoveItem(associatedInstance.FilesystemViewModel.WorkingDirectory);
         }
@@ -402,7 +402,7 @@ namespace Files.Interacts
             }
         }
 
-        public virtual void PinDirectoryToSidebar(RoutedEventArgs e)
+        public virtual void PinDirectoryToFavorites(RoutedEventArgs e)
         {
             App.SidebarPinnedController.Model.AddItem(associatedInstance.FilesystemViewModel.WorkingDirectory);
         }

--- a/Files/Interacts/BaseLayoutCommandsViewModel.cs
+++ b/Files/Interacts/BaseLayoutCommandsViewModel.cs
@@ -38,7 +38,7 @@ namespace Files.Interacts
             RunAsAnotherUserCommand = new RelayCommand<RoutedEventArgs>(commandsModel.RunAsAnotherUser);
             SidebarPinItemCommand = new RelayCommand<RoutedEventArgs>(commandsModel.SidebarPinItem);
             SidebarUnpinItemCommand = new RelayCommand<RoutedEventArgs>(commandsModel.SidebarUnpinItem);
-            UnpinDirectoryFromSidebarCommand = new RelayCommand<RoutedEventArgs>(commandsModel.UnpinDirectoryFromSidebar);
+            UnpinDirectoryFromFavoritesCommand = new RelayCommand<RoutedEventArgs>(commandsModel.UnpinDirectoryFromFavorites);
             OpenItemCommand = new RelayCommand<RoutedEventArgs>(commandsModel.OpenItem);
             EmptyRecycleBinCommand = new RelayCommand<RoutedEventArgs>(commandsModel.EmptyRecycleBin);
             QuickLookCommand = new RelayCommand<RoutedEventArgs>(commandsModel.QuickLook);
@@ -59,7 +59,7 @@ namespace Files.Interacts
             CopyPathOfSelectedItemCommand = new RelayCommand<RoutedEventArgs>(commandsModel.CopyPathOfSelectedItem);
             OpenDirectoryInDefaultTerminalCommand = new RelayCommand<RoutedEventArgs>(commandsModel.OpenDirectoryInDefaultTerminal);
             ShareItemCommand = new RelayCommand<RoutedEventArgs>(commandsModel.ShareItem);
-            PinDirectoryToSidebarCommand = new RelayCommand<RoutedEventArgs>(commandsModel.PinDirectoryToSidebar);
+            PinDirectoryToFavoritesCommand = new RelayCommand<RoutedEventArgs>(commandsModel.PinDirectoryToFavorites);
             ItemPointerPressedCommand = new RelayCommand<PointerRoutedEventArgs>(commandsModel.ItemPointerPressed);
             UnpinItemFromStartCommand = new RelayCommand<RoutedEventArgs>(commandsModel.UnpinItemFromStart);
             PinItemToStartCommand = new RelayCommand<RoutedEventArgs>(commandsModel.PinItemToStart);
@@ -98,7 +98,7 @@ namespace Files.Interacts
 
         public ICommand OpenItemCommand { get; private set; }
 
-        public ICommand UnpinDirectoryFromSidebarCommand { get; private set; }
+        public ICommand UnpinDirectoryFromFavoritesCommand { get; private set; }
 
         public ICommand EmptyRecycleBinCommand { get; private set; }
 
@@ -138,7 +138,7 @@ namespace Files.Interacts
 
         public ICommand ShareItemCommand { get; private set; }
 
-        public ICommand PinDirectoryToSidebarCommand { get; private set; }
+        public ICommand PinDirectoryToFavoritesCommand { get; private set; }
 
         public ICommand ItemPointerPressedCommand { get; private set; }
 

--- a/Files/Interacts/IBaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/IBaseLayoutCommandImplementationModel.cs
@@ -23,7 +23,7 @@ namespace Files.Interacts
 
         void SidebarUnpinItem(RoutedEventArgs e);
 
-        void UnpinDirectoryFromSidebar(RoutedEventArgs e);
+        void UnpinDirectoryFromFavorites(RoutedEventArgs e);
 
         void OpenItem(RoutedEventArgs e);
 
@@ -65,7 +65,7 @@ namespace Files.Interacts
 
         void ShareItem(RoutedEventArgs e);
 
-        void PinDirectoryToSidebar(RoutedEventArgs e);
+        void PinDirectoryToFavorites(RoutedEventArgs e);
 
         void ItemPointerPressed(PointerRoutedEventArgs e);
 

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -324,8 +324,8 @@
   <data name="SidebarPictures" xml:space="preserve">
     <value>Pictures</value>
   </data>
-  <data name="SideBarUnpinFromSideBar.Text" xml:space="preserve">
-    <value>Unpin from sidebar</value>
+  <data name="SideBarUnpinFromFavorites.Text" xml:space="preserve">
+    <value>Unpin from Favorites</value>
   </data>
   <data name="SidebarVideos" xml:space="preserve">
     <value>Videos</value>
@@ -1003,7 +1003,7 @@
     <value>Move overflow items into a sub menu</value>
   </data>
   <data name="SettingsRecycleBinSwitch.Title" xml:space="preserve">
-    <value>Pin Recycle Bin to the sidebar</value>
+    <value>Pin Recycle Bin to Favorites</value>
   </data>
   <data name="SettingsPreferencesShowConfirmDeleteDialogSwitch.Header" xml:space="preserve">
     <value>Show a confirmation dialog when deleting files or folders</value>
@@ -1656,8 +1656,8 @@
   <data name="PropertyItemName" xml:space="preserve">
     <value>Item Name</value>
   </data>
-  <data name="BaseLayoutContextFlyoutUnpinDirectoryFromSidebar.Text" xml:space="preserve">
-    <value>Unpin directory from sidebar</value>
+  <data name="BaseLayoutContextFlyoutUnpinFromFavorites.Text" xml:space="preserve">
+    <value>Unpin from Favorites</value>
   </data>
   <data name="SidebarNetworkDrives" xml:space="preserve">
     <value>Network drives</value>

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -162,10 +162,10 @@
                     </MenuFlyoutItem>
                     <MenuFlyoutItem
                         x:Name="UnpinItem"
-                        x:Uid="SideBarUnpinFromSideBar"
+                        x:Uid="SideBarUnpinFromFavorites"
                         x:Load="{x:Bind ShowUnpinItem, Mode=OneWay}"
                         Click="{x:Bind UnpinItem_Click}"
-                        Text="Unpin from Sidebar">
+                        Text="Unpin from Favorites">
                         <MenuFlyoutItem.Icon>
                             <FontIcon Glyph="&#xE77A;" />
                         </MenuFlyoutItem.Icon>

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -126,7 +126,7 @@ namespace Files.UserControls
         private bool showUnpinItem;
 
         /// <summary>
-        /// Binding property for the MenuFlyoutItem SideBarUnpinFromSideBar
+        /// Binding property for the MenuFlyoutItem SideBarUnpinFromFavorites
         /// </summary>
         public bool ShowUnpinItem
         {


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Closes #5447 
- Related to #5370

**Details of Changes**
- Renamed unpining strings to keep consistency with 'Pin to Favorites'
- Renamed Pin recycle bin string of sidebar settings to keep consistency with 'Pin to Favorites'
- Renamed methods from Pin/UnpinDirectoryToSidebar to Pin/UnpinDirectoryToFavorites -> Internal minor change using the same base, since you don't pin the folders to sidebar, but to Favorites. I didn't remove the "directory" part just in case in the future Files needs a method like PinFileToFavorites.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Sidebar:
![image](https://user-images.githubusercontent.com/11770760/126186617-f03c2373-cb07-4dc7-9f4a-6a9d883c3ca5.png)
![image](https://user-images.githubusercontent.com/11770760/126187259-3df765cb-b453-4d55-8919-5139a856e01d.png)

Right click menu:
![image](https://user-images.githubusercontent.com/11770760/126186750-b9b74b69-6ca0-457b-960a-0bc146c8d573.png)

Settings:
![image](https://user-images.githubusercontent.com/11770760/126186796-d6a309f8-a842-4f74-bc77-9d1931d7d826.png)
