### PR TITLE
Fixes

### DIFF
--- a/src/Files/Filesystem/FileTagsHelper.cs
+++ b/src/Files/Filesystem/FileTagsHelper.cs
@@ -35,6 +35,11 @@ namespace Files.Filesystem
 
         public static void WriteFileTag(string filePath, string tag)
         {
+            var isReadOnly = NativeFileOperationsHelper.HasFileAttribute(filePath, System.IO.FileAttributes.ReadOnly);
+            if (isReadOnly) // Unset read-only attribute (#7534)
+            {
+                NativeFileOperationsHelper.UnsetFileAttribute(filePath, System.IO.FileAttributes.ReadOnly);
+            }
             if (tag == null)
             {
                 NativeFileOperationsHelper.DeleteFileFromApp($"{filePath}:files");
@@ -42,6 +47,10 @@ namespace Files.Filesystem
             else if (ReadFileTag(filePath) != tag)
             {
                 NativeFileOperationsHelper.WriteStringToFile($"{filePath}:files", tag);
+            }
+            if (isReadOnly) // Restore read-only attribute (#7534)
+            {
+                NativeFileOperationsHelper.SetFileAttribute(filePath, System.IO.FileAttributes.ReadOnly);
             }
         }
 

--- a/src/Files/Helpers/ItemListDisplayHelpers/BulkConcurrentObservableCollection.cs
+++ b/src/Files/Helpers/ItemListDisplayHelpers/BulkConcurrentObservableCollection.cs
@@ -412,7 +412,11 @@ namespace Files.Helpers
             }
 
             Remove(item);
-            Insert(result.IndexOf(item), item);
+            var index = result.IndexOf(item);
+            if (index != -1)
+            {
+                Insert(index, item);
+            }
         }
 
         int IList.Add(object value)

--- a/src/Files/Helpers/UIFilesystemHelpers.cs
+++ b/src/Files/Helpers/UIFilesystemHelpers.cs
@@ -118,7 +118,9 @@ namespace Files.Helpers
                 Clipboard.SetContent(dataPackage);
                 if (onlyStandard && canFlush)
                 {
-                    Clipboard.Flush();
+                    // Calling Flush will break copy-paste when 2 Files instances are open (#7521)
+                    // Calling Flush should be done only when closing/suspending the app
+                    //Clipboard.Flush();
                 }
             }
             catch
@@ -213,7 +215,9 @@ namespace Files.Helpers
                 Clipboard.SetContent(dataPackage);
                 if (onlyStandard && canFlush)
                 {
-                    Clipboard.Flush();
+                    // Calling Flush will break copy-paste when 2 Files instances are open (#7521)
+                    // Calling Flush should be done only when closing/suspending the app
+                    //Clipboard.Flush();
                 }
             }
             catch

--- a/src/Files/Helpers/UIFilesystemHelpers.cs
+++ b/src/Files/Helpers/UIFilesystemHelpers.cs
@@ -118,7 +118,7 @@ namespace Files.Helpers
                 Clipboard.SetContent(dataPackage);
                 if (onlyStandard && canFlush)
                 {
-                    // Calling Flush will break copy-paste when 2 Files instances are open (#7521)
+                    // Calling Flush will break copy-paste when 2 Files instances are open (#7521) and when many files are copied
                     // Calling Flush should be done only when closing/suspending the app
                     //Clipboard.Flush();
                 }
@@ -215,7 +215,7 @@ namespace Files.Helpers
                 Clipboard.SetContent(dataPackage);
                 if (onlyStandard && canFlush)
                 {
-                    // Calling Flush will break copy-paste when 2 Files instances are open (#7521)
+                    // Calling Flush will break copy-paste when 2 Files instances are open (#7521) and when many files are copied
                     // Calling Flush should be done only when closing/suspending the app
                     //Clipboard.Flush();
                 }

--- a/src/Files/Helpers/Win32Helpers.cs
+++ b/src/Files/Helpers/Win32Helpers.cs
@@ -10,12 +10,12 @@ namespace Files.Helpers
 {
     public static class Win32Helpers
     {
-        public static async Task InvokeWin32ComponentAsync(string applicationPath, IShellPage associatedInstance, string arguments = null, bool runAsAdmin = false, string workingDirectory = null)
+        public static async Task<bool> InvokeWin32ComponentAsync(string applicationPath, IShellPage associatedInstance, string arguments = null, bool runAsAdmin = false, string workingDirectory = null)
         {
-            await InvokeWin32ComponentsAsync(applicationPath.CreateEnumerable(), associatedInstance, arguments, runAsAdmin, workingDirectory);
+            return await InvokeWin32ComponentsAsync(applicationPath.CreateEnumerable(), associatedInstance, arguments, runAsAdmin, workingDirectory);
         }
 
-        public static async Task InvokeWin32ComponentsAsync(IEnumerable<string> applicationPaths, IShellPage associatedInstance, string arguments = null, bool runAsAdmin = false, string workingDirectory = null)
+        public static async Task<bool> InvokeWin32ComponentsAsync(IEnumerable<string> applicationPaths, IShellPage associatedInstance, string arguments = null, bool runAsAdmin = false, string workingDirectory = null)
         {
             Debug.WriteLine("Launching EXE in FullTrustProcess");
 
@@ -45,7 +45,10 @@ namespace Files.Helpers
                 }
 
                 await connection.SendMessageAsync(value);
+                return true;
             }
+
+            return false;
         }
     }
 }

--- a/src/Files/Views/PaneHolderPage.xaml.cs
+++ b/src/Files/Views/PaneHolderPage.xaml.cs
@@ -144,12 +144,12 @@ namespace Files.Views
         {
             get
             {
-                if (ActivePane.IsColumnView)
+                if (ActivePane != null && ActivePane.IsColumnView)
                 {
                     return (ActivePane.SlimContentPage as ColumnViewBrowser).ActiveColumnShellPage;
                 }
 
-                return ActivePane;
+                return ActivePane ?? PaneLeft;
             }
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7521
- Closes #7530
- Closes #7534
- Closes Appcenter issue [1773535228u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/1773535228u/overview)
- Tentative fix for Appcenter issue [759876355u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/1773535228u/overview)

**Details of Changes**
Add details of changes here.
- Fix crash when deleting items from bin & bin is grouped (1773535228u)
- Do not call Cliboard.Flush (#7521)
- When multiple files are selected, open them together (#7530)
- Ability to set tags on folders with custom icon by temporarily removing the read-only attribute (#7534)

**Validation**
How did you test these changes?
- [x] Built and ran the app
