### PR TITLE
Fix an issue where a rebuild would be triggered despite unchanged project items

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -1037,10 +1037,10 @@
     <Content Include="Assets\WSL\ubuntupng.png" />
     <Content Include="Properties\Default.rd.xml" />
     <None Include="Resources\PreviewPanePropertiesInformation.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Resources\PropertiesInformation.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <PRIResource Include="Strings\lv-LV\Resources.resw" />
     <PRIResource Include="Strings\sv-SE\Resources.resw" />


### PR DESCRIPTION
**Details of Changes**
Add details of changes here.
- Modify CopyToOutputDirectory property on certain project items to PreserveNewest, preventing unnecessarily-delayed deployment
- Only applies to scenarios when no project item changes were made before running Files from VS

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] ~~Tested the changes for accessibility~~
