### PR TITLE
Fix right pane being always loaded

### DIFF
--- a/src/Files/Views/PaneHolderPage.xaml
+++ b/src/Files/Views/PaneHolderPage.xaml
@@ -60,38 +60,32 @@
                     Width="0"
                     MinWidth="0" />
             </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
 
-            <local:ModernShellPage
-                x:Name="PaneLeft"
-                Grid.Row="1"
-                BorderBrush="{ThemeResource ControlStrokeColorDefault}"
-                ContentChanged="Pane_ContentChanged"
-                CurrentInstanceBorderThickness="0,0,0,1"
-                IsPageMainPane="True"
-                Loaded="PaneLeft_Loaded"
-                NavParams="{x:Bind NavParamsLeft, Mode=OneWay}"
-                PaneHolder="{x:Bind}" />
+            <Border x:Name="PaneLeftBorder">
+                <local:ModernShellPage
+                    x:Name="PaneLeft"
+                    ContentChanged="Pane_ContentChanged"
+                    IsPageMainPane="True"
+                    Loaded="PaneLeft_Loaded"
+                    NavParams="{x:Bind NavParamsLeft, Mode=OneWay}"
+                    PaneHolder="{x:Bind}" />
+            </Border>
 
-            <local:ModernShellPage
-                x:Name="PaneRight"
-                Grid.Row="1"
+            <Border
+                x:Name="PaneRightBorder"
                 Grid.Column="1"
-                x:Load="{x:Bind IsRightPaneVisible, Mode=OneWay}"
-                BorderBrush="{ThemeResource ControlStrokeColorDefault}"
-                ContentChanged="Pane_ContentChanged"
-                CurrentInstanceBorderThickness="0,0,0,1"
-                IsPageMainPane="False"
-                Loaded="PaneRight_Loaded"
-                NavParams="{x:Bind NavParamsRight, Mode=OneWay}"
-                PaneHolder="{x:Bind}" />
+                x:Load="{x:Bind IsRightPaneVisible, Mode=OneWay}">
+                <local:ModernShellPage
+                    x:Name="PaneRight"
+                    ContentChanged="Pane_ContentChanged"
+                    IsPageMainPane="False"
+                    Loaded="PaneRight_Loaded"
+                    NavParams="{x:Bind NavParamsRight, Mode=OneWay}"
+                    PaneHolder="{x:Bind}" />
+            </Border>
 
             <Custom:GridSplitter
                 x:Name="PaneResizer"
-                Grid.Row="1"
                 Grid.Column="1"
                 Width="5"
                 MinWidth="5"

--- a/src/Files/Views/PaneHolderPage.xaml.cs
+++ b/src/Files/Views/PaneHolderPage.xaml.cs
@@ -284,7 +284,7 @@ namespace Files.Views
                 InitialPageType = typeof(PaneHolderPage),
                 NavigationArg = new PaneNavigationArguments()
                 {
-                    LeftPaneNavPathParam = e.NavigationArg as string ?? PaneLeft.TabItemArguments?.NavigationArg as string,
+                    LeftPaneNavPathParam = e?.NavigationArg as string ?? PaneLeft.TabItemArguments?.NavigationArg as string,
                     RightPaneNavPathParam = IsRightPaneVisible ? PaneRight?.TabItemArguments?.NavigationArg as string : null
                 }
             };


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue for which the secondary pane always gets loaded (even if it's closed)
- Fixes an issue where cycling elements with Tab key selects some invisible elements

**Details of Changes**
Add details of changes here.
- x:Load does not work on Page / UserControl elements, so add a Border around it and apply x:Load to that

**Validation**
How did you test these changes?
- [x] Built and ran the app
