### PR TITLE
Added thumbnail fallback for obtaining icons for some pinned folders

### DIFF
--- a/Files/DataModels/SidebarPinnedModel.cs
+++ b/Files/DataModels/SidebarPinnedModel.cs
@@ -269,6 +269,19 @@ namespace Files.DataModels
                         locationItem.IconData = await thumbnail.ToByteArrayAsync();
                         locationItem.Icon = await locationItem.IconData.ToBitmapAsync();
                     }
+                    else
+                    {
+                        using var thumbnailFallback = await res.Result.GetThumbnailAsync(
+                        Windows.Storage.FileProperties.ThumbnailMode.SingleItem,
+                        24,
+                        Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
+
+                        if (thumbnailFallback != null)
+                        {
+                            locationItem.IconData = await thumbnailFallback.ToByteArrayAsync();
+                            locationItem.Icon = await locationItem.IconData.ToBitmapAsync();
+                        }
+                    }
                 }
                 else
                 {

--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -571,6 +571,7 @@
                     x:Uid="NavSettingsButton"
                     Width="36"
                     Height="32"
+                    AccessKey="E"
                     AutomationProperties.Name="Settings"
                     Background="Transparent"
                     Command="{x:Bind SettingsButtonCommand, Mode=OneWay}"

--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -571,7 +571,6 @@
                     x:Uid="NavSettingsButton"
                     Width="36"
                     Height="32"
-                    AccessKey="E"
                     AutomationProperties.Name="Settings"
                     Background="Transparent"
                     Command="{x:Bind SettingsButtonCommand, Mode=OneWay}"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Closes #5423

**Details of Changes**
- Added thumbnail fallback for fixing #5423 . Some folders doesn't have an icon on ListView but they have on SingleItem, so with this change more folders will have thumbnail icons when pinned. I added as a fallback because some folders have a bad thumbnail on SingleItem style (they have a black background).

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before:
![image](https://user-images.githubusercontent.com/11770760/126900796-8730946f-05f5-4f0b-bf90-5218d97f34b2.png)

After:
![image](https://user-images.githubusercontent.com/11770760/126900766-bc60c526-f87b-4d9e-863c-7fcc613c69ff.png)