### PR TITLE
add Separator in menu Sort

### DIFF
--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -402,6 +402,7 @@
                                 IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
                                 Text="Date deleted" />
                         </MenuFlyoutSubItem>
+                        <MenuFlyoutSeparator x:Name="NavToolbarSortSeparator" />
                         <ToggleMenuFlyoutItem
                             x:Uid="NavToolbarSortDirectionOptionAscending"
                             IsChecked="{x:Bind ViewModel.IsSortedAscending, Mode=TwoWay}"

--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -402,7 +402,7 @@
                                 IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
                                 Text="Date deleted" />
                         </MenuFlyoutSubItem>
-                        <MenuFlyoutSeparator x:Name="NavToolbarSortSeparator" />
+                        <MenuFlyoutSeparator />
                         <ToggleMenuFlyoutItem
                             x:Uid="NavToolbarSortDirectionOptionAscending"
                             IsChecked="{x:Bind ViewModel.IsSortedAscending, Mode=TwoWay}"


### PR DESCRIPTION
Adds a separator in the Sort menu, to isolate the Ascending/Descending radio buttons.
A separator is already used for the same buttons in the context menu. 

![Separator](https://user-images.githubusercontent.com/46631671/132348618-7bffc1a9-222f-4915-8101-0fce96acfede.png)
