### PR TITLE
Fixed search button on home page

### DIFF
--- a/Files/UserControls/NavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar.xaml
@@ -502,7 +502,6 @@
                     AutomationProperties.Name="Search"
                     Background="Transparent"
                     Click="SearchButton_Click"
-                    IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
                     Style="{StaticResource ToolBarButtonStyle}"
                     ToolTipService.ToolTip="Search (Ctrl+F)"
                     Visibility="Collapsed">


### PR DESCRIPTION
**Resolved / Related Issues**
Since #5969, the search is available in the homepage. However, in a small window, the search bar is replaced by a button to make it appear. This button is not active on the homepage. It is not possible to search all the drives in a small window.

**Details of Changes**
The SearchButton, to display the search bar, is always active.

**Screenshots (optional)**
before/after
![button_before](https://user-images.githubusercontent.com/46631671/143771326-38237331-444a-422b-9f92-34921b36acad.png)
![button_after](https://user-images.githubusercontent.com/46631671/143771330-f9135743-b7ca-45b8-bfca-2068ed715406.png)