### PR TITLE
Fix wrong resources

### DIFF
--- a/src/Files/Enums/LocalizedEnum.cs
+++ b/src/Files/Enums/LocalizedEnum.cs
@@ -5,7 +5,19 @@ namespace Files.Enums
 {
     public class LocalizedEnum<T> where T : Enum
     {
-        public string Name => $"{typeof(T).Name}_{Enum.GetName(typeof(T), Value)}".GetLocalized();
+        public string Name
+        {
+            get
+            {
+                var localized = $"{typeof(T).Name}_{Enum.GetName(typeof(T), Value)}".GetLocalized();
+                if (string.IsNullOrEmpty(localized))
+                {
+                    localized = $"{Enum.GetName(typeof(T), Value)}".GetLocalized();
+                }
+                return localized;
+            }
+        }
+
         public T Value { get; set; }
 
         public LocalizedEnum(T value)

--- a/src/Files/MultilingualResources/Files.af.xlf
+++ b/src/Files/MultilingualResources/Files.af.xlf
@@ -3432,9 +3432,13 @@ Ons gebruik App Center om tred te hou met programgebruik, foute te vind en ongel
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.ar.xlf
+++ b/src/Files/MultilingualResources/Files.ar.xlf
@@ -3456,9 +3456,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.ca.xlf
+++ b/src/Files/MultilingualResources/Files.ca.xlf
@@ -3436,9 +3436,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.cs-CZ.xlf
+++ b/src/Files/MultilingualResources/Files.cs-CZ.xlf
@@ -3467,9 +3467,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.da-DK.xlf
+++ b/src/Files/MultilingualResources/Files.da-DK.xlf
@@ -3459,9 +3459,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.da.xlf
+++ b/src/Files/MultilingualResources/Files.da.xlf
@@ -3457,9 +3457,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.de-DE.xlf
+++ b/src/Files/MultilingualResources/Files.de-DE.xlf
@@ -3435,9 +3435,13 @@ Wir benutzen das App Center, um einen Überblick über die Nutzung von Files zu 
           <source>Show folder size</source>
           <target state="translated">Ordnergröße anzeigen</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="translated">Überspringen</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.el.xlf
+++ b/src/Files/MultilingualResources/Files.el.xlf
@@ -3435,9 +3435,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.en-GB.xlf
+++ b/src/Files/MultilingualResources/Files.en-GB.xlf
@@ -3432,9 +3432,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="translated">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="translated">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.es-419.xlf
+++ b/src/Files/MultilingualResources/Files.es-419.xlf
@@ -3436,9 +3436,13 @@ Usamos App Center para realizar un seguimiento del uso de la aplicación, encont
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.es-ES.xlf
+++ b/src/Files/MultilingualResources/Files.es-ES.xlf
@@ -3435,9 +3435,13 @@ Utilizamos App Center para hacer un seguimiento del uso de la aplicación, encon
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/src/Files/MultilingualResources/Files.fr-FR.xlf
@@ -3434,9 +3434,13 @@ Nous utilisons l'App Center pour suivre l'utilisation de l'application, trouver 
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.he-IL.xlf
+++ b/src/Files/MultilingualResources/Files.he-IL.xlf
@@ -3444,9 +3444,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.hi-IN.xlf
+++ b/src/Files/MultilingualResources/Files.hi-IN.xlf
@@ -3451,9 +3451,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.hr-HR.xlf
+++ b/src/Files/MultilingualResources/Files.hr-HR.xlf
@@ -3433,9 +3433,13 @@ Koristimo App Center za praćenje korištenja aplikacija, pronalaženje grešaka
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.hu-HU.xlf
+++ b/src/Files/MultilingualResources/Files.hu-HU.xlf
@@ -3435,9 +3435,13 @@ Az App Center szolgáltatásait használjuk az app használatának monitorozás�
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.id-ID.xlf
+++ b/src/Files/MultilingualResources/Files.id-ID.xlf
@@ -3435,9 +3435,13 @@ Kami menggunakan App Center untuk melacak penggunaan aplikasi, menemukan bug, da
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.it-IT.xlf
+++ b/src/Files/MultilingualResources/Files.it-IT.xlf
@@ -3436,9 +3436,13 @@ Usiamo App Center per tenere traccia dell'utilizzo dell'app, trovare bug e risol
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.it-IT.xlf
+++ b/src/Files/MultilingualResources/Files.it-IT.xlf
@@ -1372,8 +1372,7 @@
         </trans-unit>
         <trans-unit id="SettingsAboutSupportUsListViewItem.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Support us on GitHub</source>
-          <target state="needs-review-translation">Supportaci su PayPal</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="translated">Supportaci su GitHub</target>
         </trans-unit>
         <trans-unit id="Details" translate="yes" xml:space="preserve">
           <source>Details</source>
@@ -2814,8 +2813,7 @@
         </trans-unit>
         <trans-unit id="SettingsSearchUnindexedItems" translate="yes" xml:space="preserve">
           <source>Show unindexed items when searching for files and folders</source>
-          <target state="needs-review-translation">Mostra elementi non indicizzati durante la ricerca (richiede più tempo)</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="translated">Mostra elementi non indicizzati durante la ricerca</target>
         </trans-unit>
         <trans-unit id="SettingsEnableLayoutPreferencesPerFolder" translate="yes" xml:space="preserve">
           <source>Enable individual preferences for individual directories</source>
@@ -3366,83 +3364,83 @@ Usiamo App Center per tenere traccia dell'utilizzo dell'app, trovare bug e risol
         </trans-unit>
         <trans-unit id="SettingsDefaultFilesManager" translate="yes" xml:space="preserve">
           <source>Default file manager</source>
-          <target state="new">Default file manager</target>
+          <target state="translated">Gestore file predefinito</target>
         </trans-unit>
         <trans-unit id="SettingsSetAsDefaultFileManager" translate="yes" xml:space="preserve">
           <source>Set Files as the default file manager</source>
-          <target state="new">Set Files as the default file manager</target>
+          <target state="translated">Imposta Files come gestore file predefinito</target>
         </trans-unit>
         <trans-unit id="EmptyRecycleBin" translate="yes" xml:space="preserve">
           <source>Empty Recycle Bin</source>
-          <target state="new">Empty Recycle Bin</target>
+          <target state="translated">Svuota il Cestino</target>
         </trans-unit>
         <trans-unit id="Sidebar" translate="yes" xml:space="preserve">
           <source>Sidebar</source>
-          <target state="new">Sidebar</target>
+          <target state="translated">Barra laterale</target>
         </trans-unit>
         <trans-unit id="FilesAndFolders" translate="yes" xml:space="preserve">
           <source>Files and folders</source>
-          <target state="new">Files and folders</target>
+          <target state="translated">File e cartelle</target>
         </trans-unit>
         <trans-unit id="OpenNewInstance" translate="yes" xml:space="preserve">
           <source>Open new instance when opening directories from the taskbar jumplist</source>
-          <target state="new">Open new instance when opening directories from the taskbar jumplist</target>
+          <target state="translated">Apri una nuova instanza quando si apre una cartella dalla barra delle applicazioni</target>
         </trans-unit>
         <trans-unit id="StartupSettings" translate="yes" xml:space="preserve">
           <source>Startup settings</source>
-          <target state="new">Startup settings</target>
+          <target state="translated">Impostazioni di Avvio</target>
         </trans-unit>
         <trans-unit id="ThirdPartyLicenses" translate="yes" xml:space="preserve">
           <source>Third party licenses</source>
-          <target state="new">Third party licenses</target>
+          <target state="translated">Licenze di terze parti</target>
         </trans-unit>
         <trans-unit id="SettingsSetAsDefaultFileManagerDescription" translate="yes" xml:space="preserve">
           <source>This setting modifies system files and can have unexpected side effects on your device. The developers take no responsibility in the event an issue occurs as a result. Continuing with this option is an acknowledgment of the risks involved with this action. Please note, uninstalling Files will not undo these changes and may prevent you from opening file explorer unless you turn off this setting before removing Files from your device.</source>
-          <target state="new">This setting modifies system files and can have unexpected side effects on your device. The developers take no responsibility in the event an issue occurs as a result. Continuing with this option is an acknowledgment of the risks involved with this action. Please note, uninstalling Files will not undo these changes and may prevent you from opening file explorer unless you turn off this setting before removing Files from your device.</target>
+          <target state="translated">Questa impostazione modifica file di sistema e può causare effetti indesiderati sul tuo dispositivo. Gli sviluppatori non si assumono alcuna responsabilità. Continuando con questa opzione si accettano i rischi legati ad essa. Da notare che disinstallare Files non annulla questa modifica e potrebbe causare l'impossibilità di aprire Esplora Risorse, ricorda di disattivare questa opzione prima di disinstallare Files!</target>
         </trans-unit>
         <trans-unit id="ClearAll" translate="yes" xml:space="preserve">
           <source>Clear all</source>
-          <target state="new">Clear all</target>
+          <target state="translated">Rimuovi tutto</target>
         </trans-unit>
         <trans-unit id="Columns" translate="yes" xml:space="preserve">
           <source>Columns</source>
-          <target state="new">Columns</target>
+          <target state="translated">Colonne</target>
         </trans-unit>
         <trans-unit id="LargeIcons" translate="yes" xml:space="preserve">
           <source>Large Icons</source>
-          <target state="new">Large Icons</target>
+          <target state="translated">Icone Grandi</target>
         </trans-unit>
         <trans-unit id="MediumIcons" translate="yes" xml:space="preserve">
           <source>Medium Icons</source>
-          <target state="new">Medium Icons</target>
+          <target state="translated">Icone Medie</target>
         </trans-unit>
         <trans-unit id="SmallIcons" translate="yes" xml:space="preserve">
           <source>Small Icons</source>
-          <target state="new">Small Icons</target>
+          <target state="translated">Icone Piccole</target>
         </trans-unit>
         <trans-unit id="Tiles" translate="yes" xml:space="preserve">
           <source>Tiles</source>
-          <target state="new">Tiles</target>
+          <target state="translated">Riquadri</target>
         </trans-unit>
         <trans-unit id="FolderWidgetCreateNewLibraryDialogTitleText" translate="yes" xml:space="preserve">
           <source>Create Library</source>
-          <target state="new">Create Library</target>
+          <target state="translated">Crea Raccolta</target>
         </trans-unit>
         <trans-unit id="FolderWidgetCreateNewLibraryInputPlaceholderText" translate="yes" xml:space="preserve">
           <source>Enter Library name</source>
-          <target state="new">Enter Library name</target>
+          <target state="translated">Inserisci il nome della Raccolta</target>
         </trans-unit>
         <trans-unit id="ShowFolderSize" translate="yes" xml:space="preserve">
           <source>Show folder size</source>
-          <target state="new">Show folder size</target>
+          <target state="translated">Mostra dimensione delle cartelle</target>
         </trans-unit>
         <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
-          <target state="new">Skip</target>
+          <target state="translated">Salta</target>
         </trans-unit>
         <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
           <source>Open Files on Windows Startup</source>
-          <target state="new">Open Files on Windows Startup</target>
+          <target state="translated">Apri Files all'avvio di Windows</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/src/Files/MultilingualResources/Files.ja-JP.xlf
@@ -3433,9 +3433,13 @@ App Centerを使用して、アプリの使用状況を追跡し、バグを見�
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.ka.xlf
+++ b/src/Files/MultilingualResources/Files.ka.xlf
@@ -3435,9 +3435,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.ko-KR.xlf
+++ b/src/Files/MultilingualResources/Files.ko-KR.xlf
@@ -3434,9 +3434,13 @@ Files는 어떤 개인정보도 수집, 저장, 공유, 게시하지 않습니�
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.lv-LV.xlf
+++ b/src/Files/MultilingualResources/Files.lv-LV.xlf
@@ -3434,9 +3434,13 @@ Mēs lietojam App Center, lai sekotu līdzi programmas lietojumam, atrastu un no
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/src/Files/MultilingualResources/Files.nl-NL.xlf
@@ -3451,9 +3451,13 @@ We gebruiken App Center om app-gebruik bij te houden, bugs te vinden en crashes 
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.or-IN.xlf
+++ b/src/Files/MultilingualResources/Files.or-IN.xlf
@@ -3450,9 +3450,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/src/Files/MultilingualResources/Files.pl-PL.xlf
@@ -3439,9 +3439,13 @@ Korzystamy z App Center, aby śledzić wykorzystanie aplikacji, znajdować błę
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.pt-BR.xlf
+++ b/src/Files/MultilingualResources/Files.pt-BR.xlf
@@ -3432,9 +3432,13 @@ Usamos o App Center para controlar o uso do aplicativo, encontrar bugs e corrigi
           <source>Show folder size</source>
           <target state="translated">Mostrar tamanho da pasta</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="translated">Pular</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.pt-PT.xlf
+++ b/src/Files/MultilingualResources/Files.pt-PT.xlf
@@ -3437,9 +3437,13 @@ Nós utilizamos o App Center para acompanhar a utilização da aplicação, enco
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/src/Files/MultilingualResources/Files.ru-RU.xlf
@@ -3437,9 +3437,13 @@ Files не собирает, хранит, распространяет или �
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.sv-SE.xlf
+++ b/src/Files/MultilingualResources/Files.sv-SE.xlf
@@ -3458,9 +3458,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.ta.xlf
+++ b/src/Files/MultilingualResources/Files.ta.xlf
@@ -3434,9 +3434,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/src/Files/MultilingualResources/Files.tr-TR.xlf
@@ -3448,9 +3448,13 @@ Uygulama kullanımını takip etmek, hataları bulmak ve çökmeleri düzeltmek 
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/src/Files/MultilingualResources/Files.uk-UA.xlf
@@ -3457,9 +3457,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.vi.xlf
+++ b/src/Files/MultilingualResources/Files.vi.xlf
@@ -3448,9 +3448,13 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/src/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -3435,9 +3435,13 @@ Files 不收集、存储、共享或发布任何个人信息。
           <source>Show folder size</source>
           <target state="translated">显示文件夹大小</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="translated">跳过</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/MultilingualResources/Files.zh-Hant.xlf
+++ b/src/Files/MultilingualResources/Files.zh-Hant.xlf
@@ -3434,9 +3434,13 @@ Files 不會收集、存儲、共享或發布任何使用者的個資。
           <source>Show folder size</source>
           <target state="new">Show folder size</target>
         </trans-unit>
-        <trans-unit id="ErrorDialogSkip" translate="yes" xml:space="preserve">
+        <trans-unit id="Skip" translate="yes" xml:space="preserve">
           <source>Skip</source>
           <target state="new">Skip</target>
+        </trans-unit>
+        <trans-unit id="SettingsOpenInLogin" translate="yes" xml:space="preserve">
+          <source>Open Files on Windows Startup</source>
+          <target state="new">Open Files on Windows Startup</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files/Strings/de-DE/Resources.resw
+++ b/src/Files/Strings/de-DE/Resources.resw
@@ -205,7 +205,7 @@
     <value>Vorwärts (Alt+Pfeiltaste rechts)</value>
   </data>
   <data name="NavUpButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Hoch (Alt+Pfeiltaste oben)</value>
+    <value>Ebenen nach oben (Alt+Pfeiltaste oben)</value>
   </data>
   <data name="NavRefreshButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Aktualisieren (F5)</value>
@@ -898,7 +898,7 @@
     <value>Jahr</value>
   </data>
   <data name="PropertySectionCore" xml:space="preserve">
-    <value>Kern</value>
+    <value>Haupteigenschaften</value>
   </data>
   <data name="PropertySectionImage" xml:space="preserve">
     <value>Bild</value>
@@ -1330,7 +1330,7 @@
     <value>Die Operation wurde beendet.</value>
   </data>
   <data name="StatusRecycleComplete" xml:space="preserve">
-    <value>Papierkorb geleert</value>
+    <value>Löschen erfolgreich</value>
   </data>
   <data name="StatusMoveComplete" xml:space="preserve">
     <value>Verschiebevorgang abgeschlossen</value>
@@ -1717,19 +1717,19 @@
     <value>Kopiere Objekte</value>
   </data>
   <data name="StatusRecycleFailed" xml:space="preserve">
-    <value>Leeren des Papierkorbes fehlgeschlagen</value>
+    <value>Löschen fehlgeschlagen</value>
   </data>
   <data name="StatusRecycleCancelled" xml:space="preserve">
-    <value>Leeren des Papierkorbes abgebrochen</value>
+    <value>Löschen abgebrochen</value>
   </data>
   <data name="canceling" xml:space="preserve">
     <value>abbrechen</value>
   </data>
   <data name="OngoingTasksDismissBannerButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Ablehnen</value>
+    <value>Verwerfen</value>
   </data>
   <data name="OngoingTasksDismissBannerButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Ablehnen</value>
+    <value>Verwerfen</value>
   </data>
   <data name="NavToolbarWidgets.Label" xml:space="preserve">
     <value>Widgets</value>
@@ -2068,7 +2068,7 @@
     <value>Zwei-Panel-Ansicht aktivieren</value>
   </data>
   <data name="SettingsVerticalTabFlyout" xml:space="preserve">
-    <value>Das Flyout für vert. Tabs in der Titleleiste anzeigen</value>
+    <value>Das Flyout für vertikale Tabs in der Titleleiste anzeigen</value>
   </data>
   <data name="SettingsShowCloudDrivesSection.Title" xml:space="preserve">
     <value>Cloud-Speicher anzeigen</value>
@@ -2101,7 +2101,7 @@
     <value>Sprache</value>
   </data>
   <data name="SettingsFilesAndFoldersShowFileExtensions" xml:space="preserve">
-    <value>Dateitypen in Namen anzeigen</value>
+    <value>Dateinamenerweiterung anzeigen</value>
   </data>
   <data name="SettingsFilesAndFoldersShowHiddenItems" xml:space="preserve">
     <value>Versteckte Dateien und Ordner anzeigen</value>
@@ -2110,7 +2110,7 @@
     <value>Geschützte Systemdateien ausblenden (empfohlen)</value>
   </data>
   <data name="SettingsOpenFilesWithOneClick" xml:space="preserve">
-    <value>Dateien durch durch einfachen Klick öffnen</value>
+    <value>Öffnen durch einfachen Klick</value>
   </data>
   <data name="SettingsListAndSortDirectoriesAlongsideFiles" xml:space="preserve">
     <value>Dateien und Ordner zusammen auflisten und sortieren</value>
@@ -2227,7 +2227,7 @@
     <value>Datumsformat</value>
   </data>
   <data name="SettingsPreferencesShowConfirmDeleteDialog.Title" xml:space="preserve">
-    <value>Einen Bestätigungsdialog vor dem Löschen zeigen</value>
+    <value>Bestätigungsdialog vor dem Löschen anzeigen</value>
   </data>
   <data name="SettingsPreferencesOpenFoldersNewTab.Title" xml:space="preserve">
     <value>Ordner in einem neuen Tab öffnen</value>
@@ -2288,10 +2288,10 @@ Wir benutzen das App Center, um einen Überblick über die Nutzung von Files zu 
     <value>Tag</value>
   </data>
   <data name="SettingsEditFileTagsExpander.Title" xml:space="preserve">
-    <value>Tags ändern</value>
+    <value>Markierung ändern</value>
   </data>
   <data name="SettingsEnableFileTags.Title" xml:space="preserve">
-    <value>Tags anschalten</value>
+    <value>Markierungen anschalten</value>
   </data>
   <data name="InsertDiscDialog.OpenDriveButton" xml:space="preserve">
     <value>Laufwerk öffnen</value>
@@ -2381,7 +2381,7 @@ Wir benutzen das App Center, um einen Überblick über die Nutzung von Files zu 
     <value>WSL-Bereich anzeigen</value>
   </data>
   <data name="SettingsOpenFoldersNewTabToggleSwitch.AutomationProperties.Name" xml:space="preserve">
-    <value>Ordner in neuem Tab öffnen</value>
+    <value>Jeden Ordner in neuem Tab öffnen</value>
   </data>
   <data name="SettingsPreferencesAppLanguageComboBox.AutomationProperties.Name" xml:space="preserve">
     <value>Sprache</value>
@@ -2553,5 +2553,32 @@ Wir benutzen das App Center, um einen Überblick über die Nutzung von Files zu 
   </data>
   <data name="ClearAll" xml:space="preserve">
     <value>Alles löschen</value>
+  </data>
+  <data name="Columns" xml:space="preserve">
+    <value>Spalten</value>
+  </data>
+  <data name="LargeIcons" xml:space="preserve">
+    <value>Große Symbole</value>
+  </data>
+  <data name="MediumIcons" xml:space="preserve">
+    <value>Mittelgroße Symbole</value>
+  </data>
+  <data name="SmallIcons" xml:space="preserve">
+    <value>Kleine Symbole</value>
+  </data>
+  <data name="Tiles" xml:space="preserve">
+    <value>Kacheln</value>
+  </data>
+  <data name="FolderWidgetCreateNewLibraryDialogTitleText" xml:space="preserve">
+    <value>Bibliothek erstellen</value>
+  </data>
+  <data name="FolderWidgetCreateNewLibraryInputPlaceholderText" xml:space="preserve">
+    <value>Bibliotheksnamen eingeben</value>
+  </data>
+  <data name="ShowFolderSize" xml:space="preserve">
+    <value>Ordnergröße anzeigen</value>
+  </data>
+  <data name="Skip" xml:space="preserve">
+    <value>Überspringen</value>
   </data>
 </root>

--- a/src/Files/Strings/en-GB/Resources.resw
+++ b/src/Files/Strings/en-GB/Resources.resw
@@ -1147,7 +1147,7 @@
     <value>Send the developers an issue report with more information</value>
   </data>
   <data name="SettingsAboutSupportUsListViewItem.AutomationProperties.Name" xml:space="preserve">
-    <value>Support us on PayPal</value>
+    <value>Support us on GitHub</value>
   </data>
   <data name="SettingsListAndSortDirectoriesAlongsideFiles" xml:space="preserve">
     <value>List and sort directories alongside files</value>
@@ -2553,5 +2553,32 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
   </data>
   <data name="ClearAll" xml:space="preserve">
     <value>Clear all</value>
+  </data>
+  <data name="Columns" xml:space="preserve">
+    <value>Columns</value>
+  </data>
+  <data name="LargeIcons" xml:space="preserve">
+    <value>Large Icons</value>
+  </data>
+  <data name="MediumIcons" xml:space="preserve">
+    <value>Medium Icons</value>
+  </data>
+  <data name="SmallIcons" xml:space="preserve">
+    <value>Small Icons</value>
+  </data>
+  <data name="Tiles" xml:space="preserve">
+    <value>Tiles</value>
+  </data>
+  <data name="FolderWidgetCreateNewLibraryDialogTitleText" xml:space="preserve">
+    <value>Create Library</value>
+  </data>
+  <data name="FolderWidgetCreateNewLibraryInputPlaceholderText" xml:space="preserve">
+    <value>Enter Library name</value>
+  </data>
+  <data name="ShowFolderSize" xml:space="preserve">
+    <value>Show folder size</value>
+  </data>
+  <data name="Skip" xml:space="preserve">
+    <value>Skip</value>
   </data>
 </root>

--- a/src/Files/Strings/en-US/Resources.resw
+++ b/src/Files/Strings/en-US/Resources.resw
@@ -174,7 +174,7 @@
   <data name="ErrorDialogIsASubfolder" xml:space="preserve">
     <value>is a subfolder of the source folder</value>
   </data>
-  <data name="ErrorDialogSkip" xml:space="preserve">
+  <data name="Skip" xml:space="preserve">
     <value>Skip</value>
   </data>
   <data name="PropertiesItemType.Text" xml:space="preserve">

--- a/src/Files/Strings/it-IT/Resources.resw
+++ b/src/Files/Strings/it-IT/Resources.resw
@@ -1036,7 +1036,7 @@
     <value>Invia agli sviluppatori un rapporto sul problema</value>
   </data>
   <data name="SettingsAboutSupportUsListViewItem.AutomationProperties.Name" xml:space="preserve">
-    <value>Supportaci su PayPal</value>
+    <value>Supportaci su GitHub</value>
   </data>
   <data name="Details" xml:space="preserve">
     <value>Dettagli</value>
@@ -2116,7 +2116,7 @@
     <value>Ordina le cartelle insieme ai file</value>
   </data>
   <data name="SettingsSearchUnindexedItems" xml:space="preserve">
-    <value>Mostra elementi non indicizzati durante la ricerca (richiede più tempo)</value>
+    <value>Mostra elementi non indicizzati durante la ricerca</value>
   </data>
   <data name="SettingsEnableLayoutPreferencesPerFolder" xml:space="preserve">
     <value>Abilita impostazioni personalizzate per ogni cartella</value>
@@ -2523,5 +2523,65 @@ Usiamo App Center per tenere traccia dell'utilizzo dell'app, trovare bug e risol
   </data>
   <data name="UseMainMonitorDPISettings" xml:space="preserve">
     <value>Usa le impostazioni DPI del monitor principale</value>
+  </data>
+  <data name="SettingsDefaultFilesManager" xml:space="preserve">
+    <value>Gestore file predefinito</value>
+  </data>
+  <data name="SettingsSetAsDefaultFileManager" xml:space="preserve">
+    <value>Imposta Files come gestore file predefinito</value>
+  </data>
+  <data name="EmptyRecycleBin" xml:space="preserve">
+    <value>Svuota il Cestino</value>
+  </data>
+  <data name="Sidebar" xml:space="preserve">
+    <value>Barra laterale</value>
+  </data>
+  <data name="FilesAndFolders" xml:space="preserve">
+    <value>File e cartelle</value>
+  </data>
+  <data name="OpenNewInstance" xml:space="preserve">
+    <value>Apri una nuova instanza quando si apre una cartella dalla barra delle applicazioni</value>
+  </data>
+  <data name="StartupSettings" xml:space="preserve">
+    <value>Impostazioni di Avvio</value>
+  </data>
+  <data name="ThirdPartyLicenses" xml:space="preserve">
+    <value>Licenze di terze parti</value>
+  </data>
+  <data name="SettingsSetAsDefaultFileManagerDescription" xml:space="preserve">
+    <value>Questa impostazione modifica file di sistema e può causare effetti indesiderati sul tuo dispositivo. Gli sviluppatori non si assumono alcuna responsabilità. Continuando con questa opzione si accettano i rischi legati ad essa. Da notare che disinstallare Files non annulla questa modifica e potrebbe causare l'impossibilità di aprire Esplora Risorse, ricorda di disattivare questa opzione prima di disinstallare Files!</value>
+  </data>
+  <data name="ClearAll" xml:space="preserve">
+    <value>Rimuovi tutto</value>
+  </data>
+  <data name="Columns" xml:space="preserve">
+    <value>Colonne</value>
+  </data>
+  <data name="LargeIcons" xml:space="preserve">
+    <value>Icone Grandi</value>
+  </data>
+  <data name="MediumIcons" xml:space="preserve">
+    <value>Icone Medie</value>
+  </data>
+  <data name="SmallIcons" xml:space="preserve">
+    <value>Icone Piccole</value>
+  </data>
+  <data name="Tiles" xml:space="preserve">
+    <value>Riquadri</value>
+  </data>
+  <data name="FolderWidgetCreateNewLibraryDialogTitleText" xml:space="preserve">
+    <value>Crea Raccolta</value>
+  </data>
+  <data name="FolderWidgetCreateNewLibraryInputPlaceholderText" xml:space="preserve">
+    <value>Inserisci il nome della Raccolta</value>
+  </data>
+  <data name="ShowFolderSize" xml:space="preserve">
+    <value>Mostra dimensione delle cartelle</value>
+  </data>
+  <data name="Skip" xml:space="preserve">
+    <value>Salta</value>
+  </data>
+  <data name="SettingsOpenInLogin" xml:space="preserve">
+    <value>Apri Files all'avvio di Windows</value>
   </data>
 </root>

--- a/src/Files/Strings/pt-BR/Resources.resw
+++ b/src/Files/Strings/pt-BR/Resources.resw
@@ -991,7 +991,7 @@
     <value>Erro</value>
   </data>
   <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Tentar novamente</value>
+    <value>Repetir</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Fechar mesmo assim</value>
@@ -1036,7 +1036,7 @@
     <value>Envie aos desenvolvedores um relatório de problema com mais informações</value>
   </data>
   <data name="SettingsAboutSupportUsListViewItem.AutomationProperties.Name" xml:space="preserve">
-    <value>Apoie-nos no PayPal</value>
+    <value>Nos apoie no GitHub</value>
   </data>
   <data name="Details" xml:space="preserve">
     <value>Detalhes</value>
@@ -2116,7 +2116,7 @@
     <value>Listar e classificar diretórios ao lado dos arquivos</value>
   </data>
   <data name="SettingsSearchUnindexedItems" xml:space="preserve">
-    <value>Mostrar itens não indexados ao pesquisar arquivos e pastas (as pesquisas podem demorar mais)</value>
+    <value>Mostrar itens não indexados ao pesquisar arquivos e pastas</value>
   </data>
   <data name="SettingsEnableLayoutPreferencesPerFolder" xml:space="preserve">
     <value>Habilite preferências individuais para diretórios individuais</value>
@@ -2473,6 +2473,21 @@ Usamos o App Center para controlar o uso do aplicativo, encontrar bugs e corrigi
   <data name="HighDpiOverride_SystemAdvanced" xml:space="preserve">
     <value>Sistema (avancado)</value>
   </data>
+  <data name="Windows7" xml:space="preserve">
+    <value>Windows 7</value>
+  </data>
+  <data name="Windows8" xml:space="preserve">
+    <value>Windows 8</value>
+  </data>
+  <data name="OSCompatibility_WindowsVista" xml:space="preserve">
+    <value>Windows Vista</value>
+  </data>
+  <data name="OSCompatibility_WindowsVistaSP1" xml:space="preserve">
+    <value>Windows Vista SP1</value>
+  </data>
+  <data name="OSCompatibility_WindowsVistaSP2" xml:space="preserve">
+    <value>Windows Vista SP2</value>
+  </data>
   <data name="ReducedColorMode_Color16Bit" xml:space="preserve">
     <value>Cores de 16 Bits (65536)</value>
   </data>
@@ -2508,5 +2523,62 @@ Usamos o App Center para controlar o uso do aplicativo, encontrar bugs e corrigi
   </data>
   <data name="UseMainMonitorDPISettings" xml:space="preserve">
     <value>Usar o DPI definido para minha tela principal</value>
+  </data>
+  <data name="SettingsDefaultFilesManager" xml:space="preserve">
+    <value>Gerenciador de arquivos padrão</value>
+  </data>
+  <data name="SettingsSetAsDefaultFileManager" xml:space="preserve">
+    <value>Definir o Files como o gerenciador de arquivos padrão</value>
+  </data>
+  <data name="EmptyRecycleBin" xml:space="preserve">
+    <value>Esvaziar a Lixeira</value>
+  </data>
+  <data name="Sidebar" xml:space="preserve">
+    <value>Barra Lateral</value>
+  </data>
+  <data name="FilesAndFolders" xml:space="preserve">
+    <value>Arquivos e pastas</value>
+  </data>
+  <data name="OpenNewInstance" xml:space="preserve">
+    <value>Abrir nova instância ao abrir diretórios da lista de atalhos na barra de tarefas</value>
+  </data>
+  <data name="StartupSettings" xml:space="preserve">
+    <value>Configurações de inicialização</value>
+  </data>
+  <data name="ThirdPartyLicenses" xml:space="preserve">
+    <value>Licenças de terceiros</value>
+  </data>
+  <data name="SettingsSetAsDefaultFileManagerDescription" xml:space="preserve">
+    <value>Esta configuração modifica arquivos do sistema e pode ter efeitos colaterais inesperados no seu dispositivo. Os desenvolvedores não assumem nenhuma responsabilidade no caso de um problema ocorrer como resultado. Continuar com essa opção é um reconhecimento dos riscos envolvidos com essa ação. Observe que a desinstalação de arquivos não desinstalará essas alterações e poderá impedi-lo de abrir o explorador de arquivos, a menos que você desligue esta configuração antes de remover arquivos do seu dispositivo.</value>
+  </data>
+  <data name="ClearAll" xml:space="preserve">
+    <value>Limpar todos</value>
+  </data>
+  <data name="Columns" xml:space="preserve">
+    <value>Colunas</value>
+  </data>
+  <data name="LargeIcons" xml:space="preserve">
+    <value>Ícones Grandes</value>
+  </data>
+  <data name="MediumIcons" xml:space="preserve">
+    <value>Ícones Médios</value>
+  </data>
+  <data name="SmallIcons" xml:space="preserve">
+    <value>Ícones Pequenos</value>
+  </data>
+  <data name="Tiles" xml:space="preserve">
+    <value>Blocos</value>
+  </data>
+  <data name="FolderWidgetCreateNewLibraryDialogTitleText" xml:space="preserve">
+    <value>Criar Biblioteca</value>
+  </data>
+  <data name="FolderWidgetCreateNewLibraryInputPlaceholderText" xml:space="preserve">
+    <value>Digite o nome da Biblioteca</value>
+  </data>
+  <data name="ShowFolderSize" xml:space="preserve">
+    <value>Mostrar tamanho da pasta</value>
+  </data>
+  <data name="Skip" xml:space="preserve">
+    <value>Pular</value>
   </data>
 </root>

--- a/src/Files/Strings/zh-Hans/Resources.resw
+++ b/src/Files/Strings/zh-Hans/Resources.resw
@@ -2581,7 +2581,7 @@ Files 不收集、存储、共享或发布任何个人信息。
   <data name="ShowFolderSize" xml:space="preserve">
     <value>显示文件夹大小</value>
   </data>
-  <data name="ErrorDialogSkip" xml:space="preserve">
+  <data name="Skip" xml:space="preserve">
     <value>跳过</value>
   </data>
 </root>

--- a/src/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files/UserControls/InnerNavigationToolbar.xaml
@@ -462,6 +462,7 @@
                                     Text="{helpers:ResourceString Name=Details}" />
 
                                 <RadioButton
+                                    x:Uid="NavToolbarTiles"
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     Width="36"


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related #issue...

**Details of Changes**
Add details of changes here.
- Fixed resources for "Skip" conflict dialog action
- Fixed fetching translated strings for Compatibility properties page
- Fixed missing translation for "Tiles" option tooltip
- Updated resw
- {Updated [it-IT] translations}

**Validation**
How did you test these changes?
- [x] Built and ran the app
