### PR TITLE
Fix advanced properties opening in the wrong window

### DIFF
--- a/src/Files/Views/Pages/PropertiesSecurity.xaml.cs
+++ b/src/Files/Views/Pages/PropertiesSecurity.xaml.cs
@@ -70,6 +70,10 @@ namespace Files.Views
 
         public override void Dispose()
         {
+            if (propsView != null)
+            {
+                propsView.Consolidated -= PropsView_Consolidated;
+            }
         }
 
         private async void OpenAdvancedProperties()
@@ -100,6 +104,7 @@ namespace Files.Views
                         propsView.Title = string.Format("SecurityAdvancedPermissionsTitle".GetLocalized(), SecurityProperties.Item.ItemName);
                         propsView.PersistedStateId = "PropertiesSecurity";
                         propsView.SetPreferredMinSize(new Size(400, 500));
+                        propsView.Consolidated += PropsView_Consolidated;
 
                         bool viewShown = await ApplicationViewSwitcher.TryShowAsStandaloneAsync(propsView.Id);
                         if (viewShown && propsView != null)
@@ -114,6 +119,17 @@ namespace Files.Views
             else
             {
                 // Unsupported
+            }
+        }
+
+        private async void PropsView_Consolidated(ApplicationView sender, ApplicationViewConsolidatedEventArgs args)
+        {
+            propsView.Consolidated -= PropsView_Consolidated;
+            propsView = null;
+
+            if (SecurityProperties != null)
+            {
+                await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => SecurityProperties.GetFilePermissions()); // Reload permissions
             }
         }
     }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
Opening advanced security properties a second time results in the advanced properties content to appear in the current properties window instead of opening a new window.

**Details of Changes**
Add details of changes here.
- Re-add some code removed in #5538. _Not_ adding back the call to "Window.Current.Close()" which was causing #2714

**Validation**
How did you test these changes?
- [x] Built and ran the app
