### PR TITLE
Added context menu option in Bundles to add items directly to a Bundle

### DIFF
--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2622,4 +2622,13 @@
   <data name="NavigationToolbarCopy.Label" xml:space="preserve">
     <value>Copy</value>
   </data>
+  <data name="BundleOptionsFlyoutAddFileMenuItem" xml:space="preserve">
+    <value>Add file</value>
+  </data>
+  <data name="BundleOptionsFlyoutAddFolderMenuItem" xml:space="preserve">
+    <value>Add folder</value>
+  </data>
+  <data name="BundleOptionsFlyoutAddItemMenuItem" xml:space="preserve">
+    <value>Add item...</value>
+  </data>
 </root>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2622,13 +2622,13 @@
   <data name="NavigationToolbarCopy.Label" xml:space="preserve">
     <value>Copy</value>
   </data>
-  <data name="BundleOptionsFlyoutAddFileMenuItem" xml:space="preserve">
+  <data name="BundleOptionsFlyoutAddFileMenuItem.Text" xml:space="preserve">
     <value>Add file</value>
   </data>
-  <data name="BundleOptionsFlyoutAddFolderMenuItem" xml:space="preserve">
+  <data name="BundleOptionsFlyoutAddFolderMenuItem.Text" xml:space="preserve">
     <value>Add folder</value>
   </data>
-  <data name="BundleOptionsFlyoutAddItemMenuItem" xml:space="preserve">
+  <data name="BundleOptionsFlyoutAddItemMenuItem.Text" xml:space="preserve">
     <value>Add item...</value>
   </data>
 </root>

--- a/Files/UserControls/Widgets/BundlesWidget.xaml
+++ b/Files/UserControls/Widgets/BundlesWidget.xaml
@@ -8,6 +8,7 @@
     xmlns:icore="using:Microsoft.Xaml.Interactions.Core"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vc="using:Files.Converters"
+    xmlns:vm="using:Files.ViewModels.Widgets.Bundles"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -60,7 +61,7 @@
                     <MenuFlyout>
                         <MenuFlyoutItem
                             x:Uid="BundlesWidgetOptionsFlyoutCreateBundleMenuItem"
-                            Command="{Binding OpenAddBundleDialogCommand, Mode=OneWay}"
+                            Command="{x:Bind ViewModel.OpenAddBundleDialogCommand, Mode=OneWay}"
                             Text="Create Bundle">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon Glyph="&#xE710;" />
@@ -69,7 +70,7 @@
                         <MenuFlyoutSeparator />
                         <MenuFlyoutItem
                             x:Uid="BundlesWidgetOptionsFlyoutImportBundlesMenuItem"
-                            Command="{Binding ImportBundlesCommand, Mode=OneWay}"
+                            Command="{x:Bind ViewModel.ImportBundlesCommand, Mode=OneWay}"
                             Text="Import Bundles">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon Glyph="&#xE8B6;" />
@@ -77,7 +78,7 @@
                         </MenuFlyoutItem>
                         <MenuFlyoutItem
                             x:Uid="BundlesWidgetOptionsFlyoutExportBundlesMenuItem"
-                            Command="{Binding ExportBundlesCommand, Mode=OneWay}"
+                            Command="{x:Bind ViewModel.ExportBundlesCommand, Mode=OneWay}"
                             Text="Export Bundles">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon Glyph="&#xEDE1;" />
@@ -95,7 +96,7 @@
             x:Load="{x:Bind ViewModel.NoBundlesAddItemLoad, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
             AllowDrop="True"
             CanReorderItems="True"
-            ItemsSource="{Binding Items, Mode=OneWay}"
+            ItemsSource="{x:Bind ViewModel.Items}"
             ReorderMode="Enabled"
             SelectionMode="None">
 
@@ -120,7 +121,7 @@
 
             <!--  Container  -->
             <GridView.ItemTemplate>
-                <DataTemplate>
+                <DataTemplate x:DataType="vm:BundleContainerViewModel">
                     <Grid
                         Width="280"
                         Height="256"
@@ -131,11 +132,11 @@
                         <i:Interaction.Behaviors>
                             <!--  No need to specify CommandParameter - `e` is passed by default  -->
                             <icore:EventTriggerBehavior EventName="DragOver">
-                                <icore:InvokeCommandAction Command="{Binding DragOverCommand, Mode=OneWay}" />
+                                <icore:InvokeCommandAction Command="{x:Bind DragOverCommand}" />
                             </icore:EventTriggerBehavior>
                             <!--  No need to specify CommandParameter - `e` is passed by default  -->
                             <icore:EventTriggerBehavior EventName="Drop">
-                                <icore:InvokeCommandAction Command="{Binding DropCommand, Mode=OneWay}" />
+                                <icore:InvokeCommandAction Command="{x:Bind DropCommand}" />
                             </icore:EventTriggerBehavior>
                         </i:Interaction.Behaviors>
 
@@ -177,7 +178,7 @@
                                         FontFamily="Segoe UI"
                                         FontWeight="SemiBold"
                                         Opacity="0.9"
-                                        Text="{Binding BundleName, Mode=OneWay}"
+                                        Text="{x:Bind BundleName, Mode=OneWay}"
                                         TextTrimming="CharacterEllipsis" />
                                 </Grid>
 
@@ -198,15 +199,39 @@
                                         <MenuFlyout Placement="BottomEdgeAlignedLeft">
                                             <MenuFlyoutItem
                                                 x:Uid="BundleOptionsFlyoutRenameBundleMenuItem"
-                                                Command="{Binding RenameBundleCommand, Mode=OneWay}"
+                                                Command="{x:Bind RenameBundleCommand}"
                                                 Text="Rename Bundle">
                                                 <MenuFlyoutItem.Icon>
                                                     <FontIcon Glyph="&#xE8AC;" />
                                                 </MenuFlyoutItem.Icon>
                                             </MenuFlyoutItem>
+                                            <MenuFlyoutSubItem
+                                                x:Uid="BundleOptionsFlyoutAddItemMenuItem"
+                                                IsEnabled="{x:Bind IsAddItemOptionEnabled, Mode=OneWay}"
+                                                Text="Add item...">
+                                                <MenuFlyoutSubItem.Icon>
+                                                    <FontIcon Glyph="&#xE710;" />
+                                                </MenuFlyoutSubItem.Icon>
+                                                <MenuFlyoutItem
+                                                    x:Uid="BundleOptionsFlyoutAddFileMenuItem"
+                                                    Command="{x:Bind AddFileCommand}"
+                                                    Text="Add file">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE7C3;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                                <MenuFlyoutItem
+                                                    x:Uid="BundleOptionsFlyoutAddFolderMenuItem"
+                                                    Command="{x:Bind AddFolderCommand}"
+                                                    Text="Add folder">
+                                                    <MenuFlyoutItem.Icon>
+                                                        <FontIcon Glyph="&#xE8B7;" />
+                                                    </MenuFlyoutItem.Icon>
+                                                </MenuFlyoutItem>
+                                            </MenuFlyoutSubItem>
                                             <MenuFlyoutItem
                                                 x:Uid="BundleOptionsFlyoutRemoveBundleMenuItem"
-                                                Command="{Binding RemoveBundleCommand, Mode=OneWay}"
+                                                Command="{x:Bind RemoveBundleCommand}"
                                                 Text="Remove Bundle">
                                                 <MenuFlyoutItem.Icon>
                                                     <FontIcon Glyph="&#xE738;" />
@@ -226,18 +251,18 @@
                                 CanDragItems="True"
                                 CanReorderItems="True"
                                 IsItemClickEnabled="True"
-                                ItemsSource="{Binding Contents, Mode=OneWay}"
+                                ItemsSource="{x:Bind Contents}"
                                 ReorderMode="Enabled"
                                 SelectionMode="None">
 
                                 <i:Interaction.Behaviors>
                                     <!--  No need to specify CommandParameter - `e` is passed by default  -->
                                     <icore:EventTriggerBehavior EventName="DragItemsStarting">
-                                        <icore:InvokeCommandAction Command="{Binding DragItemsStartingCommand, Mode=OneWay}" />
+                                        <icore:InvokeCommandAction Command="{x:Bind DragItemsStartingCommand}" />
                                     </icore:EventTriggerBehavior>
                                     <!--  No need to specify CommandParameter - `e` is passed by default  -->
                                     <icore:EventTriggerBehavior EventName="ItemClick">
-                                        <icore:InvokeCommandAction Command="{Binding OpenItemCommand, Mode=OneWay}" />
+                                        <icore:InvokeCommandAction Command="{x:Bind OpenItemCommand}" />
                                     </icore:EventTriggerBehavior>
                                 </i:Interaction.Behaviors>
 
@@ -260,7 +285,7 @@
 
                                 <GridView.ItemTemplate>
                                     <!--  Bundle Item design  -->
-                                    <DataTemplate>
+                                    <DataTemplate x:DataType="vm:BundleItemViewModel">
                                         <Grid>
                                             <Border
                                                 Width="119"
@@ -284,7 +309,7 @@
                                                         Height="20"
                                                         HorizontalAlignment="Left"
                                                         VerticalAlignment="Center"
-                                                        Source="{Binding Icon, Mode=OneWay}" />
+                                                        Source="{x:Bind Icon, Mode=OneWay}" />
 
                                                     <!--  Bundle Item name  -->
                                                     <TextBlock
@@ -293,7 +318,7 @@
                                                         VerticalAlignment="Center"
                                                         FontSize="12"
                                                         MaxLines="1"
-                                                        Text="{Binding Name, Mode=OneWay}"
+                                                        Text="{x:Bind Name, Mode=OneWay}"
                                                         TextTrimming="CharacterEllipsis" />
                                                 </Grid>
 
@@ -301,25 +326,25 @@
                                                     <MenuFlyout>
                                                         <MenuFlyoutItem
                                                             x:Uid="BundleItemFlyouOpenInNewTabMenuItem"
-                                                            Command="{Binding OpenInNewTabCommand, Mode=OneWay}"
+                                                            Command="{x:Bind OpenInNewTabCommand}"
                                                             Text="Open in new tab"
-                                                            Visibility="{Binding OpenInNewTabVisibility, Mode=OneWay}">
+                                                            Visibility="{x:Bind OpenInNewTabVisibility, Mode=OneWay}">
                                                             <MenuFlyoutItem.Icon>
                                                                 <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF106;" />
                                                             </MenuFlyoutItem.Icon>
                                                         </MenuFlyoutItem>
                                                         <MenuFlyoutItem
                                                             x:Uid="BundlesOpenInNewPane"
-                                                            Command="{Binding OpenInNewPaneCommand, Mode=OneWay}"
+                                                            Command="{x:Bind OpenInNewPaneCommand}"
                                                             Text="Open in new Pane"
-                                                            Visibility="{Binding OpenInNewPaneVisibility, Mode=OneWay}">
+                                                            Visibility="{x:Bind OpenInNewPaneVisibility, Mode=OneWay}">
                                                             <MenuFlyoutItem.Icon>
                                                                 <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF106;" />
                                                             </MenuFlyoutItem.Icon>
                                                         </MenuFlyoutItem>
                                                         <MenuFlyoutItem
                                                             x:Uid="BundleItemFlyouOpenItemLocationMenuItem"
-                                                            Command="{Binding OpenItemLocationCommand, Mode=OneWay}"
+                                                            Command="{x:Bind OpenItemLocationCommand}"
                                                             Text="Open item location">
                                                             <MenuFlyoutItem.Icon>
                                                                 <FontIcon Glyph="&#xED25;" />
@@ -328,7 +353,7 @@
                                                         <MenuFlyoutSeparator />
                                                         <MenuFlyoutItem
                                                             x:Uid="BundleItemFlyouRemoveFromBundleMenuItem"
-                                                            Command="{Binding RemoveItemCommand, Mode=OneWay}"
+                                                            Command="{x:Bind RemoveItemCommand}"
                                                             Text="Remove from bundle">
                                                             <MenuFlyoutItem.Icon>
                                                                 <FontIcon Glyph="&#xE738;" />
@@ -338,7 +363,7 @@
                                                 </Border.ContextFlyout>
 
                                                 <ToolTipService.ToolTip>
-                                                    <ToolTip Content="{Binding Path, Mode=OneWay}" />
+                                                    <ToolTip Content="{x:Bind Path, Mode=OneWay}" />
                                                 </ToolTipService.ToolTip>
                                             </Border>
                                         </Grid>
@@ -352,7 +377,7 @@
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center"
                                 RowSpacing="5"
-                                Visibility="{Binding NoBundleContentsTextVisibility, Mode=OneWay}">
+                                Visibility="{x:Bind NoBundleContentsTextVisibility, Mode=OneWay}">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
@@ -442,11 +467,11 @@
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Center"
                                     PlaceholderText="Enter Bundle name"
-                                    Text="{Binding BundleNameTextInput, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                                    Text="{x:Bind ViewModel.BundleNameTextInput, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
                                     <i:Interaction.Behaviors>
                                         <!--  No need to specify CommandParameter - `e` is passed by default  -->
                                         <icore:EventTriggerBehavior EventName="KeyDown">
-                                            <icore:InvokeCommandAction Command="{Binding InputTextKeyDownCommand, Mode=OneWay}" />
+                                            <icore:InvokeCommandAction Command="{x:Bind ViewModel.InputTextKeyDownCommand}" />
                                         </icore:EventTriggerBehavior>
                                     </i:Interaction.Behaviors>
                                 </TextBox>
@@ -464,7 +489,7 @@
                                         VerticalAlignment="Center"
                                         FontFamily="Segoe UI"
                                         FontSize="12"
-                                        Text="{Binding AddBundleErrorText, Mode=OneWay}"
+                                        Text="{x:Bind ViewModel.AddBundleErrorText, Mode=OneWay}"
                                         TextWrapping="Wrap" />
 
                                     <!--  Confirmation Button  -->
@@ -475,7 +500,7 @@
                                         VerticalAlignment="Center"
                                         HorizontalContentAlignment="Center"
                                         VerticalContentAlignment="Center"
-                                        Command="{Binding AddBundleCommand, Mode=OneWay}"
+                                        Command="{x:Bind ViewModel.AddBundleCommand}"
                                         Content="Confirm" />
                                 </Grid>
                             </Grid>

--- a/Files/UserControls/Widgets/BundlesWidget.xaml
+++ b/Files/UserControls/Widgets/BundlesWidget.xaml
@@ -325,19 +325,21 @@
                                                 <Border.ContextFlyout>
                                                     <MenuFlyout>
                                                         <MenuFlyoutItem
+                                                            x:Name="OpenInNewTab"
                                                             x:Uid="BundleItemFlyouOpenInNewTabMenuItem"
+                                                            x:Load="{x:Bind OpenInNewTabLoad, Mode=OneWay}"
                                                             Command="{x:Bind OpenInNewTabCommand}"
-                                                            Text="Open in new tab"
-                                                            Visibility="{x:Bind OpenInNewTabVisibility, Mode=OneWay}">
+                                                            Text="Open in new tab">
                                                             <MenuFlyoutItem.Icon>
                                                                 <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF106;" />
                                                             </MenuFlyoutItem.Icon>
                                                         </MenuFlyoutItem>
                                                         <MenuFlyoutItem
+                                                            x:Name="OpenInNewPane"
                                                             x:Uid="BundlesOpenInNewPane"
+                                                            x:Load="{x:Bind OpenInNewPaneLoad, Mode=OneWay}"
                                                             Command="{x:Bind OpenInNewPaneCommand}"
-                                                            Text="Open in new Pane"
-                                                            Visibility="{x:Bind OpenInNewPaneVisibility, Mode=OneWay}">
+                                                            Text="Open in new Pane">
                                                             <MenuFlyoutItem.Icon>
                                                                 <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF106;" />
                                                             </MenuFlyoutItem.Icon>
@@ -373,11 +375,12 @@
 
                             <!--  No Bundle contents text info  -->
                             <Grid
+                                x:Name="NoContentsInformation"
                                 Grid.Row="2"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center"
-                                RowSpacing="5"
-                                Visibility="{x:Bind NoBundleContentsTextVisibility, Mode=OneWay}">
+                                x:Load="{x:Bind NoBundleContentsTextLoad, Mode=OneWay}"
+                                RowSpacing="5">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />

--- a/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
@@ -69,12 +69,12 @@ namespace Files.ViewModels.Widgets.Bundles
             set => SetProperty(ref bundleName, value);
         }
 
-        private Visibility noBundleContentsTextVisibility;
+        private bool noBundleContentsTextLoad;
 
-        public Visibility NoBundleContentsTextVisibility
+        public bool NoBundleContentsTextLoad
         {
-            get => noBundleContentsTextVisibility;
-            set => SetProperty(ref noBundleContentsTextVisibility, value);
+            get => noBundleContentsTextLoad;
+            set => SetProperty(ref noBundleContentsTextLoad, value);
         }
 
         private bool isAddItemOptionEnabled;
@@ -401,7 +401,7 @@ namespace Files.ViewModels.Widgets.Bundles
 
             if (Contents.Count == 0)
             {
-                NoBundleContentsTextVisibility = Visibility.Visible;
+                NoBundleContentsTextLoad = true;
             }
         }
 
@@ -488,7 +488,7 @@ namespace Files.ViewModels.Widgets.Bundles
                 itemAddedInternally = true;
                 Contents.Add(bundleItem);
                 itemAddedInternally = false;
-                NoBundleContentsTextVisibility = Visibility.Collapsed;
+                NoBundleContentsTextLoad = false;
                 await bundleItem.UpdateIcon();
                 return true;
             }
@@ -518,7 +518,7 @@ namespace Files.ViewModels.Widgets.Bundles
 
             if (Contents.Count > 0)
             {
-                NoBundleContentsTextVisibility = Visibility.Collapsed;
+                NoBundleContentsTextLoad = false;
             }
 
             return this;

--- a/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
@@ -141,6 +141,7 @@ namespace Files.ViewModels.Widgets.Bundles
             if (folder != null)
             {
                 await AddItemFromPath(folder.Path, FilesystemItemType.Directory);
+                SaveBundle();
             }
         }
 
@@ -154,6 +155,7 @@ namespace Files.ViewModels.Widgets.Bundles
             if (file != null)
             {
                 await AddItemFromPath(file.Path, FilesystemItemType.File);
+                SaveBundle();
             }
         }
 

--- a/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
+using Windows.Storage.Pickers;
 using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -76,6 +77,13 @@ namespace Files.ViewModels.Widgets.Bundles
             set => SetProperty(ref noBundleContentsTextVisibility, value);
         }
 
+        private bool isAddItemOptionEnabled;
+        public bool IsAddItemOptionEnabled
+        {
+            get => isAddItemOptionEnabled;
+            set => SetProperty(ref isAddItemOptionEnabled, value);
+        }
+
         #endregion Public Properties
 
         #region Commands
@@ -92,30 +100,62 @@ namespace Files.ViewModels.Widgets.Bundles
 
         public ICommand DragItemsStartingCommand { get; private set; }
 
+        public ICommand AddFileCommand { get; private set; }
+
+        public ICommand AddFolderCommand { get; private set; }
+
         #endregion Commands
 
         #region Constructor
 
         public BundleContainerViewModel()
         {
-            // Create commands
-            RemoveBundleCommand = new RelayCommand(RemoveBundle);
-            RenameBundleCommand = new RelayCommand(RenameBundle);
-            DragOverCommand = new RelayCommand<DragEventArgs>(DragOver);
-            DropCommand = new RelayCommand<DragEventArgs>(Drop);
-
             internalCollectionCount = Contents.Count;
             Contents.CollectionChanged += Contents_CollectionChanged;
+
+            // Create commands
+            RemoveBundleCommand = new RelayCommand(RemoveBundle);
+            RenameBundleCommand = new AsyncRelayCommand(RenameBundle);
+            DragOverCommand = new RelayCommand<DragEventArgs>(DragOver);
+            DropCommand = new AsyncRelayCommand<DragEventArgs>(Drop);
+            DragItemsStartingCommand = new RelayCommand<DragItemsStartingEventArgs>(DragItemsStarting);
             OpenItemCommand = new RelayCommand<ItemClickEventArgs>((e) =>
             {
                 (e.ClickedItem as BundleItemViewModel).OpenItem();
             });
-            DragItemsStartingCommand = new RelayCommand<DragItemsStartingEventArgs>(DragItemsStarting);
+            AddFileCommand = new AsyncRelayCommand(AddFile);
+            AddFolderCommand = new AsyncRelayCommand(AddFolder);
         }
 
         #endregion Constructor
 
         #region Command Implementation
+
+        private async Task AddFolder()
+        {
+            FolderPicker folderPicker = new FolderPicker();
+            folderPicker.FileTypeFilter.Add("*");
+
+            StorageFolder folder = await folderPicker.PickSingleFolderAsync();
+
+            if (folder != null)
+            {
+                await AddItemFromPath(folder.Path, FilesystemItemType.Directory);
+            }
+        }
+
+        private async Task AddFile()
+        {
+            FileOpenPicker filePicker = new FileOpenPicker();
+            filePicker.FileTypeFilter.Add("*");
+
+            StorageFile file = await filePicker.PickSingleFileAsync();
+
+            if (file != null)
+            {
+                await AddItemFromPath(file.Path, FilesystemItemType.File);
+            }
+        }
 
         private void RemoveBundle()
         {
@@ -128,7 +168,7 @@ namespace Files.ViewModels.Widgets.Bundles
             }
         }
 
-        private async void RenameBundle()
+        private async Task RenameBundle()
         {
             TextBox inputText = new TextBox()
             {
@@ -255,10 +295,11 @@ namespace Files.ViewModels.Widgets.Bundles
             {
                 e.AcceptedOperation = DataPackageOperation.None;
             }
+
             e.Handled = true;
         }
 
-        private async void Drop(DragEventArgs e)
+        private async Task Drop(DragEventArgs e)
         {
             var deferral = e?.GetDeferral();
             try
@@ -269,22 +310,9 @@ namespace Files.ViewModels.Widgets.Bundles
                 {
                     IReadOnlyList<IStorageItem> items = await e.DataView.GetStorageItemsAsync();
 
-                    foreach (IStorageItem item in items)
+                    if (await AddItemsFromPath(items.ToDictionary((item) => item.Path, (item) => item.IsOfType(StorageItemTypes.Folder) ? FilesystemItemType.Directory : FilesystemItemType.File)))
                     {
-                        if (Contents.Count < Constants.Widgets.Bundles.MaxAmountOfItemsPerBundle)
-                        {
-                            if (!Contents.Any((i) => i.Path == item.Path)) // Don't add existing items!
-                            {
-                                await AddBundleItem(new BundleItemViewModel(item.Path, item.IsOfType(StorageItemTypes.Folder) ? FilesystemItemType.Directory : FilesystemItemType.File)
-                                {
-                                    ParentBundleName = BundleName,
-                                    NotifyItemRemoved = NotifyItemRemovedHandle,
-                                    OpenPath = OpenPath,
-                                    OpenPathInNewPane = OpenPathInNewPane,
-                                });
-                                itemsAdded = true;
-                            }
-                        }
+                        itemsAdded = true;
                     }
                 }
                 else if (e.DataView.Contains(StandardDataFormats.Text))
@@ -315,21 +343,12 @@ namespace Files.ViewModels.Widgets.Bundles
 
                     IStorageItem item = await StorageItemHelpers.ToStorageItem<IStorageItem>(itemPath);
 
-                    if (item != null || itemPath.EndsWith(".lnk"))
+                    if (item != null || (itemPath.EndsWith(".lnk") || itemPath.EndsWith(".url")))
                     {
-                        if (Contents.Count < Constants.Widgets.Bundles.MaxAmountOfItemsPerBundle)
+                        if (await AddItemFromPath(itemPath,
+                            itemPath.EndsWith(".lnk") || itemPath.EndsWith(".url") ? FilesystemItemType.File : (item.IsOfType(StorageItemTypes.Folder) ? FilesystemItemType.Directory : FilesystemItemType.File)))
                         {
-                            if (!Contents.Any((i) => i.Path == itemPath)) // Don't add existing items!
-                            {
-                                await AddBundleItem(new BundleItemViewModel(itemPath, itemPath.EndsWith(".lnk") ? FilesystemItemType.File : (item.IsOfType(StorageItemTypes.Folder) ? FilesystemItemType.Directory : FilesystemItemType.File))
-                                {
-                                    ParentBundleName = BundleName,
-                                    NotifyItemRemoved = NotifyItemRemovedHandle,
-                                    OpenPath = OpenPath,
-                                    OpenPathInNewPane = OpenPathInNewPane,
-                                });
-                                itemsAdded = true;
-                            }
+                            itemsAdded = true;
                         }
                     }
 
@@ -394,6 +413,8 @@ namespace Files.ViewModels.Widgets.Bundles
             }
 
             internalCollectionCount = Contents.Count;
+
+            UpdateAddItemOption();
         }
 
         #endregion Handlers
@@ -415,29 +436,85 @@ namespace Files.ViewModels.Widgets.Bundles
             return false;
         }
 
+        private async Task<bool> AddItemFromPath(string path, FilesystemItemType itemType)
+        {
+            // Make sure we don't exceed maximum amount && make sure we don't make duplicates
+            if (Contents.Count < Constants.Widgets.Bundles.MaxAmountOfItemsPerBundle && !Contents.Any((item) => item.Path == path))
+            {
+                return await AddBundleItem(new BundleItemViewModel(path, itemType)
+                {
+                    ParentBundleName = BundleName,
+                    NotifyItemRemoved = NotifyItemRemovedHandle,
+                    OpenPath = OpenPath,
+                    OpenPathInNewPane = OpenPathInNewPane,
+                });
+            }
+
+            return false;
+        }
+
+        private async Task<bool> AddItemsFromPath(IDictionary<string, FilesystemItemType> paths)
+        {
+            return await AddBundleItems(paths.Select((item) => new BundleItemViewModel(item.Key, item.Value)
+            {
+                ParentBundleName = BundleName,
+                NotifyItemRemoved = NotifyItemRemovedHandle,
+                OpenPath = OpenPath,
+                OpenPathInNewPane = OpenPathInNewPane
+            }));
+        }
+
+        private void UpdateAddItemOption()
+        {
+            if (Contents.Count >= Constants.Widgets.Bundles.MaxAmountOfItemsPerBundle)
+            {
+                IsAddItemOptionEnabled = false;
+            }
+            else
+            {
+                IsAddItemOptionEnabled = true;
+            }
+        }
+
         #endregion Private Helpers
 
         #region Public Helpers
 
-        public async Task AddBundleItem(BundleItemViewModel bundleItem)
+        public async Task<bool> AddBundleItem(BundleItemViewModel bundleItem)
         {
-            if (bundleItem != null)
+            // Make sure we don't exceed maximum amount && make sure we don't make duplicates
+            if (bundleItem != null && Contents.Count < Constants.Widgets.Bundles.MaxAmountOfItemsPerBundle && !Contents.Any((item) => item.Path == bundleItem.Path))
             {
                 itemAddedInternally = true;
                 Contents.Add(bundleItem);
                 itemAddedInternally = false;
                 NoBundleContentsTextVisibility = Visibility.Collapsed;
                 await bundleItem.UpdateIcon();
+                return true;
             }
+
+            return false;
         }
 
-        public BundleContainerViewModel SetBundleItems(List<BundleItemViewModel> items)
+        public async Task<bool> AddBundleItems(IEnumerable<BundleItemViewModel> bundleItems)
         {
-            Contents.CollectionChanged -= Contents_CollectionChanged;
+            List<Task<bool>> taskDelegates = new List<Task<bool>>();
 
-            Contents = new ObservableCollection<BundleItemViewModel>(items);
-            internalCollectionCount = Contents.Count;
-            Contents.CollectionChanged += Contents_CollectionChanged;
+            foreach (var item in bundleItems)
+            {
+                taskDelegates.Add(AddBundleItem(item));
+            }
+
+            IEnumerable<bool> result = await Task.WhenAll(taskDelegates);
+
+            return result.Any((item) => item);
+        }
+
+        public async Task<BundleContainerViewModel> SetBundleItems(IEnumerable<BundleItemViewModel> items)
+        {
+            Contents.Clear();
+
+            await AddBundleItems(items);
 
             if (Contents.Count > 0)
             {
@@ -475,21 +552,12 @@ namespace Files.ViewModels.Widgets.Bundles
                 item?.Dispose();
             }
 
-            BundleName = null;
             NotifyBundleItemRemoved = null;
             NotifyItemRemoved = null;
-            RemoveBundleCommand = null;
-            RenameBundleCommand = null;
-            DragOverCommand = null;
-            DropCommand = null;
-            OpenItemCommand = null;
-            DragItemsStartingCommand = null;
-
             OpenPath = null;
             OpenPathInNewPane = null;
 
             Contents.CollectionChanged -= Contents_CollectionChanged;
-            Contents = null;
         }
 
         #endregion IDisposable

--- a/Files/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using Files.Extensions;
 using Files.Filesystem;
 using Files.Helpers;
-using Files.SettingsInterfaces;
 using Files.Views;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
@@ -11,7 +10,6 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 
@@ -70,14 +68,14 @@ namespace Files.ViewModels.Widgets.Bundles
             UriSource = new Uri("ms-appx:///Assets/FolderIcon.svg"),
         };
 
-        public Visibility OpenInNewTabVisibility
+        public bool OpenInNewTabLoad
         {
-            get => TargetType == FilesystemItemType.Directory ? Visibility.Visible : Visibility.Collapsed;
+            get => TargetType == FilesystemItemType.Directory;
         }
 
-        public Visibility OpenInNewPaneVisibility
+        public bool OpenInNewPaneLoad
         {
-            get => App.AppSettings.IsDualPaneEnabled && TargetType == FilesystemItemType.Directory ? Visibility.Visible : Visibility.Collapsed;
+            get => App.AppSettings.IsDualPaneEnabled && TargetType == FilesystemItemType.Directory;
         }
 
         #endregion Public Properties

--- a/Files/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
@@ -5,12 +5,10 @@ using Files.SettingsInterfaces;
 using Files.Views;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
-using Microsoft.Toolkit.Uwp;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using Windows.ApplicationModel.Core;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.UI.Xaml;
@@ -21,12 +19,6 @@ namespace Files.ViewModels.Widgets.Bundles
 {
     public class BundleItemViewModel : ObservableObject, IDisposable
     {
-        #region Singleton
-
-        private IBundlesSettings BundlesSettings => App.BundlesSettings;
-
-        #endregion Singleton
-
         #region Actions
 
         public Action<string, FilesystemItemType, bool, bool, IEnumerable<string>> OpenPath { get; set; }
@@ -52,7 +44,7 @@ namespace Files.ViewModels.Widgets.Bundles
             {
                 string fileName = System.IO.Path.GetFileName(this.Path);
 
-                if (fileName.EndsWith(".lnk"))
+                if (fileName.EndsWith(".lnk") || fileName.EndsWith(".url"))
                 {
                     fileName = fileName.Remove(fileName.Length - 4);
                 }
@@ -149,7 +141,7 @@ namespace Files.ViewModels.Widgets.Bundles
             {
                 try
                 {
-                    if (Path.EndsWith(".lnk"))
+                    if (Path.EndsWith(".lnk") || Path.EndsWith(".url"))
                     {
                         byte[] iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Path, 24u);
                         Icon = iconData != null ? await iconData.ToBitmapAsync() : null;
@@ -189,11 +181,11 @@ namespace Files.ViewModels.Widgets.Bundles
 
         public void RemoveItem()
         {
-            if (BundlesSettings.SavedBundles.ContainsKey(ParentBundleName))
+            if (App.BundlesSettings.SavedBundles.ContainsKey(ParentBundleName))
             {
-                Dictionary<string, List<string>> allBundles = BundlesSettings.SavedBundles;
+                Dictionary<string, List<string>> allBundles = App.BundlesSettings.SavedBundles;
                 allBundles[ParentBundleName].Remove(Path);
-                BundlesSettings.SavedBundles = allBundles;
+                App.BundlesSettings.SavedBundles = allBundles;
                 NotifyItemRemoved(this);
             }
         }
@@ -204,12 +196,7 @@ namespace Files.ViewModels.Widgets.Bundles
 
         public void Dispose()
         {
-            Path = null;
             Icon = null;
-
-            OpenInNewTabCommand = null;
-            OpenItemLocationCommand = null;
-            RemoveItemCommand = null;
 
             OpenPath = null;
             OpenPathInNewPane = null;

--- a/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
@@ -3,7 +3,6 @@ using Files.Enums;
 using Files.EventArguments.Bundles;
 using Files.Filesystem;
 using Files.Helpers;
-using Files.SettingsInterfaces;
 using Files.ViewModels.Dialogs;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Mvvm.Input;
@@ -30,12 +29,6 @@ namespace Files.ViewModels.Widgets.Bundles
     /// </summary>
     public class BundlesViewModel : ObservableObject, IDisposable
     {
-        #region Singleton
-
-        private IBundlesSettings BundlesSettings => App.BundlesSettings;
-
-        #endregion Singleton
-
         #region Private Members
 
         private bool itemAddedInternally;
@@ -99,14 +92,14 @@ namespace Files.ViewModels.Widgets.Bundles
 
         public BundlesViewModel()
         {
+            Items.CollectionChanged += Items_CollectionChanged;
+
             // Create commands
             InputTextKeyDownCommand = new RelayCommand<KeyRoutedEventArgs>(InputTextKeyDown);
-            OpenAddBundleDialogCommand = new RelayCommand(OpenAddBundleDialog);
+            OpenAddBundleDialogCommand = new AsyncRelayCommand(OpenAddBundleDialog);
             AddBundleCommand = new RelayCommand(() => AddBundle(BundleNameTextInput));
-            ImportBundlesCommand = new RelayCommand(ImportBundles);
-            ExportBundlesCommand = new RelayCommand(ExportBundles);
-
-            Items.CollectionChanged += Items_CollectionChanged;
+            ImportBundlesCommand = new AsyncRelayCommand(ImportBundles);
+            ExportBundlesCommand = new AsyncRelayCommand(ExportBundles);
         }
 
         #endregion Constructor
@@ -122,7 +115,7 @@ namespace Files.ViewModels.Widgets.Bundles
             }
         }
 
-        private async void OpenAddBundleDialog()
+        private async Task OpenAddBundleDialog()
         {
             TextBox inputText = new TextBox()
             {
@@ -201,9 +194,9 @@ namespace Files.ViewModels.Widgets.Bundles
             string savedBundleNameTextInput = name;
             BundleNameTextInput = string.Empty;
 
-            if (BundlesSettings.SavedBundles == null || (BundlesSettings.SavedBundles?.ContainsKey(savedBundleNameTextInput) ?? false)) // Init
+            if (App.BundlesSettings.SavedBundles == null || (App.BundlesSettings.SavedBundles?.ContainsKey(savedBundleNameTextInput) ?? false)) // Init
             {
-                BundlesSettings.SavedBundles = new Dictionary<string, List<string>>()
+                App.BundlesSettings.SavedBundles = new Dictionary<string, List<string>>()
                 {
                     { savedBundleNameTextInput, new List<string>() { null } }
                 };
@@ -225,7 +218,7 @@ namespace Files.ViewModels.Widgets.Bundles
             Save();
         }
 
-        private async void ImportBundles()
+        private async Task ImportBundles()
         {
             FileOpenPicker filePicker = new FileOpenPicker();
             filePicker.FileTypeFilter.Add(System.IO.Path.GetExtension(Constants.LocalSettings.BundlesSettingsFileName));
@@ -238,7 +231,7 @@ namespace Files.ViewModels.Widgets.Bundles
                 {
                     string data = NativeFileOperationsHelper.ReadStringFromFile(file.Path);
                     var deserialized = JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(data);
-                    BundlesSettings.ImportSettings(JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(data));
+                    App.BundlesSettings.ImportSettings(JsonConvert.DeserializeObject<Dictionary<string, List<string>>>(data));
                     await Load(); // Update the collection
                 }
                 catch // Couldn't deserialize, data is corrupted
@@ -247,7 +240,7 @@ namespace Files.ViewModels.Widgets.Bundles
             }
         }
 
-        private async void ExportBundles()
+        private async Task ExportBundles()
         {
             FileSavePicker filePicker = new FileSavePicker();
             filePicker.FileTypeChoices.Add("Json File", new List<string>() { System.IO.Path.GetExtension(Constants.LocalSettings.BundlesSettingsFileName) });
@@ -256,7 +249,7 @@ namespace Files.ViewModels.Widgets.Bundles
 
             if (file != null)
             {
-                NativeFileOperationsHelper.WriteStringToFile(file.Path, (string)BundlesSettings.ExportSettings());
+                NativeFileOperationsHelper.WriteStringToFile(file.Path, (string)App.BundlesSettings.ExportSettings());
             }
         }
 
@@ -337,7 +330,7 @@ namespace Files.ViewModels.Widgets.Bundles
 
         public void Save()
         {
-            if (BundlesSettings.SavedBundles != null)
+            if (App.BundlesSettings.SavedBundles != null)
             {
                 Dictionary<string, List<string>> bundles = new Dictionary<string, List<string>>();
 
@@ -358,18 +351,18 @@ namespace Files.ViewModels.Widgets.Bundles
                     bundles.Add(bundle.BundleName, bundleItems);
                 }
 
-                BundlesSettings.SavedBundles = bundles; // Calls Set()
+                App.BundlesSettings.SavedBundles = bundles; // Calls Set()
             }
         }
 
         public async Task Load()
         {
-            if (BundlesSettings.SavedBundles != null)
+            if (App.BundlesSettings.SavedBundles != null)
             {
                 Items.Clear();
 
                 // For every bundle in saved bundle collection:
-                foreach (var bundle in BundlesSettings.SavedBundles)
+                foreach (var bundle in App.BundlesSettings.SavedBundles)
                 {
                     List<BundleItemViewModel> bundleItems = new List<BundleItemViewModel>();
 
@@ -387,14 +380,13 @@ namespace Files.ViewModels.Widgets.Bundles
                                     OpenPath = OpenPathHandle,
                                     OpenPathInNewPane = OpenPathInNewPaneHandle,
                                 });
-                                await bundleItems.Last().UpdateIcon();
                             }
                         }
                     }
 
                     // Fill current bundle with collected bundle items
                     itemAddedInternally = true;
-                    Items.Add(new BundleContainerViewModel()
+                    Items.Add(await new BundleContainerViewModel()
                     {
                         BundleName = bundle.Key,
                         NotifyItemRemoved = NotifyItemRemovedHandle,

--- a/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
@@ -308,7 +308,7 @@ namespace Files.ViewModels.Widgets.Bundles
 
                     if (bundle.Contents.Count == 0)
                     {
-                        bundle.NoBundleContentsTextVisibility = Visibility.Visible;
+                        bundle.NoBundleContentsTextLoad = true;
                     }
                 }
             }


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #5256

**Details of Changes**
This PR adds a context menu option in bundles to directly select and add file/folder to a bundle. This PR also improves performance by utilizing `{x:Bind}` and `x:Load` replacing `{Binding}` and `Visibility`, respectively. Further improvements have been made to code as well, featuring use of `AsyncRelayCommand` and `Task.WaitAll()` for better stability.

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/53011783/126642300-3af6635c-65cf-4623-9134-73fab1364034.png)

![image](https://user-images.githubusercontent.com/53011783/126642401-c23a776f-8ed2-45b4-84ac-9c0f9cc9e64c.png)

