### PR TITLE
add keybaord shortcut to duplicate tab

### DIFF
--- a/src/Files/Views/ColumnShellPage.xaml
+++ b/src/Files/Views/ColumnShellPage.xaml
@@ -123,6 +123,11 @@
             Key="F1"
             Invoked="KeyboardAccelerator_Invoked"
             IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}" />
+        <KeyboardAccelerator
+            Key="K"
+            Invoked="KeyboardAccelerator_Invoked"
+            IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
+            Modifiers="Control" />
     </Page.KeyboardAccelerators>
     <Grid
         x:Name="RootGrid"

--- a/src/Files/Views/ColumnShellPage.xaml.cs
+++ b/src/Files/Views/ColumnShellPage.xaml.cs
@@ -694,6 +694,10 @@ namespace Files.Views
                     UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible = !UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible;
                     break;
 
+                case (true, false, false, true, VirtualKey.K): // ctrl + k, duplicate tab
+                    await NavigationHelpers.OpenPathInNewTab(this.FilesystemViewModel.WorkingDirectory);
+                    break;
+
                 case (false, false, false, _, VirtualKey.F1): // F1, open Files wiki
                     await Launcher.LaunchUriAsync(new Uri(@"https://files.community/docs"));
                     break;

--- a/src/Files/Views/MainPage.xaml
+++ b/src/Files/Views/MainPage.xaml
@@ -164,6 +164,13 @@
                 </icore:EventTriggerBehavior>
             </i:Interaction.Behaviors>
         </KeyboardAccelerator>
+        <KeyboardAccelerator Key="K" Modifiers="Control">
+            <i:Interaction.Behaviors>
+                <icore:EventTriggerBehavior EventName="Invoked">
+                    <icore:InvokeCommandAction Command="{x:Bind ViewModel.AddNewInstanceAcceleratorCommand}" />
+                </icore:EventTriggerBehavior>
+            </i:Interaction.Behaviors>
+        </KeyboardAccelerator>
         <KeyboardAccelerator Key="F11">
             <i:Interaction.Behaviors>
                 <icore:EventTriggerBehavior EventName="Invoked">

--- a/src/Files/Views/ModernShellPage.xaml
+++ b/src/Files/Views/ModernShellPage.xaml
@@ -100,6 +100,11 @@
             IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
             Modifiers="Menu" />
         <KeyboardAccelerator
+            Key="K"
+            Invoked="KeyboardAccelerator_Invoked"
+            IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
+            Modifiers="Control" />
+        <KeyboardAccelerator
             Key="F2"
             Invoked="KeyboardAccelerator_Invoked"
             IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"

--- a/src/Files/Views/ModernShellPage.xaml.cs
+++ b/src/Files/Views/ModernShellPage.xaml.cs
@@ -749,6 +749,10 @@ namespace Files.Views
                 case (true, false, false, true, VirtualKey.H): // ctrl + h, show/hide hidden items
                     UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible = !UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible;
                     break;
+                
+                case (true, false, false, true, VirtualKey.K): // ctrl + k, duplicate tab
+                    await NavigationHelpers.OpenPathInNewTab(this.FilesystemViewModel.WorkingDirectory);
+                    break;
 
                 case (false, false, false, _, VirtualKey.F1): // F1, open Files wiki
                     await Launcher.LaunchUriAsync(new Uri(@"https://files.community/docs"));


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes https://github.com/files-community/Files/issues/6579
- Related PR to update files.community website documentation with this shortcut: https://github.com/files-community/Website/pull/119

**Details of Changes**
- Added a keyboard shortcut (Ctrl + k) to duplicate tabs with current path
- If in "Home" it creates a new home tab, otherwise it takes the current path

**Validation**
How did you test these changes?
- [X] Built and ran the app
