### PR TITLE
Added a hotkey for playing audio and video in the preview pane

### DIFF
--- a/Files/UserControls/FilePreviews/MediaPreview.xaml
+++ b/Files/UserControls/FilePreviews/MediaPreview.xaml
@@ -9,7 +9,9 @@
     d:DesignWidth="400"
     Unloaded="{x:Bind ViewModel.PreviewControlBase_Unloaded}"
     mc:Ignorable="d">
-
+    <UserControl.KeyboardAccelerators>
+        <KeyboardAccelerator Key="P" Modifiers="Control,Menu" Invoked="{x:Bind PlayerContext.MediaPlayer.Play}"/>
+    </UserControl.KeyboardAccelerators>
     <Grid CornerRadius="{StaticResource ControlCornerRadius}">
         <MediaPlayerElement
             x:Name="PlayerContext"

--- a/Files/UserControls/FilePreviews/MediaPreview.xaml
+++ b/Files/UserControls/FilePreviews/MediaPreview.xaml
@@ -10,7 +10,7 @@
     Unloaded="{x:Bind ViewModel.PreviewControlBase_Unloaded}"
     mc:Ignorable="d">
     <UserControl.KeyboardAccelerators>
-        <KeyboardAccelerator Key="P" Modifiers="Control,Menu" Invoked="{x:Bind PlayerContext.MediaPlayer.Play}"/>
+        <KeyboardAccelerator Key="P" Modifiers="Control,Menu" Invoked="TogglePlaybackAcceleratorInvoked"/>
     </UserControl.KeyboardAccelerators>
     <Grid CornerRadius="{StaticResource ControlCornerRadius}">
         <MediaPlayerElement

--- a/Files/UserControls/FilePreviews/MediaPreview.xaml.cs
+++ b/Files/UserControls/FilePreviews/MediaPreview.xaml.cs
@@ -1,9 +1,11 @@
-﻿using Files.Services;
+﻿using System;
+using Files.Services;
 using Files.ViewModels.Previews;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Windows.Media.Playback;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
@@ -33,6 +35,18 @@ namespace Files.UserControls.FilePreviews
             if (sender.Volume != UserSettingsService.PreviewPaneSettingsService.PreviewPaneMediaVolume)
             {
                 UserSettingsService.PreviewPaneSettingsService.PreviewPaneMediaVolume = sender.Volume;
+            }
+        }
+
+        private void TogglePlaybackAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            if (PlayerContext.MediaPlayer.PlaybackSession.PlaybackState is not MediaPlaybackState.Playing)
+            {
+                PlayerContext.MediaPlayer.Play();
+            }
+            else
+            {
+                PlayerContext.MediaPlayer.Pause();
             }
         }
     }


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #6287 

**Details of Changes**
- Added a keyboard accelerator in MediaPreview user control that plays media on "ctrl+alt+p " as suggested.

**Validation**
- [X] Built and ran the app.