### PR TITLE
Translation zh-Hans Updated

### DIFF
--- a/src/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/src/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -2798,7 +2798,7 @@
         </trans-unit>
         <trans-unit id="SettingsListAndSortDirectoriesAlongsideFiles" translate="yes" xml:space="preserve">
           <source>List and sort directories alongside files</source>
-          <target state="translated">列出和排序文件旁的目录</target>
+          <target state="translated">文件夹与文件一同分类排序</target>
         </trans-unit>
         <trans-unit id="SettingsSearchUnindexedItems" translate="yes" xml:space="preserve">
           <source>Show unindexed items when searching for files and folders</source>


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7765 

**Details of Changes**
Add details of changes here.
- Fixed translation.

Before: "列出和排序文件旁的目录";
After: "文件夹与文件一同分类排序";

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility
