### PR TITLE
fix link to Files docs in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ We welcome your contributions to the Files project, especially to fix bugs and t
 improvements which address the top issues reported by Files users. Some general guidelines:
 
 * **DO** create one pull request per Issue, and ensure that the Issue is linked in the pull request.
-* **DO** follow our [Coding and Style](https://files-community.github.io/docs/#/articles/code-style) guidelines, and keep code changes as small as possible.
+* **DO** follow our [Coding and Style](https://files.community/docs/contributing/code-style) guidelines, and keep code changes as small as possible.
 * **DO** include corresponding tests whenever possible.
 * **DO** check for additional occurrences of the same problem in other parts of the codebase before submitting your PR.
 * **DO** [link the issue](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue) you are addressing in the 


### PR DESCRIPTION
**Details of Changes**

Old URL referred to the old Files website. This PR is for fixing the link to the code style in Files docs.