### PR TITLE
Do not release the Semaphore if it was not acquired first

### DIFF
--- a/Common/Logger.cs
+++ b/Common/Logger.cs
@@ -8,8 +8,9 @@ namespace Files.Common
 {
     public class Logger
     {
-        ILogWriter LogWriter { get; }
-        SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1);
+        private readonly SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1);
+
+        private ILogWriter LogWriter { get; }
 
         public Logger(ILogWriter logWriter)
         {
@@ -58,9 +59,9 @@ namespace Files.Common
 
         private async void LogAsync(string type, string caller, string message, int attemptNumber = 0)
         {
+            await semaphoreSlim.WaitAsync();
             try
             {
-                await semaphoreSlim.WaitAsync();
                 await LogWriter.WriteLineToLogAsync($"{DateTime.Now:yyyy-MM-dd HH:mm:ss.ffff}|{type}|{caller}|{message}");
             }
             catch (IOException e) when (!(e is FileNotFoundException))
@@ -88,9 +89,9 @@ namespace Files.Common
 
         private void LogSync(string type, string caller, string message)
         {
+            semaphoreSlim.Wait();
             try
             {
-                semaphoreSlim.Wait();
                 LogWriter.WriteLineToLog($"{DateTime.Now:yyyy-MM-dd HH:mm:ss.ffff}|{type}|{caller}|{message}");
             }
             catch (Exception e)


### PR DESCRIPTION
You should release the semaphore only if you have acquired it first. In case an exception occurs when acquiring it, the previous code was releasing it anyway.