### PR TITLE
Fix properties window not closing on OK

### DIFF
--- a/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
+++ b/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
@@ -810,7 +810,7 @@ namespace FilesFullTrust.MessageHandlers
             {
                 get
                 {
-                    var ongoing = operations.ToList().Where(x => !x.Value.Canceled);
+                    var ongoing = operations.ToArray().Where(x => !x.Value.Canceled);
                     return ongoing.Any() ? (int)ongoing.Average(x => x.Value.Progress) : 0;
                 }
             }

--- a/Files/ViewModels/Properties/FileProperties.cs
+++ b/Files/ViewModels/Properties/FileProperties.cs
@@ -73,10 +73,11 @@ namespace Files.ViewModels.Properties
                     ViewModel.ShortcutItemType = isApplication ? "PropertiesShortcutTypeApplication".GetLocalized() :
                         Item.IsLinkItem ? "PropertiesShortcutTypeLink".GetLocalized() : "PropertiesShortcutTypeFile".GetLocalized();
                     ViewModel.ShortcutItemPath = shortcutItem.TargetPath;
+                    ViewModel.IsShortcutItemPathReadOnly = shortcutItem.IsSymLink;
                     ViewModel.ShortcutItemWorkingDir = shortcutItem.WorkingDirectory;
-                    ViewModel.ShortcutItemWorkingDirVisibility = Item.IsLinkItem ? Visibility.Collapsed : Visibility.Visible;
+                    ViewModel.ShortcutItemWorkingDirVisibility = Item.IsLinkItem || shortcutItem.IsSymLink ? Visibility.Collapsed : Visibility.Visible;
                     ViewModel.ShortcutItemArguments = shortcutItem.Arguments;
-                    ViewModel.ShortcutItemArgumentsVisibility = Item.IsLinkItem ? Visibility.Collapsed : Visibility.Visible;
+                    ViewModel.ShortcutItemArgumentsVisibility = Item.IsLinkItem || shortcutItem.IsSymLink ? Visibility.Collapsed : Visibility.Visible;
                     ViewModel.IsSelectedItemShortcut = ".lnk".Equals(Item.FileExtension, StringComparison.OrdinalIgnoreCase);
                     ViewModel.ShortcutItemOpenLinkCommand = new RelayCommand(async () =>
                     {

--- a/Files/ViewModels/Properties/FolderProperties.cs
+++ b/Files/ViewModels/Properties/FolderProperties.cs
@@ -56,6 +56,7 @@ namespace Files.ViewModels.Properties
                     var shortcutItem = (ShortcutItem)Item;
                     ViewModel.ShortcutItemType = "PropertiesShortcutTypeFolder".GetLocalized();
                     ViewModel.ShortcutItemPath = shortcutItem.TargetPath;
+                    ViewModel.IsShortcutItemPathReadOnly = false;
                     ViewModel.ShortcutItemWorkingDir = shortcutItem.WorkingDirectory;
                     ViewModel.ShortcutItemWorkingDirVisibility = Visibility.Collapsed;
                     ViewModel.ShortcutItemArguments = shortcutItem.Arguments;

--- a/Files/ViewModels/SelectedItemsPropertiesViewModel.cs
+++ b/Files/ViewModels/SelectedItemsPropertiesViewModel.cs
@@ -543,6 +543,14 @@ namespace Files.ViewModels
             set => SetProperty(ref shortcutItemPath, value);
         }
 
+        private bool isShortcutItemPathReadOnly;
+
+        public bool IsShortcutItemPathReadOnly
+        {
+            get => isShortcutItemPathReadOnly;
+            set => SetProperty(ref isShortcutItemPathReadOnly, value);
+        }
+
         private string shortcutItemWorkingDir;
 
         public string ShortcutItemWorkingDir

--- a/Files/Views/Pages/PropertiesCompatibility.xaml
+++ b/Files/Views/Pages/PropertiesCompatibility.xaml
@@ -2,6 +2,7 @@
     x:Class="Files.Views.PropertiesCompatibility"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Files.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="using:Files.Helpers"
     xmlns:local1="using:Files.ViewModels.Properties"
@@ -18,6 +19,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <converters:NullToTrueConverter x:Key="NullToFalseConverter" Inverse="True" />
         </ResourceDictionary>
     </local1:PropertiesTab.Resources>
 
@@ -30,6 +32,7 @@
                 TextTrimming="CharacterEllipsis" />
             <ComboBox
                 DisplayMemberPath="Name"
+                IsEnabled="{x:Bind CompatibilityProperties.CompatibilityOptions, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}"
                 ItemsSource="{x:Bind CompatibilityProperties.OSCompatibilityList, Mode=OneWay}"
                 SelectedValue="{x:Bind CompatibilityProperties.OSCompatibility, Mode=TwoWay}" />
 
@@ -40,6 +43,7 @@
                 TextTrimming="CharacterEllipsis" />
             <ComboBox
                 DisplayMemberPath="Name"
+                IsEnabled="{x:Bind CompatibilityProperties.CompatibilityOptions, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}"
                 ItemsSource="{x:Bind CompatibilityProperties.ReducedColorModeList, Mode=OneWay}"
                 SelectedValue="{x:Bind CompatibilityProperties.ReducedColorMode, Mode=TwoWay}" />
 
@@ -70,6 +74,7 @@
                     Grid.Row="0"
                     Grid.Column="1"
                     VerticalAlignment="Center"
+                    IsEnabled="{x:Bind CompatibilityProperties.CompatibilityOptions, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}"
                     IsOn="{x:Bind CompatibilityProperties.ExecuteAt640X480, Mode=TwoWay}" />
 
                 <TextBlock
@@ -82,6 +87,7 @@
                     Grid.Row="1"
                     Grid.Column="1"
                     VerticalAlignment="Center"
+                    IsEnabled="{x:Bind CompatibilityProperties.CompatibilityOptions, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}"
                     IsOn="{x:Bind CompatibilityProperties.DisableMaximized, Mode=TwoWay}" />
 
                 <TextBlock
@@ -94,6 +100,7 @@
                     Grid.Row="2"
                     Grid.Column="1"
                     VerticalAlignment="Center"
+                    IsEnabled="{x:Bind CompatibilityProperties.CompatibilityOptions, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}"
                     IsOn="{x:Bind CompatibilityProperties.RunAsAdministrator, Mode=TwoWay}" />
 
                 <TextBlock
@@ -106,6 +113,7 @@
                     Grid.Row="3"
                     Grid.Column="1"
                     VerticalAlignment="Center"
+                    IsEnabled="{x:Bind CompatibilityProperties.CompatibilityOptions, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}"
                     IsOn="{x:Bind CompatibilityProperties.RegisterForRestart, Mode=TwoWay}" />
             </Grid>
 
@@ -116,6 +124,7 @@
                 TextTrimming="CharacterEllipsis" />
             <ComboBox
                 DisplayMemberPath="Name"
+                IsEnabled="{x:Bind CompatibilityProperties.CompatibilityOptions, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}"
                 ItemsSource="{x:Bind CompatibilityProperties.HighDpiOptionList, Mode=OneWay}"
                 SelectedValue="{x:Bind CompatibilityProperties.HighDpiOption, Mode=TwoWay}" />
 
@@ -126,6 +135,7 @@
                 TextTrimming="CharacterEllipsis" />
             <ComboBox
                 DisplayMemberPath="Name"
+                IsEnabled="{x:Bind CompatibilityProperties.CompatibilityOptions, Mode=OneWay, Converter={StaticResource NullToFalseConverter}}"
                 ItemsSource="{x:Bind CompatibilityProperties.HighDpiOverrideList, Mode=OneWay}"
                 SelectedValue="{x:Bind CompatibilityProperties.HighDpiOverride, Mode=TwoWay}" />
 

--- a/Files/Views/Pages/PropertiesShortcut.xaml
+++ b/Files/Views/Pages/PropertiesShortcut.xaml
@@ -92,6 +92,7 @@
                 Grid.Column="1"
                 Style="{StaticResource PropertyValueTextBox}"
                 Text="{x:Bind ViewModel.ShortcutItemPath, Mode=TwoWay}"
+                IsReadOnly="{x:Bind ViewModel.IsShortcutItemPathReadOnly, Mode=OneWay}"
                 Visibility="Visible" />
 
             <TextBlock

--- a/Files/Views/Pages/PropertiesShortcut.xaml.cs
+++ b/Files/Views/Pages/PropertiesShortcut.xaml.cs
@@ -11,14 +11,10 @@ namespace Files.Views
             InitializeComponent();
         }
 
-#pragma warning disable 1998
-
-        public async override Task<bool> SaveChangesAsync(ListedItem item)
+        public override Task<bool> SaveChangesAsync(ListedItem item)
         {
-            return false;
+            return Task.FromResult(true);
         }
-
-#pragma warning restore 1998
 
         public override void Dispose()
         {


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Follow up of #7006
- Closes #7209

**Details of Changes**
Add details of changes here.
- Set symlink target path in Properties as readonly and hide arguments, working directory
- Fixes an issue where Properties window does not close if Shortcut section is expanded
- Fixes #3524514594u (crash if fulltrust process fails to fetch Compatibility properties)

**Validation**
How did you test these changes?
- [x] Built and ran the app
