### PR TITLE
Workaround for cut context menu

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -649,10 +649,9 @@ namespace Files
                 });
                 if (desiredWidth.Any())
                 {
-                    var itc = commandBar.FindDescendant<ItemsControl>();
-                    if (itc != null)
+                    if (commandBar.FindDescendant<ItemsControl>() is ItemsControl itemsControl)
                     {
-                        itc.MinWidth = desiredWidth.Max();
+                        itemsControl.MinWidth = Math.Min(commandBar.MaxWidth, desiredWidth.Max());
                     }
                 }
             }

--- a/Files/ViewModels/MainPageViewModel.cs
+++ b/Files/ViewModels/MainPageViewModel.cs
@@ -314,7 +314,10 @@ namespace Files.ViewModels
             if (iconSource.ImageSource == null)
             {
                 var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 24u, Windows.Storage.FileProperties.ThumbnailMode.ListView);
-                iconSource.ImageSource = await iconData?.ToBitmapAsync();
+                if (iconData != null)
+                {
+                    iconSource.ImageSource = await iconData.ToBitmapAsync();
+                }
             }
 
             return (tabLocationHeader, iconSource);


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Alternative workaround for issue #5555
- Fixes #5720 (4092406467u)

**Details of Changes**
Add details of changes here.
- Current workaround for #5555 is to set the context menu AppBarButtons MinWidth to a large value. This results in a context menu being always large. This solution only sets MinWidth if needed.

**Validation**
How did you test these changes?
- [x] Built and ran the app
