### PR TITLE
Reduce allocations in CreateEnumerable

### DIFF
--- a/Files/Extensions/EnumerableExtensions.cs
+++ b/Files/Extensions/EnumerableExtensions.cs
@@ -14,7 +14,7 @@ namespace Files.Extensions
         /// <param name="item">The item</param>
         /// <returns><see cref="IEnumerable{T}"/> with <paramref name="item"/></returns>
         internal static IEnumerable<T> CreateEnumerable<T>(this T item) =>
-            CreateList<T>(item);
+            new[] { item };
 
         internal static List<T> CreateList<T>(this T item) =>
             new List<T>() { item };


### PR DESCRIPTION
`new List<T>` with a single item allocates an array of 4 items in addition to the `List<T>`. Using an array with a single item reduces allocation and is faster to create and iterate.