### PR TITLE
Fix issue where image previews in preview pane wouldn't work

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1074,7 +1074,8 @@ namespace Files.ViewModels
             ImageSource groupImage = null;
             if (item.PrimaryItemAttribute != StorageItemTypes.Folder)
             {
-                var headerIconInfo = await FileThumbnailHelper.LoadIconFromPathAsync(item.ItemPath, 76, ThumbnailMode.ListView);
+                var headerIconInfo = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(item.ItemPath, 64u);
+
                 if (headerIconInfo != null && !item.IsShortcutItem)
                 {
                     groupImage = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => headerIconInfo.ToBitmapAsync(), Windows.System.DispatcherQueuePriority.Low);

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1072,7 +1072,7 @@ namespace Files.ViewModels
         private async Task<ImageSource> GetItemTypeGroupIcon(ListedItem item, BaseStorageFile matchingStorageItem = null)
         {
             ImageSource groupImage = null;
-            if (item.PrimaryItemAttribute != StorageItemTypes.Folder)
+            if (item.PrimaryItemAttribute != StorageItemTypes.Folder || item.IsZipItem)
             {
                 var headerIconInfo = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(item.ItemPath, 64u);
 

--- a/Files/ViewModels/Previews/ImagePreviewViewModel.cs
+++ b/Files/ViewModels/Previews/ImagePreviewViewModel.cs
@@ -30,21 +30,10 @@ namespace Files.ViewModels.Previews
 
         public override async Task<List<FileProperty>> LoadPreviewAndDetails()
         {
-            FileRandomAccessStream stream = (FileRandomAccessStream)await Item.ItemFile.OpenAsync(FileAccessMode.Read);
-
-            // svg files require a different type of source
-            if (!Item.ItemPath.EndsWith(".svg"))
-            {
-                var bitmap = new BitmapImage();
-                ImageSource = bitmap;
-                await bitmap.SetSourceAsync(stream);
-            }
-            else
-            {
-                var bitmap = new SvgImageSource();
-                ImageSource = bitmap;
-                await bitmap.SetSourceAsync(stream);
-            }
+            IRandomAccessStream stream = await Item.ItemFile.OpenAsync(FileAccessMode.Read);
+            BitmapImage bitmap = new();
+            await bitmap.SetSourceAsync(stream);
+            ImageSource = bitmap;
 
             return new List<FileProperty>();
         }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related #issue...

**Details of Changes**
Add details of changes here.
- An invalid cast to `FileRandomAccessStream` was being made, causing image previews to not be shown. The cast was unnecessary. This pr removes the cast and instead just uses the `IRandomAccessStream` return type, fixing the issue. 
- also removes some old code for svg previews that's no longer being used
- fix issue where header images would show item preview thumbnails instead of type thumbnails in zoomed out view when grouped by type. This issue was due to needing to get the thumbnail via the ftp in order to show just the app thumbnail. 

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
