### PR TITLE
Select newly created files or folders

### DIFF
--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -115,6 +115,10 @@ namespace Files.ViewModels
 
         public event ItemLoadStatusChangedEventHandler ItemLoadStatusChanged;
 
+        public delegate void ListedItemAddedEventHandler(object sender, ListedItemAddedEventArgs e);
+
+        public event ListedItemAddedEventHandler ListedItemAdded;
+
         public async Task SetWorkingDirectoryAsync(string value)
         {
             if (string.IsNullOrWhiteSpace(value))
@@ -627,6 +631,30 @@ namespace Files.ViewModels
             {
                 App.Logger.Warn(ex, ex.Message);
             }
+        }
+
+        private async Task NotifyListedItemAddedAsync(ListedItem addedItem)
+        {
+            // don't notify if there wasn't a listed item
+            if (addedItem == null)
+            {
+                return;
+            }
+
+            void NotifyUI()
+            {
+                ListedItemAdded?.Invoke(this, new ListedItemAddedEventArgs() { Item = addedItem });
+            }
+
+            if (NativeWinApiHelper.IsHasThreadAccessPropertyPresent && CoreApplication.MainView.DispatcherQueue.HasThreadAccess)
+            {
+                NotifyUI();
+            }
+            else
+            {
+                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(NotifyUI);
+            }
+
         }
 
         private Task OrderFilesAndFoldersAsync()
@@ -1874,7 +1902,9 @@ namespace Files.ViewModels
             const int UPDATE_BATCH_SIZE = 32;
             var sampler = new IntervalSampler(200);
             var updateQueue = new Queue<string>();
+
             bool anyEdits = false;
+            ListedItem lastItemAdded = null;
 
             try
             {
@@ -1892,6 +1922,13 @@ namespace Files.ViewModels
                                 switch (operation.Action)
                                 {
                                     case FILE_ACTION_ADDED:
+                                        lastItemAdded = await AddFileOrFolderAsync(operation.FileName, returnformat);
+                                        if (lastItemAdded != null)
+                                        {
+                                            anyEdits = true;                      
+                                        }
+                                        break;
+
                                     case FILE_ACTION_RENAMED_NEW_NAME:
                                         await AddFileOrFolderAsync(operation.FileName, returnformat);
                                         anyEdits = true;
@@ -1920,6 +1957,10 @@ namespace Files.ViewModels
                             {
                                 await OrderFilesAndFoldersAsync();
                                 await ApplyFilesAndFoldersChangesAsync();
+                                if (lastItemAdded != null)
+                                {
+                                    await NotifyListedItemAddedAsync(lastItemAdded);
+                                }
                                 anyEdits = false;
                             }
                         }
@@ -1949,6 +1990,10 @@ namespace Files.ViewModels
                     {
                         await OrderFilesAndFoldersAsync();
                         await ApplyFilesAndFoldersChangesAsync();
+                        if (lastItemAdded != null) 
+                        { 
+                            await NotifyListedItemAddedAsync(lastItemAdded);
+                        }
                         anyEdits = false;
                     }
                 }
@@ -2053,7 +2098,7 @@ namespace Files.ViewModels
             enumFolderSemaphore.Release();
         }
 
-        private async Task AddFileOrFolderAsync(string fileOrFolderPath, string dateReturnFormat)
+        private async Task<ListedItem> AddFileOrFolderAsync(string fileOrFolderPath, string dateReturnFormat)
         {
             FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
             int additionalFlags = FIND_FIRST_EX_CASE_SENSITIVE;
@@ -2064,7 +2109,7 @@ namespace Files.ViewModels
             {
                 // If we cannot find the file (probably since it doesn't exist anymore)
                 // simply exit without adding it
-                return;
+                return null;
             }
 
             FindClose(hFile);
@@ -2074,7 +2119,7 @@ namespace Files.ViewModels
             if (isHidden && (!UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible || (isSystem && UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden)))
             {
                 // Do not add to file list if hidden/system attribute is set and system/hidden file are not to be shown
-                return;
+                return null;
             }
 
             ListedItem listedItem;
@@ -2088,6 +2133,7 @@ namespace Files.ViewModels
             }
 
             await AddFileOrFolderAsync(listedItem);
+            return listedItem;
         }
 
         private async Task<(ListedItem Item, CloudDriveSyncStatus? SyncStatus, long? Size, DateTimeOffset Created, DateTimeOffset Modified)?> GetFileOrFolderUpdateInfoAsync(ListedItem item, bool hasSyncStatus)
@@ -2262,6 +2308,11 @@ namespace Files.ViewModels
             AppServiceConnectionHelper.ConnectionChanged -= AppServiceConnectionHelper_ConnectionChanged;
             DefaultIcons.Clear();
         }
+    }
+
+    public class ListedItemAddedEventArgs : EventArgs
+    {
+        public ListedItem Item { get; set; }
     }
 
     public class PageTypeUpdatedEventArgs

--- a/src/Files/Views/ColumnShellPage.xaml.cs
+++ b/src/Files/Views/ColumnShellPage.xaml.cs
@@ -504,6 +504,7 @@ namespace Files.Views
             FilesystemViewModel.DirectoryInfoUpdated += FilesystemViewModel_DirectoryInfoUpdated;
             FilesystemViewModel.PageTypeUpdated += FilesystemViewModel_PageTypeUpdated;
             FilesystemViewModel.OnSelectionRequestedEvent += FilesystemViewModel_OnSelectionRequestedEvent;
+            FilesystemViewModel.ListedItemAdded += FilesystemViewModel_ListedItemAdded;
             OnNavigationParamsChanged();
             this.Loaded -= Page_Loaded;
         }
@@ -530,6 +531,18 @@ namespace Files.Views
                 {
                     ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{FilesystemViewModel.FilesAndFolders.Count} {"ItemsCount/Text".GetLocalized()}";
                 }
+            }
+        }
+
+        private void FilesystemViewModel_ListedItemAdded(object sender, ListedItemAddedEventArgs e)
+        {
+            ListedItem itemToSelect = e?.Item;
+            if (itemToSelect != null && ContentPage != null)
+            {
+                // set focus since selection might occur before the UI finishes updating
+                ContentPage.ItemManipulationModel.FocusFileList();
+                ContentPage.ItemManipulationModel.SetSelectedItem(itemToSelect);
+                ContentPage.ItemManipulationModel.ScrollIntoView(itemToSelect);
             }
         }
 
@@ -842,6 +855,7 @@ namespace Files.Views
                 FilesystemViewModel.DirectoryInfoUpdated -= FilesystemViewModel_DirectoryInfoUpdated;
                 FilesystemViewModel.PageTypeUpdated -= FilesystemViewModel_PageTypeUpdated;
                 FilesystemViewModel.OnSelectionRequestedEvent -= FilesystemViewModel_OnSelectionRequestedEvent;
+                FilesystemViewModel.ListedItemAdded -= FilesystemViewModel_ListedItemAdded;
                 FilesystemViewModel.Dispose();
             }
 

--- a/src/Files/Views/ModernShellPage.xaml.cs
+++ b/src/Files/Views/ModernShellPage.xaml.cs
@@ -548,6 +548,7 @@ namespace Files.Views
             FilesystemViewModel.DirectoryInfoUpdated += FilesystemViewModel_DirectoryInfoUpdated;
             FilesystemViewModel.PageTypeUpdated += FilesystemViewModel_PageTypeUpdated;
             FilesystemViewModel.OnSelectionRequestedEvent += FilesystemViewModel_OnSelectionRequestedEvent;
+            FilesystemViewModel.ListedItemAdded += FilesystemViewModel_ListedItemAdded;
             OnNavigationParamsChanged();
             this.Loaded -= Page_Loaded;
         }
@@ -574,6 +575,18 @@ namespace Files.Views
                 {
                     ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{FilesystemViewModel.FilesAndFolders.Count} {"ItemsCount/Text".GetLocalized()}";
                 }
+            }
+        }
+
+        private void FilesystemViewModel_ListedItemAdded(object sender, ListedItemAddedEventArgs e)
+        {
+            ListedItem itemToSelect = e?.Item;
+            if (itemToSelect != null && ContentPage != null)
+            {
+                // set focus since selection might occur before the UI finishes updating
+                ContentPage.ItemManipulationModel.FocusFileList();
+                ContentPage.ItemManipulationModel.SetSelectedItem(itemToSelect);
+                ContentPage.ItemManipulationModel.ScrollIntoView(itemToSelect);
             }
         }
 
@@ -950,6 +963,7 @@ namespace Files.Views
                 FilesystemViewModel.DirectoryInfoUpdated -= FilesystemViewModel_DirectoryInfoUpdated;
                 FilesystemViewModel.PageTypeUpdated -= FilesystemViewModel_PageTypeUpdated;
                 FilesystemViewModel.OnSelectionRequestedEvent -= FilesystemViewModel_OnSelectionRequestedEvent;
+                FilesystemViewModel.ListedItemAdded -= FilesystemViewModel_ListedItemAdded;
                 FilesystemViewModel.Dispose();
             }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Resolves #7310 

**Details of Changes**
- Recent file/folder creations are captured before batched to be handled in bulk
    1. Capture the last item processed by the queue 
    2. When the bulk operation ends, inform the UI thread with the latest item added
- Performant since the UI is only informed on new single file additions (not edits, replacements, etc.)
- Changes applied to both the modern and column-view; uncertain if columns needs this behavior though

**Validation**
How did you test these changes?
- [X] Built and ran the app

**Screenshots (optional)**
![Files-7310](https://user-images.githubusercontent.com/29434693/149589568-10ac976f-2b9a-4f23-a22f-eed4eb46ed69.gif)
