### PR TITLE
Fix select search suggestion

### DIFF
--- a/Files/ISearchBox.cs
+++ b/Files/ISearchBox.cs
@@ -9,11 +9,7 @@ namespace Files
     public interface ISearchBox
     {
         event TypedEventHandler<ISearchBox, SearchBoxTextChangedEventArgs> TextChanged;
-
-        event TypedEventHandler<ISearchBox, SearchBoxSuggestionChosenEventArgs> SuggestionChosen;
-
         event TypedEventHandler<ISearchBox, SearchBoxQuerySubmittedEventArgs> QuerySubmitted;
-
         event EventHandler<ISearchBox> Escaped;
 
         string Query { get; set; }
@@ -38,13 +34,6 @@ namespace Files
                 _ => SearchBoxTextChangeReason.ProgrammaticChange
             };
         }
-    }
-
-    public class SearchBoxSuggestionChosenEventArgs
-    {
-        public ListedItem SelectedSuggestion { get; }
-
-        public SearchBoxSuggestionChosenEventArgs(ListedItem selectedSuggestion) => SelectedSuggestion = selectedSuggestion;
     }
 
     public class SearchBoxQuerySubmittedEventArgs

--- a/Files/UserControls/SearchBox.xaml
+++ b/Files/UserControls/SearchBox.xaml
@@ -69,7 +69,6 @@
         ItemsSource="{x:Bind SearchBoxViewModel.Suggestions, Mode=OneWay}"
         PlaceholderText="Search"
         QuerySubmitted="SearchRegion_QuerySubmitted"
-        SuggestionChosen="SearchRegion_SuggestionChosen"
         Text="{x:Bind SearchBoxViewModel.Query, Mode=TwoWay}"
         TextBoxStyle="{StaticResource TextBoxStyle}"
         TextChanged="SearchRegion_TextChanged"

--- a/Files/UserControls/SearchBox.xaml.cs
+++ b/Files/UserControls/SearchBox.xaml.cs
@@ -7,27 +7,22 @@ namespace Files.UserControls
 {
     public sealed partial class SearchBox : UserControl
     {
+        public static readonly DependencyProperty SearchBoxViewModelProperty =
+            DependencyProperty.Register(nameof(SearchBoxViewModel), typeof(SearchBoxViewModel), typeof(SearchBox), new PropertyMetadata(null));
+
         public SearchBoxViewModel SearchBoxViewModel
         {
             get => (SearchBoxViewModel)GetValue(SearchBoxViewModelProperty);
             set => SetValue(SearchBoxViewModelProperty, value);
         }
 
-        // Using a DependencyProperty as the backing store for SearchBoxViewModel.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty SearchBoxViewModelProperty =
-            DependencyProperty.Register(nameof(SearchBoxViewModel), typeof(SearchBoxViewModel), typeof(SearchBox), new PropertyMetadata(null));
+        public SearchBox() => InitializeComponent();
 
-        public SearchBox()
-        {
-            InitializeComponent();
-        }
-
-        private void SearchRegion_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs e) => SearchBoxViewModel.SearchRegion_TextChanged(sender, e);
-
-        private void SearchRegion_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs e) => SearchBoxViewModel.SearchRegion_QuerySubmitted(sender, e);
-
-        private void SearchRegion_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs e) => SearchBoxViewModel.SearchRegion_SuggestionChosen(sender, e);
-
-        private void SearchRegion_Escaped(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs e) => SearchBoxViewModel.SearchRegion_Escaped(sender, e);
+        private void SearchRegion_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs e)
+            => SearchBoxViewModel.SearchRegion_TextChanged(sender, e);
+        private void SearchRegion_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs e)
+            => SearchBoxViewModel.SearchRegion_QuerySubmitted(sender, e);
+        private void SearchRegion_Escaped(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs e)
+            => SearchBoxViewModel.SearchRegion_Escaped(sender, e);
     }
 }

--- a/Files/ViewModels/NavToolbarViewModel.cs
+++ b/Files/ViewModels/NavToolbarViewModel.cs
@@ -326,7 +326,6 @@ namespace Files.ViewModels
         public NavToolbarViewModel()
         {
             dragOverTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
-            SearchBox.SuggestionChosen += SearchRegion_SuggestionChosen;
             SearchBox.Escaped += SearchRegion_Escaped;
             UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
         }
@@ -732,8 +731,6 @@ namespace Files.ViewModels
             CloseSearchBox();
         }
 
-        private void SearchRegion_SuggestionChosen(ISearchBox sender, SearchBoxSuggestionChosenEventArgs args) => IsSearchBoxVisible = false;
-
         private void SearchRegion_Escaped(object sender, ISearchBox searchBox) => IsSearchBoxVisible = false;
 
         public ICommand SelectAllContentPageItemsCommand { get; set; }
@@ -1063,7 +1060,6 @@ namespace Files.ViewModels
 
         public void Dispose()
         {
-            SearchBox.SuggestionChosen -= SearchRegion_SuggestionChosen;
             SearchBox.Escaped -= SearchRegion_Escaped;
             UserSettingsService.OnSettingChangedEvent -= UserSettingsService_OnSettingChangedEvent;
 

--- a/Files/ViewModels/SearchBoxViewModel.cs
+++ b/Files/ViewModels/SearchBoxViewModel.cs
@@ -13,7 +13,6 @@ namespace Files.ViewModels
     public class SearchBoxViewModel : ObservableObject, ISearchBox
     {
         private string query;
-
         public string Query
         {
             get => query;
@@ -21,11 +20,7 @@ namespace Files.ViewModels
         }
 
         public event TypedEventHandler<ISearchBox, SearchBoxTextChangedEventArgs> TextChanged;
-
-        public event TypedEventHandler<ISearchBox, SearchBoxSuggestionChosenEventArgs> SuggestionChosen;
-
         public event TypedEventHandler<ISearchBox, SearchBoxQuerySubmittedEventArgs> QuerySubmitted;
-
         public event EventHandler<ISearchBox> Escaped;
 
         private readonly SuggestionComparer suggestionComparer = new SuggestionComparer();
@@ -71,14 +66,6 @@ namespace Files.ViewModels
         public void SearchRegion_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs e)
         {
             QuerySubmitted?.Invoke(this, new SearchBoxQuerySubmittedEventArgs(e.ChosenSuggestion as ListedItem));
-        }
-
-        public void SearchRegion_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs e)
-        {
-            if (e.SelectedItem is ListedItem listedItem)
-            {
-                SuggestionChosen?.Invoke(this, new SearchBoxSuggestionChosenEventArgs(listedItem));
-            }
         }
 
         public void SearchRegion_Escaped(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs e)

--- a/Files/Views/ColumnShellPage.xaml.cs
+++ b/Files/Views/ColumnShellPage.xaml.cs
@@ -174,9 +174,7 @@ namespace Files.Views
             NavToolbarViewModel.EditModeEnabled += NavigationToolbar_EditModeEnabled;
             NavToolbarViewModel.ItemDraggedOverPathItem += ColumnShellPage_NavigationRequested;
             NavToolbarViewModel.PathBoxQuerySubmitted += NavigationToolbar_QuerySubmitted;
-
             NavToolbarViewModel.SearchBox.TextChanged += ColumnShellPage_TextChanged;
-            NavToolbarViewModel.SearchBox.SuggestionChosen += ColumnShellPage_SuggestionChosen;
             NavToolbarViewModel.SearchBox.QuerySubmitted += ColumnShellPage_QuerySubmitted;
 
             NavToolbarViewModel.InstanceViewModel = InstanceViewModel;
@@ -280,26 +278,25 @@ namespace Files.Views
             }
         }
 
-        private async void ColumnShellPage_SuggestionChosen(ISearchBox sender, SearchBoxSuggestionChosenEventArgs e)
+        private async void ColumnShellPage_QuerySubmitted(ISearchBox sender, SearchBoxQuerySubmittedEventArgs e)
         {
-            if (e.SelectedSuggestion.PrimaryItemAttribute == StorageItemTypes.Folder)
+            if (e.ChosenSuggestion is ListedItem item)
             {
-                ItemDisplayFrame.Navigate(typeof(ColumnViewBase), new NavigationArguments()
+                if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    NavPathParam = e.SelectedSuggestion.ItemPath,
-                    AssociatedTabInstance = this
-                });
+                    ItemDisplayFrame.Navigate(typeof(ColumnViewBase), new NavigationArguments()
+                    {
+                        NavPathParam = item.ItemPath,
+                        AssociatedTabInstance = this,
+                    });
+                }
+                else
+                {
+                    // TODO: Add fancy file launch options similar to Interactions.cs OpenSelectedItems()
+                    await Win32Helpers.InvokeWin32ComponentAsync(item.ItemPath, this);
+                }
             }
-            else
-            {
-                // TODO: Add fancy file launch options similar to Interactions.cs OpenSelectedItems()
-                await Win32Helpers.InvokeWin32ComponentAsync(e.SelectedSuggestion.ItemPath, this);
-            }
-        }
-
-        private void ColumnShellPage_QuerySubmitted(ISearchBox sender, SearchBoxQuerySubmittedEventArgs e)
-        {
-            if (e.ChosenSuggestion == null && !string.IsNullOrWhiteSpace(sender.Query))
+            else if (e.ChosenSuggestion is null && !string.IsNullOrWhiteSpace(sender.Query))
             {
                 SubmitSearch(sender.Query, UserSettingsService.PreferencesSettingsService.SearchUnindexedItems);
             }
@@ -834,7 +831,6 @@ namespace Files.Views
             NavToolbarViewModel.PathBoxQuerySubmitted -= NavigationToolbar_QuerySubmitted;
 
             NavToolbarViewModel.SearchBox.TextChanged -= ColumnShellPage_TextChanged;
-            NavToolbarViewModel.SearchBox.SuggestionChosen -= ColumnShellPage_SuggestionChosen;
             NavToolbarViewModel.SearchBox.QuerySubmitted -= ColumnShellPage_QuerySubmitted;
 
             InstanceViewModel.FolderSettings.LayoutPreferencesUpdateRequired -= FolderSettings_LayoutPreferencesUpdateRequired;

--- a/Files/Views/ColumnShellPage.xaml.cs
+++ b/Files/Views/ColumnShellPage.xaml.cs
@@ -282,19 +282,7 @@ namespace Files.Views
         {
             if (e.ChosenSuggestion is ListedItem item)
             {
-                if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
-                {
-                    ItemDisplayFrame.Navigate(typeof(ColumnViewBase), new NavigationArguments()
-                    {
-                        NavPathParam = item.ItemPath,
-                        AssociatedTabInstance = this,
-                    });
-                }
-                else
-                {
-                    // TODO: Add fancy file launch options similar to Interactions.cs OpenSelectedItems()
-                    await Win32Helpers.InvokeWin32ComponentAsync(item.ItemPath, this);
-                }
+                await NavigationHelpers.OpenPath(item.ItemPath, this);
             }
             else if (e.ChosenSuggestion is null && !string.IsNullOrWhiteSpace(sender.Query))
             {

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -14,7 +14,6 @@ using Files.Views.LayoutModes;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp;
-using Microsoft.Toolkit.Uwp.UI;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -24,7 +23,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
-using Windows.ApplicationModel.DataTransfer;
 using Windows.ApplicationModel.Resources.Core;
 using Windows.Storage;
 using Windows.System;
@@ -150,7 +148,6 @@ namespace Files.Views
             storageHistoryHelpers = new StorageHistoryHelpers(new StorageHistoryOperations(this, cancellationTokenSource.Token));
 
             NavToolbarViewModel.SearchBox.TextChanged += ModernShellPage_TextChanged;
-            NavToolbarViewModel.SearchBox.SuggestionChosen += ModernShellPage_SuggestionChosen;
             NavToolbarViewModel.SearchBox.QuerySubmitted += ModernShellPage_QuerySubmitted;
             NavToolbarViewModel.InstanceViewModel = InstanceViewModel;
             InitToolbarCommands();
@@ -279,26 +276,25 @@ namespace Files.Views
             }
         }
 
-        private async void ModernShellPage_SuggestionChosen(ISearchBox sender, SearchBoxSuggestionChosenEventArgs e)
+        private async void ModernShellPage_QuerySubmitted(ISearchBox sender, SearchBoxQuerySubmittedEventArgs e)
         {
-            if (e.SelectedSuggestion.PrimaryItemAttribute == StorageItemTypes.Folder)
+            if (e.ChosenSuggestion is ListedItem item)
             {
-                ItemDisplayFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(e.SelectedSuggestion.ItemPath), new NavigationArguments()
+                if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
-                    NavPathParam = e.SelectedSuggestion.ItemPath,
-                    AssociatedTabInstance = this
-                });
+                    ItemDisplayFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(item.ItemPath), new NavigationArguments()
+                    {
+                        NavPathParam = item.ItemPath,
+                        AssociatedTabInstance = this,
+                    });
+                }
+                else
+                {
+                    // TODO: Add fancy file launch options similar to Interactions.cs OpenSelectedItems()
+                    await Win32Helpers.InvokeWin32ComponentAsync(item.ItemPath, this);
+                }
             }
-            else
-            {
-                // TODO: Add fancy file launch options similar to Interactions.cs OpenSelectedItems()
-                await Win32Helpers.InvokeWin32ComponentAsync(e.SelectedSuggestion.ItemPath, this);
-            }
-        }
-
-        private void ModernShellPage_QuerySubmitted(ISearchBox sender, SearchBoxQuerySubmittedEventArgs e)
-        {
-            if (e.ChosenSuggestion == null && !string.IsNullOrWhiteSpace(sender.Query))
+            else if (e.ChosenSuggestion is null && !string.IsNullOrWhiteSpace(sender.Query))
             {
                 SubmitSearch(sender.Query, UserSettingsService.PreferencesSettingsService.SearchUnindexedItems);
             }

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -280,19 +280,7 @@ namespace Files.Views
         {
             if (e.ChosenSuggestion is ListedItem item)
             {
-                if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
-                {
-                    ItemDisplayFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(item.ItemPath), new NavigationArguments()
-                    {
-                        NavPathParam = item.ItemPath,
-                        AssociatedTabInstance = this,
-                    });
-                }
-                else
-                {
-                    // TODO: Add fancy file launch options similar to Interactions.cs OpenSelectedItems()
-                    await Win32Helpers.InvokeWin32ComponentAsync(item.ItemPath, this);
-                }
+                await NavigationHelpers.OpenPath(item.ItemPath, this);
             }
             else if (e.ChosenSuggestion is null && !string.IsNullOrWhiteSpace(sender.Query))
             {


### PR DESCRIPTION
**Resolved / Related Issues**
The selection in search suggestions has a problem. The file is opened by selecting the item. If there are several suggestions and you want to open the second, moving with the keyboard will open the first by passing over it, and you cannot open the second.

**Details of Changes**
The event SuggestionChosen is removed. The event QuerySubmitted opens the file when he receives a suggestion.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
before/after for select the second item on the keyboard.

https://user-images.githubusercontent.com/46631671/144091046-0cac7c4f-97a6-401d-a758-d0de99f4bad1.mp4

https://user-images.githubusercontent.com/46631671/144091114-1535b239-fd5b-4c3d-bd19-8656671f2e9b.mp4
