### PR TITLE
feat: Use Windows Terminal as initial default if present

### DIFF
--- a/Files/DataModels/TerminalFileModel.cs
+++ b/Files/DataModels/TerminalFileModel.cs
@@ -32,15 +32,15 @@ namespace Files.DataModels
             return Terminals.First();
         }
 
-        public async void ResetToDefaultTerminal()
+        public void ResetToDefaultTerminal()
         {
-            if (await TerminalController.IsWindowsTerminalBuildInstalled())
+            if (Terminals.Any(x => x.Name == "Windows Terminal"))
             {
                 DefaultTerminalName = "Windows Terminal";
             }
             else
             {
-                DefaultTerminalName = "cmd";
+                DefaultTerminalName = "CMD";
             }
         }
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Windows Terminal will now be used as the initial default, if installed.

**Details of Changes**
This change better supports users on Windows 11. Additionally, it slightly improved code quality in the TerminalController file.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] ~~Tested the changes for accessibility~~

**NOTE: Please test this PR on Windows 10 before merge.**