### PR TITLE
Fix resource for Sortby/Groupby on NavigationBar

### DIFF
--- a/Files/Helpers/ContextFlyoutItemHelper.cs
+++ b/Files/Helpers/ContextFlyoutItemHelper.cs
@@ -322,7 +322,7 @@ namespace Files.Helpers
                 },
                 new ContextMenuFlyoutItemViewModel()
                 {
-                    Text = "NavToolbarGroupByRadioButtons/Header".GetLocalized(),
+                    Text = "NavToolbarGroupByRadioButtons/Text".GetLocalized(),
                     Glyph = "\uF168",
                     ShowInRecycleBin = true,
                     ShowInSearchPage = true,

--- a/Files/MultilingualResources/Files.ar.xlf
+++ b/Files/MultilingualResources/Files.ar.xlf
@@ -2434,11 +2434,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">فتح باستخدام</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">تجميع حسب</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">فرز حسب</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.cs-CZ.xlf
+++ b/Files/MultilingualResources/Files.cs-CZ.xlf
@@ -2446,11 +2446,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Otevřít v aplikaci</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Seskupit podle</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Seřadit podle</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.da-DK.xlf
+++ b/Files/MultilingualResources/Files.da-DK.xlf
@@ -2433,11 +2433,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Åbn med</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Gruppér efter</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Sortér efter</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.da.xlf
+++ b/Files/MultilingualResources/Files.da.xlf
@@ -2433,11 +2433,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Åbn med</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Gruppér efter</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Sortér efter</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -2417,11 +2417,11 @@
           <source>Open with</source>
           <target state="translated">Öffnen mit</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Gruppieren nach</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Sortieren nach</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.el.xlf
+++ b/Files/MultilingualResources/Files.el.xlf
@@ -2594,11 +2594,11 @@
           <source>Sort</source>
           <target state="translated">Ταξινόμηση</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Ομάδα από</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Ταξινόμηση κατά</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.en-GB.xlf
+++ b/Files/MultilingualResources/Files.en-GB.xlf
@@ -2614,11 +2614,11 @@
           <source>Sort</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Sort</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Group by</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Sort By:</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.es-419.xlf
+++ b/Files/MultilingualResources/Files.es-419.xlf
@@ -2475,11 +2475,11 @@
           <source>Sort</source>
           <target state="translated">Organizar por</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Agrupar por</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Ordenar por</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -2411,11 +2411,11 @@
           <source>Open with</source>
           <target state="translated">Abrir con</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Agrupar por</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Ordenar por</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -2410,11 +2410,11 @@
           <source>Open with</source>
           <target state="translated">Ouvrir avec</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Groupe par</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Trier par</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.he-IL.xlf
+++ b/Files/MultilingualResources/Files.he-IL.xlf
@@ -2425,11 +2425,11 @@
           <source>Open with</source>
           <target state="new">Open with</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="new">Group By</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="new">Sort By</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.hi-IN.xlf
+++ b/Files/MultilingualResources/Files.hi-IN.xlf
@@ -2431,11 +2431,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">इसमें खोलें</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">इस आधार पर समूहीकृत करें</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">इससे सॉर्ट करें</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.hu-HU.xlf
+++ b/Files/MultilingualResources/Files.hu-HU.xlf
@@ -2415,11 +2415,11 @@
           <source>Open with</source>
           <target state="translated">Társítás</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Csoportosítás</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Rendezés</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.id-ID.xlf
+++ b/Files/MultilingualResources/Files.id-ID.xlf
@@ -2459,11 +2459,11 @@
           <source>Sort</source>
           <target state="translated" state-qualifier="tm-suggestion">Urutkan</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Grupkan Menurut</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated" state-qualifier="tm-suggestion">Urutkan Menurut</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -2411,11 +2411,11 @@
           <source>Open with</source>
           <target state="translated">Apri con</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Raggruppa per</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Ordina per</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -2434,11 +2434,11 @@
           <source>Open with</source>
           <target state="translated">プログラムから開く</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">グループで表示</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">並べ替えて表示</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.ka.xlf
+++ b/Files/MultilingualResources/Files.ka.xlf
@@ -2587,11 +2587,11 @@
           <source>Sort</source>
           <target state="translated">დალაგება</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">დაჯგუფება</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">დალაგება</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.ko-KR.xlf
+++ b/Files/MultilingualResources/Files.ko-KR.xlf
@@ -2433,11 +2433,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">다른 프로그램으로 열기</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">그룹화 방법</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">정렬 기준</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.lv-LV.xlf
+++ b/Files/MultilingualResources/Files.lv-LV.xlf
@@ -2411,11 +2411,11 @@
           <source>Open with</source>
           <target state="translated">Atvērt ar</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Grupēt pēc</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Kārtot pēc</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -2412,11 +2412,11 @@
           <source>Open with</source>
           <target state="translated" state-qualifier="tm-suggestion">Openen met</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated" state-qualifier="tm-suggestion">Groeperen op</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated" state-qualifier="tm-suggestion">Sorteren op</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.or-IN.xlf
+++ b/Files/MultilingualResources/Files.or-IN.xlf
@@ -2430,11 +2430,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ଏଥିରେ ଖୋଲନ୍ତୁ</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ଏହା ଦ୍ଵାରା ଗୋଷ୍ଠୀ</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ଏହା ଦ୍ୱାରା ସର୍ଟ୍‌ କରନ୍ତୁ</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -2437,11 +2437,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Otwórz za pomocą</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Grupuj wg</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Sortowanie według</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.pt-BR.xlf
+++ b/Files/MultilingualResources/Files.pt-BR.xlf
@@ -2411,11 +2411,11 @@
           <source>Open with</source>
           <target state="translated">Abrir com</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Agrupar por</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Ordenar por</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.pt-PT.xlf
+++ b/Files/MultilingualResources/Files.pt-PT.xlf
@@ -2410,11 +2410,11 @@
           <source>Open with</source>
           <target state="translated">Abrir com</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Agrupar por</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Ordenar por</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -2413,11 +2413,11 @@
           <source>Open with</source>
           <target state="translated">Открыть с помощью</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">Группировка</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">Сортировка</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.sv-SE.xlf
+++ b/Files/MultilingualResources/Files.sv-SE.xlf
@@ -2436,11 +2436,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Öppna med</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Gruppera efter</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Sortera efter</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -2431,11 +2431,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">இதனுடன் திற</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">இதன்படி குழுவாக்கு</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">இதன்படி வரிசைப்படுத்து</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -2410,11 +2410,11 @@
           <source>Open with</source>
           <target state="translated" state-qualifier="tm-suggestion">Bununla aç</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated" state-qualifier="tm-suggestion">Gruplandırma Ölçütü</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated" state-qualifier="tm-suggestion">Sıralama Ölçütü</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -2435,11 +2435,11 @@
           <source>Open with</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Відкрити за допомогою</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Групувати за</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Сортувати за</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -2413,11 +2413,11 @@
           <source>Open with</source>
           <target state="translated">打开方式</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">分组依据</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">排序方式</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.zh-Hant.xlf
+++ b/Files/MultilingualResources/Files.zh-Hant.xlf
@@ -2411,11 +2411,11 @@
           <source>Open with</source>
           <target state="translated">開啟檔案 -</target>
         </trans-unit>
-        <trans-unit id="NavToolbarGroupByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarGroupByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Group By</source>
           <target state="translated">分類</target>
         </trans-unit>
-        <trans-unit id="NavToolbarSortByRadioButtons.Header" translate="yes" xml:space="preserve">
+        <trans-unit id="NavToolbarSortByRadioButtons.Text" translate="yes" xml:space="preserve">
           <source>Sort By</source>
           <target state="translated">排序</target>
         </trans-unit>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2073,7 +2073,7 @@
   <data name="NavToolbarSortOptionsButton.Label" xml:space="preserve">
     <value>Sort</value>
   </data>
-  <data name="NavToolbarGroupByRadioButtons.Header" xml:space="preserve">
+  <data name="NavToolbarGroupByRadioButtons.Text" xml:space="preserve">
     <value>Group By</value>
   </data>
   <data name="NavToolbarGroupByOptionNone.Text" xml:space="preserve">
@@ -2100,7 +2100,7 @@
   <data name="NavToolbarArrangementOptionType.Text" xml:space="preserve">
     <value>Type</value>
   </data>
-  <data name="NavToolbarSortByRadioButtons.Header" xml:space="preserve">
+  <data name="NavToolbarSortByRadioButtons.Text" xml:space="preserve">
     <value>Sort By</value>
   </data>
   <data name="NavToolbarSortDirectionRadioButtons.Header" xml:space="preserve">

--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -313,7 +313,7 @@
                 </AppBarButton.Content>
                 <AppBarButton.Flyout>
                     <MenuFlyout Placement="Bottom" ShouldConstrainToRootBounds="False">
-                        <MenuFlyoutSubItem Text="Sort by">
+                        <MenuFlyoutSubItem x:Uid="NavToolbarSortByRadioButtons" Text="Sort by">
                             <ToggleMenuFlyoutItem
                                 x:Uid="NavToolbarArrangementOptionName"
                                 IsChecked="{x:Bind ViewModel.IsSortedByName, Mode=TwoWay}"
@@ -355,7 +355,7 @@
                                 IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
                                 Text="Date deleted" />
                         </MenuFlyoutSubItem>
-                        <MenuFlyoutSubItem Text="Group by">
+                        <MenuFlyoutSubItem x:Uid="NavToolbarGroupByRadioButtons" Text="Group by">
                             <ToggleMenuFlyoutItem
                                 x:Uid="NavToolbarGroupByOptionNone"
                                 IsChecked="{x:Bind ViewModel.IsGroupedByNone, Mode=TwoWay}"


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Sort by and Group by buttons in Navigation Toolbar are not translated due to missing Uid.

**Details of Changes**
Add details of changes here.
- Fix the missing Uids for the menu flyout
- Existing translations are preserved

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/9673091/129934185-44acd54e-2b88-4a9f-ad08-80b2168ab5ae.png)
