### PR TITLE
Fixed delete dialog primary button focus issue

### DIFF
--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -14,7 +14,6 @@
     CornerRadius="{StaticResource OverlayCornerRadius}"
     DefaultButton="Primary"
     IsPrimaryButtonEnabled="{x:Bind ViewModel.PrimaryButtonEnabled, Mode=OneWay}"
-    Loaded="RootDialog_Loaded"
     PrimaryButtonCommand="{x:Bind ViewModel.PrimaryButtonCommand, Mode=OneWay}"
     PrimaryButtonText="{x:Bind ViewModel.PrimaryButtonText, Mode=OneWay}"
     RequestedTheme="{x:Bind helpers:ThemeHelper.RootTheme}"

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -14,6 +14,7 @@
     CornerRadius="{StaticResource OverlayCornerRadius}"
     DefaultButton="Primary"
     IsPrimaryButtonEnabled="{x:Bind ViewModel.PrimaryButtonEnabled, Mode=OneWay}"
+    Loaded="OnLoaded"
     PrimaryButtonCommand="{x:Bind ViewModel.PrimaryButtonCommand, Mode=OneWay}"
     PrimaryButtonText="{x:Bind ViewModel.PrimaryButtonText, Mode=OneWay}"
     RequestedTheme="{x:Bind helpers:ThemeHelper.RootTheme}"
@@ -62,7 +63,7 @@
                 x:Load="{x:Bind ViewModel.PermanentlyDeleteLoad, Mode=OneWay}"
                 Content="Permanently delete"
                 IsChecked="{x:Bind ViewModel.PermanentlyDelete, Mode=TwoWay}"
-                IsEnabled="{x:Bind ViewModel.PermanentlyDeleteEnabled, Mode=OneWay}" />
+                IsEnabled="False" />
 
             <Grid>
                 <ListView

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -20,6 +20,7 @@
     SecondaryButtonCommand="{x:Bind ViewModel.SecondaryButtonCommand, Mode=OneWay}"
     SecondaryButtonText="{x:Bind ViewModel.SecondaryButtonText, Mode=OneWay}"
     Style="{StaticResource DefaultContentDialogStyle}"
+    Loaded="FilesystemOperationDialog_OnLoaded"
     mc:Ignorable="d">
     <i:Interaction.Behaviors>
         <!--  No need to specify CommandParameter - `e` is passed by default  -->

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -20,6 +20,7 @@
     SecondaryButtonCommand="{x:Bind ViewModel.SecondaryButtonCommand, Mode=OneWay}"
     SecondaryButtonText="{x:Bind ViewModel.SecondaryButtonText, Mode=OneWay}"
     Style="{StaticResource DefaultContentDialogStyle}"
+    Loaded="OnLoaded"
     mc:Ignorable="d">
 
     <ContentDialog.Resources>

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -20,14 +20,7 @@
     SecondaryButtonCommand="{x:Bind ViewModel.SecondaryButtonCommand, Mode=OneWay}"
     SecondaryButtonText="{x:Bind ViewModel.SecondaryButtonText, Mode=OneWay}"
     Style="{StaticResource DefaultContentDialogStyle}"
-    Loaded="FilesystemOperationDialog_OnLoaded"
     mc:Ignorable="d">
-    <i:Interaction.Behaviors>
-        <!--  No need to specify CommandParameter - `e` is passed by default  -->
-        <icore:EventTriggerBehavior EventName="Loaded">
-            <icore:InvokeCommandAction Command="{x:Bind ViewModel.LoadedCommand, Mode=OneWay}" />
-        </icore:EventTriggerBehavior>
-    </i:Interaction.Behaviors>
 
     <ContentDialog.Resources>
         <ResourceDictionary>
@@ -66,7 +59,9 @@
             <CheckBox
                 x:Name="chkPermanentlyDelete"
                 x:Uid="DeleteItemsDialogPermanentlyDeleteCheckBox"
-                x:Load="{x:Bind ViewModel.PermanentlyDeleteLoad, Mode=OneWay}"
+                x:Load="{x:Bind ViewModel.PermanentlyDeleteLoad}"
+                IsChecked="{x:Bind ViewModel.PermanentlyDelete, Mode=TwoWay}"
+                IsEnabled="{x:Bind ViewModel.PermanentlyDeleteEnabled}"
                 Content="Permanently delete"/>
 
             <Grid>

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -14,13 +14,13 @@
     CornerRadius="{StaticResource OverlayCornerRadius}"
     DefaultButton="Primary"
     IsPrimaryButtonEnabled="{x:Bind ViewModel.PrimaryButtonEnabled, Mode=OneWay}"
+    Loaded="RootDialog_Loaded"
     PrimaryButtonCommand="{x:Bind ViewModel.PrimaryButtonCommand, Mode=OneWay}"
     PrimaryButtonText="{x:Bind ViewModel.PrimaryButtonText, Mode=OneWay}"
     RequestedTheme="{x:Bind helpers:ThemeHelper.RootTheme}"
     SecondaryButtonCommand="{x:Bind ViewModel.SecondaryButtonCommand, Mode=OneWay}"
     SecondaryButtonText="{x:Bind ViewModel.SecondaryButtonText, Mode=OneWay}"
     Style="{StaticResource DefaultContentDialogStyle}"
-    Loaded="OnLoaded"
     mc:Ignorable="d">
 
     <ContentDialog.Resources>
@@ -60,17 +60,19 @@
             <CheckBox
                 x:Name="chkPermanentlyDelete"
                 x:Uid="DeleteItemsDialogPermanentlyDeleteCheckBox"
-                x:Load="{x:Bind ViewModel.PermanentlyDeleteLoad}"
+                x:Load="{x:Bind ViewModel.PermanentlyDeleteLoad, Mode=OneWay}"
+                Content="Permanently delete"
                 IsChecked="{x:Bind ViewModel.PermanentlyDelete, Mode=TwoWay}"
-                IsEnabled="{x:Bind ViewModel.PermanentlyDeleteEnabled}"
-                Content="Permanently delete"/>
+                IsEnabled="{x:Bind ViewModel.PermanentlyDeleteEnabled, Mode=OneWay}" />
 
             <Grid>
                 <ListView
                     x:Name="DetailsGrid"
                     Grid.Row="1"
                     MaxHeight="200"
-                    IsItemClickEnabled="False">
+                    IsItemClickEnabled="False"
+                    ItemsSource="{x:Bind ViewModel.Items}"
+                    SelectionMode="{x:Bind ViewModel.ItemsSelectionMode, Mode=OneWay}">
 
                     <ListView.ItemsPanel>
                         <ItemsPanelTemplate>
@@ -206,9 +208,7 @@
                                                 x:Uid="ConflictingItemsDialogItemOptionReplaceExisting"
                                                 Command="{Binding ReplaceExistingCommand}"
                                                 Text="Replace" />
-                                            <MenuFlyoutItem
-                                                Command="{Binding SkipCommand}"
-                                                Text="{helpers:ResourceString Name=Skip}" />
+                                            <MenuFlyoutItem Command="{Binding SkipCommand}" Text="{helpers:ResourceString Name=Skip}" />
                                         </MenuFlyout>
                                     </muxc:SplitButton.Flyout>
                                 </muxc:SplitButton>

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -66,18 +66,14 @@
                 x:Name="chkPermanentlyDelete"
                 x:Uid="DeleteItemsDialogPermanentlyDeleteCheckBox"
                 x:Load="{x:Bind ViewModel.PermanentlyDeleteLoad, Mode=OneWay}"
-                Content="Permanently delete"
-                IsChecked="{x:Bind ViewModel.PermanentlyDelete, Mode=TwoWay}"
-                IsEnabled="{x:Bind ViewModel.PermanentlyDeleteEnabled, Mode=OneWay}" />
+                Content="Permanently delete"/>
 
             <Grid>
                 <ListView
                     x:Name="DetailsGrid"
                     Grid.Row="1"
                     MaxHeight="200"
-                    IsItemClickEnabled="False"
-                    ItemsSource="{x:Bind ViewModel.Items}"
-                    SelectionMode="{x:Bind ViewModel.ItemsSelectionMode, Mode=OneWay}">
+                    IsItemClickEnabled="False">
 
                     <ListView.ItemsPanel>
                         <ItemsPanelTemplate>

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -14,7 +14,6 @@
     CornerRadius="{StaticResource OverlayCornerRadius}"
     DefaultButton="Primary"
     IsPrimaryButtonEnabled="{x:Bind ViewModel.PrimaryButtonEnabled, Mode=OneWay}"
-    Loaded="OnLoaded"
     PrimaryButtonCommand="{x:Bind ViewModel.PrimaryButtonCommand, Mode=OneWay}"
     PrimaryButtonText="{x:Bind ViewModel.PrimaryButtonText, Mode=OneWay}"
     RequestedTheme="{x:Bind helpers:ThemeHelper.RootTheme}"

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -62,14 +62,13 @@
                 x:Load="{x:Bind ViewModel.PermanentlyDeleteLoad, Mode=OneWay}"
                 Content="Permanently delete"
                 IsChecked="{x:Bind ViewModel.PermanentlyDelete, Mode=TwoWay}"
-                IsEnabled="False" />
+                IsEnabled="{x:Bind ViewModel.PermanentlyDeleteEnabled, Mode=OneWay}" />
 
             <Grid>
                 <ListView
                     x:Name="DetailsGrid"
                     Grid.Row="1"
                     MaxHeight="200"
-                    IsEnabled="False"
                     IsItemClickEnabled="False"
                     ItemsSource="{x:Bind ViewModel.Items}"
                     SelectionMode="{x:Bind ViewModel.ItemsSelectionMode, Mode=OneWay}">

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -63,13 +63,14 @@
                 x:Load="{x:Bind ViewModel.PermanentlyDeleteLoad, Mode=OneWay}"
                 Content="Permanently delete"
                 IsChecked="{x:Bind ViewModel.PermanentlyDelete, Mode=TwoWay}"
-                IsEnabled="{x:Bind ViewModel.PermanentlyDeleteEnabled, Mode=OneWay}" />
+                IsEnabled="False" />
 
             <Grid>
                 <ListView
                     x:Name="DetailsGrid"
                     Grid.Row="1"
                     MaxHeight="200"
+                    IsEnabled="False"
                     IsItemClickEnabled="False"
                     ItemsSource="{x:Bind ViewModel.Items}"
                     SelectionMode="{x:Bind ViewModel.ItemsSelectionMode, Mode=OneWay}">

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -69,9 +69,7 @@
                     x:Name="DetailsGrid"
                     Grid.Row="1"
                     MaxHeight="200"
-                    IsItemClickEnabled="False"
-                    ItemsSource="{x:Bind ViewModel.Items}"
-                    SelectionMode="{x:Bind ViewModel.ItemsSelectionMode, Mode=OneWay}">
+                    IsItemClickEnabled="False">
 
                     <ListView.ItemsPanel>
                         <ItemsPanelTemplate>

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml
@@ -69,7 +69,10 @@
                     x:Name="DetailsGrid"
                     Grid.Row="1"
                     MaxHeight="200"
-                    IsItemClickEnabled="False">
+                    IsEnabled="False"
+                    IsItemClickEnabled="False"
+                    ItemsSource="{x:Bind ViewModel.Items}"
+                    SelectionMode="{x:Bind ViewModel.ItemsSelectionMode, Mode=OneWay}">
 
                     <ListView.ItemsPanel>
                         <ItemsPanelTemplate>

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -33,6 +33,7 @@ namespace Files.Dialogs
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
+            Loaded -= OnLoaded;
             DetailsGrid.ItemsSource = ViewModel.Items;
             DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
         }

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -3,8 +3,6 @@ using Files.ViewModels.Dialogs;
 using Microsoft.Toolkit.Uwp.UI;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -28,14 +26,6 @@ namespace Files.Dialogs
             ViewModel = viewModel;
             ViewModel.View = this;
             ViewModel.LoadedCommand.Execute(null);
-
-            Loaded += OnLoaded;
-        }
-
-        private void OnLoaded(object sender, RoutedEventArgs e)
-        {
-            DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
-            DetailsGrid.ItemsSource = ViewModel.Items;
         }
 
         private void MenuFlyoutItem_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
@@ -95,17 +85,6 @@ namespace Files.Dialogs
             {
                 (sender as Grid).FindAscendant<ListViewItem>().ContextFlyout = ItemContextFlyout;
             }
-        }
-
-        private async void RootDialog_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
-        {
-            ViewModel.LoadedCommand.Execute(null);
-            await Task.Delay(50);
-            if (chkPermanentlyDelete != null)
-            {
-                chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
-            }
-            DetailsGrid.IsEnabled = true;
         }
     }
 

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -91,7 +91,10 @@ namespace Files.Dialogs
         {
             ViewModel.LoadedCommand.Execute(null);
             await Task.Delay(50);
-            chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
+            if (chkPermanentlyDelete != null)
+            {
+                chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
+            }
             DetailsGrid.IsEnabled = true;
         }
     }

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -3,6 +3,7 @@ using Files.ViewModels.Dialogs;
 using Microsoft.Toolkit.Uwp.UI;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -86,13 +87,12 @@ namespace Files.Dialogs
             }
         }
 
-        private void RootDialog_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        private async void RootDialog_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             ViewModel.LoadedCommand.Execute(null);
-            if (this.FindDescendant("PrimaryButton") is Button primary)
-            {
-                primary.Focus(Windows.UI.Xaml.FocusState.Keyboard);
-            }
+            await Task.Delay(50);
+            chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
+            DetailsGrid.IsEnabled = true;
         }
     }
 

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -27,13 +27,10 @@ namespace Files.Dialogs
             ViewModel = viewModel;
             ViewModel.View = this;
             ViewModel.LoadedCommand.Execute(null);
-
-            Loaded += OnLoaded;
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
-
             DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
             DetailsGrid.ItemsSource = ViewModel.Items;
         }

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -26,6 +26,15 @@ namespace Files.Dialogs
 
             ViewModel = viewModel;
             ViewModel.View = this;
+            ViewModel.LoadedCommand.Execute(null);
+
+            Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
+            DetailsGrid.ItemsSource = ViewModel.Items;
         }
 
         private void MenuFlyoutItem_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -3,7 +3,6 @@ using Files.ViewModels.Dialogs;
 using Microsoft.Toolkit.Uwp.UI;
 using System.Collections.Generic;
 using System.Linq;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -3,6 +3,7 @@ using Files.ViewModels.Dialogs;
 using Microsoft.Toolkit.Uwp.UI;
 using System.Collections.Generic;
 using System.Linq;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -25,15 +26,6 @@ namespace Files.Dialogs
 
             ViewModel = viewModel;
             ViewModel.View = this;
-
-            //HACK: Moved setting controls to loaded event seems to fix DefaultButton focus issue.
-            Loaded += (_, _) =>
-            {
-                chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
-                chkPermanentlyDelete.IsChecked = ViewModel.PermanentlyDelete;
-                DetailsGrid.ItemsSource = ViewModel.Items;
-                DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
-            };
         }
 
         private void MenuFlyoutItem_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
@@ -93,6 +85,14 @@ namespace Files.Dialogs
             {
                 (sender as Grid).FindAscendant<ListViewItem>().ContextFlyout = ItemContextFlyout;
             }
+        }
+
+        private void FilesystemOperationDialog_OnLoaded(object sender, RoutedEventArgs e)
+        {
+            chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
+            chkPermanentlyDelete.IsChecked = ViewModel.PermanentlyDelete;
+            DetailsGrid.ItemsSource = ViewModel.Items;
+            DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
         }
     }
 

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -26,6 +26,16 @@ namespace Files.Dialogs
 
             ViewModel = viewModel;
             ViewModel.View = this;
+            ViewModel.LoadedCommand.Execute(null);
+
+            Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+
+            DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
+            DetailsGrid.ItemsSource = ViewModel.Items;
         }
 
         private void MenuFlyoutItem_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
@@ -85,14 +95,6 @@ namespace Files.Dialogs
             {
                 (sender as Grid).FindAscendant<ListViewItem>().ContextFlyout = ItemContextFlyout;
             }
-        }
-
-        private void FilesystemOperationDialog_OnLoaded(object sender, RoutedEventArgs e)
-        {
-            chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
-            chkPermanentlyDelete.IsChecked = ViewModel.PermanentlyDelete;
-            DetailsGrid.ItemsSource = ViewModel.Items;
-            DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
         }
     }
 

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -29,8 +29,19 @@ namespace Files.Dialogs
             ViewModel.LoadedCommand.Execute(null);
         }
 
-        private void OnLoaded(object sender, RoutedEventArgs e)
+        protected override void OnApplyTemplate()
         {
+            base.OnApplyTemplate();
+            var primaryButton = this.FindDescendant("PrimaryButton") as Button;
+            if (primaryButton != null)
+            {
+                primaryButton.GotFocus += PrimaryButton_GotFocus;
+            }
+        }
+
+        private void PrimaryButton_GotFocus(object sender, RoutedEventArgs e)
+        {
+            (sender as Button).GotFocus -= PrimaryButton_GotFocus;
             chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
             DetailsGrid.ItemsSource = ViewModel.Items;
             DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -3,6 +3,7 @@ using Files.ViewModels.Dialogs;
 using Microsoft.Toolkit.Uwp.UI;
 using System.Collections.Generic;
 using System.Linq;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -25,6 +26,15 @@ namespace Files.Dialogs
 
             ViewModel = viewModel;
             ViewModel.View = this;
+
+            //HACK: Moved setting controls to loaded event seems to fix DefaultButton focus issue.
+            Loaded += (_, _) =>
+            {
+                chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
+                chkPermanentlyDelete.IsChecked = ViewModel.PermanentlyDelete;
+                DetailsGrid.ItemsSource = ViewModel.Items;
+                DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
+            };
         }
 
         private void MenuFlyoutItem_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -3,7 +3,6 @@ using Files.ViewModels.Dialogs;
 using Microsoft.Toolkit.Uwp.UI;
 using System.Collections.Generic;
 using System.Linq;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -26,13 +25,6 @@ namespace Files.Dialogs
 
             ViewModel = viewModel;
             ViewModel.View = this;
-            ViewModel.LoadedCommand.Execute(null);
-        }
-
-        private void OnLoaded(object sender, RoutedEventArgs e)
-        {
-            DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
-            DetailsGrid.ItemsSource = ViewModel.Items;
         }
 
         private void MenuFlyoutItem_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
@@ -91,6 +83,15 @@ namespace Files.Dialogs
             if (ViewModel.MustResolveConflicts)
             {
                 (sender as Grid).FindAscendant<ListViewItem>().ContextFlyout = ItemContextFlyout;
+            }
+        }
+
+        private void RootDialog_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            ViewModel.LoadedCommand.Execute(null);
+            if (this.FindDescendant("PrimaryButton") is Button primary)
+            {
+                primary.Focus(Windows.UI.Xaml.FocusState.Keyboard);
             }
         }
     }

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.Toolkit.Uwp.UI;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -27,13 +27,11 @@ namespace Files.Dialogs
             ViewModel = viewModel;
             ViewModel.View = this;
             ViewModel.LoadedCommand.Execute(null);
-
-            Loaded += OnLoaded;
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
-            Loaded -= OnLoaded;
+            chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
             DetailsGrid.ItemsSource = ViewModel.Items;
             DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
         }

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -3,6 +3,7 @@ using Files.ViewModels.Dialogs;
 using Microsoft.Toolkit.Uwp.UI;
 using System.Collections.Generic;
 using System.Linq;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -26,6 +27,14 @@ namespace Files.Dialogs
             ViewModel = viewModel;
             ViewModel.View = this;
             ViewModel.LoadedCommand.Execute(null);
+
+            Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            DetailsGrid.ItemsSource = ViewModel.Items;
+            DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
         }
 
         private void MenuFlyoutItem_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)

--- a/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -43,8 +43,7 @@ namespace Files.Dialogs
         {
             (sender as Button).GotFocus -= PrimaryButton_GotFocus;
             chkPermanentlyDelete.IsEnabled = ViewModel.PermanentlyDeleteEnabled;
-            DetailsGrid.ItemsSource = ViewModel.Items;
-            DetailsGrid.SelectionMode = ViewModel.ItemsSelectionMode;
+            DetailsGrid.IsEnabled = true;
         }
 
         private void MenuFlyoutItem_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5788
- Related #5584

**Details of Changes**
Add details of changes here.
- Fixed default focus of Primary button in ContentDialog by moving x:Bind tags to the dialog loaded event. 
- Deleting a file in the recycle bin and pressing enter now confirms the deletion.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
