### PR TITLE
Remove async when not needed

### DIFF
--- a/Files.Launcher/Helpers/CloudDrivesDetector.cs
+++ b/Files.Launcher/Helpers/CloudDrivesDetector.cs
@@ -1,4 +1,4 @@
-﻿using Files.Common;
+using Files.Common;
 using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
@@ -24,7 +24,7 @@ namespace FilesFullTrust.Helpers
             return tasks.Where(o => o.Result != null).SelectMany(o => o.Result).OrderBy(o => o.ID.ToString()).ThenBy(o => o.Name).Distinct().ToList();
         }
 
-        private static async Task<List<CloudProvider>> DetectGenericCloudDrive()
+        private static Task<List<CloudProvider>> DetectGenericCloudDrive()
         {
             var results = new List<CloudProvider>();
             using var clsidKey = Registry.ClassesRoot.OpenSubKey(@"CLSID");
@@ -72,16 +72,16 @@ namespace FilesFullTrust.Helpers
                     });
                 }
             }
-            return await Task.FromResult(results);
+            return Task.FromResult(results);
         }
 
-        private static async Task<List<CloudProvider>> DetectOneDrive()
+        private static Task<List<CloudProvider>> DetectOneDrive()
         {
             using var oneDriveAccountsKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\OneDrive\Accounts");
 
             if (oneDriveAccountsKey == null)
             {
-                return null;
+                return Task.FromResult<List<CloudProvider>>(null);
             }
 
             var oneDriveAccounts = new List<CloudProvider>();
@@ -101,16 +101,16 @@ namespace FilesFullTrust.Helpers
                     });
                 }
             }
-            return await Task.FromResult(oneDriveAccounts);
+            return Task.FromResult(oneDriveAccounts);
         }
 
-        private static async Task<List<CloudProvider>> DetectSharepoint()
+        private static Task<List<CloudProvider>> DetectSharepoint()
         {
             using var oneDriveAccountsKey = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\OneDrive\Accounts");
 
             if (oneDriveAccountsKey == null)
             {
-                return null;
+                return Task.FromResult<List<CloudProvider>>(null);
             }
 
             var sharepointAccounts = new List<CloudProvider>();
@@ -157,7 +157,7 @@ namespace FilesFullTrust.Helpers
                 }
             }
 
-            return await Task.FromResult(sharepointAccounts);
+            return Task.FromResult(sharepointAccounts);
         }
     }
 }

--- a/Files/Filesystem/StorageItems/BaseStorageItem.cs
+++ b/Files/Filesystem/StorageItems/BaseStorageItem.cs
@@ -61,11 +61,11 @@ namespace Files.Filesystem.StorageItems
     {
         public virtual IAsyncOperation<IDictionary<string, object>> RetrievePropertiesAsync(IEnumerable<string> propertiesToRetrieve)
         {
-            return AsyncInfo.Run<IDictionary<string, object>>(async (cancellationToken) =>
+            return AsyncInfo.Run<IDictionary<string, object>>((cancellationToken) =>
             {
                 var props = new Dictionary<string, object>();
                 propertiesToRetrieve.ForEach(x => props[x] = null);
-                return props;
+                return Task.FromResult<IDictionary<string, object>>(props);
             });
         }
 

--- a/Files/Views/Pages/PropertiesCustomization.xaml.cs
+++ b/Files/Views/Pages/PropertiesCustomization.xaml.cs
@@ -27,9 +27,9 @@ namespace Files.Views
             }, new SuppressNavigationTransitionInfo());
         }
 
-        public override async Task<bool> SaveChangesAsync(ListedItem item)
+        public override Task<bool> SaveChangesAsync(ListedItem item)
         {
-            return await Task.FromResult(true);
+            return Task.FromResult(true);
         }
 
         public override void Dispose()


### PR DESCRIPTION
**Details of Changes**
Using `async` keyword generate a state machine which has perf impact. I removed it from methods where it's trivial to remove them and doesn't impact the readability of the code