### PR TITLE
Show basic preview for recycle bin items

### DIFF
--- a/Files/Helpers/NavigationHelpers.cs
+++ b/Files/Helpers/NavigationHelpers.cs
@@ -132,6 +132,7 @@ namespace Files.Helpers
         /// <param name="openSilent">Determines whether history of opened item is saved (... to Recent Items/Windows Timeline/opening in background)</param>
         /// <param name="openViaApplicationPicker">Determines whether open file using application picker</param>
         /// <param name="selectItems">List of filenames that are selected upon navigation</param>
+        /// <param name="forceOpenInNewTab">Open folders in a new tab regardless of the "OpenFoldersInNewTab" option</param>
         public static async Task<bool> OpenPath(string path, IShellPage associatedInstance, FilesystemItemType? itemType = null, bool openSilent = false, bool openViaApplicationPicker = false, IEnumerable<string> selectItems = null, string args = default, bool forceOpenInNewTab = false)
         {
             string previousDir = associatedInstance.FilesystemViewModel.WorkingDirectory;

--- a/Files/ViewModels/PreviewPaneViewModel.cs
+++ b/Files/ViewModels/PreviewPaneViewModel.cs
@@ -220,6 +220,11 @@ namespace Files.ViewModels
             {
                 SelectedItem?.FileDetails?.Clear();
 
+                if(SelectedItem.IsRecycleBinItem)
+                {
+                    await LoadBasicPreviewAsync();
+                }
+
                 try
                 {
                     PreviewPaneState = PreviewPaneStates.LoadingPreview;
@@ -234,18 +239,8 @@ namespace Files.ViewModels
                     // If that fails, revert to no preview/details available as long as the item is not a shortcut or folder
                     if (SelectedItem != null && !SelectedItem.IsShortcutItem && SelectedItem.PrimaryItemAttribute != StorageItemTypes.Folder)
                     {
-                        try
-                        {
-                            var basicModel = new BasicPreviewViewModel(SelectedItem);
-                            await basicModel.LoadAsync();
-                            PreviewPaneContent = new BasicPreview(basicModel);
-                            PreviewPaneState = PreviewPaneStates.PreviewAndDetailsAvailable;
-                            return;
-                        }
-                        catch (Exception ex)
-                        {
-                            Debug.WriteLine(ex);
-                        }
+                        await LoadBasicPreviewAsync();
+                        return;
                     }
 
                     PreviewPaneContent = null;
@@ -274,6 +269,21 @@ namespace Files.ViewModels
                     // the preview will need refreshing as the file details won't be accurate
                     needsRefresh = true;
                     break;
+            }
+        }
+
+        private async Task LoadBasicPreviewAsync()
+        {
+            try
+            {
+                var basicModel = new BasicPreviewViewModel(SelectedItem);
+                await basicModel.LoadAsync();
+                PreviewPaneContent = new BasicPreview(basicModel);
+                PreviewPaneState = PreviewPaneStates.PreviewAndDetailsAvailable;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex);
             }
         }
 

--- a/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -616,10 +616,7 @@ namespace Files.Views.LayoutModes
                  && ((!UserSettingsService.PreferencesSettingsService.OpenFilesWithOneClick && item.PrimaryItemAttribute == StorageItemTypes.File) 
                  || (!UserSettingsService.PreferencesSettingsService.OpenFoldersWithOneClick && item.PrimaryItemAttribute == StorageItemTypes.Folder)))
             {
-                if (!MainViewModel.MultiselectEnabled)
-                {
-                    NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
-                }
+                NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
             }
             ResetRenameDoubleClick();
         }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -539,10 +539,7 @@ namespace Files.Views.LayoutModes
                  && ((!UserSettingsService.PreferencesSettingsService.OpenFilesWithOneClick && item.PrimaryItemAttribute == StorageItemTypes.File)
                  || (!UserSettingsService.PreferencesSettingsService.OpenFoldersWithOneClick && item.PrimaryItemAttribute == StorageItemTypes.Folder)))
             {
-                if (!MainViewModel.MultiselectEnabled)
-                {
-                    NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
-                }
+                NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
             }
             ResetRenameDoubleClick();
         }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7196

**Details of Changes**
Add details of changes here.
- Only show the basic preview for recycle bin items
- allow opening folders with double click when multiselect is enabled

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

I can't test that the previews work properly in the recycle bin because the full trust process is still broken, so if someone could test that it would be appreciated.

**Screenshots (optional)**
Add screenshots here.
