### PR TITLE
Avoid crash when dragging files from WinRAR

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -879,6 +879,7 @@ namespace Files
                 e.Handled = true;
 
                 var (handledByFtp, draggedItems) = await Filesystem.FilesystemHelpers.GetDraggedStorageItems(e.DataView);
+                draggedItems ??= new List<IStorageItemWithPath>();
 
                 if (draggedItems.Any(draggedItem => draggedItem.Path == item.ItemPath))
                 {

--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -583,6 +583,7 @@ namespace Files.Filesystem
         public async Task<ReturnResult> CopyItemsFromClipboard(DataPackageView packageView, string destination, bool showDialog, bool registerHistory)
         {
             var (handledByFtp, source) = await GetDraggedStorageItems(packageView);
+            source ??= new List<IStorageItemWithPath>();
 
             if (handledByFtp)
             {
@@ -814,6 +815,7 @@ namespace Files.Filesystem
             }
 
             var (handledByFtp, source) = await GetDraggedStorageItems(packageView);
+            source ??= new List<IStorageItemWithPath>();
 
             if (handledByFtp)
             {
@@ -913,6 +915,7 @@ namespace Files.Filesystem
             }
 
             var (handledByFtp, source) = await GetDraggedStorageItems(packageView);
+            source ??= new List<IStorageItemWithPath>();
 
             if (handledByFtp)
             {
@@ -948,6 +951,7 @@ namespace Files.Filesystem
             }
 
             var (handledByFtp, source) = await GetDraggedStorageItems(packageView);
+            source ??= new List<IStorageItemWithPath>();
 
             if (handledByFtp)
             {

--- a/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -535,6 +535,7 @@ namespace Files.Interacts
                 e.Handled = true;
 
                 var (handledByFtp, draggedItems) = await Filesystem.FilesystemHelpers.GetDraggedStorageItems(e.DataView);
+                draggedItems ??= new List<IStorageItemWithPath>();
 
                 var pwd = associatedInstance.FilesystemViewModel.WorkingDirectory.TrimPath();
                 var folderName = (Path.IsPathRooted(pwd) && Path.GetPathRoot(pwd) == pwd) ? Path.GetPathRoot(pwd) : Path.GetFileName(pwd);

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -558,6 +558,7 @@ namespace Files.UserControls
                 e.Handled = true;
 
                 var (handledByFtp, storageItems) = await Filesystem.FilesystemHelpers.GetDraggedStorageItems(e.DataView);
+                storageItems ??= new List<IStorageItemWithPath>();
 
                 if (string.IsNullOrEmpty(locationItem.Path) ||
                     (storageItems.Any() && storageItems.AreItemsAlreadyInFolder(locationItem.Path))
@@ -699,6 +700,7 @@ namespace Files.UserControls
             e.Handled = true;
 
             var (handledByFtp, storageItems) = await Filesystem.FilesystemHelpers.GetDraggedStorageItems(e.DataView);
+            storageItems ??= new List<IStorageItemWithPath>();
 
             if ("DriveCapacityUnknown".GetLocalized().Equals(driveItem.SpaceText, StringComparison.OrdinalIgnoreCase) ||
                 (storageItems.Any() && storageItems.AreItemsAlreadyInFolder(driveItem.Path)))

--- a/Files/ViewModels/NavToolbarViewModel.cs
+++ b/Files/ViewModels/NavToolbarViewModel.cs
@@ -443,6 +443,8 @@ namespace Files.ViewModels
             var deferral = e.GetDeferral();
 
             var (handledByFtp, storageItems) = await Filesystem.FilesystemHelpers.GetDraggedStorageItems(e.DataView);
+            storageItems ??= new List<IStorageItemWithPath>();
+
             if (handledByFtp)
             {
                 e.AcceptedOperation = DataPackageOperation.None;

--- a/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
@@ -312,6 +312,7 @@ namespace Files.ViewModels.Widgets.Bundles
                 if (Filesystem.FilesystemHelpers.HasDraggedStorageItems(e.DataView))
                 {
                     var (_, items) = await Filesystem.FilesystemHelpers.GetDraggedStorageItems(e.DataView);
+                    items ??= new List<IStorageItemWithPath>();
 
                     if (await AddItemsFromPath(items.ToDictionary((item) => item.Path, (item) => item.ItemType)))
                     {


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related #5980

**Details of Changes**
Add details of changes here.
- Added null check to avoid crash when dragging files from WinRAR

The issue is reproducible only in Azure/Release mode. This PR _only avoids the crash_, dragging Files from WinRAR is currently not working in Release.

**Validation**
How did you test these changes?
- [x] Built and ran the app
