### PR TITLE
Fix: Rename the First Document Name in Grid View (Medium) Cause Anoth…

### DIFF
--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -161,7 +161,16 @@
                         Text="{x:Bind ItemName, Mode=OneWay}"
                         TextTrimming="CharacterEllipsis"
                         TextWrapping="NoWrap"
-                        Visibility="{Binding IsOpen, ElementName=EditPopup, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
+                        Visibility="Visible">
+                        <i:Interaction.Behaviors>
+                            <icore:DataTriggerBehavior Binding="{Binding IsOpen, ElementName=EditPopup, Mode=OneWay}" Value="False">
+                                <icore:ChangePropertyAction TargetObject="{Binding ElementName=ItemName}" PropertyName="Opacity" Value="1" />
+                            </icore:DataTriggerBehavior>
+                            <icore:DataTriggerBehavior Binding="{Binding IsOpen, ElementName=EditPopup, Mode=OneWay}" Value="True">
+                                <icore:ChangePropertyAction TargetObject="{Binding ElementName=ItemName}" PropertyName="Opacity" Value="0" />
+                            </icore:DataTriggerBehavior>
+                        </i:Interaction.Behaviors>
+                    </TextBlock>
                 </Grid>
                 <Popup
                     x:Name="EditPopup"


### PR DESCRIPTION
…er Files to shift

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related https://github.com/files-community/Files/issues/5667

**Details of Changes**
Add details of changes here.
`Visibility=Collapse` won't reserve the space of the control which causes that issue. So set `Opacity` rather than `Visibility` property.

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots (optional)**
Add screenshots here.
![image](https://user-images.githubusercontent.com/45145954/128215755-9ceb52e1-054e-420e-acae-935c32eed30b.png)
