### PR TITLE
Cache event args to avoid allocations

### DIFF
--- a/Files/Helpers/ItemListDisplayHelpers/BulkConcurrentObservableCollection.cs
+++ b/Files/Helpers/ItemListDisplayHelpers/BulkConcurrentObservableCollection.cs
@@ -1,4 +1,4 @@
-﻿using Files.Extensions;
+using Files.Extensions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -110,11 +110,11 @@ namespace Files.Helpers
         {
             if (!isBulkOperationStarted)
             {
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+                PropertyChanged?.Invoke(this, EventArgsCache.IndexerPropertyChanged);
                 CollectionChanged?.Invoke(this, e);
                 if (countChanged)
                 {
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
+                    PropertyChanged?.Invoke(this, EventArgsCache.CountPropertyChanged);
                 }
             }
 
@@ -211,9 +211,9 @@ namespace Files.Helpers
             GroupedCollection?.ForEach(gp => gp.EndBulkOperation());
             GroupedCollection?.EndBulkOperation();
 
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+            OnCollectionChanged(EventArgsCache.ResetCollectionChanged);
+            PropertyChanged?.Invoke(this, EventArgsCache.CountPropertyChanged);
+            PropertyChanged?.Invoke(this, EventArgsCache.IndexerPropertyChanged);
         }
 
         public void Add(T item)
@@ -234,7 +234,7 @@ namespace Files.Helpers
             }
             GroupedCollection?.Clear();
 
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            OnCollectionChanged(EventArgsCache.ResetCollectionChanged);
         }
 
         public bool Contains(T item)
@@ -307,7 +307,7 @@ namespace Files.Helpers
 
         public void AddRange(IEnumerable<T> items)
         {
-            if (items.Count() == 0)
+            if (!items.Any())
             {
                 return;
             }
@@ -322,7 +322,7 @@ namespace Files.Helpers
 
         public void InsertRange(int index, IEnumerable<T> items)
         {
-            if (items.Count() == 0)
+            if (!items.Any())
             {
                 return;
             }
@@ -425,5 +425,12 @@ namespace Files.Helpers
         void IList.Remove(object value) => Remove((T)value);
 
         void ICollection.CopyTo(Array array, int index) => CopyTo((T[])array, index);
+
+        private static class EventArgsCache
+        {
+            internal static readonly PropertyChangedEventArgs CountPropertyChanged = new PropertyChangedEventArgs("Count");
+            internal static readonly PropertyChangedEventArgs IndexerPropertyChanged = new PropertyChangedEventArgs("Item[]");
+            internal static readonly NotifyCollectionChangedEventArgs ResetCollectionChanged = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
+        }
     }
 }


### PR DESCRIPTION
Similar to the [ObservableCollection](https://source.dot.net/#System.ObjectModel/System/Collections/ObjectModel/ObservableCollection.cs,f63ea2601f5edbbb,references)