### PR TITLE
Fix string for de, hu, nl causing crash when opening conflicts dialog

### DIFF
--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -2206,7 +2206,7 @@
         </trans-unit>
         <trans-unit id="ConflictingItemsDialogSubtitleSingleConflictMultipleNonConflicts" translate="yes" xml:space="preserve">
           <source>There is one conflicting file name, and {0} outgoing item(s).</source>
-          <target state="translated">Es gibt einen Dateinamenkonflikt und {1} verbleibende Elemente.</target>
+          <target state="translated">Es gibt einen Dateinamenkonflikt und {0} verbleibende Elemente.</target>
         </trans-unit>
         <trans-unit id="ConflictingItemsDialogItemOptionReplaceExisting.Text" translate="yes" xml:space="preserve">
           <source>Replace existing</source>

--- a/Files/MultilingualResources/Files.hu-HU.xlf
+++ b/Files/MultilingualResources/Files.hu-HU.xlf
@@ -2176,7 +2176,7 @@
         </trans-unit>
         <trans-unit id="ConflictingItemsDialogSubtitleSingleConflictMultipleNonConflicts" translate="yes" xml:space="preserve">
           <source>There is one conflicting file name, and {0} outgoing item(s).</source>
-          <target state="translated">Nincsenek ütköző fájlnevek, {1} kimenő elem.</target>
+          <target state="translated">Nincsenek ütköző fájlnevek, {0} kimenő elem.</target>
         </trans-unit>
         <trans-unit id="ConflictingItemsDialogItemOptionReplaceExisting.Text" translate="yes" xml:space="preserve">
           <source>Replace existing</source>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -2190,7 +2190,7 @@
         </trans-unit>
         <trans-unit id="ConflictingItemsDialogSubtitleSingleConflictMultipleNonConflicts" translate="yes" xml:space="preserve">
           <source>There is one conflicting file name, and {0} outgoing item(s).</source>
-          <target state="translated">Er is een conflicterende itemnaam en {1} uitgaand(e) item(s).</target>
+          <target state="translated">Er is een conflicterende itemnaam en {0} uitgaand(e) item(s).</target>
         </trans-unit>
         <trans-unit id="ConflictingItemsDialogItemOptionReplaceExisting.Text" translate="yes" xml:space="preserve">
           <source>Replace existing</source>


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes Appcenter: [3064744457u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/3064744457u)

**Details of Changes**
Add details of changes here.
- Fix string for de, hu, nl causing crash when opening conflicts dialog

**Validation**
How did you test these changes?
- [x] Built and ran the app
