### PR TITLE
Open drive selection page when opening StorageSense for drive != C:

### DIFF
--- a/Files.Launcher/MessageHandlers/ApplicationLaunchHandler.cs
+++ b/Files.Launcher/MessageHandlers/ApplicationLaunchHandler.cs
@@ -24,6 +24,15 @@ namespace FilesFullTrust.MessageHandlers
         {
             switch (arguments)
             {
+                case "LaunchSettings":
+                    {
+                        var page = message.Get("page", (string)null);
+                        var appActiveManager = new Shell32.IApplicationActivationManager();
+                        appActiveManager.ActivateApplication("windows.immersivecontrolpanel_cw5n1h2txyewy!microsoft.windows.immersivecontrolpanel",
+                            page, Shell32.ACTIVATEOPTIONS.AO_NONE, out _);
+                        break;
+                    }
+
                 case "LaunchApp":
                     if (message.ContainsKey("Application"))
                     {

--- a/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -226,6 +226,7 @@
                                         Background="Transparent"
                                         BorderBrush="Transparent"
                                         Click="GoToStorageSense_Click"
+                                        Tag="{x:Bind Path}"
                                         ToolTipService.ToolTip="Open Storage Sense">
                                         <FontIcon
                                             HorizontalAlignment="Center"

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Windows.Foundation.Collections;
+using Windows.Foundation.Metadata;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -198,7 +199,22 @@ namespace Files.UserControls.Widgets
 
         private async void GoToStorageSense_Click(object sender, RoutedEventArgs e)
         {
-            await Launcher.LaunchUriAsync(new Uri("ms-settings:storagesense"));
+            string clickedCard = (sender as Button).Tag.ToString();
+            var connection = await AppServiceConnectionHelper.Instance;
+            if (connection != null
+                && !clickedCard.StartsWith("C:", StringComparison.OrdinalIgnoreCase)
+                && ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+            {
+                await connection.SendMessageAsync(new ValueSet()
+                {
+                    { "Arguments", "LaunchSettings" },
+                    { "page", "page=SettingsPageStorageSenseStorageOverview&target=SystemSettings_StorageSense_VolumeListLink" }
+                });
+            }
+            else
+            {
+                await Launcher.LaunchUriAsync(new Uri("ms-settings:storagesense"));
+            }
         }
 
         private async Task<bool> CheckEmptyDrive(string drivePath)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6664

**Details of Changes**
Add details of changes here.
- Open the [Overview](https://user-images.githubusercontent.com/9673091/139582020-cfffce12-e0d3-43a2-9d36-c092664b958b.png) page when clicking on C: drive and the [Drive selection](https://user-images.githubusercontent.com/9673091/139582034-d651f887-2893-402a-83eb-66d906bdeab0.png) page when clicking on other drives.

@yair100 if you wish you can test the behavior proposed in #6664 (and confirm that it works on windows 11, I've tested only in a virtual machine).

**Validation**
How did you test these changes?
- [x] Tested on Windows 10 1809, Windows 10 21H2, Windows 11
