### PR TITLE
Properly toggle "permanent delete" check in confirmation dialog

### DIFF
--- a/src/Common/ShellOperationResult.cs
+++ b/src/Common/ShellOperationResult.cs
@@ -16,7 +16,7 @@ namespace Files.Common
     public class ShellOperationItemResult
     {
         public bool Succeeded { get; set; }
-        public int HRresult { get; set; }
+        public int HResult { get; set; }
         public string Source { get; set; }
         public string Destination { get; set; }
     }

--- a/src/Files.Launcher/Helpers/FileUtils.cs
+++ b/src/Files.Launcher/Helpers/FileUtils.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace FilesFullTrust.Helpers
+{
+    // https://stackoverflow.com/questions/317071/how-do-i-find-out-which-process-is-locking-a-file-using-net/317209#317209
+    public static class FileUtils
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        struct RM_UNIQUE_PROCESS
+        {
+            public int dwProcessId;
+            public System.Runtime.InteropServices.ComTypes.FILETIME ProcessStartTime;
+        }
+
+        const int RmRebootReasonNone = 0;
+        const int CCH_RM_MAX_APP_NAME = 255;
+        const int CCH_RM_MAX_SVC_NAME = 63;
+
+        enum RM_APP_TYPE
+        {
+            RmUnknownApp = 0,
+            RmMainWindow = 1,
+            RmOtherWindow = 2,
+            RmService = 3,
+            RmExplorer = 4,
+            RmConsole = 5,
+            RmCritical = 1000
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        struct RM_PROCESS_INFO
+        {
+            public RM_UNIQUE_PROCESS Process;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_APP_NAME + 1)]
+            public string strAppName;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_SVC_NAME + 1)]
+            public string strServiceShortName;
+
+            public RM_APP_TYPE ApplicationType;
+            public uint AppStatus;
+            public uint TSSessionId;
+            [MarshalAs(UnmanagedType.Bool)]
+            public bool bRestartable;
+        }
+
+        [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)]
+        static extern int RmRegisterResources(uint pSessionHandle,
+                                              UInt32 nFiles,
+                                              string[] rgsFilenames,
+                                              UInt32 nApplications,
+                                              [In] RM_UNIQUE_PROCESS[] rgApplications,
+                                              UInt32 nServices,
+                                              string[] rgsServiceNames);
+
+        [DllImport("rstrtmgr.dll", CharSet = CharSet.Auto)]
+        static extern int RmStartSession(out uint pSessionHandle, int dwSessionFlags, string strSessionKey);
+
+        [DllImport("rstrtmgr.dll")]
+        static extern int RmEndSession(uint pSessionHandle);
+
+        [DllImport("rstrtmgr.dll")]
+        static extern int RmGetList(uint dwSessionHandle,
+                                    out uint pnProcInfoNeeded,
+                                    ref uint pnProcInfo,
+                                    [In, Out] RM_PROCESS_INFO[] rgAffectedApps,
+                                    ref uint lpdwRebootReasons);
+
+        /// <summary>
+        /// Find out what process(es) have a lock on the specified file.
+        /// </summary>
+        /// <param name="path">Path of the file.</param>
+        /// <returns>Processes locking the file</returns>
+        /// <remarks>See also:
+        /// http://msdn.microsoft.com/en-us/library/windows/desktop/aa373661(v=vs.85).aspx
+        /// http://wyupdate.googlecode.com/svn-history/r401/trunk/frmFilesInUse.cs (no copyright in code at time of viewing)
+        /// 
+        /// </remarks>
+        static public List<Process> WhoIsLocking(string path)
+        {
+            uint handle;
+            string key = Guid.NewGuid().ToString();
+            List<Process> processes = new List<Process>();
+
+            int res = RmStartSession(out handle, 0, key);
+            if (res != 0) throw new Exception("Could not begin restart session.  Unable to determine file locker.");
+
+            try
+            {
+                const int ERROR_MORE_DATA = 234;
+                uint pnProcInfoNeeded = 0,
+                     pnProcInfo = 0,
+                     lpdwRebootReasons = RmRebootReasonNone;
+
+                string[] resources = new string[] { path }; // Just checking on one resource.
+
+                res = RmRegisterResources(handle, (uint)resources.Length, resources, 0, null, 0, null);
+
+                if (res != 0) throw new Exception("Could not register resource.");
+
+                //Note: there's a race condition here -- the first call to RmGetList() returns
+                //      the total number of process. However, when we call RmGetList() again to get
+                //      the actual processes this number may have increased.
+                res = RmGetList(handle, out pnProcInfoNeeded, ref pnProcInfo, null, ref lpdwRebootReasons);
+
+                if (res == ERROR_MORE_DATA)
+                {
+                    // Create an array to store the process results
+                    RM_PROCESS_INFO[] processInfo = new RM_PROCESS_INFO[pnProcInfoNeeded];
+                    pnProcInfo = pnProcInfoNeeded;
+
+                    // Get the list
+                    res = RmGetList(handle, out pnProcInfoNeeded, ref pnProcInfo, processInfo, ref lpdwRebootReasons);
+                    if (res == 0)
+                    {
+                        processes = new List<Process>((int)pnProcInfo);
+
+                        // Enumerate all of the results and add them to the 
+                        // list to be returned
+                        for (int i = 0; i < pnProcInfo; i++)
+                        {
+                            try
+                            {
+                                processes.Add(Process.GetProcessById(processInfo[i].Process.dwProcessId));
+                            }
+                            // catch the error -- in case the process is no longer running
+                            catch (ArgumentException) { }
+                        }
+                    }
+                    else throw new Exception("Could not list processes locking resource.");
+                }
+                else if (res != 0) throw new Exception("Could not list processes locking resource. Failed to get size of result.");
+            }
+            finally
+            {
+                RmEndSession(handle);
+            }
+
+            return processes;
+        }
+    }
+}

--- a/src/Files.Launcher/Helpers/ShellFolderHelpers.cs
+++ b/src/Files.Launcher/Helpers/ShellFolderHelpers.cs
@@ -92,5 +92,14 @@ namespace FilesFullTrust.Helpers
             link.TargetPath = linkItem.TargetPath;
             return link;
         }
+
+        public static string GetParsingPath(this ShellItem item)
+        {
+            if (item == null)
+            {
+                return null;
+            }
+            return item.IsFileSystem ? item.FileSystemPath : item.ParsingName;
+        }
     }
 }

--- a/src/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
+++ b/src/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
@@ -176,7 +176,7 @@ namespace FilesFullTrust.MessageHandlers
                                     shellOperationResult.Items.Add(new ShellOperationItemResult()
                                     {
                                         Succeeded = e.Result.Succeeded,
-                                        Destination = e.DestItem != null ? (e.DestItem.IsFileSystem ? e.DestItem.FileSystemPath : e.DestItem.ParsingName) : null,
+                                        Destination = e.DestItem.GetParsingPath(),
                                         HResult = (int)e.Result
                                     });
                                 };
@@ -253,7 +253,7 @@ namespace FilesFullTrust.MessageHandlers
                                         shellOperationResult.Items.Add(new ShellOperationItemResult()
                                         {
                                             Succeeded = false,
-                                            Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
+                                            Source = e.SourceItem.GetParsingPath(),
                                             HResult = (int)HRESULT.COPYENGINE_E_RECYCLE_BIN_NOT_FOUND
                                         });
                                         throw new Win32Exception(HRESULT.COPYENGINE_E_RECYCLE_BIN_NOT_FOUND); // E_FAIL, stops operation
@@ -263,7 +263,7 @@ namespace FilesFullTrust.MessageHandlers
                                         shellOperationResult.Items.Add(new ShellOperationItemResult()
                                         {
                                             Succeeded = true,
-                                            Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
+                                            Source = e.SourceItem.GetParsingPath(),
                                             HResult = (int)HRESULT.COPYENGINE_E_USER_CANCELLED
                                         });
                                         throw new Win32Exception(HRESULT.COPYENGINE_E_USER_CANCELLED); // E_FAIL, stops operation
@@ -345,8 +345,8 @@ namespace FilesFullTrust.MessageHandlers
                                     shellOperationResult.Items.Add(new ShellOperationItemResult()
                                     {
                                         Succeeded = e.Result.Succeeded,
-                                        Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
-                                        Destination = e.DestItem != null ? (e.DestItem.IsFileSystem ? e.DestItem.FileSystemPath : e.DestItem.ParsingName) : null,
+                                        Source = e.SourceItem.GetParsingPath(),
+                                        Destination = e.DestItem.GetParsingPath(),
                                         HResult = (int)e.Result
                                     });
                                 };
@@ -418,12 +418,11 @@ namespace FilesFullTrust.MessageHandlers
                                 var renameTcs = new TaskCompletionSource<bool>();
                                 op.PostRenameItem += (s, e) =>
                                 {
-                                    var sourcePath = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName;
                                     shellOperationResult.Items.Add(new ShellOperationItemResult()
                                     {
                                         Succeeded = e.Result.Succeeded,
-                                        Source = sourcePath,
-                                        Destination = !string.IsNullOrEmpty(e.Name) ? Path.Combine(Path.GetDirectoryName(sourcePath), e.Name) : null,
+                                        Source = e.SourceItem.GetParsingPath(),
+                                        Destination = !string.IsNullOrEmpty(e.Name) ? Path.Combine(Path.GetDirectoryName(e.SourceItem.GetParsingPath()), e.Name) : null,
                                         HResult = (int)e.Result
                                     });
                                 };
@@ -498,12 +497,11 @@ namespace FilesFullTrust.MessageHandlers
                                 var moveTcs = new TaskCompletionSource<bool>();
                                 op.PostMoveItem += (s, e) =>
                                 {
-                                    var destPath = e.DestFolder != null ? (e.DestFolder.IsFileSystem ? e.DestFolder.FileSystemPath : e.DestFolder.ParsingName) : null;
                                     shellOperationResult.Items.Add(new ShellOperationItemResult()
                                     {
                                         Succeeded = e.Result.Succeeded,
-                                        Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
-                                        Destination = destPath != null && !string.IsNullOrEmpty(e.Name) ? Path.Combine(destPath, e.Name) : null,
+                                        Source = e.SourceItem.GetParsingPath(),
+                                        Destination = e.DestFolder.GetParsingPath() != null && !string.IsNullOrEmpty(e.Name) ? Path.Combine(e.DestFolder.GetParsingPath(), e.Name) : null,
                                         HResult = (int)e.Result
                                     });
                                 };
@@ -586,12 +584,11 @@ namespace FilesFullTrust.MessageHandlers
                                 var copyTcs = new TaskCompletionSource<bool>();
                                 op.PostCopyItem += (s, e) =>
                                 {
-                                    var destPath = e.DestFolder != null ? (e.DestFolder.IsFileSystem ? e.DestFolder.FileSystemPath : e.DestFolder.ParsingName) : null;
                                     shellOperationResult.Items.Add(new ShellOperationItemResult()
                                     {
                                         Succeeded = e.Result.Succeeded,
-                                        Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
-                                        Destination = destPath != null && !string.IsNullOrEmpty(e.Name) ? Path.Combine(destPath, e.Name) : null,
+                                        Source = e.SourceItem.GetParsingPath(),
+                                        Destination = e.DestFolder.GetParsingPath() != null && !string.IsNullOrEmpty(e.Name) ? Path.Combine(e.DestFolder.GetParsingPath(), e.Name) : null,
                                         HResult = (int)e.Result
                                     });
                                 };
@@ -833,11 +830,11 @@ namespace FilesFullTrust.MessageHandlers
         {
             if (e.Result.Succeeded)
             {
-                var sourcePath = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName;
-                var destPath = e.DestFolder != null ? (e.DestFolder.IsFileSystem ? e.DestFolder.FileSystemPath : e.DestFolder.ParsingName) : null;
+                var sourcePath = e.SourceItem.GetParsingPath();
+                var destPath = e.DestFolder.GetParsingPath();
                 var destination = operationType switch
                 {
-                    "delete" => e.DestItem != null ? (e.DestItem.IsFileSystem ? e.DestItem.FileSystemPath : e.DestItem.ParsingName) : null,
+                    "delete" => e.DestItem.GetParsingPath(),
                     "rename" => !string.IsNullOrEmpty(e.Name) ? Path.Combine(Path.GetDirectoryName(sourcePath), e.Name) : null,
                     "copy" => destPath != null && !string.IsNullOrEmpty(e.Name) ? Path.Combine(destPath, e.Name) : null,
                     _ => destPath != null && !string.IsNullOrEmpty(e.Name) ? Path.Combine(destPath, e.Name) : null

--- a/src/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
+++ b/src/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
@@ -166,7 +166,7 @@ namespace FilesFullTrust.MessageHandlers
                                     {
                                         Succeeded = false,
                                         Destination = filePath,
-                                        HRresult = (int)-1
+                                        HResult = (int)-1
                                     });
                                 }
 
@@ -177,7 +177,7 @@ namespace FilesFullTrust.MessageHandlers
                                     {
                                         Succeeded = e.Result.Succeeded,
                                         Destination = e.DestItem != null ? (e.DestItem.IsFileSystem ? e.DestItem.FileSystemPath : e.DestItem.ParsingName) : null,
-                                        HRresult = (int)e.Result
+                                        HResult = (int)e.Result
                                     });
                                 };
                                 op.FinishOperations += (s, e) => createTcs.TrySetResult(e.Result.Succeeded);
@@ -240,7 +240,7 @@ namespace FilesFullTrust.MessageHandlers
                                         {
                                             Succeeded = false,
                                             Source = fileToDeletePath[i],
-                                            HRresult = (int)-1
+                                            HResult = (int)-1
                                         });
                                     }
                                 }
@@ -254,7 +254,7 @@ namespace FilesFullTrust.MessageHandlers
                                         {
                                             Succeeded = false,
                                             Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
-                                            HRresult = (int)HRESULT.COPYENGINE_E_RECYCLE_BIN_NOT_FOUND
+                                            HResult = (int)HRESULT.COPYENGINE_E_RECYCLE_BIN_NOT_FOUND
                                         });
                                         throw new Win32Exception(HRESULT.COPYENGINE_E_RECYCLE_BIN_NOT_FOUND); // E_FAIL, stops operation
                                     }
@@ -264,7 +264,7 @@ namespace FilesFullTrust.MessageHandlers
                                         {
                                             Succeeded = true,
                                             Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
-                                            HRresult = (int)HRESULT.COPYENGINE_E_USER_CANCELLED
+                                            HResult = (int)HRESULT.COPYENGINE_E_USER_CANCELLED
                                         });
                                         throw new Win32Exception(HRESULT.COPYENGINE_E_USER_CANCELLED); // E_FAIL, stops operation
                                     }
@@ -324,7 +324,7 @@ namespace FilesFullTrust.MessageHandlers
                                         {
                                             Succeeded = false,
                                             Source = fileToDeletePath[i],
-                                            HRresult = (int)-1
+                                            HResult = (int)-1
                                         });
                                     }
                                 }
@@ -347,7 +347,7 @@ namespace FilesFullTrust.MessageHandlers
                                         Succeeded = e.Result.Succeeded,
                                         Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
                                         Destination = e.DestItem != null ? (e.DestItem.IsFileSystem ? e.DestItem.FileSystemPath : e.DestItem.ParsingName) : null,
-                                        HRresult = (int)e.Result
+                                        HResult = (int)e.Result
                                     });
                                 };
                                 op.PostDeleteItem += (s, e) => UpdateFileTagsDb(s, e, "delete");
@@ -408,7 +408,7 @@ namespace FilesFullTrust.MessageHandlers
                                     {
                                         Succeeded = false,
                                         Source = fileToRenamePath,
-                                        HRresult = (int)-1
+                                        HResult = (int)-1
                                     });
                                 }
 
@@ -424,7 +424,7 @@ namespace FilesFullTrust.MessageHandlers
                                         Succeeded = e.Result.Succeeded,
                                         Source = sourcePath,
                                         Destination = !string.IsNullOrEmpty(e.Name) ? Path.Combine(Path.GetDirectoryName(sourcePath), e.Name) : null,
-                                        HRresult = (int)e.Result
+                                        HResult = (int)e.Result
                                     });
                                 };
                                 op.PostRenameItem += (s, e) => UpdateFileTagsDb(s, e, "rename");
@@ -487,7 +487,7 @@ namespace FilesFullTrust.MessageHandlers
                                             Succeeded = false,
                                             Source = fileToMovePath[i],
                                             Destination = moveDestination[i],
-                                            HRresult = (int)-1
+                                            HResult = (int)-1
                                         });
                                     }
                                 }
@@ -504,7 +504,7 @@ namespace FilesFullTrust.MessageHandlers
                                         Succeeded = e.Result.Succeeded,
                                         Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
                                         Destination = destPath != null && !string.IsNullOrEmpty(e.Name) ? Path.Combine(destPath, e.Name) : null,
-                                        HRresult = (int)e.Result
+                                        HResult = (int)e.Result
                                     });
                                 };
                                 op.PostMoveItem += (s, e) => UpdateFileTagsDb(s, e, "move");
@@ -575,7 +575,7 @@ namespace FilesFullTrust.MessageHandlers
                                             Succeeded = false,
                                             Source = fileToCopyPath[i],
                                             Destination = copyDestination[i],
-                                            HRresult = (int)-1
+                                            HResult = (int)-1
                                         });
                                     }
                                 }
@@ -592,7 +592,7 @@ namespace FilesFullTrust.MessageHandlers
                                         Succeeded = e.Result.Succeeded,
                                         Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
                                         Destination = destPath != null && !string.IsNullOrEmpty(e.Name) ? Path.Combine(destPath, e.Name) : null,
-                                        HRresult = (int)e.Result
+                                        HResult = (int)e.Result
                                     });
                                 };
                                 op.PostCopyItem += (s, e) => UpdateFileTagsDb(s, e, "copy");

--- a/src/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
+++ b/src/Files.Launcher/MessageHandlers/FileOperationsHandler.cs
@@ -214,6 +214,82 @@ namespace FilesFullTrust.MessageHandlers
                     }
                     break;
 
+                case "TestRecycle":
+                    {
+                        var fileToDeletePath = ((string)message["filepath"]).Split('|');
+                        var (success, shellOperationResult) = await Win32API.StartSTATask(async () =>
+                        {
+                            using (var op = new ShellFileOperations())
+                            {
+                                op.Options = ShellFileOperations.OperationFlags.Silent
+                                            | ShellFileOperations.OperationFlags.NoConfirmation
+                                            | ShellFileOperations.OperationFlags.NoErrorUI;
+                                op.Options |= ShellFileOperations.OperationFlags.RecycleOnDelete;
+
+                                var shellOperationResult = new ShellOperationResult();
+
+                                for (var i = 0; i < fileToDeletePath.Length; i++)
+                                {
+                                    if (!Extensions.IgnoreExceptions(() =>
+                                    {
+                                        using var shi = new ShellItem(fileToDeletePath[i]);
+                                        op.QueueDeleteOperation(shi);
+                                    }))
+                                    {
+                                        shellOperationResult.Items.Add(new ShellOperationItemResult()
+                                        {
+                                            Succeeded = false,
+                                            Source = fileToDeletePath[i],
+                                            HRresult = (int)-1
+                                        });
+                                    }
+                                }
+
+                                var deleteTcs = new TaskCompletionSource<bool>();
+                                op.PreDeleteItem += (s, e) =>
+                                {
+                                    if (!e.Flags.HasFlag(ShellFileOperations.TransferFlags.DeleteRecycleIfPossible))
+                                    {
+                                        shellOperationResult.Items.Add(new ShellOperationItemResult()
+                                        {
+                                            Succeeded = false,
+                                            Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
+                                            HRresult = (int)HRESULT.COPYENGINE_E_RECYCLE_BIN_NOT_FOUND
+                                        });
+                                        throw new Win32Exception(HRESULT.COPYENGINE_E_RECYCLE_BIN_NOT_FOUND); // E_FAIL, stops operation
+                                    }
+                                    else
+                                    {
+                                        shellOperationResult.Items.Add(new ShellOperationItemResult()
+                                        {
+                                            Succeeded = true,
+                                            Source = e.SourceItem.IsFileSystem ? e.SourceItem.FileSystemPath : e.SourceItem.ParsingName,
+                                            HRresult = (int)HRESULT.COPYENGINE_E_USER_CANCELLED
+                                        });
+                                        throw new Win32Exception(HRESULT.COPYENGINE_E_USER_CANCELLED); // E_FAIL, stops operation
+                                    }
+                                };
+                                op.FinishOperations += (s, e) => deleteTcs.TrySetResult(e.Result.Succeeded);
+
+                                try
+                                {
+                                    op.PerformOperations();
+                                }
+                                catch
+                                {
+                                    deleteTcs.TrySetResult(false);
+                                }
+
+                                return (await deleteTcs.Task, shellOperationResult);
+                            }
+                        });
+                        await Win32API.SendMessageAsync(connection, new ValueSet() {
+                            { "Success", success },
+                            { "Result", JsonConvert.SerializeObject(shellOperationResult) }
+                        }, message.Get("RequestID", (string)null));
+                    }
+                    break;
+
                 case "DeleteItem":
                     {
                         var fileToDeletePath = ((string)message["filepath"]).Split('|');

--- a/src/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/src/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -183,7 +183,7 @@ namespace Files.Filesystem
             var sw = new Stopwatch();
             sw.Start();
 
-            IStorageHistory history = await filesystemOperations.DeleteItemsAsync(source, banner.Progress, banner.ErrorCode, permanently, cancellationToken);
+            IStorageHistory history = await filesystemOperations.DeleteItemsAsync(source, banner.Progress, banner.ErrorCode, permanently, token);
             ((IProgress<float>)banner.Progress).Report(100.0f);
             await Task.Yield();
 

--- a/src/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/src/Files/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -116,7 +116,7 @@ namespace Files.Filesystem
             var deleteFromRecycleBin = source.Select(item => item.Path).Any(path => recycleBinHelpers.IsPathUnderRecycleBin(path));
             var canBeSentToBin = !deleteFromRecycleBin && await recycleBinHelpers.HasRecycleBin(source.FirstOrDefault()?.Path);
 
-            if (UserSettingsService.PreferencesSettingsService.ShowConfirmDeleteDialog && showDialog) // Check if the setting to show a confirmation dialog is on
+            if (((!permanently && !canBeSentToBin) || UserSettingsService.PreferencesSettingsService.ShowConfirmDeleteDialog) && showDialog) // Check if the setting to show a confirmation dialog is on
             {
                 List<FilesystemItemsOperationItemModel> incomingItems = new List<FilesystemItemsOperationItemModel>();
 
@@ -301,7 +301,7 @@ namespace Files.Filesystem
 
             banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
 
-            if (UserSettingsService.PreferencesSettingsService.ShowConfirmDeleteDialog && showDialog) // Check if the setting to show a confirmation dialog is on
+            if (((!permanently && !canBeSentToBin) || UserSettingsService.PreferencesSettingsService.ShowConfirmDeleteDialog) && showDialog) // Check if the setting to show a confirmation dialog is on
             {
                 List<FilesystemItemsOperationItemModel> incomingItems = new List<FilesystemItemsOperationItemModel>();
 

--- a/src/Files/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
+++ b/src/Files/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
@@ -283,7 +283,7 @@ namespace Files.Filesystem
             {
                 // Retry failed operations
                 var failedSources = deleteResult.Items.Where(x => source.Select(s => s.Path).Contains(x.Source))
-                    .Where(x => !x.Succeeded && x.HRresult != HRESULT.COPYENGINE_E_USER_CANCELLED && x.HRresult != HRESULT.COPYENGINE_E_RECYCLE_BIN_NOT_FOUND);
+                    .Where(x => !x.Succeeded && x.HResult != HResult.COPYENGINE_E_USER_CANCELLED && x.HResult != HResult.COPYENGINE_E_RECYCLE_BIN_NOT_FOUND);
                 return await filesystemOperations.DeleteItemsAsync(
                     failedSources.Select(x => source.Single(s => s.Path == x.Source)), progress, errorCode, permanently, cancellationToken);
             }
@@ -538,7 +538,7 @@ namespace Files.Filesystem
             }
         }
 
-        private struct HRESULT
+        private struct HResult
         {
             public const int S_OK = 0;
             public const int COPYENGINE_E_USER_CANCELLED = -2144927744;

--- a/src/Files/Helpers/RecycleBinHelpers.cs
+++ b/src/Files/Helpers/RecycleBinHelpers.cs
@@ -111,14 +111,16 @@ namespace Files.Helpers
             var connection = await AppServiceConnectionHelper.Instance;
             if (connection != null)
             {
-                var value = new ValueSet
+                var (status, response) = await connection.SendMessageForResponseAsync(new ValueSet()
                 {
-                    { "Arguments", "RecycleBin" },
-                    { "action", "Query" },
-                    { "drive", path }
-                };
-                var (status, response) = await connection.SendMessageForResponseAsync(value);
-                return status == AppServiceResponseStatus.Success && response.Get("HasRecycleBin", false);
+                    { "Arguments", "FileOperation" },
+                    { "fileop", "TestRecycle" },
+                    { "filepath", path }
+                });
+                var result = (status == AppServiceResponseStatus.Success && response.Get("Success", false));
+                var shellOpResult = JsonConvert.DeserializeObject<ShellOperationResult>(response.Get("Result", ""));
+                result &= shellOpResult != null && shellOpResult.Items.All(x => x.Succeeded);
+                return result;
             }
             return false;
         }

--- a/src/Files/ViewModels/StatusCenterViewModel.cs
+++ b/src/Files/ViewModels/StatusCenterViewModel.cs
@@ -101,6 +101,7 @@ namespace Files.ViewModels
             PostedStatusBanner postedBanner = new PostedStatusBanner(banner, this);
             StatusBannersSource.Insert(0, banner);
             ProgressBannerPosted?.Invoke(this, postedBanner);
+            UpdateBanner(banner);
             return postedBanner;
         }
 
@@ -113,6 +114,7 @@ namespace Files.ViewModels
             PostedStatusBanner postedBanner = new PostedStatusBanner(banner, this, cancellationTokenSource);
             StatusBannersSource.Insert(0, banner);
             ProgressBannerPosted?.Invoke(this, postedBanner);
+            UpdateBanner(banner);
             return postedBanner;
         }
 
@@ -122,6 +124,7 @@ namespace Files.ViewModels
             PostedStatusBanner postedBanner = new PostedStatusBanner(banner, this);
             StatusBannersSource.Insert(0, banner);
             ProgressBannerPosted?.Invoke(this, postedBanner);
+            UpdateBanner(banner);
             return postedBanner;
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7028
- Closes #7492
- Closes #7334
- Closes #6849

**Details of Changes**
Add details of changes here.
- Added a method to check whether deleting a file would move it to the recycle bin or not, the method e.g returns false in removable drives, network drives and if the recycle bin is disabled for a drive
- If recycle bin is not enabled, automatically check the "permanent delete" dialog option
- Call "UpdateBanner" when a banner is posted to fix #7028

Note: code in "FileUtils.cs" is currently not used and can be ignored, it's ground work to implement #1681.

**Validation**
How did you test these changes?
- [x] Built and ran the app
