### PR TITLE
Fix icons of shortcuts appearing blurry after layout change

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -708,6 +708,7 @@ namespace Files.ViewModels
 
         private async Task LoadItemThumbnail(ListedItem item, uint thumbnailSize = 20, IStorageItem matchingStorageItem = null, bool forceReload = false)
         {
+            var wasIconLoaded = false;
             if (item.IsLibraryItem || item.PrimaryItemAttribute == StorageItemTypes.File)
             {
                 if (!forceReload && item.CustomIconData != null)
@@ -719,6 +720,7 @@ namespace Files.ViewModels
                         item.LoadWebShortcutGlyph = false;
                         item.LoadFileIcon = true;
                     }, Windows.System.DispatcherQueuePriority.Low);
+                    wasIconLoaded = true;
                 }
                 else
                 {
@@ -738,6 +740,7 @@ namespace Files.ViewModels
                                     item.LoadWebShortcutGlyph = false;
                                     item.LoadFileIcon = true;
                                 }, Windows.System.DispatcherQueuePriority.Low);
+                                wasIconLoaded = true;
                             }
 
                             var overlayInfo = await FileThumbnailHelper.LoadOverlayAsync(item.ItemPath);
@@ -752,7 +755,7 @@ namespace Files.ViewModels
                     }
                 }
 
-                if (!item.LoadFileIcon)
+                if (!wasIconLoaded)
                 {
                     var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize);
                     if (iconInfo.IconData != null)
@@ -788,6 +791,7 @@ namespace Files.ViewModels
                         item.LoadFolderGlyph = false;
                         item.LoadFileIcon = true;
                     }, Windows.System.DispatcherQueuePriority.Low);
+                    wasIconLoaded = true;
                 }
                 else
                 {
@@ -808,6 +812,7 @@ namespace Files.ViewModels
                                     item.LoadFolderGlyph = false;
                                     item.LoadFileIcon = true;
                                 }, Windows.System.DispatcherQueuePriority.Low);
+                                wasIconLoaded = true;
                             }
 
                             var overlayInfo = await FileThumbnailHelper.LoadOverlayAsync(item.ItemPath);
@@ -822,7 +827,7 @@ namespace Files.ViewModels
                     }
                 }
 
-                if (!item.LoadFileIcon)
+                if (!wasIconLoaded)
                 {
                     var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize);
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue causing icons of shortcuts and hidden items appearing blurry after layout change

**Validation**
How did you test these changes?
- [x] Built and ran the app
