### PR TITLE
Added drop to Pin folder/s to Favorites

### DIFF
--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -499,6 +499,8 @@ namespace Files.UserControls
 
         private object dragOverSection, dragOverItem = null;
 
+        private bool isDropOnProcess = false;
+
         private void NavigationViewItem_DragEnter(object sender, DragEventArgs e)
         {
             VisualStateManager.GoToState(sender as Microsoft.UI.Xaml.Controls.NavigationViewItem, "DragEnter", false);
@@ -543,6 +545,8 @@ namespace Files.UserControls
         {
             VisualStateManager.GoToState(sender as Microsoft.UI.Xaml.Controls.NavigationViewItem, "DragLeave", false);
 
+            isDropOnProcess = false;
+
             if ((sender as Microsoft.UI.Xaml.Controls.NavigationViewItem).DataContext is INavigationControlItem)
             {
                 if (sender == dragOverItem)
@@ -570,6 +574,7 @@ namespace Files.UserControls
             if (Filesystem.FilesystemHelpers.HasDraggedStorageItems(e.DataView))
             {
                 e.Handled = true;
+                isDropOnProcess = true;
 
                 var (handledByFtp, storageItems) = await Filesystem.FilesystemHelpers.GetDraggedStorageItems(e.DataView);
                 storageItems ??= new List<IStorageItemWithPath>();
@@ -710,7 +715,7 @@ namespace Files.UserControls
 
                 var deferral = e.GetDeferral();
 
-                if (string.IsNullOrEmpty(locationItem.Path) && SectionType.Favorites.Equals(locationItem.Section)) // Pin to Favorites section
+                if (string.IsNullOrEmpty(locationItem.Path) && SectionType.Favorites.Equals(locationItem.Section) && isDropOnProcess) // Pin to Favorites section
                 {
                     var storageItems = await e.DataView.GetStorageItemsAsync();
                     foreach (var item in storageItems)
@@ -731,6 +736,7 @@ namespace Files.UserControls
                     });
                 }
 
+                isDropOnProcess = false;
                 deferral.Complete();
             }
             else if ((e.DataView.Properties["sourceLocationItem"] as Microsoft.UI.Xaml.Controls.NavigationViewItem).DataContext is LocationItem sourceLocationItem)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Closes #2626

**Details of Changes**
- Added the ability to drop folder/s to favorites.

You can drop several folders to Favorites at the same time. You can include files on the selection, but they will be ignored. You can include on the selection folders that are already pinned, but they will be ignored too.


**Validation**
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
With two files and folders selected:
![GIF 15-09-2021 14-30-01](https://user-images.githubusercontent.com/11770760/133433558-68452036-9294-4d16-adcc-1288f86be89f.gif)

When the operation is allowed:
![image](https://user-images.githubusercontent.com/11770760/133929989-fde6c9aa-41d6-42b2-8e77-52db3b850a48.png)

With a folder that is already pinned selected the operation is not allowed:
![image](https://user-images.githubusercontent.com/11770760/133433709-c7b89ba8-4935-479c-9228-c15b77af101d.png)

Just adding files will not work neither:
![image](https://user-images.githubusercontent.com/11770760/133433940-cf0a6af9-dcb8-4e1c-a2fd-e9e1d45477a8.png)

