### PR TITLE
Ignore case when checking zip extension

### DIFF
--- a/Files.Launcher/Helpers/ShellFolderHelpers.cs
+++ b/Files.Launcher/Helpers/ShellFolderHelpers.cs
@@ -34,7 +34,7 @@ namespace FilesFullTrust.Helpers
             {
                 return null;
             }
-            bool isFolder = folderItem.IsFolder && Path.GetExtension(folderItem.Name) != ".zip";
+            bool isFolder = folderItem.IsFolder && !".zip".Equals(Path.GetExtension(folderItem.Name), StringComparison.OrdinalIgnoreCase);
             if (folderItem.Properties == null)
             {
                 return new ShellFileItem(isFolder, folderItem.FileSystemPath, Path.GetFileName(folderItem.Name), folderItem.Name, DateTime.Now, DateTime.Now, DateTime.Now, null, 0, null);

--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -204,11 +204,14 @@ namespace Files.Filesystem
 
                 if (image.PixelWidth > 0)
                 {
-                    LoadFileIcon = true;
-                    PlaceholderDefaultIcon = null;
-                    NeedsPlaceholderGlyph = false;
-                    LoadDefaultIcon = false;
-                    LoadWebShortcutGlyph = false;
+                    Common.Extensions.IgnoreExceptions(() =>
+                    {
+                        LoadFileIcon = true;
+                        PlaceholderDefaultIcon = null;
+                        NeedsPlaceholderGlyph = false;
+                        LoadDefaultIcon = false;
+                        LoadWebShortcutGlyph = false;
+                    }, App.Logger); // 2009482836u
                 }
             }
         }

--- a/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -319,7 +319,7 @@ namespace Files.Filesystem.StorageEnumerators
                     opacity = Constants.UI.DimItemOpacity;
                 }
 
-                if (itemFileExtension == ".zip" && await ZipStorageFolder.CheckDefaultZipApp(itemPath))
+                if (".zip".Equals(itemFileExtension, StringComparison.OrdinalIgnoreCase) && await ZipStorageFolder.CheckDefaultZipApp(itemPath))
                 {
                     return new ZipItem(null, dateReturnFormat)
                     {

--- a/Files/Filesystem/StorageItems/ZipStorageFile.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFile.cs
@@ -391,7 +391,7 @@ namespace Files.Filesystem.StorageItems
 
         public static IAsyncOperation<BaseStorageFile> FromPathAsync(string path)
         {
-            var marker = path.IndexOf(".zip");
+            var marker = path.IndexOf(".zip", StringComparison.OrdinalIgnoreCase);
             if (marker != -1)
             {
                 var containerPath = path.Substring(0, marker + ".zip".Length);

--- a/Files/Filesystem/StorageItems/ZipStorageFolder.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFolder.cs
@@ -507,7 +507,7 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run<BaseStorageFolder>(async (cancellationToken) =>
             {
-                var marker = path.IndexOf(".zip");
+                var marker = path.IndexOf(".zip", StringComparison.OrdinalIgnoreCase);
                 if (marker != -1)
                 {
                     var containerPath = path.Substring(0, marker + ".zip".Length);
@@ -526,7 +526,7 @@ namespace Files.Filesystem.StorageItems
 
         public static bool IsZipPath(string path)
         {
-            var marker = path.IndexOf(".zip");
+            var marker = path.IndexOf(".zip", StringComparison.OrdinalIgnoreCase);
             if (marker != -1)
             {
                 marker += ".zip".Length;

--- a/Files/Helpers/ZipHelpers.cs
+++ b/Files/Helpers/ZipHelpers.cs
@@ -112,7 +112,7 @@ namespace Files.Helpers
                     {
                         int currentBlockSize = 0;
 
-                        if (!await Common.Extensions.IgnoreExceptions(async () =>
+                        try
                         {
                             using (Stream entryStream = zipFile.GetInputStream(entry))
                             {
@@ -126,8 +126,10 @@ namespace Files.Helpers
                                     }
                                 }
                             }
-                        }, App.Logger))
+                        }
+                        catch (Exception ex)
                         {
+                            App.Logger.Warn(ex, $"Error extracting file: {filePath}");
                             return; // TODO: handle error
                         }
                     }

--- a/Files/Helpers/ZipHelpers.cs
+++ b/Files/Helpers/ZipHelpers.cs
@@ -112,17 +112,23 @@ namespace Files.Helpers
                     {
                         int currentBlockSize = 0;
 
-                        using (Stream entryStream = zipFile.GetInputStream(entry))
+                        if (!await Common.Extensions.IgnoreExceptions(async () =>
                         {
-                            while ((currentBlockSize = await entryStream.ReadAsync(buffer, 0, buffer.Length)) > 0)
+                            using (Stream entryStream = zipFile.GetInputStream(entry))
                             {
-                                await destinationStream.WriteAsync(buffer, 0, currentBlockSize);
-
-                                if (cancellationToken.IsCancellationRequested) // Check if cancelled
+                                while ((currentBlockSize = await entryStream.ReadAsync(buffer, 0, buffer.Length)) > 0)
                                 {
-                                    return;
+                                    await destinationStream.WriteAsync(buffer, 0, currentBlockSize);
+
+                                    if (cancellationToken.IsCancellationRequested) // Check if cancelled
+                                    {
+                                        return;
+                                    }
                                 }
                             }
+                        }, App.Logger))
+                        {
+                            return; // TODO: handle error
                         }
                     }
 

--- a/Files/Services/Implementation/FileTagsSettingsService.cs
+++ b/Files/Services/Implementation/FileTagsSettingsService.cs
@@ -33,7 +33,7 @@ namespace Files.Services.Implementation
 
         public FileTag GetTagById(string uid)
         {
-            var tag = FileTagList.SingleOrDefault(x => x.Uid == uid);
+            var tag = FileTagList.SingleOrDefault(x => x.Uid is not null && x.Uid == uid);
             if (!string.IsNullOrEmpty(uid) && tag == null)
             {
                 tag = new FileTag("FileTagUnknown".GetLocalized(), "#9ea3a1", uid);

--- a/Files/Services/Implementation/FileTagsSettingsService.cs
+++ b/Files/Services/Implementation/FileTagsSettingsService.cs
@@ -33,7 +33,12 @@ namespace Files.Services.Implementation
 
         public FileTag GetTagById(string uid)
         {
-            var tag = FileTagList.SingleOrDefault(x => x.Uid is not null && x.Uid == uid);
+            if (FileTagList.Any(x => x.Uid == null))
+            {
+                // Tags file is invalid, regenerate
+                FileTagList = s_defaultFileTags;
+            }
+            var tag = FileTagList.SingleOrDefault(x => x.Uid == uid);
             if (!string.IsNullOrEmpty(uid) && tag == null)
             {
                 tag = new FileTag("FileTagUnknown".GetLocalized(), "#9ea3a1", uid);


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6495
- Closes #6491
- Test fix for #6605
- Fixes 1152067677u
- Fixes 2989330824u
- Fixes 2009482836u

**Details of Changes**
Add details of changes here.
- Added try-catch when extracting files
- Compare zip extension ignoring case
- Regenerate file tags json file if invalid

**Validation**
How did you test these changes?
- [x] Built and ran the app
