### PR TITLE
Fix ToByteArrayAsync to read the result of ReadAsync

### DIFF
--- a/Files/Extensions/ImageSourceExtensions.cs
+++ b/Files/Extensions/ImageSourceExtensions.cs
@@ -20,25 +20,21 @@ namespace Files.Extensions
 
         private static async Task<byte[]> ToByteArrayAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
-            MemoryStream memoryStream = null;
-            try
+            MemoryStream memoryStream;
+            if (stream.CanSeek)
             {
-                if (stream.CanSeek)
-                {
-                    var length = stream.Length - stream.Position;
-                    memoryStream = new MemoryStream((int)length);
-                }
-                else
-                {
-                    memoryStream = new MemoryStream();
-                }
+                var length = stream.Length - stream.Position;
+                memoryStream = new MemoryStream((int)length);
+            }
+            else
+            {
+                memoryStream = new MemoryStream();
+            }
 
+            using (memoryStream)
+            {
                 await stream.CopyToAsync(memoryStream, bufferSize: 81920, cancellationToken).ConfigureAwait(false);
                 return memoryStream.ToArray();
-            }
-            finally
-            {
-                memoryStream?.Dispose();
             }
         }
     }

--- a/Files/Extensions/ImageSourceExtensions.cs
+++ b/Files/Extensions/ImageSourceExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage.Streams;
 
@@ -12,10 +13,33 @@ namespace Files.Extensions
             {
                 return null;
             }
-            var readStream = stream.AsStreamForRead();
-            var byteArray = new byte[readStream.Length];
-            await readStream.ReadAsync(byteArray, 0, byteArray.Length);
-            return byteArray;
+
+            using var readStream = stream.AsStreamForRead();
+            return await readStream.ToByteArrayAsync();
+        }
+
+        private static async Task<byte[]> ToByteArrayAsync(this Stream stream, CancellationToken cancellationToken = default)
+        {
+            MemoryStream memoryStream = null;
+            try
+            {
+                if (stream.CanSeek)
+                {
+                    var length = stream.Length - stream.Position;
+                    memoryStream = new MemoryStream((int)length);
+                }
+                else
+                {
+                    memoryStream = new MemoryStream();
+                }
+
+                await stream.CopyToAsync(memoryStream, bufferSize: 81920, cancellationToken).ConfigureAwait(false);
+                return memoryStream.ToArray();
+            }
+            finally
+            {
+                memoryStream?.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
`ReadAsync` doesn't guarantee to read the _requested_ bytes. The contract is to read at least 1 byte. So, you need to iterate until the stream is fully read.