### PR TITLE
fix: Remove extraneous slash from certain PathBoxItems

### DIFF
--- a/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -37,7 +37,7 @@ namespace Files.Filesystem
                 return new PathBoxItem()
                 {
                     Title = allDrives.FirstOrDefault(y => y.ItemType == NavigationControlItemType.Drive && y.Path.Contains(component, StringComparison.OrdinalIgnoreCase)) != null ?
-                            allDrives.FirstOrDefault(y => y.ItemType == NavigationControlItemType.Drive && y.Path.Contains(component, StringComparison.OrdinalIgnoreCase)).Text : $@"Drive ({component}\)",
+                            allDrives.FirstOrDefault(y => y.ItemType == NavigationControlItemType.Drive && y.Path.Contains(component, StringComparison.OrdinalIgnoreCase)).Text : $@"Drive ({component})",
                     Path = path,
                 };
             }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6522 

**Details of Changes**
Remove redundant and extraneous slash from certain PathBox items

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] ~~Tested the changes for accessibility~~

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/20365014/138627858-a0d82c00-8f15-43f6-bee6-b8f864ed7120.png)
