### PR TITLE
Add action on label for change layout

### DIFF
--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2641,22 +2641,19 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
   <data name="LinkToFolderCaptionText" xml:space="preserve">
     <value>Create link in {0}</value>
   </data>
-  <data name="NavToolbarColumnsHeader.Text" xml:space="preserve">
+  <data name="Columns" xml:space="preserve">
     <value>Columns</value>
   </data>
-  <data name="NavToolbarDetailsHeader.Text" xml:space="preserve">
-    <value>Details</value>
-  </data>
-  <data name="NavToolbarLargeIconsHeader.Text" xml:space="preserve">
+  <data name="LargeIcons" xml:space="preserve">
     <value>Large Icons</value>
   </data>
-  <data name="NavToolbarMediumIconsHeader.Text" xml:space="preserve">
+  <data name="MediumIcons" xml:space="preserve">
     <value>Medium Icons</value>
   </data>
-  <data name="NavToolbarSmallIconsHeader.Text" xml:space="preserve">
+  <data name="Small Icons" xml:space="preserve">
     <value>Small Icons</value>
   </data>
-  <data name="NavToolbarTilesHeader.Text" xml:space="preserve">
+  <data name="Tiles" xml:space="preserve">
     <value>Tiles</value>
   </data>
   <data name="NavToolbarShowFileExtensions.AutomationProperties.Name" xml:space="preserve">

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2650,7 +2650,7 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
   <data name="MediumIcons" xml:space="preserve">
     <value>Medium Icons</value>
   </data>
-  <data name="Small Icons" xml:space="preserve">
+  <data name="SmallIcons" xml:space="preserve">
     <value>Small Icons</value>
   </data>
   <data name="Tiles" xml:space="preserve">

--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -486,10 +486,12 @@
                                 </RadioButton>
 
                                 <TextBlock
+                                    x:Name="NavToolbarDetailsHeader"
                                     x:Uid="NavToolbarDetailsHeader"
                                     Grid.Row="0"
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
+                                    PointerReleased="NavToolbarDetailsHeader_PointerReleased"
                                     Text="Details" />
 
                                 <RadioButton
@@ -513,10 +515,12 @@
                                 </RadioButton>
 
                                 <TextBlock
+                                    x:Name="NavToolbarTilesHeader"
                                     x:Uid="NavToolbarTilesHeader"
                                     Grid.Row="1"
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
+                                    PointerReleased="NavToolbarTilesHeader_PointerReleased"
                                     Text="Tiles" />
 
                                 <RadioButton
@@ -540,10 +544,12 @@
                                 </RadioButton>
 
                                 <TextBlock
+                                    x:Name="NavToolbarSmallIconsHeader"
                                     x:Uid="NavToolbarSmallIconsHeader"
                                     Grid.Row="2"
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
+                                    PointerReleased="NavToolbarSmallIconsHeader_PointerReleased"
                                     Text="Small Icons" />
 
                                 <Border
@@ -576,10 +582,12 @@
                                 </RadioButton>
 
                                 <TextBlock
+                                    x:Name="NavToolbarMediumIconsHeader"
                                     x:Uid="NavToolbarMediumIconsHeader"
                                     Grid.Row="0"
                                     Grid.Column="4"
                                     VerticalAlignment="Center"
+                                    PointerReleased="NavToolbarMediumIconsHeader_PointerReleased"
                                     Text="Medium Icons" />
 
                                 <RadioButton
@@ -603,10 +611,12 @@
                                 </RadioButton>
 
                                 <TextBlock
+                                    x:Name="NavToolbarLargeIconsHeader"
                                     x:Uid="NavToolbarLargeIconsHeader"
                                     Grid.Row="1"
                                     Grid.Column="4"
                                     VerticalAlignment="Center"
+                                    PointerReleased="NavToolbarLargeIconsHeader_PointerReleased"
                                     Text="Large Icons" />
 
                                 <RadioButton
@@ -633,10 +643,12 @@
                                 </RadioButton>
 
                                 <TextBlock
+                                    x:Name="NavToolbarColumnsHeader"
                                     x:Uid="NavToolbarColumnsHeader"
                                     Grid.Row="2"
                                     Grid.Column="4"
                                     VerticalAlignment="Center"
+                                    PointerReleased="NavToolbarColumnsHeader_PointerReleased"
                                     Text="Columns" />
                             </Grid>
 

--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -485,20 +485,13 @@
                                     <FontIcon FontSize="16" Glyph="&#xE179;" />
                                 </RadioButton>
 
-                                <HyperlinkButton
+                                <TextBlock
                                     x:Name="NavToolbarDetailsHeader"
                                     Grid.Row="0"
-                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                                    Style="{ThemeResource TextBlockButtonStyle}"
-                                    Grid.Column="1"
+                                    Grid.Column="1" 
+                                    Tapped="NavToolbarDetailsHeader_Tapped"
                                     VerticalAlignment="Center"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=Details}" >
-                                    <HyperlinkButton.Resources>
-                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
-                                    </HyperlinkButton.Resources>
-                                </HyperlinkButton>
+                                    Text="{helpers:ResourceString Name=Details}" />
 
                                 <RadioButton
                                     x:Uid="NavToolbarTiles"
@@ -520,20 +513,13 @@
                                     <FontIcon FontSize="16" Glyph="&#xE15C;" />
                                 </RadioButton>
 
-                                <HyperlinkButton
+                                <TextBlock
                                     x:Name="NavToolbarTilesHeader"
                                     Grid.Row="1"
-                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Grid.Column="1"
-                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     VerticalAlignment="Center"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTiles, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=Tiles}">
-                                    <HyperlinkButton.Resources>
-                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
-                                    </HyperlinkButton.Resources>
-                                </HyperlinkButton>
+                                    Tapped="NavToolbarTilesHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=Tiles}"/>
 
                                 <RadioButton
                                     x:Uid="NavToolbarSmallIcons"
@@ -555,20 +541,13 @@
                                     <FontIcon FontSize="16" Glyph="&#xE80A;" />
                                 </RadioButton>
 
-                                <HyperlinkButton
+                                <TextBlock
                                     x:Name="NavToolbarSmallIconsHeader"
                                     Grid.Row="2"
-                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Grid.Column="1"
-                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     VerticalAlignment="Center"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmall, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=SmallIcons}">
-                                    <HyperlinkButton.Resources>
-                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
-                                    </HyperlinkButton.Resources>
-                                </HyperlinkButton>
+                                    Tapped="NavToolbarSmallIconsHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=SmallIcons}"/>
 
                                 <Border
                                     Grid.RowSpan="3"
@@ -600,20 +579,13 @@
                                     <FontIcon FontSize="16" Glyph="&#xF0E2;" />
                                 </RadioButton>
 
-                                <HyperlinkButton
+                                <TextBlock
                                     x:Name="NavToolbarMediumIconsHeader"
                                     Grid.Row="0"
                                     Grid.Column="4"
-                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     VerticalAlignment="Center"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=MediumIcons}">
-                                    <HyperlinkButton.Resources>
-                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
-                                    </HyperlinkButton.Resources>
-                                </HyperlinkButton>
+                                    Tapped="NavToolbarMediumIconsHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=MediumIcons}"/>
 
                                 <RadioButton
                                     x:Uid="NavToolbarLargeIcons"
@@ -635,20 +607,13 @@
                                     <FontIcon FontSize="16" Glyph="&#xE739;" />
                                 </RadioButton>
 
-                                <HyperlinkButton
+                                <TextBlock
                                     x:Name="NavToolbarLargeIconsHeader"
-                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Grid.Row="1"
-                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     Grid.Column="4"
                                     VerticalAlignment="Center"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLarge, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=LargeIcons}">
-                                    <HyperlinkButton.Resources>
-                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
-                                    </HyperlinkButton.Resources>
-                                </HyperlinkButton>
+                                    Tapped="NavToolbarLargeIconsHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=LargeIcons}"/>
 
                                 <RadioButton
                                     x:Uid="NavToolbarColumnView"
@@ -673,20 +638,13 @@
                                         Glyph="&#xF115;" />
                                 </RadioButton>
 
-                                <HyperlinkButton
+                                <TextBlock
                                     x:Name="NavToolbarColumnsHeader"
-                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     Grid.Row="2"
                                     Grid.Column="4"
                                     VerticalAlignment="Center"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnView, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=Columns}" >
-                                    <HyperlinkButton.Resources>
-                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
-                                    </HyperlinkButton.Resources>
-                                </HyperlinkButton>
+                                    Tapped="NavToolbarColumnsHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=Columns}"/>
                             </Grid>
 
                             <Border

--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -485,14 +485,15 @@
                                     <FontIcon FontSize="16" Glyph="&#xE179;" />
                                 </RadioButton>
 
-                                <TextBlock
+                                <HyperlinkButton
                                     x:Name="NavToolbarDetailsHeader"
-                                    x:Uid="NavToolbarDetailsHeader"
-                                    Grid.Row="0"
+                                    Grid.Row="0" 
+                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
-                                    PointerReleased="NavToolbarDetailsHeader_PointerReleased"
-                                    Text="Details" />
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    Content="{helpers:ResourceString Name=Details}" />
 
                                 <RadioButton
                                     x:Uid="NavToolbarTiles"
@@ -514,14 +515,15 @@
                                     <FontIcon FontSize="16" Glyph="&#xE15C;" />
                                 </RadioButton>
 
-                                <TextBlock
+                                <HyperlinkButton
                                     x:Name="NavToolbarTilesHeader"
-                                    x:Uid="NavToolbarTilesHeader"
                                     Grid.Row="1"
                                     Grid.Column="1"
+                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     VerticalAlignment="Center"
-                                    PointerReleased="NavToolbarTilesHeader_PointerReleased"
-                                    Text="Tiles" />
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTiles, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    Content="{helpers:ResourceString Name=Tiles}" />
 
                                 <RadioButton
                                     x:Uid="NavToolbarSmallIcons"
@@ -543,14 +545,15 @@
                                     <FontIcon FontSize="16" Glyph="&#xE80A;" />
                                 </RadioButton>
 
-                                <TextBlock
+                                <HyperlinkButton
                                     x:Name="NavToolbarSmallIconsHeader"
-                                    x:Uid="NavToolbarSmallIconsHeader"
                                     Grid.Row="2"
                                     Grid.Column="1"
+                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     VerticalAlignment="Center"
-                                    PointerReleased="NavToolbarSmallIconsHeader_PointerReleased"
-                                    Text="Small Icons" />
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmall, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    Content="{helpers:ResourceString Name=SmallIcons}" />
 
                                 <Border
                                     Grid.RowSpan="3"
@@ -581,14 +584,15 @@
                                     <FontIcon FontSize="16" Glyph="&#xF0E2;" />
                                 </RadioButton>
 
-                                <TextBlock
+                                <HyperlinkButton
                                     x:Name="NavToolbarMediumIconsHeader"
-                                    x:Uid="NavToolbarMediumIconsHeader"
                                     Grid.Row="0"
                                     Grid.Column="4"
+                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     VerticalAlignment="Center"
-                                    PointerReleased="NavToolbarMediumIconsHeader_PointerReleased"
-                                    Text="Medium Icons" />
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    Content="{helpers:ResourceString Name=MediumIcons}" />
 
                                 <RadioButton
                                     x:Uid="NavToolbarLargeIcons"
@@ -610,14 +614,15 @@
                                     <FontIcon FontSize="16" Glyph="&#xE739;" />
                                 </RadioButton>
 
-                                <TextBlock
+                                <HyperlinkButton
                                     x:Name="NavToolbarLargeIconsHeader"
-                                    x:Uid="NavToolbarLargeIconsHeader"
                                     Grid.Row="1"
+                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     Grid.Column="4"
                                     VerticalAlignment="Center"
-                                    PointerReleased="NavToolbarLargeIconsHeader_PointerReleased"
-                                    Text="Large Icons" />
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLarge, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    Content="{helpers:ResourceString Name=LargeIcons}" />
 
                                 <RadioButton
                                     x:Uid="NavToolbarColumnView"
@@ -642,14 +647,15 @@
                                         Glyph="&#xF115;" />
                                 </RadioButton>
 
-                                <TextBlock
+                                <HyperlinkButton
                                     x:Name="NavToolbarColumnsHeader"
-                                    x:Uid="NavToolbarColumnsHeader"
+                                    Style="{ThemeResource TextBlockButtonStyle}"
                                     Grid.Row="2"
                                     Grid.Column="4"
                                     VerticalAlignment="Center"
-                                    PointerReleased="NavToolbarColumnsHeader_PointerReleased"
-                                    Text="Columns" />
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnView, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    Content="{helpers:ResourceString Name=Columns}" />
                             </Grid>
 
                             <Border

--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -494,7 +494,11 @@
                                     VerticalAlignment="Center"
                                     Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView, Mode=OneWay}"
                                     CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=Details}" />
+                                    Content="{helpers:ResourceString Name=Details}" >
+                                    <HyperlinkButton.Resources>
+                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
+                                    </HyperlinkButton.Resources>
+                                </HyperlinkButton>
 
                                 <RadioButton
                                     x:Uid="NavToolbarTiles"
@@ -525,7 +529,11 @@
                                     VerticalAlignment="Center"
                                     Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTiles, Mode=OneWay}"
                                     CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=Tiles}" />
+                                    Content="{helpers:ResourceString Name=Tiles}">
+                                    <HyperlinkButton.Resources>
+                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
+                                    </HyperlinkButton.Resources>
+                                </HyperlinkButton>
 
                                 <RadioButton
                                     x:Uid="NavToolbarSmallIcons"
@@ -556,7 +564,11 @@
                                     VerticalAlignment="Center"
                                     Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmall, Mode=OneWay}"
                                     CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=SmallIcons}" />
+                                    Content="{helpers:ResourceString Name=SmallIcons}">
+                                    <HyperlinkButton.Resources>
+                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
+                                    </HyperlinkButton.Resources>
+                                </HyperlinkButton>
 
                                 <Border
                                     Grid.RowSpan="3"
@@ -597,7 +609,11 @@
                                     VerticalAlignment="Center"
                                     Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium, Mode=OneWay}"
                                     CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=MediumIcons}" />
+                                    Content="{helpers:ResourceString Name=MediumIcons}">
+                                    <HyperlinkButton.Resources>
+                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
+                                    </HyperlinkButton.Resources>
+                                </HyperlinkButton>
 
                                 <RadioButton
                                     x:Uid="NavToolbarLargeIcons"
@@ -628,7 +644,11 @@
                                     VerticalAlignment="Center"
                                     Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLarge, Mode=OneWay}"
                                     CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=LargeIcons}" />
+                                    Content="{helpers:ResourceString Name=LargeIcons}">
+                                    <HyperlinkButton.Resources>
+                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
+                                    </HyperlinkButton.Resources>
+                                </HyperlinkButton>
 
                                 <RadioButton
                                     x:Uid="NavToolbarColumnView"
@@ -662,7 +682,11 @@
                                     VerticalAlignment="Center"
                                     Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnView, Mode=OneWay}"
                                     CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    Content="{helpers:ResourceString Name=Columns}" />
+                                    Content="{helpers:ResourceString Name=Columns}" >
+                                    <HyperlinkButton.Resources>
+                                        <SolidColorBrush x:Key="HyperlinkButtonBackgroundPointerOver" Color="Transparent"/>
+                                    </HyperlinkButton.Resources>
+                                </HyperlinkButton>
                             </Grid>
 
                             <Border

--- a/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/Files/UserControls/InnerNavigationToolbar.xaml
@@ -487,7 +487,8 @@
 
                                 <HyperlinkButton
                                     x:Name="NavToolbarDetailsHeader"
-                                    Grid.Row="0" 
+                                    Grid.Row="0"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Style="{ThemeResource TextBlockButtonStyle}"
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
@@ -518,6 +519,7 @@
                                 <HyperlinkButton
                                     x:Name="NavToolbarTilesHeader"
                                     Grid.Row="1"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Grid.Column="1"
                                     Style="{ThemeResource TextBlockButtonStyle}"
                                     VerticalAlignment="Center"
@@ -548,6 +550,7 @@
                                 <HyperlinkButton
                                     x:Name="NavToolbarSmallIconsHeader"
                                     Grid.Row="2"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Grid.Column="1"
                                     Style="{ThemeResource TextBlockButtonStyle}"
                                     VerticalAlignment="Center"
@@ -567,6 +570,7 @@
                                 <RadioButton
                                     x:Uid="NavToolbarMediumIcons"
                                     Grid.Row="0"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Grid.Column="3"
                                     Width="36"
                                     Height="32"
@@ -588,6 +592,7 @@
                                     x:Name="NavToolbarMediumIconsHeader"
                                     Grid.Row="0"
                                     Grid.Column="4"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Style="{ThemeResource TextBlockButtonStyle}"
                                     VerticalAlignment="Center"
                                     Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium, Mode=OneWay}"
@@ -616,6 +621,7 @@
 
                                 <HyperlinkButton
                                     x:Name="NavToolbarLargeIconsHeader"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Grid.Row="1"
                                     Style="{ThemeResource TextBlockButtonStyle}"
                                     Grid.Column="4"
@@ -649,6 +655,7 @@
 
                                 <HyperlinkButton
                                     x:Name="NavToolbarColumnsHeader"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Style="{ThemeResource TextBlockButtonStyle}"
                                     Grid.Row="2"
                                     Grid.Column="4"

--- a/Files/UserControls/InnerNavigationToolbar.xaml.cs
+++ b/Files/UserControls/InnerNavigationToolbar.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Input;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media.Imaging;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
@@ -26,7 +27,7 @@ namespace Files.UserControls
             this.InitializeComponent();
         }
 
-        public IUserSettingsService UserSettingsService { get; } = 
+        public IUserSettingsService UserSettingsService { get; } =
             Ioc.Default.GetService<IUserSettingsService>();
 
         public MainViewModel MainViewModel => App.MainViewModel;
@@ -192,5 +193,18 @@ namespace Files.UserControls
                 }
             }
         }
+
+        private void NavToolbarDetailsHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView.Execute(true);
+        private void NavToolbarTilesHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTiles.Execute(true);
+        private void NavToolbarSmallIconsHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmall.Execute(true);
+        private void NavToolbarMediumIconsHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium.Execute(true);
+        private void NavToolbarLargeIconsHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLarge.Execute(true);
+        private void NavToolbarColumnsHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnView.Execute(true);
     }
 }

--- a/Files/UserControls/InnerNavigationToolbar.xaml.cs
+++ b/Files/UserControls/InnerNavigationToolbar.xaml.cs
@@ -193,18 +193,5 @@ namespace Files.UserControls
                 }
             }
         }
-
-        private void NavToolbarDetailsHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView.Execute(true);
-        private void NavToolbarTilesHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTiles.Execute(true);
-        private void NavToolbarSmallIconsHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmall.Execute(true);
-        private void NavToolbarMediumIconsHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium.Execute(true);
-        private void NavToolbarLargeIconsHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLarge.Execute(true);
-        private void NavToolbarColumnsHeader_PointerReleased(object sender, PointerRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnView.Execute(true);
     }
 }

--- a/Files/UserControls/InnerNavigationToolbar.xaml.cs
+++ b/Files/UserControls/InnerNavigationToolbar.xaml.cs
@@ -193,5 +193,18 @@ namespace Files.UserControls
                 }
             }
         }
+
+        private void NavToolbarDetailsHeader_Tapped(object sender, TappedRoutedEventArgs e)
+    => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView.Execute(true);
+        private void NavToolbarTilesHeader_Tapped(object sender, TappedRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTiles.Execute(true);
+        private void NavToolbarSmallIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmall.Execute(true);
+        private void NavToolbarMediumIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium.Execute(true);
+        private void NavToolbarLargeIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLarge.Execute(true);
+        private void NavToolbarColumnsHeader_Tapped(object sender, TappedRoutedEventArgs e)
+            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnView.Execute(true);
     }
 }


### PR DESCRIPTION
**Resolved / Related Issues**
In UI design, it is recommended to be able to activate a radio button by clicking on its label. It is not possible to change the layout. I always have the reflex to click on the label instead of the button.

**Details of Changes**
Add a click event on the labels to activate the change layout command. 

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**

https://user-images.githubusercontent.com/46631671/144438854-6deef908-9178-40d2-ab33-f3115b5a1e05.mp4
