### PR TITLE
Fixed an issue where the option to reset the default file explorer wouldn't work after reinstalling Files

### DIFF
--- a/Files.Launcher/MessageHandlers/Win32MessageHandler.cs
+++ b/Files.Launcher/MessageHandlers/Win32MessageHandler.cs
@@ -146,11 +146,14 @@ namespace FilesFullTrust.MessageHandlers
                         var enable = (bool)message["Value"];
                         var destFolder = Path.Combine(ApplicationData.Current.LocalFolder.Path, "FilesOpenDialog");
                         Directory.CreateDirectory(destFolder);
-                        if (enable)
+                        foreach (var file in Directory.GetFiles(Path.Combine(Package.Current.InstalledLocation.Path, "Files.Launcher", "Assets", "FilesOpenDialog")))
                         {
-                            foreach (var file in Directory.GetFiles(Path.Combine(Package.Current.InstalledLocation.Path, "Files.Launcher", "Assets", "FilesOpenDialog")))
+                            if (!Extensions.IgnoreExceptions(() => File.Copy(file, Path.Combine(destFolder, Path.GetFileName(file)), true), Program.Logger))
                             {
-                                File.Copy(file, Path.Combine(destFolder, Path.GetFileName(file)), true);
+                                // Error copying files
+                                DetectIsSetAsDefaultFileManager();
+                                await Win32API.SendMessageAsync(connection, new ValueSet() { { "Success", false } }, message.Get("RequestID", (string)null));
+                                return;
                             }
                         }
 
@@ -175,11 +178,14 @@ namespace FilesFullTrust.MessageHandlers
                         var enable = (bool)message["Value"];
                         var destFolder = Path.Combine(ApplicationData.Current.LocalFolder.Path, "FilesOpenDialog");
                         Directory.CreateDirectory(destFolder);
-                        if (enable)
+                        foreach (var file in Directory.GetFiles(Path.Combine(Package.Current.InstalledLocation.Path, "Files.Launcher", "Assets", "FilesOpenDialog")))
                         {
-                            foreach (var file in Directory.GetFiles(Path.Combine(Package.Current.InstalledLocation.Path, "Files.Launcher", "Assets", "FilesOpenDialog")))
+                            if (!Extensions.IgnoreExceptions(() => File.Copy(file, Path.Combine(destFolder, Path.GetFileName(file)), true), Program.Logger))
                             {
-                                File.Copy(file, Path.Combine(destFolder, Path.GetFileName(file)), true);
+                                // Error copying files
+                                DetectIsSetAsOpenFileDialog();
+                                await Win32API.SendMessageAsync(connection, new ValueSet() { { "Success", false } }, message.Get("RequestID", (string)null));
+                                return;
                             }
                         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Helps with #6729

**Details of Changes**
Add details of changes here.
- Fixed an issue where after reinstalling Files it was not possible to turn off the "Set Files As Default" option. The install/uninstall reg files were only copied when enabling the setting.

**Validation**
How did you test these changes?
- [x] Built and ran the app
