### PR TITLE
Downgrade dotnet SDK to 6.0.100

### DIFF
--- a/builds/azure-pipelines-release.yml
+++ b/builds/azure-pipelines-release.yml
@@ -61,7 +61,7 @@ jobs:
   - task: UseDotNet@2
     inputs:
       packageType: sdk
-      version: 6.x
+      version: 6.0.100
 
   - task: DownloadSecureFile@1
     name: caCertificate

--- a/builds/azure-pipelines.yml
+++ b/builds/azure-pipelines.yml
@@ -52,7 +52,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: sdk
-    version: 6.x
+    version: 6.0.100
 
 - task: MSBuild@1
   inputs:


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue causing the fulltrust process to crash on start

**Details of Changes**
Add details of changes here.
- Forces Azure to use SDK version 6.0.100

**Validation**
How did you test these changes?
- [x] Built and ran the app
