### PR TITLE
Fixed an issue where restoring items from recycle bin would remove the file extension

### DIFF
--- a/Files.Launcher/DeviceWatcher.cs
+++ b/Files.Launcher/DeviceWatcher.cs
@@ -41,9 +41,9 @@ namespace FilesFullTrust
         private async void DeviceModifiedEvent(object sender, EventArrivedEventArgs e)
         {
             CimInstance obj = e.NewEvent.Instance;
-            var deviceName = (string)obj.CimInstanceProperties["Name"].Value;
-            var deviceId = (string)obj.CimInstanceProperties["DeviceID"].Value;
-            var volumeName = (string)obj.CimInstanceProperties["VolumeName"].Value;
+            var deviceName = (string)obj.CimInstanceProperties["Name"]?.Value;
+            var deviceId = (string)obj.CimInstanceProperties["DeviceID"]?.Value;
+            var volumeName = (string)obj.CimInstanceProperties["VolumeName"]?.Value;
             var eventType = volumeName != null ? DeviceEvent.Inserted : DeviceEvent.Ejected;
             System.Diagnostics.Debug.WriteLine($"Drive modify event: {deviceName}, {deviceId}, {eventType}");
             await SendEvent(deviceName, deviceId, eventType);

--- a/Files.Launcher/Helpers/ShellFolderHelpers.cs
+++ b/Files.Launcher/Helpers/ShellFolderHelpers.cs
@@ -34,7 +34,7 @@ namespace FilesFullTrust.Helpers
             {
                 return null;
             }
-            bool isFolder = folderItem.IsFolder && !".zip".Equals(Path.GetExtension(folderItem.Name), StringComparison.OrdinalIgnoreCase);
+            bool isFolder = folderItem.IsFolder && !folderItem.Attributes.HasFlag(ShellItemAttribute.Stream);
             if (folderItem.Properties == null)
             {
                 return new ShellFileItem(isFolder, folderItem.FileSystemPath, Path.GetFileName(folderItem.Name), folderItem.Name, DateTime.Now, DateTime.Now, DateTime.Now, null, 0, null);
@@ -43,11 +43,9 @@ namespace FilesFullTrust.Helpers
                 Ole32.PROPERTYKEY.System.ParsingPath, out var parsingPath);
             parsingPath ??= folderItem.FileSystemPath; // True path on disk
             folderItem.Properties.TryGetValue<string>(
-                Ole32.PROPERTYKEY.System.ItemName, out var rawFileName);
-            folderItem.Properties.TryGetValue<string>(
                 Ole32.PROPERTYKEY.System.ItemNameDisplay, out var fileName);
             string filePath = folderItem.Name; // Original file path + name (recycle bin only)
-            if (!isFolder && !string.IsNullOrEmpty(rawFileName) && Path.GetExtension(rawFileName) is string realExtension && !string.IsNullOrEmpty(realExtension))
+            if (!isFolder && !string.IsNullOrEmpty(parsingPath) && Path.GetExtension(parsingPath) is string realExtension && !string.IsNullOrEmpty(realExtension))
             {
                 if (!string.IsNullOrEmpty(fileName) && !fileName.EndsWith(realExtension))
                 {
@@ -73,7 +71,6 @@ namespace FilesFullTrust.Helpers
                 folderItem.Properties.GetPropertyString(Ole32.PROPERTYKEY.System.Size) : null;
             folderItem.Properties.TryGetValue<string>(
                 Ole32.PROPERTYKEY.System.ItemTypeText, out var fileType);
-            folderItem.Properties.TryGetValue<string>(Ole32.PROPERTYKEY.System.FileExtension, out var fileExtension);
             return new ShellFileItem(isFolder, parsingPath, fileName, filePath, recycleDate, modifiedDate, createdDate, fileSize, fileSizeBytes ?? 0, fileType);
         }
     }

--- a/Files.Launcher/Helpers/ShellFolderHelpers.cs
+++ b/Files.Launcher/Helpers/ShellFolderHelpers.cs
@@ -39,8 +39,7 @@ namespace FilesFullTrust.Helpers
             {
                 return new ShellFileItem(isFolder, folderItem.FileSystemPath, Path.GetFileName(folderItem.Name), folderItem.Name, DateTime.Now, DateTime.Now, DateTime.Now, null, 0, null);
             }
-            folderItem.Properties.TryGetValue<string>(
-                Ole32.PROPERTYKEY.System.ParsingPath, out var parsingPath);
+            var parsingPath = folderItem.GetDisplayName(ShellItemDisplayString.DesktopAbsoluteParsing);
             parsingPath ??= folderItem.FileSystemPath; // True path on disk
             folderItem.Properties.TryGetValue<string>(
                 Ole32.PROPERTYKEY.System.ItemNameDisplay, out var fileName);

--- a/Files.Launcher/Helpers/ShellFolderHelpers.cs
+++ b/Files.Launcher/Helpers/ShellFolderHelpers.cs
@@ -43,7 +43,14 @@ namespace FilesFullTrust.Helpers
                 Ole32.PROPERTYKEY.System.ParsingPath, out var parsingPath);
             parsingPath ??= folderItem.FileSystemPath; // True path on disk
             folderItem.Properties.TryGetValue<string>(
+                Ole32.PROPERTYKEY.System.ItemName, out var rawFileName);
+            folderItem.Properties.TryGetValue<string>(
                 Ole32.PROPERTYKEY.System.ItemNameDisplay, out var fileName);
+            if (!isFolder && !string.IsNullOrEmpty(rawFileName) && !string.IsNullOrEmpty(fileName)
+                && Path.GetExtension(rawFileName) is string realExtension && !string.IsNullOrEmpty(realExtension) && !fileName.EndsWith(realExtension))
+            {
+                fileName = $"{fileName}{realExtension}";
+            }
             fileName ??= Path.GetFileName(folderItem.Name); // Original file name
             string filePath = folderItem.Name; // Original file path + name (recycle bin only)
             folderItem.Properties.TryGetValue<System.Runtime.InteropServices.ComTypes.FILETIME?>(
@@ -60,6 +67,7 @@ namespace FilesFullTrust.Helpers
                 folderItem.Properties.GetPropertyString(Ole32.PROPERTYKEY.System.Size) : null;
             folderItem.Properties.TryGetValue<string>(
                 Ole32.PROPERTYKEY.System.ItemTypeText, out var fileType);
+            folderItem.Properties.TryGetValue<string>(Ole32.PROPERTYKEY.System.FileExtension, out var fileExtension);
             return new ShellFileItem(isFolder, parsingPath, fileName, filePath, recycleDate, modifiedDate, createdDate, fileSize, fileSizeBytes ?? 0, fileType);
         }
     }

--- a/Files.Launcher/Helpers/ShellFolderHelpers.cs
+++ b/Files.Launcher/Helpers/ShellFolderHelpers.cs
@@ -44,6 +44,7 @@ namespace FilesFullTrust.Helpers
             parsingPath ??= folderItem.FileSystemPath; // True path on disk
             folderItem.Properties.TryGetValue<string>(
                 Ole32.PROPERTYKEY.System.ItemNameDisplay, out var fileName);
+            fileName ??= Path.GetFileName(folderItem.Name); // Original file name
             string filePath = folderItem.Name; // Original file path + name (recycle bin only)
             if (!isFolder && !string.IsNullOrEmpty(parsingPath) && Path.GetExtension(parsingPath) is string realExtension && !string.IsNullOrEmpty(realExtension))
             {
@@ -56,7 +57,6 @@ namespace FilesFullTrust.Helpers
                     filePath = $"{filePath}{realExtension}";
                 }
             }
-            fileName ??= Path.GetFileName(folderItem.Name); // Original file name
             folderItem.Properties.TryGetValue<System.Runtime.InteropServices.ComTypes.FILETIME?>(
                 Ole32.PROPERTYKEY.System.Recycle.DateDeleted, out var fileTime);
             var recycleDate = fileTime?.ToDateTime().ToLocalTime() ?? DateTime.Now; // This is LocalTime

--- a/Files.Launcher/Helpers/ShellFolderHelpers.cs
+++ b/Files.Launcher/Helpers/ShellFolderHelpers.cs
@@ -46,13 +46,19 @@ namespace FilesFullTrust.Helpers
                 Ole32.PROPERTYKEY.System.ItemName, out var rawFileName);
             folderItem.Properties.TryGetValue<string>(
                 Ole32.PROPERTYKEY.System.ItemNameDisplay, out var fileName);
-            if (!isFolder && !string.IsNullOrEmpty(rawFileName) && !string.IsNullOrEmpty(fileName)
-                && Path.GetExtension(rawFileName) is string realExtension && !string.IsNullOrEmpty(realExtension) && !fileName.EndsWith(realExtension))
+            string filePath = folderItem.Name; // Original file path + name (recycle bin only)
+            if (!isFolder && !string.IsNullOrEmpty(rawFileName) && Path.GetExtension(rawFileName) is string realExtension && !string.IsNullOrEmpty(realExtension))
             {
-                fileName = $"{fileName}{realExtension}";
+                if (!string.IsNullOrEmpty(fileName) && !fileName.EndsWith(realExtension))
+                {
+                    fileName = $"{fileName}{realExtension}";
+                }
+                if (!string.IsNullOrEmpty(filePath) && !filePath.EndsWith(realExtension))
+                {
+                    filePath = $"{filePath}{realExtension}";
+                }
             }
             fileName ??= Path.GetFileName(folderItem.Name); // Original file name
-            string filePath = folderItem.Name; // Original file path + name (recycle bin only)
             folderItem.Properties.TryGetValue<System.Runtime.InteropServices.ComTypes.FILETIME?>(
                 Ole32.PROPERTYKEY.System.Recycle.DateDeleted, out var fileTime);
             var recycleDate = fileTime?.ToDateTime().ToLocalTime() ?? DateTime.Now; // This is LocalTime

--- a/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
+++ b/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
@@ -252,7 +252,7 @@ namespace FilesFullTrust.MessageHandlers
                                         HRresult = (int)e.Result
                                     });
                                 };
-                                op.PostDeleteItem += (s, e) => UpdateFileTageDb(s, e, "delete");
+                                op.PostDeleteItem += (s, e) => UpdateFileTagsDb(s, e, "delete");
                                 op.FinishOperations += (s, e) => deleteTcs.TrySetResult(e.Result.Succeeded);
                                 op.UpdateProgress += (s, e) =>
                                 {
@@ -317,7 +317,7 @@ namespace FilesFullTrust.MessageHandlers
                                         HRresult = (int)e.Result
                                     });
                                 };
-                                op.PostRenameItem += (s, e) => UpdateFileTageDb(s, e, "rename");
+                                op.PostRenameItem += (s, e) => UpdateFileTagsDb(s, e, "rename");
                                 op.FinishOperations += (s, e) => renameTcs.TrySetResult(e.Result.Succeeded);
 
                                 try
@@ -384,7 +384,7 @@ namespace FilesFullTrust.MessageHandlers
                                         HRresult = (int)e.Result
                                     });
                                 };
-                                op.PostMoveItem += (s, e) => UpdateFileTageDb(s, e, "move");
+                                op.PostMoveItem += (s, e) => UpdateFileTagsDb(s, e, "move");
                                 op.FinishOperations += (s, e) => moveTcs.TrySetResult(e.Result.Succeeded);
                                 op.UpdateProgress += (s, e) =>
                                 {
@@ -459,7 +459,7 @@ namespace FilesFullTrust.MessageHandlers
                                         HRresult = (int)e.Result
                                     });
                                 };
-                                op.PostCopyItem += (s, e) => UpdateFileTageDb(s, e, "copy");
+                                op.PostCopyItem += (s, e) => UpdateFileTagsDb(s, e, "copy");
                                 op.FinishOperations += (s, e) => copyTcs.TrySetResult(e.Result.Succeeded);
                                 op.UpdateProgress += (s, e) =>
                                 {
@@ -705,7 +705,7 @@ namespace FilesFullTrust.MessageHandlers
             progressHandler.WaitForCompletion();
         }
 
-        private void UpdateFileTageDb(object sender, ShellFileOperations.ShellFileOpEventArgs e, string operationType)
+        private void UpdateFileTagsDb(object sender, ShellFileOperations.ShellFileOpEventArgs e, string operationType)
         {
             if (e.Result.Succeeded)
             {

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -75,6 +75,7 @@ namespace FilesFullTrust
                 deviceWatcher?.Dispose();
                 connection?.Dispose();
                 appServiceExit?.Dispose();
+                appServiceExit = null;
             }
         }
 
@@ -115,7 +116,7 @@ namespace FilesFullTrust
             }
             else
             {
-                appServiceExit.Set();
+                appServiceExit?.Set();
             }
         }
 
@@ -135,7 +136,7 @@ namespace FilesFullTrust
             }
             if (!isConnected)
             {
-                appServiceExit.Set();
+                appServiceExit?.Set();
             }
         }
 
@@ -166,7 +167,7 @@ namespace FilesFullTrust
             }
             else // Disconnected
             {
-                appServiceExit.Set();
+                appServiceExit?.Set();
             }
         }
 
@@ -207,7 +208,7 @@ namespace FilesFullTrust
             {
                 case "Terminate":
                     // Exit fulltrust process (UWP is closed or suspended)
-                    appServiceExit.Set();
+                    appServiceExit?.Set();
                     break;
 
                 case "Elevate":
@@ -225,7 +226,7 @@ namespace FilesFullTrust
                                 elevatedProcess.Start();
                             }
                             await Win32API.SendMessageAsync(connection, new ValueSet() { { "Success", 0 } }, message.Get("RequestID", (string)null));
-                            appServiceExit.Set();
+                            appServiceExit?.Set();
                         }
                         catch (Win32Exception)
                         {


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #6709

**Details of Changes**
- File extensions would not show in recycle bin even when the option is turned on in Files. Disabling Show file extensions in File Explorer causes this issue, this PR fixes it. 

**Validation**
How did you test these changes?
- [x] Built and ran the app
