### PR TITLE
Add "open with" flyout with app list to context menu

### DIFF
--- a/Files.Launcher/MessageHandlers/ContextMenuHandler.cs
+++ b/Files.Launcher/MessageHandlers/ContextMenuHandler.cs
@@ -124,7 +124,7 @@ namespace FilesFullTrust.MessageHandlers
         {
             var knownItems = new List<string>()
             {
-                "opennew", "openas", "opencontaining", "opennewprocess",
+                "opennew", "opencontaining", "opennewprocess",
                 "runas", "runasuser", "pintohome", "PinToStartScreen",
                 "cut", "copy", "paste", "delete", "properties", "link",
                 "Windows.ModernShare", "Windows.Share", "setdesktopwallpaper",

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -612,6 +612,7 @@ namespace Files
 
         private void AddShellItemsToMenu(List<ContextMenuFlyoutItemViewModel> shellMenuItems, Microsoft.UI.Xaml.Controls.CommandBarFlyout contextMenuFlyout, bool shiftPressed)
         {
+            var openWithSubItems = ItemModelListToContextFlyoutHelper.GetMenuFlyoutItemsFromModel(ShellContextmenuHelper.GetOpenWithItems(shellMenuItems));
             var mainShellMenuItems = shellMenuItems.RemoveFrom(!App.AppSettings.MoveOverflowMenuItemsToSubMenu ? int.MaxValue : shiftPressed ? 6 : 4);
             var overflowShellMenuItems = shellMenuItems.Except(mainShellMenuItems).ToList();
 
@@ -648,6 +649,22 @@ namespace Files
                     (contextMenuFlyout.SecondaryCommands.First(x => x is FrameworkElement fe && fe.Tag as string == "OverflowSeparator") as AppBarSeparator).Visibility = Visibility.Visible;
                     overflowItem.Visibility = Visibility.Visible;
                 }
+            }
+            
+            // add items to openwith dropdown
+            var openWithOverflow = contextMenuFlyout.SecondaryCommands.FirstOrDefault(x => x is AppBarButton abb && (abb.Tag as string) == "OpenWithOverflow") as AppBarButton;
+            if (openWithSubItems is not null && openWithOverflow is not null)
+            {
+                var openWith = contextMenuFlyout.SecondaryCommands.FirstOrDefault(x => x is AppBarButton abb && (abb.Tag as string) == "OpenWith") as AppBarButton;
+                var flyout = new MenuFlyout();
+                foreach (var item in openWithSubItems)
+                {
+                    flyout.Items.Add(item);
+                }
+
+                openWithOverflow.Flyout = flyout;
+                openWith.Visibility = Visibility.Collapsed;
+                openWithOverflow.Visibility = Visibility.Visible;
             }
         }
 

--- a/Files/Helpers/ContextFlyoutItemHelper.cs
+++ b/Files/Helpers/ContextFlyoutItemHelper.cs
@@ -60,7 +60,7 @@ namespace Files.Helpers
         public static List<ContextMenuFlyoutItemViewModel> Filter(List<ContextMenuFlyoutItemViewModel> items, List<ListedItem> selectedItems, bool shiftPressed, CurrentInstanceViewModel currentInstanceViewModel, bool removeOverflowMenu = true)
         {
             items = items.Where(x => Check(item: x, currentInstanceViewModel: currentInstanceViewModel, selectedItems: selectedItems, shiftPressed: shiftPressed)).ToList();
-            items.ForEach(x => x.Items = x.Items.Where(y => Check(item: y, currentInstanceViewModel: currentInstanceViewModel, selectedItems: selectedItems, shiftPressed: shiftPressed)).ToList());
+            items.ForEach(x => x.Items = x.Items?.Where(y => Check(item: y, currentInstanceViewModel: currentInstanceViewModel, selectedItems: selectedItems, shiftPressed: shiftPressed)).ToList());
 
             var overflow = items.Where(x => x.ID == "ItemOverflow").FirstOrDefault();
             if (overflow != null)
@@ -478,6 +478,7 @@ namespace Files.Helpers
                 {
                     Text = "ContextMenuMoreItemsLabel".GetLocalized(),
                     Glyph = "\xE712",
+                    Items = new List<ContextMenuFlyoutItemViewModel>(),
                     ID = "ItemOverflow",
                     Tag = "ItemOverflow",
                     IsHidden = true,
@@ -509,7 +510,18 @@ namespace Files.Helpers
                     Text = "BaseLayoutItemContextFlyoutOpenItemWith/Text".GetLocalized(),
                     Glyph = "\uE17D",
                     Command = commandsViewModel.OpenItemWithApplicationPickerCommand,
+                    Tag = "OpenWith",
                     CollapseLabel = true,
+                    ShowItem = selectedItems.All(i => i.PrimaryItemAttribute == Windows.Storage.StorageItemTypes.File && !i.IsShortcutItem),
+                },
+                new ContextMenuFlyoutItemViewModel()
+                {
+                    Text = "BaseLayoutItemContextFlyoutOpenItemWith/Text".GetLocalized(),
+                    Glyph = "\uE17D",
+                    Tag = "OpenWithOverflow",
+                    IsHidden = true,
+                    CollapseLabel = true,
+                    Items = new List<ContextMenuFlyoutItemViewModel>(),
                     ShowItem = selectedItems.All(i => i.PrimaryItemAttribute == Windows.Storage.StorageItemTypes.File && !i.IsShortcutItem),
                 },
                 new ContextMenuFlyoutItemViewModel()
@@ -804,6 +816,7 @@ namespace Files.Helpers
                 {
                     Text = "ContextMenuMoreItemsLabel".GetLocalized(),
                     Glyph = "\xE712",
+                    Items = new List<ContextMenuFlyoutItemViewModel>(),
                     ID = "ItemOverflow",
                     Tag = "ItemOverflow",
                     IsHidden = true,

--- a/Files/Helpers/ItemModelListToContextFlyoutHelper.cs
+++ b/Files/Helpers/ItemModelListToContextFlyoutHelper.cs
@@ -14,6 +14,11 @@ namespace Files.Helpers.ContextFlyouts
     {
         public static List<MenuFlyoutItemBase> GetMenuFlyoutItemsFromModel(List<ContextMenuFlyoutItemViewModel> items)
         {
+            if(items is null)
+            {
+                return null;
+            }
+
             var flyout = new List<MenuFlyoutItemBase>();
             items.ForEach(i =>
             {
@@ -70,7 +75,7 @@ namespace Files.Helpers.ContextFlyouts
                     Text = item.Text,
                     Tag = item.Tag,
                 };
-                item.Items.ForEach(i =>
+                item.Items?.ForEach(i =>
                 {
                     flyoutSubItem.Items.Add(GetMenuItem(i));
                 });
@@ -153,7 +158,7 @@ namespace Files.Helpers.ContextFlyouts
             return flyoutItem;
         }
 
-        private static ICommandBarElement GetCommandBarItem(ContextMenuFlyoutItemViewModel item)
+        public static ICommandBarElement GetCommandBarItem(ContextMenuFlyoutItemViewModel item)
         {
             return item.ItemType switch
             {
@@ -185,7 +190,7 @@ namespace Files.Helpers.ContextFlyouts
             }
 
             MenuFlyout ctxFlyout = null;
-            if (item.Items.Count > 0 || item.ID == "ItemOverflow")
+            if ((item.Items is not null && item.Items.Count > 0) || item.ID == "ItemOverflow")
             {
                 ctxFlyout = new MenuFlyout();
                 GetMenuFlyoutItemsFromModel(item.Items).ForEach(i => ctxFlyout.Items.Add(i));

--- a/Files/Helpers/ShellContextMenuHelper.cs
+++ b/Files/Helpers/ShellContextMenuHelper.cs
@@ -117,6 +117,7 @@ namespace Files.Helpers
                     {
                         Text = menuFlyoutItem.Label.Replace("&", ""),
                         Tag = (menuFlyoutItem, menuHandle),
+                        Items = new List<ContextMenuFlyoutItemViewModel>(),
                     };
                     LoadMenuFlyoutItem(menuLayoutSubItem.Items, menuFlyoutItem.SubItems, menuHandle, showIcons);
                     menuItemsListLocal.Insert(0, menuLayoutSubItem);
@@ -161,6 +162,13 @@ namespace Files.Helpers
 
                 return (null, null);
             }
+        }
+
+        public static List<ContextMenuFlyoutItemViewModel> GetOpenWithItems(List<ContextMenuFlyoutItemViewModel> flyout)
+        {
+            var item = flyout.FirstOrDefault(x => x.Tag is ValueTuple<Win32ContextMenuItem, string> vt && vt.Item1.CommandString == "openas");
+            flyout.Remove(item);
+            return item?.Items;
         }
     }
 }

--- a/Files/ViewModels/ContextMenuFlyoutItemViewModel.cs
+++ b/Files/ViewModels/ContextMenuFlyoutItemViewModel.cs
@@ -18,7 +18,7 @@ namespace Files.ViewModels
         public object Tag { get; set; }
         public ItemType ItemType { get; set; }
         public bool IsSubItem { get; set; }
-        public List<ContextMenuFlyoutItemViewModel> Items { get; set; } = new List<ContextMenuFlyoutItemViewModel>();
+        public List<ContextMenuFlyoutItemViewModel> Items { get; set; }
         public BitmapImage BitmapIcon { get; set; }
 
         /// <summary>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related #issue...

**Details of Changes**
Add details of changes here.
- After shell items are loaded, the standard open with option is replaced by one with a list of apps that the file can be opened with

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/59544401/128586097-2c2f826c-2d62-4725-94cd-922057c6c403.png)

