### PR TITLE
Fix issues with context menu

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -546,6 +546,10 @@ namespace Files
         {
             try
             {
+                if (BaseContextMenuFlyout.GetValue(ContextMenuExtensions.ItemsControlProperty) is ItemsControl itc)
+                {
+                    itc.MaxHeight = 480;
+                }
                 shellContextMenuItemCancellationToken?.Cancel();
                 shellContextMenuItemCancellationToken = new CancellationTokenSource();
                 var shiftPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
@@ -558,6 +562,7 @@ namespace Files
                     (i as AppBarButton).Click += new RoutedEventHandler((s, e) => BaseContextMenuFlyout.Hide());  // Workaround for WinUI (#5508)
                 });
                 primaryElements.ForEach(i => BaseContextMenuFlyout.PrimaryCommands.Add(i));
+                secondaryElements.OfType<FrameworkElement>().ForEach(i => i.MinWidth = 250);
                 secondaryElements.ForEach(i => BaseContextMenuFlyout.SecondaryCommands.Add(i));
 
                 if (!InstanceViewModel.IsPageTypeSearchResults)
@@ -579,6 +584,10 @@ namespace Files
 
         private async Task LoadMenuItemsAsync()
         {
+            if (ItemContextMenuFlyout.GetValue(ContextMenuExtensions.ItemsControlProperty) is ItemsControl itc)
+            {
+                itc.MaxHeight = 480;
+            }
             shellContextMenuItemCancellationToken?.Cancel();
             shellContextMenuItemCancellationToken = new CancellationTokenSource();
             SelectedItemsPropertiesViewModel.CheckFileExtension(SelectedItem?.FileExtension);
@@ -592,6 +601,7 @@ namespace Files
                 (i as AppBarButton).Click += new RoutedEventHandler((s, e) => ItemContextMenuFlyout.Hide()); // Workaround for WinUI (#5508)
             });
             primaryElements.ForEach(i => ItemContextMenuFlyout.PrimaryCommands.Add(i));
+            secondaryElements.OfType<FrameworkElement>().ForEach(i => i.MinWidth = 250);
             secondaryElements.ForEach(i => ItemContextMenuFlyout.SecondaryCommands.Add(i));
 
             if (AppSettings.AreFileTagsEnabled && !InstanceViewModel.IsPageTypeSearchResults && !InstanceViewModel.IsPageTypeRecycleBin)
@@ -633,6 +643,17 @@ namespace Files
 
             var overflowItems = ItemModelListToContextFlyoutHelper.GetMenuFlyoutItemsFromModel(overflowShellMenuItems);
             var mainItems = ItemModelListToContextFlyoutHelper.GetAppBarButtonsFromModelIgnorePrimary(mainShellMenuItems);
+
+            // Workaround for #5555
+            var openedPopups = Windows.UI.Xaml.Media.VisualTreeHelper.GetOpenPopups(Window.Current);
+            var secondaryMenu = openedPopups.FirstOrDefault(popup => popup.Name == "OverflowPopup");
+            var itemsControl = secondaryMenu?.Child.FindDescendant<ItemsControl>();
+            if (itemsControl is not null)
+            {
+                contextMenuFlyout.SetValue(ContextMenuExtensions.ItemsControlProperty, itemsControl);
+                itemsControl.MaxHeight = Math.Min(480, itemsControl.ActualHeight);
+                mainItems.OfType<FrameworkElement>().ForEach(x => x.MaxWidth = itemsControl.ActualWidth - 10);
+            }
 
             var overflowItem = contextMenuFlyout.SecondaryCommands.FirstOrDefault(x => x is AppBarButton appBarButton && (appBarButton.Tag as string) == "ItemOverflow") as AppBarButton;
             if (overflowItem is not null)
@@ -685,23 +706,15 @@ namespace Files
             }
 
             // Workaround for #5555
-            var openedPopups = Windows.UI.Xaml.Media.VisualTreeHelper.GetOpenPopups(Window.Current);
-            var menu = openedPopups.FirstOrDefault(popup => popup.Child is FlyoutPresenter);
-            var commandBar = (menu?.Child as FlyoutPresenter)?.Content as Microsoft.UI.Xaml.Controls.Primitives.CommandBarFlyoutCommandBar;
-            if (commandBar != null)
+            if (itemsControl is not null)
             {
-                var desiredWidth = commandBar.SecondaryCommands.OfType<AppBarButton>().Select(x =>
+                itemsControl.Items.OfType<FrameworkElement>().ForEach(item =>
                 {
-                    x.Measure(new Size(Double.PositiveInfinity, Double.PositiveInfinity));
-                    return x.DesiredSize.Width;
-                });
-                if (desiredWidth.Any())
-                {
-                    if (commandBar.FindDescendant<ItemsControl>() is ItemsControl itemsControl)
+                    if (item.FindDescendant("OverflowTextLabel") is TextBlock label)
                     {
-                        itemsControl.MinWidth = Math.Min(commandBar.MaxWidth, desiredWidth.Max());
+                        label.TextTrimming = TextTrimming.CharacterEllipsis;
                     }
-                }
+                });
             }
         }
 
@@ -1034,5 +1047,21 @@ namespace Files
             preRenamingItem = null;
             tapDebounceTimer.Stop();
         }
+    }
+
+    public class ContextMenuExtensions : DependencyObject
+    {
+        public static ItemsControl GetItemsControl(DependencyObject obj)
+        {
+            return (ItemsControl)obj.GetValue(ItemsControlProperty);
+        }
+
+        public static void SetItemsControl(DependencyObject obj, ItemsControl value)
+        {
+            obj.SetValue(ItemsControlProperty, value);
+        }
+
+        public static readonly DependencyProperty ItemsControlProperty =
+            DependencyProperty.RegisterAttached("ItemsControl", typeof(ItemsControl), typeof(ContextMenuExtensions), new PropertyMetadata(null));
     }
 }

--- a/Files/Helpers/ItemModelListToContextFlyoutHelper.cs
+++ b/Files/Helpers/ItemModelListToContextFlyoutHelper.cs
@@ -14,7 +14,7 @@ namespace Files.Helpers.ContextFlyouts
     {
         public static List<MenuFlyoutItemBase> GetMenuFlyoutItemsFromModel(List<ContextMenuFlyoutItemViewModel> items)
         {
-            if(items is null)
+            if (items is null)
             {
                 return null;
             }
@@ -154,7 +154,7 @@ namespace Files.Helpers.ContextFlyouts
             {
                 flyoutItem.KeyboardAcceleratorTextOverride = i.KeyboardAcceleratorTextOverride;
             }
-            
+
             return flyoutItem;
         }
 
@@ -203,10 +203,12 @@ namespace Files.Helpers.ContextFlyouts
                 {
                     Source = item.BitmapIcon,
                 };
-            } else if(item.ColoredIcon.IsValid)
+            }
+            else if (item.ColoredIcon.IsValid)
             {
                 content = item.ColoredIcon.ToColoredIcon();
-            } else if(item.ShowLoadingIndicator)
+            }
+            else if (item.ShowLoadingIndicator)
             {
                 content = new Microsoft.UI.Xaml.Controls.ProgressRing()
                 {

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -347,8 +347,8 @@ namespace Files.UserControls
                     return;
                 }
                 IsInPointerPressed = true;
-                await NavigationHelpers.OpenPathInNewTab(item.Path);
                 e.Handled = true;
+                await NavigationHelpers.OpenPathInNewTab(item.Path);
             }
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5767
- Closes #5578

**Details of Changes**
Add details of changes here.
- Fix an issue where middle click on sidebar would open two tabs
- Fix a few issues with context menu (workarounds for WinUI issues)
    - Fix menu cut off (#5767)
    - Fix menu jumping around when loading shell items
    - Fix menu remaining open when clicking on subitems (#5578)
    - Fix primary items hidden when shown at the bottom of the menu

Let me know if the new menu behavior is acceptable.

**Validation**
How did you test these changes?
- [x] Built and ran the app
