### PR TITLE
Do not block while loading drive properties

### DIFF
--- a/src/Files/DataModels/NavigationControlItems/DriveItem.cs
+++ b/src/Files/DataModels/NavigationControlItems/DriveItem.cs
@@ -145,7 +145,7 @@ namespace Files.DataModels.NavigationControlItems
             item.Path = string.IsNullOrEmpty(root.Path) ? $"\\\\?\\{root.Name}\\" : root.Path;
             item.DeviceID = deviceId;
             item.Root = root;
-            await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => item.UpdatePropertiesAsync());
+            _ = CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => item.UpdatePropertiesAsync());
 
             return item;
         }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7453

**Details of Changes**
Add details of changes here.
- No need to await properties loading when creating DriveItem

**Validation**
How did you test these changes?
- [x] Built and ran the app
