### PR TITLE
Fix home page not loading on app start

### DIFF
--- a/Files/ViewModels/MainPageViewModel.cs
+++ b/Files/ViewModels/MainPageViewModel.cs
@@ -441,7 +441,7 @@ namespace Files.ViewModels
             TabItem tabItem = new TabItem()
             {
                 Header = null,
-                IconSource = fontIconSource,
+                IconSource = null,
                 Description = null
             };
             tabItem.Control.NavigationArguments = new TabItemArguments()
@@ -451,7 +451,9 @@ namespace Files.ViewModels
             };
             tabItem.Control.ContentChanged += Control_ContentChanged;
             await UpdateTabInfo(tabItem, tabViewItemArgs);
-            AppInstances.Insert(atIndex == -1 ? AppInstances.Count : atIndex, tabItem);
+            var index = atIndex == -1 ? AppInstances.Count : atIndex;
+            AppInstances.Insert(index, tabItem);
+            App.MainViewModel.TabStripSelectedIndex = index;
         }
 
         public static async void Control_ContentChanged(object sender, TabItemArguments e)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fix home page not loading on app start

I don't know if it's just me but I'm getting this issue where on app startup the homepage doesn't load. This happens if I select "continue where you left off" and I close the app with only the homepage being open.

<img width="500" src="https://user-images.githubusercontent.com/9673091/130359934-9ae74cb8-b0ed-46bf-ab72-6d9770fb8d7b.png" />

**Details of Changes**
Add details of changes here.
Added `App.MainViewModel.TabStripSelectedIndex = index;` in `AddNewTabByParam` to match `AddNewTabByPathAsync`.

Since I don't understand why the solution works, can you confirm that it makes sense?

@BanCrash perhaps you've seen this too?

**Validation**
How did you test these changes?
- [x] Built and ran the app
