### PR TITLE
Added ctrl+shift+k shortcut to duplicate tab

### DIFF
--- a/src/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/src/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -37,6 +37,7 @@
                         <MenuFlyoutItem
                             x:Uid="HorizontalMultitaskingControlDuplicateTab"
                             Click="{x:Bind vm:MainPageViewModel.DuplicateTabAtIndex}"
+                            KeyboardAcceleratorTextOverride="Ctrl+Shift+K"
                             Text="Duplicate tab">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF11B;" />

--- a/src/Files/ViewModels/MainPageViewModel.cs
+++ b/src/Files/ViewModels/MainPageViewModel.cs
@@ -49,6 +49,8 @@ namespace Files.ViewModels
 
         public ICommand AddNewInstanceAcceleratorCommand { get; private set; }
 
+        public ICommand ReopenClosedTabAcceleratorCommand { get; private set; }
+
         public MainPageViewModel()
         {
             // Create commands
@@ -56,6 +58,7 @@ namespace Files.ViewModels
             OpenNewWindowAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(OpenNewWindowAccelerator);
             CloseSelectedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(CloseSelectedTabKeyboardAccelerator);
             AddNewInstanceAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(AddNewInstanceAccelerator);
+            ReopenClosedTabAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(ReopenClosedTabAccelerator);
         }
 
         private void NavigateToNumberedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs e)
@@ -162,16 +165,13 @@ namespace Files.ViewModels
 
         private async void AddNewInstanceAccelerator(KeyboardAcceleratorInvokedEventArgs e)
         {
-            bool shift = e.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
+            await AddNewTabAsync();
+            e.Handled = true;
+        }
 
-            if (!shift)
-            {
-                await AddNewTabAsync();
-            }
-            else // ctrl + shift + t, restore recently closed tab
-            {
-                ((BaseMultitaskingControl)MultitaskingControl).ReopenClosedTab(null, null);
-            }
+        private void ReopenClosedTabAccelerator(KeyboardAcceleratorInvokedEventArgs e)
+        {
+            ((BaseMultitaskingControl)MultitaskingControl).ReopenClosedTab(null, null);
             e.Handled = true;
         }
 

--- a/src/Files/Views/ColumnShellPage.xaml
+++ b/src/Files/Views/ColumnShellPage.xaml
@@ -132,7 +132,7 @@
             Key="K"
             Invoked="KeyboardAccelerator_Invoked"
             IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-            Modifiers="Control" />
+            Modifiers="Control,Shift" />
     </Page.KeyboardAccelerators>
     <Grid
         x:Name="RootGrid"

--- a/src/Files/Views/ColumnShellPage.xaml.cs
+++ b/src/Files/Views/ColumnShellPage.xaml.cs
@@ -719,7 +719,7 @@ namespace Files.Views
                     UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible = !UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible;
                     break;
 
-                case (true, false, false, true, VirtualKey.K): // ctrl + k, duplicate tab
+                case (true, true, false, true, VirtualKey.K): // ctrl + shift + k, duplicate tab
                     await NavigationHelpers.OpenPathInNewTab(this.FilesystemViewModel.WorkingDirectory);
                     break;
 

--- a/src/Files/Views/MainPage.xaml
+++ b/src/Files/Views/MainPage.xaml
@@ -160,11 +160,11 @@
         <KeyboardAccelerator Key="T" Modifiers="Control,Shift">
             <i:Interaction.Behaviors>
                 <icore:EventTriggerBehavior EventName="Invoked">
-                    <icore:InvokeCommandAction Command="{x:Bind ViewModel.AddNewInstanceAcceleratorCommand}" />
+                    <icore:InvokeCommandAction Command="{x:Bind ViewModel.ReopenClosedTabAcceleratorCommand}" />
                 </icore:EventTriggerBehavior>
             </i:Interaction.Behaviors>
         </KeyboardAccelerator>
-        <KeyboardAccelerator Key="K" Modifiers="Control">
+        <KeyboardAccelerator Key="K" Modifiers="Control,Shift">
             <i:Interaction.Behaviors>
                 <icore:EventTriggerBehavior EventName="Invoked">
                     <icore:InvokeCommandAction Command="{x:Bind ViewModel.AddNewInstanceAcceleratorCommand}" />

--- a/src/Files/Views/ModernShellPage.xaml
+++ b/src/Files/Views/ModernShellPage.xaml
@@ -108,7 +108,7 @@
             Key="K"
             Invoked="KeyboardAccelerator_Invoked"
             IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-            Modifiers="Control" />
+            Modifiers="Control,Shift" />
         <KeyboardAccelerator
             Key="F2"
             Invoked="KeyboardAccelerator_Invoked"

--- a/src/Files/Views/ModernShellPage.xaml.cs
+++ b/src/Files/Views/ModernShellPage.xaml.cs
@@ -776,7 +776,7 @@ namespace Files.Views
                     UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible = !UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible;
                     break;
                 
-                case (true, false, false, true, VirtualKey.K): // ctrl + k, duplicate tab
+                case (true, true, false, true, VirtualKey.K): // ctrl + shift + k, duplicate tab
                     await NavigationHelpers.OpenPathInNewTab(this.FilesystemViewModel.WorkingDirectory);
                     break;
 


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes https://github.com/files-community/Files/issues/6579
- There was a related PR that introduced the shortcut initially. @yair100 requested changing to ctrl+shift+k from ctrl+k here, which is what this PR addresses https://github.com/files-community/Files/pull/7884/files/22452e1370295e056d98e439a71f8df00358f1e4#r790197339
- Updated the related documentation PR on the Website repo here https://github.com/files-community/Website/pull/119

**Details of Changes**
- Change duplicate tab shortcut from ctrl+k to ctrl+shift+k
- Required changing `AddNewInstanceAccelerator` because anything invoking this command with "Shift" was reopening closed tabs. I opted to extract this behavior into it's own command to decouple it from the invoker. Originally considered this (untested) alternative solution which matches the existing pattern but believe my current change which decouples is better:
```csharp
private async void AddNewInstanceAccelerator(KeyboardAcceleratorInvokedEventArgs e)
{
    bool shift = e.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
    bool ctrl = e.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Control);
    VirtualKey key = e.KeyboardAccelerator.Key;

    if (!(shift && ctrl && key == VirtualKey.T))
    {
        await AddNewTabAsync();
    }
    else // ctrl + shift + t, restore recently closed tab
    {
        ((BaseMultitaskingControl)MultitaskingControl).ReopenClosedTab(null, null);
    }
    e.Handled = true;
}
```

**Validation**
- [X] Built and ran the app