### PR TITLE
Fix size column for archive files

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -270,8 +270,8 @@ namespace Files
                             SelectedItemsPropertiesViewModel.SelectedItemsCountString = $"{SelectedItems.Count} {"ItemsSelected/Text".GetLocalized()}";
                             ResetRenameDoubleClick();
 
-                            bool hasCumulSize = selectedItems.All(item => !string.IsNullOrEmpty(item.FileSize));
-                            if (hasCumulSize)
+                            bool isSizeKnown = selectedItems.All(item => !string.IsNullOrEmpty(item.FileSize));
+                            if (isSizeKnown)
                             {
                                 long size = selectedItems.Sum(item => item.FileSizeBytes);
                                 SelectedItemsPropertiesViewModel.ItemSize = ByteSizeLib.ByteSize.FromBytes(size).ToBinaryString().ConvertSizeAbbreviation();
@@ -624,8 +624,8 @@ namespace Files
                 var items = selectedItems;
                 if (items is not null)
                 {
-                    bool hasCumulSize = items.All(item => !string.IsNullOrEmpty(item.FileSize));
-                    if (hasCumulSize)
+                    bool isSizeKnown = items.All(item => !string.IsNullOrEmpty(item.FileSize));
+                    if (isSizeKnown)
                     {
                         long size = items.Sum(item => item.FileSizeBytes);
                         SelectedItemsPropertiesViewModel.ItemSizeBytes = size;

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -270,7 +270,7 @@ namespace Files
                             SelectedItemsPropertiesViewModel.SelectedItemsCountString = $"{SelectedItems.Count} {"ItemsSelected/Text".GetLocalized()}";
                             ResetRenameDoubleClick();
 
-                            bool isSizeKnown = selectedItems.All(item => !string.IsNullOrEmpty(item.FileSize));
+                            bool isSizeKnown = !selectedItems.Any(item => string.IsNullOrEmpty(item.FileSize));
                             if (isSizeKnown)
                             {
                                 long size = selectedItems.Sum(item => item.FileSizeBytes);
@@ -624,7 +624,7 @@ namespace Files
                 var items = selectedItems;
                 if (items is not null)
                 {
-                    bool isSizeKnown = items.All(item => !string.IsNullOrEmpty(item.FileSize));
+                    bool isSizeKnown = !items.Any(item => string.IsNullOrEmpty(item.FileSize));
                     if (isSizeKnown)
                     {
                         long size = items.Sum(item => item.FileSizeBytes);

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -270,8 +270,12 @@ namespace Files
                             SelectedItemsPropertiesViewModel.SelectedItemsCountString = $"{SelectedItems.Count} {"ItemsSelected/Text".GetLocalized()}";
                             ResetRenameDoubleClick();
 
-                            long size = SelectedItems.Sum(item => item.FileSizeBytes);
-                            SelectedItemsPropertiesViewModel.ItemSize = ByteSizeLib.ByteSize.FromBytes(size).ToBinaryString().ConvertSizeAbbreviation();
+                            bool hasCumulSize = selectedItems.All(item => !string.IsNullOrEmpty(item.FileSize));
+                            if (hasCumulSize)
+                            {
+                                long size = selectedItems.Sum(item => item.FileSizeBytes);
+                                SelectedItemsPropertiesViewModel.ItemSize = ByteSizeLib.ByteSize.FromBytes(size).ToBinaryString().ConvertSizeAbbreviation();
+                            }
                         }
                     }
 
@@ -620,9 +624,13 @@ namespace Files
                 var items = selectedItems;
                 if (items is not null)
                 {
-                    long size = items.Sum(item => item.FileSizeBytes);
-                    SelectedItemsPropertiesViewModel.ItemSizeBytes = size;
-                    SelectedItemsPropertiesViewModel.ItemSize = ByteSizeLib.ByteSize.FromBytes(size).ToBinaryString().ConvertSizeAbbreviation();
+                    bool hasCumulSize = items.All(item => !string.IsNullOrEmpty(item.FileSize));
+                    if (hasCumulSize)
+                    {
+                        long size = items.Sum(item => item.FileSizeBytes);
+                        SelectedItemsPropertiesViewModel.ItemSizeBytes = size;
+                        SelectedItemsPropertiesViewModel.ItemSize = ByteSizeLib.ByteSize.FromBytes(size).ToBinaryString().ConvertSizeAbbreviation();
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Resolved / Related Issues**
The statusbar always displays the cumulative size counting 0 for files whose size is not known. This impacts zip folders.

**Details of Changes**
The cumulative size is no longer displayed if one of the elements does not have a known size.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility