### PR TITLE
Update Files.de-DE.xlf

### DIFF
--- a/src/Files/MultilingualResources/Files.de-DE.xlf
+++ b/src/Files/MultilingualResources/Files.de-DE.xlf
@@ -3133,15 +3133,15 @@ Wir benutzen das App Center, um einen Überblick über die Nutzung von Files zu 
         </trans-unit>
         <trans-unit id="NavToolbarShowHiddenItems.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show hidden items</source>
-          <target state="translated">Versteckte Dateien und Ordner anzeigen</target>
+          <target state="translated">Versteckte Elemente anzeigen</target>
         </trans-unit>
         <trans-unit id="NavToolbarShowFileExtensions.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show file extensions</source>
-          <target state="translated">Dateiendungen anzeigen</target>
+          <target state="translated">Dateierweiterungen anzeigen</target>
         </trans-unit>
         <trans-unit id="NavToolbarShowHiddenItemsHeader.Text" translate="yes" xml:space="preserve">
           <source>Show hidden items</source>
-          <target state="translated">Versteckte Dateien und Ordner anzeigen</target>
+          <target state="translated">Versteckte Elemente anzeigen</target>
         </trans-unit>
         <trans-unit id="SettingsShowFavoritesSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show favorites section</source>


### PR DESCRIPTION
- Identical text for "Show File Extensions"
- Shortened text for "Show hidden items". The German translation was too long and would overlap the ToggleSwitch next to it