### PR TITLE
Fixes an issue causing file tags list to be serialized wrong

### DIFF
--- a/Files/Controllers/TerminalController.cs
+++ b/Files/Controllers/TerminalController.cs
@@ -35,6 +35,7 @@ namespace Files.Controllers
 
         public TerminalController()
         {
+            Model = new TerminalFileModel();
         }
 
         public async Task InitializeAsync()
@@ -42,6 +43,10 @@ namespace Files.Controllers
             await LoadAsync();
             await GetInstalledTerminalsAsync();
             await StartWatchConfigChangeAsync();
+            CoreApplication.MainView.DispatcherQueue.TryEnqueue(() =>
+            {
+                ModelChanged?.Invoke(this);
+            });
         }
 
         private async Task LoadAsync()

--- a/Files/DataModels/TerminalFileModel.cs
+++ b/Files/DataModels/TerminalFileModel.cs
@@ -29,7 +29,7 @@ namespace Files.DataModels
                 ResetToDefaultTerminal();
             }
 
-            return Terminals.First();
+            return Terminals.FirstOrDefault();
         }
 
         public void ResetToDefaultTerminal()

--- a/Files/Helpers/NavigationHelpers.cs
+++ b/Files/Helpers/NavigationHelpers.cs
@@ -49,9 +49,12 @@ namespace Files.Helpers
         public static async Task OpenDirectoryInTerminal(string workingDir)
         {
             var terminal = App.TerminalController.Model.GetDefaultTerminal();
+            if (terminal == null)
+            {
+                return;
+            }
 
             var connection = await AppServiceConnectionHelper.Instance;
-
             if (connection != null)
             {
                 var value = new ValueSet()

--- a/Files/Models/JsonSettings/Implementation/DefaultJsonSettingsDatabase.cs
+++ b/Files/Models/JsonSettings/Implementation/DefaultJsonSettingsDatabase.cs
@@ -23,7 +23,7 @@ namespace Files.Models.JsonSettings.Implementation
 
         protected virtual Dictionary<string, object> GetNewSettingsCache()
         {
-            string settingsData = settingsSerializer.ReadFromFile();
+            string settingsData = settingsSerializer.ReadFromFile() ?? string.Empty;
 
             return jsonSettingsSerializer.DeserializeFromJson<Dictionary<string, object>>(settingsData) ?? new Dictionary<string, object>();
         }

--- a/Files/Properties/Default.rd.xml
+++ b/Files/Properties/Default.rd.xml
@@ -29,6 +29,7 @@
 
     <Type Name="Files.Views.PaneNavigationArguments" Dynamic="Required All" />
 	<Type Name="Files.UserControls.MultitaskingControl.TabItemArguments" Dynamic="Required All" />
+	<Type Name="Files.Filesystem.FileTag" Dynamic="Required All" />
 
     <!-- Add your application specific runtime directives here. -->
   </Application>

--- a/Files/Services/Implementation/FileTagsSettingsService.cs
+++ b/Files/Services/Implementation/FileTagsSettingsService.cs
@@ -35,7 +35,7 @@ namespace Files.Services.Implementation
         {
             if (FileTagList.Any(x => x.Uid == null))
             {
-                // Tags file is invalid, regenerate
+                App.Logger.Warn("Tags file is invalid, regenerate");
                 FileTagList = s_defaultFileTags;
             }
             var tag = FileTagList.SingleOrDefault(x => x.Uid == uid);


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6605
 - Closes (maybe) [1528823123u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/1528823123u/overview), [813232478u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/813232478u/overview), [4277801717u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/4277801717u/overview)
 - Closes (maybe) [2261357081u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/2261357081u/overview)

**Details of Changes**
Add details of changes here.
- Added FileTag class to rd.xml. Without it file tags do not get serialized correctly in Release mode
- Fixed an issue where going to Preferences before sidebar is loaded crashed the app

**Validation**
How did you test these changes?
- [x] Built and ran the app
