### PR TITLE
Fix for #6897 - grouping by date might include files from previous week 

### DIFF
--- a/Files/Extensions/DateTimeExtensions.cs
+++ b/Files/Extensions/DateTimeExtensions.cs
@@ -82,12 +82,12 @@ namespace Files.Extensions
                 return ("ItemTimeText_Yesterday".GetLocalized(), today.Subtract(TimeSpan.FromDays(1)).ToUserDateString(), "\ue161", 1);
             }
 
-            if (diff.Days <= 7 && w.GetWeekOfYear() == t2.GetWeekOfYear() && w.Year == t2.Year)
+            if (diff.Days < 7 && w.GetWeekOfYear() == t2.GetWeekOfYear() && w.Year == t2.Year)
             {
                 return ("ItemTimeText_ThisWeek".GetLocalized(), t.Subtract(TimeSpan.FromDays((int)t.DayOfWeek)).ToUserDateString(), "\uE162", 2);
             }
 
-            if (diff.Days <= 14 && w.GetWeekOfYear() == t2.GetWeekOfYear() && w.Year == t2.Year)
+            if (diff.Days < 14 && w.GetWeekOfYear() == t2.GetWeekOfYear() && w.Year == t2.Year)
             {
                 return ("ItemTimeText_LastWeek".GetLocalized(), t.Subtract(TimeSpan.FromDays((int)t.DayOfWeek + 7)).Date.ToShortDateString(), "\uE162", 3);
             }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6897

**Details of Changes**
Add details of changes here.
- Fixed the number of days comparison.
- If the difference is 7 then it was modified 8 days ago. If the difference is 14 then it was modified 15 days ago.
- Therefore "This week" is difference of 6 days or less and "Last week" is difference of 13 or less (between 7 to 13 inclusive)

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility
