### PR TITLE
Import/export all settings into a zipped archive

### DIFF
--- a/Common/FileTagsDb.cs
+++ b/Common/FileTagsDb.cs
@@ -1,6 +1,7 @@
 ﻿using LiteDB;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Common
 {
@@ -147,6 +148,18 @@ namespace Common
         public void Dispose()
         {
             db.Dispose();
+        }
+
+        public void Import(string json)
+        {
+            var dataValues = JsonSerializer.DeserializeArray(json);
+            db.Engine.Delete("taggedfiles", Query.All());
+            db.Engine.InsertBulk("taggedfiles", dataValues.Select(x => x.AsDocument));
+        }
+
+        public string Export()
+        {
+            return JsonSerializer.Serialize(new BsonArray(db.Engine.FindAll("taggedfiles")));
         }
 
         public class TaggedFile

--- a/Files/Controllers/SidebarPinnedController.cs
+++ b/Files/Controllers/SidebarPinnedController.cs
@@ -50,7 +50,7 @@ namespace Files.Controllers
             {
                 if (JsonFile == FileSystemStatusCode.NotFound)
                 {
-                    var oldItems = await ReadV1PinnedItemsFile() ?? await ReadV2PinnedItemsFile();
+                    var oldItems = await ReadV2PinnedItemsFile() ?? await ReadV1PinnedItemsFile();
                     if (oldItems != null)
                     {
                         foreach (var item in oldItems)

--- a/Files/Controllers/SidebarPinnedController.cs
+++ b/Files/Controllers/SidebarPinnedController.cs
@@ -1,6 +1,9 @@
 ﻿using Files.DataModels;
+using Files.Enums;
+using Files.Filesystem;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Windows.Storage;
@@ -9,11 +12,11 @@ namespace Files.Controllers
 {
     public class SidebarPinnedController : IJson
     {
-        private StorageFolder Folder { get; set; }
-        private StorageFile JsonFile { get; set; }
-
         public SidebarPinnedModel Model { get; set; }
+
         public string JsonFileName { get; } = "PinnedItems.json";
+
+        private string folderPath => Path.Combine(ApplicationData.Current.LocalFolder.Path, "settings");
 
         public SidebarPinnedController()
         {
@@ -28,49 +31,58 @@ namespace Files.Controllers
 
         private async Task LoadAsync()
         {
-            Folder = ApplicationData.Current.LocalCacheFolder;
-
-            try
+            StorageFolder Folder = await FilesystemTasks.Wrap(() => ApplicationData.Current.LocalFolder.CreateFolderAsync("settings", CreationCollisionOption.OpenIfExists).AsTask());
+            if (Folder == null)
             {
-                JsonFile = await Folder.GetFileAsync(JsonFileName);
+                Model.AddDefaultItems();
+                await Model.AddAllItemsToSidebar();
+                return;
             }
-            catch (FileNotFoundException)
-            {
-                try
-                {
-                    var oldPinnedItemsFile = await Folder.GetFileAsync("PinnedItems.txt");
-                    var oldPinnedItems = await FileIO.ReadLinesAsync(oldPinnedItemsFile);
-                    await oldPinnedItemsFile.DeleteAsync();
 
-                    foreach (var line in oldPinnedItems)
+            var JsonFile = await FilesystemTasks.Wrap(() => Folder.GetFileAsync(JsonFileName).AsTask());
+            if (!JsonFile)
+            {
+                if (JsonFile == FileSystemStatusCode.NotFound)
+                {
+                    var oldItems = await ReadV1PinnedItemsFile() ?? await ReadV2PinnedItemsFile();
+                    if (oldItems != null)
                     {
-                        if (!Model.FavoriteItems.Contains(line))
+                        foreach (var item in oldItems)
                         {
-                            Model.FavoriteItems.Add(line);
+                            if (!Model.FavoriteItems.Contains(item))
+                            {
+                                Model.FavoriteItems.Add(item);
+                            }
                         }
                     }
+                    else
+                    {
+                        Model.AddDefaultItems();
+                    }
+
+                    Model.Save();
+                    await Model.AddAllItemsToSidebar();
+                    return;
                 }
-                catch (FileNotFoundException)
+                else
                 {
                     Model.AddDefaultItems();
+                    await Model.AddAllItemsToSidebar();
+                    return;
                 }
-
-                JsonFile = await Folder.CreateFileAsync(JsonFileName, CreationCollisionOption.ReplaceExisting);
-                await FileIO.WriteTextAsync(JsonFile, JsonConvert.SerializeObject(Model, Formatting.Indented));
             }
 
             try
             {
-                Model = JsonConvert.DeserializeObject<SidebarPinnedModel>(await FileIO.ReadTextAsync(JsonFile));
+                Model = JsonConvert.DeserializeObject<SidebarPinnedModel>(await FileIO.ReadTextAsync(JsonFile.Result));
                 if (Model == null)
                 {
-                    throw new Exception($"{JsonFileName} is empty, regenerating...");
+                    throw new ArgumentException($"{JsonFileName} is empty, regenerating...");
                 }
                 Model.SetController(this);
             }
             catch (Exception)
             {
-                await JsonFile.DeleteAsync();
                 Model = new SidebarPinnedModel();
                 Model.SetController(this);
                 Model.AddDefaultItems();
@@ -82,12 +94,40 @@ namespace Files.Controllers
 
         public void SaveModel()
         {
-            using (var file = File.CreateText(ApplicationData.Current.LocalCacheFolder.Path + Path.DirectorySeparatorChar + JsonFileName))
+            try
             {
-                JsonSerializer serializer = new JsonSerializer();
-                serializer.Formatting = Formatting.Indented;
-                serializer.Serialize(file, Model);
+                using (var file = File.CreateText(Path.Combine(folderPath, JsonFileName)))
+                {
+                    JsonSerializer serializer = new JsonSerializer();
+                    serializer.Formatting = Formatting.Indented;
+                    serializer.Serialize(file, Model);
+                }
             }
+            catch
+            {
+            }
+        }
+
+        private async Task<IEnumerable<string>> ReadV1PinnedItemsFile()
+        {
+            return await Common.Extensions.IgnoreExceptions(async () =>
+            {
+                var oldPinnedItemsFile = await ApplicationData.Current.LocalCacheFolder.GetFileAsync("PinnedItems.txt");
+                var oldPinnedItems = await FileIO.ReadLinesAsync(oldPinnedItemsFile);
+                await oldPinnedItemsFile.DeleteAsync();
+                return oldPinnedItems;
+            });
+        }
+
+        private async Task<IEnumerable<string>> ReadV2PinnedItemsFile()
+        {
+            return await Common.Extensions.IgnoreExceptions(async () =>
+            {
+                var oldPinnedItemsFile = await ApplicationData.Current.LocalCacheFolder.GetFileAsync("PinnedItems.json");
+                var model = JsonConvert.DeserializeObject<SidebarPinnedModel>(await FileIO.ReadTextAsync(oldPinnedItemsFile));
+                await oldPinnedItemsFile.DeleteAsync();
+                return model.FavoriteItems;
+            });
         }
     }
 }

--- a/Files/Controllers/SidebarPinnedController.cs
+++ b/Files/Controllers/SidebarPinnedController.cs
@@ -29,6 +29,12 @@ namespace Files.Controllers
             await LoadAsync();
         }
 
+        public async Task ReloadAsync()
+        {
+            await LoadAsync();
+            Model.RemoveStaleSidebarItems();
+        }
+
         private async Task LoadAsync()
         {
             StorageFolder Folder = await FilesystemTasks.Wrap(() => ApplicationData.Current.LocalFolder.CreateFolderAsync("settings", CreationCollisionOption.OpenIfExists).AsTask());

--- a/Files/Controllers/TerminalController.cs
+++ b/Files/Controllers/TerminalController.cs
@@ -81,10 +81,10 @@ namespace Files.Controllers
                 Model = JsonConvert.DeserializeObject<TerminalFileModel>(content);
                 if (Model == null)
                 {
-                    throw new JsonParsingNullException(JsonFileName);
+                    throw new ArgumentException($"{JsonFileName} is empty, regenerating...");
                 }
             }
-            catch (JsonParsingNullException)
+            catch (ArgumentException)
             {
                 Model = await GetDefaultTerminalFileModel();
                 SaveModel();
@@ -220,13 +220,6 @@ namespace Files.Controllers
             catch
             {
             }
-        }
-    }
-
-    public class JsonParsingNullException : Exception
-    {
-        public JsonParsingNullException(string jsonFileName) : base($"{jsonFileName} is empty, regenerating...")
-        {
         }
     }
 }

--- a/Files/DataModels/SidebarPinnedModel.cs
+++ b/Files/DataModels/SidebarPinnedModel.cs
@@ -28,7 +28,7 @@ namespace Files.DataModels
 
         private SidebarPinnedController controller;
 
-        private LocationItem favoriteSection, homeSection;
+        private LocationItem favoriteSection;
 
         [JsonIgnore]
         public MainViewModel MainViewModel => App.MainViewModel;
@@ -43,6 +43,7 @@ namespace Files.DataModels
 
         public SidebarPinnedModel()
         {
+            favoriteSection = SidebarControl.SideBarItems.FirstOrDefault(x => x.Text == "SidebarFavorites".GetLocalized()) as LocationItem;
         }
 
         /// <summary>
@@ -282,7 +283,7 @@ namespace Files.DataModels
                     }
                 }
 
-                if (!favoriteSection.ChildItems.Contains(locationItem))
+                if (!favoriteSection.ChildItems.Any(x => x.Path == locationItem.Path))
                 {
                     await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => favoriteSection.ChildItems.Insert(insertIndex, locationItem));
                 }
@@ -303,7 +304,7 @@ namespace Files.DataModels
             var lastItem = favoriteSection.ChildItems.LastOrDefault(x => x.ItemType == NavigationControlItemType.Location && !x.Path.Equals(CommonPaths.RecycleBinPath));
             int insertIndex = lastItem != null ? favoriteSection.ChildItems.IndexOf(lastItem) + 1 : 0;
 
-            if (!favoriteSection.ChildItems.Contains(section))
+            if (!favoriteSection.ChildItems.Any(x => x.Section == section.Section))
             {
                 favoriteSection.ChildItems.Insert(insertIndex, section);
             }
@@ -322,7 +323,7 @@ namespace Files.DataModels
             await SidebarControl.SideBarItemsSemaphore.WaitAsync();
             try
             {
-                homeSection = new LocationItem()
+                var homeSection = new LocationItem()
                 {
                     Text = "SidebarHome".GetLocalized(),
                     Section = SectionType.Home,
@@ -332,7 +333,7 @@ namespace Files.DataModels
                     Path = "Home".GetLocalized(),
                     ChildItems = new ObservableCollection<INavigationControlItem>()
                 };
-                favoriteSection = new LocationItem()
+                favoriteSection ??= new LocationItem()
                 {
                     Text = "SidebarFavorites".GetLocalized(),
                     Section = SectionType.Favorites,
@@ -347,7 +348,7 @@ namespace Files.DataModels
                     AddItemToSidebarAsync(homeSection);
                 }
 
-                if (!SidebarControl.SideBarItems.Contains(favoriteSection))
+                if (!SidebarControl.SideBarItems.Any(x => x.Text == "SidebarFavorites".GetLocalized()))
                 {
                     SidebarControl.SideBarItems.BeginBulkOperation();
                     var index = 0; // First section

--- a/Files/Extensions/ShellNewEntryExtensions.cs
+++ b/Files/Extensions/ShellNewEntryExtensions.cs
@@ -85,12 +85,8 @@ namespace Files.Extensions
             {
                 if (shellEntry.Data != null)
                 {
-                    //await FileIO.WriteBytesAsync(createdFile.Result, this.Data); // Calls unsupported OpenTransactedWriteAsync
-                    using (var fileStream = await createdFile.Result.OpenStreamForWriteAsync())
-                    {
-                        await fileStream.WriteAsync(shellEntry.Data, 0, shellEntry.Data.Length);
-                        await fileStream.FlushAsync();
-                    }
+                    //await FileIO.WriteBytesAsync(createdFile.Result, shellEntry.Data); // Calls unsupported OpenTransactedWriteAsync
+                    await createdFile.Result.WriteBytesAsync(shellEntry.Data);
                 }
             }
             return createdFile;

--- a/Files/Filesystem/StorageItems/BaseStorageItem.cs
+++ b/Files/Filesystem/StorageItems/BaseStorageItem.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
@@ -460,6 +461,41 @@ namespace Files.Filesystem.StorageItems
                 }
                 return null;
             }
+        }
+
+        public async Task<string> ReadTextAsync(int maxLength = -1)
+        {
+            using var inputStream = await OpenSequentialReadAsync();
+            using var dataReader = new DataReader(inputStream);
+            StringBuilder builder = new StringBuilder();
+            uint bytesRead, bytesToRead;
+            do
+            {
+                bytesToRead = maxLength < 0 ? 4096 : (uint)Math.Min(maxLength, 4096);
+                bytesRead = await dataReader.LoadAsync(bytesToRead);
+                builder.Append(dataReader.ReadString(bytesRead));
+            } while (bytesRead > 0);
+            return builder.ToString();
+        }
+
+        public async Task WriteTextAsync(string text)
+        {
+            using var stream = await OpenAsync(FileAccessMode.ReadWrite, StorageOpenOptions.AllowOnlyReaders);
+            using var outputStream = stream.GetOutputStreamAt(0);
+            using var dataWriter = new DataWriter(outputStream);
+            dataWriter.WriteString(text);
+            await dataWriter.StoreAsync();
+            await stream.FlushAsync();
+        }
+
+        public async Task WriteBytesAsync(byte[] dataBytes)
+        {
+            using var stream = await OpenAsync(FileAccessMode.ReadWrite, StorageOpenOptions.AllowOnlyReaders);
+            using var outputStream = stream.GetOutputStreamAt(0);
+            using var dataWriter = new DataWriter(outputStream);
+            dataWriter.WriteBytes(dataBytes);
+            await dataWriter.StoreAsync();
+            await stream.FlushAsync();
         }
     }
 }

--- a/Files/Filesystem/StorageItems/StreamWithContentType.cs
+++ b/Files/Filesystem/StorageItems/StreamWithContentType.cs
@@ -120,7 +120,8 @@ namespace Files.Filesystem.StorageItems
 
         public IInputStream GetInputStreamAt(ulong position)
         {
-            throw new NotSupportedException();
+            Seek(position);
+            return this;
         }
 
         public IOutputStream GetOutputStreamAt(ulong position)

--- a/Files/Filesystem/StorageItems/ZipStorageFile.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFile.cs
@@ -52,7 +52,7 @@ namespace Files.Filesystem.StorageItems
                         {
                             return null;
                         }
-                        return new FileStream(hFile, FileAccess.Read).AsRandomAccessStream();
+                        return new FileStream(hFile, rw ? FileAccess.ReadWrite : FileAccess.Read).AsRandomAccessStream();
                     }
                 }
 

--- a/Files/Filesystem/StorageItems/ZipStorageFile.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFile.cs
@@ -350,7 +350,7 @@ namespace Files.Filesystem.StorageItems
             get
             {
                 var itemType = "ItemTypeFile".GetLocalized();
-                if (Name.Contains("."))
+                if (Name.Contains(".", StringComparison.Ordinal))
                 {
                     itemType = System.IO.Path.GetExtension(Name).Trim('.') + " " + itemType;
                 }

--- a/Files/Filesystem/StorageItems/ZipStorageFile.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFile.cs
@@ -56,7 +56,7 @@ namespace Files.Filesystem.StorageItems
                     }
                 }
 
-                ZipFile zipFile = await OpenZipFileAsync(rw);
+                ZipFile zipFile = await OpenZipFileAsync(accessMode);
                 if (zipFile == null)
                 {
                     return null;
@@ -102,7 +102,7 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run<BaseStorageFile>(async (cancellationToken) =>
             {
-                using (ZipFile zipFile = await OpenZipFileAsync(false))
+                using (ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.Read))
                 {
                     if (zipFile == null)
                     {
@@ -132,7 +132,7 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run(async (cancellationToken) =>
             {
-                using (ZipFile zipFile = await OpenZipFileAsync(false))
+                using (ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.Read))
                 {
                     if (zipFile == null)
                     {
@@ -239,7 +239,7 @@ namespace Files.Filesystem.StorageItems
                     }
                 }
 
-                ZipFile zipFile = await OpenZipFileAsync(false);
+                ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.Read);
                 if (zipFile == null)
                 {
                     return null;
@@ -280,7 +280,7 @@ namespace Files.Filesystem.StorageItems
                     }
                 }
 
-                ZipFile zipFile = await OpenZipFileAsync(false);
+                ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.Read);
                 if (zipFile == null)
                 {
                     return null;
@@ -364,13 +364,14 @@ namespace Files.Filesystem.StorageItems
 
         #region Private
 
-        private IAsyncOperation<ZipFile> OpenZipFileAsync(bool readWrite, bool openProtected = false)
+        private IAsyncOperation<ZipFile> OpenZipFileAsync(FileAccessMode accessMode, bool openProtected = false)
         {
             return AsyncInfo.Run<ZipFile>(async (cancellationToken) =>
             {
+                bool readWrite = accessMode == FileAccessMode.ReadWrite;
                 if (BackingFile != null)
                 {
-                    return new ZipFile((await BackingFile.OpenAsync(readWrite ? FileAccessMode.ReadWrite : FileAccessMode.Read)).AsStream());
+                    return new ZipFile((await BackingFile.OpenAsync(accessMode)).AsStream());
                 }
                 else
                 {
@@ -394,7 +395,7 @@ namespace Files.Filesystem.StorageItems
                 {
                     // If called from here it fails with Access Denied?!
                     //var hFile = NativeFileOperationsHelper.OpenFileForRead(ContainerPath);
-                    using (ZipFile zipFile = await OpenZipFileAsync(false, openProtected: true))
+                    using (ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.Read, openProtected: true))
                     {
                         if (zipFile == null)
                         {
@@ -455,7 +456,7 @@ namespace Files.Filesystem.StorageItems
 
         private async Task<BaseBasicProperties> GetBasicProperties()
         {
-            using (ZipFile zipFile = await OpenZipFileAsync(false))
+            using (ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.Read))
             {
                 if (zipFile == null)
                 {

--- a/Files/Filesystem/StorageItems/ZipStorageFolder.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFolder.cs
@@ -125,7 +125,7 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run<BaseStorageFile>(async (cancellationToken) =>
             {
-                using (ZipFile zipFile = await OpenZipFileAsync(true))
+                using (ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.ReadWrite))
                 {
                     if (zipFile == null)
                     {
@@ -165,7 +165,7 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run<BaseStorageFolder>(async (cancellationToken) =>
             {
-                using (ZipFile zipFile = await OpenZipFileAsync(true))
+                using (ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.ReadWrite))
                 {
                     if (zipFile == null)
                     {
@@ -220,7 +220,7 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run<IStorageItem>(async (cancellationToken) =>
             {
-                using (ZipFile zipFile = await OpenZipFileAsync(false))
+                using (ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.Read))
                 {
                     if (zipFile == null)
                     {
@@ -270,7 +270,7 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run<IReadOnlyList<IStorageItem>>(async (cancellationToken) =>
             {
-                using (ZipFile zipFile = await OpenZipFileAsync(false))
+                using (ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.Read))
                 {
                     if (zipFile == null)
                     {
@@ -564,13 +564,14 @@ namespace Files.Filesystem.StorageItems
 
         #region Private
 
-        private IAsyncOperation<ZipFile> OpenZipFileAsync(bool readWrite)
+        private IAsyncOperation<ZipFile> OpenZipFileAsync(FileAccessMode accessMode)
         {
             return AsyncInfo.Run<ZipFile>(async (cancellationToken) =>
             {
+                bool readWrite = accessMode == FileAccessMode.ReadWrite;
                 if (BackingFile != null)
                 {
-                    return new ZipFile((await BackingFile.OpenAsync(readWrite ? FileAccessMode.ReadWrite : FileAccessMode.Read)).AsStream());
+                    return new ZipFile((await BackingFile.OpenAsync(accessMode)).AsStream());
                 }
                 else
                 {
@@ -625,7 +626,7 @@ namespace Files.Filesystem.StorageItems
 
         private async Task<BaseBasicProperties> GetBasicProperties()
         {
-            using (ZipFile zipFile = await OpenZipFileAsync(false))
+            using (ZipFile zipFile = await OpenZipFileAsync(FileAccessMode.Read))
             {
                 if (zipFile == null)
                 {

--- a/Files/Filesystem/StorageItems/ZipStorageFolder.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFolder.cs
@@ -104,6 +104,18 @@ namespace Files.Filesystem.StorageItems
             DateCreated = entry.DateTime;
         }
 
+        public ZipStorageFolder(BaseStorageFile backingFile)
+        {
+            if (string.IsNullOrEmpty(backingFile.Path))
+            {
+                throw new ArgumentException("Backing file Path cannot be null");
+            }
+            Name = System.IO.Path.GetFileName(backingFile.Path.TrimEnd('\\', '/'));
+            Path = backingFile.Path;
+            ContainerPath = backingFile.Path;
+            BackingFile = backingFile;
+        }
+
         public override IAsyncOperation<BaseStorageFile> CreateFileAsync(string desiredName)
         {
             return CreateFileAsync(desiredName, CreationCollisionOption.FailIfExists);
@@ -113,13 +125,12 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run<BaseStorageFile>(async (cancellationToken) =>
             {
-                var hFile = NativeFileOperationsHelper.OpenFileForRead(ContainerPath, true);
-                if (hFile.IsInvalid)
+                using (ZipFile zipFile = await OpenZipFileAsync(true))
                 {
-                    return null;
-                }
-                using (ZipFile zipFile = new ZipFile(new FileStream(hFile, FileAccess.ReadWrite)))
-                {
+                    if (zipFile == null)
+                    {
+                        return null;
+                    }
                     zipFile.IsStreamOwner = true;
 
                     var znt = new ZipNameTransform(ContainerPath);
@@ -140,7 +151,7 @@ namespace Files.Filesystem.StorageItems
                     zipFile.CommitUpdate();
 
                     var wnt = new WindowsNameTransform(ContainerPath);
-                    return new ZipStorageFile(wnt.TransformFile(zipDesiredName), ContainerPath);
+                    return new ZipStorageFile(wnt.TransformFile(zipDesiredName), ContainerPath) { BackingFile = BackingFile };
                 }
             });
         }
@@ -154,13 +165,12 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run<BaseStorageFolder>(async (cancellationToken) =>
             {
-                var hFile = NativeFileOperationsHelper.OpenFileForRead(ContainerPath, true);
-                if (hFile.IsInvalid)
+                using (ZipFile zipFile = await OpenZipFileAsync(true))
                 {
-                    return null;
-                }
-                using (ZipFile zipFile = new ZipFile(new FileStream(hFile, FileAccess.ReadWrite)))
-                {
+                    if (zipFile == null)
+                    {
+                        return null;
+                    }
                     zipFile.IsStreamOwner = true;
 
                     var znt = new ZipNameTransform(ContainerPath);
@@ -181,7 +191,11 @@ namespace Files.Filesystem.StorageItems
                     zipFile.CommitUpdate();
 
                     var wnt = new WindowsNameTransform(ContainerPath);
-                    return new ZipStorageFolder(wnt.TransformFile(zipDesiredName), ContainerPath) { ZipEncoding = ZipEncoding };
+                    return new ZipStorageFolder(wnt.TransformFile(zipDesiredName), ContainerPath)
+                    {
+                        ZipEncoding = ZipEncoding,
+                        BackingFile = BackingFile
+                    };
                 }
             });
         }
@@ -206,13 +220,12 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run<IStorageItem>(async (cancellationToken) =>
             {
-                var hFile = NativeFileOperationsHelper.OpenFileForRead(ContainerPath);
-                if (hFile.IsInvalid)
+                using (ZipFile zipFile = await OpenZipFileAsync(false))
                 {
-                    return null;
-                }
-                using (ZipFile zipFile = new ZipFile(new FileStream(hFile, FileAccess.Read)))
-                {
+                    if (zipFile == null)
+                    {
+                        return null;
+                    }
                     zipFile.IsStreamOwner = true;
                     ZipEncoding ??= DetectFileEncoding(zipFile);
                     var entry = zipFile.GetEntry(name);
@@ -221,11 +234,15 @@ namespace Files.Filesystem.StorageItems
                         var wnt = new WindowsNameTransform(ContainerPath);
                         if (entry.IsDirectory)
                         {
-                            return new ZipStorageFolder(wnt.TransformDirectory(DecodeEntryName(entry, ZipEncoding)), ContainerPath, entry) { ZipEncoding = ZipEncoding };
+                            return new ZipStorageFolder(wnt.TransformDirectory(DecodeEntryName(entry, ZipEncoding)), ContainerPath, entry)
+                            {
+                                ZipEncoding = ZipEncoding,
+                                BackingFile = BackingFile
+                            };
                         }
                         else
                         {
-                            return new ZipStorageFile(wnt.TransformFile(DecodeEntryName(entry, ZipEncoding)), ContainerPath, entry);
+                            return new ZipStorageFile(wnt.TransformFile(DecodeEntryName(entry, ZipEncoding)), ContainerPath, entry) { BackingFile = BackingFile };
                         }
                     }
                     return null;
@@ -253,13 +270,12 @@ namespace Files.Filesystem.StorageItems
         {
             return AsyncInfo.Run<IReadOnlyList<IStorageItem>>(async (cancellationToken) =>
             {
-                var hFile = NativeFileOperationsHelper.OpenFileForRead(ContainerPath);
-                if (hFile.IsInvalid)
+                using (ZipFile zipFile = await OpenZipFileAsync(false))
                 {
-                    return null;
-                }
-                using (ZipFile zipFile = new ZipFile(new FileStream(hFile, FileAccess.Read)))
-                {
+                    if (zipFile == null)
+                    {
+                        return null;
+                    }
                     zipFile.IsStreamOwner = true;
                     ZipEncoding ??= DetectFileEncoding(zipFile);
                     var wnt = new WindowsNameTransform(ContainerPath, true); // Check with Path.GetFullPath
@@ -277,12 +293,16 @@ namespace Files.Filesystem.StorageItems
                                     var itemPath = System.IO.Path.Combine(Path, split[0]);
                                     if (!items.Any(x => x.Path == itemPath))
                                     {
-                                        items.Add(new ZipStorageFolder(itemPath, ContainerPath, entry) { ZipEncoding = ZipEncoding });
+                                        items.Add(new ZipStorageFolder(itemPath, ContainerPath, entry)
+                                        {
+                                            ZipEncoding = ZipEncoding,
+                                            BackingFile = BackingFile
+                                        });
                                     }
                                 }
                                 else
                                 {
-                                    items.Add(new ZipStorageFile(winPath, ContainerPath, entry));
+                                    items.Add(new ZipStorageFile(winPath, ContainerPath, entry) { BackingFile = BackingFile });
                                 }
                             }
                         }
@@ -321,32 +341,8 @@ namespace Files.Filesystem.StorageItems
                     var zipFile = new SystemStorageFile(await StorageFile.GetFileFromPathAsync(Path));
                     return await zipFile.GetBasicPropertiesAsync();
                 }
-                return GetBasicProperties();
+                return await GetBasicProperties();
             });
-        }
-
-        private BaseBasicProperties GetBasicProperties()
-        {
-            if (Path == ContainerPath)
-            {
-                return new BaseBasicProperties();
-            }
-            var hFile = NativeFileOperationsHelper.OpenFileForRead(ContainerPath);
-            if (hFile.IsInvalid)
-            {
-                return new BaseBasicProperties();
-            }
-            using (ZipFile zipFile = new ZipFile(new FileStream(hFile, FileAccess.Read)))
-            {
-                zipFile.IsStreamOwner = true;
-                var znt = new ZipNameTransform(ContainerPath);
-                var entry = zipFile.GetEntry(znt.TransformFile(Path));
-                if (entry != null)
-                {
-                    return new ZipFolderBasicProperties(entry);
-                }
-                return new BaseBasicProperties();
-            }
         }
 
         public override bool IsOfType(StorageItemTypes type) => type == StorageItemTypes.Folder;
@@ -360,6 +356,8 @@ namespace Files.Filesystem.StorageItems
         public override string Path { get; }
 
         public string ContainerPath { get; private set; }
+
+        public BaseStorageFile BackingFile { get; set; }
 
         public override IAsyncOperation<IndexedState> GetIndexedStateAsync()
         {
@@ -524,6 +522,18 @@ namespace Files.Filesystem.StorageItems
             });
         }
 
+        public static IAsyncOperation<BaseStorageFolder> FromStorageFileAsync(BaseStorageFile file)
+        {
+            return AsyncInfo.Run<BaseStorageFolder>(async (cancellationToken) =>
+            {
+                if (await CheckAccess(file))
+                {
+                    return new ZipStorageFolder(file);
+                }
+                return null;
+            });
+        }
+
         public static bool IsZipPath(string path)
         {
             var marker = path.IndexOf(".zip", StringComparison.OrdinalIgnoreCase);
@@ -536,27 +546,6 @@ namespace Files.Filesystem.StorageItems
                 }
             }
             return false;
-        }
-
-        private static bool CheckAccess(string path)
-        {
-            try
-            {
-                var hFile = NativeFileOperationsHelper.OpenFileForRead(path);
-                if (hFile.IsInvalid)
-                {
-                    return false;
-                }
-                using (ZipFile zipFile = new ZipFile(new FileStream(hFile, FileAccess.Read)))
-                {
-                    zipFile.IsStreamOwner = true;
-                }
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
         }
 
         public override string DisplayName => Name;
@@ -572,6 +561,86 @@ namespace Files.Filesystem.StorageItems
         public override string FolderRelativeId => $"0\\{Name}";
 
         public override IStorageItemExtraProperties Properties => new BaseBasicStorageItemExtraProperties(this);
+
+        #region Private
+
+        private IAsyncOperation<ZipFile> OpenZipFileAsync(bool readWrite)
+        {
+            return AsyncInfo.Run<ZipFile>(async (cancellationToken) =>
+            {
+                if (BackingFile != null)
+                {
+                    return new ZipFile((await BackingFile.OpenAsync(readWrite ? FileAccessMode.ReadWrite : FileAccessMode.Read)).AsStream());
+                }
+                else
+                {
+                    var hFile = NativeFileOperationsHelper.OpenFileForRead(ContainerPath, readWrite);
+                    if (hFile.IsInvalid)
+                    {
+                        return null;
+                    }
+                    return new ZipFile(new FileStream(hFile, readWrite ? FileAccess.ReadWrite : FileAccess.Read));
+                }
+            });
+        }
+
+        private static bool CheckAccess(string path)
+        {
+            return Common.Extensions.IgnoreExceptions(() =>
+            {
+                var hFile = NativeFileOperationsHelper.OpenFileForRead(path);
+                if (hFile.IsInvalid)
+                {
+                    return false;
+                }
+                using (var stream = new FileStream(hFile, FileAccess.Read))
+                {
+                    return CheckAccess(stream);
+                }
+            });
+        }
+
+        private static async Task<bool> CheckAccess(IStorageFile file)
+        {
+            return await Common.Extensions.IgnoreExceptions(async () =>
+            {
+                using (var stream = await file.OpenReadAsync())
+                {
+                    return CheckAccess(stream.AsStream());
+                }
+            });
+        }
+
+        private static bool CheckAccess(Stream stream)
+        {
+            return Common.Extensions.IgnoreExceptions(() =>
+            {
+                using (ZipFile zipFile = new ZipFile(stream))
+                {
+                    zipFile.IsStreamOwner = false;
+                }
+                return true;
+            });
+        }
+
+        private async Task<BaseBasicProperties> GetBasicProperties()
+        {
+            using (ZipFile zipFile = await OpenZipFileAsync(false))
+            {
+                if (zipFile == null)
+                {
+                    return new BaseBasicProperties();
+                }
+                zipFile.IsStreamOwner = true;
+                var znt = new ZipNameTransform(ContainerPath);
+                var entry = zipFile.GetEntry(znt.TransformFile(Path));
+                if (entry != null)
+                {
+                    return new ZipFolderBasicProperties(entry);
+                }
+                return new BaseBasicProperties();
+            }
+        }
 
         private class FileDataSource : IStaticDataSource
         {
@@ -595,5 +664,7 @@ namespace Files.Filesystem.StorageItems
 
             public override ulong Size => (ulong)zipEntry.Size;
         }
+
+        #endregion
     }
 }

--- a/Files/Helpers/RegistryToJsonSettingsMerger.cs
+++ b/Files/Helpers/RegistryToJsonSettingsMerger.cs
@@ -45,7 +45,7 @@ namespace Files.Helpers
                     userSettingsService.MultitaskingSettingsService.AlwaysOpenDualPaneInNewTab = appSettings.Get(false, "AlwaysOpenDualPaneInNewTab");
 
                     // Widgets
-                    userSettingsService.WidgetsSettingsService.ShowFoldersWidget = appSettings.Get(true, "ShowFolderWidgetWidget");
+                    userSettingsService.WidgetsSettingsService.ShowFoldersWidget = appSettings.Get(true, "ShowFoldersWidget");
                     userSettingsService.WidgetsSettingsService.ShowRecentFilesWidget = appSettings.Get(true, "ShowRecentFilesWidget");
                     userSettingsService.WidgetsSettingsService.ShowDrivesWidget = appSettings.Get(true, "ShowDrivesWidget");
                     userSettingsService.WidgetsSettingsService.ShowBundlesWidget = appSettings.Get(false, "ShowBundlesWidget");

--- a/Files/Services/IBundlesSettingsService.cs
+++ b/Files/Services/IBundlesSettingsService.cs
@@ -1,9 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using Files.EventArguments;
+using System;
+using System.Collections.Generic;
 
 namespace Files.Services
 {
     public interface IBundlesSettingsService
     {
+        event EventHandler<SettingChangedEventArgs> OnSettingChangedEvent;
+
         bool FlushSettings();
 
         object ExportSettings();

--- a/Files/Services/IBundlesSettingsService.cs
+++ b/Files/Services/IBundlesSettingsService.cs
@@ -1,12 +1,11 @@
-﻿using Files.EventArguments;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Files.Services
 {
     public interface IBundlesSettingsService
     {
-        event EventHandler<SettingChangedEventArgs> OnSettingChangedEvent;
+        event EventHandler OnSettingImportedEvent;
 
         bool FlushSettings();
 

--- a/Files/Services/IFileTagsSettingsService.cs
+++ b/Files/Services/IFileTagsSettingsService.cs
@@ -1,5 +1,4 @@
-﻿using Files.EventArguments;
-using Files.Filesystem;
+﻿using Files.Filesystem;
 using System;
 using System.Collections.Generic;
 
@@ -7,7 +6,7 @@ namespace Files.Services
 {
     public interface IFileTagsSettingsService
     {
-        event EventHandler<SettingChangedEventArgs> OnSettingChangedEvent;
+        event EventHandler OnSettingImportedEvent;
 
         IList<FileTag> FileTagList { get; set; }
 

--- a/Files/Services/IFileTagsSettingsService.cs
+++ b/Files/Services/IFileTagsSettingsService.cs
@@ -1,14 +1,22 @@
-﻿using Files.Filesystem;
+﻿using Files.EventArguments;
+using Files.Filesystem;
+using System;
 using System.Collections.Generic;
 
 namespace Files.Services
 {
     public interface IFileTagsSettingsService
     {
+        event EventHandler<SettingChangedEventArgs> OnSettingChangedEvent;
+
         IList<FileTag> FileTagList { get; set; }
 
         FileTag GetTagById(string uid);
 
         IEnumerable<FileTag> GetTagsByName(string tagName);
+
+        object ExportSettings();
+
+        bool ImportSettings(object import);
     }
 }

--- a/Files/Services/Implementation/BundlesSettingsService.cs
+++ b/Files/Services/Implementation/BundlesSettingsService.cs
@@ -1,4 +1,5 @@
-﻿using Files.Models.JsonSettings;
+﻿using Files.Extensions;
+using Files.Models.JsonSettings;
 using System.Collections.Generic;
 using Windows.Storage;
 
@@ -20,19 +21,22 @@ namespace Files.Services.Implementation
 
         public override bool ImportSettings(object import)
         {
-            try
+            if (import is string importString)
             {
-                SavedBundles = (Dictionary<string, List<string>>)import;
-                
-                FlushSettings();
+                SavedBundles = jsonSettingsSerializer.DeserializeFromJson<Dictionary<string, List<string>>>(importString);
+            }
+            else if (import is Dictionary<string, List<string>> importDict)
+            {
+                SavedBundles = importDict;
+            }
 
+            if (SavedBundles != null)
+            {
+                FlushSettings();
                 return true;
             }
-            catch
-            {
-                // TODO: Display the error?
-                return false;
-            }
+
+            return false;
         }
 
         public override object ExportSettings()

--- a/Files/Services/Implementation/BundlesSettingsService.cs
+++ b/Files/Services/Implementation/BundlesSettingsService.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Extensions;
 using Files.Models.JsonSettings;
+using System;
 using System.Collections.Generic;
 using Windows.Storage;
 
@@ -7,6 +8,8 @@ namespace Files.Services.Implementation
 {
     public sealed class BundlesSettingsService : BaseObservableJsonSettingsModel, IBundlesSettingsService
     {
+        public event EventHandler OnSettingImportedEvent;
+
         public BundlesSettingsService()
             : base(System.IO.Path.Combine(ApplicationData.Current.LocalFolder.Path, Constants.LocalSettings.SettingsFolderName, Constants.LocalSettings.BundlesSettingsFileName),
                   isCachingEnabled: true)
@@ -33,6 +36,7 @@ namespace Files.Services.Implementation
             if (SavedBundles != null)
             {
                 FlushSettings();
+                OnSettingImportedEvent?.Invoke(this, null);
                 return true;
             }
 

--- a/Files/Services/Implementation/FileTagsSettingsService.cs
+++ b/Files/Services/Implementation/FileTagsSettingsService.cs
@@ -10,6 +10,8 @@ namespace Files.Services.Implementation
 {
     public sealed class FileTagsSettingsService : BaseJsonSettingsModel, IFileTagsSettingsService
     {
+        public event EventHandler OnSettingImportedEvent;
+
         private static readonly List<FileTag> s_defaultFileTags = new List<FileTag>()
         {
             new FileTag("Blue", "#0072BD"),
@@ -68,6 +70,7 @@ namespace Files.Services.Implementation
             if (FileTagList != null)
             {
                 FlushSettings();
+                OnSettingImportedEvent?.Invoke(this, null);
                 return true;
             }
 

--- a/Files/Services/Implementation/FileTagsSettingsService.cs
+++ b/Files/Services/Implementation/FileTagsSettingsService.cs
@@ -51,5 +51,33 @@ namespace Files.Services.Implementation
         {
             return FileTagList.Where(x => x.TagName.StartsWith(tagName, StringComparison.OrdinalIgnoreCase));
         }
+
+        public override bool ImportSettings(object import)
+        {
+            if (import is string importString)
+            {
+                FileTagList = jsonSettingsSerializer.DeserializeFromJson<List<FileTag>>(importString);
+            }
+            else if (import is List<FileTag> importList)
+            {
+                FileTagList = importList;
+            }
+
+            FileTagList ??= s_defaultFileTags;
+
+            if (FileTagList != null)
+            {
+                FlushSettings();
+                return true;
+            }
+
+            return false;
+        }
+
+        public override object ExportSettings()
+        {
+            // Return string in Json format
+            return jsonSettingsSerializer.SerializeToJson(FileTagList);
+        }
     }
 }

--- a/Files/Services/Implementation/UserSettingsService.cs
+++ b/Files/Services/Implementation/UserSettingsService.cs
@@ -63,7 +63,15 @@ namespace Files.Services.Implementation
 
         public override bool ImportSettings(object import)
         {
-            var settingsImport = jsonSettingsSerializer.DeserializeFromJson<Dictionary<string, object>>((string)import);
+            Dictionary<string, object> settingsImport = null;
+            if (import is string importString)
+            {
+                settingsImport = jsonSettingsSerializer.DeserializeFromJson<Dictionary<string, object>>(importString);
+            }
+            else if (import is Dictionary<string, object> importDict)
+            {
+                settingsImport = importDict;
+            }
 
             if (!settingsImport.IsEmpty())
             {

--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -231,7 +231,7 @@
                                 <ToggleSwitch
                                     x:Uid="NavToolbarShowFolderWidget"
                                     Header="Show Folders widget"
-                                    IsOn="{x:Bind ViewModel.ShowFolderWidgetWidget, Mode=TwoWay}" />
+                                    IsOn="{x:Bind ViewModel.ShowFoldersWidget, Mode=TwoWay}" />
                                 <ToggleSwitch
                                     x:Uid="NavToolbarShowDrivesWidget"
                                     Header="Show Drives widget"

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -360,18 +360,19 @@ namespace Files.ViewModels
             shouldDisplayFileExtensions =  UserSettingsService.PreferencesSettingsService.ShowFileExtensions;
 
             UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
-            FileTagsSettingsService.OnSettingChangedEvent += FileTagsSettingsService_OnSettingChangedEvent;
+            FileTagsSettingsService.OnSettingImportedEvent += FileTagsSettingsService_OnSettingImportedEvent;
             AppServiceConnectionHelper.ConnectionChanged += AppServiceConnectionHelper_ConnectionChanged;
         }
 
-        private void FileTagsSettingsService_OnSettingChangedEvent(object sender, SettingChangedEventArgs e)
+        private async void FileTagsSettingsService_OnSettingImportedEvent(object sender, EventArgs e)
         {
-            switch (e.settingName)
+            await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
             {
-                case nameof(FileTagsSettingsService.FileTagList):
-                    // Reload tags
-                    break;
-            }
+                if (WorkingDirectory != "Home".GetLocalized())
+                {
+                    RefreshItems(null);
+                }
+            });
         }
 
         private async void UserSettingsService_OnSettingChangedEvent(object sender, SettingChangedEventArgs e)
@@ -2263,7 +2264,7 @@ namespace Files.ViewModels
                 Connection.RequestReceived -= Connection_RequestReceived;
             }
             UserSettingsService.OnSettingChangedEvent -= UserSettingsService_OnSettingChangedEvent;
-            FileTagsSettingsService.OnSettingChangedEvent -= FileTagsSettingsService_OnSettingChangedEvent;
+            FileTagsSettingsService.OnSettingImportedEvent -= FileTagsSettingsService_OnSettingImportedEvent;
             AppServiceConnectionHelper.ConnectionChanged -= AppServiceConnectionHelper_ConnectionChanged;
             DefaultIcons.Clear();
         }

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -58,6 +58,7 @@ namespace Files.ViewModels
         private List<ListedItem> filesAndFolders;
 
         private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
+        private IFileTagsSettingsService FileTagsSettingsService { get; } = Ioc.Default.GetService<IFileTagsSettingsService>();
 
         // only used for Binding and ApplyFilesAndFoldersChangesAsync, don't manipulate on this!
         public BulkConcurrentObservableCollection<ListedItem> FilesAndFolders { get; }
@@ -359,7 +360,18 @@ namespace Files.ViewModels
             shouldDisplayFileExtensions =  UserSettingsService.PreferencesSettingsService.ShowFileExtensions;
 
             UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
+            FileTagsSettingsService.OnSettingChangedEvent += FileTagsSettingsService_OnSettingChangedEvent;
             AppServiceConnectionHelper.ConnectionChanged += AppServiceConnectionHelper_ConnectionChanged;
+        }
+
+        private void FileTagsSettingsService_OnSettingChangedEvent(object sender, SettingChangedEventArgs e)
+        {
+            switch (e.settingName)
+            {
+                case nameof(FileTagsSettingsService.FileTagList):
+                    // Reload tags
+                    break;
+            }
         }
 
         private async void UserSettingsService_OnSettingChangedEvent(object sender, SettingChangedEventArgs e)
@@ -2251,6 +2263,7 @@ namespace Files.ViewModels
                 Connection.RequestReceived -= Connection_RequestReceived;
             }
             UserSettingsService.OnSettingChangedEvent -= UserSettingsService_OnSettingChangedEvent;
+            FileTagsSettingsService.OnSettingChangedEvent -= FileTagsSettingsService_OnSettingChangedEvent;
             AppServiceConnectionHelper.ConnectionChanged -= AppServiceConnectionHelper_ConnectionChanged;
             DefaultIcons.Clear();
         }

--- a/Files/ViewModels/NavToolbarViewModel.cs
+++ b/Files/ViewModels/NavToolbarViewModel.cs
@@ -328,6 +328,21 @@ namespace Files.ViewModels
             dragOverTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
             SearchBox.SuggestionChosen += SearchRegion_SuggestionChosen;
             SearchBox.Escaped += SearchRegion_Escaped;
+            UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
+        }
+
+        private void UserSettingsService_OnSettingChangedEvent(object sender, EventArguments.SettingChangedEventArgs e)
+        {
+            switch (e.settingName)
+            {
+                case nameof(ShowFoldersWidget):
+                case nameof(ShowDrivesWidget):
+                case nameof(ShowBundlesWidget):
+                case nameof(ShowRecentFilesWidget):
+                    RefreshWidgetsRequested?.Invoke(this, EventArgs.Empty);
+                    OnPropertyChanged(e.settingName);
+                    break;
+            }
         }
 
         private DispatcherQueueTimer dragOverTimer;
@@ -642,7 +657,7 @@ namespace Files.ViewModels
 
         #region WidgetsPage Widgets
 
-        public bool ShowFolderWidgetWidget
+        public bool ShowFoldersWidget
         {
             get => UserSettingsService.WidgetsSettingsService.ShowFoldersWidget;
             set
@@ -1050,6 +1065,7 @@ namespace Files.ViewModels
         {
             SearchBox.SuggestionChosen -= SearchRegion_SuggestionChosen;
             SearchBox.Escaped -= SearchRegion_Escaped;
+            UserSettingsService.OnSettingChangedEvent -= UserSettingsService_OnSettingChangedEvent;
 
             InstanceViewModel.FolderSettings.SortDirectionPreferenceUpdated -= FolderSettings_SortDirectionPreferenceUpdated;
             InstanceViewModel.FolderSettings.SortOptionPreferenceUpdated -= FolderSettings_SortOptionPreferenceUpdated;

--- a/Files/ViewModels/Previews/BasePreviewModel.cs
+++ b/Files/ViewModels/Previews/BasePreviewModel.cs
@@ -153,18 +153,7 @@ namespace Files.ViewModels.Previews
 
         public static async Task<string> ReadFileAsText(BaseStorageFile file, int maxLength = 10 * 1024 * 1024)
         {
-            using (var stream = await file.OpenStreamForReadAsync())
-            {
-                var result = new StringBuilder();
-                var bytesRead = 0;
-                do
-                {
-                    var buffer = new byte[maxLength];
-                    bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length);
-                    result.Append(Encoding.UTF8.GetString(buffer, 0, bytesRead));
-                } while (bytesRead > 0 && result.Length <= maxLength);
-                return result.ToString();
-            }
+            return await file.ReadTextAsync(maxLength);
         }
     }
 }

--- a/Files/ViewModels/SettingsViewModels/AboutViewModel.cs
+++ b/Files/ViewModels/SettingsViewModels/AboutViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Files.Extensions;
+﻿using Files.Filesystem;
+using Files.Filesystem.StorageItems;
 using Files.Helpers;
 using Files.Services;
 using Microsoft.Toolkit.Mvvm.ComponentModel;
@@ -22,6 +23,8 @@ namespace Files.ViewModels.SettingsViewModels
     public class AboutViewModel : ObservableObject
     {
         private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
+        private IBundlesSettingsService BundlesSettingsService { get; } = Ioc.Default.GetService<IBundlesSettingsService>();
+        protected IFileTagsSettingsService FileTagsSettingsService { get; } = Ioc.Default.GetService<IFileTagsSettingsService>();
 
         public RelayCommand OpenLogLocationCommand => new RelayCommand(() => SettingsViewModel.OpenLogLocation());
         public RelayCommand CopyVersionInfoCommand => new RelayCommand(() => CopyVersionInfo());
@@ -42,31 +45,92 @@ namespace Files.ViewModels.SettingsViewModels
         private async Task ExportSettings()
         {
             FileSavePicker filePicker = new FileSavePicker();
-            filePicker.FileTypeChoices.Add("Json File", Path.GetExtension(Constants.LocalSettings.UserSettingsFileName).CreateList());
+            filePicker.FileTypeChoices.Add("Zip File", new[] { ".zip" });
+            filePicker.SuggestedFileName = $"Files_{App.AppVersion}";
 
             StorageFile file = await filePicker.PickSaveFileAsync();
             if (file != null)
             {
-                string export = (string)UserSettingsService.ExportSettings();
-                await FileIO.WriteTextAsync(file, export);
+                try
+                {
+                    var zipFolder = await ZipStorageFolder.FromStorageFileAsync(file);
+                    if (zipFolder == null)
+                    {
+                        return;
+                    }
+                    var localFolderPath = ApplicationData.Current.LocalFolder.Path;
+                    // Export user settings
+                    var userSettings = await zipFolder.CreateFileAsync(Constants.LocalSettings.UserSettingsFileName, CreationCollisionOption.ReplaceExisting);
+                    string exportSettings = (string)UserSettingsService.ExportSettings();
+                    await userSettings.WriteTextAsync(exportSettings);
+                    // Export bundles
+                    var bundles = await zipFolder.CreateFileAsync(Constants.LocalSettings.BundlesSettingsFileName, CreationCollisionOption.ReplaceExisting);
+                    string exportBundles = (string)BundlesSettingsService.ExportSettings();
+                    await bundles.WriteTextAsync(exportBundles);
+                    // Export pinned items
+                    var pinnedItems = await BaseStorageFile.GetFileFromPathAsync(Path.Combine(localFolderPath, Constants.LocalSettings.SettingsFolderName, App.SidebarPinnedController.JsonFileName));
+                    await pinnedItems.CopyAsync(zipFolder, pinnedItems.Name, NameCollisionOption.ReplaceExisting);
+                    // Export terminals config
+                    var terminals = await BaseStorageFile.GetFileFromPathAsync(Path.Combine(localFolderPath, Constants.LocalSettings.SettingsFolderName, App.TerminalController.JsonFileName));
+                    await terminals.CopyAsync(zipFolder, terminals.Name, NameCollisionOption.ReplaceExisting);
+                    // Export file tags list and DB
+                    var fileTagsList = await zipFolder.CreateFileAsync(Constants.LocalSettings.FileTagSettingsFileName, CreationCollisionOption.ReplaceExisting);
+                    string exportTags = (string)FileTagsSettingsService.ExportSettings();
+                    await fileTagsList.WriteTextAsync(exportTags);
+                    var fileTagsDB = await zipFolder.CreateFileAsync(Path.GetFileName(FileTagsHelper.FileTagsDbPath), CreationCollisionOption.ReplaceExisting);
+                    string exportTagsDB = FileTagsHelper.DbInstance.Export();
+                    await fileTagsDB.WriteTextAsync(exportTagsDB);
+                }
+                catch (Exception ex)
+                {
+                    App.Logger.Warn(ex, "Error exporting settings");
+                }
             }
         }
 
         private async Task ImportSettings()
         {
             FileOpenPicker filePicker = new FileOpenPicker();
-            filePicker.FileTypeFilter.Add(Path.GetExtension(Constants.LocalSettings.UserSettingsFileName));
+            filePicker.FileTypeFilter.Add(".zip");
 
             StorageFile file = await filePicker.PickSingleFileAsync();
             if (file != null)
             {
                 try
                 {
-                    string import = await FileIO.ReadTextAsync(file);
-                    UserSettingsService.ImportSettings(import);
+                    var zipFolder = await ZipStorageFolder.FromStorageFileAsync(file);
+                    if (zipFolder == null)
+                    {
+                        return;
+                    }
+                    var localFolderPath = ApplicationData.Current.LocalFolder.Path;
+                    var settingsFolder = await StorageFolder.GetFolderFromPathAsync(Path.Combine(localFolderPath, Constants.LocalSettings.SettingsFolderName));
+                    // Import user settings
+                    var userSettingsFile = await zipFolder.GetFileAsync(Constants.LocalSettings.UserSettingsFileName);
+                    string importSettings = await userSettingsFile.ReadTextAsync();
+                    UserSettingsService.ImportSettings(importSettings);
+                    // Import bundles
+                    var bundles = await zipFolder.GetFileAsync(Constants.LocalSettings.BundlesSettingsFileName);
+                    string importBundles = await bundles.ReadTextAsync();
+                    BundlesSettingsService.ImportSettings(importBundles);
+                    // Import pinned items
+                    var pinnedItems = await zipFolder.GetFileAsync(App.SidebarPinnedController.JsonFileName);
+                    await pinnedItems.CopyAsync(settingsFolder, pinnedItems.Name, NameCollisionOption.ReplaceExisting);
+                    await App.SidebarPinnedController.ReloadAsync();
+                    // Import terminals config
+                    var terminals = await zipFolder.GetFileAsync(App.TerminalController.JsonFileName);
+                    await terminals.CopyAsync(settingsFolder, terminals.Name, NameCollisionOption.ReplaceExisting);
+                    // Import file tags list and DB
+                    var fileTagsList = await zipFolder.GetFileAsync(Constants.LocalSettings.FileTagSettingsFileName);
+                    string importTags = await fileTagsList.ReadTextAsync();
+                    FileTagsSettingsService.ImportSettings(importTags);
+                    var fileTagsDB = await zipFolder.GetFileAsync(Path.GetFileName(FileTagsHelper.FileTagsDbPath));
+                    string importTagsDB = await fileTagsDB.ReadTextAsync();
+                    FileTagsHelper.DbInstance.Import(importTagsDB);
                 }
-                catch
+                catch (Exception ex)
                 {
+                    App.Logger.Warn(ex, "Error importing settings");
                     UIHelpers.CloseAllDialogs();
                     await DialogDisplayHelper.ShowDialogAsync("SettingsImportErrorTitle".GetLocalized(), "SettingsImportErrorDescription".GetLocalized());
                 }

--- a/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundlesViewModel.cs
@@ -105,7 +105,7 @@ namespace Files.ViewModels.Widgets.Bundles
             ImportBundlesCommand = new AsyncRelayCommand(ImportBundles);
             ExportBundlesCommand = new AsyncRelayCommand(ExportBundles);
 
-            BundlesSettingsService.OnSettingChangedEvent += BundlesSettingsService_OnSettingChangedEvent;
+            BundlesSettingsService.OnSettingImportedEvent += BundlesSettingsService_OnSettingImportedEvent;
         }
 
         #endregion Constructor
@@ -259,14 +259,9 @@ namespace Files.ViewModels.Widgets.Bundles
 
         #region Handlers
 
-        private async void BundlesSettingsService_OnSettingChangedEvent(object sender, EventArguments.SettingChangedEventArgs e)
+        private async void BundlesSettingsService_OnSettingImportedEvent(object sender, EventArgs e)
         {
-            switch (e.settingName)
-            {
-                case nameof(BundlesSettingsService.SavedBundles):
-                    await Load();
-                    break;
-            }
+            await Load();
         }
 
         private void OpenPathHandle(string path, FilesystemItemType itemType, bool openSilent, bool openViaApplicationPicker, IEnumerable<string> selectItems)
@@ -285,8 +280,6 @@ namespace Files.ViewModels.Widgets.Bundles
         /// <param name="item"></param>
         private void NotifyItemRemovedHandle(BundleContainerViewModel item)
         {
-            BundlesSettingsService.OnSettingChangedEvent -= BundlesSettingsService_OnSettingChangedEvent;
-
             Items.Remove(item);
             item?.Dispose();
 
@@ -464,6 +457,7 @@ namespace Files.ViewModels.Widgets.Bundles
             }
 
             Items.CollectionChanged -= Items_CollectionChanged;
+            BundlesSettingsService.OnSettingImportedEvent -= BundlesSettingsService_OnSettingImportedEvent;
         }
 
         #endregion IDisposable


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7032

**Details of Changes**
Add details of changes here.
- Extends the import/export command in About page to all settings. Settings are exported in a .zip file. It includes: pinned items, user settings, file tags, terminal profiles, bundles. On import, all settings are applied without restart.

**Validation**
How did you test these changes?
- [x] Built and ran the app
