### PR TITLE
Switching layouts in an empty folder correctly shows empty folder text.

### DIFF
--- a/src/Files/BaseLayout.cs
+++ b/src/Files/BaseLayout.cs
@@ -391,6 +391,7 @@ namespace Files
                     // Remove old layout from back stack
                     ParentShellPageInstance.RemoveLastPageFromBackStack();
                 }
+                ParentShellPageInstance.FilesystemViewModel.UpdateEmptyTextType();
             }
         }
 

--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -510,7 +510,7 @@ namespace Files.ViewModels
 
         private bool IsSearchResults { get; set; }
 
-        private void UpdateEmptyTextType()
+        public void UpdateEmptyTextType()
         {
             EmptyTextType = FilesAndFolders.Count == 0 ? (IsSearchResults ? EmptyTextType.NoSearchResultsFound : EmptyTextType.FolderEmpty) : EmptyTextType.None;
         }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5121

**Details of Changes**
Add details of changes here.
- Changed the `UpdateEmptyTextType()` method to public to allow being called from BaseLayout.cs `BaseFolderSettings_LayoutModeChangeRequested()`

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
