### PR TITLE
Fixed repeatedly clicking Restore Default button causing crash

### DIFF
--- a/src/Files/Views/CustomFolderIcons.xaml.cs
+++ b/src/Files/Views/CustomFolderIcons.xaml.cs
@@ -30,7 +30,6 @@ namespace Files.Views
         {
             this.InitializeComponent();
             RestoreDefaultIconCommand = new AsyncRelayCommand(RestoreDefaultIcon);
-
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -124,9 +123,7 @@ namespace Files.Views
                     appInstance?.FilesystemViewModel?.RefreshItems(null);
                 });
             }
-
             await Task.Delay(1500);
-
             RestoreDefaultButton.IsEnabled = true;
         }
 

--- a/src/Files/Views/CustomFolderIcons.xaml.cs
+++ b/src/Files/Views/CustomFolderIcons.xaml.cs
@@ -30,6 +30,7 @@ namespace Files.Views
         {
             this.InitializeComponent();
             RestoreDefaultIconCommand = new AsyncRelayCommand(RestoreDefaultIcon);
+
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -111,6 +112,8 @@ namespace Files.Views
 
         private async Task RestoreDefaultIcon()
         {
+            RestoreDefaultButton.IsEnabled = false;
+
             var setIconTask = IsShortcutItem ?
                 SetCustomFileIcon(selectedItemPath, null) :
                 SetCustomFolderIcon(selectedItemPath, null);
@@ -121,6 +124,10 @@ namespace Files.Views
                     appInstance?.FilesystemViewModel?.RefreshItems(null);
                 });
             }
+
+            await Task.Delay(1500);
+
+            RestoreDefaultButton.IsEnabled = true;
         }
 
         private async Task<bool> SetCustomFolderIcon(string folderPath, string iconFile, int iconIndex = 0)

--- a/src/Files/Views/CustomFolderIcons.xaml.cs
+++ b/src/Files/Views/CustomFolderIcons.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Input;
 using Windows.ApplicationModel.AppService;
 using Windows.ApplicationModel.Core;
 using Windows.Foundation.Collections;
+using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
@@ -120,11 +121,12 @@ namespace Files.Views
             {
                 await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
                 {
-                    appInstance?.FilesystemViewModel?.RefreshItems(null);
+                    appInstance?.FilesystemViewModel?.RefreshItems(null, async () =>
+                    {
+                        await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => RestoreDefaultButton.IsEnabled = true);
+                    });
                 });
             }
-            await Task.Delay(1500);
-            RestoreDefaultButton.IsEnabled = true;
         }
 
         private async Task<bool> SetCustomFolderIcon(string folderPath, string iconFile, int iconIndex = 0)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6737

**Details of Changes**
Add details of changes here.
- Disables the button with a short delay before re-enabling.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.

**Comment**
I was thinking maybe we could use events (as opposed to the delay) to restore the button once the RefreshItems() method had completed. But as it is running on a different thread I don't believe that is possible?