### PR TITLE
Show file operation progress on Taskbar & continue operations when minimized

### DIFF
--- a/Files.Launcher/Helpers/DisposableDictionary.cs
+++ b/Files.Launcher/Helpers/DisposableDictionary.cs
@@ -56,6 +56,11 @@ namespace FilesFullTrust.Helpers
             (elem as IDisposable)?.Dispose();
         }
 
+        public bool HasValues()
+        {
+            return dict.Keys.Count > 0;
+        }
+
         public void Dispose()
         {
             foreach (var elem in dict)

--- a/Files.Launcher/Helpers/DisposableDictionary.cs
+++ b/Files.Launcher/Helpers/DisposableDictionary.cs
@@ -56,11 +56,6 @@ namespace FilesFullTrust.Helpers
             (elem as IDisposable)?.Dispose();
         }
 
-        public bool HasValues()
-        {
-            return dict.Keys.Count > 0;
-        }
-
         public void Dispose()
         {
             foreach (var elem in dict)

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -66,6 +66,9 @@ namespace FilesFullTrust
 
                 // Wait until the connection gets closed
                 appServiceExit.WaitOne();
+
+                // Wait for ongoing file operations
+                messageHandlers.OfType<FileOperationsHandler>().Single().WaitForCompletion();
             }
             finally
             {

--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -312,6 +312,13 @@ namespace FilesFullTrust
             }
         }
 
+        public static Shell32.ITaskbarList4 CreateTaskbarObject()
+        {
+            var taskbar2 = new Shell32.ITaskbarList2();
+            taskbar2.HrInit();
+            return taskbar2 as Shell32.ITaskbarList4;
+        }
+
         private static Bitmap GetAlphaBitmapFromBitmapData(BitmapData bmpData)
         {
             using var tmp = new Bitmap(bmpData.Width, bmpData.Height, bmpData.Stride, PixelFormat.Format32bppArgb, bmpData.Scan0);
@@ -344,10 +351,13 @@ namespace FilesFullTrust
 
         public static async Task SendMessageAsync(NamedPipeServerStream pipe, ValueSet valueSet, string requestID = null)
         {
-            var message = new Dictionary<string, object>(valueSet);
-            message.Add("RequestID", requestID);
-            var serialized = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message));
-            await pipe.WriteAsync(serialized, 0, serialized.Length);
+            await Extensions.IgnoreExceptions(async () =>
+            {
+                var message = new Dictionary<string, object>(valueSet);
+                message.Add("RequestID", requestID);
+                var serialized = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message));
+                await pipe.WriteAsync(serialized, 0, serialized.Length);
+            });
         }
 
         // There is usually no need to define Win32 COM interfaces/P-Invoke methods here.

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -71,6 +71,7 @@ namespace Files
             InitializeComponent();
             Suspending += OnSuspending;
             LeavingBackground += OnLeavingBackground;
+            AppServiceConnectionHelper.Register();
         }
 
         private static async Task EnsureSettingsAndConfigurationAreBootstrapped()

--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -263,7 +263,6 @@ namespace Files.Filesystem
                         {
                             { "Arguments", "FileOperation" },
                             { "fileop", "CopyItem" },
-                            { "operationID", Guid.NewGuid().ToString() },
                             { "filepath", source.Path },
                             { "destpath", destination },
                             { "overwrite", collision == NameCollisionOption.ReplaceExisting }
@@ -321,7 +320,6 @@ namespace Files.Filesystem
                         {
                             { "Arguments", "FileOperation" },
                             { "fileop", "CopyItem" },
-                            { "operationID", Guid.NewGuid().ToString() },
                             { "filepath", source.Path },
                             { "destpath", destination },
                             { "overwrite", collision == NameCollisionOption.ReplaceExisting }
@@ -486,7 +484,6 @@ namespace Files.Filesystem
                             {
                                 { "Arguments", "FileOperation" },
                                 { "fileop", "MoveItem" },
-                                { "operationID", Guid.NewGuid().ToString() },
                                 { "filepath", source.Path },
                                 { "destpath", destination },
                                 { "overwrite", collision == NameCollisionOption.ReplaceExisting }
@@ -532,7 +529,6 @@ namespace Files.Filesystem
                         {
                             { "Arguments", "FileOperation" },
                             { "fileop", "MoveItem" },
-                            { "operationID", Guid.NewGuid().ToString() },
                             { "filepath", source.Path },
                             { "destpath", destination },
                             { "overwrite", collision == NameCollisionOption.ReplaceExisting }
@@ -626,10 +622,8 @@ namespace Files.Filesystem
                     {
                         { "Arguments", "FileOperation" },
                         { "fileop", "DeleteItem" },
-                        { "operationID", Guid.NewGuid().ToString() },
                         { "filepath", source.Path },
-                        { "permanently", permanently },
-                        { "HWND", NativeWinApiHelper.CoreWindowHandle.ToInt64() }
+                        { "permanently", permanently }
                     });
                 }
             }
@@ -742,7 +736,6 @@ namespace Files.Filesystem
                         {
                             { "Arguments", "FileOperation" },
                             { "fileop", "RenameItem" },
-                            { "operationID", Guid.NewGuid().ToString() },
                             { "filepath", source.Path },
                             { "newName", newName },
                             { "overwrite", collision == NameCollisionOption.ReplaceExisting }
@@ -853,7 +846,6 @@ namespace Files.Filesystem
                     {
                         { "Arguments", "FileOperation" },
                         { "fileop", "MoveItem" },
-                        { "operationID", Guid.NewGuid().ToString() },
                         { "filepath", source.Path },
                         { "destpath", destination },
                         { "overwrite", false }
@@ -947,6 +939,8 @@ namespace Files.Filesystem
                     connection = await AppServiceConnectionHelper.Instance;
                     if (connection != null)
                     {
+                        operation.Add("operationID", Guid.NewGuid().ToString());
+                        operation.Add("HWND", NativeWinApiHelper.CoreWindowHandle.ToInt64());
                         var (status, response) = await connection.SendMessageForResponseAsync(operation);
                         var fsResult = (FilesystemResult)(status == AppServiceResponseStatus.Success
                             && response.Get("Success", false));

--- a/Files/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
@@ -97,7 +97,8 @@ namespace Files.Filesystem
                     { "operationID", operationID },
                     { "filepath", string.Join('|', sourceRename.Select(s => s.Path)) },
                     { "destpath", string.Join('|', destinationRename) },
-                    { "overwrite", false }
+                    { "overwrite", false },
+                    { "HWND", NativeWinApiHelper.CoreWindowHandle.ToInt64() }
                 });
                 result &= (FilesystemResult)(status == AppServiceResponseStatus.Success
                     && response.Get("Success", false));
@@ -113,7 +114,8 @@ namespace Files.Filesystem
                     { "operationID", operationID },
                     { "filepath", string.Join('|', sourceReplace.Select(s => s.Path)) },
                     { "destpath", string.Join('|', destinationReplace) },
-                    { "overwrite", true }
+                    { "overwrite", true },
+                    { "HWND", NativeWinApiHelper.CoreWindowHandle.ToInt64() }
                 });
                 result &= (FilesystemResult)(status == AppServiceResponseStatus.Success
                     && response.Get("Success", false));
@@ -342,7 +344,8 @@ namespace Files.Filesystem
                     { "operationID", operationID },
                     { "filepath", string.Join('|', sourceRename.Select(s => s.Path)) },
                     { "destpath", string.Join('|', destinationRename) },
-                    { "overwrite", false }
+                    { "overwrite", false },
+                    { "HWND", NativeWinApiHelper.CoreWindowHandle.ToInt64() }
                 });
                 result &= (FilesystemResult)(status == AppServiceResponseStatus.Success
                     && response.Get("Success", false));
@@ -358,7 +361,8 @@ namespace Files.Filesystem
                     { "operationID", operationID },
                     { "filepath", string.Join('|', sourceReplace.Select(s => s.Path)) },
                     { "destpath", string.Join('|', destinationReplace) },
-                    { "overwrite", true }
+                    { "overwrite", true },
+                    { "HWND", NativeWinApiHelper.CoreWindowHandle.ToInt64() }
                 });
                 result &= (FilesystemResult)(status == AppServiceResponseStatus.Success
                     && response.Get("Success", false));
@@ -469,7 +473,8 @@ namespace Files.Filesystem
                 { "operationID", operationID },
                 { "filepath", source.Path },
                 { "destpath", destination },
-                { "overwrite", false }
+                { "overwrite", false },
+                { "HWND", NativeWinApiHelper.CoreWindowHandle.ToInt64() }
             });
             var result = (FilesystemResult)(status == AppServiceResponseStatus.Success
                 && response.Get("Success", false));

--- a/Files/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
@@ -78,7 +78,7 @@ namespace Files.Filesystem
             var operationID = Guid.NewGuid().ToString();
             using var r = cancellationToken.Register(CancelOperation, operationID, false);
 
-            EventHandler<Dictionary<string, object>> handler = (s, e) => OnProgressUpdated(s, e, progress);
+            EventHandler<Dictionary<string, object>> handler = (s, e) => OnProgressUpdated(s, e, operationID, progress);
             connection.RequestReceived += handler;
 
             var sourceReplace = source.Where((src, index) => collisions.ElementAt(index) == FileNameConflictResolveOptionType.ReplaceExisting);
@@ -238,7 +238,7 @@ namespace Files.Filesystem
             var operationID = Guid.NewGuid().ToString();
             using var r = cancellationToken.Register(CancelOperation, operationID, false);
 
-            EventHandler<Dictionary<string, object>> handler = (s, e) => OnProgressUpdated(s, e, progress);
+            EventHandler<Dictionary<string, object>> handler = (s, e) => OnProgressUpdated(s, e, operationID, progress);
             connection.RequestReceived += handler;
 
             var deleteResult = new ShellOperationResult();
@@ -325,7 +325,7 @@ namespace Files.Filesystem
             var operationID = Guid.NewGuid().ToString();
             using var r = cancellationToken.Register(CancelOperation, operationID, false);
 
-            EventHandler<Dictionary<string, object>> handler = (s, e) => OnProgressUpdated(s, e, progress);
+            EventHandler<Dictionary<string, object>> handler = (s, e) => OnProgressUpdated(s, e, operationID, progress);
             connection.RequestReceived += handler;
 
             var sourceReplace = source.Where((src, index) => collisions.ElementAt(index) == FileNameConflictResolveOptionType.ReplaceExisting);
@@ -462,7 +462,7 @@ namespace Files.Filesystem
             var operationID = Guid.NewGuid().ToString();
             using var r = cancellationToken.Register(CancelOperation, operationID, false);
 
-            EventHandler<Dictionary<string, object>> handler = (s, e) => OnProgressUpdated(s, e, progress);
+            EventHandler<Dictionary<string, object>> handler = (s, e) => OnProgressUpdated(s, e, operationID, progress);
             connection.RequestReceived += handler;
 
             var moveResult = new ShellOperationResult();
@@ -511,12 +511,16 @@ namespace Files.Filesystem
             }
         }
 
-        private void OnProgressUpdated(object sender, Dictionary<string, object> message, IProgress<float> progress)
+        private void OnProgressUpdated(object sender, Dictionary<string, object> message, string currentOperation, IProgress<float> progress)
         {
             if (message.ContainsKey("OperationID"))
             {
-                var value = (long)message["Progress"];
-                progress?.Report(value);
+                var operationID = (string)message["OperationID"];
+                if (operationID == currentOperation)
+                {
+                    var value = (long)message["Progress"];
+                    progress?.Report(value);
+                }
             }
         }
 

--- a/Files/Helpers/AppServiceConnectionHelper.cs
+++ b/Files/Helpers/AppServiceConnectionHelper.cs
@@ -20,7 +20,7 @@ namespace Files.Helpers
 
         public static event EventHandler<Task<NamedPipeAsAppServiceConnection>> ConnectionChanged;
 
-        static AppServiceConnectionHelper()
+        public static void Register()
         {
             App.Current.Suspending += OnSuspending;
             App.Current.LeavingBackground += OnLeavingBackground;

--- a/Files/ViewModels/StatusCenterViewModel.cs
+++ b/Files/ViewModels/StatusCenterViewModel.cs
@@ -112,6 +112,7 @@ namespace Files.ViewModels
             }
 
             StatusBannersSource.Remove(banner);
+            UpdateBanner(banner);
             return true;
         }
 

--- a/Files/Views/ColumnShellPage.xaml.cs
+++ b/Files/Views/ColumnShellPage.xaml.cs
@@ -913,11 +913,10 @@ namespace Files.Views
         private void SetLoadingIndicatorForTabs(bool isLoading)
         {
             var multitaskingControls = ((Window.Current.Content as Frame).Content as MainPage).ViewModel.MultitaskingControls;
-            var tabItemControl = this.FindAscendant<TabItemControl>();
 
             foreach (var x in multitaskingControls)
             {
-                x.SetLoadingIndicatorStatus(x.Items.FirstOrDefault(x => x.Control == tabItemControl), isLoading);
+                x.SetLoadingIndicatorStatus(x.Items.FirstOrDefault(x => x.Control.TabItemContent == PaneHolder), isLoading);
             }
         }
 

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -1017,11 +1017,10 @@ namespace Files.Views
         private void SetLoadingIndicatorForTabs(bool isLoading)
         {
             var multitaskingControls = ((Window.Current.Content as Frame).Content as MainPage).ViewModel.MultitaskingControls;
-            var tabItemControl = this.FindAscendant<TabItemControl>();
 
             foreach (var x in multitaskingControls)
             {
-                x.SetLoadingIndicatorStatus(x.Items.FirstOrDefault(x => x.Control == tabItemControl), isLoading);
+                x.SetLoadingIndicatorStatus(x.Items.FirstOrDefault(x => x.Control.TabItemContent == PaneHolder), isLoading);
             }
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6266
- Closes #6171

**Details of Changes**
Add details of changes here.
- Show ongoing progress for file operations on taskbar
- Do not stop filesystem operations when Files window is minimized
- Fixes an issue where the progress ring would show on the toolbar after canceling an operation
- Fixes an issue where a tab would show the loading indicator indefinitely on app start

**Validation**
How did you test these changes?
- [x] Built and ran the app
