### PR TITLE
#1225 Removing redundant information on properties dialogue when multiple items are selected.

### DIFF
--- a/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/Files/Views/Pages/PropertiesGeneral.xaml
@@ -193,22 +193,6 @@
                 ShowError="{x:Bind ViewModel.ItemMD5HashCalcError, Mode=OneWay}"
                 Visibility="{x:Bind ViewModel.ItemMD5HashProgressVisibility, Mode=OneWay}" />
 
-            <TextBlock
-                x:Name="PropertiesCount"
-                x:Uid="PropertiesFilesAndFoldersCount"
-                Grid.Row="7"
-                Grid.Column="0"
-                Style="{StaticResource PropertyName}"
-                Text="Contains:"
-                Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
-            <TextBlock
-                x:Name="itemFilesAndFoldersCountValue"
-                Grid.Row="7"
-                Grid.Column="1"
-                Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.FilesAndFoldersCountString, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
-
             <MenuFlyoutSeparator
                 Grid.Row="8"
                 Grid.Column="0"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved/related issues by this PR.
- Closes #1225 Removing redundant information on properties dialogue when multiple items are selected.
- Based on comment https://github.com/files-community/Files/pull/6629#issuecomment-953947125

**Details of Changes**
- Removing redundant information on properties dialogue when multiple items are selected.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility

**Screenshots (optional)**
**Before**
<img width="302" alt="image" src="https://user-images.githubusercontent.com/11182796/139565625-c31d05c9-557e-4b04-aa20-861063ece6e4.png">

**After**
<img width="302" alt="image" src="https://user-images.githubusercontent.com/11182796/139565643-f2c28c60-f2e5-4789-b14b-94d89ba7d795.png">

