### PR TITLE
Minor fixes to FTP

### DIFF
--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1378,7 +1378,7 @@ namespace Files.ViewModels
                 client.Port = FtpHelpers.GetFtpPort(path);
                 client.Credentials = FtpManager.Credentials.Get(client.Host, FtpManager.Anonymous);
                 
-                static Task<FtpProfile> WrappedAutoConnectFtpAsync(FtpClient client)
+                static async Task<FtpProfile> WrappedAutoConnectFtpAsync(FtpClient client)
                 {
                     try
                     {


### PR DESCRIPTION
**Resolved / Related Issues**
Auth failure could yield `FtpAuthenticationException` instead of returning a null `FtpProfile`
