### PR TITLE
Added Access key to open settings

### DIFF
--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -572,6 +572,7 @@
                     Width="36"
                     Height="32"
                     AutomationProperties.Name="Settings"
+                    AccessKey="O"
                     Background="Transparent"
                     Command="{x:Bind SettingsButtonCommand, Mode=OneWay}"
                     Style="{StaticResource ToolBarButtonStyle}"

--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -572,7 +572,7 @@
                     Width="36"
                     Height="32"
                     AutomationProperties.Name="Settings"
-                    AccessKey="O"
+                    AccessKey="I"
                     Background="Transparent"
                     Command="{x:Bind SettingsButtonCommand, Mode=OneWay}"
                     Style="{StaticResource ToolBarButtonStyle}"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Related #5502 (@winston-de comment)

**Details of Changes**
- Added an access key for accessing settings. I went with "O" since "S" is already used by selection menu. Also, I figured out that it should be an access key that is also used on settings, to avoid a possible exception when you are already on settings and click the access key for opening them again.

I tried to also add a shortcut for entirely closing #5502, but it's throwing an odd exception about the impossibility of opening more than 1 Content Dialog, so until someone implemented it well or I figure out what it's going on at least you will be able to open settings using keyboard via access keys.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before:
![image](https://user-images.githubusercontent.com/11770760/126900802-01483fa9-56e1-4b83-979e-0f574ee275b9.png)

After:
![image](https://user-images.githubusercontent.com/11770760/126912301-ba9c76dc-db4a-4076-bb44-80e834c8f21b.png)
