### PR TITLE
Focus readme files only when preview pane is open

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1169,7 +1169,7 @@ namespace Files.ViewModels
                     // Find and select README file
                     foreach (var item in filesAndFolders)
                     {
-                        if (item.ItemName.Contains("readme", StringComparison.InvariantCultureIgnoreCase))
+                        if (item.PrimaryItemAttribute == StorageItemTypes.File && item.ItemName.Contains("readme", StringComparison.InvariantCultureIgnoreCase))
                         {
                             OnSelectionRequestedEvent?.Invoke(this, new List<ListedItem>() { item });
                             break;

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1164,13 +1164,16 @@ namespace Files.ViewModels
                     AdaptiveLayoutHelpers.PredictLayoutMode(folderSettings, this);
                 }
 
-                // Find and select README file
-                foreach (var item in filesAndFolders)
+                if (AppSettings.PreviewPaneEnabled)
                 {
-                    if (item.ItemName.Contains("readme", StringComparison.InvariantCultureIgnoreCase))
+                    // Find and select README file
+                    foreach (var item in filesAndFolders)
                     {
-                        OnSelectionRequestedEvent?.Invoke(this, new List<ListedItem>() { item });
-                        break;
+                        if (item.ItemName.Contains("readme", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            OnSelectionRequestedEvent?.Invoke(this, new List<ListedItem>() { item });
+                            break;
+                        }
                     }
                 }
             }

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -28,8 +28,6 @@ namespace Files.Views
     /// </summary>
     public sealed partial class MainPage : Page, INotifyPropertyChanged
     {
-        public static MainPage Instance => (MainPage)((Frame)Window.Current.Content).Content;
-
         public SettingsViewModel AppSettings => App.AppSettings;
         public MainViewModel MainViewModel => App.MainViewModel;
 

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -28,6 +28,8 @@ namespace Files.Views
     /// </summary>
     public sealed partial class MainPage : Page, INotifyPropertyChanged
     {
+        public static MainPage Instance => (MainPage)((Frame)Window.Current.Content).Content;
+
         public SettingsViewModel AppSettings => App.AppSettings;
         public MainViewModel MainViewModel => App.MainViewModel;
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
\-

**Details of Changes**
A readme file will be selected only when preview pane is opened.

**Validation**
How did you test these changes?
- [x] Built and ran the app
