### PR TITLE
Manually scroll to offset

### DIFF
--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -74,7 +74,7 @@ namespace Files.Views.LayoutModes
         private void ItemManipulationModel_ScrollIntoViewInvoked(object sender, ListedItem e)
         {
             FileList.ScrollIntoView(e);
-            ContentScroller.ChangeView(null, FileList.Items.IndexOf(e) * 36, null, true); // Scroll to index * item height
+            ContentScroller?.ChangeView(null, FileList.Items.IndexOf(e) * 36, null, true); // Scroll to index * item height
         }
 
         private void ItemManipulationModel_StartRenameItemInvoked(object sender, EventArgs e)

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -46,6 +46,8 @@ namespace Files.Views.LayoutModes
 
         private RelayCommand<string> UpdateSortOptionsCommand { get; set; }
 
+        public ScrollViewer ContentScroller { get; private set; }
+
         public DetailsLayoutBrowser() : base()
         {
             InitializeComponent();
@@ -72,6 +74,7 @@ namespace Files.Views.LayoutModes
         private void ItemManipulationModel_ScrollIntoViewInvoked(object sender, ListedItem e)
         {
             FileList.ScrollIntoView(e);
+            ContentScroller.ChangeView(null, FileList.Items.IndexOf(e) * 36, null, true); // Scroll to index * item height
         }
 
         private void ItemManipulationModel_StartRenameItemInvoked(object sender, EventArgs e)
@@ -783,9 +786,9 @@ namespace Files.Views.LayoutModes
 
         private void FileList_Loaded(object sender, RoutedEventArgs e)
         {
-            var contentScroller = FileList.FindDescendant<ScrollViewer>(x => x.Name == "ScrollViewer");
-            contentScroller.ViewChanged -= ContentScroller_ViewChanged;
-            contentScroller.ViewChanged += ContentScroller_ViewChanged;
+            ContentScroller = FileList.FindDescendant<ScrollViewer>(x => x.Name == "ScrollViewer");
+            ContentScroller.ViewChanged -= ContentScroller_ViewChanged;
+            ContentScroller.ViewChanged += ContentScroller_ViewChanged;
         }
 
         private void ContentScroller_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6322

**Details of Changes**
Add details of changes here.
- Fixes an issue for which typing a letter does not scroll the file list to the first matching item

Explanation: in a custom ListView template the ItemsPresenter must be the first child of the ScrollViewer or ScrollIntoView stops working. In this PR we manually scroll to "item index * item height".

Note: why we can't change the ListView Template -> #6667

**Validation**
How did you test these changes?
- [x] Built and ran the app
