### PR TITLE
Fixed an issue where changing the sort option would create a hidden file

### DIFF
--- a/Files/ViewModels/FolderSettingsViewModel.cs
+++ b/Files/ViewModels/FolderSettingsViewModel.cs
@@ -8,7 +8,6 @@ using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Mvvm.Input;
 using Newtonsoft.Json;
 using System;
-using System.IO;
 using System.Linq;
 using Windows.Storage;
 using static Files.ViewModels.FolderLayoutInformation;
@@ -539,7 +538,7 @@ namespace Files.ViewModels
 
         private static LayoutPreferences ReadLayoutPreferencesFromAds(string folderPath)
         {
-            var str = NativeFileOperationsHelper.ReadStringFromFile(Path.Combine(folderPath, "desktop.files.json"));
+            var str = NativeFileOperationsHelper.ReadStringFromFile($"{folderPath}:files_layoutmode");
             try
             {
                 return string.IsNullOrEmpty(str) ? null : JsonConvert.DeserializeObject<LayoutPreferences>(str);
@@ -552,14 +551,12 @@ namespace Files.ViewModels
 
         private static bool WriteLayoutPreferencesToAds(string folderPath, LayoutPreferences prefs)
         {
-            var prefsFilePath = Path.Combine(folderPath, "desktop.files.json");
             if (LayoutPreferences.DefaultLayoutPreferences.Equals(prefs))
             {
-                NativeFileOperationsHelper.DeleteFileFromApp(prefsFilePath);
+                NativeFileOperationsHelper.DeleteFileFromApp($"{folderPath}:files_layoutmode");
                 return false;
             }
-            return NativeFileOperationsHelper.WriteStringToFile(
-                prefsFilePath, JsonConvert.SerializeObject(prefs), NativeFileOperationsHelper.File_Attributes.Hidden);
+            return NativeFileOperationsHelper.WriteStringToFile($"{folderPath}:files_layoutmode", JsonConvert.SerializeObject(prefs));
         }
 
         private static LayoutPreferences ReadLayoutPreferencesFromSettings(string folderPath)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6739

**Details of Changes**
Add details of changes here.
This PR reverts a change mistakenly introduced in #6648 which causes layout mode preferences to be saved in a hidden file called "files.desktop.json" instead as an alternate data stream of the folder.

{ I was testing such a change because the current solution causes some issues for me: I have a few folders "stuck" in a layout mode I can't change anymore and the only solution is to create a new folder and copy the contents over. The file-based solution would fix this and give the users a little more control. But I didn't mean to include it in that PR and it was not discussed. }

**Validation**
How did you test these changes?
- [x] Built and ran the app
