### PR TITLE
Show network shortcuts on the sidebar

### DIFF
--- a/Common/ShellLinkItem.cs
+++ b/Common/ShellLinkItem.cs
@@ -1,0 +1,27 @@
+﻿namespace Files.Common
+{
+    public class ShellLinkItem : ShellFileItem
+    {
+        public string TargetPath;
+        public string Arguments;
+        public string WorkingDirectory;
+        public bool RunAsAdmin;
+
+        public ShellLinkItem()
+        {
+        }
+
+        public ShellLinkItem(ShellFileItem baseItem)
+        {
+            this.RecyclePath = baseItem.RecyclePath;
+            this.FileName = baseItem.FileName;
+            this.FilePath = baseItem.FilePath;
+            this.RecycleDate = baseItem.RecycleDate;
+            this.ModifiedDate = baseItem.ModifiedDate;
+            this.CreatedDate = baseItem.CreatedDate;
+            this.FileSize = baseItem.FileSize;
+            this.FileSizeBytes = baseItem.FileSizeBytes;
+            this.FileType = baseItem.FileType;
+        }
+    }
+}

--- a/Files.Launcher/Helpers/ShellFolderHelpers.cs
+++ b/Files.Launcher/Helpers/ShellFolderHelpers.cs
@@ -44,7 +44,7 @@ namespace FilesFullTrust.Helpers
             folderItem.Properties.TryGetValue<string>(
                 Ole32.PROPERTYKEY.System.ItemNameDisplay, out var fileName);
             fileName ??= Path.GetFileName(folderItem.Name); // Original file name
-            string filePath = folderItem.Name; // Original file path + name (recycle bin only)
+            string filePath = Path.Combine(Path.GetDirectoryName(parsingPath), folderItem.Name); // In recycle bin "Name" contains original file path + name
             if (!isFolder && !string.IsNullOrEmpty(parsingPath) && Path.GetExtension(parsingPath) is string realExtension && !string.IsNullOrEmpty(realExtension))
             {
                 if (!string.IsNullOrEmpty(fileName) && !fileName.EndsWith(realExtension, StringComparison.OrdinalIgnoreCase))
@@ -71,6 +71,26 @@ namespace FilesFullTrust.Helpers
             folderItem.Properties.TryGetValue<string>(
                 Ole32.PROPERTYKEY.System.ItemTypeText, out var fileType);
             return new ShellFileItem(isFolder, parsingPath, fileName, filePath, recycleDate, modifiedDate, createdDate, fileSize, fileSizeBytes ?? 0, fileType);
+        }
+
+        public static ShellLinkItem GetShellLinkItem(ShellLink linkItem)
+        {
+            if (linkItem == null)
+            {
+                return null;
+            }
+            var baseItem = GetShellFileItem(linkItem);
+            if (baseItem == null)
+            {
+                return null;
+            }
+            var link = new ShellLinkItem(baseItem);
+            link.IsFolder = !string.IsNullOrEmpty(link.TargetPath) && linkItem.Target.IsFolder;
+            link.RunAsAdmin = linkItem.RunAsAdministrator;
+            link.Arguments = linkItem.Arguments;
+            link.WorkingDirectory = linkItem.WorkingDirectory;
+            link.TargetPath = linkItem.TargetPath;
+            return link;
         }
     }
 }

--- a/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
+++ b/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
@@ -507,11 +507,7 @@ namespace FilesFullTrust.MessageHandlers
                             using var link = new ShellLink(linkPath, LinkResolution.NoUIWithMsgPump, null, TimeSpan.FromMilliseconds(100));
                             await Win32API.SendMessageAsync(connection, new ValueSet()
                             {
-                                { "TargetPath", link.TargetPath },
-                                { "Arguments", link.Arguments },
-                                { "WorkingDirectory", link.WorkingDirectory },
-                                { "RunAsAdmin", link.RunAsAdministrator },
-                                { "IsFolder", !string.IsNullOrEmpty(link.TargetPath) && link.Target.IsFolder }
+                                { "ShortcutInfo", JsonConvert.SerializeObject(ShellFolderExtensions.GetShellLinkItem(link)) }
                             }, message.Get("RequestID", (string)null));
                         }
                         else if (linkPath.EndsWith(".url", StringComparison.OrdinalIgnoreCase))
@@ -525,11 +521,7 @@ namespace FilesFullTrust.MessageHandlers
                             });
                             await Win32API.SendMessageAsync(connection, new ValueSet()
                             {
-                                { "TargetPath", linkUrl },
-                                { "Arguments", null },
-                                { "WorkingDirectory", null },
-                                { "RunAsAdmin", false },
-                                { "IsFolder", false }
+                                { "ShortcutInfo", JsonConvert.SerializeObject(new ShellLinkItem() { TargetPath = linkUrl }) }
                             }, message.Get("RequestID", (string)null));
                         }
                     }
@@ -539,11 +531,7 @@ namespace FilesFullTrust.MessageHandlers
                         Program.Logger.Warn(ex, ex.Message);
                         await Win32API.SendMessageAsync(connection, new ValueSet()
                         {
-                            { "TargetPath", null },
-                            { "Arguments", null },
-                            { "WorkingDirectory", null },
-                            { "RunAsAdmin", false },
-                            { "IsFolder", false }
+                            { "ShortcutInfo", JsonConvert.SerializeObject(null) }
                         }, message.Get("RequestID", (string)null));
                     }
                     break;

--- a/Files.Launcher/MessageHandlers/NetworkDrivesHandler.cs
+++ b/Files.Launcher/MessageHandlers/NetworkDrivesHandler.cs
@@ -45,23 +45,31 @@ namespace FilesFullTrust.MessageHandlers
                 case "GetNetworkLocations":
                     var networkLocations = await Win32API.StartSTATask(() =>
                     {
-                        var netl = new ValueSet();
+                        var locations = new List<ShellLinkItem>();
                         using (var nethood = new ShellFolder(Shell32.KNOWNFOLDERID.FOLDERID_NetHood))
                         {
                             foreach (var item in nethood)
                             {
-                                var linkPath = item is ShellLink link ? link.TargetPath : (string)item.Properties["System.Link.TargetParsingPath"];
-                                if (linkPath != null)
+                                if (item is ShellLink link)
                                 {
-                                    netl.Add(item.Name, linkPath);
+                                    locations.Add(ShellFolderExtensions.GetShellLinkItem(link));
+                                }
+                                else
+                                {
+                                    var linkPath = (string)item.Properties["System.Link.TargetParsingPath"];
+                                    if (linkPath != null)
+                                    {
+                                        var linkItem = ShellFolderExtensions.GetShellFileItem(item);
+                                        locations.Add(new ShellLinkItem(linkItem) { TargetPath = linkPath });
+                                    }
                                 }
                             }
                         }
-                        return netl;
+                        return locations;
                     });
-                    networkLocations ??= new ValueSet();
-                    networkLocations.Add("Count", networkLocations.Count);
-                    await Win32API.SendMessageAsync(connection, networkLocations, message.Get("RequestID", (string)null));
+                    var response = new ValueSet();
+                    response.Add("NetworkLocations", JsonConvert.SerializeObject(networkLocations));
+                    await Win32API.SendMessageAsync(connection, response, message.Get("RequestID", (string)null));
                     break;
 
                 case "OpenMapNetworkDriveDialog":

--- a/Files.Launcher/MessageHandlers/NetworkDrivesHandler.cs
+++ b/Files.Launcher/MessageHandlers/NetworkDrivesHandler.cs
@@ -48,12 +48,12 @@ namespace FilesFullTrust.MessageHandlers
                         var netl = new ValueSet();
                         using (var nethood = new ShellFolder(Shell32.KNOWNFOLDERID.FOLDERID_NetHood))
                         {
-                            foreach (var link in nethood)
+                            foreach (var item in nethood)
                             {
-                                var linkPath = (string)link.Properties["System.Link.TargetParsingPath"];
+                                var linkPath = item is ShellLink link ? link.TargetPath : (string)item.Properties["System.Link.TargetParsingPath"];
                                 if (linkPath != null)
                                 {
-                                    netl.Add(link.Name, linkPath);
+                                    netl.Add(item.Name, linkPath);
                                 }
                             }
                         }

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -203,7 +203,7 @@ namespace Files
             bool canEnablePrelaunch = ApiInformation.IsMethodPresent("Windows.ApplicationModel.Core.CoreApplication", "EnablePrelaunch");
 
             await EnsureSettingsAndConfigurationAreBootstrapped();
-            InitializeAppComponentsAsync().ContinueWith(t => Logger.Warn(t.Exception, "Error during LoadOtherStuffAsync()"), TaskContinuationOptions.OnlyOnFaulted);
+            _ = InitializeAppComponentsAsync().ContinueWith(t => Logger.Warn(t.Exception, "Error during InitializeAppComponentsAsync()"), TaskContinuationOptions.OnlyOnFaulted);
 
             var rootFrame = EnsureWindowIsInitialized();
 
@@ -261,7 +261,7 @@ namespace Files
             SystemInformation.Instance.TrackAppUse(e);
 
             await EnsureSettingsAndConfigurationAreBootstrapped();
-            InitializeAppComponentsAsync().ContinueWith(t => Logger.Warn(t.Exception, "Error during LoadOtherStuffAsync()"), TaskContinuationOptions.OnlyOnFaulted);
+            _ = InitializeAppComponentsAsync().ContinueWith(t => Logger.Warn(t.Exception, "Error during InitializeAppComponentsAsync()"), TaskContinuationOptions.OnlyOnFaulted);
 
             var rootFrame = EnsureWindowIsInitialized();
 
@@ -327,7 +327,7 @@ namespace Files
             Logger.Info($"App activated by {args.Kind.ToString()}");
 
             await EnsureSettingsAndConfigurationAreBootstrapped();
-            InitializeAppComponentsAsync().ContinueWith(t => Logger.Warn(t.Exception, "Error during LoadOtherStuffAsync()"), TaskContinuationOptions.OnlyOnFaulted);
+            _ = InitializeAppComponentsAsync().ContinueWith(t => Logger.Warn(t.Exception, "Error during InitializeAppComponentsAsync()"), TaskContinuationOptions.OnlyOnFaulted);
 
             var rootFrame = EnsureWindowIsInitialized();
 

--- a/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -1,4 +1,5 @@
 ﻿using ByteSizeLib;
+using Files.Common;
 using Files.Extensions;
 using Files.Filesystem.StorageItems;
 using Files.Helpers;
@@ -6,6 +7,7 @@ using Files.Helpers.FileListCache;
 using Files.Services;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Uwp;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -259,21 +261,20 @@ namespace Files.Filesystem.StorageEnumerators
                     {
                         return null;
                     }
-                    if (status == AppServiceResponseStatus.Success
-                        && response.ContainsKey("TargetPath"))
+                    if (status == AppServiceResponseStatus.Success && response.ContainsKey("ShortcutInfo"))
                     {
                         var isUrl = findData.cFileName.EndsWith(".url", StringComparison.OrdinalIgnoreCase);
-                        string target = (string)response["TargetPath"];
+                        var shInfo = JsonConvert.DeserializeObject<ShellLinkItem>((string)response["ShortcutInfo"]);
 
                         return new ShortcutItem(null, dateReturnFormat)
                         {
-                            PrimaryItemAttribute = (bool)response["IsFolder"] ? StorageItemTypes.Folder : StorageItemTypes.File,
+                            PrimaryItemAttribute = shInfo.IsFolder ? StorageItemTypes.Folder : StorageItemTypes.File,
                             FileExtension = itemFileExtension,
                             IsHiddenItem = isHidden,
                             Opacity = opacity,
                             FileImage = null,
-                            LoadFileIcon = !(bool)response["IsFolder"] && itemThumbnailImgVis,
-                            LoadWebShortcutGlyph = !(bool)response["IsFolder"] && isUrl && itemEmptyImgVis,
+                            LoadFileIcon = !shInfo.IsFolder && itemThumbnailImgVis,
+                            LoadWebShortcutGlyph = !shInfo.IsFolder && isUrl && itemEmptyImgVis,
                             ItemNameRaw = itemName,
                             ItemDateModifiedReal = itemModifiedDate,
                             ItemDateAccessedReal = itemLastAccessDate,
@@ -282,10 +283,10 @@ namespace Files.Filesystem.StorageEnumerators
                             ItemPath = itemPath,
                             FileSize = itemSize,
                             FileSizeBytes = itemSizeBytes,
-                            TargetPath = target,
-                            Arguments = (string)response["Arguments"],
-                            WorkingDirectory = (string)response["WorkingDirectory"],
-                            RunAsAdmin = (bool)response["RunAsAdmin"],
+                            TargetPath = shInfo.TargetPath,
+                            Arguments = shInfo.Arguments,
+                            WorkingDirectory = shInfo.WorkingDirectory,
+                            RunAsAdmin = shInfo.RunAsAdmin,
                             IsUrl = isUrl,
                         };
                     }

--- a/Files/Helpers/NavigationHelpers.cs
+++ b/Files/Helpers/NavigationHelpers.cs
@@ -7,6 +7,7 @@ using Files.ViewModels;
 using Files.Views;
 using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Uwp;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -132,7 +133,7 @@ namespace Files.Helpers
             bool isShortcutItem = path.EndsWith(".lnk", StringComparison.Ordinal) || path.EndsWith(".url", StringComparison.Ordinal);
             FilesystemResult opened = (FilesystemResult)false;
 
-            var shortcutInfo = new ShortcutItem();
+            var shortcutInfo = new ShellLinkItem();
             if (itemType == null || isShortcutItem || isHiddenItem || isReparsePoint)
             {
                 if (isShortcutItem)
@@ -149,15 +150,14 @@ namespace Files.Helpers
                         { "filepath", path }
                     });
 
-                    if (status == AppServiceResponseStatus.Success)
+                    if (status == AppServiceResponseStatus.Success && response.ContainsKey("ShortcutInfo"))
                     {
-                        shortcutInfo.TargetPath = response.Get("TargetPath", string.Empty);
-                        shortcutInfo.Arguments = response.Get("Arguments", string.Empty);
-                        shortcutInfo.WorkingDirectory = response.Get("WorkingDirectory", string.Empty);
-                        shortcutInfo.RunAsAdmin = response.Get("RunAsAdmin", false);
-                        shortcutInfo.PrimaryItemAttribute = response.Get("IsFolder", false) ? StorageItemTypes.Folder : StorageItemTypes.File;
-
-                        itemType = response.Get("IsFolder", false) ? FilesystemItemType.Directory : FilesystemItemType.File;
+                        var shInfo = JsonConvert.DeserializeObject<ShellLinkItem>((string)response["ShortcutInfo"]);
+                        if (shInfo != null)
+                        {
+                            shortcutInfo = shInfo;
+                        }
+                        itemType = shInfo != null && shInfo.IsFolder ? FilesystemItemType.Directory : FilesystemItemType.File;
                     }
                     else
                     {
@@ -262,7 +262,7 @@ namespace Files.Helpers
             return opened;
         }
 
-        private static async Task<FilesystemResult> OpenDirectory(string path, IShellPage associatedInstance, IEnumerable<string> selectItems, ShortcutItem shortcutInfo)
+        private static async Task<FilesystemResult> OpenDirectory(string path, IShellPage associatedInstance, IEnumerable<string> selectItems, ShellLinkItem shortcutInfo)
         {
             IUserSettingsService userSettingsService = Ioc.Default.GetService<IUserSettingsService>();
 
@@ -352,7 +352,7 @@ namespace Files.Helpers
             return opened;
         }
 
-        private static async Task<FilesystemResult> OpenFile(string path, IShellPage associatedInstance, IEnumerable<string> selectItems, ShortcutItem shortcutInfo, bool openViaApplicationPicker = false, string args = default)
+        private static async Task<FilesystemResult> OpenFile(string path, IShellPage associatedInstance, IEnumerable<string> selectItems, ShellLinkItem shortcutInfo, bool openViaApplicationPicker = false, string args = default)
         {
             var opened = (FilesystemResult)false;
             bool isHiddenItem = NativeFileOperationsHelper.HasFileAttribute(path, System.IO.FileAttributes.Hidden);

--- a/Files/ViewModels/Properties/DriveProperties.cs
+++ b/Files/ViewModels/Properties/DriveProperties.cs
@@ -52,6 +52,7 @@ namespace Files.ViewModels.Properties
                 {
                     ViewModel.IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Drive.Path, 80);
                 }
+                ViewModel.IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Drive.DeviceID, 80); // For network shortcuts
             }
 
             if (diskRoot == null || diskRoot.Properties == null)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7183

**Details of Changes**
Add details of changes here.
It's possible to manually add shortcuts (.lnk) to the `%AppData%\Roaming\Microsoft\Windows\Network Shortcuts` folder. These are shown in explorer under This PC > Network Locations. This PR adds support for showing these in the sidebar network section.
- Show network shortcuts on the sidebar
- Show icon for shortcut items

**Validation**
How did you test these changes?
- [x] Built and ran the app
