### PR TITLE
Fix "folder is in use" error after moving a file

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -22,6 +22,11 @@ namespace Files.Common
             }
         }
 
+        public static IEnumerable<T> DistinctBy<T, TKey>(this IEnumerable<T> items, Func<T, TKey> property)
+        {
+            return items.GroupBy(property).Select(x => x.First());
+        }
+
         public static async Task<IEnumerable<T>> WhereAsync<T>(this IEnumerable<T> source, Func<T, Task<bool>> predicate)
         {
             var results = await Task.WhenAll(source.Select(async x => (x, await predicate(x))));

--- a/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
+++ b/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
@@ -565,11 +565,11 @@ namespace FilesFullTrust.MessageHandlers
                 {
                     Extensions.IgnoreExceptions(() =>
                     {
-                        using var si = new ShellItem(destination);
                         if (operationType == "copy")
                         {
                             var tag = dbInstance.GetTag(e.SourceItem.FileSystemPath);
-                            dbInstance.SetTag(destination, (ulong?)si.Properties["System.FileFRN"], tag); // copy tag to new files
+                            dbInstance.SetTag(destination, FileTagsHandler.GetFileFRN(destination), tag); // copy tag to new files
+                            using var si = new ShellItem(destination);
                             if (si.IsFolder) // File tag is not copied automatically for folders
                             {
                                 FileTagsHandler.WriteFileTag(destination, tag);
@@ -577,7 +577,7 @@ namespace FilesFullTrust.MessageHandlers
                         }
                         else
                         {
-                            dbInstance.UpdateTag(e.SourceItem.FileSystemPath, (ulong?)si.Properties["System.FileFRN"], destination); // move tag to new files
+                            dbInstance.UpdateTag(e.SourceItem.FileSystemPath, FileTagsHandler.GetFileFRN(destination), destination); // move tag to new files
                         }
                     }, Program.Logger);
                 }
@@ -597,8 +597,7 @@ namespace FilesFullTrust.MessageHandlers
                                 Extensions.IgnoreExceptions(() =>
                                 {
                                     var subPath = t.FilePath.Replace(e.SourceItem.FileSystemPath, destination);
-                                    using var si = new ShellItem(subPath);
-                                    dbInstance.SetTag(subPath, (ulong?)si.Properties["System.FileFRN"], t.Tag);
+                                    dbInstance.SetTag(subPath, FileTagsHandler.GetFileFRN(subPath), t.Tag);
                                 }, Program.Logger);
                             });
                         }
@@ -609,8 +608,7 @@ namespace FilesFullTrust.MessageHandlers
                                 Extensions.IgnoreExceptions(() =>
                                 {
                                     var subPath = t.FilePath.Replace(e.SourceItem.FileSystemPath, destination);
-                                    using var si = new ShellItem(subPath);
-                                    dbInstance.UpdateTag(t.FilePath, (ulong?)si.Properties["System.FileFRN"], subPath);
+                                    dbInstance.UpdateTag(t.FilePath, FileTagsHandler.GetFileFRN(subPath), subPath);
                                 }, Program.Logger);
                             });
                         }

--- a/Files.Launcher/MessageHandlers/FileTagsHandler.cs
+++ b/Files.Launcher/MessageHandlers/FileTagsHandler.cs
@@ -48,6 +48,24 @@ namespace FilesFullTrust.MessageHandlers
             }
         }
 
+        public static ulong? GetFileFRN(string filePath)
+        {
+            //using var si = new ShellItem(filePath);
+            //return (ulong?)si.Properties["System.FileFRN"]; // Leaves open file handles
+            using var hFile = Kernel32.CreateFile(filePath, Kernel32.FileAccess.GENERIC_READ, FileShare.ReadWrite, null, FileMode.Open, FileFlagsAndAttributes.FILE_FLAG_BACKUP_SEMANTICS);
+            if (hFile.IsInvalid)
+            {
+                return null;
+            }
+            ulong? frn = null;
+            Extensions.IgnoreExceptions(() =>
+            {
+                var fileID = Kernel32.GetFileInformationByHandleEx<Kernel32.FILE_ID_INFO>(hFile, Kernel32.FILE_INFO_BY_HANDLE_CLASS.FileIdInfo);
+                frn = BitConverter.ToUInt64(fileID.FileId.Identifier, 0);
+            });
+            return frn;
+        }
+
         public void UpdateTagsDb()
         {
             string fileTagsDbPath = Path.Combine(ApplicationData.Current.LocalFolder.Path, "filetags.db");
@@ -76,8 +94,7 @@ namespace FilesFullTrust.MessageHandlers
                     {
                         if (!Extensions.IgnoreExceptions(() =>
                         {
-                            using var si = new ShellItem(file.FilePath);
-                            var frn = (ulong?)si.Properties["System.FileFRN"];
+                            var frn = GetFileFRN(file.FilePath);
                             dbInstance.UpdateTag(file.FilePath, frn, null);
                             dbInstance.SetTag(file.FilePath, (ulong?)frn, tag);
                         }, Program.Logger))

--- a/Files/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
@@ -185,6 +185,7 @@ namespace Files.Filesystem
                 return await filesystemOperations.DeleteItemsAsync(source, progress, errorCode, permanently, cancellationToken);
             }
 
+            source = source.DistinctBy(x => x.Path); // #5771
             var deleleFilePaths = source.Select(s => s.Path);
 
             var deleteFromRecycleBin = source.Any() ? recycleBinHelpers.IsPathUnderRecycleBin(source.ElementAt(0).Path) : false;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5771 (probably)
- Fixes an issue where, after dropping a file into a folder, renaming that folder will result in a "Folder is in use" error dialog (depends on the moved file type, e.g DOCX files have this issue)

**Validation**
How did you test these changes?
- [x] Built and ran the app
