### PR TITLE
Fix SrollIntoView not working in DetailsView

### DIFF
--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -793,29 +793,14 @@
                                                         VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
                                                         VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
                                                         ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}">
-                                                        <Grid>
-                                                            <Grid.RowDefinitions>
-                                                                <RowDefinition Height="*" />
-                                                                <RowDefinition Height="Auto" />
-                                                            </Grid.RowDefinitions>
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="Auto" />
-                                                                <ColumnDefinition Width="*" />
-                                                            </Grid.ColumnDefinitions>
-                                                            <ItemsPresenter
-                                                                Padding="{TemplateBinding Padding}"
-                                                                HorizontalAlignment="Stretch"
-                                                                FooterTemplate="{TemplateBinding FooterTemplate}"
-                                                                FooterTransitions="{TemplateBinding FooterTransitions}"
-                                                                HeaderTemplate="{TemplateBinding HeaderTemplate}"
-                                                                HeaderTransitions="{TemplateBinding HeaderTransitions}" />
-
-                                                            <ContentPresenter
-                                                                Grid.Row="1"
-                                                                Grid.ColumnSpan="2"
-                                                                Padding="8,0,8,8"
-                                                                Content="{TemplateBinding Footer}" />
-                                                        </Grid>
+                                                        <ItemsPresenter
+                                                            Padding="{TemplateBinding Padding}"
+                                                            HorizontalAlignment="Stretch"
+                                                            Footer="{TemplateBinding Footer}"
+                                                            FooterTemplate="{TemplateBinding FooterTemplate}"
+                                                            FooterTransitions="{TemplateBinding FooterTransitions}"
+                                                            HeaderTemplate="{TemplateBinding HeaderTemplate}"
+                                                            HeaderTransitions="{TemplateBinding HeaderTransitions}" />
                                                     </ScrollViewer>
                                                 </Grid>
                                             </Border>

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -786,6 +786,19 @@ namespace Files.Views.LayoutModes
             var contentScroller = FileList.FindDescendant<ScrollViewer>(x => x.Name == "ScrollViewer");
             contentScroller.ViewChanged -= ContentScroller_ViewChanged;
             contentScroller.ViewChanged += ContentScroller_ViewChanged;
+
+            // Show empty space after last column
+            var presenter = contentScroller.FindDescendant<ScrollContentPresenter>(x => x.Name == "ScrollContentPresenter");
+            if (presenter is not null)
+            {
+                var parentGrid = presenter.Parent as Grid;
+                if (parentGrid is not null && parentGrid.ColumnDefinitions.Count == 2)
+                {
+                    presenter.SetValue(Grid.ColumnSpanProperty, 1);
+                    parentGrid.ColumnDefinitions[0].Width = GridLength.Auto;
+                    parentGrid.ColumnDefinitions[1].Width = new GridLength(1, GridUnitType.Star);
+                }
+            }
         }
 
         private void ContentScroller_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6322

**Details of Changes**
Add details of changes here.
- Fixes an issue for which typing a letter does not scroll the file list to the first matching item

Explanation: in a custom ListView template the ItemsPresenter must be the first child of the ScrollViewer or ScrollIntoView stops working

@yaichenbaum lets try again :) Needs testing on Windows 11.

**Validation**
How did you test these changes?
- [x] Built and ran the app
