### PR TITLE
update README Prerequisites with required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Have any questions? Check out our [documentation site](https://files.community/d
 ### 1: Prerequisites
 
 - [Git](https://git-scm.com)
-- [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) with the UWP Development Kit.
+- [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) with the UWP Development Kit, including C++ UWP build tools.
+- C++ ATL for UWP build tools
 
 ### 2: Clone the repository.
 


### PR DESCRIPTION
**Resolved / Related Issues**
Discovered when trying to setup the project. No related issue defined.

Building according to the current prerequisites in the README on a fresh install of VS 2022 fails due to some missing prerequisites.

**Details of Changes**
I added the required prerequisites to the list of prerequisites in the readme. These are the C++ UWP build tools as an option in the mentioned UWP kit (not checked by default) and the C++ ATL for build tools in "Individual components".

The required packages are seen here:
![image](https://user-images.githubusercontent.com/12960453/149195879-59ad6b46-a528-495b-9a9d-575edfc881d5.png)
