### PR TITLE
#1225 Multiple Files Properties: Move Files And Folders Count next to…

### DIFF
--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -74,16 +74,20 @@
                     ItemSize="80"
                     ViewModel="{x:Bind ViewModel}" />
             </Grid>
+            <StackPanel Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left">
             <TextBox
                 x:Name="ItemFileName"
                 x:Uid="PropertiesItemFileName"
-                Grid.Row="0"
-                Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
                 Text="{x:Bind ViewModel.ItemName, Mode=TwoWay}"
                 Visibility="{x:Bind ViewModel.ItemNameVisibility, Mode=OneWay}" />
-
-            <MenuFlyoutSeparator
+            <TextBlock
+                x:Name="itemFilesAndFoldersCountValueTop"
+                Style="{StaticResource PropertyValueTextBlock}"
+                Text="{x:Bind ViewModel.FilesAndFoldersCountString, Mode=OneWay}"
+                Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
+            </StackPanel>
+                <MenuFlyoutSeparator
                 Grid.Row="1"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"


### PR DESCRIPTION
Multiple Files Properties: Move Files And Folders Count next to the icon #1225

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved/related issues by this PR.
- Closes #1225 Multiple Files Properties: Move Files And Folders Count next to the icon
- 
**Details of Changes**
- Added a new text block control to display the number of files and folders next to the Icon when a user selects multiple files.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility

**Screenshots**
**Multiple files properties:**
<img width="302" alt="image" src="https://user-images.githubusercontent.com/11182796/139030459-10dd1610-a773-4ad9-b6a0-8b6965393a90.png">


**Drive properties:**
<img width="302" alt="image" src="https://user-images.githubusercontent.com/11182796/139029357-ff2ca0e2-366a-42d4-8615-a37002406607.png">

**Single file properties:**
![image](https://user-images.githubusercontent.com/11182796/139029762-4ef20c91-b43e-42d3-8389-0b449bfb7340.png)


