### PR TITLE
Fix file thumbnail cropping and rounded thumbnail corners

### DIFF
--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -178,6 +178,7 @@
 
                     <CornerRadius x:Key="NavigationViewContentGridCornerRadius">0</CornerRadius>
                     <CornerRadius x:Key="GridViewThumbnailCornerRadius">2</CornerRadius>
+                    <CornerRadius x:Key="DetailsLayoutThumbnailCornerRadius">2</CornerRadius>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -177,6 +177,7 @@
                     </LinearGradientBrush>
 
                     <CornerRadius x:Key="NavigationViewContentGridCornerRadius">0</CornerRadius>
+                    <CornerRadius x:Key="GridViewThumbnailCornerRadius">2</CornerRadius>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/Files/UserControls/FilePreviews/BasicPreview.xaml
+++ b/Files/UserControls/FilePreviews/BasicPreview.xaml
@@ -12,7 +12,7 @@
     <Grid>
         <Viewbox StretchDirection="DownOnly">
             <ContentPresenter CornerRadius="{StaticResource ControlCornerRadius}">
-                <Image Source="{x:Bind Model.Item.FileImage}" />
+                <Image Source="{x:Bind Model.FileImage}" />
             </ContentPresenter>
         </Viewbox>
     </Grid>

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -729,7 +729,9 @@ namespace Files.ViewModels
                         var matchingStorageFile = (StorageFile)matchingStorageItem ?? await GetFileFromPathAsync(item.ItemPath);
                         if (matchingStorageFile != null)
                         {
-                            using var Thumbnail = await matchingStorageFile.GetThumbnailAsync(ThumbnailMode.ListView, thumbnailSize, ThumbnailOptions.ResizeThumbnail);
+                            var mode = thumbnailSize < 80 ? ThumbnailMode.ListView : ThumbnailMode.SingleItem;
+
+                            using var Thumbnail = await matchingStorageFile.GetThumbnailAsync(mode, thumbnailSize, ThumbnailOptions.UseCurrentScale);
                             if (!(Thumbnail == null || Thumbnail.Size == 0 || Thumbnail.OriginalHeight == 0 || Thumbnail.OriginalWidth == 0))
                             {
                                 await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>

--- a/Files/ViewModels/Previews/BasePreviewModel.cs
+++ b/Files/ViewModels/Previews/BasePreviewModel.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media.Imaging;
 
 namespace Files.ViewModels.Previews
 {
@@ -48,20 +49,18 @@ namespace Files.ViewModels.Previews
         /// <returns>A list of details</returns>
         public async virtual Task<List<FileProperty>> LoadPreviewAndDetails()
         {
-            var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 400);
-
-            if (iconData != null)
-            {
-                Item.FileImage = await iconData.ToBitmapAsync();
-            }
-            else
-            {
-                using var icon = await Item.ItemFile.GetThumbnailAsync(ThumbnailMode.SingleItem, 400);
-                Item.FileImage ??= new Windows.UI.Xaml.Media.Imaging.BitmapImage();
-                await Item.FileImage.SetSourceAsync(icon);
-            }
+            using var icon = await Item.ItemFile.GetThumbnailAsync(ThumbnailMode.SingleItem, 400);
+            FileImage ??= new Windows.UI.Xaml.Media.Imaging.BitmapImage();
+            await FileImage.SetSourceAsync(icon);
 
             return new List<FileProperty>();
+        }
+
+        private BitmapImage fileImage;
+        public BitmapImage FileImage
+        {
+            get => fileImage;
+            set => SetProperty(ref fileImage, value);
         }
 
         private async Task<List<FileProperty>> GetSystemFileProperties()

--- a/Files/ViewModels/Previews/ShortcutPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/ShortcutPreviewViewModel.cs
@@ -63,7 +63,7 @@ namespace Files.ViewModels.Previews
 
             if (iconData != null)
             {
-                Item.FileImage = await iconData.ToBitmapAsync();
+                FileImage = await iconData.ToBitmapAsync();
             }
         }
     }

--- a/Files/Views/LayoutModes/ColumnViewBase.xaml
+++ b/Files/Views/LayoutModes/ColumnViewBase.xaml
@@ -204,14 +204,20 @@
                                     Height="24"
                                     Opacity="{x:Bind Opacity, Mode=OneWay}"
                                     Tag="ItemImage">
-                                    <Image
-                                        x:Name="Picture"
-                                        HorizontalAlignment="Stretch"
-                                        VerticalAlignment="Stretch"
+                                    <ContentPresenter
+                                        x:Name="PicturePresenter"
+                                        Width="24"
+                                        Height="24"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        x:Load="{x:Bind LoadFileIcon, Mode=OneWay}"
                                         x:Phase="1"
-                                        Source="{x:Bind FileImage, Mode=OneWay}"
-                                        Stretch="Uniform"
-                                        Visibility="{x:Bind LoadFileIcon, Mode=OneWay}" />
+                                        CornerRadius="{StaticResource DetailsLayoutThumbnailCornerRadius}">
+                                        <Image
+                                            x:Name="Picture"
+                                            Source="{x:Bind FileImage, Mode=OneWay}"
+                                            Stretch="Uniform" />
+                                    </ContentPresenter>
                                     <FontIcon
                                         x:Name="FolderGlyphIcon"
                                         Width="24"

--- a/Files/Views/LayoutModes/ColumnViewBrowser.xaml
+++ b/Files/Views/LayoutModes/ColumnViewBrowser.xaml
@@ -222,14 +222,20 @@
                                                 Height="24"
                                                 Opacity="{x:Bind Opacity, Mode=OneWay}"
                                                 Tag="ItemImage">
-                                                <Image
-                                                    x:Name="Picture"
-                                                    HorizontalAlignment="Stretch"
-                                                    VerticalAlignment="Stretch"
+                                                <ContentPresenter
+                                                    x:Name="PicturePresenter"
+                                                    Width="24"
+                                                    Height="24"
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"
+                                                    x:Load="{x:Bind LoadFileIcon, Mode=OneWay}"
                                                     x:Phase="1"
-                                                    Source="{x:Bind FileImage, Mode=OneWay}"
-                                                    Stretch="Uniform"
-                                                    Visibility="{x:Bind LoadFileIcon, Mode=OneWay}" />
+                                                    CornerRadius="{StaticResource DetailsLayoutThumbnailCornerRadius}">
+                                                    <Image
+                                                        x:Name="Picture"
+                                                        Source="{x:Bind FileImage, Mode=OneWay}"
+                                                        Stretch="Uniform" />
+                                                </ContentPresenter>
                                                 <FontIcon
                                                     x:Name="FolderGlyphIcon"
                                                     Width="24"

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -497,16 +497,20 @@
                                     Opacity="{x:Bind Opacity, Mode=OneWay}"
                                     TabFocusNavigation="Local"
                                     Tag="ItemImage">
-                                    <Image
-                                        x:Name="Picture"
+                                    <ContentPresenter
+                                        x:Name="PicturePresenter"
                                         Width="20"
                                         Height="20"
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
                                         x:Load="{x:Bind LoadFileIcon, Mode=OneWay}"
                                         x:Phase="1"
-                                        Source="{x:Bind FileImage, Mode=OneWay}"
-                                        Stretch="Uniform" />
+                                        CornerRadius="{StaticResource DetailsLayoutThumbnailCornerRadius}">
+                                        <Image
+                                            x:Name="Picture"
+                                            Source="{x:Bind FileImage, Mode=OneWay}"
+                                            Stretch="Uniform" />
+                                    </ContentPresenter>
                                     <FontIcon
                                         x:Name="FolderGlyphIcon"
                                         Width="20"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -65,15 +65,19 @@
                     Height="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}"
                     Opacity="{x:Bind Opacity, Mode=OneWay}"
                     Tag="ItemImage">
-                    <Image
-                        x:Name="Picture"
+                    <ContentPresenter
+                        x:Name="PictureBorder"
                         Margin="12"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
                         x:Load="{x:Bind LoadFileIcon, Mode=OneWay}"
                         x:Phase="1"
-                        Source="{x:Bind FileImage, Mode=OneWay}"
-                        Stretch="Uniform" />
+                        CornerRadius="{StaticResource GridViewThumbnailCornerRadius}">
+                        <Image
+                            x:Name="Picture"
+                            Source="{x:Bind FileImage, Mode=OneWay}"
+                            Stretch="Uniform" />
+                    </ContentPresenter>
                     <Viewbox
                         x:Name="FolderGlyphIcon"
                         MaxWidth="{Binding FolderSettings.GridViewSize, ElementName=PageRoot, Mode=OneWay}"
@@ -217,16 +221,20 @@
                     MinHeight="100"
                     Opacity="{x:Bind Opacity, Mode=OneWay}"
                     Tag="ItemImage">
-                    <Image
-                        x:Name="Picture"
-                        Width="74"
+                    <ContentPresenter
+                        x:Name="PictureBorder"
                         Margin="0,12,0,12"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
                         x:Load="{x:Bind LoadFileIcon, Mode=OneWay}"
                         x:Phase="1"
-                        Source="{x:Bind FileImage, Mode=OneWay}"
-                        Stretch="Uniform" />
+                        CornerRadius="{StaticResource GridViewThumbnailCornerRadius}">
+                        <Image
+                            x:Name="Picture"
+                            Width="74"
+                            Source="{x:Bind FileImage, Mode=OneWay}"
+                            Stretch="Uniform" />
+                    </ContentPresenter>
                     <FontIcon
                         x:Name="FolderGlyphIcon"
                         HorizontalAlignment="Stretch"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -190,7 +190,6 @@
 
         <DataTemplate x:Name="TilesBrowserTemplate" x:DataType="local2:ListedItem">
             <Grid
-                Width="260"
                 Height="100"
                 Margin="0,0,0,0"
                 Padding="0"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5682
- Closes #5631 

**Details of Changes**
Add details of changes here.
- Switch to single item thumbnail mode and change resize mode
- Round corners for grid view thumbnails
- Show proper file preview images in preview pane and grid view
- Fix issue where file name would sometimes be cut off in tiles view

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/59544401/128617468-1834da7a-11b6-4b86-a102-8bad2c3f588a.png)
