### PR TITLE
Fix file extension being lost when renaming, fixes for search

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -501,7 +501,7 @@ namespace Files
                     List<ListedItem> liItemsToSelect = new List<ListedItem>();
                     foreach (string item in navigationArguments.SelectItems)
                     {
-                        liItemsToSelect.Add(ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.Where((li) => li.ItemName == item).First());
+                        liItemsToSelect.Add(ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.Where((li) => li.ItemNameRaw == item).First());
                     }
 
                     ItemManipulationModel.SetSelectedItems(liItemsToSelect);

--- a/Files/Filesystem/Search/FolderSearch.cs
+++ b/Files/Filesystem/Search/FolderSearch.cs
@@ -346,7 +346,7 @@ namespace Files.Filesystem.Search
                 listedItem = new ListedItem(null)
                 {
                     PrimaryItemAttribute = StorageItemTypes.File,
-                    ItemName = findData.cFileName,
+                    ItemNameRaw = findData.cFileName,
                     ItemPath = itemPath,
                     IsHiddenItem = isHidden,
                     LoadFileIcon = false,
@@ -362,7 +362,7 @@ namespace Files.Filesystem.Search
                     listedItem = new ListedItem(null)
                     {
                         PrimaryItemAttribute = StorageItemTypes.Folder,
-                        ItemName = findData.cFileName,
+                        ItemNameRaw = findData.cFileName,
                         ItemPath = itemPath,
                         IsHiddenItem = isHidden,
                         LoadFileIcon = false,
@@ -397,7 +397,7 @@ namespace Files.Filesystem.Search
                 listedItem = new ListedItem(null)
                 {
                     PrimaryItemAttribute = StorageItemTypes.Folder,
-                    ItemName = folder.DisplayName,
+                    ItemNameRaw = folder.DisplayName,
                     ItemPath = folder.Path,
                     ItemDateModifiedReal = props.DateModified,
                     ItemDateCreatedReal = folder.DateCreated,
@@ -422,7 +422,7 @@ namespace Files.Filesystem.Search
                 listedItem = new ListedItem(null)
                 {
                     PrimaryItemAttribute = StorageItemTypes.File,
-                    ItemName = file.DisplayName,
+                    ItemNameRaw = file.Name,
                     ItemPath = file.Path,
                     LoadFileIcon = false,
                     FileExtension = itemFileExtension,

--- a/Files/Filesystem/Search/FolderSearch.cs
+++ b/Files/Filesystem/Search/FolderSearch.cs
@@ -204,7 +204,7 @@ namespace Files.Filesystem.Search
                     return (hFileTsk, findDataTsk);
                 }).WithTimeoutAsync(TimeSpan.FromSeconds(5));
 
-                if (hFile != IntPtr.Zero)
+                if (hFile != IntPtr.Zero && hFile.ToInt64() != -1)
                 {
                     var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
                     var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
@@ -283,7 +283,7 @@ namespace Files.Filesystem.Search
                 return (hFileTsk, findDataTsk);
             }).WithTimeoutAsync(TimeSpan.FromSeconds(5));
 
-            if (hFile != IntPtr.Zero)
+            if (hFile != IntPtr.Zero && hFile.ToInt64() != -1)
             {
                 await Task.Run(() =>
                 {

--- a/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
@@ -164,7 +164,7 @@ namespace Files.Filesystem.StorageEnumerators
                 return new ListedItem(folder.FolderRelativeId, dateReturnFormat)
                 {
                     PrimaryItemAttribute = StorageItemTypes.Folder,
-                    ItemName = folder.DisplayName,
+                    ItemNameRaw = folder.DisplayName,
                     ItemDateModifiedReal = basicProperties.DateModified,
                     ItemDateCreatedReal = folder.DateCreated,
                     ItemType = folder.DisplayType,
@@ -191,8 +191,7 @@ namespace Files.Filesystem.StorageEnumerators
 
             var basicProperties = await file.GetBasicPropertiesAsync();
             // Display name does not include extension
-            var itemName = string.IsNullOrEmpty(file.DisplayName) || userSettingsService.PreferencesSettingsService.ShowFileExtensions ?
-                file.Name : file.DisplayName;
+            var itemName = file.Name;
             var itemModifiedDate = basicProperties.DateModified;
             var itemCreatedDate = file.DateCreated;
             var itemPath = string.IsNullOrEmpty(file.Path) ? PathNormalization.Combine(currentStorageFolder.Path, file.Name) : file.Path;
@@ -231,7 +230,7 @@ namespace Files.Filesystem.StorageEnumerators
                     Opacity = 1,
                     FileImage = null,
                     LoadFileIcon = itemThumbnailImgVis,
-                    ItemName = itemName,
+                    ItemNameRaw = itemName,
                     ItemDateModifiedReal = itemModifiedDate,
                     ItemDateCreatedReal = itemCreatedDate,
                     ItemType = itemType,

--- a/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -157,7 +157,7 @@ namespace Files.Filesystem.StorageEnumerators
             return new ListedItem(null, dateReturnFormat)
             {
                 PrimaryItemAttribute = StorageItemTypes.Folder,
-                ItemName = itemName,
+                ItemNameRaw = itemName,
                 ItemDateModifiedReal = itemModifiedDate,
                 ItemDateCreatedReal = itemCreatedDate,
                 ItemType = folderTypeTextLocalized,
@@ -182,23 +182,7 @@ namespace Files.Filesystem.StorageEnumerators
             IUserSettingsService userSettingsService = Ioc.Default.GetService<IUserSettingsService>();
 
             var itemPath = Path.Combine(pathRoot, findData.cFileName);
-
-            string itemName;
-            if (userSettingsService.PreferencesSettingsService.ShowFileExtensions && !findData.cFileName.EndsWith(".lnk") && !findData.cFileName.EndsWith(".url"))
-            {
-                itemName = findData.cFileName; // never show extension for shortcuts
-            }
-            else
-            {
-                if (findData.cFileName.StartsWith("."))
-                {
-                    itemName = findData.cFileName; // Always show full name for dotfiles.
-                }
-                else
-                {
-                    itemName = Path.GetFileNameWithoutExtension(itemPath);
-                }
-            }
+            var itemName = findData.cFileName;
 
             DateTime itemModifiedDate, itemCreatedDate, itemLastAccessDate;
             try
@@ -284,7 +268,7 @@ namespace Files.Filesystem.StorageEnumerators
                             FileImage = null,
                             LoadFileIcon = !(bool)response["IsFolder"] && itemThumbnailImgVis,
                             LoadWebShortcutGlyph = !(bool)response["IsFolder"] && isUrl && itemEmptyImgVis,
-                            ItemName = itemName,
+                            ItemNameRaw = itemName,
                             ItemDateModifiedReal = itemModifiedDate,
                             ItemDateAccessedReal = itemLastAccessDate,
                             ItemDateCreatedReal = itemCreatedDate,
@@ -327,7 +311,7 @@ namespace Files.Filesystem.StorageEnumerators
                         FileExtension = itemFileExtension,
                         FileImage = null,
                         LoadFileIcon = itemThumbnailImgVis,
-                        ItemName = itemName,
+                        ItemNameRaw = itemName,
                         IsHiddenItem = isHidden,
                         Opacity = opacity,
                         ItemDateModifiedReal = itemModifiedDate,
@@ -347,7 +331,7 @@ namespace Files.Filesystem.StorageEnumerators
                         FileExtension = itemFileExtension,
                         FileImage = null,
                         LoadFileIcon = itemThumbnailImgVis,
-                        ItemName = itemName,
+                        ItemNameRaw = itemName,
                         IsHiddenItem = isHidden,
                         Opacity = opacity,
                         ItemDateModifiedReal = itemModifiedDate,

--- a/Files/Filesystem/StorageItems/FtpStorageFile.cs
+++ b/Files/Filesystem/StorageItems/FtpStorageFile.cs
@@ -18,7 +18,7 @@ namespace Files.Filesystem.StorageItems
         public FtpStorageFile(FtpItem ftpItem)
         {
             DateCreated = ftpItem.ItemDateCreatedReal;
-            Name = ftpItem.ItemName;
+            Name = ftpItem.ItemNameRaw;
             Path = ftpItem.ItemPath;
             FtpPath = FtpHelpers.GetFtpPath(ftpItem.ItemPath);
         }

--- a/Files/Filesystem/StorageItems/FtpStorageFolder.cs
+++ b/Files/Filesystem/StorageItems/FtpStorageFolder.cs
@@ -20,7 +20,7 @@ namespace Files.Filesystem.StorageItems
         public FtpStorageFolder(FtpItem ftpItem)
         {
             DateCreated = ftpItem.ItemDateCreatedReal;
-            Name = ftpItem.ItemName;
+            Name = ftpItem.ItemNameRaw;
             Path = ftpItem.ItemPath;
             FtpPath = FtpHelpers.GetFtpPath(ftpItem.ItemPath);
         }

--- a/Files/Helpers/UIFilesystemHelpers.cs
+++ b/Files/Helpers/UIFilesystemHelpers.cs
@@ -234,11 +234,10 @@ namespace Files.Helpers
             }
         }
 
-        public static async Task<bool> RenameFileItemAsync(ListedItem item, string oldName, string newName, IShellPage associatedInstance)
+        public static async Task<bool> RenameFileItemAsync(ListedItem item, string newName, IShellPage associatedInstance)
         {
-            IUserSettingsService userSettingsService = Ioc.Default.GetService<IUserSettingsService>();
-
-            if (oldName == newName || string.IsNullOrEmpty(newName))
+            newName = item.ItemNameRaw.Replace(item.ItemName, newName);
+            if (item.ItemNameRaw == newName || string.IsNullOrEmpty(newName))
             {
                 return true;
             }
@@ -246,21 +245,11 @@ namespace Files.Helpers
             ReturnResult renamed = ReturnResult.InProgress;
             if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
             {
-                if (item.IsShortcutItem)
-                {
-                    newName += item.FileExtension;
-                }
-
                 renamed = await associatedInstance.FilesystemHelpers.RenameAsync(StorageItemHelpers.FromPathAndType(item.ItemPath, FilesystemItemType.Directory),
                     newName, NameCollisionOption.FailIfExists, true);
             }
             else
             {
-                if (item.IsShortcutItem || !userSettingsService.PreferencesSettingsService.ShowFileExtensions)
-                {
-                    newName += item.FileExtension;
-                }
-
                 renamed = await associatedInstance.FilesystemHelpers.RenameAsync(StorageItemHelpers.FromPathAndType(item.ItemPath, FilesystemItemType.File),
                     newName, NameCollisionOption.FailIfExists, true);
             }

--- a/Files/Helpers/UIFilesystemHelpers.cs
+++ b/Files/Helpers/UIFilesystemHelpers.cs
@@ -246,6 +246,11 @@ namespace Files.Helpers
             ReturnResult renamed = ReturnResult.InProgress;
             if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
             {
+                if (item.IsShortcutItem)
+                {
+                    newName += item.FileExtension;
+                }
+
                 renamed = await associatedInstance.FilesystemHelpers.RenameAsync(StorageItemHelpers.FromPathAndType(item.ItemPath, FilesystemItemType.Directory),
                     newName, NameCollisionOption.FailIfExists, true);
             }

--- a/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -255,7 +255,7 @@ namespace Files.Interacts
             associatedInstance.NavigateWithArguments(associatedInstance.InstanceViewModel.FolderSettings.GetLayoutType(folderPath), new NavigationArguments()
             {
                 NavPathParam = folderPath,
-                SelectItems = new[] { item.ItemName },
+                SelectItems = new[] { item.ItemNameRaw },
                 AssociatedTabInstance = associatedInstance
             });
         }

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -978,7 +978,7 @@ namespace Files.ViewModels
                                         cts.Token.ThrowIfCancellationRequested();
                                         await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
                                         {
-                                            item.ItemName = matchingStorageFolder.DisplayName;
+                                            item.ItemNameRaw = matchingStorageFolder.DisplayName;
                                         });
                                         await fileListCache.SaveFileDisplayNameToCache(item.ItemPath, matchingStorageFolder.DisplayName);
                                         if (folderSettings.DirectorySortOption == SortOption.Name && !isLoadingItems)
@@ -1316,7 +1316,7 @@ namespace Files.ViewModels
             {
                 PrimaryItemAttribute = StorageItemTypes.Folder,
                 ItemPropertiesInitialized = true,
-                ItemName = path.StartsWith(CommonPaths.RecycleBinPath) ? ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin") :
+                ItemNameRaw = path.StartsWith(CommonPaths.RecycleBinPath) ? ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin") :
                            path.StartsWith(CommonPaths.NetworkFolderPath) ? "Network".GetLocalized() : isFtp ? "FTP" : "Unknown",
                 ItemDateModifiedReal = DateTimeOffset.Now, // Fake for now
                 ItemDateCreatedReal = DateTimeOffset.Now, // Fake for now
@@ -1526,7 +1526,7 @@ namespace Files.ViewModels
                 {
                     PrimaryItemAttribute = StorageItemTypes.Folder,
                     ItemPropertiesInitialized = true,
-                    ItemName = rootFolder.DisplayName,
+                    ItemNameRaw = rootFolder.DisplayName,
                     ItemDateModifiedReal = basicProps.DateModified,
                     ItemType = rootFolder.DisplayType,
                     FileImage = null,
@@ -1584,7 +1584,7 @@ namespace Files.ViewModels
                 {
                     PrimaryItemAttribute = StorageItemTypes.Folder,
                     ItemPropertiesInitialized = true,
-                    ItemName = Path.GetFileName(path.TrimEnd('\\')),
+                    ItemNameRaw = Path.GetFileName(path.TrimEnd('\\')),
                     ItemDateModifiedReal = itemModifiedDate,
                     ItemDateCreatedReal = itemCreatedDate,
                     ItemType = folderTypeTextLocalized,
@@ -1950,7 +1950,7 @@ namespace Files.ViewModels
                 var binItem = new RecycleBinItem(null, dateReturnFormat)
                 {
                     PrimaryItemAttribute = StorageItemTypes.Folder,
-                    ItemName = item.FileName,
+                    ItemNameRaw = item.FileName,
                     ItemDateModifiedReal = item.ModifiedDate,
                     ItemDateCreatedReal = item.CreatedDate,
                     ItemDateDeletedReal = item.RecycleDate,
@@ -1974,23 +1974,7 @@ namespace Files.ViewModels
             else
             {
                 // File
-                string itemName;
-                if (UserSettingsService.PreferencesSettingsService.ShowFileExtensions && !item.FileName.EndsWith(".lnk") && !item.FileName.EndsWith(".url"))
-                {
-                    itemName = item.FileName; // never show extension for shortcuts
-                }
-                else
-                {
-                    if (item.FileName.StartsWith("."))
-                    {
-                        itemName = item.FileName; // Always show full name for dotfiles.
-                    }
-                    else
-                    {
-                        itemName = Path.GetFileNameWithoutExtension(item.FileName);
-                    }
-                }
-
+                string itemName = item.FileName;
                 string itemFileExtension = null;
                 if (item.FileName.Contains('.'))
                 {
@@ -2004,7 +1988,7 @@ namespace Files.ViewModels
                     LoadFileIcon = false,
                     IsHiddenItem = false,
                     Opacity = 1,
-                    ItemName = itemName,
+                    ItemNameRaw = itemName,
                     ItemDateModifiedReal = item.ModifiedDate,
                     ItemDateCreatedReal = item.CreatedDate,
                     ItemDateDeletedReal = item.RecycleDate,

--- a/Files/ViewModels/NavToolbarViewModel.cs
+++ b/Files/ViewModels/NavToolbarViewModel.cs
@@ -938,7 +938,7 @@ namespace Files.ViewModels
                         suggestions = currPath.Select(x => new ListedItem(null)
                         {
                             ItemPath = x.Path,
-                            ItemName = x.Folder.DisplayName
+                            ItemNameRaw = x.Folder.DisplayName
                         }).ToList();
                     }
                     else if (currPath.Any())
@@ -947,19 +947,19 @@ namespace Files.ViewModels
                         suggestions = currPath.Select(x => new ListedItem(null)
                         {
                             ItemPath = x.Path,
-                            ItemName = x.Folder.DisplayName
+                            ItemNameRaw = x.Folder.DisplayName
                         }).Concat(
                             subPath.Select(x => new ListedItem(null)
                             {
                                 ItemPath = x.Path,
-                                ItemName = PathNormalization.Combine(currPath.First().Folder.DisplayName, x.Folder.DisplayName)
+                                ItemNameRaw = PathNormalization.Combine(currPath.First().Folder.DisplayName, x.Folder.DisplayName)
                             })).ToList();
                     }
                     else
                     {
                         suggestions = new List<ListedItem>() { new ListedItem(null) {
                         ItemPath = shellpage.FilesystemViewModel.WorkingDirectory,
-                        ItemName = "NavigationToolbarVisiblePathNoResults".GetLocalized() } };
+                        ItemNameRaw = "NavigationToolbarVisiblePathNoResults".GetLocalized() } };
                     }
 
                     // NavigationBarSuggestions becoming empty causes flickering of the suggestion box
@@ -971,7 +971,7 @@ namespace Files.ViewModels
                         {
                             if (si < NavigationBarSuggestions.Count)
                             {
-                                NavigationBarSuggestions[si].ItemName = suggestions[si].ItemName;
+                                NavigationBarSuggestions[si].ItemNameRaw = suggestions[si].ItemNameRaw;
                                 NavigationBarSuggestions[si].ItemPath = suggestions[si].ItemPath;
                             }
                             else
@@ -987,11 +987,11 @@ namespace Files.ViewModels
                     else
                     {
                         // At least an element in common, show animation
-                        foreach (var s in NavigationBarSuggestions.ExceptBy(suggestions, x => x.ItemName).ToList())
+                        foreach (var s in NavigationBarSuggestions.ExceptBy(suggestions, x => x.ItemNameRaw).ToList())
                         {
                             NavigationBarSuggestions.Remove(s);
                         }
-                        foreach (var s in suggestions.ExceptBy(NavigationBarSuggestions, x => x.ItemName).ToList())
+                        foreach (var s in suggestions.ExceptBy(NavigationBarSuggestions, x => x.ItemNameRaw).ToList())
                         {
                             NavigationBarSuggestions.Insert(suggestions.IndexOf(s), s);
                         }
@@ -1003,7 +1003,7 @@ namespace Files.ViewModels
                     NavigationBarSuggestions.Add(new ListedItem(null)
                     {
                         ItemPath = shellpage.FilesystemViewModel.WorkingDirectory,
-                        ItemName = "NavigationToolbarVisiblePathNoResults".GetLocalized()
+                        ItemNameRaw = "NavigationToolbarVisiblePathNoResults".GetLocalized()
                     });
                 }
             }

--- a/Files/ViewModels/Properties/SecurityProperties.cs
+++ b/Files/ViewModels/Properties/SecurityProperties.cs
@@ -31,7 +31,7 @@ namespace Files.ViewModels.Properties
         {
             Item = new ListedItem()
             {
-                ItemName = item.Text,
+                ItemNameRaw = item.Text,
                 ItemPath = item.Path,
                 PrimaryItemAttribute = Windows.Storage.StorageItemTypes.Folder
             };

--- a/Files/Views/ColumnShellPage.xaml.cs
+++ b/Files/Views/ColumnShellPage.xaml.cs
@@ -990,7 +990,7 @@ namespace Files.Views
             ItemDisplayFrame.BackStack.Remove(ItemDisplayFrame.BackStack.Last());
         }
 
-        public async void SubmitSearch(string query, bool searchUnindexedItems)
+        public void SubmitSearch(string query, bool searchUnindexedItems)
         {
             FilesystemViewModel.CancelSearch();
             InstanceViewModel.CurrentSearchQuery = query;
@@ -1003,15 +1003,6 @@ namespace Files.Views
                 SearchQuery = query,
                 SearchUnindexedItems = searchUnindexedItems,
             });
-
-            var searchInstance = new FolderSearch
-            {
-                Query = query,
-                Folder = FilesystemViewModel.WorkingDirectory,
-                ThumbnailSize = InstanceViewModel.FolderSettings.GetIconSize(),
-                SearchUnindexedItems = searchUnindexedItems
-            };
-            await FilesystemViewModel.SearchAsync(searchInstance);
         }
     }
 }

--- a/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -243,12 +243,7 @@ namespace Files.Views.LayoutModes
         {
             EndRename(textBox);
             string newItemName = textBox.Text.Trim().TrimEnd('.');
-
-            bool successful = await UIFilesystemHelpers.RenameFileItemAsync(RenamingItem, OldItemName, newItemName, ParentShellPageInstance);
-            if (!successful)
-            {
-                RenamingItem.ItemName = OldItemName;
-            }
+            await UIFilesystemHelpers.RenameFileItemAsync(RenamingItem, newItemName, ParentShellPageInstance);
         }
 
         private void EndRename(TextBox textBox)

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -423,12 +423,7 @@ namespace Files.Views.LayoutModes
         {
             EndRename(textBox);
             string newItemName = textBox.Text.Trim().TrimEnd('.');
-
-            bool successful = await UIFilesystemHelpers.RenameFileItemAsync(RenamingItem, OldItemName, newItemName, ParentShellPageInstance);
-            if (!successful)
-            {
-                RenamingItem.ItemName = OldItemName;
-            }
+            await UIFilesystemHelpers.RenameFileItemAsync(RenamingItem, newItemName, ParentShellPageInstance);
         }
 
         private void EndRename(TextBox textBox)

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -331,12 +331,7 @@ namespace Files.Views.LayoutModes
         {
             EndRename(textBox);
             string newItemName = textBox.Text.Trim().TrimEnd('.');
-
-            bool successful = await UIFilesystemHelpers.RenameFileItemAsync(RenamingItem, OldItemName, newItemName, ParentShellPageInstance);
-            if (!successful)
-            {
-                RenamingItem.ItemName = OldItemName;
-            }
+            await UIFilesystemHelpers.RenameFileItemAsync(RenamingItem, newItemName, ParentShellPageInstance);
         }
 
         private void EndRename(TextBox textBox)

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -237,7 +237,7 @@ namespace Files.Views
                 ListedItem listedItem = new ListedItem(null)
                 {
                     ItemPath = locationItem.Path,
-                    ItemName = locationItem.Text,
+                    ItemNameRaw = locationItem.Text,
                     PrimaryItemAttribute = StorageItemTypes.Folder,
                     ItemType = "FileFolderListItem".GetLocalized(),
                 };

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -304,7 +304,7 @@ namespace Files.Views
             }
         }
 
-        public async void SubmitSearch(string query, bool searchUnindexedItems)
+        public void SubmitSearch(string query, bool searchUnindexedItems)
         {
             FilesystemViewModel.CancelSearch();
             InstanceViewModel.CurrentSearchQuery = query;
@@ -317,14 +317,6 @@ namespace Files.Views
                 SearchQuery = query,
                 SearchUnindexedItems = searchUnindexedItems,
             });
-            var searchInstance = new FolderSearch
-            {
-                Query = InstanceViewModel.CurrentSearchQuery,
-                Folder = FilesystemViewModel.WorkingDirectory,
-                ThumbnailSize = InstanceViewModel.FolderSettings.GetIconSize(),
-                SearchUnindexedItems = InstanceViewModel.SearchedUnindexedItems
-            };
-            await FilesystemViewModel.SearchAsync(searchInstance);
         }
 
         private void ModernShellPage_RefreshRequested(object sender, EventArgs e)

--- a/Files/Views/Pages/PropertiesGeneral.xaml.cs
+++ b/Files/Views/Pages/PropertiesGeneral.xaml.cs
@@ -83,7 +83,6 @@ namespace Files.Views
                 if (!string.IsNullOrWhiteSpace(ViewModel.ItemName) && ViewModel.OriginalItemName != ViewModel.ItemName)
                 {
                     return await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => UIFilesystemHelpers.RenameFileItemAsync(item,
-                          ViewModel.OriginalItemName,
                           ViewModel.ItemName,
                           AppInstance));
                 }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7012
- May fix #5823

**Details of Changes**
Add details of changes here.
- Fixes an issue where file extension is lost when renaming a shortcut to a folder
- Adds an ItemNameRaw property to ListedItem, moves the logic to get the "Display" name from the raw name into ListedItem and subclasses.
- Fixes an issue where file extensions where shown in Search result page regardless of the "show file extensions" setting
- Fixes an issue where search results were loaded twice when submitting search
- Fixes an issue where a file with a random name shows when search yields no results

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested renaming files and shortcuts changing the "show file extensions" setting