### PR TITLE
Ability to set tags on read-only folders

### DIFF
--- a/src/Files/Filesystem/FileTagsHelper.cs
+++ b/src/Files/Filesystem/FileTagsHelper.cs
@@ -35,6 +35,11 @@ namespace Files.Filesystem
 
         public static void WriteFileTag(string filePath, string tag)
         {
+            var isReadOnly = NativeFileOperationsHelper.HasFileAttribute(filePath, System.IO.FileAttributes.ReadOnly);
+            if (isReadOnly) // Unset read-only attribute (#7534)
+            {
+                NativeFileOperationsHelper.UnsetFileAttribute(filePath, System.IO.FileAttributes.ReadOnly);
+            }
             if (tag == null)
             {
                 NativeFileOperationsHelper.DeleteFileFromApp($"{filePath}:files");
@@ -42,6 +47,10 @@ namespace Files.Filesystem
             else if (ReadFileTag(filePath) != tag)
             {
                 NativeFileOperationsHelper.WriteStringToFile($"{filePath}:files", tag);
+            }
+            if (isReadOnly) // Restore read-only attribute (#7534)
+            {
+                NativeFileOperationsHelper.SetFileAttribute(filePath, System.IO.FileAttributes.ReadOnly);
             }
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7534

**Details of Changes**
Add details of changes here.
- Folders with a custom icon are set as "read-only". To save the tag remove the RO attribute, write the tag and restore the attribute.