### PR TITLE
Change return type of AddIfNotPresent

### DIFF
--- a/Files/Extensions/EnumerableExtensions.cs
+++ b/Files/Extensions/EnumerableExtensions.cs
@@ -43,30 +43,22 @@ namespace Files.Extensions
             return block.Completion;
         }
 
-        public static bool AddIfNotPresent<T>(this IList<T> list, T element)
+        public static IList<T> AddIfNotPresent<T>(this IList<T> list, T element)
         {
             if (!list.Contains(element))
             {
                 list.Add(element);
-                return true;
             }
-            else
-            {
-                return false;
-            }
+            return list;
         }
 
-        public static bool AddIfNotPresent<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        public static IDictionary<TKey, TValue> AddIfNotPresent<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {
             if (!dictionary.ContainsKey(key))
             {
                 dictionary.Add(key, value);
-                return true;
             }
-            else
-            {
-                return false;
-            }
+            return dictionary;
         }
     }
 }

--- a/Files/Extensions/LinqExtensions.cs
+++ b/Files/Extensions/LinqExtensions.cs
@@ -33,22 +33,22 @@ namespace Files.Extensions
                 action(value);
         }
 
-        internal static void AddSorted<T>(this IList<T> list, T item) where T : IComparable<T>
+        internal static IList<T> AddSorted<T>(this IList<T> list, T item) where T : IComparable<T>
         {
             if (list.Count == 0)
             {
                 list.Add(item);
-                return;
+                return list;
             }
             if (list[list.Count - 1].CompareTo(item) <= 0)
             {
                 list.Add(item);
-                return;
+                return list;
             }
             if (list[0].CompareTo(item) >= 0)
             {
                 list.Insert(0, item);
-                return;
+                return list;
             }
             int index = list.ToList().BinarySearch(item);
             if (index < 0)
@@ -56,6 +56,7 @@ namespace Files.Extensions
                 index = ~index;
             }
             list.Insert(index, item);
+            return list;
         }
 
         /// <summary>


### PR DESCRIPTION
**Resolved / Related Issues**
EnumerableExtensions.AddIfNotPresent returns a Boolean. This result is never used.
This makes sense, because the purpose of this function is to avoid testing.

**Details of Changes**
This pr change the return type by the input (list or dictionary).
This will allow this function to be placed in a modification chain, like LINQ

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility