### PR TITLE
Fix crash when closing properties dialog

### DIFF
--- a/Files/Helpers/FilePropertiesHelpers.cs
+++ b/Files/Helpers/FilePropertiesHelpers.cs
@@ -74,10 +74,6 @@ namespace Files.Helpers
                     newView.Title = "PropertiesTitle".GetLocalized();
                     newView.PersistedStateId = "Properties";
                     newView.SetPreferredMinSize(new Size(400, 500));
-                    newView.Consolidated += delegate
-                    {
-                        Window.Current.Close();
-                    };
 
                     bool viewShown = await ApplicationViewSwitcher.TryShowAsStandaloneAsync(newView.Id);
                     if (viewShown && newView != null)

--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -69,7 +69,6 @@ namespace Files.Views
             if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
             {
                 // Set window size in the loaded event to prevent flickering
-                ApplicationView.GetForCurrentView().Consolidated += Properties_Consolidated;
                 TitleBar = ApplicationView.GetForCurrentView().TitleBar;
                 TitleBar.ButtonBackgroundColor = Colors.Transparent;
                 TitleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
@@ -79,18 +78,6 @@ namespace Files.Views
             {
                 propertiesDialog = DependencyObjectHelpers.FindParent<ContentDialog>(this);
                 propertiesDialog.Closed += PropertiesDialog_Closed;
-            }
-        }
-
-        private void Properties_Consolidated(ApplicationView sender, ApplicationViewConsolidatedEventArgs args)
-        {
-            AppSettings.ThemeModeChanged -= AppSettings_ThemeModeChanged;
-            ApplicationView.GetForCurrentView().Consolidated -= Properties_Consolidated;
-            (contentFrame.Content as PropertiesTab).Dispose();
-            if (tokenSource != null && !tokenSource.IsCancellationRequested)
-            {
-                tokenSource.Cancel();
-                tokenSource = null;
             }
         }
 

--- a/Files/Views/Pages/PropertiesSecurity.xaml.cs
+++ b/Files/Views/Pages/PropertiesSecurity.xaml.cs
@@ -70,10 +70,6 @@ namespace Files.Views
 
         public override void Dispose()
         {
-            if (propsView != null)
-            {
-                propsView.Consolidated -= PropsView_Consolidated;
-            }
         }
 
         private async void OpenAdvancedProperties()
@@ -104,7 +100,6 @@ namespace Files.Views
                         propsView.Title = string.Format("SecurityAdvancedPermissionsTitle".GetLocalized(), SecurityProperties.Item.ItemName);
                         propsView.PersistedStateId = "PropertiesSecurity";
                         propsView.SetPreferredMinSize(new Size(400, 500));
-                        propsView.Consolidated += PropsView_Consolidated;
 
                         bool viewShown = await ApplicationViewSwitcher.TryShowAsStandaloneAsync(propsView.Id);
                         if (viewShown && propsView != null)
@@ -119,18 +114,6 @@ namespace Files.Views
             else
             {
                 // Unsupported
-            }
-        }
-
-        private async void PropsView_Consolidated(ApplicationView sender, ApplicationViewConsolidatedEventArgs args)
-        {
-            Window.Current.Close();
-            propsView.Consolidated -= PropsView_Consolidated;
-            propsView = null;
-
-            if (SecurityProperties != null)
-            {
-                await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => SecurityProperties.GetFilePermissions()); // Reload permissions
             }
         }
     }

--- a/Files/Views/Pages/PropertiesSecurityAdvanced.xaml.cs
+++ b/Files/Views/Pages/PropertiesSecurityAdvanced.xaml.cs
@@ -71,7 +71,6 @@ namespace Files.Views
             if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
             {
                 // Set window size in the loaded event to prevent flickering
-                ApplicationView.GetForCurrentView().Consolidated += Properties_Consolidated;
                 TitleBar = ApplicationView.GetForCurrentView().TitleBar;
                 TitleBar.ButtonBackgroundColor = Colors.Transparent;
                 TitleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
@@ -82,12 +81,6 @@ namespace Files.Views
             }
 
             ViewModel.GetFilePermissions();
-        }
-
-        private void Properties_Consolidated(ApplicationView sender, ApplicationViewConsolidatedEventArgs args)
-        {
-            App.AppSettings.ThemeModeChanged -= AppSettings_ThemeModeChanged;
-            ApplicationView.GetForCurrentView().Consolidated -= Properties_Consolidated;
         }
 
         private void Properties_Unloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #2714

**Details of Changes**
Add details of changes here.
- The consolidated lambdas appear to have been causing the exception, removing it fixes it
- also removes the app view consolidated cleanup event handlers because the whole process gets nuked from orbit anyway

**Validation**
How did you test these changes?
- [x] Built and ran the app in release mode
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.

For reference, the exception stack trace seemed to lead back to Windows_UI_Xaml!DirectUI::Window::get_SystemBackdrop+0x59