### PR TITLE
Fixed a crash that would occur when dropping a shortcut over an executable file

### DIFF
--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -416,8 +416,12 @@ namespace Files.Filesystem
                     // Open with piggybacks off of the link operation, since there isn't one for it
                     if (isTargetExecutable)
                     {
-                        var items = await packageView.GetStorageItemsAsync();
-                        NavigationHelpers.OpenItemsWithExecutable(associatedInstance, items.ToList(), destination);
+                        var handledByFtp = await CheckDragNeedsFulltrust(packageView);
+                        if (!handledByFtp)
+                        {
+                            var items = await GetDraggedStorageItems(packageView);
+                            NavigationHelpers.OpenItemsWithExecutable(associatedInstance, items.ToList(), destination);
+                        }
                         return ReturnResult.Success;
                     }
                     else

--- a/Files/Helpers/NavigationHelpers.cs
+++ b/Files/Helpers/NavigationHelpers.cs
@@ -86,7 +86,7 @@ namespace Files.Helpers
             }
         }
 
-        public static async void OpenItemsWithExecutable(IShellPage associatedInstance, List<IStorageItem> items, string executable)
+        public static async void OpenItemsWithExecutable(IShellPage associatedInstance, List<IStorageItemWithPath> items, string executable)
         {
             if (associatedInstance.FilesystemViewModel.WorkingDirectory.StartsWith(CommonPaths.RecycleBinPath))
             {


### PR DESCRIPTION
Add details of changes here.
- Fixed a crash when dropping a shortcut over an executable file

**Validation**
How did you test these changes?
- [x] Built and ran the app
