### PR TITLE
Fix thumbnails getting squished into squares

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -751,7 +751,7 @@ namespace Files.ViewModels
             }
         }
 
-        private async Task LoadItemThumbnail(ListedItem item, uint thumbnailSize = 20, IStorageItem matchingStorageItem = null, bool forceReload = false)
+        private async Task LoadItemThumbnail(ListedItem item, uint thumbnailSize = 20, IStorageItem matchingStorageItem = null)
         {
             var wasIconLoaded = false;
             if (item.IsLibraryItem || item.PrimaryItemAttribute == StorageItemTypes.File || item.IsZipItem)
@@ -923,7 +923,7 @@ namespace Files.ViewModels
                                 if (matchingStorageFile != null)
                                 {
                                     cts.Token.ThrowIfCancellationRequested();
-                                    await LoadItemThumbnail(item, thumbnailSize, matchingStorageFile, true);
+                                    await LoadItemThumbnail(item, thumbnailSize, matchingStorageFile);
 
                                     var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageFile);
                                     var fileFRN = await FileTagsHelper.GetFileFRN(matchingStorageFile);
@@ -944,7 +944,7 @@ namespace Files.ViewModels
                             }
                             if (!wasSyncStatusLoaded)
                             {
-                                await LoadItemThumbnail(item, thumbnailSize, null, true);
+                                await LoadItemThumbnail(item, thumbnailSize, null);
                             }
                         }
                         else
@@ -956,7 +956,7 @@ namespace Files.ViewModels
                                 if (matchingStorageFolder != null)
                                 {
                                     cts.Token.ThrowIfCancellationRequested();
-                                    await LoadItemThumbnail(item, thumbnailSize, matchingStorageFolder, true);
+                                    await LoadItemThumbnail(item, thumbnailSize, matchingStorageFolder);
                                     if (matchingStorageFolder.DisplayName != item.ItemName && !matchingStorageFolder.DisplayName.StartsWith("$R"))
                                     {
                                         cts.Token.ThrowIfCancellationRequested();
@@ -992,7 +992,7 @@ namespace Files.ViewModels
                             if (!wasSyncStatusLoaded)
                             {
                                 cts.Token.ThrowIfCancellationRequested();
-                                await LoadItemThumbnail(item, thumbnailSize, null, true);
+                                await LoadItemThumbnail(item, thumbnailSize, null);
                             }
                         }
 


### PR DESCRIPTION
**Details of Changes**
Add details of changes here.
- Fixed a small issue with #6104 for which thumbnails get stretched into squares

As the docs for DecodePixelWidth say: "if DecodePixelHeight is also set, the aspect ratio of the bitmap is ignored. If DecodePixelHeight is not set, the aspect ratio remains the same."

**Validation**
How did you test these changes?
- [x] Built and ran the app
