### PR TITLE
Fix Copy & Paste when 2 Files instance are open

### DIFF
--- a/src/Files/Helpers/UIFilesystemHelpers.cs
+++ b/src/Files/Helpers/UIFilesystemHelpers.cs
@@ -118,7 +118,9 @@ namespace Files.Helpers
                 Clipboard.SetContent(dataPackage);
                 if (onlyStandard && canFlush)
                 {
-                    Clipboard.Flush();
+                    // Calling Flush will break copy-paste when 2 Files instances are open (#7521)
+                    // Calling Flush should be done only when closing/suspending the app
+                    //Clipboard.Flush();
                 }
             }
             catch
@@ -213,7 +215,9 @@ namespace Files.Helpers
                 Clipboard.SetContent(dataPackage);
                 if (onlyStandard && canFlush)
                 {
-                    Clipboard.Flush();
+                    // Calling Flush will break copy-paste when 2 Files instances are open (#7521)
+                    // Calling Flush should be done only when closing/suspending the app
+                    //Clipboard.Flush();
                 }
             }
             catch


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7521

**Details of Changes**
Add details of changes here.
- Do not call Clipboard.Flush (#7521). Calling flush breaks copy paste when many files are selected or when 2 Files instances are open. It makes no sense to call Flush while the app is open, should be done only when app is exiting (think e.g of Word closing dialog "there is a lot of data in the clipboard..")
For now this PR only comments out the call.
