### PR TITLE
Added experimental option to show folder sizes

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -15,7 +15,6 @@ using Microsoft.Toolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Uwp;
 using Microsoft.Toolkit.Uwp.UI;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -290,7 +289,23 @@ namespace Files
             }
         }
 
-        public ListedItem SelectedItem { get; private set; }
+        private ListedItem selectedItem;
+        public ListedItem SelectedItem
+        {
+            get => selectedItem;
+            private set
+            {
+                if (selectedItem is not null)
+                {
+                    selectedItem.PropertyChanged -= SelectedItem_PropertyChanged;
+                }
+                selectedItem = value;
+                if (selectedItem is not null)
+                {
+                    selectedItem.PropertyChanged += SelectedItem_PropertyChanged;
+                }
+            }
+        }
 
         private DispatcherQueueTimer dragOverTimer, tapDebounceTimer;
 
@@ -535,6 +550,7 @@ namespace Files
             FolderSettings.GroupOptionPreferenceUpdated -= FolderSettings_GroupOptionPreferenceUpdated;
             ItemContextMenuFlyout.Opening -= ItemContextFlyout_Opening;
             BaseContextMenuFlyout.Opening -= BaseContextFlyout_Opening;
+            SelectedItem = null;
 
             var parameter = e.Parameter as NavigationArguments;
             if (!parameter.IsLayoutSwitch)
@@ -607,6 +623,19 @@ namespace Files
             catch (Exception error)
             {
                 Debug.WriteLine(error);
+            }
+        }
+
+        private void SelectedItem_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(ListedItem.FileSize):
+                    SelectedItemsPropertiesViewModel.ItemSize = SelectedItem.FileSize;
+                    break;
+                case nameof(ListedItem.FileSizeBytes):
+                    SelectedItemsPropertiesViewModel.ItemSizeBytes = SelectedItem.FileSizeBytes;
+                    break;
             }
         }
 

--- a/Files/Filesystem/FolderHelpers.cs
+++ b/Files/Filesystem/FolderHelpers.cs
@@ -63,7 +63,7 @@ namespace Files.Filesystem
         {
             CoreDispatcher dispatcher;
 
-            if (folder.FileSizeBytes == 0 && folder.ContainsFilesOrFolders)
+            if (folder.PrimaryItemAttribute == Windows.Storage.StorageItemTypes.Folder && folder.FileSizeBytes == 0 && folder.ContainsFilesOrFolders)
             {
                 dispatcher = CoreApplication.MainView.CoreWindow.Dispatcher;
 

--- a/Files/Filesystem/FolderHelpers.cs
+++ b/Files/Filesystem/FolderHelpers.cs
@@ -1,8 +1,13 @@
-﻿using Files.Filesystem.StorageItems;
+﻿using ByteSizeLib;
+using Files.Extensions;
+using Files.Filesystem.StorageItems;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
+using Windows.UI.Core;
 using static Files.Helpers.NativeFindStorageItemHelper;
 
 namespace Files.Filesystem
@@ -52,6 +57,79 @@ namespace Files.Filesystem
             var result = FindNextFile(hFile, out _);
             FindClose(hFile);
             return result;
+        }
+
+        public static async void UpdateFolder(ListedItem folder, CancellationToken cancellationToken)
+        {
+            CoreDispatcher dispatcher;
+
+            if (folder.FileSizeBytes == 0 && folder.ContainsFilesOrFolders)
+            {
+                dispatcher = CoreApplication.MainView.CoreWindow.Dispatcher;
+
+                await dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                {
+                    folder.FileSize = GetSizeString(0);
+                });
+
+                _ = await Calculate(folder.ItemPath);
+            }
+
+            static string GetSizeString(long size) => ByteSize.FromBytes(size).ToBinaryString().ConvertSizeAbbreviation();
+
+            async Task<long> Calculate(string folderPath)
+            {
+                if (string.IsNullOrEmpty(folderPath))
+                {
+                    return 0;
+                }
+
+                FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
+                int additionalFlags = FIND_FIRST_EX_LARGE_FETCH;
+
+                IntPtr hFile = FindFirstFileExFromApp(folderPath + "\\*.*", findInfoLevel, out WIN32_FIND_DATA findData,
+                                    FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, additionalFlags);
+
+                long size = 0;
+                if (hFile.ToInt64() != -1)
+                {
+                    do
+                    {
+                        if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
+                        {
+                            size += findData.GetSize();
+                        }
+                        else if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
+                        {
+                            if (findData.cFileName is not "." and not "..")
+                            {
+                                string path = Path.Combine(folderPath, findData.cFileName);
+                                size += await Calculate(path);
+                            }
+                        }
+
+                        await dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                        {
+                            if (size > folder.FileSizeBytes)
+                            {
+                                folder.FileSizeBytes = size;
+                                folder.FileSize = GetSizeString(size);
+                            };
+                        });
+
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            break;
+                        }
+                    } while (FindNextFile(hFile, out findData));
+                    FindClose(hFile);
+                    return size;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
         }
     }
 }

--- a/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -46,6 +46,7 @@ namespace Files.Filesystem.StorageEnumerators
             var count = 0;
 
             IUserSettingsService userSettingsService = Ioc.Default.GetService<IUserSettingsService>();
+            bool showFolderSize = userSettingsService.PreferencesSettingsService.ShowFolderSize;
 
             do
             {
@@ -87,6 +88,11 @@ namespace Files.Filesystem.StorageEnumerators
                                 }
                                 tempList.Add(folder);
                                 ++count;
+
+                                if (showFolderSize)
+                                {
+                                    FolderHelpers.UpdateFolder(folder, cancellationToken);
+                                }
                             }
                         }
                     }

--- a/Files/Helpers/RegistryToJsonSettingsMerger.cs
+++ b/Files/Helpers/RegistryToJsonSettingsMerger.cs
@@ -38,6 +38,7 @@ namespace Files.Helpers
                     userSettingsService.PreferencesSettingsService.AreLayoutPreferencesPerFolder = appSettings.Get(true, "AreLayoutPreferencesPerFolder");
                     userSettingsService.PreferencesSettingsService.AdaptiveLayoutEnabled = appSettings.Get(true, "AdaptiveLayoutEnabled");
                     userSettingsService.PreferencesSettingsService.AreFileTagsEnabled = appSettings.Get(false, "AreFileTagsEnabled");
+                    userSettingsService.PreferencesSettingsService.ShowFolderSize = appSettings.Get(false, "ShowFolderSize");
 
                     // Multitasking
                     userSettingsService.MultitaskingSettingsService.IsVerticalTabFlyoutEnabled = appSettings.Get(true, "IsVerticalTabFlyoutEnabled");

--- a/Files/Services/IPreferencesSettingsService.cs
+++ b/Files/Services/IPreferencesSettingsService.cs
@@ -66,6 +66,11 @@ namespace Files.Services
         bool AreFileTagsEnabled { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not to show folder size.
+        /// </summary>
+        bool ShowFolderSize { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not to navigate to a specific location when launching the app.
         /// </summary>
         bool OpenSpecificPageOnStartup { get; set; }

--- a/Files/Services/Implementation/PreferencesSettingsService.cs
+++ b/Files/Services/Implementation/PreferencesSettingsService.cs
@@ -27,6 +27,7 @@ namespace Files.Services.Implementation
                 case nameof(AreLayoutPreferencesPerFolder):
                 case nameof(AdaptiveLayoutEnabled):
                 case nameof(AreFileTagsEnabled):
+                case nameof(ShowFolderSize):
                 case nameof(OpenSpecificPageOnStartup):
                 case nameof(ContinueLastSessionOnStartUp):
                 case nameof(OpenNewTabOnStartup):
@@ -105,6 +106,12 @@ namespace Files.Services.Implementation
         }
 
         public bool AreFileTagsEnabled
+        {
+            get => Get(false);
+            set => Set(value);
+        }
+
+        public bool ShowFolderSize
         {
             get => Get(false);
             set => Set(value);

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -2875,7 +2875,7 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
   <data name="FolderWidgetCreateNewLibraryInputPlaceholderText" xml:space="preserve">
     <value>Enter Library name</value>
   </data>
-  <data name="SettingsShowFolderSize.Title" xml:space="preserve">
+  <data name="ShowFolderSize" xml:space="preserve">
     <value>Show folder size</value>
   </data>
 </root>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -2874,5 +2874,8 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
   </data>
   <data name="FolderWidgetCreateNewLibraryInputPlaceholderText" xml:space="preserve">
     <value>Enter Library name</value>
+  </data>
+  <data name="SettingsShowFolderSize.Title" xml:space="preserve">
+    <value>Show folder size</value>
   </data>
 </root>

--- a/Files/ViewModels/ItemViewModel.cs
+++ b/Files/ViewModels/ItemViewModel.cs
@@ -383,6 +383,7 @@ namespace Files.ViewModels
                 case nameof(UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreFileTagsEnabled):
+                case nameof(UserSettingsService.PreferencesSettingsService.ShowFolderSize):
                     await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
                     {
                         if (WorkingDirectory != "Home".GetLocalized())

--- a/Files/ViewModels/SettingsViewModels/ExperimentalViewModel.cs
+++ b/Files/ViewModels/SettingsViewModels/ExperimentalViewModel.cs
@@ -46,6 +46,19 @@ namespace Files.ViewModels.SettingsViewModels
             }
         }
 
+        public bool ShowFolderSize
+        {
+            get => UserSettingsService.PreferencesSettingsService.ShowFolderSize;
+            set
+            {
+                if (value != UserSettingsService.PreferencesSettingsService.ShowFolderSize)
+                {
+                    UserSettingsService.PreferencesSettingsService.ShowFolderSize = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         private async Task LaunchFileTagsConfigFile()
         {
             var configFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appdata:///local/settings/filetags.json"));

--- a/Files/Views/SettingsPages/Experimental.xaml
+++ b/Files/Views/SettingsPages/Experimental.xaml
@@ -75,7 +75,7 @@
 
             <local:SettingsBlockControl
                 x:Uid="SettingsShowFolderSize"
-                Title="Show folder size"
+                Title="{helpers:ResourceString Name=ShowFolderSize}"
                 HorizontalAlignment="Stretch">
                 <local:SettingsBlockControl.Icon>
                     <FontIcon Glyph="&#xE2B2;" />

--- a/Files/Views/SettingsPages/Experimental.xaml
+++ b/Files/Views/SettingsPages/Experimental.xaml
@@ -74,7 +74,6 @@
             </local:SettingsBlockControl>
 
             <local:SettingsBlockControl
-                x:Uid="SettingsShowFolderSize"
                 Title="{helpers:ResourceString Name=ShowFolderSize}"
                 HorizontalAlignment="Stretch">
                 <local:SettingsBlockControl.Icon>

--- a/Files/Views/SettingsPages/Experimental.xaml
+++ b/Files/Views/SettingsPages/Experimental.xaml
@@ -73,6 +73,16 @@
                 </local:SettingsBlockControl.ExpandableContent>
             </local:SettingsBlockControl>
 
+            <local:SettingsBlockControl
+                x:Uid="SettingsShowFolderSize"
+                Title="Show folder size"
+                HorizontalAlignment="Stretch">
+                <local:SettingsBlockControl.Icon>
+                    <FontIcon Glyph="&#xE2B2;" />
+                </local:SettingsBlockControl.Icon>
+                <ToggleSwitch IsOn="{Binding ShowFolderSize, Mode=TwoWay}" Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+            </local:SettingsBlockControl>
+
             <TextBlock
                 Padding="0,12,0,4"
                 FontSize="14"


### PR DESCRIPTION
**Resolved / Related Issues**
It is not practical to know the total size occupied by a folder. You have to select one, open its property panel, and wait for the calculation. It is therefore not easy to spot a folder whose size is larger than desired. Closes #3944 #6880.

**Details of Changes**
Add experimental setting for show folder size. The size is calculated asynchronously with no visible loss in performance. The size is visible in details view and status bar.

Works for local folders & library & OneDrive.
Should work on other clouds and ftp but I haven't tested because I don't have one.
Does not work inside a zip file. It can come later.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility
