### PR TITLE
Add empty space to the right of the last column instead of stretching

### DIFF
--- a/Files/Helpers/XamlHelpers/DependencyObjectHelpers.cs
+++ b/Files/Helpers/XamlHelpers/DependencyObjectHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
@@ -19,6 +20,29 @@ namespace Files.Helpers.XamlHelpers
                     return asType;
                 }
                 var retVal = FindChild<T>(current);
+                if (retVal != null)
+                {
+                    return retVal;
+                }
+            }
+            return null;
+        }
+
+        public static T FindChild<T>(DependencyObject startNode, Func<T, bool> predicate) where T : DependencyObject
+        {
+            int count = VisualTreeHelper.GetChildrenCount(startNode);
+            for (int i = 0; i < count; i++)
+            {
+                DependencyObject current = VisualTreeHelper.GetChild(startNode, i);
+                if (current.GetType().Equals(typeof(T)) || current.GetType().GetTypeInfo().IsSubclassOf(typeof(T)))
+                {
+                    T asType = (T)current;
+                    if (predicate(asType))
+                    {
+                        return asType;
+                    }
+                }
+                var retVal = FindChild<T>(current, predicate);
                 if (retVal != null)
                 {
                     return retVal;

--- a/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
+++ b/Files/UserControls/Selection/RectangleSelection_ListViewBase.cs
@@ -170,7 +170,7 @@ namespace Files.UserControls.Selection
         {
             if (scrollViewer == null)
             {
-                scrollViewer = DependencyObjectHelpers.FindChild<ScrollViewer>(uiElement);
+                scrollViewer = DependencyObjectHelpers.FindChild<ScrollViewer>(uiElement, sv => sv.VerticalScrollMode != ScrollMode.Disabled);
             }
 
             if (scrollViewer != null)
@@ -193,7 +193,7 @@ namespace Files.UserControls.Selection
                 uiElement.PointerCaptureLost += RectangleSelection_PointerReleased;
                 uiElement.PointerCanceled += RectangleSelection_PointerReleased;
 
-                scrollViewer = DependencyObjectHelpers.FindChild<ScrollViewer>(uiElement);
+                scrollViewer = DependencyObjectHelpers.FindChild<ScrollViewer>(uiElement, sv => sv.VerticalScrollMode != ScrollMode.Disabled);
                 if (scrollViewer == null)
                 {
                     uiElement.LayoutUpdated += RectangleSelection_LayoutUpdated;

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -118,13 +118,19 @@
                                             VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
                                             VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
                                             ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}">
-                                            <ItemsPresenter
-                                                Padding="{TemplateBinding Padding}"
-                                                Footer="{TemplateBinding Footer}"
-                                                FooterTemplate="{TemplateBinding FooterTemplate}"
-                                                FooterTransitions="{TemplateBinding FooterTransitions}"
-                                                HeaderTemplate="{TemplateBinding HeaderTemplate}"
-                                                HeaderTransitions="{TemplateBinding HeaderTransitions}" />
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                    <ColumnDefinition Width="*"/>
+                                                </Grid.ColumnDefinitions>
+                                                <ItemsPresenter
+                                                    Padding="{TemplateBinding Padding}"
+                                                    Footer="{TemplateBinding Footer}"
+                                                    FooterTemplate="{TemplateBinding FooterTemplate}"
+                                                    FooterTransitions="{TemplateBinding FooterTransitions}"
+                                                    HeaderTemplate="{TemplateBinding HeaderTemplate}"
+                                                    HeaderTransitions="{TemplateBinding HeaderTransitions}" />
+                                            </Grid>
                                         </ScrollViewer>
                                     </Grid>
                                 </ScrollViewer>

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -120,8 +120,8 @@
                                             ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="Auto"/>
-                                                    <ColumnDefinition Width="*"/>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="*" MinWidth="24" />
                                                 </Grid.ColumnDefinitions>
                                                 <ItemsPresenter
                                                     Padding="{TemplateBinding Padding}"


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- For #4643
- Fixes #5453

**Details of Changes**
Add details of changes here.
- Add empty space to the right of the last column instead of stretching
- Fix details view not scrolling when using selection rectangle (not perfect but better than nothing)

**Validation**
How did you test these changes?
- [x] Built and ran the app
