### PR TITLE
feat: Prelaunch app content & properly redirect to pre-launched instance if available

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -166,6 +166,23 @@ namespace Files
                 Window.Current.Activate();
                 Window.Current.CoreWindow.Activated += CoreWindow_Activated;
             }
+            else
+            {
+                if (rootFrame.Content == null)
+                {
+                    // When the navigation stack isn't restored navigate to the first page,
+                    // configuring the new page by passing required information as a navigation
+                    // parameter
+                    rootFrame.Navigate(typeof(MainPage), e.Arguments, new SuppressNavigationTransitionInfo());
+                }
+                else
+                {
+                    if (!(string.IsNullOrEmpty(e.Arguments) && MainPageViewModel.AppInstances.Count > 0))
+                    {
+                        await MainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), e.Arguments);
+                    }
+                }
+            }
         }
 
         protected override async void OnFileActivated(FileActivatedEventArgs e)
@@ -393,13 +410,8 @@ namespace Files
         /// <param name="e">Details about the suspend request.</param>
         private void OnSuspending(object sender, SuspendingEventArgs e)
         {
+            SuspendingDeferral deferral = e.SuspendingOperation.GetDeferral();
             SaveSessionTabs();
-
-            var deferral = e.SuspendingOperation.GetDeferral();
-            //TODO: Save application state and stop any background activity
-
-            LibraryManager?.Dispose();
-            DrivesManager?.Dispose();
             deferral.Complete();
         }
 

--- a/Files/Program.cs
+++ b/Files/Program.cs
@@ -68,8 +68,8 @@ namespace Files
                         if (AppInstance.GetInstances().Any(x => x.Key.Equals(PrelaunchInstanceKey)) && !wasPrelaunchInstanceActivated)
                         {
                             var plInstance = AppInstance.GetInstances().First(x => x.Key.Equals(PrelaunchInstanceKey));
-                            plInstance.RedirectActivationTo();
                             ApplicationData.Current.LocalSettings.Values["WAS_PRELAUNCH_INSTANCE_ACTIVATED"] = true;
+                            plInstance.RedirectActivationTo();
                             return;
                         }
                         else


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Should help in many cases with #2568 -- since we now properly preload the initial app UI, rather than just an empty window
- Redirect properly to pre-launched AppInstance if available

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] ~~Tested the changes for accessibility~~

In a simulated prelaunch scenario, the app resumes from suspend almost instantly and displays the app UI with minimal/no splash screen shown.

**Please note:** The changes to Program.cs are tentative due to the high risk of regressions in functionality. ~~Additionally, an issue is present where trying to open more app instances after being redirected to the initial pre-launched instance won't work. Your feedback and suggestions here are very welcome.~~ **(Fixed)**