### PR TITLE
Fix dragdrop image to CorelDraw

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -7,6 +7,7 @@ using Files.Helpers.ContextFlyouts;
 using Files.Interacts;
 using Files.UserControls;
 using Files.ViewModels;
+using Files.ViewModels.Previews;
 using Files.Views;
 using Microsoft.Toolkit.Uwp;
 using Microsoft.Toolkit.Uwp.UI;
@@ -664,7 +665,20 @@ namespace Files
                 }
             }
 
-            if (selectedStorageItems.Count > 0)
+            if (selectedStorageItems.Count == 1)
+            {
+                if (selectedStorageItems[0] is IStorageFile file)
+                {
+                    var itemExtension = System.IO.Path.GetExtension(file.Name);
+                    if (ImagePreviewViewModel.Extensions.Any((ext) => ext.Equals(itemExtension, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        var streamRef = Windows.Storage.Streams.RandomAccessStreamReference.CreateFromFile(file);
+                        e.Data.SetBitmap(streamRef);
+                    }
+                }
+                e.Data.SetStorageItems(selectedStorageItems, false);
+            }
+            else if (selectedStorageItems.Count > 1)
             {
                 e.Data.SetStorageItems(selectedStorageItems, false);
             }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5646

**Details of Changes**
Add details of changes here.
- Call SetBitmap() when the dragged file is an image so dropping the file in CorelDraw works.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested with CorelDraw 2021
