### PR TITLE
allow restoring tabs from previous instance using ctrl+shift+t

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -1398,7 +1398,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="FluentFTP">
-      <Version>34.0.2</Version>
+      <Version>35.0.2</Version>
     </PackageReference>
     <PackageReference Include="ini-parser-netstandard">
       <Version>2.5.2</Version>

--- a/Files/Helpers/AppUpdater.cs
+++ b/Files/Helpers/AppUpdater.cs
@@ -78,6 +78,7 @@ namespace Files.Helpers
                 context = await Task.Run(() => StoreContext.GetDefault());
             }
 
+            App.SaveSessionTabs(); // save the tabs so they can be restored after the update completes
             var downloadOperation = context.RequestDownloadAndInstallStorePackageUpdatesAsync(updateList);
             return await downloadOperation.AsTask();
         }

--- a/Files/Helpers/ContextFlyoutItemHelper.cs
+++ b/Files/Helpers/ContextFlyoutItemHelper.cs
@@ -869,7 +869,7 @@ namespace Files.Helpers
                         OverlayLayerGlyph = "\uF026",
                     },
                     Command = commandsViewModel.ShareItemCommand,
-                    ShowItem = DataTransferManager.IsSupported() && !selectedItems.Any(i => i.IsHiddenItem || (i.IsShortcutItem && !i.IsLinkItem) || i.PrimaryItemAttribute == StorageItemTypes.Folder),
+                    ShowItem = DataTransferManager.IsSupported() && !selectedItems.Any(i => i.IsHiddenItem || (i.IsShortcutItem && !i.IsLinkItem) || (i.PrimaryItemAttribute == StorageItemTypes.Folder && !i.IsZipItem)),
                 },
                 new ContextMenuFlyoutItemViewModel()
                 {

--- a/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -378,7 +378,7 @@ namespace Files.Interacts
                             return;
                         }
                     }
-                    else if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
+                    else if (item.PrimaryItemAttribute == StorageItemTypes.Folder && !item.IsZipItem)
                     {
                         if (await StorageItemHelpers.ToStorageItem<BaseStorageFolder>(item.ItemPath, associatedInstance) is BaseStorageFolder folder)
                         {

--- a/Files/UserControls/MultitaskingControl/BaseMultitaskingControl.cs
+++ b/Files/UserControls/MultitaskingControl/BaseMultitaskingControl.cs
@@ -41,7 +41,7 @@ namespace Files.UserControls.MultitaskingControl
         public ObservableCollection<TabItem> Items => MainPageViewModel.AppInstances;
 
         // RecentlyClosedTabs is shared between all multitasking controls
-        public static List<ITabItem> RecentlyClosedTabs { get; private set; } = new List<ITabItem>();
+        public static List<TabItemArguments[]> RecentlyClosedTabs { get; private set; } = new List<TabItemArguments[]>();
 
         private void MultitaskingControl_CurrentInstanceChanged(object sender, CurrentInstanceChangedEventArgs e)
         {
@@ -111,9 +111,12 @@ namespace Files.UserControls.MultitaskingControl
             if (!isRestoringClosedTab && RecentlyClosedTabs.Any())
             {
                 isRestoringClosedTab = true;
-                ITabItem lastTab = RecentlyClosedTabs.Last();
+                var lastTab = RecentlyClosedTabs.Last();
                 RecentlyClosedTabs.Remove(lastTab);
-                await MainPageViewModel.AddNewTabByParam(lastTab.TabItemArguments.InitialPageType, lastTab.TabItemArguments.NavigationArg);
+                foreach (var item in lastTab)
+                {
+                    await MainPageViewModel.AddNewTabByParam(item.InitialPageType, item.NavigationArg);
+                }
                 isRestoringClosedTab = false;
             }
         }
@@ -133,7 +136,9 @@ namespace Files.UserControls.MultitaskingControl
             {
                 Items.Remove(tabItem);
                 tabItem?.Unload(); // Dispose and save tab arguments
-                RecentlyClosedTabs.Add((ITabItem)tabItem);
+                RecentlyClosedTabs.Add(new TabItemArguments[] {
+                    tabItem.TabItemArguments
+                });
             }
         }
 

--- a/Files/ViewModels/MainPageViewModel.cs
+++ b/Files/ViewModels/MainPageViewModel.cs
@@ -330,6 +330,18 @@ namespace Files.ViewModels
                 {
                     try
                     {
+                        // add last session tabs to closed tabs stack if those tabs are not about to be opened
+                        if(!App.AppSettings.ResumeAfterRestart && !App.AppSettings.ContinueLastSessionOnStartUp)
+                        {
+                            var items = new TabItemArguments[App.AppSettings.LastSessionPages.Length];
+                            for(int i = 0; i < items.Length; i++)
+                            {
+                                var tabArgs = TabItemArguments.Deserialize(App.AppSettings.LastSessionPages[i]);
+                                items[i] = tabArgs;
+                            }
+                            BaseMultitaskingControl.RecentlyClosedTabs.Add(items);
+                        }
+
                         if (App.AppSettings.ResumeAfterRestart)
                         {
                             App.AppSettings.ResumeAfterRestart = false;

--- a/Files/ViewModels/NavToolbarViewModel.cs
+++ b/Files/ViewModels/NavToolbarViewModel.cs
@@ -978,7 +978,7 @@ namespace Files.ViewModels
         }
 
         public bool CanCopy => SelectedItems is not null && SelectedItems.Any();
-        public bool CanShare => SelectedItems is not null && SelectedItems.Any() && DataTransferManager.IsSupported() && !SelectedItems.Any(x => (x.IsShortcutItem && !x.IsLinkItem) || x.IsHiddenItem || x.PrimaryItemAttribute == StorageItemTypes.Folder);
+        public bool CanShare => SelectedItems is not null && SelectedItems.Any() && DataTransferManager.IsSupported() && !SelectedItems.Any(x => (x.IsShortcutItem && !x.IsLinkItem) || x.IsHiddenItem || (x.PrimaryItemAttribute == StorageItemTypes.Folder && !x.IsZipItem));
         public bool CanRename => SelectedItems is not null && SelectedItems.Count == 1;
 
         public void Dispose()


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

this will make it possible to reopen tabs after update, crash, etc, without enabling 

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related #issue...

**Details of Changes**
Add details of changes here.
- allow setting groups of previously opened tabs
- remove unneeded references to closed ITabItems and instead store the arguments (since those are whats used anyway)
- add previous session tabs to closed tabs list if not re-opening those tabs
- fix issue where share would be disabled for zip files

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] tested w/ and w/o continue where you left off setting enabled
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
