### PR TITLE
Fix Path visibility

### DIFF
--- a/Files/Converters/MultiBooleanConverter.cs
+++ b/Files/Converters/MultiBooleanConverter.cs
@@ -19,5 +19,8 @@ namespace Files.Converters
 
         public static Visibility OrConvertToVisibility(bool a, bool b)
             => (a || b) ? Visibility.Visible : Visibility.Collapsed;
+
+        public static Visibility OrNotConvertToVisibility(bool a, bool b)
+            => OrConvertToVisibility(a, !b);
     }
 }

--- a/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -30,7 +30,6 @@
     <ContentDialog.Resources>
         <ResourceDictionary>
             <x:Double x:Key="ContentDialogMaxWidth">800</x:Double>
-            <vc:VisiblityInvertConverter x:Key="VisiblityInvertConverter" />
         </ResourceDictionary>
     </ContentDialog.Resources>
 

--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -16,7 +16,6 @@
         <ResourceDictionary>
             <Style x:Key="AccentColorFontIconStyle" TargetType="FontIcon" />
             <converters:LayoutModeToBoolConverter x:Key="LayoutModeConverter" />
-            <converters:VisiblityInvertConverter x:Key="VisiblityInvertConverter" />
             <converters1:BoolNegationConverter x:Key="BoolNegationConverter" />
             <converters1:BoolToVisibilityConverter
                 x:Key="NegatedBoolToVisibilityConverter"

--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -458,7 +458,7 @@
                 Text="{x:Bind ViewModel.PathText, Mode=OneWay}"
                 TextChanged="{x:Bind ViewModel.VisiblePath_TextChanged, Mode=OneWay}"
                 TextMemberPath="ItemPath"
-                Visibility="{x:Bind ViewModel.IsSearchBoxVisible, Mode=OneWay, Converter={StaticResource VisiblityInvertConverter}}" />
+                Visibility="{x:Bind converters:MultiBooleanConverter.OrNotConvertToVisibility(ShowSearchBox, ViewModel.IsSearchBoxVisible), Mode=OneWay}" />
 
             <Grid
                 x:Name="ClickablePath"
@@ -473,7 +473,7 @@
                 BorderThickness="1"
                 CornerRadius="{StaticResource ControlCornerRadius}"
                 PointerPressed="ManualPathEntryItem_Click"
-                Visibility="{x:Bind ViewModel.IsSearchBoxVisible, Mode=OneWay, Converter={StaticResource VisiblityInvertConverter}}">
+                Visibility="{x:Bind converters:MultiBooleanConverter.OrNotConvertToVisibility(ShowSearchBox, ViewModel.IsSearchBoxVisible), Mode=OneWay}">
                 <uc:PathBreadcrumb
                     VerticalAlignment="Stretch"
                     HorizontalContentAlignment="Stretch"

--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -24,7 +24,6 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <converters:LayoutModeToBoolConverter x:Key="LayoutModeConverter" />
-            <converters:VisiblityInvertConverter x:Key="VisiblityInvertConverter" />
             <converters1:BoolNegationConverter x:Key="BoolNegationConverter" />
             <converters1:BoolToVisibilityConverter
                 x:Key="NegatedBoolToVisibilityConverter"

--- a/Files/UserControls/Widgets/BundlesWidget.xaml
+++ b/Files/UserControls/Widgets/BundlesWidget.xaml
@@ -15,7 +15,6 @@
 
     <UserControl.Resources>
         <!--  Converters  -->
-        <vc:VisiblityInvertConverter x:Key="VisiblityInvertConverter" />
         <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
     </UserControl.Resources>
 


### PR DESCRIPTION
**Resolved / Related Issues**
The control VisiblePath and ClickablePath are not visible when SearchBox is focused by CTRL+F.
This should only be done in compact mode, since the search bar is always displayed in normal mode. 

**Details of Changes**
The control VisiblePath and ClickablePath are visible when ShowSearchBox or not IsSearchBoxVisible.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before/After
![PathBefore](https://user-images.githubusercontent.com/46631671/127870750-4d7ee5ba-3a25-4d0a-bada-892985a009cb.png)
![PathAfter](https://user-images.githubusercontent.com/46631671/127870770-98f0387e-f889-4758-ab1a-097bc2e8b267.png)