### PR TITLE
Remove always true condition

### DIFF
--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -456,7 +456,7 @@ namespace FilesFullTrust
             while (true)
             {
                 prevHwnd = User32.FindWindowEx(HWND.NULL, prevHwnd, null, null);
-                if (prevHwnd == null || prevHwnd == HWND.NULL)
+                if (prevHwnd == HWND.NULL)
                 {
                     break;
                 }


### PR DESCRIPTION
**Details of Changes**

Comparing a struct with null is always false as a struct cannot be null.
