### PR TITLE
Always specify starting index in CollectionChanged

### DIFF
--- a/Files/Helpers/ItemListDisplayHelpers/BulkConcurrentObservableCollection.cs
+++ b/Files/Helpers/ItemListDisplayHelpers/BulkConcurrentObservableCollection.cs
@@ -1,4 +1,5 @@
-﻿using Files.Extensions;
+﻿using Files.Common;
+using Files.Extensions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -110,12 +111,12 @@ namespace Files.Helpers
         {
             if (!isBulkOperationStarted)
             {
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
-                CollectionChanged?.Invoke(this, e);
                 if (countChanged)
                 {
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
                 }
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+                CollectionChanged?.Invoke(this, e);
             }
 
             if (IsGrouped)
@@ -223,7 +224,7 @@ namespace Files.Helpers
                 collection.Add(item);
             }
 
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, collection.Count - 1));
         }
 
         public void Clear()
@@ -317,7 +318,7 @@ namespace Files.Helpers
                 collection.AddRange(items);
             }
 
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, items.ToList()));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, items.ToList(), collection.Count - items.Count()));
         }
 
         public void InsertRange(int index, IEnumerable<T> items)
@@ -373,7 +374,7 @@ namespace Files.Helpers
                 collection.RemoveRange(index + count, count);
             }
 
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newItems, oldItems, index));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newItems, oldItems, index), false);
         }
 
         public void Sort()
@@ -403,6 +404,18 @@ namespace Files.Helpers
             ReplaceRange(0, result);
         }
 
+        public void OrderOne(Func<List<T>, IEnumerable<T>> func, T item)
+        {
+            IList<T> result;
+            lock (SyncRoot)
+            {
+                result = func.Invoke(collection).ToList();
+            }
+
+            Remove(item);
+            Insert(result.IndexOf(item), item);
+        }
+
         int IList.Add(object value)
         {
             int index;
@@ -412,7 +425,7 @@ namespace Files.Helpers
                 index = ((IList)collection).Add((T)value);
             }
 
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, value));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, value, collection.Count - 1));
             return index;
         }
 

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -489,6 +489,15 @@ namespace Files.ViewModels
                 {
                     FilesAndFolders.Insert(Math.Min(newIndex, FilesAndFolders.Count), item);
                 }
+                if (folderSettings.DirectoryGroupOption != GroupOption.None)
+                {
+                    var key = FilesAndFolders.ItemGroupKeySelector?.Invoke(item);
+                    var group = FilesAndFolders.GroupedCollection?.FirstOrDefault(x => x.Model.Key == key);
+                    if (group != null)
+                    {
+                        group.OrderOne(list => SortingHelper.OrderFileList(list, folderSettings.DirectorySortOption, folderSettings.DirectorySortDirection), item);
+                    }
+                }
                 UpdateEmptyTextType();
                 DirectoryInfoUpdated?.Invoke(this, EventArgs.Empty);
             });


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7170

**Details of Changes**
Add details of changes here.
- Always specify starting index in CollectionChanged for Add operation
- Fixes an issue where items are not sorted if collection is grouped and an item DisplayName != Name

**Validation**
How did you test these changes?
- [x] Built and ran the app
