### PR TITLE
Move drag area to MainPage

### DIFF
--- a/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml.cs
+++ b/Files/UserControls/Settings/ThemeSampleDisplayControl.xaml.cs
@@ -13,7 +13,7 @@ namespace Files.UserControls.Settings
             set
             {
                 SetValue(SampleThemeProperty, value);
-                ReevaluateThemeResourceBinding();
+                _ = ReevaluateThemeResourceBinding();
             }
         }
 
@@ -29,15 +29,15 @@ namespace Files.UserControls.Settings
 
         private void ThemeSampleDisplayControl_Loaded(object sender, RoutedEventArgs e)
         {
-            ReevaluateThemeResourceBinding();
+            _ = ReevaluateThemeResourceBinding();
         }
 
         public async Task<bool> ReevaluateThemeResourceBinding()
         {
-            if(SampleTheme.Path != null)
+            if (SampleTheme.Path != null)
             {
                 var resources = await App.ExternalResourcesHelper.TryLoadResourceDictionary(SampleTheme);
-                if(resources != null)
+                if (resources != null)
                 {
                     Resources.MergedDictionaries.Add(resources);
                     RequestedTheme = ElementTheme.Dark;

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -308,18 +308,6 @@
                                         UseSystemFocusVisuals="True" />
                                 </Grid>
 
-                                <!--  This defines the drag area for the title bar  -->
-                                <Grid
-                                    x:Name="DragArea"
-                                    Grid.ColumnSpan="2"
-                                    Height="50"
-                                    Margin="32,0,0,0"
-                                    HorizontalAlignment="Stretch"
-                                    VerticalAlignment="Top"
-                                    Background="Transparent"
-                                    Canvas.ZIndex="1"
-                                    Loaded="DragArea_Loaded" />
-
                                 <!--  This is a special spot just for tabs so that the title bar DragArea can function properly  -->
                                 <Border
                                     x:Name="TabContentBorder"

--- a/Files/UserControls/SidebarControl.xaml
+++ b/Files/UserControls/SidebarControl.xaml
@@ -842,7 +842,6 @@
                                                 <Setter Target="TabContentBorder.(Grid.ColumnSpan)" Value="2" />
                                                 <Setter Target="TitlebarBackgroundBorder.(Grid.Column)" Value="0" />
                                                 <Setter Target="TitlebarBackgroundBorder.(Grid.ColumnSpan)" Value="2" />
-                                                <Setter Target="DragArea.Margin" Value="0,0,0,0" />
                                             </VisualState.Setters>
                                         </VisualState>
                                         <VisualState x:Name="ClosedCompactRight">
@@ -882,7 +881,6 @@
                                                 <Setter Target="TabContentBorder.(Grid.ColumnSpan)" Value="2" />
                                                 <Setter Target="TitlebarBackgroundBorder.(Grid.Column)" Value="0" />
                                                 <Setter Target="TitlebarBackgroundBorder.(Grid.ColumnSpan)" Value="2" />
-                                                <Setter Target="DragArea.Margin" Value="0,0,0,0" />
                                             </VisualState.Setters>
                                         </VisualState>
                                         <VisualState x:Name="OpenOverlayLeft">
@@ -942,7 +940,6 @@
                                                 <Setter Target="TabContentBorder.(Grid.ColumnSpan)" Value="2" />
                                                 <Setter Target="TitlebarBackgroundBorder.(Grid.Column)" Value="0" />
                                                 <Setter Target="TitlebarBackgroundBorder.(Grid.ColumnSpan)" Value="2" />
-                                                <Setter Target="DragArea.Margin" Value="0,0,0,0" />
                                             </VisualState.Setters>
                                         </VisualState>
                                         <VisualState x:Name="OpenInlineRight">
@@ -983,7 +980,6 @@
                                                 <Setter Target="TabContentBorder.(Grid.ColumnSpan)" Value="2" />
                                                 <Setter Target="TitlebarBackgroundBorder.(Grid.Column)" Value="0" />
                                                 <Setter Target="TitlebarBackgroundBorder.(Grid.ColumnSpan)" Value="2" />
-                                                <Setter Target="DragArea.Margin" Value="0,0,0,0" />
                                             </VisualState.Setters>
                                         </VisualState>
                                         <VisualState x:Name="OpenCompactOverlayLeft">

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -881,11 +881,6 @@ namespace Files.UserControls
             SidebarItemNewPaneInvoked?.Invoke(this, new SidebarItemNewPaneInvokedEventArgs(item));
         }
 
-        private void DragArea_Loaded(object sender, RoutedEventArgs e)
-        {
-            Window.Current.SetTitleBar(sender as Grid);
-        }
-
         private void ResizeElementBorder_ManipulationStarted(object sender, ManipulationStartedRoutedEventArgs e)
         {
             if (DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Expanded)

--- a/Files/Views/MainPage.xaml
+++ b/Files/Views/MainPage.xaml
@@ -271,6 +271,18 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition x:Name="RightPaddingColumn" Width="0" />
                 </Grid.ColumnDefinitions>
+
+                <!--  This defines the drag area for the title bar  -->
+                <Grid
+                    x:Name="DragArea"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    Height="50"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Top"
+                    Background="Transparent"
+                    Loaded="DragArea_Loaded" />
+
                 <usercontrols:HorizontalMultitaskingControl
                     x:Name="horizontalMultitaskingControl"
                     Grid.Column="1"

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -103,6 +103,12 @@ namespace Files.Views
                 ViewModel.MultitaskingControl.CurrentInstanceChanged += MultitaskingControl_CurrentInstanceChanged;
             }
         }
+
+        private void DragArea_Loaded(object sender, RoutedEventArgs e)
+        {
+            Window.Current.SetTitleBar(sender as Grid);
+        }
+
         private void TitleBar_LayoutMetricsChanged(CoreApplicationViewTitleBar sender, object args)
         {
             RightPaddingColumn.Width = new GridLength(sender.SystemOverlayRightInset);

--- a/Files/Views/SettingsPages/Appearance.xaml
+++ b/Files/Views/SettingsPages/Appearance.xaml
@@ -148,12 +148,12 @@
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
-            <StaticResource x:Key="GridViewItemBackgroundSelected" ResourceKey="SystemAccentColor"/>
+            <StaticResource x:Key="GridViewItemBackgroundSelected" ResourceKey="SystemAccentColor" />
             <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
         </ResourceDictionary>
     </Page.Resources>
     <Page.DataContext>
-        <settingsviewmodels:AppearanceViewModel x:Name="ViewModel" PropertyChanged="ViewModel_PropertyChanged"/>
+        <settingsviewmodels:AppearanceViewModel x:Name="ViewModel" PropertyChanged="ViewModel_PropertyChanged" />
     </Page.DataContext>
 
     <Grid>
@@ -200,11 +200,15 @@
                     </local:SettingsBlockControl.Icon>
                     <local:SettingsBlockControl.ExpandableContent>
                         <StackPanel>
-                            <GridView x:Name="AppThemeSelectionGridView" Padding="5"
-                                ItemsSource="{Binding CustomThemes}" SelectionMode="Single" SelectedItem="{Binding SelectedTheme, Mode=TwoWay}">
+                            <GridView
+                                x:Name="AppThemeSelectionGridView"
+                                Padding="5"
+                                ItemsSource="{Binding CustomThemes}"
+                                SelectedItem="{Binding SelectedTheme, Mode=TwoWay}"
+                                SelectionMode="Single">
                                 <GridView.ItemTemplate>
                                     <DataTemplate>
-                                        <local:ThemeSampleDisplayControl SampleTheme="{Binding Mode=OneWay}"/>
+                                        <local:ThemeSampleDisplayControl SampleTheme="{Binding Mode=OneWay}" />
                                     </DataTemplate>
                                 </GridView.ItemTemplate>
                             </GridView>

--- a/Files/Views/SettingsPages/Appearance.xaml.cs
+++ b/Files/Views/SettingsPages/Appearance.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Dialogs;
 using Files.Helpers;
+using Files.Helpers.XamlHelpers;
 using Files.UserControls.Settings;
 using Files.ViewModels;
 using Files.ViewModels.SettingsViewModels;
@@ -23,7 +24,7 @@ namespace Files.SettingsPages
         {
             for (int i = 0; i < ViewModel.CustomThemes.Count; i++)
             {
-                if(ViewModel.CustomThemes[i].Path == ViewModel.SelectedTheme.Path)
+                if (ViewModel.CustomThemes[i].Path == ViewModel.SelectedTheme.Path)
                 {
                     AppThemeSelectionGridView.SelectedIndex = i;
                 }
@@ -43,16 +44,18 @@ namespace Files.SettingsPages
 
         private async void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if(e.PropertyName == nameof(ViewModel.SelectedElementTheme))
+            if (e.PropertyName == nameof(ViewModel.SelectedElementTheme))
             {
-                var containers = AppThemeSelectionGridView.ItemsPanelRoot.Children;
-                foreach(var container in containers)
+                foreach (var theme in ViewModel.CustomThemes)
                 {
-                    var listViewItemPresenter = VisualTreeHelper.GetChild(container, 0);
-                    var item = VisualTreeHelper.GetChild(listViewItemPresenter, 0) as ThemeSampleDisplayControl;
-                    if(item !=  null)
+                    var container = AppThemeSelectionGridView.ContainerFromItem(theme);
+                    if (container != null)
                     {
-                        await item.ReevaluateThemeResourceBinding();
+                        var item = DependencyObjectHelpers.FindChild<ThemeSampleDisplayControl>(container);
+                        if (item != null)
+                        {
+                            await item.ReevaluateThemeResourceBinding();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5476
- Closes #5487

**Details of Changes**
Add details of changes here.
- Moved the drag area to MainPage (on `main` + Windows 10 I cannot drag the window by the titlebar)
- Fixes crash when changing app theme

**Validation**
How did you test these changes?
- [x] Built and ran the app
