### PR TITLE
Respect Move overflow items to a submenu setting on sidebar shell items

### DIFF
--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -963,12 +963,24 @@ namespace Files.UserControls
                     var shiftPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
                     var shellMenuItems = await ContextFlyoutItemHelper.GetItemContextShellCommandsAsync(connection: await AppServiceConnectionHelper.Instance, currentInstanceViewModel: null, workingDir: null,
                         new List<ListedItem>() { new ListedItem(null) { ItemPath = RightClickedItem.Path } }, shiftPressed: shiftPressed, showOpenMenu: false);
-                    var overflowItems = ItemModelListToContextFlyoutHelper.GetMenuFlyoutItemsFromModel(shellMenuItems);
-                    var overflowItem = itemContextMenuFlyout.SecondaryCommands.FirstOrDefault(x => x is AppBarButton appBarButton && (appBarButton.Tag as string) == "ItemOverflow") as AppBarButton;
-                    if (overflowItem is not null)
+                    if (!App.AppSettings.MoveOverflowMenuItemsToSubMenu)
                     {
-                        overflowItems.ForEach(i => (overflowItem.Flyout as MenuFlyout).Items.Add(i));
-                        overflowItem.Visibility = overflowItems.Any() ? Visibility.Visible : Visibility.Collapsed;
+                        var (_, secondaryElements) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(shellMenuItems);
+                        if (secondaryElements.Any())
+                        {
+                            itemContextMenuFlyout.SecondaryCommands.Add(new AppBarSeparator());
+                            secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
+                        }
+                    }
+                    else
+                    {
+                        var overflowItems = ItemModelListToContextFlyoutHelper.GetMenuFlyoutItemsFromModel(shellMenuItems);
+                        var overflowItem = itemContextMenuFlyout.SecondaryCommands.FirstOrDefault(x => x is AppBarButton appBarButton && (appBarButton.Tag as string) == "ItemOverflow") as AppBarButton;
+                        if (overflowItem is not null)
+                        {
+                            overflowItems.ForEach(i => (overflowItem.Flyout as MenuFlyout).Items.Add(i));
+                            overflowItem.Visibility = overflowItems.Any() ? Visibility.Visible : Visibility.Collapsed;
+                        }
                     }
                 }
             }

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -981,6 +981,14 @@ namespace Files.UserControls
                         var (_, secondaryElements) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(shellMenuItems);
                         if (secondaryElements.Any())
                         {
+                            var openedPopups = Windows.UI.Xaml.Media.VisualTreeHelper.GetOpenPopups(Window.Current);
+                            var secondaryMenu = openedPopups.FirstOrDefault(popup => popup.Name == "OverflowPopup");
+                            var itemsControl = secondaryMenu?.Child.FindDescendant<ItemsControl>();
+                            if (itemsControl is not null)
+                            {
+                                secondaryElements.OfType<FrameworkElement>().ForEach(x => x.MaxWidth = itemsControl.ActualWidth - 10); // Set items max width to current menu width (#5555)
+                            }
+
                             itemContextMenuFlyout.SecondaryCommands.Add(new AppBarSeparator());
                             secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
                         }

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Files.DataModels;
 using Files.DataModels.NavigationControlItems;
+using Files.Extensions;
 using Files.Filesystem;
 using Files.Filesystem.StorageItems;
 using Files.Helpers;
@@ -374,6 +375,12 @@ namespace Files.UserControls
                 RightClickedItem = item;
                 var menuItems = GetLocationItemMenuItems();
                 var (_, secondaryElements) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(menuItems);
+
+                if (!App.AppSettings.MoveOverflowMenuItemsToSubMenu)
+                {
+                    secondaryElements.OfType<FrameworkElement>().ForEach(i => i.MinWidth = 250); // Set menu min width if the overflow menu setting is disabled
+                }
+
                 secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
                 itemContextMenuFlyout.ShowAt(sidebarItem, new Windows.UI.Xaml.Controls.Primitives.FlyoutShowOptions() { Position = e.GetPosition(sidebarItem) });
 
@@ -420,6 +427,12 @@ namespace Files.UserControls
             RightClickedItem = item;
             var menuItems = GetLocationItemMenuItems();
             var (_, secondaryElements) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(menuItems);
+
+            if (!App.AppSettings.MoveOverflowMenuItemsToSubMenu)
+            {
+                secondaryElements.OfType<FrameworkElement>().ForEach(i => i.MinWidth = 250); // Set menu min width if the overflow menu setting is disabled
+            }
+
             secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
             itemContextMenuFlyout.ShowAt(sidebarItem, new Windows.UI.Xaml.Controls.Primitives.FlyoutShowOptions() { Position = e.GetPosition(sidebarItem) });
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Closes #5856

**Details of Changes**
- Added the option to respect the move overflow items to a submenu on sidebar shell items to keep consistency.
- Added a min width when that option is enabled to avoid possible issues with a small context menu when adding shell items.

**Validation**
- [x] Built and ran the app

**Screenshots (optional)**
Setting enabled, works as does it now:
![image](https://user-images.githubusercontent.com/11770760/132518782-4bf89848-a57b-46e4-8337-c467fcffa0c8.png)

Setting disabled, works as added on this PR:
![image](https://user-images.githubusercontent.com/11770760/132518889-e6137e55-5cdf-4b0d-946a-a7499f379018.png)