### PR TITLE
Double click gridsplitter to resize columns to fit content

### DIFF
--- a/Files/Helpers/XamlHelpers/DependencyObjectHelpers.cs
+++ b/Files/Helpers/XamlHelpers/DependencyObjectHelpers.cs
@@ -69,27 +69,6 @@ namespace Files.Helpers.XamlHelpers
             }
         }
 
-        public static IEnumerable<T> FindChildren<T>(DependencyObject startNode, Func<T, bool> predicate) where T : DependencyObject
-        {
-            int count = VisualTreeHelper.GetChildrenCount(startNode);
-            for (int i = 0; i < count; i++)
-            {
-                DependencyObject current = VisualTreeHelper.GetChild(startNode, i);
-                if (current.GetType().Equals(typeof(T)) || (current.GetType().GetTypeInfo().IsSubclassOf(typeof(T))))
-                {
-                    T asType = (T)current;
-                    if (predicate(asType))
-                    {
-                        yield return asType;
-                    }
-                }
-                foreach(var item in FindChildren<T>(current, predicate))
-                {
-                    yield return item;
-                }
-            }
-        }
-
         public static T FindParent<T>(DependencyObject child) where T : DependencyObject
         {
             T parent = null;

--- a/Files/Helpers/XamlHelpers/DependencyObjectHelpers.cs
+++ b/Files/Helpers/XamlHelpers/DependencyObjectHelpers.cs
@@ -51,7 +51,7 @@ namespace Files.Helpers.XamlHelpers
             return null;
         }
 
-        public static void FindChildren<T>(IList<T> results, DependencyObject startNode) where T : DependencyObject
+        public static IEnumerable<T> FindChildren<T>(DependencyObject startNode) where T : DependencyObject
         {
             int count = VisualTreeHelper.GetChildrenCount(startNode);
             for (int i = 0; i < count; i++)
@@ -60,9 +60,33 @@ namespace Files.Helpers.XamlHelpers
                 if (current.GetType().Equals(typeof(T)) || (current.GetType().GetTypeInfo().IsSubclassOf(typeof(T))))
                 {
                     T asType = (T)current;
-                    results.Add(asType);
+                    yield return asType;
                 }
-                FindChildren<T>(results, current);
+                foreach (var item in FindChildren<T>(current))
+                {
+                    yield return item;
+                }
+            }
+        }
+
+        public static IEnumerable<T> FindChildren<T>(DependencyObject startNode, Func<T, bool> predicate) where T : DependencyObject
+        {
+            int count = VisualTreeHelper.GetChildrenCount(startNode);
+            for (int i = 0; i < count; i++)
+            {
+                DependencyObject current = VisualTreeHelper.GetChild(startNode, i);
+                if (current.GetType().Equals(typeof(T)) || (current.GetType().GetTypeInfo().IsSubclassOf(typeof(T))))
+                {
+                    T asType = (T)current;
+                    if (predicate(asType))
+                    {
+                        yield return asType;
+                    }
+                }
+                foreach(var item in FindChildren<T>(current, predicate))
+                {
+                    yield return item;
+                }
             }
         }
 

--- a/Files/ViewModels/ColumnsViewModel.cs
+++ b/Files/ViewModels/ColumnsViewModel.cs
@@ -1,14 +1,6 @@
 ﻿using Microsoft.Toolkit.Mvvm.ComponentModel;
-using Microsoft.Toolkit.Uwp.UI.Controls;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Input;
 
 namespace Files.ViewModels
 {

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -333,6 +333,7 @@
 
                             <controls:GridSplitter
                                 Grid.Column="3"
+                                DoubleTapped="GridSplitter_DoubleTapped"
                                 ManipulationCompleted="GridSplitter_ManipulationCompleted"
                                 ManipulationDelta="GridSplitter_ManipulationDelta"
                                 Style="{StaticResource HeaderGridSplitterStyle}" />
@@ -348,6 +349,7 @@
 
                             <controls:GridSplitter
                                 Grid.Column="5"
+                                DoubleTapped="GridSplitter_DoubleTapped"
                                 ManipulationCompleted="GridSplitter_ManipulationCompleted"
                                 ManipulationDelta="GridSplitter_ManipulationDelta"
                                 Style="{StaticResource HeaderGridSplitterStyle}"
@@ -364,6 +366,7 @@
 
                             <controls:GridSplitter
                                 Grid.Column="7"
+                                DoubleTapped="GridSplitter_DoubleTapped"
                                 ManipulationCompleted="GridSplitter_ManipulationCompleted"
                                 ManipulationDelta="GridSplitter_ManipulationDelta"
                                 Style="{StaticResource HeaderGridSplitterStyle}"
@@ -380,6 +383,7 @@
 
                             <controls:GridSplitter
                                 Grid.Column="9"
+                                DoubleTapped="GridSplitter_DoubleTapped"
                                 ManipulationCompleted="GridSplitter_ManipulationCompleted"
                                 ManipulationDelta="GridSplitter_ManipulationDelta"
                                 Style="{StaticResource HeaderGridSplitterStyle}"
@@ -396,6 +400,7 @@
 
                             <controls:GridSplitter
                                 Grid.Column="11"
+                                DoubleTapped="GridSplitter_DoubleTapped"
                                 ManipulationCompleted="GridSplitter_ManipulationCompleted"
                                 ManipulationDelta="GridSplitter_ManipulationDelta"
                                 Style="{StaticResource HeaderGridSplitterStyle}"
@@ -412,6 +417,7 @@
 
                             <controls:GridSplitter
                                 Grid.Column="13"
+                                DoubleTapped="GridSplitter_DoubleTapped"
                                 ManipulationCompleted="GridSplitter_ManipulationCompleted"
                                 ManipulationDelta="GridSplitter_ManipulationDelta"
                                 Style="{StaticResource HeaderGridSplitterStyle}"
@@ -428,6 +434,7 @@
 
                             <controls:GridSplitter
                                 Grid.Column="15"
+                                DoubleTapped="GridSplitter_DoubleTapped"
                                 ManipulationCompleted="GridSplitter_ManipulationCompleted"
                                 ManipulationDelta="GridSplitter_ManipulationDelta"
                                 Style="{StaticResource HeaderGridSplitterStyle}"
@@ -444,6 +451,7 @@
 
                             <controls:GridSplitter
                                 Grid.Column="17"
+                                DoubleTapped="GridSplitter_DoubleTapped"
                                 ManipulationCompleted="GridSplitter_ManipulationCompleted"
                                 ManipulationDelta="GridSplitter_ManipulationDelta"
                                 Style="{StaticResource HeaderGridSplitterStyle}"

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -705,6 +706,26 @@ namespace Files.Views.LayoutModes
                     ParentShellPageInstance.FilesystemViewModel.CancelExtendedPropertiesLoadingForItem(item);
                 }
             }
+        }
+
+        private void GridSplitter_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+        {
+            var columnToResize = Grid.GetColumn(sender as Microsoft.Toolkit.Uwp.UI.Controls.GridSplitter) - 1;
+            switch (columnToResize)
+            {
+                case 2: // file name column
+                    {
+                        var tbs = DependencyObjectHelpers.FindChildren<TextBlock>(FileList.ItemsPanelRoot, x => x.Name == "ItemName");
+                        var maxWidth = tbs.Select(tb =>
+                        {
+                            tb.Measure(new Size(Double.PositiveInfinity, Double.PositiveInfinity));
+                            return tb.DesiredSize.Width;
+                        }).Max();
+                        ColumnsViewModel.NameColumn.UserLength = new GridLength(maxWidth + 30, GridUnitType.Pixel);
+                        break;
+                    }
+            }
+            e.Handled = true;
         }
     }
 }

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -710,6 +710,11 @@ namespace Files.Views.LayoutModes
 
         private void GridSplitter_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
         {
+            if (!FileList.Items.Any())
+            {
+                return;
+            }
+
             var columnToResize = Grid.GetColumn(sender as Microsoft.Toolkit.Uwp.UI.Controls.GridSplitter) - 1;
             switch (columnToResize)
             {

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -727,13 +727,13 @@ namespace Files.Views.LayoutModes
                 1 => FileList.Items.Cast<ListedItem>().Select(x => x.ItemName?.Length ?? 0).Max(), // file name column
                 2 => FileList.Items.Cast<RecycleBinItem>().Select(x => x.ItemOriginalPath?.Length ?? 0).Max(), // original path column
                 3 => FileList.Items.Cast<RecycleBinItem>().Select(x => x.ItemDateDeleted?.Length ?? 0).Max(), // date deleted column
+                4 => 20, // cloud status column
                 5 => FileList.Items.Cast<ListedItem>().Select(x => x.ItemDateModified?.Length ?? 0).Max(), // date modified column
                 6 => FileList.Items.Cast<ListedItem>().Select(x => x.ItemDateCreated?.Length ?? 0).Max(), // date created column
                 7 => FileList.Items.Cast<ListedItem>().Select(x => x.ItemType?.Length ?? 0).Max(), // item type column
-                8 => FileList.Items.Cast<ListedItem>().Select(x => x.FileSize?.Length ?? 0).Max(), // item size column
-                _ => 0 // cloud status column
+                _ => FileList.Items.Cast<ListedItem>().Select(x => x.FileSize?.Length ?? 0).Max(), // item size column
             };
-            var colunmSizeToFit = MeasureTextColumn(columnToResize, 5, maxItemLength);
+            var colunmSizeToFit = columnToResize == 4 ? maxItemLength : MeasureTextColumn(columnToResize, 5, maxItemLength);
             if (colunmSizeToFit > 0)
             {
                 var column = columnToResize switch

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -715,13 +715,14 @@ namespace Files.Views.LayoutModes
             {
                 case 2: // file name column
                     {
-                        var tbs = DependencyObjectHelpers.FindChildren<TextBlock>(FileList.ItemsPanelRoot).Where(x => x.Name == "ItemName");
-                        var maxWidth = tbs.Select(tb =>
+                        var tbs = DependencyObjectHelpers.FindChildren<TextBlock>(FileList.ItemsPanelRoot).Where(x => x.Name == "ItemName").Take(5);
+                        var widthPerLetter = tbs.Select(tb =>
                         {
                             tb.Measure(new Size(Double.PositiveInfinity, Double.PositiveInfinity));
-                            return tb.DesiredSize.Width;
-                        }).Max();
-                        ColumnsViewModel.NameColumn.UserLength = new GridLength(maxWidth + 30, GridUnitType.Pixel);
+                            return tb.DesiredSize.Width / tb.Text.Length;
+                        }).Average();
+                        var maxLength = FileList.Items.Cast<ListedItem>().Select(x => x.ItemName.Length).Max();
+                        ColumnsViewModel.NameColumn.UserLength = new GridLength(maxLength * widthPerLetter + 30, GridUnitType.Pixel);
                         break;
                     }
             }

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -747,7 +747,7 @@ namespace Files.Views.LayoutModes
                     7 => ColumnsViewModel.ItemTypeColumn,
                     _ => ColumnsViewModel.SizeColumn
                 };
-                column.UserLength = new GridLength(colunmSizeToFit + 30, GridUnitType.Pixel);
+                column.UserLength = new GridLength(Math.Min(colunmSizeToFit + 30, column.NormalMaxLength), GridUnitType.Pixel);
             }
 
             ParentShellPageInstance.InstanceViewModel.FolderSettings.ColumnsViewModel = ColumnsViewModel;

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -715,7 +715,7 @@ namespace Files.Views.LayoutModes
             {
                 case 2: // file name column
                     {
-                        var tbs = DependencyObjectHelpers.FindChildren<TextBlock>(FileList.ItemsPanelRoot, x => x.Name == "ItemName");
+                        var tbs = DependencyObjectHelpers.FindChildren<TextBlock>(FileList.ItemsPanelRoot).Where(x => x.Name == "ItemName");
                         var maxWidth = tbs.Select(tb =>
                         {
                             tb.Measure(new Size(Double.PositiveInfinity, Double.PositiveInfinity));

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -710,28 +710,62 @@ namespace Files.Views.LayoutModes
 
         private void GridSplitter_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
         {
+            var columnToResize = (Grid.GetColumn(sender as Microsoft.Toolkit.Uwp.UI.Controls.GridSplitter) - 1) / 2;
+            ResizeColumnToFit(columnToResize);
+            e.Handled = true;
+        }
+
+        private void ResizeColumnToFit(int columnToResize)
+        {
             if (!FileList.Items.Any())
             {
                 return;
             }
 
-            var columnToResize = Grid.GetColumn(sender as Microsoft.Toolkit.Uwp.UI.Controls.GridSplitter) - 1;
-            switch (columnToResize)
+            var maxItemLength = columnToResize switch
             {
-                case 2: // file name column
-                    {
-                        var tbs = DependencyObjectHelpers.FindChildren<TextBlock>(FileList.ItemsPanelRoot).Where(x => x.Name == "ItemName").Take(5);
-                        var widthPerLetter = tbs.Select(tb =>
-                        {
-                            tb.Measure(new Size(Double.PositiveInfinity, Double.PositiveInfinity));
-                            return tb.DesiredSize.Width / tb.Text.Length;
-                        }).Average();
-                        var maxLength = FileList.Items.Cast<ListedItem>().Select(x => x.ItemName.Length).Max();
-                        ColumnsViewModel.NameColumn.UserLength = new GridLength(maxLength * widthPerLetter + 30, GridUnitType.Pixel);
-                        break;
-                    }
+                1 => FileList.Items.Cast<ListedItem>().Select(x => x.ItemName?.Length ?? 0).Max(), // file name column
+                2 => FileList.Items.Cast<RecycleBinItem>().Select(x => x.ItemOriginalPath?.Length ?? 0).Max(), // original path column
+                3 => FileList.Items.Cast<RecycleBinItem>().Select(x => x.ItemDateDeleted?.Length ?? 0).Max(), // date deleted column
+                5 => FileList.Items.Cast<ListedItem>().Select(x => x.ItemDateModified?.Length ?? 0).Max(), // date modified column
+                6 => FileList.Items.Cast<ListedItem>().Select(x => x.ItemDateCreated?.Length ?? 0).Max(), // date created column
+                7 => FileList.Items.Cast<ListedItem>().Select(x => x.ItemType?.Length ?? 0).Max(), // item type column
+                8 => FileList.Items.Cast<ListedItem>().Select(x => x.FileSize?.Length ?? 0).Max(), // item size column
+                _ => 0 // cloud status column
+            };
+            var colunmSizeToFit = MeasureTextColumn(columnToResize, 5, maxItemLength);
+            if (colunmSizeToFit > 0)
+            {
+                var column = columnToResize switch
+                {
+                    1 => ColumnsViewModel.NameColumn,
+                    2 => ColumnsViewModel.OriginalPathColumn,
+                    3 => ColumnsViewModel.DateDeletedColumn,
+                    4 => ColumnsViewModel.StatusColumn,
+                    5 => ColumnsViewModel.DateModifiedColumn,
+                    6 => ColumnsViewModel.DateCreatedColumn,
+                    7 => ColumnsViewModel.ItemTypeColumn,
+                    _ => ColumnsViewModel.SizeColumn
+                };
+                column.UserLength = new GridLength(colunmSizeToFit + 30, GridUnitType.Pixel);
             }
-            e.Handled = true;
+
+            ParentShellPageInstance.InstanceViewModel.FolderSettings.ColumnsViewModel = ColumnsViewModel;
+        }
+
+        private double MeasureTextColumn(int columnIndex, int measureItems, int maxItemLength)
+        {
+            var tbs = DependencyObjectHelpers.FindChildren<TextBlock>(FileList.ItemsPanelRoot).Where(x => Grid.GetColumn(x.Parent as Grid) == columnIndex);
+            var widthPerLetter = tbs.Where(tb => !string.IsNullOrEmpty(tb.Text)).Take(measureItems).Select(tb =>
+            {
+                tb.Measure(new Size(Double.PositiveInfinity, Double.PositiveInfinity));
+                return tb.DesiredSize.Width / Math.Max(1, tb.Text.Length);
+            });
+            if (!widthPerLetter.Any())
+            {
+                return 0;
+            }
+            return widthPerLetter.Average() * maxItemLength;
         }
     }
 }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- For #4643

**Details of Changes**
Add details of changes here.
- Double clicking the header divider should fit the column to width

@winston-de I was looking into implementing the above change and this is what I came up with.
This seems to work fine when the items are not too many (until list virtualization kicks in). What do you think?

**Validation**
How did you test these changes?
- [x] Built and ran the app
