### PR TITLE
Use windowed flyouts to improve accessibility at smaller window sizes

### DIFF
--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -167,7 +167,7 @@
                     <FontIcon FontSize="10" Glyph="&#xF246;" />
                 </AppBarButton.Icon>
                 <AppBarButton.Flyout>
-                    <Flyout Placement="Bottom">
+                    <Flyout Placement="Bottom" ShouldConstrainToRootBounds="False">
                         <StackPanel Spacing="12">
                             <TextBlock
                                 x:Uid="NavToolbarManageWidgetsFlyoutHeader"
@@ -271,7 +271,7 @@
                     <local:ColoredIcon BaseLayerGlyph="&#xF029;" OverlayLayerGlyph="&#xF02A;" />
                 </AppBarButton.Content>
                 <AppBarButton.Flyout>
-                    <Flyout>
+                    <Flyout ShouldConstrainToRootBounds="False">
                         <local:ArrangementOptions
                             x:Name="ArrangementOptionsFlyoutContent"
                             IsPageTypeCloudDrive="{x:Bind ViewModel.InstanceViewModel.IsPageTypeCloudDrive, Mode=OneWay}"
@@ -297,7 +297,7 @@
                     <FontIcon FontSize="10" Glyph="&#xE152;" />
                 </AppBarButton.Icon>
                 <AppBarButton.Flyout>
-                    <Flyout Placement="Bottom">
+                    <Flyout Placement="Bottom" ShouldConstrainToRootBounds="False">
                         <StackPanel Spacing="12">
                             <TextBlock
                                 x:Uid="NavToolbarLayout"

--- a/Files/Views/MainPage.xaml
+++ b/Files/Views/MainPage.xaml
@@ -346,7 +346,7 @@
                                         Glyph="&#xF5ED;" />
                                 </Button.Content>
                                 <Button.Flyout>
-                                    <Flyout x:Name="VerticalTabViewFlyout">
+                                    <Flyout x:Name="VerticalTabViewFlyout" ShouldConstrainToRootBounds="False" Placement="Bottom">
                                         <usercontrols:VerticalTabViewControl
                                             x:Name="VerticalTabs"
                                             HorizontalAlignment="Stretch"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related #issue...

**Details of Changes**
Add details of changes here.
- set ``ShouldConstrainToRootBounds="False"`` for flyouts so that the full ui can be shown at smaller window sizes, and to prevent overlap with the secondary commands flyout when the command bar is overflowing

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/59544401/126914641-b59c2884-9c72-42a3-a8c2-0268d564c254.png)
![image](https://user-images.githubusercontent.com/59544401/126914683-6bcf913d-4361-4de7-aa2a-ad29a69df0b0.png)
