### PR TITLE
Fix wrong file names in zip files when they contain Chinese characters

### DIFF
--- a/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
+++ b/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
@@ -810,6 +810,10 @@ namespace FilesFullTrust.MessageHandlers
 
             private void UpdateTaskbarProgress()
             {
+                if (OwnerWindow == null || taskbar == null)
+                {
+                    return;
+                }
                 if (operations.Any())
                 {
                     taskbar.SetProgressValue(OwnerWindow.Handle, (ulong)Progress, 100);

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -1453,6 +1453,9 @@
     <PackageReference Include="SQLitePCLRaw.bundle_green">
       <Version>2.0.6</Version>
     </PackageReference>
+    <PackageReference Include="Ude.NetStandard">
+      <Version>1.2.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="..\Files.Package\Package.appxmanifest">

--- a/Files/Filesystem/StorageItems/ZipStorageFolder.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFolder.cs
@@ -1,4 +1,5 @@
-﻿using Files.Helpers;
+﻿using Files.Extensions;
+using Files.Helpers;
 using ICSharpCode.SharpZipLib.Zip;
 using Microsoft.Toolkit.Uwp;
 using System;
@@ -248,7 +249,7 @@ namespace Files.Filesystem.StorageItems
                     foreach (var entry in zipFile.OfType<ZipEntry>()) // Returns all items recursively
                     {
                         string winPath = System.IO.Path.GetFullPath(entry.IsDirectory ? wnt.TransformDirectory(DecodeEntryName(entry, ZipEncoding)) : wnt.TransformFile(DecodeEntryName(entry, ZipEncoding)));
-                        if (winPath.StartsWith(Path)) // Child of self
+                        if (winPath.StartsWith(Path.WithEnding("\\"))) // Child of self
                         {
                             var split = winPath.Substring(Path.Length).Split(new[] { '\\' }, StringSplitOptions.RemoveEmptyEntries);
                             if (split.Length > 0)

--- a/Files/Filesystem/StorageItems/ZipStorageFolder.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFolder.cs
@@ -17,6 +17,8 @@ namespace Files.Filesystem.StorageItems
 {
     public sealed class ZipStorageFolder : BaseStorageFolder
     {
+        public Encoding ZipEncoding { get; set; } = null;
+
         static ZipStorageFolder()
         {
             // Register all supported codepages (default is UTF-X only)
@@ -24,25 +26,48 @@ namespace Files.Filesystem.StorageItems
             ZipStrings.CodePage = 437; // Use extended ascii so you can convert the string back to bytes
         }
 
-        public static string DecodeEntryName(ZipEntry entry)
+        public static string DecodeEntryName(ZipEntry entry, Encoding zipEncoding)
         {
-            if (entry.IsUnicodeText)
+            if (zipEncoding == null || entry.IsUnicodeText)
             {
                 return entry.Name;
             }
             var decoded = Common.Extensions.IgnoreExceptions(() =>
             {
                 var rawBytes = Encoding.GetEncoding(437).GetBytes(entry.Name);
-                Ude.CharsetDetector cdet = new Ude.CharsetDetector();
-                cdet.Feed(rawBytes, 0, rawBytes.Length);
-                cdet.DataEnd();
-                if (cdet.Charset != null)
-                {
-                    return Encoding.GetEncoding(cdet.Charset).GetString(rawBytes);
-                }
-                return null;
+                return zipEncoding.GetString(rawBytes);
             });
             return decoded ?? entry.Name;
+        }
+
+        public static Encoding DetectFileEncoding(ZipFile zipFile)
+        {
+            long readEntries = 0;
+            Ude.CharsetDetector cdet = new Ude.CharsetDetector();
+            foreach (var entry in zipFile.OfType<ZipEntry>())
+            {
+                readEntries++;
+                if (entry.IsUnicodeText)
+                {
+                    return Encoding.UTF8;
+                }
+                var guessedEncoding = Common.Extensions.IgnoreExceptions(() =>
+                {
+                    var rawBytes = Encoding.GetEncoding(437).GetBytes(entry.Name);
+                    cdet.Feed(rawBytes, 0, rawBytes.Length);
+                    cdet.DataEnd();
+                    if (cdet.Charset != null && cdet.Confidence >= 0.9 && (readEntries >= Math.Min(zipFile.Count, 50)))
+                    {
+                        return Encoding.GetEncoding(cdet.Charset);
+                    }
+                    return null;
+                });
+                if (guessedEncoding != null)
+                {
+                    return guessedEncoding;
+                }
+            }
+            return Encoding.UTF8;
         }
 
         public ZipStorageFolder(string path, string containerPath)
@@ -137,7 +162,7 @@ namespace Files.Filesystem.StorageItems
                     zipFile.CommitUpdate();
 
                     var wnt = new WindowsNameTransform(ContainerPath);
-                    return new ZipStorageFolder(wnt.TransformFile(zipDesiredName), ContainerPath);
+                    return new ZipStorageFolder(wnt.TransformFile(zipDesiredName), ContainerPath) { ZipEncoding = ZipEncoding };
                 }
             });
         }
@@ -170,17 +195,18 @@ namespace Files.Filesystem.StorageItems
                 using (ZipFile zipFile = new ZipFile(new FileStream(hFile, FileAccess.Read)))
                 {
                     zipFile.IsStreamOwner = true;
+                    ZipEncoding ??= DetectFileEncoding(zipFile);
                     var entry = zipFile.GetEntry(name);
                     if (entry != null)
                     {
                         var wnt = new WindowsNameTransform(ContainerPath);
                         if (entry.IsDirectory)
                         {
-                            return new ZipStorageFolder(wnt.TransformDirectory(DecodeEntryName(entry)), ContainerPath, entry);
+                            return new ZipStorageFolder(wnt.TransformDirectory(DecodeEntryName(entry, ZipEncoding)), ContainerPath, entry) { ZipEncoding = ZipEncoding };
                         }
                         else
                         {
-                            return new ZipStorageFile(wnt.TransformFile(DecodeEntryName(entry)), ContainerPath, entry);
+                            return new ZipStorageFile(wnt.TransformFile(DecodeEntryName(entry, ZipEncoding)), ContainerPath, entry);
                         }
                     }
                     return null;
@@ -216,11 +242,12 @@ namespace Files.Filesystem.StorageItems
                 using (ZipFile zipFile = new ZipFile(new FileStream(hFile, FileAccess.Read)))
                 {
                     zipFile.IsStreamOwner = true;
+                    ZipEncoding ??= DetectFileEncoding(zipFile);
                     var wnt = new WindowsNameTransform(ContainerPath, true); // Check with Path.GetFullPath
                     var items = new List<IStorageItem>();
                     foreach (var entry in zipFile.OfType<ZipEntry>()) // Returns all items recursively
                     {
-                        string winPath = System.IO.Path.GetFullPath(entry.IsDirectory ? wnt.TransformDirectory(DecodeEntryName(entry)) : wnt.TransformFile(DecodeEntryName(entry)));
+                        string winPath = System.IO.Path.GetFullPath(entry.IsDirectory ? wnt.TransformDirectory(DecodeEntryName(entry, ZipEncoding)) : wnt.TransformFile(DecodeEntryName(entry, ZipEncoding)));
                         if (winPath.StartsWith(Path)) // Child of self
                         {
                             var split = winPath.Substring(Path.Length).Split(new[] { '\\' }, StringSplitOptions.RemoveEmptyEntries);
@@ -231,7 +258,7 @@ namespace Files.Filesystem.StorageItems
                                     var itemPath = System.IO.Path.Combine(Path, split[0]);
                                     if (!items.Any(x => x.Path == itemPath))
                                     {
-                                        items.Add(new ZipStorageFolder(itemPath, ContainerPath, entry));
+                                        items.Add(new ZipStorageFolder(itemPath, ContainerPath, entry) { ZipEncoding = ZipEncoding });
                                     }
                                 }
                                 else

--- a/Files/Helpers/PathNormalization.cs
+++ b/Files/Helpers/PathNormalization.cs
@@ -16,7 +16,7 @@ namespace Files.Helpers
             {
                 var pathAsUri = new Uri(path.Replace("\\", "/"));
                 rootPath = pathAsUri.GetLeftPart(UriPartial.Authority);
-                if (pathAsUri.IsFile)
+                if (pathAsUri.IsFile && !string.IsNullOrEmpty(rootPath))
                 {
                     rootPath = new Uri(rootPath).LocalPath;
                 }

--- a/Files/Helpers/ZipHelpers.cs
+++ b/Files/Helpers/ZipHelpers.cs
@@ -47,8 +47,8 @@ namespace Files.Helpers
                 var directories = new List<string>();
                 try
                 {
-                    directories.AddRange(directoryEntries.Select((item) => wnt.TransformDirectory(item.Name)));
-                    directories.AddRange(fileEntries.Select((item) => Path.GetDirectoryName(wnt.TransformFile(item.Name))));
+                    directories.AddRange(directoryEntries.Select((entry) => wnt.TransformDirectory(ZipStorageFolder.DecodeEntryName(entry, zipEncoding))));
+                    directories.AddRange(fileEntries.Select((entry) => Path.GetDirectoryName(wnt.TransformFile(ZipStorageFolder.DecodeEntryName(entry, zipEncoding)))));
                 }
                 catch (InvalidNameException ex)
                 {

--- a/Files/Helpers/ZipHelpers.cs
+++ b/Files/Helpers/ZipHelpers.cs
@@ -98,7 +98,7 @@ namespace Files.Helpers
                         continue; // TODO: support password protected archives
                     }
 
-                    string filePath = wnt.TransformFile(entry.Name);
+                    string filePath = wnt.TransformFile(ZipStorageFolder.DecodeEntryName(entry));
 
                     var hFile = NativeFileOperationsHelper.CreateFileForWrite(filePath);
                     if (hFile.IsInvalid)

--- a/Files/Helpers/ZipHelpers.cs
+++ b/Files/Helpers/ZipHelpers.cs
@@ -42,6 +42,7 @@ namespace Files.Helpers
                 }
 
                 var wnt = new WindowsNameTransform(destinationFolder.Path);
+                var zipEncoding = ZipStorageFolder.DetectFileEncoding(zipFile);
 
                 var directories = new List<string>();
                 try
@@ -98,7 +99,7 @@ namespace Files.Helpers
                         continue; // TODO: support password protected archives
                     }
 
-                    string filePath = wnt.TransformFile(ZipStorageFolder.DecodeEntryName(entry));
+                    string filePath = wnt.TransformFile(ZipStorageFolder.DecodeEntryName(entry, zipEncoding));
 
                     var hFile = NativeFileOperationsHelper.CreateFileForWrite(filePath);
                     if (hFile.IsInvalid)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6282

**Details of Changes**
Add details of changes here.
- Added auto detection of the encoding of file names inside zip files

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested browsing and extraction of the attached zip files

[ZIP1_WIN1252.zip](https://github.com/files-community/Files/files/7289814/ZIP1_WIN1252.zip)
[ZIP2_GB2312.zip](https://github.com/files-community/Files/files/7289815/ZIP2_GB2312.zip)
[ZIP3_UTF8.zip](https://github.com/files-community/Files/files/7289816/ZIP3_UTF8.zip)