### PR TITLE
Fix focus cycle in column view when some settings change

### DIFF
--- a/src/Files/BaseLayout.cs
+++ b/src/Files/BaseLayout.cs
@@ -486,8 +486,6 @@ namespace Files
             UpdateCollectionViewSource();
             FolderSettings.IsLayoutModeChanging = false;
 
-            ItemManipulationModel.FocusFileList(); // Set focus on layout specific file list control
-
             SetSelectedItemsOnNavigation();
 
             ItemContextMenuFlyout.Opening += ItemContextFlyout_Opening;
@@ -508,6 +506,10 @@ namespace Files
 
                     ItemManipulationModel.SetSelectedItems(liItemsToSelect);
                     ItemManipulationModel.FocusSelectedItems();
+                }
+                else
+                {
+                    ItemManipulationModel.FocusFileList(); // Set focus on layout specific file list control
                 }
             }
             catch (Exception)

--- a/src/Files/Behaviors/StickyHeaderBehavior.cs
+++ b/src/Files/Behaviors/StickyHeaderBehavior.cs
@@ -187,6 +187,7 @@ namespace Files.Behaviors
             }
 
             var expressionClipAnimation = ExpressionFunctions.Max(-scrollPropSet.Translation.Y, 0);
+            _contentClip.TopInset = (float)System.Math.Max(-_scrollViewer.VerticalOffset, 0);
             _contentClip.StartAnimation("TopInset", expressionClipAnimation);
 
             return true;

--- a/src/Files/Views/ColumnShellPage.xaml.cs
+++ b/src/Files/Views/ColumnShellPage.xaml.cs
@@ -818,9 +818,11 @@ namespace Files.Views
                     break;
 
                 case ItemLoadStatusChangedEventArgs.ItemLoadStatus.InProgress:
-                    var browser = this.FindAscendant<ColumnViewBrowser>();
-                    NavToolbarViewModel.CanGoBack = browser.ParentShellPageInstance.CanNavigateBackward;
-                    NavToolbarViewModel.CanGoForward = browser.ParentShellPageInstance.CanNavigateForward;
+                    if (this.FindAscendant<ColumnViewBrowser>() is ColumnViewBrowser browser)
+                    {
+                        NavToolbarViewModel.CanGoBack = browser.ParentShellPageInstance.CanNavigateBackward;
+                        NavToolbarViewModel.CanGoForward = browser.ParentShellPageInstance.CanNavigateForward;
+                    }
                     SetLoadingIndicatorForTabs(true);
                     break;
 

--- a/src/Files/Views/ColumnShellPage.xaml.cs
+++ b/src/Files/Views/ColumnShellPage.xaml.cs
@@ -827,8 +827,6 @@ namespace Files.Views
                 case ItemLoadStatusChangedEventArgs.ItemLoadStatus.Complete:
                     SetLoadingIndicatorForTabs(false);
                     NavToolbarViewModel.CanRefresh = true;
-                    // Set focus to the file list to allow arrow navigation
-                    ContentPage?.ItemManipulationModel.FocusFileList();
                     // Select previous directory
                     if (!string.IsNullOrWhiteSpace(e.PreviousDirectory))
                     {

--- a/src/Files/Views/ModernShellPage.xaml.cs
+++ b/src/Files/Views/ModernShellPage.xaml.cs
@@ -976,8 +976,6 @@ namespace Files.Views
                 case ItemLoadStatusChangedEventArgs.ItemLoadStatus.Complete:
                     NavToolbarViewModel.CanRefresh = true;
                     SetLoadingIndicatorForTabs(false);
-                    // Set focus to the file list to allow arrow navigation
-                    ContentPage?.ItemManipulationModel.FocusFileList();
                     // Select previous directory
                     if (!InstanceViewModel.IsPageTypeSearchResults && !string.IsNullOrWhiteSpace(e.PreviousDirectory))
                     {


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue causing focus in column view to move around on it's own when toggling some settings (e.g "show file extensions")
- Fixes an issue causing a crash when refreshing a folder after changing from column view to another layout
- Fixes an issue where the file list is invisible or cut after navigating while the list is scrolled

**Validation**
How did you test these changes?
- [x] Built and ran the app
