### PR TITLE
New theme selection UI

### DIFF
--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -2,14 +2,9 @@
     x:Class="Files.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
     xmlns:contract13NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,13)"
     xmlns:contract13Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,13)"
-    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:fsvm="using:Files.ViewModels"
-    xmlns:local="using:Microsoft.UI.Xaml.Controls"
-    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives">
+    xmlns:fsvm="using:Files.ViewModels">
 
     <Application.Resources>
         <ResourceDictionary>
@@ -67,7 +62,7 @@
                             <SolidColorBrush x:Key="PreviewPaneBackgroundBrush" Color="#21000000" />
 
                             <contract13Present:SolidColorBrush x:Key="RootBackgroundBrush" Color="Transparent" />
-                            <contract13NotPresent:ThemeResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                            <contract13NotPresent:StaticResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
                             <StaticResource x:Key="PropertiesDialogRootBackgroundBrush" ResourceKey="RootBackgroundBrush" />
 
@@ -110,7 +105,7 @@
                             <SolidColorBrush x:Key="PreviewPaneBackgroundBrush" Color="#31000000" />
 
                             <contract13Present:SolidColorBrush x:Key="RootBackgroundBrush" Color="Transparent" />
-                            <contract13NotPresent:ThemeResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                            <contract13NotPresent:StaticResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
                             <StaticResource x:Key="PropertiesDialogRootBackgroundBrush" ResourceKey="RootBackgroundBrush" />
 
@@ -162,7 +157,7 @@
                             <SolidColorBrush x:Key="PreviewPaneBackgroundBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
 
                             <contract13Present:SolidColorBrush x:Key="RootBackgroundBrush" Color="Transparent" />
-                            <contract13NotPresent:ThemeResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                            <contract13NotPresent:StaticResource x:Key="RootBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
 
                             <StaticResource x:Key="PropertiesDialogRootBackgroundBrush" ResourceKey="RootBackgroundBrush" />
 

--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -166,6 +166,7 @@
                             <Color x:Key="LayerFillColorDefault">#11000000</Color>
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
+                    <x:Double x:Key="SettingsBlockControlDefaultWidth">385</x:Double>
                     <LinearGradientBrush x:Key="ControlElevationBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
                         <LinearGradientBrush.RelativeTransform>
                             <ScaleTransform CenterY="0.5" ScaleY="-1" />

--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -166,7 +166,7 @@
                             <Color x:Key="LayerFillColorDefault">#11000000</Color>
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
-                    <x:Double x:Key="SettingsBlockControlDefaultWidth">385</x:Double>
+                    <x:Double x:Key="SettingsBlockControlDefaultWidth">384</x:Double>
                     <LinearGradientBrush x:Key="ControlElevationBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">
                         <LinearGradientBrush.RelativeTransform>
                             <ScaleTransform CenterY="0.5" ScaleY="-1" />

--- a/Files/Dialogs/SettingsDialog.xaml
+++ b/Files/Dialogs/SettingsDialog.xaml
@@ -13,7 +13,7 @@
     mc:Ignorable="d">
     <ContentDialog.Resources>
         <ResourceDictionary>
-            <x:Double x:Key="ContentDialogMaxWidth">800</x:Double>
+            <x:Double x:Key="ContentDialogMaxWidth">1300</x:Double>
             <Thickness x:Key="ContentDialogPadding">0</Thickness>
             <SolidColorBrush x:Key="ContentDialogTopOverlay" Color="Transparent" />
             <ResourceDictionary.ThemeDictionaries>
@@ -147,7 +147,7 @@
             HorizontalScrollMode="Disabled"
             VerticalScrollBarVisibility="Auto"
             VerticalScrollMode="Enabled">
-            <Frame x:Name="SettingsContentFrame" Width="380" />
+            <Frame x:Name="SettingsContentFrame" Width="410" />
         </ScrollViewer>
 
         <Button

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -339,6 +339,9 @@
     <Compile Include="UserControls\Settings\SettingsDisplayControl.xaml.cs">
       <DependentUpon>SettingsDisplayControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="UserControls\Settings\ThemeSampleDisplayControl.xaml.cs">
+      <DependentUpon>ThemeSampleDisplayControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UserControls\StringEncodedImage.xaml.cs">
       <DependentUpon>StringEncodedImage.xaml</DependentUpon>
     </Compile>
@@ -1219,6 +1222,10 @@
     <Page Include="UserControls\Settings\SettingsDisplayControl.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UserControls\Settings\ThemeSampleDisplayControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="UserControls\SidebarControl.xaml">
       <SubType>Designer</SubType>

--- a/Files/Helpers/ExternalResourcesHelper.cs
+++ b/Files/Helpers/ExternalResourcesHelper.cs
@@ -81,6 +81,7 @@ namespace Files.Helpers
                 {
                     Name = file.Name.Replace(".xaml", ""),
                     Path = file.Name,
+                    AbsolutePath = file.Path,
                     IsFromOptionalPackage = isOptionalPackage
                 });
             }
@@ -88,35 +89,41 @@ namespace Files.Helpers
 
         public async Task<bool> TryLoadThemeAsync(AppTheme theme)
         {
+
             try
             {
-                StorageFile file;
-                if (theme.IsFromOptionalPackage)
-                {
-                    if (OptionalPackageThemesFolder != null)
-                    {
-                        file = await OptionalPackageThemesFolder.GetFileAsync(theme.Path);
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    file = await ThemeFolder.GetFileAsync(theme.Path);
-                }
-                CurrentThemeResources = await FileIO.ReadTextAsync(file);
-                var xaml = XamlReader.Load(CurrentThemeResources) as ResourceDictionary;
-                xaml.Add("CustomThemeID", theme.Key);
+                var xaml = await TryLoadResourceDictionary(theme);
                 App.Current.Resources.MergedDictionaries.Add(xaml);
-
                 return true;
             }
             catch (Exception)
             {
                 return false;
             }
+        }
+        
+        public async Task<ResourceDictionary> TryLoadResourceDictionary(AppTheme theme)
+        {
+            StorageFile file;
+            if (theme.IsFromOptionalPackage)
+            {
+                if (OptionalPackageThemesFolder != null)
+                {
+                    file = await OptionalPackageThemesFolder.GetFileAsync(theme.Path);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                file = await ThemeFolder.GetFileAsync(theme.Path);
+            }
+            var code = await FileIO.ReadTextAsync(file);
+            var xaml = XamlReader.Load(code) as ResourceDictionary;
+            xaml.Add("CustomThemeID", theme.Key);
+            return xaml;
         }
 
         public async void UpdateTheme(AppTheme OldTheme, AppTheme NewTheme)
@@ -146,10 +153,11 @@ namespace Files.Helpers
         }
     }
 
-    public struct AppTheme
+    public class AppTheme
     {
         public string Name { get; set; }
         public string Path { get; set; }
+        public string AbsolutePath { get; set; }
         public bool IsFromOptionalPackage { get; set; }
         public string Key => $"{Name}-{IsFromOptionalPackage}";
     }

--- a/Files/MultilingualResources/Files.pt-PT.xlf
+++ b/Files/MultilingualResources/Files.pt-PT.xlf
@@ -28,7 +28,7 @@
         </trans-unit>
         <trans-unit id="SidebarDrives" translate="yes" xml:space="preserve">
           <source>Drives</source>
-          <target state="translated">Dispositivos e Unidades</target>
+          <target state="translated">Unidades</target>
         </trans-unit>
         <trans-unit id="nameColumn.Header" translate="yes" xml:space="preserve">
           <source>Name</source>
@@ -3222,59 +3222,59 @@
         </trans-unit>
         <trans-unit id="NavigationToolbarEnterCompactOverlay.Label" translate="yes" xml:space="preserve">
           <source>Enter compact overlay</source>
-          <target state="new">Enter compact overlay</target>
+          <target state="translated">Entrar modo sobreposição compacta</target>
         </trans-unit>
         <trans-unit id="NavigationToolbarExitCompactOverlay.Label" translate="yes" xml:space="preserve">
           <source>Exit compact overlay</source>
-          <target state="new">Exit compact overlay</target>
+          <target state="translated">Sair modo sobreposição compacta</target>
         </trans-unit>
         <trans-unit id="WSL" translate="yes" xml:space="preserve">
           <source>WSL</source>
-          <target state="new">WSL</target>
+          <target state="translated">WSL</target>
         </trans-unit>
         <trans-unit id="SideBarHideSectionFromSideBar.Text" translate="yes" xml:space="preserve">
           <source>Hide {0} section</source>
-          <target state="new">Hide {0} section</target>
+          <target state="translated">Ocultar secção {0}</target>
         </trans-unit>
         <trans-unit id="SettingsMultitaskingAlwaysOpenDualPane.Title" translate="yes" xml:space="preserve">
           <source>Always open new tabs in dual pane mode</source>
-          <target state="new">Always open new tabs in dual pane mode</target>
+          <target state="translated">Abrir sempre novos separadores no modo painel duplo</target>
         </trans-unit>
         <trans-unit id="SettingsMultitaskingEnableDualPane.Title" translate="yes" xml:space="preserve">
           <source>Enable dual pane view</source>
-          <target state="new">Enable dual pane view</target>
+          <target state="translated">Ligar vista painel duplo</target>
         </trans-unit>
         <trans-unit id="SettingsVerticalTabFlyoutSwitch.Title" translate="yes" xml:space="preserve">
           <source>Display the vertical tab flyout on the title bar</source>
-          <target state="new">Display the vertical tab flyout on the title bar</target>
+          <target state="translated">Mostrar menu vertical desdobrável na barra de título </target>
         </trans-unit>
         <trans-unit id="SettingsShowCloudDrivesSection.Title" translate="yes" xml:space="preserve">
           <source>Show cloud drives section on the sidebar</source>
-          <target state="new">Show cloud drives section on the sidebar</target>
+          <target state="translated">Mostrar secção unidade de nuvem na barra lateral</target>
         </trans-unit>
         <trans-unit id="SettingsShowDrivesSection.Title" translate="yes" xml:space="preserve">
           <source>Show drives section on the sidebar</source>
-          <target state="new">Show drives section on the sidebar</target>
+          <target state="translated">Mostrar secção unidades na barra lateral</target>
         </trans-unit>
         <trans-unit id="SettingsShowWslSection.Title" translate="yes" xml:space="preserve">
           <source>Show WSL section on the sidebar</source>
-          <target state="new">Show WSL section on the sidebar</target>
+          <target state="translated">Mostrar secção WSL na barra lateral</target>
         </trans-unit>
         <trans-unit id="SettingsShowNetworkDrivesSection.Title" translate="yes" xml:space="preserve">
           <source>Show network drives section on the sidebar</source>
-          <target state="new">Show network drives section on the sidebar</target>
+          <target state="translated">Mostrar secção unidades de rede na barra lateral</target>
         </trans-unit>
         <trans-unit id="SettingsRecycleBinSwitch.Title" translate="yes" xml:space="preserve">
           <source>Pin Recycle Bin to the sidebar</source>
-          <target state="new">Pin Recycle Bin to the sidebar</target>
+          <target state="translated">Afixar Reciclagem na barra lateral</target>
         </trans-unit>
         <trans-unit id="SettingsShowLibrarySection.Title" translate="yes" xml:space="preserve">
           <source>Show library section on the sidebar</source>
-          <target state="new">Show library section on the sidebar</target>
+          <target state="translated">Mostrar secção biblioteca na barra lateral</target>
         </trans-unit>
         <trans-unit id="SettingsAppearanceTheme.Title" translate="yes" xml:space="preserve">
           <source>Choose your color</source>
-          <target state="new">Choose your color</target>
+          <target state="translated">Escolha a sua cor</target>
         </trans-unit>
         <trans-unit id="SettingsAppearanceCustomThemes.Title" translate="yes" xml:space="preserve">
           <source>Custom themes</source>
@@ -3282,55 +3282,55 @@
         </trans-unit>
         <trans-unit id="SettingsContextMenuOverflowSwitch.Title" translate="yes" xml:space="preserve">
           <source>Move overflow items into a sub menu</source>
-          <target state="new">Move overflow items into a sub menu</target>
+          <target state="translated">Mover sobra de itens para um submenu</target>
         </trans-unit>
         <trans-unit id="SettingsPreferencesAppLanguage.Title" translate="yes" xml:space="preserve">
           <source>Language</source>
-          <target state="new">Language</target>
+          <target state="translated">Idioma</target>
         </trans-unit>
         <trans-unit id="SettingsFilesAndFoldersShowFileExtensions.Title" translate="yes" xml:space="preserve">
           <source>Show extensions for known file types</source>
-          <target state="new">Show extensions for known file types</target>
+          <target state="translated">Mostrar extensões para tipos de ficheiros conhecidos</target>
         </trans-unit>
         <trans-unit id="SettingsFilesAndFoldersShowHiddenItems.Title" translate="yes" xml:space="preserve">
           <source>Show hidden files and folders</source>
-          <target state="new">Show hidden files and folders</target>
+          <target state="translated">Mostrar ficheiros e pastas ocultas</target>
         </trans-unit>
         <trans-unit id="SettingsFilesAndFoldersHideSystemItems.Title" translate="yes" xml:space="preserve">
           <source>Hide protected operating system files (Recommended)</source>
-          <target state="new">Hide protected operating system files (Recommended)</target>
+          <target state="translated">Ocultar ficheiros protegidos do sistema operativo (Recomendado)</target>
         </trans-unit>
         <trans-unit id="SettingsOpenItemsWithOneclick.Title" translate="yes" xml:space="preserve">
           <source>Open items with a single click</source>
-          <target state="new">Open items with a single click</target>
+          <target state="translated">Abrir itens com um clique único</target>
         </trans-unit>
         <trans-unit id="SettingsListAndSortDirectoriesAlongsideFiles.Title" translate="yes" xml:space="preserve">
           <source>List and sort directories alongside files</source>
-          <target state="new">List and sort directories alongside files</target>
+          <target state="translated">Listar e ordenar diretórios ao lado dos ficheiros</target>
         </trans-unit>
         <trans-unit id="SettingsSearchUnindexedItems.Title" translate="yes" xml:space="preserve">
           <source>Show unindexed items when searching for files and folders (searches may take longer)</source>
-          <target state="new">Show unindexed items when searching for files and folders (searches may take longer)</target>
+          <target state="translated">Mostrar itens não indexados ao pesquisar ficheiros e pastas (as pesquisas podem demorar mais)</target>
         </trans-unit>
         <trans-unit id="SettingsEnableLayoutPreferencesPerFolder.Title" translate="yes" xml:space="preserve">
           <source>Enable individual preferences for individual directories</source>
-          <target state="new">Enable individual preferences for individual directories</target>
+          <target state="translated">Ligar preferências individuais para diretórios individuais</target>
         </trans-unit>
         <trans-unit id="SettingsUsefulLinks.Title" translate="yes" xml:space="preserve">
           <source>Useful links</source>
-          <target state="new">Useful links</target>
+          <target state="translated">Links úteis</target>
         </trans-unit>
         <trans-unit id="SettingCopyVersionInfo.Content" translate="yes" xml:space="preserve">
           <source>Copy</source>
-          <target state="new">Copy</target>
+          <target state="translated">Copiar</target>
         </trans-unit>
         <trans-unit id="SettingsAboutOpenLogLocationButton.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Open log location</source>
-          <target state="new">Open log location</target>
+          <target state="translated">Abrir localização do log</target>
         </trans-unit>
         <trans-unit id="SettingsAboutOpenLogLocationButtonText.Text" translate="yes" xml:space="preserve">
           <source>Open log location</source>
-          <target state="new">Open log location</target>
+          <target state="translated">Abrir localização do log</target>
         </trans-unit>
         <trans-unit id="BaseLayoutItemContextFlyoutPinToFavorites.Text" translate="yes" xml:space="preserve">
           <source>Pin to Favorites</source>

--- a/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml
+++ b/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml
@@ -8,71 +8,77 @@
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400">
-    
-    <Grid x:Name="RootGrid" Padding="10" Width="120px" Height="120px">
+
+    <Grid Width="120px" Height="120px" Padding="10">
         <Grid.RowDefinitions>
-            <RowDefinition Height="20px"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="25px"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
+        <Grid CornerRadius="4" BorderThickness="1" 
+            BorderBrush="{ThemeResource SystemControlBackgroundBaseMediumHighBrush}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="20px"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="25px"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
 
-        <Grid x:Name="LeftSidePanel" Grid.ColumnSpan="2" Grid.RowSpan="2" Background="{ThemeResource PaneHolderPageBackgroundBrush}">
-            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+            <Grid x:Name="LeftSidePanel" Grid.ColumnSpan="2" Grid.RowSpan="2" Background="{ThemeResource PaneHolderPageBackgroundBrush}">
+                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                 Fill="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"/>
-            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                 Fill="{ThemeResource HorizontalTabControlBackgroundBrush}"/>
-            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                 Fill="{ThemeResource PaneHolderPageBackgroundBrush}"/>
-            
-            <Rectangle Height="3px" Width="14px" Fill="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+
+                <Rectangle Height="3px" Width="14px" Fill="{ThemeResource SystemControlForegroundBaseMediumBrush}"
                 VerticalAlignment="Top" HorizontalAlignment="Left" Margin="6,6,0,0" RadiusX="1" RadiusY="1"/>
-        </Grid>
-        <Grid x:Name="TopNavigationPanel" Grid.Column="1">
-            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+            </Grid>
+            <Grid x:Name="TopNavigationPanel" Grid.Column="1">
+                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                 Fill="{ThemeResource NavigationToolbarBackgroundBrush}"/>
-            <Rectangle x:Name="SelectedTabMockUp" Height="8px" Width="30px" Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
+                <Rectangle x:Name="SelectedTabMockUp" Height="8px" Width="30px" Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
                 Margin="4,4,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" RadiusX="2" RadiusY="2"/>
-        </Grid>
-        <Grid Grid.Column="1" Grid.Row="1" >
-            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+            </Grid>
+            <Grid Grid.Column="1" Grid.Row="1" >
+                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                 Fill="{ThemeResource ControlFillColorTertiaryBrush}"/>
-            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                 Fill="{ThemeResource FileBrowserBackgroundBrush}"/>
 
-            <Grid HorizontalAlignment="Stretch" Margin="6,6,20,0" VerticalAlignment="Top" Height="30">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="5px"/>
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition Height="5px"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
-                    <ColumnDefinition Width="5px"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <Rectangle RadiusX="4" RadiusY="4" Width="20" Height="20" Grid.RowSpan="4"
+                <Grid HorizontalAlignment="Stretch" Margin="6,6,20,0" VerticalAlignment="Top" Height="30">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="5px"/>
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition Height="5px"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition Width="5px"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Rectangle RadiusX="4" RadiusY="4" Width="20" Height="20" Grid.RowSpan="4"
                     Fill="{ThemeResource SystemControlHighlightAltBaseMediumBrush}"/>
-                <Rectangle RadiusX="2" RadiusY="2" HorizontalAlignment="Stretch"
+                    <Rectangle RadiusX="2" RadiusY="2" HorizontalAlignment="Stretch"
                     Height="4" Grid.Column="2" Grid.Row="1"
                     Fill="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}"/>
-                <Rectangle RadiusX="2" RadiusY="2" HorizontalAlignment="Stretch"
+                    <Rectangle RadiusX="2" RadiusY="2" HorizontalAlignment="Stretch"
                     Height="3" Grid.Column="2" Grid.Row="2" Margin="0,0,5,0"
                     Fill="{ThemeResource SystemAccentColor}"/>
-            </Grid>
+                </Grid>
 
-            <Border Height="1" HorizontalAlignment="Stretch" VerticalAlignment="Top" Opacity="0.1"
+                <Border Height="1" HorizontalAlignment="Stretch" VerticalAlignment="Top" Opacity="0.1"
                 Background="{ThemeResource SystemControlBackgroundBaseMediumHighBrush}"/>
-            <Border Width="1" HorizontalAlignment="Left" VerticalAlignment="Stretch" Opacity="0.1"
+                <Border Width="1" HorizontalAlignment="Left" VerticalAlignment="Stretch" Opacity="0.1"
                 Margin="0,1,0,0" Background="{ThemeResource SystemControlBackgroundBaseMediumHighBrush}"/>
+            </Grid>
         </Grid>
-
-        <TextBlock Grid.Row="2" Grid.ColumnSpan="2" FontSize="12"
+        <TextBlock Grid.Row="1" FontSize="12"
             Foreground="{ThemeResource SystemControlBackgroundBaseHighBrush}"
             Text="{x:Bind SampleTheme.Name, Mode=OneWay}"/>
     </Grid>
+    
 </UserControl>

--- a/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml
+++ b/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml
@@ -1,0 +1,78 @@
+﻿<UserControl
+    x:Class="Files.UserControls.Settings.ThemeSampleDisplayControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Files.UserControls.Settings"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+    
+    <Grid x:Name="RootGrid" Padding="10" Width="120px" Height="120px">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="20px"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="25px"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <Grid x:Name="LeftSidePanel" Grid.ColumnSpan="2" Grid.RowSpan="2" Background="{ThemeResource PaneHolderPageBackgroundBrush}">
+            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                Fill="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"/>
+            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                Fill="{ThemeResource HorizontalTabControlBackgroundBrush}"/>
+            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                Fill="{ThemeResource PaneHolderPageBackgroundBrush}"/>
+            
+            <Rectangle Height="3px" Width="14px" Fill="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                VerticalAlignment="Top" HorizontalAlignment="Left" Margin="6,6,0,0" RadiusX="1" RadiusY="1"/>
+        </Grid>
+        <Grid x:Name="TopNavigationPanel" Grid.Column="1">
+            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                Fill="{ThemeResource NavigationToolbarBackgroundBrush}"/>
+            <Rectangle x:Name="SelectedTabMockUp" Height="8px" Width="30px" Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
+                Margin="4,4,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" RadiusX="2" RadiusY="2"/>
+        </Grid>
+        <Grid Grid.Column="1" Grid.Row="1" >
+            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                Fill="{ThemeResource ControlFillColorTertiaryBrush}"/>
+            <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                Fill="{ThemeResource FileBrowserBackgroundBrush}"/>
+
+            <Grid HorizontalAlignment="Stretch" Margin="6,6,20,0" VerticalAlignment="Top" Height="30">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="5px"/>
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition Height="5px"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition Width="5px"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Rectangle RadiusX="4" RadiusY="4" Width="20" Height="20" Grid.RowSpan="4"
+                    Fill="{ThemeResource SystemControlHighlightAltBaseMediumBrush}"/>
+                <Rectangle RadiusX="2" RadiusY="2" HorizontalAlignment="Stretch"
+                    Height="4" Grid.Column="2" Grid.Row="1"
+                    Fill="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}"/>
+                <Rectangle RadiusX="2" RadiusY="2" HorizontalAlignment="Stretch"
+                    Height="3" Grid.Column="2" Grid.Row="2" Margin="0,0,5,0"
+                    Fill="{ThemeResource SystemAccentColor}"/>
+            </Grid>
+
+            <Border Height="1" HorizontalAlignment="Stretch" VerticalAlignment="Top" Opacity="0.1"
+                Background="{ThemeResource SystemControlBackgroundBaseMediumHighBrush}"/>
+            <Border Width="1" HorizontalAlignment="Left" VerticalAlignment="Stretch" Opacity="0.1"
+                Margin="0,1,0,0" Background="{ThemeResource SystemControlBackgroundBaseMediumHighBrush}"/>
+        </Grid>
+
+        <TextBlock Grid.Row="2" Grid.ColumnSpan="2" FontSize="12"
+            Foreground="{ThemeResource SystemControlBackgroundBaseHighBrush}"
+            Text="{x:Bind SampleTheme.Name, Mode=OneWay}"/>
+    </Grid>
+</UserControl>

--- a/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml
+++ b/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml
@@ -21,59 +21,75 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="25px"/>
+                <ColumnDefinition Width="35px"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <Grid x:Name="LeftSidePanel" Grid.ColumnSpan="2" Grid.RowSpan="2" Background="{ThemeResource PaneHolderPageBackgroundBrush}">
-                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                Fill="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"/>
-                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                Fill="{ThemeResource HorizontalTabControlBackgroundBrush}"/>
-                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                Fill="{ThemeResource PaneHolderPageBackgroundBrush}"/>
+            <Grid x:Name="LeftSidePanel" Grid.ColumnSpan="2" Grid.Row="1" Background="{ThemeResource PaneHolderPageBackgroundBrush}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="10"/>
+                    <RowDefinition Height="10"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition />
+                </Grid.RowDefinitions>
 
-                <Rectangle Height="3px" Width="14px" Fill="{ThemeResource SystemControlForegroundBaseMediumBrush}"
-                VerticalAlignment="Top" HorizontalAlignment="Left" Margin="6,6,0,0" RadiusX="1" RadiusY="1"/>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="3"/>
+                    <ColumnDefinition Width="10"/>
+                    <ColumnDefinition Width="20"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.RowSpan="4" Grid.ColumnSpan="4"
+                    Fill="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"/>
+                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.RowSpan="4" Grid.ColumnSpan="4"
+                    Fill="{ThemeResource HorizontalTabControlBackgroundBrush}"/>
+                <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.RowSpan="4" Grid.ColumnSpan="4"
+                    Fill="{ThemeResource PaneHolderPageBackgroundBrush}"/>
+
+                <Rectangle Grid.Row="0" Grid.Column="1"
+                    Fill="{ThemeResource SystemAccentColor}" RadiusX="2" RadiusY="2" Height="6" Width="6"/>
+                <Rectangle Grid.Row="0" Grid.Column="2"
+                    Fill="{ThemeResource SystemControlForegroundBaseMediumBrush}" RadiusX="1" RadiusY="1" Height="2" Width="15"/>
+
+                <Rectangle Grid.Row="1" Grid.Column="1"
+                    Fill="{ThemeResource SystemAccentColor}" RadiusX="2" RadiusY="2" Height="6" Width="6"/>
+                <Rectangle Grid.Row="1" Grid.Column="2"
+                    Fill="{ThemeResource SystemControlForegroundBaseMediumBrush}" RadiusX="1" RadiusY="1" Height="2" Width="15"/>
+                
+                <Rectangle Grid.Row="3" Grid.Column="1"
+                    Fill="{ThemeResource SystemControlForegroundBaseMediumBrush}" RadiusX="2" RadiusY="2" Height="6" Width="6"/>
+                <Rectangle Grid.Row="3" Grid.Column="2"
+                    Fill="{ThemeResource SystemControlForegroundBaseMediumBrush}" RadiusX="1" RadiusY="1" Height="2" Width="15"/>
             </Grid>
-            <Grid x:Name="TopNavigationPanel" Grid.Column="1">
+            
+            <Grid x:Name="TopNavigationPanel" Grid.ColumnSpan="2">
                 <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                Fill="{ThemeResource NavigationToolbarBackgroundBrush}"/>
-                <Rectangle x:Name="SelectedTabMockUp" Height="8px" Width="30px" Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
-                Margin="4,4,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" RadiusX="2" RadiusY="2"/>
+                    Fill="{ThemeResource NavigationToolbarBackgroundBrush}"/>
+
+                <StackPanel Spacing="6" HorizontalAlignment="Left" Margin="0,0,0,4"
+                    VerticalAlignment="Stretch" Orientation="Horizontal">
+                    <Rectangle Height="3px" Width="14px" Fill="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                        VerticalAlignment="Center" Margin="6,0,0,0" RadiusX="1" RadiusY="1"/>
+                    <Rectangle x:Name="SelectedTabMockUp" Height="8px" Width="30px" Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
+                        Margin="4,0,0,0" VerticalAlignment="Center" RadiusX="2" RadiusY="2"/>
+                </StackPanel>
             </Grid>
+            
             <Grid Grid.Column="1" Grid.Row="1" >
                 <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                Fill="{ThemeResource ControlFillColorTertiaryBrush}"/>
+                    Fill="{ThemeResource ControlFillColorTertiaryBrush}"/>
                 <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                Fill="{ThemeResource FileBrowserBackgroundBrush}"/>
+                    Fill="{ThemeResource FileBrowserBackgroundBrush}"/>
 
-                <Grid HorizontalAlignment="Stretch" Margin="6,6,20,0" VerticalAlignment="Top" Height="30">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="5px"/>
-                        <RowDefinition />
-                        <RowDefinition />
-                        <RowDefinition Height="5px"/>
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition />
-                        <ColumnDefinition Width="5px"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <Rectangle RadiusX="4" RadiusY="4" Width="20" Height="20" Grid.RowSpan="4"
-                    Fill="{ThemeResource SystemControlHighlightAltBaseMediumBrush}"/>
-                    <Rectangle RadiusX="2" RadiusY="2" HorizontalAlignment="Stretch"
-                    Height="4" Grid.Column="2" Grid.Row="1"
-                    Fill="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}"/>
-                    <Rectangle RadiusX="2" RadiusY="2" HorizontalAlignment="Stretch"
-                    Height="3" Grid.Column="2" Grid.Row="2" Margin="0,0,5,0"
-                    Fill="{ThemeResource SystemAccentColor}"/>
-                </Grid>
+                <StackPanel HorizontalAlignment="Stretch" Margin="6,6,20,0" VerticalAlignment="Top" Height="30" Spacing="6">
+                    <Rectangle RadiusX="4" RadiusY="4" Width="20" Height="20" Fill="{ThemeResource SystemAccentColor}"/>
+                    <Rectangle RadiusX="2" RadiusY="2" HorizontalAlignment="Stretch" Margin="5,0"
+                        Height="4" Fill="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}"/>
+                </StackPanel>
 
-                <Border Height="1" HorizontalAlignment="Stretch" VerticalAlignment="Top" Opacity="0.1"
-                Background="{ThemeResource SystemControlBackgroundBaseMediumHighBrush}"/>
-                <Border Width="1" HorizontalAlignment="Left" VerticalAlignment="Stretch" Opacity="0.1"
-                Margin="0,1,0,0" Background="{ThemeResource SystemControlBackgroundBaseMediumHighBrush}"/>
+                <Border Width="1" HorizontalAlignment="Left" VerticalAlignment="Stretch" Opacity="0.6" 
+                    Margin="-0.5,6,0,6" Background="{ThemeResource SystemControlBackgroundBaseMediumHighBrush}"/>
             </Grid>
         </Grid>
         <TextBlock Grid.Row="1" FontSize="12"

--- a/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml.cs
+++ b/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml.cs
@@ -1,22 +1,7 @@
 ﻿using Files.Helpers;
-using Files.ViewModels.SettingsViewModels;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-
-// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace Files.UserControls.Settings
 {
@@ -49,50 +34,16 @@ namespace Files.UserControls.Settings
 
         public async Task<bool> ReevaluateThemeResourceBinding()
         {
-            //var fallBackDictionaryWinUI = Resources.MergedDictionaries[0].ThemeDictionaries[ThemeHelper.RootTheme.ToString()] as ResourceDictionary;
-            // var fallBackDictionaryFiles = Resources.MergedDictionaries[1].ThemeDictionaries[ThemeHelper.RootTheme.ToString()] as ResourceDictionary;
-            if (RootGrid != null)
+            if(SampleTheme.Path != null)
             {
-                if(SampleTheme.Path != null)
+                var resources = await App.ExternalResourcesHelper.TryLoadResourceDictionary(SampleTheme);
+                if(resources != null)
                 {
-                    var resources = await App.ExternalResourcesHelper.TryLoadResourceDictionary(SampleTheme);
-                    if(resources != null)
-                    {
-                        Resources.MergedDictionaries.Add(resources);
-                        RequestedTheme = ElementTheme.Dark;
-                        RequestedTheme = ElementTheme.Light;
-                        RequestedTheme = ThemeHelper.RootTheme;
-                    }
+                    Resources.MergedDictionaries.Add(resources);
+                    RequestedTheme = ElementTheme.Dark;
+                    RequestedTheme = ElementTheme.Light;
+                    RequestedTheme = ThemeHelper.RootTheme;
                 }
-                //try
-                //{
-                //    dictionary = TryGetCorrectThemeResourceDictionary(resources, ThemeHelper.RootTheme);
-                //}
-                //var dictionary = SampleTheme.LoadedResources;
-                //if (SampleTheme.LoadedResources == null)
-                //{
-                //    if (SampleTheme.Path != null)
-                //    {
-                //        catch (Exception) { }
-                //    }
-                //}
-                //else
-                //{
-                //    try
-                //    {
-                //        Resources.MergedDictionaries.Add(SampleTheme.LoadedResources);
-                //        dictionary = TryGetCorrectThemeResourceDictionary(SampleTheme.LoadedResources, ThemeHelper.RootTheme);
-                //    }
-                //    catch (Exception) { }
-                //}
-
-                //try
-                //{
-                //    LeftSidePanel.Background = TryGetResource("SolidBackgroundFillColorSecondaryBrush", dictionary, null);
-                //    TopNavigationPanel.Background = TryGetResource("SolidBackgroundFillColorSecondaryBrush", dictionary, null);
-                //    SelectedTabMockUp.Fill = TryGetResource("TabViewItemHeaderBackgroundSelected", dictionary, null);
-                //}
-                //catch (Exception) { }
             }
             return true;
         }

--- a/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml.cs
+++ b/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml.cs
@@ -1,0 +1,100 @@
+﻿using Files.Helpers;
+using Files.ViewModels.SettingsViewModels;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Files.UserControls.Settings
+{
+    public sealed partial class ThemeSampleDisplayControl : UserControl
+    {
+        public AppTheme SampleTheme
+        {
+            get { return (AppTheme)GetValue(SampleThemeProperty); }
+            set
+            {
+                SetValue(SampleThemeProperty, value);
+                ReevaluateThemeResourceBinding();
+            }
+        }
+
+        // Using a DependencyProperty as the backing store for SampleTheme.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty SampleThemeProperty =
+            DependencyProperty.Register("SampleTheme", typeof(AppTheme), typeof(ThemeSampleDisplayControl), new PropertyMetadata(null));
+
+        public ThemeSampleDisplayControl()
+        {
+            this.InitializeComponent();
+            Loaded += ThemeSampleDisplayControl_Loaded;
+        }
+
+        private void ThemeSampleDisplayControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            ReevaluateThemeResourceBinding();
+        }
+
+        public async Task<bool> ReevaluateThemeResourceBinding()
+        {
+            //var fallBackDictionaryWinUI = Resources.MergedDictionaries[0].ThemeDictionaries[ThemeHelper.RootTheme.ToString()] as ResourceDictionary;
+            // var fallBackDictionaryFiles = Resources.MergedDictionaries[1].ThemeDictionaries[ThemeHelper.RootTheme.ToString()] as ResourceDictionary;
+            if (RootGrid != null)
+            {
+                if(SampleTheme.Path != null)
+                {
+                    var resources = await App.ExternalResourcesHelper.TryLoadResourceDictionary(SampleTheme);
+                    if(resources != null)
+                    {
+                        Resources.MergedDictionaries.Add(resources);
+                        RequestedTheme = ElementTheme.Dark;
+                        RequestedTheme = ElementTheme.Light;
+                        RequestedTheme = ThemeHelper.RootTheme;
+                    }
+                }
+                //try
+                //{
+                //    dictionary = TryGetCorrectThemeResourceDictionary(resources, ThemeHelper.RootTheme);
+                //}
+                //var dictionary = SampleTheme.LoadedResources;
+                //if (SampleTheme.LoadedResources == null)
+                //{
+                //    if (SampleTheme.Path != null)
+                //    {
+                //        catch (Exception) { }
+                //    }
+                //}
+                //else
+                //{
+                //    try
+                //    {
+                //        Resources.MergedDictionaries.Add(SampleTheme.LoadedResources);
+                //        dictionary = TryGetCorrectThemeResourceDictionary(SampleTheme.LoadedResources, ThemeHelper.RootTheme);
+                //    }
+                //    catch (Exception) { }
+                //}
+
+                //try
+                //{
+                //    LeftSidePanel.Background = TryGetResource("SolidBackgroundFillColorSecondaryBrush", dictionary, null);
+                //    TopNavigationPanel.Background = TryGetResource("SolidBackgroundFillColorSecondaryBrush", dictionary, null);
+                //    SelectedTabMockUp.Fill = TryGetResource("TabViewItemHeaderBackgroundSelected", dictionary, null);
+                //}
+                //catch (Exception) { }
+            }
+            return true;
+        }
+    }
+}

--- a/Files/ViewModels/SettingsViewModels/AppearanceViewModel.cs
+++ b/Files/ViewModels/SettingsViewModels/AppearanceViewModel.cs
@@ -37,8 +37,14 @@ namespace Files.ViewModels.SettingsViewModels
                 if (SetProperty(ref selectedThemeIndex, value))
                 {
                     ThemeHelper.RootTheme = (ElementTheme)value;
+                    OnPropertyChanged(nameof(SelectedElementTheme));
                 }
             }
+        }
+
+        public ElementTheme SelectedElementTheme
+        {
+            get => (ElementTheme)selectedThemeIndex;
         }
 
         public bool MoveOverflowMenuItemsToSubMenu
@@ -66,13 +72,16 @@ namespace Files.ViewModels.SettingsViewModels
             {
                 if (SetProperty(ref selectedTheme, value))
                 {
-                    // Remove the old resource file and load the new file
-                    App.ExternalResourcesHelper.UpdateTheme(App.AppSettings.SelectedTheme, selectedTheme);
+                    if(selectedTheme != null)
+                    {
+                        // Remove the old resource file and load the new file
+                        App.ExternalResourcesHelper.UpdateTheme(App.AppSettings.SelectedTheme, selectedTheme);
 
-                    App.AppSettings.SelectedTheme = selectedTheme;
+                        App.AppSettings.SelectedTheme = selectedTheme;
 
-                    // Force the application to use the correct resource file
-                    UpdateTheme();
+                        // Force the application to use the correct resource file
+                        UpdateTheme();
+                    }
                 }
             }
         }

--- a/Files/Views/SettingsPages/Appearance.xaml
+++ b/Files/Views/SettingsPages/Appearance.xaml
@@ -148,6 +148,7 @@
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
+            <StaticResource x:Key="GridViewItemBackgroundSelected" ResourceKey="SystemAccentColor"/>
             <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
         </ResourceDictionary>
     </Page.Resources>

--- a/Files/Views/SettingsPages/Appearance.xaml
+++ b/Files/Views/SettingsPages/Appearance.xaml
@@ -15,12 +15,144 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/ResourceDictionaries/RightAlignedToggleSwitchStyle.xaml" />
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" ControlsResourcesVersion="Version2" />
+                <ResourceDictionary>
+                    <ResourceDictionary.ThemeDictionaries>
+                        <ResourceDictionary x:Key="Light">
+                            <SolidColorBrush x:Key="CloudDriveSyncStatusOnlineColor" Color="#0078D7" />
+                            <SolidColorBrush x:Key="CloudDriveSyncStatusOfflineColor" Color="#30BB03" />
+                            <SolidColorBrush x:Key="CloudDriveSyncStatusExcludedColor" Color="#AAAAAA" />
+                            <Color x:Key="SolidBackgroundAcrylic">#FFFFFF</Color>
+                            <!--  Corner Radius  -->
+                            <CornerRadius x:Key="ControlCornerRadius">4</CornerRadius>
+                            <CornerRadius x:Key="OverlayCornerRadius">8</CornerRadius>
+                            <CornerRadius x:Key="NavToolbarCornerRadius">0,0,0,8</CornerRadius>
+                            <!--  Tabs  -->
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundSelected" Color="#4AFFFFFF" />
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundPressed" Color="{StaticResource SubtleFillColorTertiary}" />
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
+                            <SolidColorBrush x:Key="TabViewItemSeparator" Color="{StaticResource DividerStrokeColorDefault}" />
+                            <SolidColorBrush x:Key="TabContainerFillColorPrimary" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
+                            <SolidColorBrush x:Key="TabContainerFillColorSecondary" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
+                            <!--  Navigation Toolbar  -->
+                            <SolidColorBrush x:Key="NavigationToolbarBackgroundBrush" Color="#00000000" />
+                            <SolidColorBrush x:Key="NavigationToolbarBreadcrumbBackgroundBrush" Color="Transparent" />
+                            <!--  Horizontal Tab Control  -->
+                            <SolidColorBrush x:Key="HorizontalTabControlBackgroundBrush" Color="Transparent" />
+                            <!--  PaneHolderPage  -->
+                            <SolidColorBrush x:Key="PaneHolderPageBackgroundBrush" Color="Transparent" />
+                            <!--  Status Bar Control  -->
+                            <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="Transparent" />
+                            <!--  File Browser Control  -->
+                            <SolidColorBrush x:Key="FileBrowserBackgroundBrush" Color="Transparent" />
+                            <SolidColorBrush x:Key="FileBrowserHeaderBackgroundBrush" Color="Transparent" />
+                            <!--  Preview pane  -->
+                            <SolidColorBrush x:Key="PreviewPaneBackgroundBrush" Color="#21000000" />
+
+                            <StaticResource x:Key="PropertiesDialogRootBackgroundBrush" ResourceKey="RootBackgroundBrush" />
+
+                            <SolidColorBrush x:Key="TitlebarContentBackgroundBrush" Color="#113A3A3A" />
+
+                            <Color x:Key="LayerFillColorDefault">#11000000</Color>
+                        </ResourceDictionary>
+                        <ResourceDictionary x:Key="Default">
+                            <SolidColorBrush x:Key="CloudDriveSyncStatusOnlineColor" Color="#0078D7" />
+                            <SolidColorBrush x:Key="CloudDriveSyncStatusOfflineColor" Color="#30BB03" />
+                            <SolidColorBrush x:Key="CloudDriveSyncStatusExcludedColor" Color="#AAAAAA" />
+                            <Color x:Key="SolidBackgroundAcrylic">#2C2C2C</Color>
+                            <!--  Corner Radius  -->
+                            <CornerRadius x:Key="ControlCornerRadius">4</CornerRadius>
+                            <CornerRadius x:Key="OverlayCornerRadius">8</CornerRadius>
+                            <CornerRadius x:Key="NavToolbarCornerRadius">0,0,0,8</CornerRadius>
+
+                            <!--  Tabs  -->
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackground" Color="{StaticResource SubtleFillColorTransparent}" />
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundSelected" Color="#4A000000" />
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundPressed" Color="{StaticResource SubtleFillColorTertiary}" />
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundPointerOver" Color="{StaticResource SubtleFillColorSecondary}" />
+                            <SolidColorBrush x:Key="TabViewItemSeparator" Color="{StaticResource DividerStrokeColorDefault}" />
+                            <SolidColorBrush x:Key="TabContainerFillColorPrimary" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
+                            <SolidColorBrush x:Key="TabContainerFillColorSecondary" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
+                            <!--  Navigation Toolbar  -->
+                            <SolidColorBrush x:Key="NavigationToolbarBackgroundBrush" Color="#00000000" />
+                            <SolidColorBrush x:Key="NavigationToolbarBreadcrumbBackgroundBrush" Color="Transparent" />
+                            <!--  Horizontal Tab Control  -->
+                            <SolidColorBrush x:Key="HorizontalTabControlBackgroundBrush" Color="Transparent" />
+                            <!--  PaneHolderPage  -->
+                            <SolidColorBrush x:Key="PaneHolderPageBackgroundBrush" Color="Transparent" />
+                            <!--  Status Bar Control  -->
+                            <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="Transparent" />
+                            <!--  File Browser Control  -->
+                            <SolidColorBrush x:Key="FileBrowserBackgroundBrush" Color="Transparent" />
+                            <SolidColorBrush x:Key="FileBrowserHeaderBackgroundBrush" Color="Transparent" />
+
+                            <!--  Preview pane  -->
+                            <SolidColorBrush x:Key="PreviewPaneBackgroundBrush" Color="#31000000" />
+
+                            <StaticResource x:Key="PropertiesDialogRootBackgroundBrush" ResourceKey="RootBackgroundBrush" />
+
+                            <SolidColorBrush x:Key="TitlebarContentBackgroundBrush" Color="#3C3A3A3A" />
+
+                            <Color x:Key="LayerFillColorDefault">#11000000</Color>
+                        </ResourceDictionary>
+                        <ResourceDictionary x:Key="HighContrast">
+                            <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{StaticResource SystemColorWindowColor}" />
+                            <StaticResource x:Key="SolidBackgroundFillColorBase" ResourceKey="SystemColorWindowColor" />
+                            <StaticResource x:Key="SolidBackgroundFillColorSecondary" ResourceKey="SystemColorWindowColor" />
+                            <StaticResource x:Key="SolidBackgroundFillColorTertiary" ResourceKey="SystemColorWindowColor" />
+                            <StaticResource x:Key="SolidBackgroundFillColorQuarternary" ResourceKey="SystemColorWindowColor" />
+                            <StaticResource x:Key="ControlStrokeColorDefault" ResourceKey="SystemColorWindowTextColor" />
+                            <StaticResource x:Key="ControlStrokeColorSecondary" ResourceKey="SystemColorWindowTextColor" />
+                            <SolidColorBrush x:Key="SolidBackgroundFillColorBaseBrush" Color="{StaticResource SystemColorWindowColor}" />
+                            <SolidColorBrush x:Key="SolidBackgroundFillColorSecondaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+                            <SolidColorBrush x:Key="SolidBackgroundFillColorTertiaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+                            <SolidColorBrush x:Key="SolidBackgroundFillColorQuarternaryBrush" Color="{StaticResource SystemColorWindowColor}" />
+                            <SolidColorBrush x:Key="CloudDriveSyncStatusOnlineColor" Color="#0078D7" />
+                            <SolidColorBrush x:Key="CloudDriveSyncStatusOfflineColor" Color="#30BB03" />
+                            <SolidColorBrush x:Key="CloudDriveSyncStatusExcludedColor" Color="#AAAAAA" />
+                            <Color x:Key="SolidBackgroundAcrylic">#2C2C2C</Color>
+                            <!--  Corner Radius  -->
+                            <CornerRadius x:Key="ControlCornerRadius">4</CornerRadius>
+                            <CornerRadius x:Key="OverlayCornerRadius">8</CornerRadius>
+                            <CornerRadius x:Key="NavToolbarCornerRadius">0,0,0,8</CornerRadius>
+                            <!--  Tabs  -->
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackground" Color="{StaticResource SystemColorWindowColor}" />
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundSelected" Color="{StaticResource SystemColorHighlightColor}" />
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundPointerOver" Color="{StaticResource SystemColorHighlightColor}" />
+                            <SolidColorBrush x:Key="TabViewItemSeparator" Color="{StaticResource SystemColorGrayTextColor}" />
+                            <SolidColorBrush x:Key="TabContainerFillColorPrimary" Color="{StaticResource SolidBackgroundFillColorTertiary}" />
+                            <SolidColorBrush x:Key="TabContainerFillColorSecondary" Color="{StaticResource SolidBackgroundFillColorSecondary}" />
+                            <!--  Navigation Toolbar  -->
+                            <SolidColorBrush x:Key="NavigationToolbarBackgroundBrush" Color="Transparent" />
+                            <SolidColorBrush x:Key="NavigationToolbarBreadcrumbBackgroundBrush" Color="Transparent" />
+                            <!--  Horizontal Tab Control  -->
+                            <SolidColorBrush x:Key="HorizontalTabControlBackgroundBrush" Color="Transparent" />
+                            <!--  PaneHolderPage  -->
+                            <SolidColorBrush x:Key="PaneHolderPageBackgroundBrush" Color="Transparent" />
+                            <!--  Status Bar Control  -->
+                            <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="Transparent" />
+                            <!--  File Browser Control  -->
+                            <SolidColorBrush x:Key="FileBrowserBackgroundBrush" Color="Transparent" />
+                            <StaticResource x:Key="FileBrowserHeaderBackgroundBrush" ResourceKey="SolidBackgroundFillColorBaseBrush" />
+                            <!--  Preview pane  -->
+                            <SolidColorBrush x:Key="PreviewPaneBackgroundBrush" Color="{StaticResource SolidBackgroundFillColorQuarternary}" />
+
+                            <StaticResource x:Key="PropertiesDialogRootBackgroundBrush" ResourceKey="RootBackgroundBrush" />
+
+                            <SolidColorBrush x:Key="TitlebarContentBackgroundBrush" Color="#3C3A3A3A" />
+
+                            <Color x:Key="LayerFillColorDefault">#11000000</Color>
+                        </ResourceDictionary>
+                    </ResourceDictionary.ThemeDictionaries>
+                </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
             <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
         </ResourceDictionary>
     </Page.Resources>
     <Page.DataContext>
-        <settingsviewmodels:AppearanceViewModel />
+        <settingsviewmodels:AppearanceViewModel x:Name="ViewModel" PropertyChanged="ViewModel_PropertyChanged"/>
     </Page.DataContext>
 
     <Grid>
@@ -46,7 +178,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsAppearanceTheme"
                     Title="Choose your color"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE790;" />
@@ -60,24 +192,22 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsAppearanceCustomThemes"
                     Title="Custom themes"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE771;" />
                     </local:SettingsBlockControl.Icon>
                     <local:SettingsBlockControl.ExpandableContent>
-                        <ComboBox
-                            x:Name="CustomThemesChooser"
-                            ItemsSource="{Binding CustomThemes}"
-                            SelectedItem="{Binding SelectedTheme, Mode=TwoWay}">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate x:DataType="helpers:AppTheme">
-                                    <Grid>
-                                        <TextBlock Text="{x:Bind Name}" />
-                                    </Grid>
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
+                        <StackPanel>
+                            <GridView x:Name="AppThemeSelectionGridView" Padding="5"
+                                ItemsSource="{Binding CustomThemes}" SelectionMode="Single" SelectedItem="{Binding SelectedTheme, Mode=TwoWay}">
+                                <GridView.ItemTemplate>
+                                    <DataTemplate>
+                                        <local:ThemeSampleDisplayControl SampleTheme="{Binding Mode=OneWay}"/>
+                                    </DataTemplate>
+                                </GridView.ItemTemplate>
+                            </GridView>
+                        </StackPanel>
                     </local:SettingsBlockControl.ExpandableContent>
                     <Button
                         x:Name="ThemesLearnMoreButton"
@@ -104,7 +234,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsContextMenuOverflowSwitch"
                     Title="Move overflow items into a sub menu"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE10C;" />

--- a/Files/Views/SettingsPages/Appearance.xaml.cs
+++ b/Files/Views/SettingsPages/Appearance.xaml.cs
@@ -50,7 +50,10 @@ namespace Files.SettingsPages
                 {
                     var listViewItemPresenter = VisualTreeHelper.GetChild(container, 0);
                     var item = VisualTreeHelper.GetChild(listViewItemPresenter, 0) as ThemeSampleDisplayControl;
-                    await item.ReevaluateThemeResourceBinding();
+                    if(item !=  null)
+                    {
+                        await item.ReevaluateThemeResourceBinding();
+                    }
                 }
             }
         }

--- a/Files/Views/SettingsPages/Appearance.xaml.cs
+++ b/Files/Views/SettingsPages/Appearance.xaml.cs
@@ -1,7 +1,13 @@
 ﻿using Files.Dialogs;
+using Files.Helpers;
+using Files.UserControls.Settings;
 using Files.ViewModels;
+using Files.ViewModels.SettingsViewModels;
 using Microsoft.Toolkit.Uwp.UI;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using static Files.ViewModels.SettingsViewModels.AppearanceViewModel;
 
 namespace Files.SettingsPages
 {
@@ -21,6 +27,20 @@ namespace Files.SettingsPages
         {
             this.FindAscendant<SettingsDialog>()?.Hide();
             SettingsViewModel.OpenThemesFolder();
+        }
+
+        private async void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if(e.PropertyName == nameof(ViewModel.SelectedElementTheme))
+            {
+                var containers = AppThemeSelectionGridView.ItemsPanelRoot.Children;
+                foreach(var container in containers)
+                {
+                    var listViewItemPresenter = VisualTreeHelper.GetChild(container, 0);
+                    var item = VisualTreeHelper.GetChild(listViewItemPresenter, 0) as ThemeSampleDisplayControl;
+                    await item.ReevaluateThemeResourceBinding();
+                }
+            }
         }
     }
 }

--- a/Files/Views/SettingsPages/Appearance.xaml.cs
+++ b/Files/Views/SettingsPages/Appearance.xaml.cs
@@ -16,6 +16,18 @@ namespace Files.SettingsPages
         public Appearance()
         {
             InitializeComponent();
+            Loaded += Appearance_Loaded;
+        }
+
+        private void Appearance_Loaded(object sender, RoutedEventArgs e)
+        {
+            for (int i = 0; i < ViewModel.CustomThemes.Count; i++)
+            {
+                if(ViewModel.CustomThemes[i].Path == ViewModel.SelectedTheme.Path)
+                {
+                    AppThemeSelectionGridView.SelectedIndex = i;
+                }
+            }
         }
 
         private void ThemesLearnMoreButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)

--- a/Files/Views/SettingsPages/FilesAndFolders.xaml
+++ b/Files/Views/SettingsPages/FilesAndFolders.xaml
@@ -37,7 +37,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsFilesAndFoldersShowHiddenItems"
                     Title="Show hidden files and folders"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE7B3;" />
@@ -48,7 +48,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsFilesAndFoldersHideSystemItems"
                     Title="Hide protected operating system files (Recommended)"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xED1A;" />
@@ -59,7 +59,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsFilesAndFoldersShowFileExtensions"
                     Title="Show extensions for known file types"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE160;" />
@@ -70,7 +70,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsOpenItemsWithOneclick"
                     Title="Open items with a single click"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE8B0;" />
@@ -81,7 +81,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsListAndSortDirectoriesAlongsideFiles"
                     Title="List and sort directories alongside files"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE174;" />
@@ -92,7 +92,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsSearchUnindexedItems"
                     Title="Show unindexed items when searching for files and folders (searches may take longer)"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE721;" />
@@ -103,7 +103,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsEnableLayoutPreferencesPerFolder"
                     Title="Enable individual preferences for individual directories"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE8B7;" />

--- a/Files/Views/SettingsPages/Multitasking.xaml
+++ b/Files/Views/SettingsPages/Multitasking.xaml
@@ -39,7 +39,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsVerticalTabFlyoutSwitch"
                     Title="Display the vertical tab flyout on the title bar"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xF5ED;" />
@@ -57,7 +57,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsMultitaskingEnableDualPane"
                     Title="Enable dual pane view"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF117;" />
@@ -68,7 +68,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsMultitaskingAlwaysOpenDualPane"
                     Title="Always open new tabs in dual pane mode"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF117;" />

--- a/Files/Views/SettingsPages/Preferences.xaml
+++ b/Files/Views/SettingsPages/Preferences.xaml
@@ -39,7 +39,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsPreferencesAppLanguage"
                     Title="Language"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xF2B7;" />

--- a/Files/Views/SettingsPages/Sidebar.xaml
+++ b/Files/Views/SettingsPages/Sidebar.xaml
@@ -39,7 +39,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsRecycleBinSwitch"
                     Title="Pin Recycle Bin to the favorites section"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <SymbolIcon Symbol="Pin" />
@@ -50,7 +50,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsShowLibrarySection"
                     Title="Show library section"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <SymbolIcon Symbol="Library" />
@@ -61,7 +61,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsShowDrivesSection"
                     Title="Show drives section"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xEDA2;" />
@@ -72,7 +72,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsShowCloudDrivesSection"
                     Title="Show cloud drives section"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE753;" />
@@ -83,7 +83,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsShowNetworkDrivesSection"
                     Title="Show network section"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xE968;" />
@@ -94,7 +94,7 @@
                 <local:SettingsBlockControl
                     x:Uid="SettingsShowWslSection"
                     Title="Show WSL section"
-                    Width="352"
+                    Width="{StaticResource SettingsBlockControlDefaultWidth}"
                     HorizontalAlignment="Left">
                     <local:SettingsBlockControl.Icon>
                         <FontIcon Glyph="&#xEC7A;" />


### PR DESCRIPTION
This PR replaces the existing theme choose UI with a theme sample preview grid:

![Screenshot of new theme selection view in settings](https://user-images.githubusercontent.com/16122379/126384839-d8dd9ebe-27b6-48b3-ad70-a22c1389d654.png)


## Open issues
* [ ] AccentColor preview behaves weird, when the selected theme overrides it, it might be picked up by the samples
* [x] The selection indicator of the GridView is too subtle
* [x] The BlackPixel theme is behaving strange, maybe we need to take a look at that theme again and fix it?
* [ ] Is the preview UI good? Could it be improved?