### PR TITLE
Added support for collapsing widgets on the homepage

### DIFF
--- a/src/Files/Dialogs/SettingsDialog.xaml
+++ b/src/Files/Dialogs/SettingsDialog.xaml
@@ -23,49 +23,49 @@
                     <SolidColorBrush x:Key="NavigationViewExpandedPaneBackground" Color="Transparent" />
                     <SolidColorBrush x:Key="NavigationViewDefaultPaneBackground" Color="Transparent" />
                     <SolidColorBrush x:Key="NavigationViewItemBackground" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundPointerOver"  Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundPointerOver" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
                     <SolidColorBrush x:Key="TopNavigationViewItemBackgroundPressed" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelected" Color="{ThemeResource SolidBackgroundFillColorTertiary}"/>
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPointerOver" Color="{ThemeResource SolidBackgroundFillColorTertiary}"/>
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPressed" Color="{ThemeResource SolidBackgroundFillColorTertiary}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPointerOver" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPressed" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelected" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPointerOver" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPressed" Color="{ThemeResource ControlStrokeColorDefault}"/>
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelected" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPointerOver" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPressed" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPointerOver" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPressed" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelected" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPointerOver" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPressed" Color="{ThemeResource ControlStrokeColorDefault}" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
                     <SolidColorBrush x:Key="NavigationViewExpandedPaneBackground" Color="Transparent" />
                     <SolidColorBrush x:Key="NavigationViewDefaultPaneBackground" Color="Transparent" />
                     <SolidColorBrush x:Key="NavigationViewItemBackground" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundPointerOver"  Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundPointerOver" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
                     <SolidColorBrush x:Key="TopNavigationViewItemBackgroundPressed" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelected" Color="{ThemeResource SolidBackgroundFillColorTertiary}"/>
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPointerOver" Color="{ThemeResource SolidBackgroundFillColorTertiary}"/>
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPressed" Color="{ThemeResource SolidBackgroundFillColorTertiary}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPointerOver" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPressed" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelected" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPointerOver" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPressed" Color="{ThemeResource ControlStrokeColorDefault}"/>
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelected" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPointerOver" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPressed" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPointerOver" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPressed" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelected" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPointerOver" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPressed" Color="{ThemeResource ControlStrokeColorDefault}" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
                     <SolidColorBrush x:Key="NavigationViewExpandedPaneBackground" Color="Transparent" />
                     <SolidColorBrush x:Key="NavigationViewDefaultPaneBackground" Color="Transparent" />
                     <SolidColorBrush x:Key="NavigationViewItemBackground" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundPointerOver"  Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundPointerOver" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
                     <SolidColorBrush x:Key="TopNavigationViewItemBackgroundPressed" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelected" Color="{ThemeResource SolidBackgroundFillColorTertiary}"/>
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPointerOver" Color="{ThemeResource SolidBackgroundFillColorTertiary}"/>
-                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPressed" Color="{ThemeResource SolidBackgroundFillColorTertiary}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPointerOver" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPressed" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelected" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPointerOver" Color="{ThemeResource ControlStrokeColorDefault}"/>
-                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPressed" Color="{ThemeResource ControlStrokeColorDefault}"/>
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelected" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPointerOver" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="TopNavigationViewItemBackgroundSelectedPressed" Color="{ThemeResource SolidBackgroundFillColorTertiary}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrush" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPointerOver" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushPressed" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelected" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPointerOver" Color="{ThemeResource ControlStrokeColorDefault}" />
+                    <SolidColorBrush x:Key="NavigationViewItemBorderBrushSelectedPressed" Color="{ThemeResource ControlStrokeColorDefault}" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
@@ -91,10 +91,10 @@
             <muxc:NavigationView.MenuItems>
                 <muxc:NavigationViewItem
                     AccessKey="A"
-                    CornerRadius="4,0,0,4"
-                    Content="{helpers:ResourceString Name=Appearance}"
-                    IsSelected="True"
                     AutomationProperties.AutomationId="SettingsItemAppearance"
+                    Content="{helpers:ResourceString Name=Appearance}"
+                    CornerRadius="4,0,0,4"
+                    IsSelected="True"
                     Tag="0">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon HorizontalAlignment="Left" Glyph="&#xE790;" />
@@ -103,9 +103,9 @@
                 <muxc:NavigationViewItem
                     x:Uid="SettingsNavPreferences"
                     AccessKey="P"
-                    CornerRadius="0"
-                    Content="Preferences"
                     AutomationProperties.AutomationId="SettingsItemPreferences"
+                    Content="Preferences"
+                    CornerRadius="0"
                     Tag="1">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF116;" />
@@ -114,8 +114,8 @@
                 <muxc:NavigationViewItem
                     x:Uid="SettingsNavMultitasking"
                     AccessKey="M"
-                    Content="Multitasking"
                     AutomationProperties.AutomationId="SettingsItemMultitasking"
+                    Content="Multitasking"
                     CornerRadius="0"
                     Tag="2">
                     <muxc:NavigationViewItem.Icon>
@@ -125,8 +125,8 @@
                 <muxc:NavigationViewItem
                     x:Uid="SettingsNavExperimental"
                     AccessKey="E"
-                    Content="Experimental"
                     AutomationProperties.AutomationId="SettingsItemExperimental"
+                    Content="Experimental"
                     CornerRadius="0"
                     Tag="3">
                     <muxc:NavigationViewItem.Icon>
@@ -135,10 +135,10 @@
                 </muxc:NavigationViewItem>
                 <muxc:NavigationViewItem
                     AccessKey="B"
-                    CornerRadius="0,4,4,0"
                     AutomationProperties.AutomationId="SettingsItemAbout"
                     Content="{helpers:ResourceString Name=About}"
-                    Tag="4"> 
+                    CornerRadius="0,4,4,0"
+                    Tag="4">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon FontSize="16" Glyph="&#xE946;" />
                     </muxc:NavigationViewItem.Icon>

--- a/src/Files/MultilingualResources/Files.af.xlf
+++ b/src/Files/MultilingualResources/Files.af.xlf
@@ -150,7 +150,7 @@
           <source>Remove this item</source>
           <target state="translated">Verwyder hierdie item</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Onlangse lêers</target>
         </trans-unit>
@@ -1527,7 +1527,7 @@
           <source>Shortcut item</source>
           <target state="translated">Kortpad item</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Skywe</target>
         </trans-unit>
@@ -1707,7 +1707,7 @@
           <source>Dual pane</source>
           <target state="translated">Dubbele paneel</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Omslae</target>
         </trans-unit>
@@ -1839,7 +1839,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Verwyder van bondel</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Bondels</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.ar.xlf
+++ b/src/Files/MultilingualResources/Files.ar.xlf
@@ -1413,7 +1413,7 @@
           <source>Shortcut item</source>
           <target state="translated">Shortcut item</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated" state-qualifier="tm-suggestion">محركات الأقراص:</target>
         </trans-unit>
@@ -1556,7 +1556,7 @@
           <target state="needs-review-translation">جزء مزدوج</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated" state-qualifier="tm-suggestion">المجلدات</target>
         </trans-unit>
@@ -1670,7 +1670,7 @@
           <source>Remove Bundle</source>
           <target state="translated">إزالة الحزمة</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated" state-qualifier="tm-suggestion">الحزم</target>
         </trans-unit>
@@ -2690,7 +2690,7 @@
           <source>Restore Libraries</source>
           <target state="new">Restore Libraries</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">الملفات الأخيرة</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.ca.xlf
+++ b/src/Files/MultilingualResources/Files.ca.xlf
@@ -151,7 +151,7 @@
           <source>Remove this item</source>
           <target state="translated">Elimina aquest element</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Arxius recents</target>
         </trans-unit>
@@ -1512,7 +1512,7 @@
           <source>Shortcut item</source>
           <target state="new">Shortcut item</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="new">Drives</target>
         </trans-unit>
@@ -1692,7 +1692,7 @@
           <source>Dual pane</source>
           <target state="new">Dual pane</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="new">Folders</target>
         </trans-unit>
@@ -1816,7 +1816,7 @@
           <source>Remove Bundle</source>
           <target state="new">Remove Bundle</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="new">Bundles</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.cs-CZ.xlf
+++ b/src/Files/MultilingualResources/Files.cs-CZ.xlf
@@ -1430,7 +1430,7 @@
           <source>Shortcut item</source>
           <target state="translated">Zástupce</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Jednotky</target>
         </trans-unit>
@@ -1573,7 +1573,7 @@
           <target state="needs-review-translation">Dvoupanelové rozhraní</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Složky</target>
         </trans-unit>
@@ -1711,7 +1711,7 @@
           <source>Remove Bundle</source>
           <target state="new">Remove Bundle</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Balíčky</target>
         </trans-unit>
@@ -2702,7 +2702,7 @@
           <source>Restore Libraries</source>
           <target state="new">Restore Libraries</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Naposledy otevřené soubory</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.da-DK.xlf
+++ b/src/Files/MultilingualResources/Files.da-DK.xlf
@@ -1411,7 +1411,7 @@
           <source>Shortcut item</source>
           <target state="translated">Genvejsemne</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Drev</target>
         </trans-unit>
@@ -1553,7 +1553,7 @@
           <source>Dual pane</source>
           <target state="translated">Dobbeltrude</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Mapper</target>
         </trans-unit>
@@ -1691,7 +1691,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Fjern samling</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Samlinger</target>
         </trans-unit>
@@ -2693,7 +2693,7 @@
           <source>Restore Libraries</source>
           <target state="new">Restore Libraries</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Seneste filer</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.da.xlf
+++ b/src/Files/MultilingualResources/Files.da.xlf
@@ -1413,7 +1413,7 @@
           <source>Shortcut item</source>
           <target state="translated">Genvejsemne</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Drev</target>
         </trans-unit>
@@ -1556,7 +1556,7 @@
           <target state="needs-review-translation">Dobbeltrude</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Mapper</target>
         </trans-unit>
@@ -1694,7 +1694,7 @@
           <source>Remove Bundle</source>
           <target state="new">Remove Bundle</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Pakker</target>
         </trans-unit>
@@ -2691,7 +2691,7 @@
           <source>Restore Libraries</source>
           <target state="new">Restore Libraries</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Seneste filer</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.de-DE.xlf
+++ b/src/Files/MultilingualResources/Files.de-DE.xlf
@@ -983,7 +983,7 @@
           <source>Move here</source>
           <target state="translated">Hierher verschieben</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Laufwerke</target>
         </trans-unit>
@@ -1539,7 +1539,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Kontextmenü anpassen</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Ordner</target>
         </trans-unit>
@@ -1675,7 +1675,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Gruppe entfernen</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Sammlungen</target>
         </trans-unit>
@@ -2664,7 +2664,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Bibliotheken wiederherstellen</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Zuletzt verwendete Dateien</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.el.xlf
+++ b/src/Files/MultilingualResources/Files.el.xlf
@@ -150,7 +150,7 @@
           <source>Remove this item</source>
           <target state="translated">Αφαιρέστε αυτό το στοιχείο</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Πρόσφατα αρχεία</target>
         </trans-unit>
@@ -1506,7 +1506,7 @@
           <source>Shortcut item</source>
           <target state="translated">Στοιχείο συντόμευσης</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Μονάδες Δίσκου</target>
         </trans-unit>
@@ -1686,7 +1686,7 @@
           <source>Dual pane</source>
           <target state="translated">Διπλό παράθυρο</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Φάκελοι</target>
         </trans-unit>
@@ -1810,7 +1810,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Αφαίρεση πακέτου</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Δέσμες</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.en-GB.xlf
+++ b/src/Files/MultilingualResources/Files.en-GB.xlf
@@ -150,7 +150,7 @@
           <source>Remove this item</source>
           <target state="translated" state-qualifier="tm-suggestion">Remove this item</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated" state-qualifier="tm-suggestion">Recent Files</target>
         </trans-unit>
@@ -1522,7 +1522,7 @@
           <source>Shortcut item</source>
           <target state="translated">Shortcut item</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated" state-qualifier="tm-suggestion">Drives</target>
         </trans-unit>
@@ -1702,7 +1702,7 @@
           <source>Dual pane</source>
           <target state="translated">Dual pane</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated" state-qualifier="tm-suggestion">Folders</target>
         </trans-unit>
@@ -1826,7 +1826,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Remove Bundle</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Bundles</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.es-419.xlf
+++ b/src/Files/MultilingualResources/Files.es-419.xlf
@@ -1446,7 +1446,7 @@
           <source>Shortcut item</source>
           <target state="translated">Elemento de acceso directo</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Dispositivos y unidades</target>
         </trans-unit>
@@ -1598,7 +1598,7 @@
           <source>Dual pane</source>
           <target state="translated">Panel Doble</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Carpetas</target>
         </trans-unit>
@@ -1722,7 +1722,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Quitar contenedor</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Contenedores</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Restaurar bibliotecas</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Archivos recientes</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.es-ES.xlf
+++ b/src/Files/MultilingualResources/Files.es-ES.xlf
@@ -966,7 +966,7 @@
           <source>Move here</source>
           <target state="translated">Mover aquí</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Dispositivos y unidades</target>
         </trans-unit>
@@ -1538,7 +1538,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Personaliza el menú contextual</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Carpetas</target>
         </trans-unit>
@@ -1666,7 +1666,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Quitar contenedor</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Contenedores</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Restaurar bibliotecas</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Archivos recientes</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/src/Files/MultilingualResources/Files.fr-FR.xlf
@@ -982,7 +982,7 @@
           <source>Move here</source>
           <target state="translated">Déplacer ici</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Disques</target>
         </trans-unit>
@@ -1538,7 +1538,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Personnaliser le menu contextuel du clic droit</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Dossiers</target>
         </trans-unit>
@@ -1666,7 +1666,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Supprimer le bundle</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Bundles</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Restaurer les bibliothèques</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Fichiers récents</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.he-IL.xlf
+++ b/src/Files/MultilingualResources/Files.he-IL.xlf
@@ -1364,7 +1364,7 @@
           <source>Move here</source>
           <target state="translated" state-qualifier="tm-suggestion">העבר לכאן</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated" state-qualifier="tm-suggestion">כוננים:</target>
         </trans-unit>
@@ -1550,7 +1550,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">התאם אישית את התפריט תלוי-ההקשר המופעל בלחיצה ימנית</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">תיקיות</target>
         </trans-unit>
@@ -1688,7 +1688,7 @@
           <source>Remove Bundle</source>
           <target state="new">Remove Bundle</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">חבילות</target>
         </trans-unit>
@@ -2676,7 +2676,7 @@
           <source>Restore Libraries</source>
           <target state="new">Restore Libraries</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="new">Recent Files</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.hi-IN.xlf
+++ b/src/Files/MultilingualResources/Files.hi-IN.xlf
@@ -1002,7 +1002,7 @@
           <source>Move here</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">यहाँ लाएँ</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ड्राइव:</target>
         </trans-unit>
@@ -1559,7 +1559,7 @@
           <source>Customize the right click context menu</source>
           <target state="new">Customize the right click context menu</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">फ़ोल्डर्स</target>
         </trans-unit>
@@ -1697,7 +1697,7 @@
           <source>Remove Bundle</source>
           <target state="new">Remove Bundle</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">बंडल्स</target>
         </trans-unit>
@@ -2685,7 +2685,7 @@
           <source>Restore Libraries</source>
           <target state="new">Restore Libraries</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">हाल ही की फ़ाइलें</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.hr-HR.xlf
+++ b/src/Files/MultilingualResources/Files.hr-HR.xlf
@@ -150,7 +150,7 @@
           <source>Remove this item</source>
           <target state="translated">Ukloni ovu stavku</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Nedavne datoteke</target>
         </trans-unit>
@@ -1522,7 +1522,7 @@
           <source>Shortcut item</source>
           <target state="translated">Stavka prečaca</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Pogoni</target>
         </trans-unit>
@@ -1703,7 +1703,7 @@
           <source>Dual pane</source>
           <target state="translated">Dvostruko okno</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Mape</target>
         </trans-unit>
@@ -1827,7 +1827,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Ukloni paket</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Paketi</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.hu-HU.xlf
+++ b/src/Files/MultilingualResources/Files.hu-HU.xlf
@@ -966,7 +966,7 @@
           <source>Move here</source>
           <target state="translated">Áthelyezés ide</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Meghajtók</target>
         </trans-unit>
@@ -1538,7 +1538,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Helyi menü testreszabása</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Mappák</target>
         </trans-unit>
@@ -1678,7 +1678,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Munkaterület eltávolítása</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Munkaterületek</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Könyvtárak visszaállítása</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Előzmények</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.id-ID.xlf
+++ b/src/Files/MultilingualResources/Files.id-ID.xlf
@@ -1430,7 +1430,7 @@
           <source>Shortcut item</source>
           <target state="translated">Item pintasan</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Drive</target>
         </trans-unit>
@@ -1578,7 +1578,7 @@
           <source>Dual pane</source>
           <target state="translated">Panel ganda</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated" state-qualifier="tm-suggestion">Folder</target>
         </trans-unit>
@@ -1702,7 +1702,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Hapus Bundel</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated" state-qualifier="tm-suggestion">Bundel</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Kembalikan Pustaka</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated" state-qualifier="tm-suggestion">File Terbaru</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.it-IT.xlf
+++ b/src/Files/MultilingualResources/Files.it-IT.xlf
@@ -982,7 +982,7 @@
           <source>Move here</source>
           <target state="translated">Sposta qui</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Risorse</target>
         </trans-unit>
@@ -1538,7 +1538,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Personalizza il menu contestuale</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Cartelle</target>
         </trans-unit>
@@ -1675,7 +1675,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Rimuovi Gruppo</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Gruppi</target>
         </trans-unit>
@@ -2843,7 +2843,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Ripristina Raccolte</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">File recenti</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/src/Files/MultilingualResources/Files.ja-JP.xlf
@@ -982,7 +982,7 @@
           <source>Move here</source>
           <target state="translated">ここに移動</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">ドライブ</target>
         </trans-unit>
@@ -1538,7 +1538,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">右クリックメニューをカスタマイズ</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">フォルダ</target>
         </trans-unit>
@@ -1666,7 +1666,7 @@
           <source>Remove Bundle</source>
           <target state="translated">バンドルを削除</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">バンドル</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">ライブラリを復元</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">最近使ったファイル</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.ka.xlf
+++ b/src/Files/MultilingualResources/Files.ka.xlf
@@ -150,7 +150,7 @@
           <source>Remove this item</source>
           <target state="translated">ამ ნივთის წაშლა</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">ბოლო ფაილები</target>
         </trans-unit>
@@ -1503,7 +1503,7 @@
           <source>Shortcut item</source>
           <target state="translated">მალსახმობის ელემენტი</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">დისკები</target>
         </trans-unit>
@@ -1684,7 +1684,7 @@
           <source>Dual pane</source>
           <target state="translated">ორმაგი სარკმელი</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">საქაღალდეები</target>
         </trans-unit>
@@ -1808,7 +1808,7 @@
           <source>Remove Bundle</source>
           <target state="translated">შეკვრის ამოშლა</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">შეკვრები</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.ko-KR.xlf
+++ b/src/Files/MultilingualResources/Files.ko-KR.xlf
@@ -1406,7 +1406,7 @@
           <source>Shortcut item</source>
           <target state="translated">바로 가기 항목</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">드라이브</target>
         </trans-unit>
@@ -1546,7 +1546,7 @@
           <source>Dual pane</source>
           <target state="translated">듀얼 패널</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">폴더</target>
         </trans-unit>
@@ -1654,7 +1654,7 @@
           <source>Remove Bundle</source>
           <target state="translated">보관함 제거</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">보관함</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">라이브러리 복원</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated" state-qualifier="tm-suggestion">최근에 사용한 파일</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.lv-LV.xlf
+++ b/src/Files/MultilingualResources/Files.lv-LV.xlf
@@ -1410,7 +1410,7 @@
           <source>Shortcut item</source>
           <target state="translated">Saīsnes vienums</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Diski</target>
         </trans-unit>
@@ -1550,7 +1550,7 @@
           <source>Dual pane</source>
           <target state="translated">Dubulti paneļi</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Mapes</target>
         </trans-unit>
@@ -1658,7 +1658,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Dzēst saišķi</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Saišķi</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Atjaunot bibliotēkas</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Nesenie faili</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/src/Files/MultilingualResources/Files.nl-NL.xlf
@@ -1360,7 +1360,7 @@
           <source>Move here</source>
           <target state="translated" state-qualifier="tm-suggestion">Hierheen verplaatsen</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Stations</target>
         </trans-unit>
@@ -1545,7 +1545,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Contextmenu aanpassen</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated" state-qualifier="tm-suggestion">Mappen</target>
         </trans-unit>
@@ -1678,7 +1678,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Bundel verwijderen</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated" state-qualifier="tm-suggestion">Bundels</target>
         </trans-unit>
@@ -2676,7 +2676,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Herstel bibliotheken</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Recente bestanden</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.or-IN.xlf
+++ b/src/Files/MultilingualResources/Files.or-IN.xlf
@@ -1374,7 +1374,7 @@
           <source>Move here</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ଏଠାକୁ ଘୁଞ୍ଚନ୍ତୁ</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ଡ୍ରାଇଭ୍‌ସମୂହ:</target>
         </trans-unit>
@@ -1559,7 +1559,7 @@
           <source>Customize the right click context menu</source>
           <target state="new">Customize the right click context menu</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ଫୋଲ୍ଡରଗୁଡିକ</target>
         </trans-unit>
@@ -1687,7 +1687,7 @@
           <source>Remove Bundle</source>
           <target state="new">Remove Bundle</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="new">Bundles</target>
         </trans-unit>
@@ -2683,7 +2683,7 @@
           <source>Restore Libraries</source>
           <target state="new">Restore Libraries</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ବର୍ତ୍ତମାନର ଫାଇଲ୍‌ଗୁଡିକ</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/src/Files/MultilingualResources/Files.pl-PL.xlf
@@ -985,7 +985,7 @@
           <source>Move here</source>
           <target state="translated">Przenieś tutaj</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Dyski</target>
         </trans-unit>
@@ -1541,7 +1541,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Dostosuj menu kontekstowe prawego przycisku myszy</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Foldery</target>
         </trans-unit>
@@ -1669,7 +1669,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Usuń Paczkę</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Paczki</target>
         </trans-unit>
@@ -2665,7 +2665,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Przywróć Biblioteki</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Ostatnio używane pliki</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.pt-BR.xlf
+++ b/src/Files/MultilingualResources/Files.pt-BR.xlf
@@ -982,7 +982,7 @@
           <source>Move here</source>
           <target state="translated">Mover aqui</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Unidades</target>
         </trans-unit>
@@ -1538,7 +1538,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Personalize o menu de contexto (Botão Direito)</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Pastas</target>
         </trans-unit>
@@ -1626,7 +1626,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Remover Pacote</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Pacotes</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Restaurar Bibliotecas</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Arquivos Recentes</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.pt-PT.xlf
+++ b/src/Files/MultilingualResources/Files.pt-PT.xlf
@@ -982,7 +982,7 @@
           <source>Move here</source>
           <target state="translated">Mover aqui</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Unidades</target>
         </trans-unit>
@@ -1538,7 +1538,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Personalize o menu de contexto do botão direito</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Pastas</target>
         </trans-unit>
@@ -1666,7 +1666,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Remover Pacote</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Pacotes</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Restaurar Bibliotecas</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Ficheiros Recentes</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/src/Files/MultilingualResources/Files.ru-RU.xlf
@@ -982,7 +982,7 @@
           <source>Move here</source>
           <target state="translated">Переместить</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Диски</target>
         </trans-unit>
@@ -1539,7 +1539,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Настройки контекстного меню</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Папки</target>
         </trans-unit>
@@ -1667,7 +1667,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Удалить Коллекцию</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Коллекции папок</target>
         </trans-unit>
@@ -2663,7 +2663,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Восстановить библиотеки</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Последние файлы</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.sv-SE.xlf
+++ b/src/Files/MultilingualResources/Files.sv-SE.xlf
@@ -1421,7 +1421,7 @@
           <source>Shortcut item</source>
           <target state="translated">Genvägsobjekt</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Enheter</target>
         </trans-unit>
@@ -1564,7 +1564,7 @@
           <target state="needs-review-translation">Dubbla paneler</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Mappar</target>
         </trans-unit>
@@ -1682,7 +1682,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Ta bort samling</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Samlingar</target>
         </trans-unit>
@@ -2694,7 +2694,7 @@
           <source>Restore Libraries</source>
           <target state="new">Restore Libraries</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Senaste filer</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.ta.xlf
+++ b/src/Files/MultilingualResources/Files.ta.xlf
@@ -968,7 +968,7 @@
           <source>Move here</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">இங்கே நகர்த்து</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">இயக்ககங்கள்:</target>
         </trans-unit>
@@ -1540,7 +1540,7 @@
           <source>Customize the right click context menu</source>
           <target state="new">Customize the right click context menu</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">கோப்புறைகள்</target>
         </trans-unit>
@@ -1668,7 +1668,7 @@
           <source>Remove Bundle</source>
           <target state="new">Remove Bundle</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="new">Bundles</target>
         </trans-unit>
@@ -2664,7 +2664,7 @@
           <source>Restore Libraries</source>
           <target state="new">Restore Libraries</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">சமீபத்திய கோப்புகள்</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/src/Files/MultilingualResources/Files.tr-TR.xlf
@@ -987,7 +987,7 @@
           <source>Move here</source>
           <target state="translated">Buraya taşı</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Sürücüler</target>
         </trans-unit>
@@ -1543,7 +1543,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Sağ tık menüsünü özelleştir</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Klasörler</target>
         </trans-unit>
@@ -1676,7 +1676,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Paketi Kaldır</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Paketler</target>
         </trans-unit>
@@ -2674,7 +2674,7 @@
           <source>Restore Libraries</source>
           <target state="translated">Kitaplıkları Geri Yükle</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated" state-qualifier="tm-suggestion">Son Dosyalar</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/src/Files/MultilingualResources/Files.uk-UA.xlf
@@ -997,7 +997,7 @@
           <source>Move here</source>
           <target state="translated">Перемістити</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Диски</target>
         </trans-unit>
@@ -1556,7 +1556,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">Налаштування контекстного меню</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Папки</target>
         </trans-unit>
@@ -1694,7 +1694,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Видалити Колекцію</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Колекції папок</target>
         </trans-unit>
@@ -2691,7 +2691,7 @@
           <source>Restore Libraries</source>
           <target state="new">Restore Libraries</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">Останні файли</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.vi.xlf
+++ b/src/Files/MultilingualResources/Files.vi.xlf
@@ -151,7 +151,7 @@
           <source>Remove this item</source>
           <target state="translated">Loại bỏ mục này</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">Tệp Gần đây</target>
         </trans-unit>
@@ -1513,7 +1513,7 @@
           <source>Shortcut item</source>
           <target state="translated">Mục tắt lối</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">Ổ đĩa:</target>
         </trans-unit>
@@ -1695,7 +1695,7 @@
           <source>Dual pane</source>
           <target state="translated">Hai màn</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">Thư mục</target>
         </trans-unit>
@@ -1824,7 +1824,7 @@
           <source>Remove Bundle</source>
           <target state="translated">Xóa bỏ bó</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">Bó</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/src/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -982,7 +982,7 @@
           <source>Move here</source>
           <target state="translated">移到此处</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">驱动器</target>
         </trans-unit>
@@ -1538,7 +1538,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">自定义右键上下文菜单</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated">文件夹</target>
         </trans-unit>
@@ -1666,7 +1666,7 @@
           <source>Remove Bundle</source>
           <target state="translated">移除包</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">包</target>
         </trans-unit>
@@ -2664,7 +2664,7 @@
           <source>Restore Libraries</source>
           <target state="translated">恢复库</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">最近使用的文件</target>
         </trans-unit>

--- a/src/Files/MultilingualResources/Files.zh-Hant.xlf
+++ b/src/Files/MultilingualResources/Files.zh-Hant.xlf
@@ -978,7 +978,7 @@
           <source>Shortcut item</source>
           <target state="translated">捷徑項目</target>
         </trans-unit>
-        <trans-unit id="DrivesWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Drives" translate="yes" xml:space="preserve">
           <source>Drives</source>
           <target state="translated">磁碟機</target>
         </trans-unit>
@@ -1538,7 +1538,7 @@
           <source>Customize the right click context menu</source>
           <target state="translated">自訂右鍵選單</target>
         </trans-unit>
-        <trans-unit id="FolderWidgetDescription.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Folders" translate="yes" xml:space="preserve">
           <source>Folders</source>
           <target state="translated" state-qualifier="tm-suggestion">資料夾</target>
         </trans-unit>
@@ -1678,7 +1678,7 @@
           <source>Remove Bundle</source>
           <target state="translated">移除綁定</target>
         </trans-unit>
-        <trans-unit id="BundlesWidgetHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="Bundles" translate="yes" xml:space="preserve">
           <source>Bundles</source>
           <target state="translated">快速存取</target>
         </trans-unit>
@@ -2662,7 +2662,7 @@
           <source>Restore Libraries</source>
           <target state="translated">重置媒體櫃</target>
         </trans-unit>
-        <trans-unit id="RecentFilesHeader.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RecentFiles" translate="yes" xml:space="preserve">
           <source>Recent Files</source>
           <target state="translated">最近使用過的檔案</target>
         </trans-unit>

--- a/src/Files/Services/IWidgetsSettingsService.cs
+++ b/src/Files/Services/IWidgetsSettingsService.cs
@@ -23,5 +23,13 @@ namespace Files.Services
         /// Gets or sets a value indicating whether or not the Bundles widget should be visible.
         /// </summary>
         bool ShowBundlesWidget { get; set; }
+
+        bool FoldersWidgetExpanded { get; set; }
+
+        bool RecentFilesWidgetExpanded { get; set; }
+
+        bool DrivesWidgetExpanded { get; set; }
+
+        bool BundlesWidgetExpanded { get; set; }
     }
 }

--- a/src/Files/Services/Implementation/WidgetsSettingsService.cs
+++ b/src/Files/Services/Implementation/WidgetsSettingsService.cs
@@ -47,5 +47,29 @@ namespace Files.Services.Implementation
             get => Get(false);
             set => Set(value);
         }
+
+        public bool FoldersWidgetExpanded
+        {
+            get => Get(true);
+            set => Set(value);
+        }
+
+        public bool RecentFilesWidgetExpanded
+        {
+            get => Get(true);
+            set => Set(value);
+        }
+
+        public bool DrivesWidgetExpanded
+        {
+            get => Get(true);
+            set => Set(value);
+        }
+
+        public bool BundlesWidgetExpanded
+        {
+            get => Get(true);
+            set => Set(value);
+        }
     }
 }

--- a/src/Files/Strings/ar/Resources.resw
+++ b/src/Files/Strings/ar/Resources.resw
@@ -1044,7 +1044,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Shortcut item</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>محركات الأقراص:</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1149,7 +1149,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>جزء مزدوج</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>المجلدات</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1227,7 +1227,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>إزالة الحزمة</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>الحزم</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -1632,7 +1632,7 @@
   <data name="DialogRestoreLibrariesButtonText" xml:space="preserve">
     <value>استعادة</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>الملفات الأخيرة</value>
   </data>
   <data name="PropertyFileOwner" xml:space="preserve">

--- a/src/Files/Strings/ca/Resources.resw
+++ b/src/Files/Strings/ca/Resources.resw
@@ -120,7 +120,7 @@
   <data name="RecentItemRemove.Text" xml:space="preserve">
     <value>Elimina aquest element</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Arxius recents</value>
   </data>
   <data name="SettingsUsefulLinks.Title" xml:space="preserve">

--- a/src/Files/Strings/cs-CZ/Resources.resw
+++ b/src/Files/Strings/cs-CZ/Resources.resw
@@ -1056,7 +1056,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Zástupce</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Jednotky</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Dvoupanelové rozhraní</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Složky</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1200,7 +1200,7 @@
   <data name="BundleItemFlyouOpenInNewTabMenuItem.Text" xml:space="preserve">
     <value>Otevřít v nové záložce</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Balíčky</value>
   </data>
   <data name="BundlesWidgetCreateBundleConfirmButton.Content" xml:space="preserve">
@@ -1611,7 +1611,7 @@
   <data name="DialogRestoreLibrariesButtonText" xml:space="preserve">
     <value>Obnovit</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Naposledy otevřené soubory</value>
   </data>
   <data name="PropertyFileOwner" xml:space="preserve">

--- a/src/Files/Strings/da-DK/Resources.resw
+++ b/src/Files/Strings/da-DK/Resources.resw
@@ -1056,7 +1056,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Genvejsemne</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Drev</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Dobbeltrude</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Mapper</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1257,7 +1257,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Fjern samling</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Samlinger</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -1749,7 +1749,7 @@
   <data name="DialogRestoreLibrariesButtonText" xml:space="preserve">
     <value>Gendan</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Seneste filer</value>
   </data>
   <data name="PropertyFileOwner" xml:space="preserve">

--- a/src/Files/Strings/da/Resources.resw
+++ b/src/Files/Strings/da/Resources.resw
@@ -1056,7 +1056,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Genvejsemne</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Drev</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Dobbeltrude</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Mapper</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1221,7 +1221,7 @@
   <data name="BundleItemFlyouOpenInNewTabMenuItem.Text" xml:space="preserve">
     <value>Åbn på en ny fane</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Pakker</value>
   </data>
   <data name="BundlesWidgetCreateBundleConfirmButton.Content" xml:space="preserve">
@@ -1611,7 +1611,7 @@
   <data name="DialogRestoreLibrariesButtonText" xml:space="preserve">
     <value>Gendan</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Seneste filer</value>
   </data>
   <data name="PropertyFileOwner" xml:space="preserve">

--- a/src/Files/Strings/de-DE/Resources.resw
+++ b/src/Files/Strings/de-DE/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Hierher verschieben</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Laufwerke</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Kontextmenü anpassen</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Ordner</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1263,7 +1263,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Gruppe entfernen</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Sammlungen</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Bibliotheken wiederherstellen</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Zuletzt verwendete Dateien</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/el/Resources.resw
+++ b/src/Files/Strings/el/Resources.resw
@@ -120,7 +120,7 @@
   <data name="RecentItemRemove.Text" xml:space="preserve">
     <value>Αφαιρέστε αυτό το στοιχείο</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Πρόσφατα αρχεία</value>
   </data>
   <data name="SettingsUsefulLinks.Title" xml:space="preserve">
@@ -1137,7 +1137,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Στοιχείο συντόμευσης</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Οδηγίες</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1272,7 +1272,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Διπλό παράθυρο</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Φάκελοι</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1365,7 +1365,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Αφαίρεση πακέτου</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Δέσμες</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">

--- a/src/Files/Strings/en-GB/Resources.resw
+++ b/src/Files/Strings/en-GB/Resources.resw
@@ -120,7 +120,7 @@
   <data name="RecentItemRemove.Text" xml:space="preserve">
     <value>Remove this item</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Recent Files</value>
   </data>
   <data name="SettingsUsefulLinks.Title" xml:space="preserve">
@@ -1149,7 +1149,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Shortcut item</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Drives</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1284,7 +1284,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Dual pane</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Folders</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1377,7 +1377,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Remove Bundle</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Bundles</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">

--- a/src/Files/Strings/en-US/Resources.resw
+++ b/src/Files/Strings/en-US/Resources.resw
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -224,9 +224,6 @@
   </data>
   <data name="RecentItemRemove.Text" xml:space="preserve">
     <value>Remove this item</value>
-  </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
-    <value>Recent Files</value>
   </data>
   <data name="SettingsUsefulLinks.Title" xml:space="preserve">
     <value>Useful links</value>
@@ -1257,7 +1254,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Shortcut item</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Drives</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1392,7 +1389,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Dual pane</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Folders</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1491,7 +1488,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Remove Bundle</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Bundles</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2874,5 +2871,8 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
   </data>
   <data name="ShowFolderSize" xml:space="preserve">
     <value>Show folder size</value>
+  </data>
+  <data name="RecentFiles" xml:space="preserve">
+    <value>Recent Files</value>
   </data>
 </root>

--- a/src/Files/Strings/es-419/Resources.resw
+++ b/src/Files/Strings/es-419/Resources.resw
@@ -1080,7 +1080,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Elemento de acceso directo</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Dispositivos y unidades</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1194,7 +1194,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Panel Doble</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Carpetas</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1287,7 +1287,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Quitar contenedor</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Contenedores</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -1992,7 +1992,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Restaurar bibliotecas</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Archivos recientes</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/es-ES/Resources.resw
+++ b/src/Files/Strings/es-ES/Resources.resw
@@ -732,7 +732,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Mover aquí</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Dispositivos y unidades</value>
   </data>
   <data name="FileItemAutomation" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Personaliza el menú contextual</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Carpetas</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1257,7 +1257,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Quitar contenedor</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Contenedores</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Restaurar bibliotecas</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Archivos recientes</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/fr-FR/Resources.resw
+++ b/src/Files/Strings/fr-FR/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Déplacer ici</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Disques</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Personnaliser le menu contextuel du clic droit</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Dossiers</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1257,7 +1257,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Supprimer le bundle</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Bundles</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Restaurer les bibliothèques</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Fichiers récents</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/he-IL/Resources.resw
+++ b/src/Files/Strings/he-IL/Resources.resw
@@ -858,7 +858,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>העבר לכאן</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>כוננים:</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -972,7 +972,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>התאם אישית את התפריט תלוי-ההקשר המופעל בלחיצה ימנית</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>תיקיות</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1011,7 +1011,7 @@
   <data name="BundleItemFlyouOpenInNewTabMenuItem.Text" xml:space="preserve">
     <value>פתח בכרטיסיה חדשה</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>חבילות</value>
   </data>
   <data name="BundlesWidgetCreateBundleConfirmButton.Content" xml:space="preserve">

--- a/src/Files/Strings/hi-IN/Resources.resw
+++ b/src/Files/Strings/hi-IN/Resources.resw
@@ -654,7 +654,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>यहाँ लाएँ</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>ड्राइव:</value>
   </data>
   <data name="SideBarEjectDevice.Text" xml:space="preserve">
@@ -894,7 +894,7 @@
   <data name="AppBarButtonRemove.Label" xml:space="preserve">
     <value>निकालें</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>फ़ोल्डर्स</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -930,7 +930,7 @@
   <data name="BundleItemFlyouOpenInNewTabMenuItem.Text" xml:space="preserve">
     <value>नए टैब में खोलें</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>बंडल्स</value>
   </data>
   <data name="BundlesWidgetCreateBundleConfirmButton.Content" xml:space="preserve">
@@ -1293,7 +1293,7 @@
   <data name="DialogRestoreLibrariesButtonText" xml:space="preserve">
     <value>पुनर्स्थापित करें</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>हाल ही की फ़ाइलें</value>
   </data>
   <data name="PropertyFileOwner" xml:space="preserve">

--- a/src/Files/Strings/hr-HR/Resources.resw
+++ b/src/Files/Strings/hr-HR/Resources.resw
@@ -120,7 +120,7 @@
   <data name="RecentItemRemove.Text" xml:space="preserve">
     <value>Ukloni ovu stavku</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Nedavne datoteke</value>
   </data>
   <data name="SettingsUsefulLinks.Title" xml:space="preserve">
@@ -1149,7 +1149,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Stavka prečaca</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Pogoni</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1284,7 +1284,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Dvostruko okno</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Mape</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1377,7 +1377,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Ukloni paket</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Paketi</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">

--- a/src/Files/Strings/hu-HU/Resources.resw
+++ b/src/Files/Strings/hu-HU/Resources.resw
@@ -732,7 +732,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Áthelyezés ide</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Meghajtók</value>
   </data>
   <data name="FileItemAutomation" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Helyi menü testreszabása</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Mappák</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1266,7 +1266,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Munkaterület eltávolítása</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Munkaterületek</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Könyvtárak visszaállítása</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Előzmények</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/id-ID/Resources.resw
+++ b/src/Files/Strings/id-ID/Resources.resw
@@ -1080,7 +1080,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Item pintasan</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Drive</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1191,7 +1191,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Panel ganda</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Folder</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1284,7 +1284,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Hapus Bundel</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Bundel</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Kembalikan Pustaka</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>File Terbaru</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/it-IT/Resources.resw
+++ b/src/Files/Strings/it-IT/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Sposta qui</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Risorse</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Personalizza il menu contestuale</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Cartelle</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1263,7 +1263,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Rimuovi Gruppo</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Gruppi</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2139,7 +2139,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Ripristina Raccolte</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>File recenti</value>
   </data>
   <data name="CreateBundleBtn.AutomationProperties.Name" xml:space="preserve">

--- a/src/Files/Strings/ja-JP/Resources.resw
+++ b/src/Files/Strings/ja-JP/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>ここに移動</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>ドライブ</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>右クリックメニューをカスタマイズ</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>フォルダ</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1257,7 +1257,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>バンドルを削除</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>バンドル</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>ライブラリを復元</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>最近使ったファイル</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/ka/Resources.resw
+++ b/src/Files/Strings/ka/Resources.resw
@@ -120,7 +120,7 @@
   <data name="RecentItemRemove.Text" xml:space="preserve">
     <value>ამ ნივთის წაშლა</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>ბოლო ფაილები</value>
   </data>
   <data name="SettingsUsefulLinks.Title" xml:space="preserve">
@@ -1134,7 +1134,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>მალსახმობის ელემენტი</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>დისკები</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1269,7 +1269,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>ორმაგი სარკმელი</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>საქაღალდეები</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1362,7 +1362,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>შეკვრის ამოშლა</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>შეკვრები</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">

--- a/src/Files/Strings/ko-KR/Resources.resw
+++ b/src/Files/Strings/ko-KR/Resources.resw
@@ -1062,7 +1062,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>바로 가기 항목</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>드라이브</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1167,7 +1167,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>듀얼 패널</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>폴더</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1248,7 +1248,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>보관함 제거</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>보관함</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>라이브러리 복원</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>최근에 사용한 파일</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/lv-LV/Resources.resw
+++ b/src/Files/Strings/lv-LV/Resources.resw
@@ -1065,7 +1065,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Saīsnes vienums</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Diski</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1170,7 +1170,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Dubulti paneļi</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Mapes</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1251,7 +1251,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Dzēst saišķi</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Saišķi</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Atjaunot bibliotēkas</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Nesenie faili</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/nl-NL/Resources.resw
+++ b/src/Files/Strings/nl-NL/Resources.resw
@@ -1023,7 +1023,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Hierheen verplaatsen</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Stations</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Contextmenu aanpassen</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Mappen</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1257,7 +1257,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Bundel verwijderen</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Bundels</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Herstel bibliotheken</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Recente bestanden</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/or-IN/Resources.resw
+++ b/src/Files/Strings/or-IN/Resources.resw
@@ -795,7 +795,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>ଏଠାକୁ ଘୁଞ୍ଚନ୍ତୁ</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>ଡ୍ରାଇଭ୍‌ସମୂହ:</value>
   </data>
   <data name="SideBarEjectDevice.Text" xml:space="preserve">
@@ -861,7 +861,7 @@
   <data name="AppBarButtonRemove.Label" xml:space="preserve">
     <value>ଅପସାରଣ</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>ଫୋଲ୍ଡରଗୁଡିକ</value>
   </data>
   <data name="BaseLayoutContextFlyoutSortByDateDeleted.Text" xml:space="preserve">
@@ -1227,7 +1227,7 @@
   <data name="DialogRestoreLibrariesButtonText" xml:space="preserve">
     <value>ପୁନଃସ୍ଥାପନା</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>ବର୍ତ୍ତମାନର ଫାଇଲ୍‌ଗୁଡିକ</value>
   </data>
   <data name="PropertyFileOwner" xml:space="preserve">

--- a/src/Files/Strings/pl-PL/Resources.resw
+++ b/src/Files/Strings/pl-PL/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Przenieś tutaj</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Dyski</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Dostosuj menu kontekstowe prawego przycisku myszy</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Foldery</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1257,7 +1257,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Usuń Paczkę</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Paczki</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Przywróć Biblioteki</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Ostatnio używane pliki</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/pt-BR/Resources.resw
+++ b/src/Files/Strings/pt-BR/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Mover aqui</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Unidades</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Personalize o menu de contexto (Botão Direito)</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Pastas</value>
   </data>
   <data name="BaseLayoutContextFlyoutSortByDateDeleted.Text" xml:space="preserve">
@@ -1227,7 +1227,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Remover Pacote</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Pacotes</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Restaurar Bibliotecas</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Arquivos Recentes</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/pt-PT/Resources.resw
+++ b/src/Files/Strings/pt-PT/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Mover aqui</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Unidades</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Personalize o menu de contexto do botão direito</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Pastas</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1257,7 +1257,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Remover Pacote</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Pacotes</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Restaurar Bibliotecas</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Ficheiros Recentes</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/ru-RU/Resources.resw
+++ b/src/Files/Strings/ru-RU/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Переместить</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Диски</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1134,7 +1134,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Настройки контекстного меню</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Папки</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1230,7 +1230,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Удалить Коллекцию</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Коллекции папок</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -1977,7 +1977,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Восстановить библиотеки</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Последние файлы</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/sv-SE/Resources.resw
+++ b/src/Files/Strings/sv-SE/Resources.resw
@@ -1062,7 +1062,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Genvägsobjekt</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Enheter</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1167,7 +1167,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Dubbla paneler</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Mappar</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1248,7 +1248,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Ta bort samling</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Samlingar</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -1701,7 +1701,7 @@
   <data name="DialogRestoreLibrariesButtonText" xml:space="preserve">
     <value>Återställ</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Senaste filer</value>
   </data>
   <data name="PropertyFileOwner" xml:space="preserve">

--- a/src/Files/Strings/ta/Resources.resw
+++ b/src/Files/Strings/ta/Resources.resw
@@ -712,7 +712,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>இங்கே நகர்த்து</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>இயக்ககங்கள்:</value>
   </data>
   <data name="FileItemAutomation" xml:space="preserve">
@@ -934,7 +934,7 @@
   <data name="AppBarButtonRemove.Label" xml:space="preserve">
     <value>அகற்று</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>கோப்புறைகள்</value>
   </data>
   <data name="BaseLayoutContextFlyoutSortByDateDeleted.Text" xml:space="preserve">
@@ -1300,7 +1300,7 @@
   <data name="DialogRestoreLibrariesButtonText" xml:space="preserve">
     <value>மீட்டெடு</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>சமீபத்திய கோப்புகள்</value>
   </data>
   <data name="PropertyFileOwner" xml:space="preserve">

--- a/src/Files/Strings/tr-TR/Resources.resw
+++ b/src/Files/Strings/tr-TR/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Buraya taşı</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Sürücüler</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Sağ tık menüsünü özelleştir</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Klasörler</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1257,7 +1257,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Paketi Kaldır</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Paketler</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>Kitaplıkları Geri Yükle</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Son Dosyalar</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/uk-UA/Resources.resw
+++ b/src/Files/Strings/uk-UA/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>Перемістити</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Диски</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1116,7 +1116,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>Налаштування контекстного меню</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Папки</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1212,7 +1212,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Видалити Колекцію</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Колекції папок</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -1668,7 +1668,7 @@
   <data name="DialogRestoreLibrariesButtonText" xml:space="preserve">
     <value>Відновити</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Останні файли</value>
   </data>
   <data name="PropertyFileOwner" xml:space="preserve">

--- a/src/Files/Strings/vi/Resources.resw
+++ b/src/Files/Strings/vi/Resources.resw
@@ -120,7 +120,7 @@
   <data name="RecentItemRemove.Text" xml:space="preserve">
     <value>Loại bỏ mục này</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>Tệp Gần đây</value>
   </data>
   <data name="SettingsUsefulLinks.Title" xml:space="preserve">
@@ -1116,7 +1116,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>Mục tắt lối</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>Ổ đĩa:</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1251,7 +1251,7 @@
   <data name="SettingsDualPane.Text" xml:space="preserve">
     <value>Hai màn</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>Thư mục</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1341,7 +1341,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>Xóa bỏ bó</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>Bó</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">

--- a/src/Files/Strings/zh-Hans/Resources.resw
+++ b/src/Files/Strings/zh-Hans/Resources.resw
@@ -744,7 +744,7 @@
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
     <value>移到此处</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>驱动器</value>
   </data>
   <data name="EjectNotificationHeader" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>自定义右键上下文菜单</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>文件夹</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1257,7 +1257,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>移除包</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>包</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2006,7 +2006,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>恢复库</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>最近使用的文件</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/Strings/zh-Hant/Resources.resw
+++ b/src/Files/Strings/zh-Hant/Resources.resw
@@ -741,7 +741,7 @@
   <data name="ShortcutItemAutomation" xml:space="preserve">
     <value>捷徑項目</value>
   </data>
-  <data name="DrivesWidgetDescription.Text" xml:space="preserve">
+  <data name="Drives" xml:space="preserve">
     <value>磁碟機</value>
   </data>
   <data name="PinToSidebarByDraggingCaptionText" xml:space="preserve">
@@ -1161,7 +1161,7 @@
   <data name="SettingsContextMenu.Text" xml:space="preserve">
     <value>自訂右鍵選單</value>
   </data>
-  <data name="FolderWidgetDescription.Text" xml:space="preserve">
+  <data name="Folders" xml:space="preserve">
     <value>資料夾</value>
   </data>
   <data name="NavToolbarDetails.ToolTipService.ToolTip" xml:space="preserve">
@@ -1266,7 +1266,7 @@
   <data name="BundleOptionsFlyoutRemoveBundleMenuItem.Text" xml:space="preserve">
     <value>移除綁定</value>
   </data>
-  <data name="BundlesWidgetHeader.Text" xml:space="preserve">
+  <data name="Bundles" xml:space="preserve">
     <value>快速存取</value>
   </data>
   <data name="BundleNoContentsTextBlock.Text" xml:space="preserve">
@@ -2004,7 +2004,7 @@
   <data name="DialogRestoreLibrariesTitleText" xml:space="preserve">
     <value>重置媒體櫃</value>
   </data>
-  <data name="RecentFilesHeader.Text" xml:space="preserve">
+  <data name="RecentFiles" xml:space="preserve">
     <value>最近使用過的檔案</value>
   </data>
   <data name="BundlesOpenInNewPane.Text" xml:space="preserve">

--- a/src/Files/UserControls/FilePreviews/MediaPreview.xaml
+++ b/src/Files/UserControls/FilePreviews/MediaPreview.xaml
@@ -10,7 +10,10 @@
     Unloaded="{x:Bind ViewModel.PreviewControlBase_Unloaded}"
     mc:Ignorable="d">
     <UserControl.KeyboardAccelerators>
-        <KeyboardAccelerator Key="P" Modifiers="Control,Menu" Invoked="TogglePlaybackAcceleratorInvoked"/>
+        <KeyboardAccelerator
+            Key="P"
+            Invoked="TogglePlaybackAcceleratorInvoked"
+            Modifiers="Control,Menu" />
     </UserControl.KeyboardAccelerators>
     <Grid CornerRadius="{StaticResource ControlCornerRadius}">
         <MediaPlayerElement

--- a/src/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files/UserControls/InnerNavigationToolbar.xaml
@@ -183,13 +183,13 @@
                 <AppBarSeparator x:Name="AdditionalActionSeparator" x:Load="{x:Bind ViewModel.HasAdditionnalAction, Mode=OneWay}" />
                 <AppBarButton
                     x:Name="EmptyRecycleBinButton"
+                    Command="{x:Bind ViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind ViewModel.CanEmptyRecycleBin, Mode=OneWay}"
                     Label="{helpers:ResourceString Name=EmptyRecycleBin}"
                     ToolTipService.ToolTip="{helpers:ResourceString Name=EmptyRecycleBin}"
-                    IsEnabled="{x:Bind ViewModel.CanEmptyRecycleBin, Mode=OneWay}"
-                    Command="{x:Bind ViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
                     Visibility="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=Collapsed}">
                     <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xEF88;" FontFamily="{StaticResource RecycleBinIcons}" />
+                        <FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
             </CommandBar.PrimaryCommands>
@@ -488,9 +488,9 @@
                                 <TextBlock
                                     x:Name="NavToolbarDetailsHeader"
                                     Grid.Row="0"
-                                    Grid.Column="1" 
-                                    Tapped="NavToolbarDetailsHeader_Tapped"
+                                    Grid.Column="1"
                                     VerticalAlignment="Center"
+                                    Tapped="NavToolbarDetailsHeader_Tapped"
                                     Text="{helpers:ResourceString Name=Details}" />
 
                                 <RadioButton
@@ -519,7 +519,7 @@
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
                                     Tapped="NavToolbarTilesHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=Tiles}"/>
+                                    Text="{helpers:ResourceString Name=Tiles}" />
 
                                 <RadioButton
                                     x:Uid="NavToolbarSmallIcons"
@@ -547,7 +547,7 @@
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
                                     Tapped="NavToolbarSmallIconsHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=SmallIcons}"/>
+                                    Text="{helpers:ResourceString Name=SmallIcons}" />
 
                                 <Border
                                     Grid.RowSpan="3"
@@ -561,7 +561,6 @@
                                 <RadioButton
                                     x:Uid="NavToolbarMediumIcons"
                                     Grid.Row="0"
-                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     Grid.Column="3"
                                     Width="36"
                                     Height="32"
@@ -573,6 +572,7 @@
                                     Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium, Mode=OneWay}"
                                     CommandParameter="{xh:SystemTypeToXaml Bool=True}"
                                     CornerRadius="{StaticResource ControlCornerRadius}"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                                     IsChecked="{x:Bind ViewModel.InstanceViewModel.FolderSettings.LayoutModeInformation, Converter={StaticResource LayoutModeConverter}, Mode=OneWay, ConverterParameter=MediumGridInfo}"
                                     Style="{StaticResource DefaultToggleButtonStyle}"
                                     ToolTipService.ToolTip="Medium Icons (Ctrl+Shift+4)">
@@ -585,7 +585,7 @@
                                     Grid.Column="4"
                                     VerticalAlignment="Center"
                                     Tapped="NavToolbarMediumIconsHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=MediumIcons}"/>
+                                    Text="{helpers:ResourceString Name=MediumIcons}" />
 
                                 <RadioButton
                                     x:Uid="NavToolbarLargeIcons"
@@ -613,7 +613,7 @@
                                     Grid.Column="4"
                                     VerticalAlignment="Center"
                                     Tapped="NavToolbarLargeIconsHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=LargeIcons}"/>
+                                    Text="{helpers:ResourceString Name=LargeIcons}" />
 
                                 <RadioButton
                                     x:Uid="NavToolbarColumnView"
@@ -644,7 +644,7 @@
                                     Grid.Column="4"
                                     VerticalAlignment="Center"
                                     Tapped="NavToolbarColumnsHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=Columns}"/>
+                                    Text="{helpers:ResourceString Name=Columns}" />
                             </Grid>
 
                             <Border

--- a/src/Files/UserControls/OngoingTasksFlyout.xaml
+++ b/src/Files/UserControls/OngoingTasksFlyout.xaml
@@ -129,14 +129,14 @@
                 Text="{helpers:ResourceString Name=OngoingTasks}" />
 
             <Button
-                x:Name="DismissAllBannersButton"                             
-                Height="32"                                
+                x:Name="DismissAllBannersButton"
+                Height="32"
+                HorizontalAlignment="Right"
                 Background="Transparent"
                 BorderBrush="Transparent"
                 Click="DismissAllBannersButton_Click"
                 Content="{helpers:ResourceString Name=ClearAll}"
-                ToolTipService.ToolTip="{helpers:ResourceString Name=ClearAll}" 
-                HorizontalAlignment="Right"/>
+                ToolTipService.ToolTip="{helpers:ResourceString Name=ClearAll}" />
         </Grid>
 
         <ListView

--- a/src/Files/UserControls/PathBreadcrumb.xaml
+++ b/src/Files/UserControls/PathBreadcrumb.xaml
@@ -203,8 +203,8 @@
                     <Border
                         VerticalAlignment="Stretch"
                         Background="Transparent"
-                        Tapped="PathBoxItem_Tapped"
-                        PointerPressed="PathBoxItem_PointerPressed">
+                        PointerPressed="PathBoxItem_PointerPressed"
+                        Tapped="PathBoxItem_Tapped">
                         <TextBlock
                             Margin="0,0,0,2"
                             VerticalAlignment="Center"

--- a/src/Files/UserControls/Widgets/BundlesWidget.xaml
+++ b/src/Files/UserControls/Widgets/BundlesWidget.xaml
@@ -18,7 +18,7 @@
         <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
     </UserControl.Resources>
 
-    <StackPanel>
+    <Grid>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
@@ -33,7 +33,7 @@
                 Height="32"
                 Padding="0"
                 HorizontalAlignment="Right"
-                VerticalAlignment="Center"
+                VerticalAlignment="Top"
                 HorizontalContentAlignment="Center"
                 VerticalContentAlignment="Center"
                 AutomationProperties.Name="More bundles options"
@@ -502,5 +502,5 @@
                 </Button.Flyout>
             </Button>
         </Grid>
-    </StackPanel>
+    </Grid>
 </UserControl>

--- a/src/Files/UserControls/Widgets/BundlesWidget.xaml
+++ b/src/Files/UserControls/Widgets/BundlesWidget.xaml
@@ -25,15 +25,6 @@
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
 
-            <TextBlock
-                x:Uid="BundlesWidgetHeader"
-                HorizontalAlignment="Left"
-                FontSize="14"
-                FontWeight="Medium"
-                Opacity="0.8"
-                Text="Bundles"
-                TextTrimming="CharacterEllipsis" />
-
             <!--  Add Bundle button  -->
             <Button
                 x:Uid="BundlesWidgetMoreOptionsButton"

--- a/src/Files/UserControls/Widgets/BundlesWidget.xaml.cs
+++ b/src/Files/UserControls/Widgets/BundlesWidget.xaml.cs
@@ -23,6 +23,8 @@ namespace Files.UserControls.Widgets
         public string WidgetName => nameof(BundlesWidget);
 
         public string AutomationProperties => "BundlesWidgetAutomationProperties/Name".GetLocalized();
+        
+        public string WidgetHeader => "Bundles".GetLocalized();
 
         public bool IsWidgetSettingEnabled => UserSettingsService.WidgetsSettingsService.ShowBundlesWidget;
 

--- a/src/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/src/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -18,15 +18,6 @@
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
 
-            <TextBlock
-                x:Uid="DrivesWidgetDescription"
-                HorizontalAlignment="Left"
-                FontFamily="Segoe UI"
-                FontSize="14"
-                FontWeight="Medium"
-                Opacity=".8"
-                Text="Drives" />
-
             <!--  Map Drive button  -->
             <Button
                 x:Uid="DrivesWidgetMoreOptionsButton"

--- a/src/Files/UserControls/Widgets/DrivesWidget.xaml
+++ b/src/Files/UserControls/Widgets/DrivesWidget.xaml
@@ -11,7 +11,7 @@
     xmlns:navigationcontrolitems="using:Files.DataModels.NavigationControlItems"
     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
     mc:Ignorable="d">
-    <StackPanel>
+    <Grid>
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
@@ -26,7 +26,7 @@
                 Height="32"
                 Padding="0"
                 HorizontalAlignment="Right"
-                VerticalAlignment="Center"
+                VerticalAlignment="Top"
                 HorizontalContentAlignment="Center"
                 VerticalContentAlignment="Center"
                 AutomationProperties.Name="More drives options"
@@ -57,8 +57,8 @@
 
         <muxc:ItemsRepeater
             x:Name="CardsList"
-            Grid.Row="0"
             HorizontalAlignment="Stretch"
+            VerticalAlignment="Top"
             ItemsSource="{x:Bind local:DrivesWidget.ItemsAdded}">
             <muxc:ItemsRepeater.Layout>
                 <muxc:UniformGridLayout
@@ -244,5 +244,5 @@
                 </DataTemplate>
             </muxc:ItemsRepeater.ItemTemplate>
         </muxc:ItemsRepeater>
-    </StackPanel>
+    </Grid>
 </UserControl>

--- a/src/Files/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -58,6 +58,8 @@ namespace Files.UserControls.Widgets
         public string WidgetName => nameof(DrivesWidget);
 
         public string AutomationProperties => "DrivesWidgetAutomationProperties/Name".GetLocalized();
+        
+        public string WidgetHeader => "Drives".GetLocalized();
 
         public bool IsWidgetSettingEnabled => UserSettingsService.WidgetsSettingsService.ShowDrivesWidget;
 

--- a/src/Files/UserControls/Widgets/FolderWidget.xaml
+++ b/src/Files/UserControls/Widgets/FolderWidget.xaml
@@ -10,24 +10,7 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
     mc:Ignorable="d">
-    <StackPanel Spacing="12">
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
-
-            <TextBlock
-                x:Uid="FolderWidgetDescription"
-                HorizontalAlignment="Left"
-                FontFamily="Segoe UI"
-                FontSize="14"
-                FontWeight="Medium"
-                Opacity=".8"
-                Text="Folders"
-                TextTrimming="CharacterEllipsis" />
-        </Grid>
-
+    <Grid>
         <muxc:ItemsRepeater
             x:Name="CardsList"
             Grid.Row="0"
@@ -141,5 +124,5 @@
                 </DataTemplate>
             </muxc:ItemsRepeater.ItemTemplate>
         </muxc:ItemsRepeater>
-    </StackPanel>
+    </Grid>
 </UserControl>

--- a/src/Files/UserControls/Widgets/FolderWidget.xaml.cs
+++ b/src/Files/UserControls/Widgets/FolderWidget.xaml.cs
@@ -136,6 +136,8 @@ namespace Files.UserControls.Widgets
 
         public string AutomationProperties => "FolderWidgetAutomationProperties/Name".GetLocalized();
 
+        public string WidgetHeader => "Folders".GetLocalized();
+
         public void Dispose()
         {
         }

--- a/src/Files/UserControls/Widgets/RecentFilesWidget.xaml
+++ b/src/Files/UserControls/Widgets/RecentFilesWidget.xaml
@@ -8,23 +8,18 @@
     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
     mc:Ignorable="d">
 
-    <Grid>
-        <Grid
-            x:Name="RecentsListGrid"
-            Grid.Row="1"
-            Grid.Column="0">
-            <StackPanel Orientation="Vertical" Spacing="4">
-                <TextBlock
+    <Grid x:Name="RecentsListGrid">
+        <StackPanel Orientation="Vertical" Spacing="4">
+            <TextBlock
                     x:Name="RecentItemDescription"
                     x:Uid="RecentItemDescription"
-                    Margin="0,24,0,0"
                     HorizontalAlignment="Stretch"
                     FontSize="14"
                     Text="Files you've previously accessed will show up here"
                     TextAlignment="Center"
                     TextWrapping="WrapWholeWords"
                     Visibility="{x:Bind Empty.Visibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                <ListView
+            <ListView
                     x:Name="RecentsView"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
@@ -34,69 +29,69 @@
                     ItemContainerTransitions="{x:Null}"
                     ItemsSource="{x:Bind recentItemsCollection}"
                     SelectionMode="None">
-                    <ListView.ItemTemplate>
-                        <DataTemplate x:DataType="local:RecentItem">
-                            <Grid
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="local:RecentItem">
+                        <Grid
                                 Padding="2.5"
                                 HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
+                                VerticalAlignment="Stretch" 
                                 AutomationProperties.Name="{x:Bind Name}"
                                 Background="Transparent"
                                 ColumnSpacing="14"
                                 ToolTipService.ToolTip="{x:Bind RecentPath}">
-                                <Grid.ContextFlyout>
-                                    <MenuFlyout>
-                                        <MenuFlyoutItem
+                            <Grid.ContextFlyout>
+                                <MenuFlyout>
+                                    <MenuFlyoutItem
                                             x:Name="RemoveRecentItem"
                                             x:Uid="RecentItemRemove"
                                             Click="RemoveRecentItem_Click"
                                             Text="Remove this item">
-                                            <MenuFlyoutItem.Icon>
-                                                <FontIcon Glyph="&#xE738;" />
-                                            </MenuFlyoutItem.Icon>
-                                        </MenuFlyoutItem>
-                                        <MenuFlyoutItem
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xE738;" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                    <MenuFlyoutItem
                                             x:Uid="RecentItemClearAll"
                                             Click="ClearRecentItems_Click"
                                             Text="Clear all items">
-                                            <MenuFlyoutItem.Icon>
-                                                <FontIcon Glyph="&#xE74D;" />
-                                            </MenuFlyoutItem.Icon>
-                                        </MenuFlyoutItem>
-                                        <MenuFlyoutItem
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xE74D;" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                    <MenuFlyoutItem
                                             x:Uid="RecentItemOpenFileLocation"
                                             Click="OpenFileLocation_Click"
                                             Text="Open file location"
                                             Visibility="{x:Bind IsFile}">
-                                            <MenuFlyoutItem.Icon>
-                                                <FontIcon Glyph="&#xED25;" />
-                                            </MenuFlyoutItem.Icon>
-                                        </MenuFlyoutItem>
-                                    </MenuFlyout>
-                                </Grid.ContextFlyout>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Grid
+                                        <MenuFlyoutItem.Icon>
+                                            <FontIcon Glyph="&#xED25;" />
+                                        </MenuFlyoutItem.Icon>
+                                    </MenuFlyoutItem>
+                                </MenuFlyout>
+                            </Grid.ContextFlyout>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid
                                     Grid.Column="0"
                                     Margin="0"
                                     VerticalAlignment="Stretch">
-                                    <FontIcon
+                                <FontIcon
                                         x:Name="FolderImg"
                                         x:Load="{x:Bind FolderImg}"
                                         x:Phase="1"
                                         FontSize="24"
                                         Foreground="#ffe793"
                                         Glyph="&#xE8B7;" />
-                                    <FontIcon
+                                <FontIcon
                                         x:Name="EmptyImg"
                                         x:Load="{x:Bind EmptyImgVis}"
                                         x:Phase="1"
                                         FontSize="24"
                                         Glyph="&#xE7C3;" />
-                                    <Image
+                                <Image
                                         x:Name="FileImg"
                                         Width="24"
                                         Height="24"
@@ -104,25 +99,24 @@
                                         x:Phase="1"
                                         Source="{x:Bind FileImg}"
                                         Stretch="UniformToFill" />
-                                </Grid>
-                                <TextBlock
+                            </Grid>
+                            <TextBlock
                                     Grid.Column="1"
                                     VerticalAlignment="Center"
                                     Text="{x:Bind Name}"
                                     TextTrimming="CharacterEllipsis"
                                     TextWrapping="NoWrap" />
-                                <TextBlock
+                            <TextBlock
                                     Grid.Column="2"
                                     VerticalAlignment="Center"
                                     FontSize="12"
                                     Text="{x:Bind RecentPath}"
                                     TextTrimming="CharacterEllipsis"
                                     TextWrapping="NoWrap" />
-                            </Grid>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
-            </StackPanel>
-        </Grid>
+                        </Grid>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/src/Files/UserControls/Widgets/RecentFilesWidget.xaml
+++ b/src/Files/UserControls/Widgets/RecentFilesWidget.xaml
@@ -15,14 +15,6 @@
             Grid.Column="0">
             <StackPanel Orientation="Vertical" Spacing="4">
                 <TextBlock
-                    x:Uid="RecentFilesHeader"
-                    HorizontalAlignment="Left"
-                    FontFamily="Segoe UI"
-                    FontSize="14"
-                    FontWeight="Medium"
-                    Opacity=".8"
-                    Text="Recent Files" />
-                <TextBlock
                     x:Name="RecentItemDescription"
                     x:Uid="RecentItemDescription"
                     Margin="0,24,0,0"

--- a/src/Files/UserControls/Widgets/RecentFilesWidget.xaml
+++ b/src/Files/UserControls/Widgets/RecentFilesWidget.xaml
@@ -11,58 +11,58 @@
     <Grid x:Name="RecentsListGrid">
         <StackPanel Orientation="Vertical" Spacing="4">
             <TextBlock
-                    x:Name="RecentItemDescription"
-                    x:Uid="RecentItemDescription"
-                    HorizontalAlignment="Stretch"
-                    FontSize="14"
-                    Text="Files you've previously accessed will show up here"
-                    TextAlignment="Center"
-                    TextWrapping="WrapWholeWords"
-                    Visibility="{x:Bind Empty.Visibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                x:Name="RecentItemDescription"
+                x:Uid="RecentItemDescription"
+                HorizontalAlignment="Stretch"
+                FontSize="14"
+                Text="Files you've previously accessed will show up here"
+                TextAlignment="Center"
+                TextWrapping="WrapWholeWords"
+                Visibility="{x:Bind Empty.Visibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             <ListView
-                    x:Name="RecentsView"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    IsItemClickEnabled="True"
-                    IsRightTapEnabled="True"
-                    ItemClick="RecentsView_ItemClick"
-                    ItemContainerTransitions="{x:Null}"
-                    ItemsSource="{x:Bind recentItemsCollection}"
-                    SelectionMode="None">
+                x:Name="RecentsView"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                IsItemClickEnabled="True"
+                IsRightTapEnabled="True"
+                ItemClick="RecentsView_ItemClick"
+                ItemContainerTransitions="{x:Null}"
+                ItemsSource="{x:Bind recentItemsCollection}"
+                SelectionMode="None">
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="local:RecentItem">
                         <Grid
-                                Padding="2.5"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch" 
-                                AutomationProperties.Name="{x:Bind Name}"
-                                Background="Transparent"
-                                ColumnSpacing="14"
-                                ToolTipService.ToolTip="{x:Bind RecentPath}">
+                            Padding="2.5"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Bind Name}"
+                            Background="Transparent"
+                            ColumnSpacing="14"
+                            ToolTipService.ToolTip="{x:Bind RecentPath}">
                             <Grid.ContextFlyout>
                                 <MenuFlyout>
                                     <MenuFlyoutItem
-                                            x:Name="RemoveRecentItem"
-                                            x:Uid="RecentItemRemove"
-                                            Click="RemoveRecentItem_Click"
-                                            Text="Remove this item">
+                                        x:Name="RemoveRecentItem"
+                                        x:Uid="RecentItemRemove"
+                                        Click="RemoveRecentItem_Click"
+                                        Text="Remove this item">
                                         <MenuFlyoutItem.Icon>
                                             <FontIcon Glyph="&#xE738;" />
                                         </MenuFlyoutItem.Icon>
                                     </MenuFlyoutItem>
                                     <MenuFlyoutItem
-                                            x:Uid="RecentItemClearAll"
-                                            Click="ClearRecentItems_Click"
-                                            Text="Clear all items">
+                                        x:Uid="RecentItemClearAll"
+                                        Click="ClearRecentItems_Click"
+                                        Text="Clear all items">
                                         <MenuFlyoutItem.Icon>
                                             <FontIcon Glyph="&#xE74D;" />
                                         </MenuFlyoutItem.Icon>
                                     </MenuFlyoutItem>
                                     <MenuFlyoutItem
-                                            x:Uid="RecentItemOpenFileLocation"
-                                            Click="OpenFileLocation_Click"
-                                            Text="Open file location"
-                                            Visibility="{x:Bind IsFile}">
+                                        x:Uid="RecentItemOpenFileLocation"
+                                        Click="OpenFileLocation_Click"
+                                        Text="Open file location"
+                                        Visibility="{x:Bind IsFile}">
                                         <MenuFlyoutItem.Icon>
                                             <FontIcon Glyph="&#xED25;" />
                                         </MenuFlyoutItem.Icon>
@@ -75,44 +75,44 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <Grid
-                                    Grid.Column="0"
-                                    Margin="0"
-                                    VerticalAlignment="Stretch">
+                                Grid.Column="0"
+                                Margin="0"
+                                VerticalAlignment="Stretch">
                                 <FontIcon
-                                        x:Name="FolderImg"
-                                        x:Load="{x:Bind FolderImg}"
-                                        x:Phase="1"
-                                        FontSize="24"
-                                        Foreground="#ffe793"
-                                        Glyph="&#xE8B7;" />
+                                    x:Name="FolderImg"
+                                    x:Load="{x:Bind FolderImg}"
+                                    x:Phase="1"
+                                    FontSize="24"
+                                    Foreground="#ffe793"
+                                    Glyph="&#xE8B7;" />
                                 <FontIcon
-                                        x:Name="EmptyImg"
-                                        x:Load="{x:Bind EmptyImgVis}"
-                                        x:Phase="1"
-                                        FontSize="24"
-                                        Glyph="&#xE7C3;" />
+                                    x:Name="EmptyImg"
+                                    x:Load="{x:Bind EmptyImgVis}"
+                                    x:Phase="1"
+                                    FontSize="24"
+                                    Glyph="&#xE7C3;" />
                                 <Image
-                                        x:Name="FileImg"
-                                        Width="24"
-                                        Height="24"
-                                        x:Load="{x:Bind FileIconVis}"
-                                        x:Phase="1"
-                                        Source="{x:Bind FileImg}"
-                                        Stretch="UniformToFill" />
+                                    x:Name="FileImg"
+                                    Width="24"
+                                    Height="24"
+                                    x:Load="{x:Bind FileIconVis}"
+                                    x:Phase="1"
+                                    Source="{x:Bind FileImg}"
+                                    Stretch="UniformToFill" />
                             </Grid>
                             <TextBlock
-                                    Grid.Column="1"
-                                    VerticalAlignment="Center"
-                                    Text="{x:Bind Name}"
-                                    TextTrimming="CharacterEllipsis"
-                                    TextWrapping="NoWrap" />
+                                Grid.Column="1"
+                                VerticalAlignment="Center"
+                                Text="{x:Bind Name}"
+                                TextTrimming="CharacterEllipsis"
+                                TextWrapping="NoWrap" />
                             <TextBlock
-                                    Grid.Column="2"
-                                    VerticalAlignment="Center"
-                                    FontSize="12"
-                                    Text="{x:Bind RecentPath}"
-                                    TextTrimming="CharacterEllipsis"
-                                    TextWrapping="NoWrap" />
+                                Grid.Column="2"
+                                VerticalAlignment="Center"
+                                FontSize="12"
+                                Text="{x:Bind RecentPath}"
+                                TextTrimming="CharacterEllipsis"
+                                TextWrapping="NoWrap" />
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>

--- a/src/Files/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -40,6 +40,8 @@ namespace Files.UserControls.Widgets
 
         public string AutomationProperties => "RecentFilesWidgetAutomationProperties/Name".GetLocalized();
 
+        public string WidgetHeader => "RecentFiles".GetLocalized();
+
         public bool IsWidgetSettingEnabled => UserSettingsService.WidgetsSettingsService.ShowRecentFilesWidget;
 
         public RecentFilesWidget()

--- a/src/Files/UserControls/Widgets/WidgetsListControl.xaml
+++ b/src/Files/UserControls/Widgets/WidgetsListControl.xaml
@@ -37,7 +37,7 @@
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="vm:WidgetsListControlItemViewModel">
                         <Grid AutomationProperties.Name="{x:Bind WidgetAutomationProperties, Mode=OneWay}">
-                            <controls:Expander Header="{x:Bind WidgetItemModel.WidgetHeader, Mode=OneWay}" Padding="16,0,16,0"
+                            <controls:Expander IsExpanded="True" Header="{x:Bind WidgetItemModel.WidgetHeader, Mode=OneWay}" Padding="16,0,16,0"
                                 HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
                                 <controls:Expander.Resources>
                                     <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent"/>
@@ -49,7 +49,7 @@
                                     <x:Double x:Key="ExpanderMinHeight">0</x:Double>
                                     <Thickness x:Key="ExpanderContentPadding">0</Thickness>
                                 </controls:Expander.Resources>
-                                <ContentControl Content="{x:Bind WidgetControl, Mode=OneWay}"/>
+                                <ContentControl Content="{x:Bind WidgetControl, Mode=OneWay}" HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch"/>
                             </controls:Expander>
                         </Grid>
                     </DataTemplate>

--- a/src/Files/UserControls/Widgets/WidgetsListControl.xaml
+++ b/src/Files/UserControls/Widgets/WidgetsListControl.xaml
@@ -2,10 +2,11 @@
     x:Class="Files.UserControls.Widgets.WidgetsListControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Files.UserControls.Widgets"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:vm="using:Files.ViewModels.Widgets" xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:vm="using:Files.ViewModels.Widgets"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -37,19 +38,26 @@
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="vm:WidgetsListControlItemViewModel">
                         <Grid AutomationProperties.Name="{x:Bind WidgetAutomationProperties, Mode=OneWay}">
-                            <controls:Expander IsExpanded="True" Header="{x:Bind WidgetItemModel.WidgetHeader, Mode=OneWay}" Padding="16,0,16,0"
-                                HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+                            <controls:Expander
+                                Padding="16,0,16,0"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                Header="{x:Bind WidgetItemModel.WidgetHeader, Mode=OneWay}"
+                                IsExpanded="True">
                                 <controls:Expander.Resources>
-                                    <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent"/>
-                                    <SolidColorBrush x:Key="ExpanderHeaderBorderBrush" Color="Transparent"/>
-                                    <SolidColorBrush x:Key="ExpanderHeaderBorderPointerOverBrush" Color="Transparent"/>
-                                    <SolidColorBrush x:Key="ExpanderHeaderBorderPressedBrush" Color="Transparent"/>
-                                    <SolidColorBrush x:Key="ExpanderContentBackground" Color="Transparent"/>
-                                    <SolidColorBrush x:Key="ExpanderContentBorderBrush" Color="Transparent"/>
+                                    <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent" />
+                                    <SolidColorBrush x:Key="ExpanderHeaderBorderBrush" Color="Transparent" />
+                                    <SolidColorBrush x:Key="ExpanderHeaderBorderPointerOverBrush" Color="Transparent" />
+                                    <SolidColorBrush x:Key="ExpanderHeaderBorderPressedBrush" Color="Transparent" />
+                                    <SolidColorBrush x:Key="ExpanderContentBackground" Color="Transparent" />
+                                    <SolidColorBrush x:Key="ExpanderContentBorderBrush" Color="Transparent" />
                                     <x:Double x:Key="ExpanderMinHeight">0</x:Double>
                                     <Thickness x:Key="ExpanderContentPadding">0</Thickness>
                                 </controls:Expander.Resources>
-                                <ContentControl Content="{x:Bind WidgetControl, Mode=OneWay}" HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch"/>
+                                <ContentControl
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Stretch"
+                                    Content="{x:Bind WidgetControl, Mode=OneWay}" />
                             </controls:Expander>
                         </Grid>
                     </DataTemplate>

--- a/src/Files/UserControls/Widgets/WidgetsListControl.xaml
+++ b/src/Files/UserControls/Widgets/WidgetsListControl.xaml
@@ -43,7 +43,7 @@
                                 HorizontalAlignment="Stretch"
                                 HorizontalContentAlignment="Stretch"
                                 Header="{x:Bind WidgetItemModel.WidgetHeader, Mode=OneWay}"
-                                IsExpanded="True">
+                                IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}">
                                 <controls:Expander.Resources>
                                     <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent" />
                                     <SolidColorBrush x:Key="ExpanderHeaderBorderBrush" Color="Transparent" />

--- a/src/Files/UserControls/Widgets/WidgetsListControl.xaml
+++ b/src/Files/UserControls/Widgets/WidgetsListControl.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Files.UserControls.Widgets"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:vm="using:Files.ViewModels.Widgets"
+    xmlns:vm="using:Files.ViewModels.Widgets" xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -18,7 +18,7 @@
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
                         <!--  Spacing  -->
-                        <Setter Property="Margin" Value="14" />
+                        <Setter Property="Margin" Value="4" />
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate TargetType="ListViewItem">
@@ -37,7 +37,20 @@
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="vm:WidgetsListControlItemViewModel">
                         <Grid AutomationProperties.Name="{x:Bind WidgetAutomationProperties, Mode=OneWay}">
-                            <ContentControl Content="{x:Bind WidgetControl, Mode=OneWay}" />
+                            <controls:Expander Header="{x:Bind WidgetItemModel.WidgetHeader, Mode=OneWay}" Padding="16,0,16,0"
+                                HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
+                                <controls:Expander.Resources>
+                                    <SolidColorBrush x:Key="ExpanderHeaderBackground" Color="Transparent"/>
+                                    <SolidColorBrush x:Key="ExpanderHeaderBorderBrush" Color="Transparent"/>
+                                    <SolidColorBrush x:Key="ExpanderHeaderBorderPointerOverBrush" Color="Transparent"/>
+                                    <SolidColorBrush x:Key="ExpanderHeaderBorderPressedBrush" Color="Transparent"/>
+                                    <SolidColorBrush x:Key="ExpanderContentBackground" Color="Transparent"/>
+                                    <SolidColorBrush x:Key="ExpanderContentBorderBrush" Color="Transparent"/>
+                                    <x:Double x:Key="ExpanderMinHeight">0</x:Double>
+                                    <Thickness x:Key="ExpanderContentPadding">0</Thickness>
+                                </controls:Expander.Resources>
+                                <ContentControl Content="{x:Bind WidgetControl, Mode=OneWay}"/>
+                            </controls:Expander>
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>

--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -1379,7 +1379,7 @@ namespace Files.ViewModels
                             {
                                 filesAndFolders.Add(listedItem);
                             }
-                            if (count == 32 || count == folderContentsList.Count - 1 || sampler.CheckNow())
+                            if (count == folderContentsList.Count - 1 || sampler.CheckNow())
                             {
                                 await OrderFilesAndFoldersAsync();
                                 await ApplyFilesAndFoldersChangesAsync();
@@ -1453,7 +1453,7 @@ namespace Files.ViewModels
                         {
                             filesAndFolders.Add(new FtpItem(list[i], path, returnformat));
 
-                            if (i == 32 || i == list.Length - 1 || sampler.CheckNow())
+                            if ( i == list.Length - 1 || sampler.CheckNow())
                             {
                                 await OrderFilesAndFoldersAsync();
                                 await ApplyFilesAndFoldersChangesAsync();

--- a/src/Files/ViewModels/Widgets/IWidgetItemModel.cs
+++ b/src/Files/ViewModels/Widgets/IWidgetItemModel.cs
@@ -6,6 +6,8 @@ namespace Files.ViewModels.Widgets
     {
         string WidgetName { get; }
 
+        string WidgetHeader { get; }
+
         string AutomationProperties { get; }
 
         bool IsWidgetSettingEnabled { get; }

--- a/src/Files/ViewModels/Widgets/WidgetsListControlItemViewModel.cs
+++ b/src/Files/ViewModels/Widgets/WidgetsListControlItemViewModel.cs
@@ -1,21 +1,36 @@
-﻿using Microsoft.Toolkit.Mvvm.ComponentModel;
-using System;
+﻿using System;
+using Microsoft.Toolkit.Mvvm.ComponentModel;
 
 namespace Files.ViewModels.Widgets
 {
     public class WidgetsListControlItemViewModel : ObservableObject, IDisposable
     {
-        private object widgetControl;
+        private readonly Action<bool> _expanderValueChangedCallback;
 
+        private readonly Func<bool> _expanderValueRequestedCallback;
+
+        private object _WidgetControl;
         public object WidgetControl
         {
-            get => widgetControl;
-            set => SetProperty(ref widgetControl, value);
+            get => _WidgetControl;
+            set => SetProperty(ref _WidgetControl, value);
         }
 
-        public WidgetsListControlItemViewModel(object widgetControl)
+        public WidgetsListControlItemViewModel(object widgetControl, Action<bool> expanderValueChangedCallback, Func<bool> expanderValueRequestedCallback)
         {
             this.WidgetControl = widgetControl;
+            this._expanderValueChangedCallback = expanderValueChangedCallback;
+            this._expanderValueRequestedCallback = expanderValueRequestedCallback;
+        }
+
+        public bool IsExpanded
+        {
+            get => _expanderValueRequestedCallback?.Invoke() ?? true;
+            set
+            {
+                _expanderValueChangedCallback?.Invoke(value);
+                OnPropertyChanged();
+            }
         }
 
         public IWidgetItemModel WidgetItemModel

--- a/src/Files/Views/CustomFolderIcons.xaml
+++ b/src/Files/Views/CustomFolderIcons.xaml
@@ -66,7 +66,7 @@
             </GridView.ItemsPanel>
             <GridView.ItemTemplate>
                 <DataTemplate x:DataType="common:IconFileInfo">
-                    <Grid Height="32" Width="32" >
+                    <Grid Width="32" Height="32">
                         <Image UserControls:ImageFromBytes.SourceBytes="{x:Bind IconDataBytes, Mode=OneWay}" />
                     </Grid>
                 </DataTemplate>

--- a/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -234,10 +234,7 @@
                     Visibility="{x:Bind FolderSettings.IsLayoutModeChanging, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
                     <ListView.ItemContainerTransitions>
                         <TransitionCollection>
-                            <AddDeleteThemeTransition />
-                            <!--<ContentThemeTransition />-->
-                            <ReorderThemeTransition />
-                            <EntranceThemeTransition IsStaggeringEnabled="False" />
+                            <ContentThemeTransition />
                         </TransitionCollection>
                     </ListView.ItemContainerTransitions>
                     <ListView.Header>
@@ -911,6 +908,11 @@
                     HorizontalAlignment="Stretch"
                     ItemsSource="{x:Bind CollectionViewSource.View.CollectionGroups, Mode=OneWay}"
                     SelectionMode="None">
+                    <ListView.ItemContainerTransitions>
+                        <TransitionCollection>
+                            <ContentThemeTransition />
+                        </TransitionCollection>
+                    </ListView.ItemContainerTransitions>
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="ICollectionViewGroup">
                             <StackPanel

--- a/src/Files/Views/MainPage.xaml
+++ b/src/Files/Views/MainPage.xaml
@@ -377,8 +377,9 @@
 
                 <ContentPresenter
                     Grid.Row="1"
-                    Grid.Column="0" HorizontalContentAlignment="Stretch"
+                    Grid.Column="0"
                     HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Stretch"
                     Content="{x:Bind ((viewmodels:MainPageViewModel)DataContext).SelectedTabItem.Control, Mode=OneWay}" />
 
                 <controls:PreviewPane

--- a/src/Files/Views/MainPage.xaml
+++ b/src/Files/Views/MainPage.xaml
@@ -377,7 +377,7 @@
 
                 <ContentPresenter
                     Grid.Row="1"
-                    Grid.Column="0"
+                    Grid.Column="0" HorizontalContentAlignment="Stretch"
                     HorizontalAlignment="Stretch"
                     Content="{x:Bind ((viewmodels:MainPageViewModel)DataContext).SelectedTabItem.Control, Mode=OneWay}" />
 

--- a/src/Files/Views/Pages/PropertiesGeneral.xaml
+++ b/src/Files/Views/Pages/PropertiesGeneral.xaml
@@ -74,20 +74,24 @@
                     ItemSize="80"
                     ViewModel="{x:Bind ViewModel}" />
             </Grid>
-            <StackPanel Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left">
-            <TextBox
-                x:Name="ItemFileName"
-                x:Uid="PropertiesItemFileName"
-                Style="{StaticResource PropertyValueTextBox}"
-                Text="{x:Bind ViewModel.ItemName, Mode=TwoWay}"
-                Visibility="{x:Bind ViewModel.ItemNameVisibility, Mode=OneWay}" />
-            <TextBlock
-                x:Name="itemFilesAndFoldersCountValueTop"
-                Style="{StaticResource PropertyValueTextBlock}"
-                Text="{x:Bind ViewModel.FilesAndFoldersCountString, Mode=OneWay}"
-                Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
+            <StackPanel
+                Grid.Row="0"
+                Grid.Column="1"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center">
+                <TextBox
+                    x:Name="ItemFileName"
+                    x:Uid="PropertiesItemFileName"
+                    Style="{StaticResource PropertyValueTextBox}"
+                    Text="{x:Bind ViewModel.ItemName, Mode=TwoWay}"
+                    Visibility="{x:Bind ViewModel.ItemNameVisibility, Mode=OneWay}" />
+                <TextBlock
+                    x:Name="itemFilesAndFoldersCountValueTop"
+                    Style="{StaticResource PropertyValueTextBlock}"
+                    Text="{x:Bind ViewModel.FilesAndFoldersCountString, Mode=OneWay}"
+                    Visibility="{x:Bind ViewModel.FilesAndFoldersCountVisibility, Mode=OneWay}" />
             </StackPanel>
-                <MenuFlyoutSeparator
+            <MenuFlyoutSeparator
                 Grid.Row="1"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"

--- a/src/Files/Views/Pages/PropertiesShortcut.xaml
+++ b/src/Files/Views/Pages/PropertiesShortcut.xaml
@@ -90,9 +90,9 @@
                 x:Name="shortcutItemPathValue"
                 Grid.Row="3"
                 Grid.Column="1"
+                IsReadOnly="{x:Bind ViewModel.IsShortcutItemPathReadOnly, Mode=OneWay}"
                 Style="{StaticResource PropertyValueTextBox}"
                 Text="{x:Bind ViewModel.ShortcutItemPath, Mode=TwoWay}"
-                IsReadOnly="{x:Bind ViewModel.IsShortcutItemPathReadOnly, Mode=OneWay}"
                 Visibility="Visible" />
 
             <TextBlock

--- a/src/Files/Views/SettingsPages/About.xaml
+++ b/src/Files/Views/SettingsPages/About.xaml
@@ -262,14 +262,12 @@
                 </Button>
             </local:SettingsBlockControl>
 
-            <local:SettingsBlockControl
-                Title="{helpers:ResourceString Name=ThirdPartyLicenses}"
-                HorizontalAlignment="Stretch">
+            <local:SettingsBlockControl Title="{helpers:ResourceString Name=ThirdPartyLicenses}" HorizontalAlignment="Stretch">
                 <local:SettingsBlockControl.Icon>
                     <FontIcon Glyph="&#xE99A;" />
                 </local:SettingsBlockControl.Icon>
                 <local:SettingsBlockControl.ExpandableContent>
-                    <StackPanel Spacing="4" Padding="4">
+                    <StackPanel Padding="4" Spacing="4">
                         <HyperlinkButton
                             AutomationProperties.Name="QuickLook"
                             Content="QuickLook"

--- a/src/Files/Views/SettingsPages/Experimental.xaml
+++ b/src/Files/Views/SettingsPages/Experimental.xaml
@@ -73,9 +73,7 @@
                 </local:SettingsBlockControl.ExpandableContent>
             </local:SettingsBlockControl>
 
-            <local:SettingsBlockControl
-                Title="{helpers:ResourceString Name=ShowFolderSize}"
-                HorizontalAlignment="Stretch">
+            <local:SettingsBlockControl Title="{helpers:ResourceString Name=ShowFolderSize}" HorizontalAlignment="Stretch">
                 <local:SettingsBlockControl.Icon>
                     <FontIcon Glyph="&#xE2B2;" />
                 </local:SettingsBlockControl.Icon>
@@ -88,12 +86,16 @@
                 FontWeight="Medium"
                 Text="{helpers:ResourceString Name=SettingsDefaultFilesManager}" />
 
-            <local:SettingsBlockControl Description="{helpers:ResourceString Name=SettingsSetAsDefaultFileManagerDescription}" Title="{helpers:ResourceString Name=SettingsSetAsDefaultFileManager}" HorizontalAlignment="Stretch">
+            <local:SettingsBlockControl
+                Title="{helpers:ResourceString Name=SettingsSetAsDefaultFileManager}"
+                HorizontalAlignment="Stretch"
+                Description="{helpers:ResourceString Name=SettingsSetAsDefaultFileManagerDescription}">
                 <local:SettingsBlockControl.Icon>
                     <FontIcon Glyph="&#xEC50;" />
                 </local:SettingsBlockControl.Icon>
-                <ToggleSwitch AutomationProperties.Name="{helpers:ResourceString Name=SettingsSetAsDefaultFileManager}"
-                    IsOn="{Binding IsSetAsDefaultFileManager, Mode=TwoWay}" 
+                <ToggleSwitch
+                    AutomationProperties.Name="{helpers:ResourceString Name=SettingsSetAsDefaultFileManager}"
+                    IsOn="{Binding IsSetAsDefaultFileManager, Mode=TwoWay}"
                     Style="{StaticResource RightAlignedToggleSwitchStyle}">
                     <i:Interaction.Behaviors>
                         <icore:EventTriggerBehavior EventName="Toggled">

--- a/src/Files/Views/SettingsPages/Preferences.xaml
+++ b/src/Files/Views/SettingsPages/Preferences.xaml
@@ -72,7 +72,7 @@
                     ItemsSource="{Binding DateFormats}"
                     SelectedIndex="{Binding SelectedDateFormatIndex, Mode=TwoWay}" />
             </local:SettingsBlockControl>
-            
+
             <local:SettingsBlockControl
                 x:Uid="SettingsPreferencesTerminalApplications"
                 Title="Terminal applications"

--- a/src/Files/Views/WidgetsPage.xaml.cs
+++ b/src/Files/Views/WidgetsPage.xaml.cs
@@ -21,6 +21,8 @@ namespace Files.Views
     {
         private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
 
+        private IWidgetsSettingsService WidgetsSettingsService { get; } = Ioc.Default.GetService<IWidgetsSettingsService>();
+
         private IShellPage AppInstance = null;
         public FolderSettingsViewModel FolderSettings => AppInstance?.InstanceViewModel.FolderSettings;
 
@@ -67,7 +69,7 @@ namespace Files.Views
 
             if (shouldReloadFolderWidget && folderWidget != null)
             {
-                Widgets.ViewModel.InsertWidget(new(folderWidget), 0);
+                Widgets.ViewModel.InsertWidget(new(folderWidget, (value) => WidgetsSettingsService.FoldersWidgetExpanded = value, () => WidgetsSettingsService.FoldersWidgetExpanded), 0);
 
                 folderWidget.LibraryCardInvoked -= FolderWidget_LibraryCardInvoked;
                 folderWidget.LibraryCardNewPaneInvoked -= FolderWidget_LibraryCardNewPaneInvoked;
@@ -80,7 +82,7 @@ namespace Files.Views
             }
             if (shouldReloadDrivesWidget && drivesWidget != null)
             {
-                Widgets.ViewModel.InsertWidget(new(drivesWidget), 1);
+                Widgets.ViewModel.InsertWidget(new(drivesWidget, (value) => WidgetsSettingsService.DrivesWidgetExpanded = value, () => WidgetsSettingsService.DrivesWidgetExpanded), 1);
 
                 drivesWidget.AppInstance = AppInstance;
                 drivesWidget.DrivesWidgetInvoked -= DrivesWidget_DrivesWidgetInvoked;
@@ -90,12 +92,12 @@ namespace Files.Views
             }
             if (shouldReloadBundles && bundlesWidget != null)
             {
-                Widgets.ViewModel.InsertWidget(new(bundlesWidget), 2);
+                Widgets.ViewModel.InsertWidget(new(bundlesWidget, (value) => WidgetsSettingsService.BundlesWidgetExpanded = value, () => WidgetsSettingsService.BundlesWidgetExpanded), 2);
                 ViewModel.LoadBundlesCommand.Execute(bundlesWidget.ViewModel);
             }
             if (shouldReloadRecentFiles && recentFilesWidget != null)
             {
-                Widgets.ViewModel.InsertWidget(new(recentFilesWidget), 3);
+                Widgets.ViewModel.InsertWidget(new(recentFilesWidget, (value) => WidgetsSettingsService.RecentFilesWidgetExpanded = value, () => WidgetsSettingsService.RecentFilesWidgetExpanded), 3);
 
                 recentFilesWidget.RecentFilesOpenLocationInvoked -= RecentFilesWidget_RecentFilesOpenLocationInvoked;
                 recentFilesWidget.RecentFileInvoked -= RecentFilesWidget_RecentFileInvoked;


### PR DESCRIPTION
**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Known issues**
Additional options flyout overlaps with content. The solution is to move the flyout to the expander header. Support should also be added to keep track of the expanded state.

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/39923744/145895117-da01ac06-1d9a-4d61-a7a9-28ae19ff9e48.png)
