### PR TITLE
Provide dragged files as StorageFile when possible

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -821,6 +821,11 @@ namespace Files
                 return;
             }
 
+            var onlyStandard = selectedStorageItems.All(x => x is StorageFile || x is StorageFolder || x is SystemStorageFile || x is SystemStorageFolder);
+            if (onlyStandard)
+            {
+                selectedStorageItems = await selectedStorageItems.ToStandardStorageItemsAsync();
+            }
             if (selectedStorageItems.Count == 1)
             {
                 if (selectedStorageItems[0] is IStorageFile file)

--- a/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -369,7 +369,7 @@ namespace Files.Filesystem
                 }
                 catch (NotSupportedException)
                 {
-                    // Ignore items that can0t be converted
+                    // Ignore items that can't be converted
                 }
             }
             return newItems;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6697

**Details of Changes**
Add details of changes here.
- Provide dragged files as StorageFile when possible. Fixes dropping to some UWP apps, e.g Snip and Sketch.

**Validation**
How did you test these changes?
- [x] Built and ran the app
