### PR TITLE
Changing the position of the date parameter and removing two compilation warnings

### DIFF
--- a/Files/Helpers/AppUpdater.cs
+++ b/Files/Helpers/AppUpdater.cs
@@ -40,17 +40,23 @@ namespace Files.Helpers
                     }
                 }
             }
+#if !DEBUG
             catch (Exception ex)
             {
-#if !DEBUG
+
                 App.Logger.Warn(ex, "Could not fetch updates.");
-#endif
+
             }
+#else
+            catch (Exception) 
+            {
+            }
+#endif
         }
 
         private async Task<bool> DownloadUpdatesConsent()
         {
-            ContentDialog dialog = new ContentDialog
+            ContentDialog dialog = new()
             {
                 Title = "ConsentDialogTitle".GetLocalized(),
                 Content = "ConsentDialogContent".GetLocalized(),

--- a/Files/Helpers/AppUpdater.cs
+++ b/Files/Helpers/AppUpdater.cs
@@ -45,7 +45,6 @@ namespace Files.Helpers
             {
 
                 App.Logger.Warn(ex, "Could not fetch updates.");
-
             }
 #else
             catch (Exception) 

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -1031,7 +1031,7 @@ namespace Files.ViewModels
                             groupImage = await GetItemTypeGroupIcon(item, matchingStorageFile);
                         }
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
                     }
                     finally

--- a/Files/Views/SettingsPages/Preferences.xaml
+++ b/Files/Views/SettingsPages/Preferences.xaml
@@ -59,6 +59,21 @@
             </local:SettingsBlockControl>
 
             <local:SettingsBlockControl
+                x:Uid="SettingsDateFormat"
+                Title="Date format"
+                HorizontalAlignment="Stretch">
+                <local:SettingsBlockControl.Icon>
+                    <FontIcon Glyph="&#xEC92;" />
+                </local:SettingsBlockControl.Icon>
+                <ComboBox
+                    x:Name="DateFormatChooser"
+                    x:Uid="SettingsDateFormatComboBox"
+                    AutomationProperties.Name="Date format"
+                    ItemsSource="{Binding DateFormats}"
+                    SelectedIndex="{Binding SelectedDateFormatIndex, Mode=TwoWay}" />
+            </local:SettingsBlockControl>
+            
+            <local:SettingsBlockControl
                 x:Uid="SettingsPreferencesTerminalApplications"
                 Title="Terminal applications"
                 HorizontalAlignment="Stretch">
@@ -100,21 +115,6 @@
                         </HyperlinkButton>
                     </local:SettingsBlockControl>
                 </local:SettingsBlockControl.ExpandableContent>
-            </local:SettingsBlockControl>
-
-            <local:SettingsBlockControl
-                x:Uid="SettingsDateFormat"
-                Title="Date format"
-                HorizontalAlignment="Stretch">
-                <local:SettingsBlockControl.Icon>
-                    <FontIcon Glyph="&#xEC92;" />
-                </local:SettingsBlockControl.Icon>
-                <ComboBox
-                    x:Name="DateFormatChooser"
-                    x:Uid="SettingsDateFormatComboBox"
-                    AutomationProperties.Name="Date format"
-                    ItemsSource="{Binding DateFormats}"
-                    SelectedIndex="{Binding SelectedDateFormatIndex, Mode=TwoWay}" />
             </local:SettingsBlockControl>
 
             <local:SettingsBlockControl Title="{helpers:ResourceString Name=FilesAndFolders}" HorizontalAlignment="Stretch">


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Closes [#7227](https://github.com/files-community/Files/issues/7227)

**Details of Changes**
Raise the position of the date format parameter below that of the language 
Removal of two unused variables which creates alerts during compilation 

**Validation**
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/11716874/144846407-f151ccb6-ad1c-45b8-b4d4-ec7e89d71d69.png)
