### PR TITLE
Fix inner toolbar state on startup

### DIFF
--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -56,7 +56,7 @@
                 <AppBarButton
                     x:Name="NewEmptySpaceAppBarButton"
                     x:Uid="BaseLayoutContextFlyoutNew"
-                    IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsCreateButtonEnabledInPage, Mode=OneWay}"
+                    IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsCreateButtonEnabledInPage, Mode=OneWay, FallbackValue=False}"
                     KeyboardAcceleratorTextOverride="Ctrl+Shift+N"
                     Label="New">
                     <AppBarButton.KeyboardAccelerators>
@@ -102,7 +102,7 @@
                     Width="Auto"
                     MinWidth="40"
                     Command="{x:Bind ViewModel.CutCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
                     Label="{x:Bind GetLocalizedString('BaseLayoutItemContextFlyoutCut/Text')}"
                     LabelPosition="Collapsed"
                     ToolTipService.ToolTip="{x:Bind GetLocalizedString('BaseLayoutItemContextFlyoutCut/Text')}">
@@ -115,7 +115,7 @@
                     Width="Auto"
                     MinWidth="40"
                     Command="{x:Bind ViewModel.CopyCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind ViewModel.CanCopy, Mode=OneWay}"
+                    IsEnabled="{x:Bind ViewModel.CanCopy, Mode=OneWay, FallbackValue=False}"
                     Label="Copy"
                     LabelPosition="Collapsed"
                     ToolTipService.ToolTip="Copy">
@@ -127,7 +127,7 @@
                     Width="Auto"
                     MinWidth="40"
                     Command="{x:Bind ViewModel.PasteItemsFromClipboardCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.InstanceViewModel.CanPasteInPage, local1:App.MainViewModel.IsPasteEnabled), Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.InstanceViewModel.CanPasteInPage, local1:App.MainViewModel.IsPasteEnabled), Mode=OneWay, FallbackValue=False}"
                     Label="Paste"
                     LabelPosition="Collapsed"
                     ToolTipService.ToolTip="{x:Bind GetLocalizedString('BaseLayoutContextFlyoutPaste/Text')}">
@@ -145,7 +145,7 @@
                     Width="Auto"
                     MinWidth="40"
                     Command="{x:Bind ViewModel.Rename, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanRename, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanRename, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
                     Label="{x:Bind GetLocalizedString('BaseLayoutItemContextFlyoutRename/Text')}"
                     LabelPosition="Collapsed"
                     ToolTipService.ToolTip="{x:Bind GetLocalizedString('BaseLayoutItemContextFlyoutRename/Text')}">
@@ -159,7 +159,7 @@
                     Width="Auto"
                     MinWidth="40"
                     Command="{x:Bind ViewModel.Share, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanShare, ViewModel.InstanceViewModel.CanShareInPage), Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanShare, ViewModel.InstanceViewModel.CanShareInPage), Mode=OneWay, FallbackValue=False}"
                     Label="{x:Bind GetLocalizedString('BaseLayoutItemContextFlyoutShare/Text')}"
                     LabelPosition="Collapsed"
                     ToolTipService.ToolTip="{x:Bind GetLocalizedString('BaseLayoutItemContextFlyoutShare/Text')}">
@@ -172,7 +172,7 @@
                     Width="Auto"
                     MinWidth="40"
                     Command="{x:Bind ViewModel.DeleteCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
                     Label="{helpers:ResourceString Name=Delete}"
                     LabelPosition="Collapsed"
                     ToolTipService.ToolTip="{helpers:ResourceString Name=Delete}">

--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -187,7 +187,7 @@
                     ToolTipService.ToolTip="{helpers:ResourceString Name=EmptyRecycleBin}"
                     IsEnabled="{x:Bind ViewModel.CanEmptyRecycleBin, Mode=OneWay}"
                     Command="{x:Bind ViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
-                    Visibility="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}">
+                    Visibility="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=Collapsed}">
                     <AppBarButton.Icon>
                         <FontIcon Glyph="&#xEF88;" FontFamily="{StaticResource RecycleBinIcons}" />
                     </AppBarButton.Icon>


### PR DESCRIPTION
**Resolved / Related Issues**
Before, on startup, the icons are actives in the inner toolbar and the EmptyRecycleBin button is visible.
They are disabled when the viewmodel is loaded. It is not beautiful and it will become even less so when we add buttons only visible on certain pages. 

**Details of Changes**
Add Fallback in the bindings.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility