### PR TITLE
Rolled back to WinUI 2.7

### DIFF
--- a/Files.Package/Package.appxmanifest
+++ b/Files.Package/Package.appxmanifest
@@ -9,7 +9,7 @@
          xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"
          xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
          IgnorableNamespaces="uap uap5 mp rescap desktop4 desktop">
-    <Identity Name="FilesDev" Publisher="CN=53EC4384-7F5B-4CF6-8C23-513FFE9D1AB7" Version="2.0.34.0" />
+    <Identity Name="FilesDev" Publisher="CN=53EC4384-7F5B-4CF6-8C23-513FFE9D1AB7" Version="2.0.39.0" />
     <Properties>
         <DisplayName>Files - Dev</DisplayName>
         <PublisherDisplayName>Yair A</PublisherDisplayName>

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -1465,7 +1465,7 @@
       <Version>7.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.8.0-prerelease.210927001</Version>
+      <Version>2.7.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Win32.Registry">
       <Version>5.0.0</Version>


### PR DESCRIPTION
The WinUI 2.8 preview doesn't currently work in the store with apps that support ARM64 so this is a temporary workaround.