### PR TITLE
Fixed image thumbnails not appearing

### DIFF
--- a/src/Files/Helpers/FileThumbnailHelper.cs
+++ b/src/Files/Helpers/FileThumbnailHelper.cs
@@ -111,19 +111,19 @@ namespace Files.Helpers
 
         public static async Task<byte[]> LoadIconFromPathAsync(string filePath, uint thumbnailSize, ThumbnailMode thumbnailMode)
         {
-            var iconData = await LoadIconWithoutOverlayAsync(filePath, thumbnailSize);
-            if (iconData == null)
+            if (!filePath.EndsWith(".lnk", StringComparison.Ordinal) && !filePath.EndsWith(".url", StringComparison.Ordinal))
             {
-                if (!filePath.EndsWith(".lnk", StringComparison.Ordinal) && !filePath.EndsWith(".url", StringComparison.Ordinal))
+                var item = await StorageHelpers.ToStorageItem<IStorageItem>(filePath);
+                if (item != null)
                 {
-                    var item = await StorageHelpers.ToStorageItem<IStorageItem>(filePath);
-                    if (item != null)
+                    var iconData = await LoadIconFromStorageItemAsync(item, thumbnailSize, thumbnailMode);
+                    if (iconData != null)
                     {
-                        iconData = await LoadIconFromStorageItemAsync(item, thumbnailSize, thumbnailMode);
+                        return iconData;
                     }
                 }
             }
-            return iconData;
+            return await LoadIconWithoutOverlayAsync(filePath, thumbnailSize);
         }
     }
 }

--- a/src/Files/Helpers/FileThumbnailHelper.cs
+++ b/src/Files/Helpers/FileThumbnailHelper.cs
@@ -111,19 +111,19 @@ namespace Files.Helpers
 
         public static async Task<byte[]> LoadIconFromPathAsync(string filePath, uint thumbnailSize, ThumbnailMode thumbnailMode)
         {
-            if (!filePath.EndsWith(".lnk", StringComparison.Ordinal) && !filePath.EndsWith(".url", StringComparison.Ordinal))
+            var iconData = await LoadIconWithoutOverlayAsync(filePath, thumbnailSize);
+            if (iconData == null)
             {
-                var item = await StorageHelpers.ToStorageItem<IStorageItem>(filePath);
-                if (item != null)
+                if (!filePath.EndsWith(".lnk", StringComparison.Ordinal) && !filePath.EndsWith(".url", StringComparison.Ordinal))
                 {
-                    var iconData = await LoadIconFromStorageItemAsync(item, thumbnailSize, thumbnailMode);
-                    if (iconData != null)
+                    var item = await StorageHelpers.ToStorageItem<IStorageItem>(filePath);
+                    if (item != null)
                     {
-                        return iconData;
+                        iconData = await LoadIconFromStorageItemAsync(item, thumbnailSize, thumbnailMode);
                     }
                 }
             }
-            return await LoadIconWithoutOverlayAsync(filePath, thumbnailSize);
+            return iconData;
         }
     }
 }

--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -828,66 +828,57 @@ namespace Files.ViewModels
             var wasIconLoaded = false;
             if (item.IsLibraryItem || item.PrimaryItemAttribute == StorageItemTypes.File || item.IsZipItem)
             {
-                if (!item.IsShortcutItem && !item.IsHiddenItem && !FtpHelpers.IsFtpPath(item.ItemPath))
+                var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize);
+                if (iconInfo.IconData != null)
                 {
-                    var matchingStorageFile = matchingStorageItem.AsBaseStorageFile() ?? await GetFileFromPathAsync(item.ItemPath);
-                    if (matchingStorageFile != null)
+                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
                     {
-                        var mode = thumbnailSize < 80 ? ThumbnailMode.ListView : ThumbnailMode.SingleItem;
-
-                        using StorageItemThumbnail Thumbnail = await FilesystemTasks.Wrap(() => matchingStorageFile.GetThumbnailAsync(mode, thumbnailSize, ThumbnailOptions.ResizeThumbnail).AsTask());
-                        if (!(Thumbnail == null || Thumbnail.Size == 0 || Thumbnail.OriginalHeight == 0 || Thumbnail.OriginalWidth == 0))
+                        item.FileImage = await iconInfo.IconData.ToBitmapAsync();
+                        if (!string.IsNullOrEmpty(item.FileExtension) &&
+                            !item.IsShortcutItem && !item.IsExecutable &&
+                            !ImagePreviewViewModel.Extensions.Contains(item.FileExtension, StringComparer.OrdinalIgnoreCase))
                         {
-                            await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                            {
-                                item.FileImage ??= new BitmapImage();
-                                item.FileImage.DecodePixelType = DecodePixelType.Logical;
-                                item.FileImage.DecodePixelWidth = (int)thumbnailSize;
-                                await item.FileImage.SetSourceAsync(Thumbnail);
-                                if (!string.IsNullOrEmpty(item.FileExtension) &&
-                                    !item.IsShortcutItem && !item.IsExecutable &&
-                                    !ImagePreviewViewModel.Extensions.Contains(item.FileExtension, StringComparer.OrdinalIgnoreCase))
-                                {
-                                    DefaultIcons.AddIfNotPresent(item.FileExtension.ToLowerInvariant(), item.FileImage);
-                                }
-                            }, Windows.System.DispatcherQueuePriority.Normal);
-                            wasIconLoaded = true;
+                            DefaultIcons.AddIfNotPresent(item.FileExtension.ToLowerInvariant(), item.FileImage);
                         }
+                    }, Windows.System.DispatcherQueuePriority.Low);
+                    wasIconLoaded = true;
+                }
 
-                        var overlayInfo = await FileThumbnailHelper.LoadOverlayAsync(item.ItemPath);
-                        if (overlayInfo != null)
-                        {
-                            await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                            {
-                                item.IconOverlay = await overlayInfo.ToBitmapAsync();
-                            }, Windows.System.DispatcherQueuePriority.Low);
-                        }
-                    }
+                if (iconInfo.OverlayData != null)
+                {
+                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
+                    {
+                        item.IconOverlay = await iconInfo.OverlayData.ToBitmapAsync();
+                    }, Windows.System.DispatcherQueuePriority.Low);
                 }
 
                 if (!wasIconLoaded)
                 {
-                    var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize);
-                    if (iconInfo.IconData != null)
+                    if (!item.IsShortcutItem && !item.IsHiddenItem && !FtpHelpers.IsFtpPath(item.ItemPath))
                     {
-                        await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
+                        var matchingStorageFile = matchingStorageItem.AsBaseStorageFile() ?? await GetFileFromPathAsync(item.ItemPath);
+                        if (matchingStorageFile != null)
                         {
-                            item.FileImage = await iconInfo.IconData.ToBitmapAsync();
-                            if (!string.IsNullOrEmpty(item.FileExtension) &&
-                                !item.IsShortcutItem && !item.IsExecutable &&
-                                !ImagePreviewViewModel.Extensions.Contains(item.FileExtension, StringComparer.OrdinalIgnoreCase))
-                            {
-                                DefaultIcons.AddIfNotPresent(item.FileExtension.ToLowerInvariant(), item.FileImage);
-                            }
-                        }, Windows.System.DispatcherQueuePriority.Low);
-                    }
+                            var mode = thumbnailSize < 80 ? ThumbnailMode.ListView : ThumbnailMode.SingleItem;
 
-                    if (iconInfo.OverlayData != null)
-                    {
-                        await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
-                        {
-                            item.IconOverlay = await iconInfo.OverlayData.ToBitmapAsync();
-                        }, Windows.System.DispatcherQueuePriority.Low);
+                            using StorageItemThumbnail Thumbnail = await FilesystemTasks.Wrap(() => matchingStorageFile.GetThumbnailAsync(mode, thumbnailSize, ThumbnailOptions.ResizeThumbnail).AsTask());
+                            if (!(Thumbnail == null || Thumbnail.Size == 0 || Thumbnail.OriginalHeight == 0 || Thumbnail.OriginalWidth == 0))
+                            {
+                                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
+                                {
+                                    item.FileImage ??= new BitmapImage();
+                                    item.FileImage.DecodePixelType = DecodePixelType.Logical;
+                                    item.FileImage.DecodePixelWidth = (int)thumbnailSize;
+                                    await item.FileImage.SetSourceAsync(Thumbnail);
+                                    if (!string.IsNullOrEmpty(item.FileExtension) &&
+                                        !item.IsShortcutItem && !item.IsExecutable &&
+                                        !ImagePreviewViewModel.Extensions.Contains(item.FileExtension, StringComparer.OrdinalIgnoreCase))
+                                    {
+                                        DefaultIcons.AddIfNotPresent(item.FileExtension.ToLowerInvariant(), item.FileImage);
+                                    }
+                                }, Windows.System.DispatcherQueuePriority.Normal);
+                            }
+                        }
                     }
                 }
             }

--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -833,7 +833,7 @@ namespace Files.ViewModels
                     var matchingStorageFile = matchingStorageItem.AsBaseStorageFile() ?? await GetFileFromPathAsync(item.ItemPath);
                     if (matchingStorageFile != null)
                     {
-                        var mode = thumbnailSize < 80 ? ThumbnailMode.ListView : ThumbnailMode.SingleItem;
+                        var mode = thumbnailSize < 80 ? ThumbnailMode.ListView : ThumbnailMode.DocumentsView;
 
                         using StorageItemThumbnail Thumbnail = await FilesystemTasks.Wrap(() => matchingStorageFile.GetThumbnailAsync(mode, thumbnailSize, ThumbnailOptions.ResizeThumbnail).AsTask());
                         if (!(Thumbnail == null || Thumbnail.Size == 0 || Thumbnail.OriginalHeight == 0 || Thumbnail.OriginalWidth == 0))

--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -797,12 +797,14 @@ namespace Files.ViewModels
             if (currentDefaultIconSize != size)
             {
                 // TODO: Add more than just the folder icon
-
                 DefaultIcons.Clear();
-                BitmapImage img = new BitmapImage();
-                using var icon = await StorageItemIconHelpers.GetIconForItemType(size, IconPersistenceOptions.Persist);
-                await img.SetSourceAsync(icon);
-                DefaultIcons.Add(string.Empty, img);
+                using StorageItemThumbnail icon = await FilesystemTasks.Wrap(() => StorageItemIconHelpers.GetIconForItemType(size, IconPersistenceOptions.Persist));
+                if (icon != null)
+                {
+                    BitmapImage img = new BitmapImage();
+                    await img.SetSourceAsync(icon);
+                    DefaultIcons.Add(string.Empty, img);
+                }
                 currentDefaultIconSize = size;
             }
         }
@@ -833,7 +835,7 @@ namespace Files.ViewModels
                     {
                         var mode = thumbnailSize < 80 ? ThumbnailMode.ListView : ThumbnailMode.SingleItem;
 
-                        using var Thumbnail = await matchingStorageFile.GetThumbnailAsync(mode, thumbnailSize, ThumbnailOptions.ResizeThumbnail);
+                        using StorageItemThumbnail Thumbnail = await FilesystemTasks.Wrap(() => matchingStorageFile.GetThumbnailAsync(mode, thumbnailSize, ThumbnailOptions.ResizeThumbnail).AsTask());
                         if (!(Thumbnail == null || Thumbnail.Size == 0 || Thumbnail.OriginalHeight == 0 || Thumbnail.OriginalWidth == 0))
                         {
                             await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
@@ -844,7 +846,7 @@ namespace Files.ViewModels
                                 await item.FileImage.SetSourceAsync(Thumbnail);
                                 if (!string.IsNullOrEmpty(item.FileExtension) &&
                                     !item.IsShortcutItem && !item.IsExecutable &&
-                                    !ImagePreviewViewModel.Extensions.Contains(item.FileExtension))
+                                    !ImagePreviewViewModel.Extensions.Contains(item.FileExtension, StringComparer.OrdinalIgnoreCase))
                                 {
                                     DefaultIcons.AddIfNotPresent(item.FileExtension.ToLowerInvariant(), item.FileImage);
                                 }
@@ -873,7 +875,7 @@ namespace Files.ViewModels
                             item.FileImage = await iconInfo.IconData.ToBitmapAsync();
                             if (!string.IsNullOrEmpty(item.FileExtension) &&
                                 !item.IsShortcutItem && !item.IsExecutable &&
-                                !ImagePreviewViewModel.Extensions.Contains(item.FileExtension))
+                                !ImagePreviewViewModel.Extensions.Contains(item.FileExtension, StringComparer.OrdinalIgnoreCase))
                             {
                                 DefaultIcons.AddIfNotPresent(item.FileExtension.ToLowerInvariant(), item.FileImage);
                             }
@@ -898,7 +900,7 @@ namespace Files.ViewModels
                     {
                         var mode = thumbnailSize < 80 ? ThumbnailMode.ListView : ThumbnailMode.SingleItem;
 
-                        using var Thumbnail = await matchingStorageFolder.GetThumbnailAsync(mode, thumbnailSize, ThumbnailOptions.ResizeThumbnail);
+                        using StorageItemThumbnail Thumbnail = await FilesystemTasks.Wrap(() => matchingStorageFolder.GetThumbnailAsync(mode, thumbnailSize, ThumbnailOptions.ResizeThumbnail).AsTask());
                         if (!(Thumbnail == null || Thumbnail.Size == 0 || Thumbnail.OriginalHeight == 0 || Thumbnail.OriginalWidth == 0))
                         {
                             await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>
@@ -1130,7 +1132,7 @@ namespace Files.ViewModels
 
                         if (matchingStorageItem != null)
                         {
-                            using var headerThumbnail = await matchingStorageItem.GetThumbnailAsync(ThumbnailMode.DocumentsView, 36, ThumbnailOptions.UseCurrentScale);
+                            using StorageItemThumbnail headerThumbnail = await FilesystemTasks.Wrap(() => matchingStorageItem.GetThumbnailAsync(ThumbnailMode.DocumentsView, 36, ThumbnailOptions.UseCurrentScale).AsTask());
                             if (headerThumbnail != null)
                             {
                                 await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () =>

--- a/src/Files/ViewModels/Previews/BasePreviewModel.cs
+++ b/src/Files/ViewModels/Previews/BasePreviewModel.cs
@@ -55,8 +55,8 @@ namespace Files.ViewModels.Previews
         /// <returns>A list of details</returns>
         public async virtual Task<List<FileProperty>> LoadPreviewAndDetails()
         {
-            var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(Item.ItemFile, 400, ThumbnailMode.SingleItem);
-            iconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 400);
+            var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 400);
+            iconData ??= await FileThumbnailHelper.LoadIconFromStorageItemAsync(Item.ItemFile, 400, ThumbnailMode.SingleItem);
             if (iconData != null)
             {
                 await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () => FileImage = await iconData.ToBitmapAsync());

--- a/src/Files/ViewModels/Previews/BasePreviewModel.cs
+++ b/src/Files/ViewModels/Previews/BasePreviewModel.cs
@@ -110,7 +110,11 @@ namespace Files.ViewModels.Previews
         public virtual async Task LoadAsync()
         {
             List<FileProperty> detailsFull = new();
-            Item.ItemFile ??= await StorageFileExtensions.DangerousGetFileFromPathAsync(Item.ItemPath);
+            if (Item.ItemFile == null)
+            {
+                var rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(Item.ItemPath));
+                Item.ItemFile = await StorageFileExtensions.DangerousGetFileFromPathAsync(Item.ItemPath, rootItem);
+            }
             await Task.Run(async () =>
             {
                 DetailsFromPreview = await LoadPreviewAndDetails();

--- a/src/Files/ViewModels/Previews/BasePreviewModel.cs
+++ b/src/Files/ViewModels/Previews/BasePreviewModel.cs
@@ -55,8 +55,8 @@ namespace Files.ViewModels.Previews
         /// <returns>A list of details</returns>
         public async virtual Task<List<FileProperty>> LoadPreviewAndDetails()
         {
-            var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 400);
-            iconData ??= await FileThumbnailHelper.LoadIconFromStorageItemAsync(Item.ItemFile, 400, ThumbnailMode.SingleItem);
+            var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(Item.ItemFile, 400, ThumbnailMode.SingleItem);
+            iconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 400);
             if (iconData != null)
             {
                 await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(async () => FileImage = await iconData.ToBitmapAsync());

--- a/src/Files/ViewModels/Previews/BasePreviewModel.cs
+++ b/src/Files/ViewModels/Previews/BasePreviewModel.cs
@@ -55,7 +55,7 @@ namespace Files.ViewModels.Previews
         /// <returns>A list of details</returns>
         public async virtual Task<List<FileProperty>> LoadPreviewAndDetails()
         {
-            var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(Item.ItemFile, 400, ThumbnailMode.SingleItem);
+            var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(Item.ItemFile, 400, ThumbnailMode.DocumentsView);
             iconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 400);
             if (iconData != null)
             {

--- a/src/Files/ViewModels/Previews/FolderPreviewViewModel.cs
+++ b/src/Files/ViewModels/Previews/FolderPreviewViewModel.cs
@@ -39,7 +39,8 @@ namespace Files.ViewModels.Previews
             ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
             string returnformat = Enum.Parse<TimeStyle>(localSettings.Values[Constants.LocalSettings.DateTimeFormat].ToString()) == TimeStyle.Application ? "D" : "g";
 
-            Folder = await StorageFileExtensions.DangerousGetFolderFromPathAsync(Item.ItemPath);
+            var rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(Item.ItemPath));
+            Folder = await StorageFileExtensions.DangerousGetFolderFromPathAsync(Item.ItemPath, rootItem);
             var items = await Folder.GetItemsAsync();
 
             var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(Folder, 400, ThumbnailMode.SingleItem);

--- a/src/Files/ViewModels/Properties/FileProperties.cs
+++ b/src/Files/ViewModels/Properties/FileProperties.cs
@@ -108,7 +108,7 @@ namespace Files.ViewModels.Properties
             ViewModel.ItemSizeVisibility = true;
             ViewModel.ItemSize = Item.FileSizeBytes.ToLongSizeString();
 
-            var fileIconData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.ItemPath, 80, Windows.Storage.FileProperties.ThumbnailMode.SingleItem);
+            var fileIconData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.ItemPath, 80, Windows.Storage.FileProperties.ThumbnailMode.DocumentsView);
             if (fileIconData != null)
             {
                 ViewModel.IconData = fileIconData;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6512
- Closes #7770
- Closes #6130
- Closes #6966

Using "ThumbnailMode.DocumentsView" instead of "ThumbnailMode.SingleItem" appears to fix the missing thumbnails issue. Even #6512 (preview for .psd files) looks fixed. Could someone double-check?

**Validation**
How did you test these changes?
- [x] Built and ran the app
