### PR TITLE
Fixes a bug that showed negative dates when the year was 9999

### DIFF
--- a/Files/Extensions/DateTimeExtensions.cs
+++ b/Files/Extensions/DateTimeExtensions.cs
@@ -10,7 +10,7 @@ namespace Files.Extensions
         {
             var elapsed = DateTimeOffset.Now - d;
 
-            if (d.Year == 1601)
+            if (d.Year == 1601 || d.Year == 9999)
             {
                 return " ";
             }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
- Related #6116

**Details of Changes**
- Added 9999 year to the not showing list. This fixes a bug that showed negative seconds on the dates. As I stated on #6116 I think we should hide those dates (1601 and 9999 years) since they are unreal and there isn't (or at least I can't imagine one) a scenario where having those dates are useful.

**Validation**
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before:
![image](https://user-images.githubusercontent.com/11770760/135757471-a76af412-517c-4211-9881-6a824f7de13c.png)

After:
![image](https://user-images.githubusercontent.com/11770760/135757508-c72d2fb7-4e13-4dc7-8821-51bcd2445526.png)

