### PR TITLE
Fixed folder size visibility in properties for hidden folders

### DIFF
--- a/src/Files/ViewModels/Properties/FolderProperties.cs
+++ b/src/Files/ViewModels/Properties/FolderProperties.cs
@@ -99,10 +99,11 @@ namespace Files.ViewModels.Properties
                 }
             }
 
+            string folderPath = (Item as ShortcutItem)?.TargetPath ?? Item.ItemPath;
             BaseStorageFolder storageFolder;
             try
             {
-                storageFolder = await AppInstance.FilesystemViewModel.GetFolderFromPathAsync((Item as ShortcutItem)?.TargetPath ?? Item.ItemPath);
+                storageFolder = await AppInstance.FilesystemViewModel.GetFolderFromPathAsync(folderPath);
             }
             catch (Exception ex)
             {
@@ -120,7 +121,7 @@ namespace Files.ViewModels.Properties
                 {
                     GetOtherProperties(storageFolder.Properties);
                 }
-                GetFolderSize(storageFolder, TokenSource.Token);
+                GetFolderSize(storageFolder.Path, TokenSource.Token);
             }
             else if (Item.ItemPath.Equals(CommonPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
             {
@@ -162,11 +163,15 @@ namespace Files.ViewModels.Properties
                     }
                 }
             }
+            else
+            {
+                GetFolderSize(folderPath, TokenSource.Token);
+            }
         }
 
-        private async void GetFolderSize(BaseStorageFolder storageFolder, CancellationToken token)
+        private async void GetFolderSize(string folderPath, CancellationToken token)
         {
-            if (string.IsNullOrEmpty(storageFolder.Path))
+            if (string.IsNullOrEmpty(folderPath))
             {
                 // In MTP devices calculating folder size would be too slow
                 // Also should use StorageFolder methods instead of FindFirstFileExFromApp
@@ -178,7 +183,7 @@ namespace Files.ViewModels.Properties
 
             var fileSizeTask = Task.Run(async () =>
             {
-                var size = await CalculateFolderSizeAsync(storageFolder.Path, token);
+                var size = await CalculateFolderSizeAsync(folderPath, token);
                 return size;
             });
             try


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #7525 (in the properties the size text doesn't show for hidden folders)

**Details of Changes**
Class StorageFolder is not available for hidden items.
The GetFolderSize function has StorageFolder as a parameter, but only uses the path.

This pr modifies GetFolderSize to use the path and work with hidden folders. 

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility