### PR TITLE
Added Install Font button when selecting a font file

### DIFF
--- a/src/Files.Launcher/MessageHandlers/InstallOperationsHandler.cs
+++ b/src/Files.Launcher/MessageHandlers/InstallOperationsHandler.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading.Tasks;
+using System.Linq;
+using Files.Common;
+
+namespace FilesFullTrust.MessageHandlers
+{
+    public class InstallOperationsHandler : IMessageHandler
+    {
+        public void Initialize(PipeStream connection)
+        {
+        }
+
+        public async Task ParseArgumentsAsync(PipeStream connection, Dictionary<string, object> message, string arguments)
+        {
+            switch (arguments)
+            {
+                case "InstallOperation":
+                    await ParseInstallOperationAsync(connection, message);
+                    break;
+            }
+        }
+
+        private async Task ParseInstallOperationAsync(PipeStream connection, Dictionary<string, object> message)
+        {
+            switch (message.Get("installop", ""))
+            {
+                case "InstallFont":
+                {
+                    var filePath = (string)message["filepath"];
+                    var fileExtension = (string)message["extension"];
+                    var isFont = new[] { ".fon", ".otf", ".ttc", ".ttf" }.Contains(fileExtension, StringComparer.OrdinalIgnoreCase);
+
+                    if (isFont)
+                    {
+                        var userFontDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "Windows", "Fonts");
+                        var destName = Path.Combine(userFontDir, Path.GetFileName(filePath));
+                        Win32API.RunPowershellCommand($"-command \"Copy-Item '{filePath}' '{userFontDir}'; New-ItemProperty -Name '{Path.GetFileNameWithoutExtension(filePath)}' -Path 'HKCU:\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts' -PropertyType string -Value '{destName}'\"", false);
+                    }
+                    break;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Files.Launcher/Program.cs
+++ b/src/Files.Launcher/Program.cs
@@ -48,6 +48,7 @@ namespace FilesFullTrust
                 messageHandlers.Add(new ContextMenuHandler());
                 messageHandlers.Add(new QuickLookHandler());
                 messageHandlers.Add(new Win32MessageHandler());
+                messageHandlers.Add(new InstallOperationsHandler());
 
                 // Connect to app service and wait until the connection gets closed
                 appServiceExit = new ManualResetEvent(false);

--- a/src/Files/Helpers/FileExtensionHelpers.cs
+++ b/src/Files/Helpers/FileExtensionHelpers.cs
@@ -17,9 +17,9 @@ namespace Files.Helpers
                 return false;
             }
 
-            return fileExtensionToCheck.Equals(".png", StringComparison.OrdinalIgnoreCase) || 
-                   fileExtensionToCheck.Equals(".jpg", StringComparison.OrdinalIgnoreCase) || 
-                   fileExtensionToCheck.Equals(".bmp", StringComparison.OrdinalIgnoreCase) || 
+            return fileExtensionToCheck.Equals(".png", StringComparison.OrdinalIgnoreCase) ||
+                   fileExtensionToCheck.Equals(".jpg", StringComparison.OrdinalIgnoreCase) ||
+                   fileExtensionToCheck.Equals(".bmp", StringComparison.OrdinalIgnoreCase) ||
                    fileExtensionToCheck.Equals(".jpeg", StringComparison.OrdinalIgnoreCase);
         }
 
@@ -55,6 +55,26 @@ namespace Files.Helpers
             return fileExtensionToCheck.Equals(".zip", StringComparison.OrdinalIgnoreCase) ||
                    fileExtensionToCheck.Equals(".msix", StringComparison.OrdinalIgnoreCase) ||
                    fileExtensionToCheck.Equals(".msixbundle", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Check if the file extension is a font file.
+        /// </summary>
+        /// <param name="fileExtensionToCheck">The file extension to check.</param>
+        /// <returns><c>true</c> if the fileExtensionToCheck is a font file;
+        /// otherwise <c>false</c>.</returns>
+        /// <remarks>Font file types are; fon, otf, ttc, ttf</remarks>
+        public static bool IsFontFile(string fileExtensionToCheck)
+        {
+            if (string.IsNullOrEmpty(fileExtensionToCheck))
+            {
+                return false;
+            }
+
+            return fileExtensionToCheck.Equals(".fon", StringComparison.OrdinalIgnoreCase) ||
+                   fileExtensionToCheck.Equals(".otf", StringComparison.OrdinalIgnoreCase) ||
+                   fileExtensionToCheck.Equals(".ttc", StringComparison.OrdinalIgnoreCase) ||
+                   fileExtensionToCheck.Equals(".ttf", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -786,8 +786,7 @@ namespace Files.Interacts
             }
         }
 
-        //TODO: Fix this method
-        public virtual async void InstallFont()
+        public async void InstallFont()
         {
             foreach (ListedItem selectedItem in SlimContentPage.SelectedItems)
             {

--- a/src/Files/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -786,6 +786,26 @@ namespace Files.Interacts
             }
         }
 
+        //TODO: Fix this method
+        public virtual async void InstallFont()
+        {
+            foreach (ListedItem selectedItem in SlimContentPage.SelectedItems)
+            {
+                var connection = await AppServiceConnectionHelper.Instance;
+                if (connection != null)
+                {
+                    var value = new ValueSet
+                    {
+                        { "Arguments", "InstallOperation" },
+                        { "installop", "InstallFont" },
+                        { "filepath", selectedItem.ItemPath },
+                        { "extension", selectedItem.FileExtension },
+                    };
+                    await connection.SendMessageAsync(value);
+                }
+            }
+        }
+
         #endregion Command Implementation
     }
 }

--- a/src/Files/Interacts/BaseLayoutCommandsViewModel.cs
+++ b/src/Files/Interacts/BaseLayoutCommandsViewModel.cs
@@ -72,6 +72,7 @@ namespace Files.Interacts
             DecompressArchiveCommand = new RelayCommand(CommandsModel.DecompressArchive);
             DecompressArchiveHereCommand = new RelayCommand(CommandsModel.DecompressArchiveHere);
             DecompressArchiveToChildFolderCommand = new RelayCommand(CommandsModel.DecompressArchiveToChildFolder);
+            InstallFontCommand = new RelayCommand(CommandsModel.InstallFont);
         }
 
         #endregion Command Initialization
@@ -167,6 +168,8 @@ namespace Files.Interacts
         public ICommand DecompressArchiveHereCommand { get; private set; }
 
         public ICommand DecompressArchiveToChildFolderCommand { get; private set; }
+
+        public ICommand InstallFontCommand { get; private set; }
 
         #endregion Commands
 

--- a/src/Files/Interacts/IBaseLayoutCommandImplementationModel.cs
+++ b/src/Files/Interacts/IBaseLayoutCommandImplementationModel.cs
@@ -97,5 +97,7 @@ namespace Files.Interacts
         void DecompressArchiveHere();
 
         void DecompressArchiveToChildFolder();
+
+        void InstallFont();
     }
 }

--- a/src/Files/Strings/en-US/Resources.resw
+++ b/src/Files/Strings/en-US/Resources.resw
@@ -2729,4 +2729,7 @@ We use App Center to track which settings are being used, find bugs, and fix cra
   <data name="ShowFolderSizesWarning" xml:space="preserve">
     <value>Calculating folder sizes is resource intensive and may cause your CPU usage to increase.</value>
   </data>
+  <data name="Install" xml:space="preserve">
+    <value>Install</value>
+  </data>
 </root>

--- a/src/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files/UserControls/InnerNavigationToolbar.xaml
@@ -292,7 +292,7 @@
                     LabelPosition="Default"
                     ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
                     <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE8D2;" />
+                        <FontIcon Glyph="&#xE185;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
             </CommandBar.PrimaryCommands>

--- a/src/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files/UserControls/InnerNavigationToolbar.xaml
@@ -200,7 +200,7 @@
                         <local:ColoredIcon BaseLayerGlyph="&#xF031;" OverlayLayerGlyph="&#xF032;" />
                     </AppBarButton.Content>
                 </AppBarButton>
-                <AppBarSeparator x:Name="AdditionalActionSeparator" x:Load="{x:Bind ViewModel.HasAdditionnalAction, Mode=OneWay}" />
+                <AppBarSeparator x:Name="AdditionalActionSeparator" x:Load="{x:Bind ViewModel.HasAdditionalAction, Mode=OneWay}" />
                 <AppBarButton
                     x:Name="EmptyRecycleBinButton"
                     AccessKey="B"
@@ -226,7 +226,7 @@
                         <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF11A;" />
                     </AppBarButton.Content>
                     <AppBarButton.Flyout>
-                        <MenuFlyout Placement="Bottom" 
+                        <MenuFlyout Placement="Bottom"
                                     helpers:MenuFlyoutHelper.IsVisible="{x:Bind ViewModel.CanExtract, Mode=OneWay}">
                             <MenuFlyoutItem
                                 Command="{x:Bind ViewModel.ExtractCommand, Mode=OneWay}"
@@ -283,6 +283,17 @@
                     ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsBackground}">
                     <AppBarButton.Icon>
                         <FontIcon Glyph="&#xE91B;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="InstallFontButton"
+                    x:Load="{x:Bind ViewModel.IsFont, Mode=OneWay, FallbackValue=False}"
+                    Command="{x:Bind ViewModel.InstallFontCommand, Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=Install}"
+                    LabelPosition="Default"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE8D2;" />
                     </AppBarButton.Icon>
                 </AppBarButton>
             </CommandBar.PrimaryCommands>

--- a/src/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files/UserControls/InnerNavigationToolbar.xaml
@@ -226,8 +226,7 @@
                         <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF11A;" />
                     </AppBarButton.Content>
                     <AppBarButton.Flyout>
-                        <MenuFlyout Placement="Bottom"
-                                    helpers:MenuFlyoutHelper.IsVisible="{x:Bind ViewModel.CanExtract, Mode=OneWay}">
+                        <MenuFlyout helpers:MenuFlyoutHelper.IsVisible="{x:Bind ViewModel.CanExtract, Mode=OneWay}" Placement="Bottom">
                             <MenuFlyoutItem
                                 Command="{x:Bind ViewModel.ExtractCommand, Mode=OneWay}"
                                 IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"

--- a/src/Files/ViewModels/NavToolbarViewModel.cs
+++ b/src/Files/ViewModels/NavToolbarViewModel.cs
@@ -678,7 +678,7 @@ namespace Files.ViewModels
 
         public void UpdateAdditionnalActions()
         {
-            OnPropertyChanged(nameof(HasAdditionnalAction));
+            OnPropertyChanged(nameof(HasAdditionalAction));
             OnPropertyChanged(nameof(CanEmptyRecycleBin));
         }
 
@@ -794,7 +794,7 @@ namespace Files.ViewModels
         public ICommand CutCommand { get; set; }
 
         public ICommand EmptyRecycleBinCommand { get; set; }
-        
+
         public ICommand PropertiesCommand { get; set; }
 
         public ICommand ExtractCommand { get; set; }
@@ -806,6 +806,8 @@ namespace Files.ViewModels
         public ICommand RunWithPowerShellCommand { get; set; }
 
         public ICommand SetAsBackgroundCommand { get; set; }
+
+        public ICommand InstallFontCommand { get; set; }
 
         public async Task SetPathBoxDropDownFlyoutAsync(MenuFlyout flyout, PathBoxItem pathItem, IShellPage shellPage)
         {
@@ -1089,18 +1091,19 @@ namespace Files.ViewModels
                     OnPropertyChanged(nameof(CanCopy));
                     OnPropertyChanged(nameof(CanShare));
                     OnPropertyChanged(nameof(CanRename));
-                    OnPropertyChanged(nameof(IsPowerShellScript));
                     OnPropertyChanged(nameof(CanViewProperties));
-                    OnPropertyChanged(nameof(IsImage));
                     OnPropertyChanged(nameof(CanExtract));
                     OnPropertyChanged(nameof(ExtractToText));
-                    OnPropertyChanged(nameof(HasAdditionnalAction));
+                    OnPropertyChanged(nameof(IsPowerShellScript));
+                    OnPropertyChanged(nameof(IsImage));
+                    OnPropertyChanged(nameof(IsFont));
+                    OnPropertyChanged(nameof(HasAdditionalAction));
                 }
             }
         }
 
-        public bool HasAdditionnalAction => InstanceViewModel.IsPageTypeRecycleBin || IsPowerShellScript || CanExtract || IsImage;
-     
+        public bool HasAdditionalAction => InstanceViewModel.IsPageTypeRecycleBin || IsPowerShellScript || CanExtract || IsImage || IsFont;
+
         public bool CanCopy            => SelectedItems is not null && SelectedItems.Any();
         public bool CanShare           => SelectedItems is not null && SelectedItems.Any() && DataTransferManager.IsSupported() && !SelectedItems.Any(x => (x.IsShortcutItem && !x.IsLinkItem) || x.IsHiddenItem || (x.PrimaryItemAttribute == StorageItemTypes.Folder && !x.IsZipItem));
         public bool CanRename          => SelectedItems is not null && SelectedItems.Count == 1;
@@ -1110,6 +1113,7 @@ namespace Files.ViewModels
         public string ExtractToText    => SelectedItems is not null && SelectedItems.Any() ? string.Format("ExtractToChildFolder".GetLocalized() + "\\", Path.GetFileNameWithoutExtension(selectedItems.First().ItemName)) : "ExtractToChildFolder".GetLocalized();
         public bool IsPowerShellScript => SelectedItems is not null && SelectedItems.Any() && FileExtensionHelpers.IsPowerShellFile(SelectedItems.First().FileExtension);
         public bool IsImage            => SelectedItems is not null && SelectedItems.Any() && FileExtensionHelpers.IsImageFile(SelectedItems.First().FileExtension);
+        public bool IsFont             => SelectedItems is not null && SelectedItems.Any() && FileExtensionHelpers.IsFontFile(SelectedItems.First().FileExtension);
 
         public void Dispose()
         {

--- a/src/Files/ViewModels/NavToolbarViewModel.cs
+++ b/src/Files/ViewModels/NavToolbarViewModel.cs
@@ -1076,7 +1076,6 @@ namespace Files.ViewModels
                     OnPropertyChanged(nameof(CanEmptyRecycleBin));
                 }
             }
-
         }
 
         private List<ListedItem> selectedItems;
@@ -1109,11 +1108,11 @@ namespace Files.ViewModels
         public bool CanRename          => SelectedItems is not null && SelectedItems.Count == 1;
         public bool CanViewProperties  => SelectedItems is not null && SelectedItems.Any();
         public bool CanEmptyRecycleBin => InstanceViewModel.IsPageTypeRecycleBin && HasItem;
-        public bool CanExtract         => SelectedItems is not null && SelectedItems.Any() && FileExtensionHelpers.IsZipFile(SelectedItems.First().FileExtension);
-        public string ExtractToText    => SelectedItems is not null && SelectedItems.Any() ? string.Format("ExtractToChildFolder".GetLocalized() + "\\", Path.GetFileNameWithoutExtension(selectedItems.First().ItemName)) : "ExtractToChildFolder".GetLocalized();
-        public bool IsPowerShellScript => SelectedItems is not null && SelectedItems.Any() && FileExtensionHelpers.IsPowerShellFile(SelectedItems.First().FileExtension);
-        public bool IsImage            => SelectedItems is not null && SelectedItems.Any() && FileExtensionHelpers.IsImageFile(SelectedItems.First().FileExtension);
-        public bool IsFont             => SelectedItems is not null && SelectedItems.Any() && FileExtensionHelpers.IsFontFile(SelectedItems.First().FileExtension);
+        public bool CanExtract         => SelectedItems is not null && SelectedItems.Count == 1 && FileExtensionHelpers.IsZipFile(SelectedItems.First().FileExtension);
+        public string ExtractToText    => SelectedItems is not null && SelectedItems.Count == 1 ? string.Format("ExtractToChildFolder".GetLocalized() + "\\", Path.GetFileNameWithoutExtension(selectedItems.First().ItemName)) : "ExtractToChildFolder".GetLocalized();
+        public bool IsPowerShellScript => SelectedItems is not null && SelectedItems.Count == 1 && FileExtensionHelpers.IsPowerShellFile(SelectedItems.First().FileExtension);
+        public bool IsImage            => SelectedItems is not null && SelectedItems.Count == 1 && FileExtensionHelpers.IsImageFile(SelectedItems.First().FileExtension);
+        public bool IsFont             => SelectedItems is not null && SelectedItems.Any() && SelectedItems.All(x => FileExtensionHelpers.IsFontFile(x.FileExtension));
 
         public void Dispose()
         {

--- a/src/Files/Views/ColumnShellPage.xaml.cs
+++ b/src/Files/Views/ColumnShellPage.xaml.cs
@@ -219,10 +219,13 @@ namespace Files.Views
             NavToolbarViewModel.DeleteCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.DeleteItemCommand.Execute(null));
             NavToolbarViewModel.CutCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.CutItemCommand.Execute(null));
             NavToolbarViewModel.EmptyRecycleBinCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.EmptyRecycleBinCommand.Execute(null));
+            NavToolbarViewModel.RunWithPowerShellCommand = new RelayCommand(async () => await Win32Helpers.InvokeWin32ComponentAsync("powershell", this, PathNormalization.NormalizePath(SlimContentPage?.SelectedItem.ItemPath)));
             NavToolbarViewModel.PropertiesCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.ShowPropertiesCommand.Execute(null));
+            NavToolbarViewModel.SetAsBackgroundCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.SetAsDesktopBackgroundItemCommand.Execute(null));
             NavToolbarViewModel.ExtractCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.DecompressArchiveCommand.Execute(null));
             NavToolbarViewModel.ExtractHereCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.DecompressArchiveHereCommand.Execute(null));
             NavToolbarViewModel.ExtractToCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.DecompressArchiveToChildFolderCommand.Execute(null));
+            NavToolbarViewModel.InstallFontCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.InstallFontCommand.Execute(null));
         }
 
         private void FolderSettings_LayoutPreferencesUpdateRequired(object sender, LayoutPreferenceEventArgs e)

--- a/src/Files/Views/ModernShellPage.xaml.cs
+++ b/src/Files/Views/ModernShellPage.xaml.cs
@@ -203,7 +203,7 @@ namespace Files.Views
             NavToolbarViewModel.DeleteCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.DeleteItemCommand.Execute(null));
             NavToolbarViewModel.CutCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.CutItemCommand.Execute(null));
             NavToolbarViewModel.EmptyRecycleBinCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.EmptyRecycleBinCommand.Execute(null));
-            NavToolbarViewModel.RunWithPowerShellCommand = new RelayCommand(async () => await Win32Helpers.InvokeWin32ComponentAsync("powershell", this, PathNormalization.NormalizePath(SlimContentPage?.SelectedItems.First().ItemPath)));
+            NavToolbarViewModel.RunWithPowerShellCommand = new RelayCommand(async () => await Win32Helpers.InvokeWin32ComponentAsync("powershell", this, PathNormalization.NormalizePath(SlimContentPage?.SelectedItem.ItemPath)));
             NavToolbarViewModel.PropertiesCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.ShowPropertiesCommand.Execute(null));
             NavToolbarViewModel.SetAsBackgroundCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.SetAsDesktopBackgroundItemCommand.Execute(null));
             NavToolbarViewModel.ExtractCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.DecompressArchiveCommand.Execute(null));

--- a/src/Files/Views/ModernShellPage.xaml.cs
+++ b/src/Files/Views/ModernShellPage.xaml.cs
@@ -209,6 +209,7 @@ namespace Files.Views
             NavToolbarViewModel.ExtractCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.DecompressArchiveCommand.Execute(null));
             NavToolbarViewModel.ExtractHereCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.DecompressArchiveHereCommand.Execute(null));
             NavToolbarViewModel.ExtractToCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.DecompressArchiveToChildFolderCommand.Execute(null));
+            NavToolbarViewModel.InstallFontCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.InstallFontCommand.Execute(null));
         }
 
         private void ModernShellPage_RefreshWidgetsRequested(object sender, EventArgs e)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related #7800

**Details of Changes**
Add details of changes here.
- Added IsFontFile extension helper.
- Added resource string (Install).
- Corrected spelling of HasAdditionalActions. 
- Added messager handler to install font (could be used for installing infs at a later stage)

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/79826944/150439383-c8226f5f-1643-4460-bd6d-10b89c2606dd.png)

**Comments**
Toolbar text might be better as Install font. I just went with what Windows had originally in the context menu. 