### PR TITLE
Replace culture-sensitive operations with ordinal operations

### DIFF
--- a/Files.Launcher/Helpers/ShellFolderHelpers.cs
+++ b/Files.Launcher/Helpers/ShellFolderHelpers.cs
@@ -47,11 +47,11 @@ namespace FilesFullTrust.Helpers
             string filePath = folderItem.Name; // Original file path + name (recycle bin only)
             if (!isFolder && !string.IsNullOrEmpty(parsingPath) && Path.GetExtension(parsingPath) is string realExtension && !string.IsNullOrEmpty(realExtension))
             {
-                if (!string.IsNullOrEmpty(fileName) && !fileName.EndsWith(realExtension, StringComparison.Ordinal))
+                if (!string.IsNullOrEmpty(fileName) && !fileName.EndsWith(realExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     fileName = $"{fileName}{realExtension}";
                 }
-                if (!string.IsNullOrEmpty(filePath) && !filePath.EndsWith(realExtension, StringComparison.Ordinal))
+                if (!string.IsNullOrEmpty(filePath) && !filePath.EndsWith(realExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     filePath = $"{filePath}{realExtension}";
                 }

--- a/Files.Launcher/Helpers/ShellFolderHelpers.cs
+++ b/Files.Launcher/Helpers/ShellFolderHelpers.cs
@@ -47,11 +47,11 @@ namespace FilesFullTrust.Helpers
             string filePath = folderItem.Name; // Original file path + name (recycle bin only)
             if (!isFolder && !string.IsNullOrEmpty(parsingPath) && Path.GetExtension(parsingPath) is string realExtension && !string.IsNullOrEmpty(realExtension))
             {
-                if (!string.IsNullOrEmpty(fileName) && !fileName.EndsWith(realExtension))
+                if (!string.IsNullOrEmpty(fileName) && !fileName.EndsWith(realExtension, StringComparison.Ordinal))
                 {
                     fileName = $"{fileName}{realExtension}";
                 }
-                if (!string.IsNullOrEmpty(filePath) && !filePath.EndsWith(realExtension))
+                if (!string.IsNullOrEmpty(filePath) && !filePath.EndsWith(realExtension, StringComparison.Ordinal))
                 {
                     filePath = $"{filePath}{realExtension}";
                 }

--- a/Files.Launcher/Helpers/ShellNewMenuHelper.cs
+++ b/Files.Launcher/Helpers/ShellNewMenuHelper.cs
@@ -16,7 +16,7 @@ namespace FilesFullTrust.Helpers
         public static async Task<List<ShellNewEntry>> GetNewContextMenuEntries()
         {
             var newMenuItems = new List<ShellNewEntry>();
-            foreach (var keyName in Registry.ClassesRoot.GetSubKeyNames().Where(x => x.StartsWith(".") && !new string[] { ShellLibraryItem.EXTENSION, ".url", ".lnk" }.Contains(x)))
+            foreach (var keyName in Registry.ClassesRoot.GetSubKeyNames().Where(x => x.StartsWith('.') && !new string[] { ShellLibraryItem.EXTENSION, ".url", ".lnk" }.Contains(x)))
             {
                 using var key = Registry.ClassesRoot.OpenSubKeySafe(keyName);
                 if (key != null)

--- a/Files.Launcher/Helpers/ShellNewMenuHelper.cs
+++ b/Files.Launcher/Helpers/ShellNewMenuHelper.cs
@@ -16,7 +16,7 @@ namespace FilesFullTrust.Helpers
         public static async Task<List<ShellNewEntry>> GetNewContextMenuEntries()
         {
             var newMenuItems = new List<ShellNewEntry>();
-            foreach (var keyName in Registry.ClassesRoot.GetSubKeyNames().Where(x => x.StartsWith('.') && !new string[] { ShellLibraryItem.EXTENSION, ".url", ".lnk" }.Contains(x)))
+            foreach (var keyName in Registry.ClassesRoot.GetSubKeyNames().Where(x => x.StartsWith('.') && !new string[] { ShellLibraryItem.EXTENSION, ".url", ".lnk" }.Contains(x, StringComparer.OrdinalIgnoreCase)))
             {
                 using var key = Registry.ClassesRoot.OpenSubKeySafe(keyName);
                 if (key != null)

--- a/Files.Launcher/MessageHandlers/ApplicationLaunchHandler.cs
+++ b/Files.Launcher/MessageHandlers/ApplicationLaunchHandler.cs
@@ -74,7 +74,7 @@ namespace FilesFullTrust.MessageHandlers
             var workingDirectory = message.Get("WorkingDirectory", "");
             var currentWindows = Win32API.GetDesktopWindows();
 
-            if (new[] { ".vhd", ".vhdx" }.Contains(Path.GetExtension(application).ToLower()))
+            if (new[] { ".vhd", ".vhdx" }.Contains(Path.GetExtension(application).ToLowerInvariant()))
             {
                 // Use powershell to mount vhds as this requires admin rights
                 Win32API.MountVhdDisk(application);
@@ -92,7 +92,7 @@ namespace FilesFullTrust.MessageHandlers
                 {
                     process.StartInfo.UseShellExecute = true;
                     process.StartInfo.Verb = "runas";
-                    if (Path.GetExtension(application).ToLower() == ".msi")
+                    if (string.Equals(Path.GetExtension(application), ".msi", StringComparison.OrdinalIgnoreCase))
                     {
                         process.StartInfo.FileName = "msiexec.exe";
                         process.StartInfo.Arguments = $"/a \"{application}\"";
@@ -102,7 +102,7 @@ namespace FilesFullTrust.MessageHandlers
                 {
                     process.StartInfo.UseShellExecute = true;
                     process.StartInfo.Verb = "runasuser";
-                    if (Path.GetExtension(application).ToLower() == ".msi")
+                    if (string.Equals(Path.GetExtension(application), ".msi", StringComparison.OrdinalIgnoreCase))
                     {
                         process.StartInfo.FileName = "msiexec.exe";
                         process.StartInfo.Arguments = $"/i \"{application}\"";
@@ -187,10 +187,10 @@ namespace FilesFullTrust.MessageHandlers
 
         private string GetMtpPath(string executable)
         {
-            if (executable.StartsWith("\\\\?\\"))
+            if (executable.StartsWith("\\\\?\\", StringComparison.Ordinal))
             {
                 using var computer = new ShellFolder(Shell32.KNOWNFOLDERID.FOLDERID_ComputerFolder);
-                using var device = computer.FirstOrDefault(i => executable.Replace("\\\\?\\", "").StartsWith(i.Name));
+                using var device = computer.FirstOrDefault(i => executable.Replace("\\\\?\\", "", StringComparison.Ordinal).StartsWith(i.Name, StringComparison.Ordinal));
                 var deviceId = device?.ParsingName;
                 var itemPath = Regex.Replace(executable, @"^\\\\\?\\[^\\]*\\?", "");
                 return deviceId != null ? Path.Combine(deviceId, itemPath) : executable;

--- a/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
+++ b/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
@@ -502,7 +502,7 @@ namespace FilesFullTrust.MessageHandlers
                     try
                     {
                         var linkPath = (string)message["filepath"];
-                        if (linkPath.EndsWith(".lnk", StringComparison.Ordinal))
+                        if (linkPath.EndsWith(".lnk", StringComparison.OrdinalIgnoreCase))
                         {
                             using var link = new ShellLink(linkPath, LinkResolution.NoUIWithMsgPump, null, TimeSpan.FromMilliseconds(100));
                             await Win32API.SendMessageAsync(connection, new ValueSet()
@@ -514,7 +514,7 @@ namespace FilesFullTrust.MessageHandlers
                                 { "IsFolder", !string.IsNullOrEmpty(link.TargetPath) && link.Target.IsFolder }
                             }, message.Get("RequestID", (string)null));
                         }
-                        else if (linkPath.EndsWith(".url", StringComparison.Ordinal))
+                        else if (linkPath.EndsWith(".url", StringComparison.OrdinalIgnoreCase))
                         {
                             var linkUrl = await Win32API.StartSTATask(() =>
                             {

--- a/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
+++ b/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
@@ -502,7 +502,7 @@ namespace FilesFullTrust.MessageHandlers
                     try
                     {
                         var linkPath = (string)message["filepath"];
-                        if (linkPath.EndsWith(".lnk"))
+                        if (linkPath.EndsWith(".lnk", StringComparison.Ordinal))
                         {
                             using var link = new ShellLink(linkPath, LinkResolution.NoUIWithMsgPump, null, TimeSpan.FromMilliseconds(100));
                             await Win32API.SendMessageAsync(connection, new ValueSet()
@@ -514,7 +514,7 @@ namespace FilesFullTrust.MessageHandlers
                                 { "IsFolder", !string.IsNullOrEmpty(link.TargetPath) && link.Target.IsFolder }
                             }, message.Get("RequestID", (string)null));
                         }
-                        else if (linkPath.EndsWith(".url"))
+                        else if (linkPath.EndsWith(".url", StringComparison.Ordinal))
                         {
                             var linkUrl = await Win32API.StartSTATask(() =>
                             {
@@ -556,7 +556,7 @@ namespace FilesFullTrust.MessageHandlers
                         var targetPath = (string)message["targetpath"];
 
                         bool success = false;
-                        if (linkSavePath.EndsWith(".lnk"))
+                        if (linkSavePath.EndsWith(".lnk", StringComparison.Ordinal))
                         {
                             var arguments = (string)message["arguments"];
                             var workingDirectory = (string)message["workingdir"];
@@ -566,7 +566,7 @@ namespace FilesFullTrust.MessageHandlers
                             newLink.SaveAs(linkSavePath); // Overwrite if exists
                             success = true;
                         }
-                        else if (linkSavePath.EndsWith(".url"))
+                        else if (linkSavePath.EndsWith(".url", StringComparison.Ordinal))
                         {
                             success = await Win32API.StartSTATask(() =>
                             {
@@ -755,7 +755,7 @@ namespace FilesFullTrust.MessageHandlers
                             {
                                 Extensions.IgnoreExceptions(() =>
                                 {
-                                    var subPath = t.FilePath.Replace(e.SourceItem.FileSystemPath, destination);
+                                    var subPath = t.FilePath.Replace(e.SourceItem.FileSystemPath, destination, StringComparison.Ordinal);
                                     dbInstance.SetTag(subPath, FileTagsHandler.GetFileFRN(subPath), t.Tag);
                                 }, Program.Logger);
                             });
@@ -766,7 +766,7 @@ namespace FilesFullTrust.MessageHandlers
                             {
                                 Extensions.IgnoreExceptions(() =>
                                 {
-                                    var subPath = t.FilePath.Replace(e.SourceItem.FileSystemPath, destination);
+                                    var subPath = t.FilePath.Replace(e.SourceItem.FileSystemPath, destination, StringComparison.Ordinal);
                                     dbInstance.UpdateTag(t.FilePath, FileTagsHandler.GetFileFRN(subPath), subPath);
                                 }, Program.Logger);
                             });

--- a/Files.Launcher/MessageHandlers/FileTagsHandler.cs
+++ b/Files.Launcher/MessageHandlers/FileTagsHandler.cs
@@ -75,11 +75,11 @@ namespace FilesFullTrust.MessageHandlers
                 if (pathFromFrn != null)
                 {
                     // Frn is valid, update file path
-                    var tag = ReadFileTag(pathFromFrn.Replace(@"\\?\", ""));
+                    var tag = ReadFileTag(pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal));
                     if (tag != null)
                     {
-                        dbInstance.UpdateTag(file.Frn ?? 0, null, pathFromFrn.Replace(@"\\?\", ""));
-                        dbInstance.SetTag(pathFromFrn.Replace(@"\\?\", ""), file.Frn, tag);
+                        dbInstance.UpdateTag(file.Frn ?? 0, null, pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal));
+                        dbInstance.SetTag(pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal), file.Frn, tag);
                     }
                     else
                     {

--- a/Files.Launcher/MessageHandlers/LibrariesHandler.cs
+++ b/Files.Launcher/MessageHandlers/LibrariesHandler.cs
@@ -55,7 +55,7 @@ namespace FilesFullTrust.MessageHandlers
 
         private async void OnLibraryChanged(WatcherChangeTypes changeType, string oldPath, string newPath)
         {
-            if (newPath != null && (!newPath.ToLower().EndsWith(ShellLibraryItem.EXTENSION) || !File.Exists(newPath)))
+            if (newPath != null && (!newPath.ToLowerInvariant().EndsWith(ShellLibraryItem.EXTENSION, StringComparison.Ordinal) || !File.Exists(newPath)))
             {
                 System.Diagnostics.Debug.WriteLine($"Ignored library event: {changeType}, {oldPath} -> {newPath}");
                 return;

--- a/Files.Launcher/MessageHandlers/RecycleBinHandler.cs
+++ b/Files.Launcher/MessageHandlers/RecycleBinHandler.cs
@@ -109,7 +109,7 @@ namespace FilesFullTrust.MessageHandlers
         private async void RecycleBinWatcher_Changed(object sender, FileSystemEventArgs e)
         {
             System.Diagnostics.Debug.WriteLine($"Recycle bin event: {e.ChangeType}, {e.FullPath}");
-            if (e.Name.StartsWith("$I"))
+            if (e.Name.StartsWith("$I", StringComparison.Ordinal))
             {
                 // Recycle bin also stores a file starting with $I for each item
                 return;

--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -506,7 +506,7 @@ namespace FilesFullTrust
                 {
                     if (Regex.IsMatch(nameWithoutExt, @".*\(\d+\)"))
                     {
-                        uniquePath = Path.Combine(directory, $"{nameWithoutExt.Substring(0, nameWithoutExt.LastIndexOf("(", StringComparison.InvariantCultureIgnoreCase))}({count}){extension}");
+                        uniquePath = Path.Combine(directory, $"{nameWithoutExt.Substring(0, nameWithoutExt.LastIndexOf("(", StringComparison.Ordinal))}({count}){extension}");
                     }
                     else
                     {
@@ -523,7 +523,7 @@ namespace FilesFullTrust
                 {
                     if (Regex.IsMatch(Name, @".*\(\d+\)"))
                     {
-                        uniquePath = Path.Combine(directory, $"{Name.Substring(0, Name.LastIndexOf("(", StringComparison.InvariantCultureIgnoreCase))}({Count})");
+                        uniquePath = Path.Combine(directory, $"{Name.Substring(0, Name.LastIndexOf("(", StringComparison.Ordinal))}({Count})");
                     }
                     else
                     {

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -165,7 +165,7 @@ namespace Files
                     ListedItem previouslySelectedItem = null;
 
                     // Use FilesAndFolders because only displayed entries should be jumped to
-                    IEnumerable<ListedItem> candidateItems = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.Where(f => f.ItemName.Length >= value.Length && f.ItemName.Substring(0, value.Length).ToLower() == value);
+                    IEnumerable<ListedItem> candidateItems = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.Where(f => f.ItemName.Length >= value.Length && string.Equals(f.ItemName.Substring(0, value.Length), value, StringComparison.OrdinalIgnoreCase));
 
                     if (IsItemSelected)
                     {
@@ -424,7 +424,7 @@ namespace Files
                 // pathRoot will be empty on recycle bin path
                 var workingDir = ParentShellPageInstance.FilesystemViewModel.WorkingDirectory ?? string.Empty;
                 string pathRoot = GetPathRoot(workingDir);
-                if (string.IsNullOrEmpty(pathRoot) || workingDir.StartsWith(CommonPaths.RecycleBinPath)) // Can't go up from recycle bin
+                if (string.IsNullOrEmpty(pathRoot) || workingDir.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal)) // Can't go up from recycle bin
                 {
                     ParentShellPageInstance.NavToolbarViewModel.CanNavigateToParent = false;
                 }
@@ -433,8 +433,8 @@ namespace Files
                     ParentShellPageInstance.NavToolbarViewModel.CanNavigateToParent = true;
                 }
 
-                ParentShellPageInstance.InstanceViewModel.IsPageTypeRecycleBin = workingDir.StartsWith(CommonPaths.RecycleBinPath);
-                ParentShellPageInstance.InstanceViewModel.IsPageTypeMtpDevice = workingDir.StartsWith("\\\\?\\");
+                ParentShellPageInstance.InstanceViewModel.IsPageTypeRecycleBin = workingDir.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal);
+                ParentShellPageInstance.InstanceViewModel.IsPageTypeMtpDevice = workingDir.StartsWith("\\\\?\\", StringComparison.Ordinal);
                 ParentShellPageInstance.InstanceViewModel.IsPageTypeFtp = FtpHelpers.IsFtpPath(workingDir);
                 ParentShellPageInstance.InstanceViewModel.IsPageTypeZipFolder = ZipStorageFolder.IsZipPath(workingDir);
                 ParentShellPageInstance.InstanceViewModel.IsPageTypeLibrary = LibraryHelper.IsLibraryPath(workingDir);

--- a/Files/CommandLine/CommandLineParser.cs
+++ b/Files/CommandLine/CommandLineParser.cs
@@ -48,7 +48,7 @@ namespace Files.CommandLine
                         //case "-Cmdless":
                         try
                         {
-                            if (kvp.Value.StartsWith("::{") || kvp.Value.StartsWith("shell:"))
+                            if (kvp.Value.StartsWith("::{", StringComparison.Ordinal) || kvp.Value.StartsWith("shell:", StringComparison.Ordinal))
                             {
                                 command.Type = ParsedCommandType.ExplorerShellCommand;
                             }
@@ -94,7 +94,7 @@ namespace Files.CommandLine
                 }
             }
 
-            return new string(commandLineCharArray).Replace("\"", "").Split('\n');
+            return new string(commandLineCharArray).Replace("\"", "", StringComparison.Ordinal).Split('\n');
         }
 
         public static List<KeyValuePair<string, string>> Parse(string[] args = null)
@@ -110,7 +110,7 @@ namespace Files.CommandLine
                 {
                     for (int i = 0; i < args.Length; i++)
                     {
-                        if (args[i].StartsWith("-") || args[i].StartsWith("/"))
+                        if (args[i].StartsWith('-') || args[i].StartsWith('/'))
                         {
                             var data = ParseData(args, i);
 
@@ -143,9 +143,9 @@ namespace Files.CommandLine
         {
             string key = null;
             string val = null;
-            if (args[index].StartsWith("-") || args[index].StartsWith("/"))
+            if (args[index].StartsWith('-') || args[index].StartsWith('/'))
             {
-                if (args[index].Contains(":"))
+                if (args[index].Contains(":", StringComparison.Ordinal))
                 {
                     string argument = args[index];
                     int endIndex = argument.IndexOf(':');
@@ -158,7 +158,7 @@ namespace Files.CommandLine
                 {
                     key = args[index];
                     int argIndex = 1 + index;
-                    if (argIndex < args.Length && !(args[argIndex].StartsWith("-") || args[argIndex].StartsWith("/")))
+                    if (argIndex < args.Length && !(args[argIndex].StartsWith('-') || args[argIndex].StartsWith('/')))
                     {
                         val = args[argIndex];
                     }

--- a/Files/DataModels/NavigationControlItems/DriveItem.cs
+++ b/Files/DataModels/NavigationControlItems/DriveItem.cs
@@ -29,7 +29,7 @@ namespace Files.DataModels.NavigationControlItems
             set
             {
                 path = value;
-                HoverDisplayText = Path.Contains("?") ? Text : Path;
+                HoverDisplayText = Path.Contains("?", StringComparison.Ordinal) ? Text : Path;
             }
         }
 

--- a/Files/DataModels/NavigationControlItems/LocationItem.cs
+++ b/Files/DataModels/NavigationControlItems/LocationItem.cs
@@ -32,7 +32,7 @@ namespace Files.DataModels.NavigationControlItems
             set
             {
                 path = value;
-                HoverDisplayText = Path.Contains("?") || Path.ToLower().StartsWith("shell:") || Path.ToLower().EndsWith(ShellLibraryItem.EXTENSION) || Path == "Home".GetLocalized() ? Text : Path;
+                HoverDisplayText = Path.Contains("?", StringComparison.Ordinal) || Path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase) || Path.EndsWith(ShellLibraryItem.EXTENSION, StringComparison.OrdinalIgnoreCase) || Path == "Home".GetLocalized() ? Text : Path;
             }
         }
 

--- a/Files/DataModels/NavigationControlItems/WslDistroItem.cs
+++ b/Files/DataModels/NavigationControlItems/WslDistroItem.cs
@@ -15,7 +15,7 @@ namespace Files.DataModels.NavigationControlItems
             set
             {
                 path = value;
-                HoverDisplayText = Path.Contains("?") ? Text : Path;
+                HoverDisplayText = Path.Contains("?", StringComparison.Ordinal) ? Text : Path;
             }
         }
 

--- a/Files/Extensions/ShellNewEntryExtensions.cs
+++ b/Files/Extensions/ShellNewEntryExtensions.cs
@@ -68,7 +68,7 @@ namespace Files.Extensions
         public static async Task<FilesystemResult<BaseStorageFile>> Create(this ShellNewEntry shellEntry, BaseStorageFolder parentFolder, string fileName)
         {
             FilesystemResult<BaseStorageFile> createdFile = null;
-            if (!fileName.EndsWith(shellEntry.Extension))
+            if (!fileName.EndsWith(shellEntry.Extension, StringComparison.Ordinal))
             {
                 fileName += shellEntry.Extension;
             }

--- a/Files/Extensions/StringExtensions.cs
+++ b/Files/Extensions/StringExtensions.cs
@@ -43,7 +43,7 @@ namespace Files.Extensions
             for (int i = 0; i <= ending.Length; i++)
             {
                 string tmp = result + ending.Right(i);
-                if (tmp.EndsWith(ending))
+                if (tmp.EndsWith(ending, StringComparison.Ordinal))
                 {
                     return tmp;
                 }
@@ -85,7 +85,7 @@ namespace Files.Extensions
         {
             foreach (var item in abbreviations)
             {
-                value = value.Replace(item.Key, item.Value);
+                value = value.Replace(item.Key, item.Value, StringComparison.Ordinal);
             }
             return value;
         }

--- a/Files/Filesystem/Cloud/Providers/GoogleDriveCloudProvider.cs
+++ b/Files/Filesystem/Cloud/Providers/GoogleDriveCloudProvider.cs
@@ -44,7 +44,7 @@ namespace Files.Filesystem.Cloud.Providers
                         // By default, the path will be prefixed with "\\?\" (unless another app has explicitly changed it).
                         // \\?\ indicates to Win32 that the filename may be longer than MAX_PATH (see MSDN).
                         // Parts of .NET (e.g. the File class) don't handle this very well, so remove this prefix.
-                        if (path.StartsWith(@"\\?\"))
+                        if (path.StartsWith(@"\\?\", StringComparison.Ordinal))
                         {
                             path = path.Substring(@"\\?\".Length);
                         }

--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -237,7 +237,7 @@ namespace Files.Filesystem
             {
                 // If drive already in list, skip.
                 if (drivesList.Any(x => x.DeviceID == deviceId ||
-                string.IsNullOrEmpty(root.Path) ? x.Path.Contains(root.Name) : x.Path == root.Path))
+                string.IsNullOrEmpty(root.Path) ? x.Path.Contains(root.Name, StringComparison.Ordinal) : x.Path == root.Path))
                 {
                     return;
                 }
@@ -393,7 +393,7 @@ namespace Files.Filesystem
                 return null;
             }
             var rootPath = Path.GetPathRoot(devicePath);
-            if (devicePath.StartsWith("\\\\?\\")) // USB device
+            if (devicePath.StartsWith("\\\\?\\", StringComparison.Ordinal)) // USB device
             {
                 // Check among already discovered drives
                 StorageFolder matchingDrive = App.DrivesManager.Drives.FirstOrDefault(x =>
@@ -407,7 +407,7 @@ namespace Files.Filesystem
                         try
                         {
                             var root = StorageDevice.FromId(item.Id);
-                            if (Helpers.PathNormalization.NormalizePath(rootPath).Replace("\\\\?\\", "") == root.Name.ToUpperInvariant())
+                            if (Helpers.PathNormalization.NormalizePath(rootPath).Replace("\\\\?\\", "", StringComparison.Ordinal) == root.Name.ToUpperInvariant())
                             {
                                 matchingDrive = root;
                                 break;
@@ -424,9 +424,9 @@ namespace Files.Filesystem
                     return new StorageFolderWithPath(matchingDrive, rootPath);
                 }
             }
-            else if (devicePath.StartsWith("\\\\")) // Network share
+            else if (devicePath.StartsWith("\\\\", StringComparison.Ordinal)) // Network share
             {
-                rootPath = rootPath.LastIndexOf("\\") > 1 ? rootPath.Substring(0, rootPath.LastIndexOf("\\")) : rootPath; // Remove share name
+                rootPath = rootPath.LastIndexOf("\\", StringComparison.Ordinal) > 1 ? rootPath.Substring(0, rootPath.LastIndexOf("\\", StringComparison.Ordinal)) : rootPath; // Remove share name
                 return new StorageFolderWithPath(await StorageFolder.GetFolderFromPathAsync(rootPath), rootPath);
             }
             // It's ok to return null here, on normal drives StorageFolder.GetFolderFromPathAsync works
@@ -450,7 +450,7 @@ namespace Files.Filesystem
                     {
                         // If drive already in list, skip.
                         var matchingDrive = drivesList.FirstOrDefault(x => x.DeviceID == deviceId ||
-                        string.IsNullOrEmpty(rootAdded.Result.Path) ? x.Path.Contains(rootAdded.Result.Name) : x.Path == rootAdded.Result.Path);
+                        string.IsNullOrEmpty(rootAdded.Result.Path) ? x.Path.Contains(rootAdded.Result.Name, StringComparison.Ordinal) : x.Path == rootAdded.Result.Path);
                         if (matchingDrive != null)
                         {
                             // Update device id to match drive letter

--- a/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -184,7 +184,7 @@ namespace Files.Filesystem
                                                      IProgress<FileSystemStatusCode> errorCode,
                                                      CancellationToken cancellationToken)
         {
-            if (destination.StartsWith(CommonPaths.RecycleBinPath))
+            if (destination.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
             {
                 errorCode?.Report(FileSystemStatusCode.Unauthorized);
                 progress?.Report(100.0f);
@@ -339,7 +339,7 @@ namespace Files.Filesystem
                 {
                     await Task.Delay(50); // Small delay for the item to appear in the file list
                     List<ListedItem> copiedListedItems = associatedInstance.FilesystemViewModel.FilesAndFolders
-                        .Where(listedItem => destination.Contains(listedItem.ItemPath)).ToList();
+                        .Where(listedItem => destination.Contains(listedItem.ItemPath, StringComparison.Ordinal)).ToList();
 
                     if (copiedListedItems.Count > 0)
                     {
@@ -400,7 +400,7 @@ namespace Files.Filesystem
                 return await CopyAsync(source, destination, collision, progress, errorCode, cancellationToken);
             }
 
-            if (destination.StartsWith(CommonPaths.RecycleBinPath))
+            if (destination.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
             {
                 errorCode?.Report(FileSystemStatusCode.Unauthorized);
                 progress?.Report(100.0f);
@@ -544,7 +544,7 @@ namespace Files.Filesystem
                 {
                     await Task.Delay(50); // Small delay for the item to appear in the file list
                     List<ListedItem> movedListedItems = associatedInstance.FilesystemViewModel.FilesAndFolders
-                        .Where(listedItem => destination.Contains(listedItem.ItemPath)).ToList();
+                        .Where(listedItem => destination.Contains(listedItem.ItemPath, StringComparison.Ordinal)).ToList();
 
                     if (movedListedItems.Count > 0)
                     {
@@ -636,7 +636,7 @@ namespace Files.Filesystem
             if (deleteFromRecycleBin)
             {
                 // Recycle bin also stores a file starting with $I for each item
-                string iFilePath = Path.Combine(Path.GetDirectoryName(source.Path), Path.GetFileName(source.Path).Replace("$R", "$I"));
+                string iFilePath = Path.Combine(Path.GetDirectoryName(source.Path), Path.GetFileName(source.Path).Replace("$R", "$I", StringComparison.Ordinal));
                 await associatedInstance.FilesystemViewModel.GetFileFromPathAsync(iFilePath)
                     .OnSuccess(iFile => iFile.DeleteAsync(StorageDeleteOption.PermanentDelete).AsTask());
             }
@@ -851,7 +851,7 @@ namespace Files.Filesystem
             if (fsResult)
             {
                 // Recycle bin also stores a file starting with $I for each item
-                string iFilePath = Path.Combine(Path.GetDirectoryName(source.Path), Path.GetFileName(source.Path).Replace("$R", "$I"));
+                string iFilePath = Path.Combine(Path.GetDirectoryName(source.Path), Path.GetFileName(source.Path).Replace("$R", "$I", StringComparison.Ordinal));
                 await associatedInstance.FilesystemViewModel.GetFileFromPathAsync(iFilePath)
                     .OnSuccess(iFile => iFile.DeleteAsync(StorageDeleteOption.PermanentDelete).AsTask());
             }

--- a/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -399,7 +399,7 @@ namespace Files.Filesystem
                 {
                     return default;
                 }
-                if (destination.StartsWith(CommonPaths.RecycleBinPath))
+                if (destination.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
                 {
                     return await RecycleItemsFromClipboard(packageView, destination, showDialog, registerHistory);
                 }
@@ -1131,7 +1131,7 @@ namespace Files.Filesystem
             foreach (string name in RestrictedFileNames)
             {
                 Regex regex = new Regex($"^{name}($|\\.)(.+)?");
-                MatchCollection matches = regex.Matches(input.ToUpper());
+                MatchCollection matches = regex.Matches(input.ToUpperInvariant());
 
                 if (matches.Count > 0)
                 {

--- a/Files/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
+++ b/Files/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
@@ -65,7 +65,7 @@ namespace Files.Filesystem
         public async Task<IStorageHistory> CopyItemsAsync(IEnumerable<IStorageItemWithPath> source, IEnumerable<string> destination, IEnumerable<FileNameConflictResolveOptionType> collisions, IProgress<float> progress, IProgress<FileSystemStatusCode> errorCode, CancellationToken cancellationToken)
         {
             var connection = await AppServiceConnectionHelper.Instance;
-            if (connection == null || source.Any(x => string.IsNullOrWhiteSpace(x.Path) || x.Path.StartsWith(@"\\?\")) || destination.Any(x => string.IsNullOrWhiteSpace(x) || x.StartsWith(@"\\?\") || FtpHelpers.IsFtpPath(x)))
+            if (connection == null || source.Any(x => string.IsNullOrWhiteSpace(x.Path) || x.Path.StartsWith(@"\\?\", StringComparison.Ordinal)) || destination.Any(x => string.IsNullOrWhiteSpace(x) || x.StartsWith(@"\\?\", StringComparison.Ordinal) || FtpHelpers.IsFtpPath(x)))
             {
                 // Fallback to builtin file operations
                 return await filesystemOperations.CopyItemsAsync(source, destination, collisions, progress, errorCode, cancellationToken);
@@ -217,7 +217,7 @@ namespace Files.Filesystem
         public async Task<IStorageHistory> DeleteItemsAsync(IEnumerable<IStorageItemWithPath> source, IProgress<float> progress, IProgress<FileSystemStatusCode> errorCode, bool permanently, CancellationToken cancellationToken)
         {
             var connection = await AppServiceConnectionHelper.Instance;
-            if (connection == null || source.Any(x => string.IsNullOrWhiteSpace(x.Path) || x.Path.StartsWith(@"\\?\") || FtpHelpers.IsFtpPath(x.Path)))
+            if (connection == null || source.Any(x => string.IsNullOrWhiteSpace(x.Path) || x.Path.StartsWith(@"\\?\", StringComparison.Ordinal) || FtpHelpers.IsFtpPath(x.Path)))
             {
                 // Fallback to builtin file operations
                 return await filesystemOperations.DeleteItemsAsync(source, progress, errorCode, permanently, cancellationToken);
@@ -232,7 +232,7 @@ namespace Files.Filesystem
             if (deleteFromRecycleBin)
             {
                 // Recycle bin also stores a file starting with $I for each item
-                deleleFilePaths = deleleFilePaths.Concat(source.Select(x => Path.Combine(Path.GetDirectoryName(x.Path), Path.GetFileName(x.Path).Replace("$R", "$I")))).Distinct();
+                deleleFilePaths = deleleFilePaths.Concat(source.Select(x => Path.Combine(Path.GetDirectoryName(x.Path), Path.GetFileName(x.Path).Replace("$R", "$I", StringComparison.Ordinal)))).Distinct();
             }
 
             var operationID = Guid.NewGuid().ToString();
@@ -312,7 +312,7 @@ namespace Files.Filesystem
         public async Task<IStorageHistory> MoveItemsAsync(IEnumerable<IStorageItemWithPath> source, IEnumerable<string> destination, IEnumerable<FileNameConflictResolveOptionType> collisions, IProgress<float> progress, IProgress<FileSystemStatusCode> errorCode, CancellationToken cancellationToken)
         {
             var connection = await AppServiceConnectionHelper.Instance;
-            if (connection == null || source.Any(x => string.IsNullOrWhiteSpace(x.Path) || x.Path.StartsWith(@"\\?\")) || destination.Any(x => string.IsNullOrWhiteSpace(x) || x.StartsWith(@"\\?\") || FtpHelpers.IsFtpPath(x)))
+            if (connection == null || source.Any(x => string.IsNullOrWhiteSpace(x.Path) || x.Path.StartsWith(@"\\?\", StringComparison.Ordinal)) || destination.Any(x => string.IsNullOrWhiteSpace(x) || x.StartsWith(@"\\?\", StringComparison.Ordinal) || FtpHelpers.IsFtpPath(x)))
             {
                 // Fallback to builtin file operations
                 return await filesystemOperations.MoveItemsAsync(source, destination, collisions, progress, errorCode, cancellationToken);
@@ -409,7 +409,7 @@ namespace Files.Filesystem
         public async Task<IStorageHistory> RenameAsync(IStorageItemWithPath source, string newName, NameCollisionOption collision, IProgress<FileSystemStatusCode> errorCode, CancellationToken cancellationToken)
         {
             var connection = await AppServiceConnectionHelper.Instance;
-            if (connection == null || string.IsNullOrWhiteSpace(source.Path) || source.Path.StartsWith(@"\\?\") || FtpHelpers.IsFtpPath(source.Path))
+            if (connection == null || string.IsNullOrWhiteSpace(source.Path) || source.Path.StartsWith(@"\\?\", StringComparison.Ordinal) || FtpHelpers.IsFtpPath(source.Path))
             {
                 // Fallback to builtin file operations
                 return await filesystemOperations.RenameAsync(source, newName, collision, errorCode, cancellationToken);
@@ -453,7 +453,7 @@ namespace Files.Filesystem
         public async Task<IStorageHistory> RestoreFromTrashAsync(IStorageItemWithPath source, string destination, IProgress<float> progress, IProgress<FileSystemStatusCode> errorCode, CancellationToken cancellationToken)
         {
             var connection = await AppServiceConnectionHelper.Instance;
-            if (connection == null || string.IsNullOrWhiteSpace(source.Path) || source.Path.StartsWith(@"\\?\") || string.IsNullOrWhiteSpace(destination) || destination.StartsWith(@"\\?\") || FtpHelpers.IsFtpPath(destination))
+            if (connection == null || string.IsNullOrWhiteSpace(source.Path) || source.Path.StartsWith(@"\\?\", StringComparison.Ordinal) || string.IsNullOrWhiteSpace(destination) || destination.StartsWith(@"\\?\", StringComparison.Ordinal) || FtpHelpers.IsFtpPath(destination))
             {
                 // Fallback to builtin file operations
                 return await filesystemOperations.RestoreFromTrashAsync(source, destination, progress, errorCode, cancellationToken);
@@ -497,7 +497,7 @@ namespace Files.Filesystem
                 {
                     // Recycle bin also stores a file starting with $I for each item
                     await DeleteItemsAsync(movedSources.Select(src => StorageItemHelpers.FromPathAndType(
-                        Path.Combine(Path.GetDirectoryName(src.Source), Path.GetFileName(src.Source).Replace("$R", "$I")),
+                        Path.Combine(Path.GetDirectoryName(src.Source), Path.GetFileName(src.Source).Replace("$R", "$I", StringComparison.Ordinal)),
                         new[] { source }.Single(s => s.Path == src.Source).ItemType)), null, null, true, cancellationToken);
                     return new StorageHistory(FileOperationType.Restore, source,
                         StorageItemHelpers.FromPathAndType(movedSources.Single().Destination, source.ItemType));

--- a/Files/Filesystem/LibraryManager.cs
+++ b/Files/Filesystem/LibraryManager.cs
@@ -229,7 +229,7 @@ namespace Files.Filesystem
 
         public bool TryGetLibrary(string path, out LibraryLocationItem library)
         {
-            if (string.IsNullOrWhiteSpace(path) || !path.ToLower().EndsWith(ShellLibraryItem.EXTENSION))
+            if (string.IsNullOrWhiteSpace(path) || !path.EndsWith(ShellLibraryItem.EXTENSION, StringComparison.OrdinalIgnoreCase))
             {
                 library = null;
                 return false;

--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -491,7 +491,7 @@ namespace Files.Filesystem
             ItemPropertiesInitialized = false;
 
             var itemType = isFile ? "ItemTypeFile".GetLocalized() : "FileFolderListItem".GetLocalized();
-            if (isFile && ItemName.Contains("."))
+            if (isFile && ItemName.Contains(".", StringComparison.Ordinal))
             {
                 itemType = FileExtension.Trim('.') + " " + itemType;
             }
@@ -526,7 +526,7 @@ namespace Files.Filesystem
         public bool RunAsAdmin { get; set; }
         public bool IsUrl { get; set; }
         public bool IsSymLink { get; set; }
-        public override bool IsExecutable => Path.GetExtension(TargetPath)?.ToLower() == ".exe";
+        public override bool IsExecutable => string.Equals(Path.GetExtension(TargetPath), ".exe", StringComparison.OrdinalIgnoreCase);
     }
 
     public class ZipItem : ListedItem

--- a/Files/Filesystem/Permissions/FileSystemAccessRuleForUI.cs
+++ b/Files/Filesystem/Permissions/FileSystemAccessRuleForUI.cs
@@ -381,7 +381,7 @@ namespace Files.Filesystem.Permissions
             }
             if (ret.Any())
             {
-                ret[0] = ret[0].First().ToString().ToUpper() + ret[0].Substring(1);
+                ret[0] = char.ToUpperInvariant(ret[0].First()) + ret[0].Substring(1);
             }
             return ret;
         }

--- a/Files/Filesystem/Search/FolderSearch.cs
+++ b/Files/Filesystem/Search/FolderSearch.cs
@@ -41,7 +41,7 @@ namespace Files.Filesystem.Search
 
         public EventHandler SearchTick;
 
-        private bool IsAQSQuery => Query is not null && (Query.StartsWith("$") || Query.Contains(":"));
+        private bool IsAQSQuery => Query is not null && (Query.StartsWith('$') || Query.Contains(":", StringComparison.Ordinal));
 
         private string QueryWithWildcard
         {
@@ -63,11 +63,11 @@ namespace Files.Filesystem.Search
             get
             {
                 // if the query starts with a $, assume the query is in aqs format, otherwise assume the user is searching for the file name
-                if (Query is not null && Query.StartsWith("$"))
+                if (Query is not null && Query.StartsWith('$'))
                 {
                     return Query.Substring(1);
                 }
-                else if (Query is not null && Query.Contains(":"))
+                else if (Query is not null && Query.Contains(":", StringComparison.Ordinal))
                 {
                     return Query;
                 }
@@ -250,7 +250,7 @@ namespace Files.Filesystem.Search
 
         private async Task AddItemsAsync(string folder, IList<ListedItem> results, CancellationToken token)
         {
-            if (AQSQuery.StartsWith("tag:"))
+            if (AQSQuery.StartsWith("tag:", StringComparison.Ordinal))
             {
                 await SearchTagsAsync(folder, results, token);
             }
@@ -337,7 +337,7 @@ namespace Files.Filesystem.Search
             {
                 string itemFileExtension = null;
                 string itemType = null;
-                if (findData.cFileName.Contains("."))
+                if (findData.cFileName.Contains(".", StringComparison.Ordinal))
                 {
                     itemFileExtension = Path.GetExtension(itemPath);
                     itemType = itemFileExtension.Trim('.') + " " + itemType;
@@ -411,7 +411,7 @@ namespace Files.Filesystem.Search
                 var props = await file.GetBasicPropertiesAsync();
                 string itemFileExtension = null;
                 string itemType = null;
-                if (file.Name.Contains("."))
+                if (file.Name.Contains(".", StringComparison.Ordinal))
                 {
                     itemFileExtension = Path.GetExtension(file.Path);
                     itemType = itemFileExtension.Trim('.') + " " + itemType;

--- a/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
@@ -206,7 +206,7 @@ namespace Files.Filesystem.StorageEnumerators
                 return null;
             }
 
-            if (file.Name.EndsWith(".lnk") || file.Name.EndsWith(".url"))
+            if (file.Name.EndsWith(".lnk", StringComparison.Ordinal) || file.Name.EndsWith(".url", StringComparison.Ordinal))
             {
                 // This shouldn't happen, StorageFile api does not support shortcuts
                 Debug.WriteLine("Something strange: StorageFile api returned a shortcut");

--- a/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -261,7 +261,7 @@ namespace Files.Filesystem.StorageEnumerators
                     IsSymLink = true
                 };
             }
-            else if (findData.cFileName.EndsWith(".lnk") || findData.cFileName.EndsWith(".url"))
+            else if (findData.cFileName.EndsWith(".lnk", StringComparison.Ordinal) || findData.cFileName.EndsWith(".url", StringComparison.Ordinal))
             {
                 if (connection != null)
                 {
@@ -279,7 +279,7 @@ namespace Files.Filesystem.StorageEnumerators
                     if (status == AppServiceResponseStatus.Success
                         && response.ContainsKey("TargetPath"))
                     {
-                        var isUrl = findData.cFileName.EndsWith(".url");
+                        var isUrl = findData.cFileName.EndsWith(".url", StringComparison.Ordinal);
                         string target = (string)response["TargetPath"];
 
                         return new ShortcutItem(null, dateReturnFormat)

--- a/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -279,7 +279,7 @@ namespace Files.Filesystem.StorageEnumerators
                     if (status == AppServiceResponseStatus.Success
                         && response.ContainsKey("TargetPath"))
                     {
-                        var isUrl = findData.cFileName.EndsWith(".url", StringComparison.Ordinal);
+                        var isUrl = findData.cFileName.EndsWith(".url", StringComparison.OrdinalIgnoreCase);
                         string target = (string)response["TargetPath"];
 
                         return new ShortcutItem(null, dateReturnFormat)

--- a/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -22,7 +22,7 @@ namespace Files.Filesystem
 
         private static PathBoxItem GetPathItem(string component, string path)
         {
-            if (component.StartsWith(CommonPaths.RecycleBinPath))
+            if (component.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
             {
                 // Handle the recycle bin: use the localized folder name
                 return new PathBoxItem()
@@ -31,7 +31,7 @@ namespace Files.Filesystem
                     Path = path,
                 };
             }
-            else if (component.Contains(":"))
+            else if (component.Contains(":", StringComparison.Ordinal))
             {
                 var allDrives = SidebarControl.SideBarItems.Where(x => (x as LocationItem)?.ChildItems != null).SelectMany(x => (x as LocationItem).ChildItems);
                 return new PathBoxItem()
@@ -55,14 +55,14 @@ namespace Files.Filesystem
         {
             List<PathBoxItem> pathBoxItems = new List<PathBoxItem>();
 
-            if (value.Contains("/"))
+            if (value.Contains("/", StringComparison.Ordinal))
             {
-                if (!value.EndsWith("/"))
+                if (!value.EndsWith('/'))
                 {
                     value += "/";
                 }
             }
-            else if (!value.EndsWith("\\"))
+            else if (!value.EndsWith('\\'))
             {
                 value += "\\";
             }
@@ -231,7 +231,7 @@ namespace Files.Filesystem
 
         public static string GetPathWithoutEnvironmentVariable(string path)
         {
-            if (path.StartsWith("~\\"))
+            if (path.StartsWith("~\\", StringComparison.Ordinal))
             {
                 path = $"{CommonPaths.HomePath}{path.Remove(0, 1)}";
             }

--- a/Files/Filesystem/StorageItems/BaseQueryResults.cs
+++ b/Files/Filesystem/StorageItems/BaseQueryResults.cs
@@ -45,12 +45,12 @@ namespace Files.Filesystem.StorageItems
                         {
                             if (colonSplit[0] == "System.FileName" || colonSplit[0] == "fileName" || colonSplit[0] == "name")
                             {
-                                items = items.Where(x => Regex.IsMatch(x.Name, colonSplit[1].Replace("\"", "").Replace("*", "(.*?)"), RegexOptions.IgnoreCase)).ToList();
+                                items = items.Where(x => Regex.IsMatch(x.Name, colonSplit[1].Replace("\"", "", StringComparison.Ordinal).Replace("*", "(.*?)", StringComparison.Ordinal), RegexOptions.IgnoreCase)).ToList();
                             }
                         }
                         else
                         {
-                            items = items.Where(x => Regex.IsMatch(x.Name, split.Replace("\"", "").Replace("*", "(.*?)"), RegexOptions.IgnoreCase)).ToList();
+                            items = items.Where(x => Regex.IsMatch(x.Name, split.Replace("\"", "", StringComparison.Ordinal).Replace("*", "(.*?)", StringComparison.Ordinal), RegexOptions.IgnoreCase)).ToList();
                         }
                     }
                 }
@@ -97,12 +97,12 @@ namespace Files.Filesystem.StorageItems
                         {
                             if (colonSplit[0] == "System.FileName" || colonSplit[0] == "fileName" || colonSplit[0] == "name")
                             {
-                                items = items.Where(x => Regex.IsMatch(x.Name, colonSplit[1].Replace("\"", "").Replace("*", "(.*?)"), RegexOptions.IgnoreCase)).ToList();
+                                items = items.Where(x => Regex.IsMatch(x.Name, colonSplit[1].Replace("\"", "", StringComparison.Ordinal).Replace("*", "(.*?)", StringComparison.Ordinal), RegexOptions.IgnoreCase)).ToList();
                             }
                         }
                         else
                         {
-                            items = items.Where(x => Regex.IsMatch(x.Name, split.Replace("\"", "").Replace("*", "(.*?)"), RegexOptions.IgnoreCase)).ToList();
+                            items = items.Where(x => Regex.IsMatch(x.Name, split.Replace("\"", "", StringComparison.Ordinal).Replace("*", "(.*?)", StringComparison.Ordinal), RegexOptions.IgnoreCase)).ToList();
                         }
                     }
                 }
@@ -149,12 +149,12 @@ namespace Files.Filesystem.StorageItems
                         {
                             if (colonSplit[0] == "System.FileName" || colonSplit[0] == "fileName" || colonSplit[0] == "name")
                             {
-                                items = items.Where(x => Regex.IsMatch(x.Name, colonSplit[1].Replace("\"", "").Replace("*", "(.*?)"), RegexOptions.IgnoreCase)).ToList();
+                                items = items.Where(x => Regex.IsMatch(x.Name, colonSplit[1].Replace("\"", "", StringComparison.Ordinal).Replace("*", "(.*?)", StringComparison.Ordinal), RegexOptions.IgnoreCase)).ToList();
                             }
                         }
                         else
                         {
-                            items = items.Where(x => Regex.IsMatch(x.Name, split.Replace("\"", "").Replace("*", "(.*?)"), RegexOptions.IgnoreCase)).ToList();
+                            items = items.Where(x => Regex.IsMatch(x.Name, split.Replace("\"", "", StringComparison.Ordinal).Replace("*", "(.*?)", StringComparison.Ordinal), RegexOptions.IgnoreCase)).ToList();
                         }
                     }
                 }

--- a/Files/Filesystem/StorageItems/FtpStorageFile.cs
+++ b/Files/Filesystem/StorageItems/FtpStorageFile.cs
@@ -336,7 +336,7 @@ namespace Files.Filesystem.StorageItems
             get
             {
                 var itemType = "ItemTypeFile".GetLocalized();
-                if (Name.Contains("."))
+                if (Name.Contains(".", StringComparison.Ordinal))
                 {
                     itemType = System.IO.Path.GetExtension(Name).Trim('.') + " " + itemType;
                 }

--- a/Files/Filesystem/StorageItems/ZipStorageFile.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFile.cs
@@ -435,7 +435,7 @@ namespace Files.Filesystem.StorageItems
             get
             {
                 var itemType = "ItemTypeFile".GetLocalized();
-                if (Name.Contains("."))
+                if (Name.Contains(".", StringComparison.Ordinal))
                 {
                     itemType = System.IO.Path.GetExtension(Name).Trim('.') + " " + itemType;
                 }

--- a/Files/Filesystem/StorageItems/ZipStorageFolder.cs
+++ b/Files/Filesystem/StorageItems/ZipStorageFolder.cs
@@ -267,7 +267,7 @@ namespace Files.Filesystem.StorageItems
                     foreach (var entry in zipFile.OfType<ZipEntry>()) // Returns all items recursively
                     {
                         string winPath = System.IO.Path.GetFullPath(entry.IsDirectory ? wnt.TransformDirectory(DecodeEntryName(entry, ZipEncoding)) : wnt.TransformFile(DecodeEntryName(entry, ZipEncoding)));
-                        if (winPath.StartsWith(Path.WithEnding("\\"))) // Child of self
+                        if (winPath.StartsWith(Path.WithEnding("\\"), StringComparison.Ordinal)) // Child of self
                         {
                             var split = winPath.Substring(Path.Length).Split(new[] { '\\' }, StringSplitOptions.RemoveEmptyEntries);
                             if (split.Length > 0)

--- a/Files/Helpers/AppServiceConnectionHelper.cs
+++ b/Files/Helpers/AppServiceConnectionHelper.cs
@@ -101,7 +101,7 @@ namespace Files.Helpers
                 {
                     // Launch fulltrust process
                     ApplicationData.Current.LocalSettings.Values["PackageSid"] =
-                        WebAuthenticationBroker.GetCurrentApplicationCallbackUri().Host.ToUpper();
+                        WebAuthenticationBroker.GetCurrentApplicationCallbackUri().Host.ToUpperInvariant();
                     await FullTrustProcessLauncher.LaunchFullTrustProcessForCurrentAppAsync();
                 }
 

--- a/Files/Helpers/ExternalResourcesHelper.cs
+++ b/Files/Helpers/ExternalResourcesHelper.cs
@@ -42,7 +42,7 @@ namespace Files.Helpers
                 var pathStr = path as string;
                 App.AppSettings.SelectedTheme = new AppTheme()
                 {
-                    Name = pathStr.Replace(".xaml", ""),
+                    Name = pathStr.Replace(".xaml", "", StringComparison.Ordinal),
                     Path = pathStr,
                 };
                 ApplicationData.Current.LocalSettings.Values.Remove("PathToThemeFile");
@@ -77,7 +77,7 @@ namespace Files.Helpers
             {
                 Themes.Add(new AppTheme()
                 {
-                    Name = file.Name.Replace(".xaml", ""),
+                    Name = file.Name.Replace(".xaml", "", StringComparison.Ordinal),
                     Path = file.Name,
                     AbsolutePath = file.Path,
                     IsFromOptionalPackage = isOptionalPackage

--- a/Files/Helpers/FileThumbnailHelper.cs
+++ b/Files/Helpers/FileThumbnailHelper.cs
@@ -111,7 +111,7 @@ namespace Files.Helpers
 
         public static async Task<byte[]> LoadIconFromPathAsync(string filePath, uint thumbnailSize, ThumbnailMode thumbnailMode)
         {
-            if (!filePath.EndsWith(".lnk") && !filePath.EndsWith(".url"))
+            if (!filePath.EndsWith(".lnk", StringComparison.Ordinal) && !filePath.EndsWith(".url", StringComparison.Ordinal))
             {
                 var item = await StorageItemHelpers.ToStorageItem<IStorageItem>(filePath);
                 if (item != null)

--- a/Files/Helpers/FtpHelpers.cs
+++ b/Files/Helpers/FtpHelpers.cs
@@ -37,7 +37,7 @@ namespace Files.Helpers
         public static bool VerifyFtpPath(string path)
         {
             var authority = GetFtpAuthority(path);
-            var index = authority.IndexOf(":");
+            var index = authority.IndexOf(":", StringComparison.Ordinal);
 
             if (index == -1)
             {
@@ -50,7 +50,7 @@ namespace Files.Helpers
         public static string GetFtpHost(string path)
         {
             var authority = GetFtpAuthority(path);
-            var index = authority.IndexOf(":");
+            var index = authority.IndexOf(":", StringComparison.Ordinal);
 
             if (index == -1)
             {
@@ -63,7 +63,7 @@ namespace Files.Helpers
         public static ushort GetFtpPort(string path)
         {
             var authority = GetFtpAuthority(path);
-            var index = authority.IndexOf(":");
+            var index = authority.IndexOf(":", StringComparison.Ordinal);
 
             if (index == -1)
             {
@@ -80,9 +80,9 @@ namespace Files.Helpers
 
         public static string GetFtpAuthority(string path)
         {
-            path = path.Replace("\\", "/");
-            var schemaIndex = path.IndexOf("://") + 3;
-            var hostIndex = path.IndexOf("/", schemaIndex);
+            path = path.Replace("\\", "/", StringComparison.Ordinal);
+            var schemaIndex = path.IndexOf("://", StringComparison.Ordinal) + 3;
+            var hostIndex = path.IndexOf("/", schemaIndex, StringComparison.Ordinal);
 
             if (hostIndex == -1)
             {
@@ -94,9 +94,9 @@ namespace Files.Helpers
 
         public static string GetFtpPath(string path)
         {
-            path = path.Replace("\\", "/");
-            var schemaIndex = path.IndexOf("://") + 3;
-            var hostIndex = path.IndexOf("/", schemaIndex);
+            path = path.Replace("\\", "/", StringComparison.Ordinal);
+            var schemaIndex = path.IndexOf("://", StringComparison.Ordinal) + 3;
+            var hostIndex = path.IndexOf("/", schemaIndex, StringComparison.Ordinal);
             return hostIndex == -1 ? "/" : path.Substring(hostIndex);
         }
     }

--- a/Files/Helpers/ItemListDisplayHelpers/GroupedCollection.cs
+++ b/Files/Helpers/ItemListDisplayHelpers/GroupedCollection.cs
@@ -151,7 +151,7 @@ namespace Files.Helpers
             {
                 return;
             }
-            var name = propName.StartsWith("get_", StringComparison.InvariantCultureIgnoreCase)
+            var name = propName.StartsWith("get_", StringComparison.OrdinalIgnoreCase)
                 ? propName.Substring(4)
                 : propName;
 

--- a/Files/Helpers/ItemListDisplayHelpers/GroupingHelper.cs
+++ b/Files/Helpers/ItemListDisplayHelpers/GroupingHelper.cs
@@ -14,11 +14,11 @@ namespace Files.Helpers
         {
             return option switch
             {
-                GroupOption.Name => x => new string(x.ItemName.Take(1).ToArray()).ToUpper(),
+                GroupOption.Name => x => new string(x.ItemName.Take(1).ToArray()).ToUpperInvariant(),
                 GroupOption.Size => x => x.PrimaryItemAttribute != StorageItemTypes.Folder ? GetGroupSizeKey(x.FileSizeBytes) : x.FileSizeDisplay,
                 GroupOption.DateCreated => x => x.ItemDateCreatedReal.GetUserSettingsFriendlyTimeSpan().text,
                 GroupOption.DateModified => x => x.ItemDateModifiedReal.GetUserSettingsFriendlyTimeSpan().text,
-                GroupOption.FileType => x => x.PrimaryItemAttribute == StorageItemTypes.Folder && !x.IsShortcutItem ? x.ItemType : x.FileExtension?.ToLower() ?? " ",
+                GroupOption.FileType => x => x.PrimaryItemAttribute == StorageItemTypes.Folder && !x.IsShortcutItem ? x.ItemType : x.FileExtension?.ToLowerInvariant() ?? " ",
                 GroupOption.SyncStatus => x => x.SyncStatusString,
                 GroupOption.FileTag => x => x.FileTag,
                 GroupOption.OriginalFolder => x => (x as RecycleBinItem)?.ItemOriginalFolder,

--- a/Files/Helpers/LibraryHelper.cs
+++ b/Files/Helpers/LibraryHelper.cs
@@ -246,6 +246,6 @@ namespace Files.Helpers
             await dialog.ShowAsync();
         }
 
-        public static bool IsLibraryPath(string path) => !string.IsNullOrEmpty(path) && path.ToLower().EndsWith(ShellLibraryItem.EXTENSION);
+        public static bool IsLibraryPath(string path) => !string.IsNullOrEmpty(path) && path.EndsWith(ShellLibraryItem.EXTENSION, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Files/Helpers/NativeFileOperationsHelper.cs
+++ b/Files/Helpers/NativeFileOperationsHelper.cs
@@ -405,7 +405,7 @@ namespace Files.Helpers
                     if (string.IsNullOrEmpty(normalisedTarget))
                     {
                         normalisedTarget = subsString;
-                        if (normalisedTarget.StartsWith(@"\??\"))
+                        if (normalisedTarget.StartsWith(@"\??\", StringComparison.Ordinal))
                         {
                             normalisedTarget = normalisedTarget.Substring(4);
                         }

--- a/Files/Helpers/NavigationHelpers.cs
+++ b/Files/Helpers/NavigationHelpers.cs
@@ -71,7 +71,7 @@ namespace Files.Helpers
 
         public static async void OpenSelectedItems(IShellPage associatedInstance, bool openViaApplicationPicker = false)
         {
-            if (associatedInstance.FilesystemViewModel.WorkingDirectory.StartsWith(CommonPaths.RecycleBinPath))
+            if (associatedInstance.FilesystemViewModel.WorkingDirectory.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
             {
                 // Do not open files and folders inside the recycle bin
                 return;
@@ -91,7 +91,7 @@ namespace Files.Helpers
 
         public static async void OpenItemsWithExecutable(IShellPage associatedInstance, List<IStorageItemWithPath> items, string executable)
         {
-            if (associatedInstance.FilesystemViewModel.WorkingDirectory.StartsWith(CommonPaths.RecycleBinPath))
+            if (associatedInstance.FilesystemViewModel.WorkingDirectory.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
             {
                 // Do not open files and folders inside the recycle bin
                 return;
@@ -129,7 +129,7 @@ namespace Files.Helpers
             bool isHiddenItem = NativeFileOperationsHelper.HasFileAttribute(path, System.IO.FileAttributes.Hidden);
             bool isDirectory = NativeFileOperationsHelper.HasFileAttribute(path, System.IO.FileAttributes.Directory);
             bool isReparsePoint = NativeFileOperationsHelper.HasFileAttribute(path, System.IO.FileAttributes.ReparsePoint);
-            bool isShortcutItem = path.EndsWith(".lnk") || path.EndsWith(".url");
+            bool isShortcutItem = path.EndsWith(".lnk", StringComparison.Ordinal) || path.EndsWith(".url", StringComparison.Ordinal);
             FilesystemResult opened = (FilesystemResult)false;
 
             var shortcutInfo = new ShortcutItem();
@@ -268,7 +268,7 @@ namespace Files.Helpers
 
             var opened = (FilesystemResult)false;
             bool isHiddenItem = NativeFileOperationsHelper.HasFileAttribute(path, System.IO.FileAttributes.Hidden);
-            bool isShortcutItem = path.EndsWith(".lnk") || path.EndsWith(".url"); // Determine
+            bool isShortcutItem = path.EndsWith(".lnk", StringComparison.Ordinal) || path.EndsWith(".url", StringComparison.Ordinal); // Determine
 
             if (isShortcutItem)
             {
@@ -356,7 +356,7 @@ namespace Files.Helpers
         {
             var opened = (FilesystemResult)false;
             bool isHiddenItem = NativeFileOperationsHelper.HasFileAttribute(path, System.IO.FileAttributes.Hidden);
-            bool isShortcutItem = path.EndsWith(".lnk") || path.EndsWith(".url") || !string.IsNullOrEmpty(shortcutInfo.TargetPath);
+            bool isShortcutItem = path.EndsWith(".lnk", StringComparison.Ordinal) || path.EndsWith(".url", StringComparison.Ordinal) || !string.IsNullOrEmpty(shortcutInfo.TargetPath);
             if (isShortcutItem)
             {
                 if (string.IsNullOrEmpty(shortcutInfo.TargetPath))
@@ -365,7 +365,7 @@ namespace Files.Helpers
                 }
                 else
                 {
-                    if (!path.EndsWith(".url"))
+                    if (!path.EndsWith(".url", StringComparison.Ordinal))
                     {
                         StorageFileWithPath childFile = await associatedInstance.FilesystemViewModel.GetFileWithPathFromPathAsync(shortcutInfo.TargetPath);
                         if (childFile != null)

--- a/Files/Helpers/PathNormalization.cs
+++ b/Files/Helpers/PathNormalization.cs
@@ -14,7 +14,7 @@ namespace Files.Helpers
             string rootPath = "";
             try
             {
-                var pathAsUri = new Uri(path.Replace("\\", "/"));
+                var pathAsUri = new Uri(path.Replace("\\", "/", StringComparison.Ordinal));
                 rootPath = pathAsUri.GetLeftPart(UriPartial.Authority);
                 if (pathAsUri.IsFile && !string.IsNullOrEmpty(rootPath))
                 {
@@ -37,7 +37,7 @@ namespace Files.Helpers
             {
                 return path;
             }
-            if (path.StartsWith("\\\\") || path.StartsWith("//") || FtpHelpers.IsFtpPath(path))
+            if (path.StartsWith("\\\\", StringComparison.Ordinal) || path.StartsWith("//", StringComparison.Ordinal) || FtpHelpers.IsFtpPath(path))
             {
                 return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToUpperInvariant();
             }
@@ -73,7 +73,7 @@ namespace Files.Helpers
             {
                 return string.Empty;
             }
-            var index = path.Contains("/") ? path.LastIndexOf("/") : path.LastIndexOf("\\");
+            var index = path.Contains("/", StringComparison.Ordinal) ? path.LastIndexOf("/", StringComparison.Ordinal) : path.LastIndexOf("\\", StringComparison.Ordinal);
             return path.Substring(0, index != -1 ? index : path.Length);
         }
 
@@ -83,7 +83,7 @@ namespace Files.Helpers
             {
                 return name;
             }
-            return folder.Contains("/") ? Path.Combine(folder, name).Replace("\\", "/") : Path.Combine(folder, name);
+            return folder.Contains("/", StringComparison.Ordinal) ? Path.Combine(folder, name).Replace("\\", "/", StringComparison.Ordinal) : Path.Combine(folder, name);
         }
     }
 }

--- a/Files/Helpers/RecycleBinHelpers.cs
+++ b/Files/Helpers/RecycleBinHelpers.cs
@@ -104,7 +104,7 @@ namespace Files.Helpers
 
         public async Task<bool> HasRecycleBin(string path)
         {
-            if (string.IsNullOrEmpty(path) || path.StartsWith(@"\\?\"))
+            if (string.IsNullOrEmpty(path) || path.StartsWith(@"\\?\", StringComparison.Ordinal))
             {
                 return false;
             }

--- a/Files/Helpers/ShellContextMenuHelper.cs
+++ b/Files/Helpers/ShellContextMenuHelper.cs
@@ -115,7 +115,7 @@ namespace Files.Helpers
                 {
                     var menuLayoutSubItem = new ContextMenuFlyoutItemViewModel()
                     {
-                        Text = menuFlyoutItem.Label.Replace("&", ""),
+                        Text = menuFlyoutItem.Label.Replace("&", "", StringComparison.Ordinal),
                         Tag = (menuFlyoutItem, menuHandle),
                         Items = new List<ContextMenuFlyoutItemViewModel>(),
                     };
@@ -126,7 +126,7 @@ namespace Files.Helpers
                 {
                     var menuLayoutItem = new ContextMenuFlyoutItemViewModel()
                     {
-                        Text = menuFlyoutItem.Label.Replace("&", ""),
+                        Text = menuFlyoutItem.Label.Replace("&", "", StringComparison.Ordinal),
                         Tag = (menuFlyoutItem, menuHandle),
                         BitmapIcon = image
                     };

--- a/Files/Helpers/StorageItemHelpers.cs
+++ b/Files/Helpers/StorageItemHelpers.cs
@@ -23,7 +23,7 @@ namespace Files.Helpers
             FilesystemResult<BaseStorageFile> file = null;
             FilesystemResult<BaseStorageFolder> folder = null;
 
-            if (path.ToLower().EndsWith(".lnk") || path.ToLower().EndsWith(".url"))
+            if (path.ToLowerInvariant().EndsWith(".lnk", StringComparison.Ordinal) || path.ToLowerInvariant().EndsWith(".url", StringComparison.Ordinal))
             {
                 // TODO: In the future, when IStorageItemWithPath will inherit from IStorageItem,
                 // we could implement this code here for getting .lnk files

--- a/Files/Helpers/UIFilesystemHelpers.cs
+++ b/Files/Helpers/UIFilesystemHelpers.cs
@@ -236,7 +236,7 @@ namespace Files.Helpers
 
         public static async Task<bool> RenameFileItemAsync(ListedItem item, string newName, IShellPage associatedInstance)
         {
-            newName = item.ItemNameRaw.Replace(item.ItemName, newName);
+            newName = item.ItemNameRaw.Replace(item.ItemName, newName, StringComparison.Ordinal);
             if (item.ItemNameRaw == newName || string.IsNullOrEmpty(newName))
             {
                 return true;

--- a/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -327,7 +327,7 @@ namespace Files.Interacts
                     var path = SlimContentPage.SelectedItem != null ? SlimContentPage.SelectedItem.ItemPath : associatedInstance.FilesystemViewModel.WorkingDirectory;
                     if (FtpHelpers.IsFtpPath(path))
                     {
-                        path = path.Replace("\\", "/");
+                        path = path.Replace("\\", "/", StringComparison.Ordinal);
                     }
                     DataPackage data = new DataPackage();
                     data.SetText(path);
@@ -546,7 +546,7 @@ namespace Files.Interacts
                 }
                 else if (handledByFtp)
                 {
-                    if (pwd.StartsWith(CommonPaths.RecycleBinPath))
+                    if (pwd.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
                     {
                         e.AcceptedOperation = DataPackageOperation.None;
                     }
@@ -564,7 +564,7 @@ namespace Files.Interacts
                 else
                 {
                     e.DragUIOverride.IsCaptionVisible = true;
-                    if (pwd.StartsWith(CommonPaths.RecycleBinPath))
+                    if (pwd.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
                     {
                         e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalized(), folderName);
                         e.AcceptedOperation = DataPackageOperation.Move;

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -615,7 +615,7 @@ namespace Files.UserControls
                 }
                 else if (handledByFtp)
                 {
-                    if (locationItem.Path.StartsWith(CommonPaths.RecycleBinPath))
+                    if (locationItem.Path.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
                     {
                         e.AcceptedOperation = DataPackageOperation.None;
                     }
@@ -633,7 +633,7 @@ namespace Files.UserControls
                 else
                 {
                     e.DragUIOverride.IsCaptionVisible = true;
-                    if (locationItem.Path.StartsWith(CommonPaths.RecycleBinPath))
+                    if (locationItem.Path.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
                     {
                         e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalized(), locationItem.Text);
                         e.AcceptedOperation = DataPackageOperation.Move;
@@ -1022,7 +1022,7 @@ namespace Files.UserControls
         {
             if (drivePath is not null)
             {
-                var matchingDrive = App.DrivesManager.Drives.FirstOrDefault(x => drivePath.StartsWith(x.Path));
+                var matchingDrive = App.DrivesManager.Drives.FirstOrDefault(x => drivePath.StartsWith(x.Path, StringComparison.Ordinal));
                 if (matchingDrive != null && matchingDrive.Type == DriveType.CDRom && matchingDrive.MaxSpace == ByteSizeLib.ByteSize.FromBytes(0))
                 {
                     bool ejectButton = await DialogDisplayHelper.ShowDialogAsync("InsertDiscDialog/Title".GetLocalized(), string.Format("InsertDiscDialog/Text".GetLocalized(), matchingDrive.Path), "InsertDiscDialog/OpenDriveButton".GetLocalized(), "Close".GetLocalized());

--- a/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -221,7 +221,7 @@ namespace Files.UserControls.Widgets
         {
             if (drivePath is not null)
             {
-                var matchingDrive = App.DrivesManager.Drives.FirstOrDefault(x => drivePath.StartsWith(x.Path));
+                var matchingDrive = App.DrivesManager.Drives.FirstOrDefault(x => drivePath.StartsWith(x.Path, StringComparison.Ordinal));
                 if (matchingDrive != null && matchingDrive.Type == DriveType.CDRom && matchingDrive.MaxSpace == ByteSizeLib.ByteSize.FromBytes(0))
                 {
                     bool ejectButton = await DialogDisplayHelper.ShowDialogAsync("InsertDiscDialog/Title".GetLocalized(), string.Format("InsertDiscDialog/Text".GetLocalized(), matchingDrive.Path), "InsertDiscDialog/OpenDriveButton".GetLocalized(), "Close".GetLocalized());

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -973,7 +973,7 @@ namespace Files.ViewModels
                                 {
                                     cts.Token.ThrowIfCancellationRequested();
                                     await LoadItemThumbnail(item, thumbnailSize, matchingStorageFolder);
-                                    if (matchingStorageFolder.DisplayName != item.ItemName && !matchingStorageFolder.DisplayName.StartsWith("$R"))
+                                    if (matchingStorageFolder.DisplayName != item.ItemName && !matchingStorageFolder.DisplayName.StartsWith("$R", StringComparison.Ordinal))
                                     {
                                         cts.Token.ThrowIfCancellationRequested();
                                         await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
@@ -1153,7 +1153,7 @@ namespace Files.ViewModels
 
                 Connection ??= await AppServiceConnectionHelper.Instance;
 
-                if (path.ToLower().EndsWith(ShellLibraryItem.EXTENSION))
+                if (path.ToLowerInvariant().EndsWith(ShellLibraryItem.EXTENSION, StringComparison.Ordinal))
                 {
                     if (App.LibraryManager.TryGetLibrary(path, out LibraryLocationItem library) && !library.IsEmpty)
                     {
@@ -1182,7 +1182,7 @@ namespace Files.ViewModels
                     // Find and select README file
                     foreach (var item in filesAndFolders)
                     {
-                        if (item.PrimaryItemAttribute == StorageItemTypes.File && item.ItemName.Contains("readme", StringComparison.InvariantCultureIgnoreCase))
+                        if (item.PrimaryItemAttribute == StorageItemTypes.File && item.ItemName.Contains("readme", StringComparison.OrdinalIgnoreCase))
                         {
                             OnSelectionRequestedEvent?.Invoke(this, new List<ListedItem>() { item });
                             break;
@@ -1211,9 +1211,9 @@ namespace Files.ViewModels
 
             await GetDefaultItemIcons(folderSettings.GetIconSize());
 
-            var isRecycleBin = path.StartsWith(CommonPaths.RecycleBinPath);
+            var isRecycleBin = path.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal);
             if (isRecycleBin ||
-                path.StartsWith(CommonPaths.NetworkFolderPath) ||
+                path.StartsWith(CommonPaths.NetworkFolderPath, StringComparison.Ordinal) ||
                 FtpHelpers.IsFtpPath(path))
             {
                 // Recycle bin and network are enumerated by the fulltrust process
@@ -1316,8 +1316,8 @@ namespace Files.ViewModels
             {
                 PrimaryItemAttribute = StorageItemTypes.Folder,
                 ItemPropertiesInitialized = true,
-                ItemNameRaw = path.StartsWith(CommonPaths.RecycleBinPath) ? ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin") :
-                           path.StartsWith(CommonPaths.NetworkFolderPath) ? "Network".GetLocalized() : isFtp ? "FTP" : "Unknown",
+                ItemNameRaw = path.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal) ? ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin") :
+                           path.StartsWith(CommonPaths.NetworkFolderPath, StringComparison.Ordinal) ? "Network".GetLocalized() : isFtp ? "FTP" : "Unknown",
                 ItemDateModifiedReal = DateTimeOffset.Now, // Fake for now
                 ItemDateCreatedReal = DateTimeOffset.Now, // Fake for now
                 ItemType = "FileFolderListItem".GetLocalized(),

--- a/Files/ViewModels/NavToolbarViewModel.cs
+++ b/Files/ViewModels/NavToolbarViewModel.cs
@@ -492,7 +492,7 @@ namespace Files.ViewModels
 
             if (!storageItems.Any(storageItem =>
                 !string.IsNullOrEmpty(storageItem?.Path) &&
-                storageItem.Path.Replace(pathBoxItem.Path, string.Empty).
+                storageItem.Path.Replace(pathBoxItem.Path, string.Empty, StringComparison.Ordinal).
                 Trim(Path.DirectorySeparatorChar).
                 Contains(Path.DirectorySeparatorChar)))
             {
@@ -816,9 +816,9 @@ namespace Files.ViewModels
 
         public async Task CheckPathInput(string currentInput, string currentSelectedPath, IShellPage shellPage)
         {
-            currentInput = currentInput.Replace("\\\\", "\\");
+            currentInput = currentInput.Replace("\\\\", "\\", StringComparison.Ordinal);
 
-            if (currentInput.StartsWith("\\") && !currentInput.StartsWith("\\\\"))
+            if (currentInput.StartsWith('\\') && !currentInput.StartsWith("\\\\", StringComparison.Ordinal))
             {
                 currentInput = currentInput.Insert(0, "\\");
             }
@@ -847,7 +847,7 @@ namespace Files.ViewModels
                     var resFolder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderWithPathFromPathAsync(currentInput, item));
                     if (resFolder || FolderHelpers.CheckFolderAccessWithWin32(currentInput))
                     {
-                        var matchingDrive = App.DrivesManager.Drives.FirstOrDefault(x => PathNormalization.NormalizePath(currentInput).StartsWith(PathNormalization.NormalizePath(x.Path)));
+                        var matchingDrive = App.DrivesManager.Drives.FirstOrDefault(x => PathNormalization.NormalizePath(currentInput).StartsWith(PathNormalization.NormalizePath(x.Path), StringComparison.Ordinal));
                         if (matchingDrive != null && matchingDrive.Type == DataModels.NavigationControlItems.DriveType.CDRom && matchingDrive.MaxSpace == ByteSizeLib.ByteSize.FromBytes(0))
                         {
                             bool ejectButton = await DialogDisplayHelper.ShowDialogAsync("InsertDiscDialog/Title".GetLocalized(), string.Format("InsertDiscDialog/Text".GetLocalized(), matchingDrive.Path), "InsertDiscDialog/OpenDriveButton".GetLocalized(), "Close".GetLocalized());

--- a/Files/ViewModels/PreviewPaneViewModel.cs
+++ b/Files/ViewModels/PreviewPaneViewModel.cs
@@ -147,7 +147,7 @@ namespace Files.ViewModels
                 return null;
             }
 
-            var ext = item.FileExtension.ToLower();
+            var ext = item.FileExtension.ToLowerInvariant();
             if (MediaPreviewViewModel.Extensions.Contains(ext))
             {
                 var model = new MediaPreviewViewModel(item);

--- a/Files/ViewModels/Previews/TextPreviewViewModel.cs
+++ b/Files/ViewModels/Previews/TextPreviewViewModel.cs
@@ -36,7 +36,7 @@ namespace Files.ViewModels.Previews
 
         public static async Task<TextPreview> TryLoadAsTextAsync(ListedItem item)
         {
-            if (ExcludedExtensions.Contains(item.FileExtension?.ToLower()) || item.FileSizeBytes > Constants.PreviewPane.TryLoadAsTextSizeLimit || item.FileSizeBytes == 0)
+            if (ExcludedExtensions.Contains(item.FileExtension?.ToLowerInvariant()) || item.FileSizeBytes > Constants.PreviewPane.TryLoadAsTextSizeLimit || item.FileSizeBytes == 0)
             {
                 return null;
             }
@@ -47,7 +47,7 @@ namespace Files.ViewModels.Previews
                 var text = await ReadFileAsText(item.ItemFile); // await FileIO.ReadTextAsync(item.ItemFile);
 
                 // Check if file is binary
-                if (text.Contains("\0\0\0\0"))
+                if (text.Contains("\0\0\0\0", StringComparison.Ordinal))
                 {
                     return null;
                 }

--- a/Files/ViewModels/Properties/FileProperties.cs
+++ b/Files/ViewModels/Properties/FileProperties.cs
@@ -414,7 +414,7 @@ namespace Files.ViewModels.Properties
             {
                 return "";
             }
-            return CryptographicBuffer.EncodeToHexString(hash.GetValueAndReset()).ToLower();
+            return CryptographicBuffer.EncodeToHexString(hash.GetValueAndReset()).ToLowerInvariant();
         }
     }
 }

--- a/Files/ViewModels/SettingsViewModel.cs
+++ b/Files/ViewModels/SettingsViewModel.cs
@@ -202,7 +202,7 @@ namespace Files.ViewModels
 
         public bool Set<TValue>(TValue value, [CallerMemberName] string propertyName = null)
         {
-            propertyName = propertyName != null && propertyName.StartsWith("set_", StringComparison.InvariantCultureIgnoreCase)
+            propertyName = propertyName != null && propertyName.StartsWith("set_", StringComparison.OrdinalIgnoreCase)
                 ? propertyName.Substring(4)
                 : propertyName;
 
@@ -231,7 +231,7 @@ namespace Files.ViewModels
             var name = propertyName ??
                        throw new ArgumentNullException(nameof(propertyName), "Cannot store property of unnamed.");
 
-            name = name.StartsWith("get_", StringComparison.InvariantCultureIgnoreCase)
+            name = name.StartsWith("get_", StringComparison.OrdinalIgnoreCase)
                 ? propertyName.Substring(4)
                 : propertyName;
 

--- a/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleContainerViewModel.cs
@@ -332,7 +332,7 @@ namespace Files.ViewModels.Widgets.Bundles
                     string itemPath = null;
                     string originBundle = null;
 
-                    if (itemText.Contains("|"))
+                    if (itemText.Contains("|", StringComparison.Ordinal))
                     {
                         dragFromBundle = true;
 
@@ -347,10 +347,10 @@ namespace Files.ViewModels.Widgets.Bundles
 
                     IStorageItem item = await StorageItemHelpers.ToStorageItem<IStorageItem>(itemPath);
 
-                    if (item != null || (itemPath.EndsWith(".lnk") || itemPath.EndsWith(".url")))
+                    if (item != null || (itemPath.EndsWith(".lnk", StringComparison.Ordinal) || itemPath.EndsWith(".url", StringComparison.Ordinal)))
                     {
                         if (await AddItemFromPath(itemPath,
-                            itemPath.EndsWith(".lnk") || itemPath.EndsWith(".url") ? FilesystemItemType.File : (item.IsOfType(StorageItemTypes.Folder) ? FilesystemItemType.Directory : FilesystemItemType.File)))
+                            itemPath.EndsWith(".lnk", StringComparison.Ordinal) || itemPath.EndsWith(".url", StringComparison.Ordinal) ? FilesystemItemType.File : (item.IsOfType(StorageItemTypes.Folder) ? FilesystemItemType.Directory : FilesystemItemType.File)))
                         {
                             itemsAdded = true;
                         }

--- a/Files/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
+++ b/Files/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
@@ -47,7 +47,7 @@ namespace Files.ViewModels.Widgets.Bundles
             {
                 string fileName = System.IO.Path.GetFileName(this.Path);
 
-                if (fileName.EndsWith(".lnk") || fileName.EndsWith(".url"))
+                if (fileName.EndsWith(".lnk", StringComparison.Ordinal) || fileName.EndsWith(".url", StringComparison.Ordinal))
                 {
                     fileName = fileName.Remove(fileName.Length - 4);
                 }

--- a/Files/Views/ColumnShellPage.xaml.cs
+++ b/Files/Views/ColumnShellPage.xaml.cs
@@ -875,10 +875,10 @@ namespace Files.Views
                     // Select previous directory
                     if (!string.IsNullOrWhiteSpace(e.PreviousDirectory))
                     {
-                        if (e.PreviousDirectory.Contains(e.Path) && !e.PreviousDirectory.Contains("Shell:RecycleBinFolder"))
+                        if (e.PreviousDirectory.Contains(e.Path, StringComparison.Ordinal) && !e.PreviousDirectory.Contains("Shell:RecycleBinFolder", StringComparison.Ordinal))
                         {
                             // Remove the WorkingDir from previous dir
-                            e.PreviousDirectory = e.PreviousDirectory.Replace(e.Path, string.Empty);
+                            e.PreviousDirectory = e.PreviousDirectory.Replace(e.Path, string.Empty, StringComparison.Ordinal);
 
                             // Get previous dir name
                             if (e.PreviousDirectory.StartsWith('\\'))
@@ -894,7 +894,7 @@ namespace Files.Views
                             string folderToSelect = string.Format("{0}\\{1}", e.Path, e.PreviousDirectory);
 
                             // Make sure we don't get double \\ in the e.Path
-                            folderToSelect = folderToSelect.Replace("\\\\", "\\");
+                            folderToSelect = folderToSelect.Replace("\\\\", "\\", StringComparison.Ordinal);
 
                             if (folderToSelect.EndsWith('\\'))
                             {

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -899,10 +899,10 @@ namespace Files.Views
             {
                 string parentDirectoryOfPath = FilesystemViewModel.WorkingDirectory.TrimEnd('\\', '/');
 
-                var lastSlashIndex = parentDirectoryOfPath.LastIndexOf("\\");
+                var lastSlashIndex = parentDirectoryOfPath.LastIndexOf("\\", StringComparison.Ordinal);
                 if (lastSlashIndex == -1)
                 {
-                    lastSlashIndex = parentDirectoryOfPath.LastIndexOf("/");
+                    lastSlashIndex = parentDirectoryOfPath.LastIndexOf("/", StringComparison.Ordinal);
                 }
                 if (lastSlashIndex != -1)
                 {
@@ -989,10 +989,10 @@ namespace Files.Views
                     // Select previous directory
                     if (!InstanceViewModel.IsPageTypeSearchResults && !string.IsNullOrWhiteSpace(e.PreviousDirectory))
                     {
-                        if (e.PreviousDirectory.Contains(e.Path) && !e.PreviousDirectory.Contains("Shell:RecycleBinFolder"))
+                        if (e.PreviousDirectory.Contains(e.Path, StringComparison.Ordinal) && !e.PreviousDirectory.Contains("Shell:RecycleBinFolder", StringComparison.Ordinal))
                         {
                             // Remove the WorkingDir from previous dir
-                            e.PreviousDirectory = e.PreviousDirectory.Replace(e.Path, string.Empty);
+                            e.PreviousDirectory = e.PreviousDirectory.Replace(e.Path, string.Empty, StringComparison.Ordinal);
 
                             // Get previous dir name
                             if (e.PreviousDirectory.StartsWith('\\'))
@@ -1008,7 +1008,7 @@ namespace Files.Views
                             string folderToSelect = string.Format("{0}\\{1}", e.Path, e.PreviousDirectory);
 
                             // Make sure we don't get double \\ in the e.Path
-                            folderToSelect = folderToSelect.Replace("\\\\", "\\");
+                            folderToSelect = folderToSelect.Replace("\\\\", "\\", StringComparison.Ordinal);
 
                             if (folderToSelect.EndsWith('\\'))
                             {

--- a/Files/Views/WidgetsPage.xaml.cs
+++ b/Files/Views/WidgetsPage.xaml.cs
@@ -132,7 +132,7 @@ namespace Files.Views
             }
             catch (ArgumentException)
             {
-                if (new DirectoryInfo(e.ItemPath).Root.ToString().Contains(@"C:\"))
+                if (new DirectoryInfo(e.ItemPath).Root.ToString().Contains(@"C:\", StringComparison.Ordinal))
                 {
                     AppInstance.NavigateWithArguments(FolderSettings.GetLayoutType(e.ItemPath), new NavigationArguments()
                     {


### PR DESCRIPTION
**Details of Changes**

- Use culture-insensitive comparisons for correctness. Depending on the culture `"Test".StartsWith(".", StringComparison.CurrentCulture)` could be true, which can be problematic when dealing with file extensions. Using `Ordinal`/`OrdinalIgnoreCase` also slightly increases the performance
- Replace `StringComparison.InvariantCulture` with `Ordinal`

For reference: https://www.meziantou.net/string-comparisons-are-harder-than-it-seems.htm