### PR TITLE
Added Spacing and Padding options for compact layouts

### DIFF
--- a/src/Files/App.xaml
+++ b/src/Files/App.xaml
@@ -65,6 +65,19 @@
                             <StaticResource x:Key="SidebarContentBackgroundBrush" ResourceKey="LayerFillColorDefaultBrush" />
                             <SolidColorBrush x:Key="TitlebarContentBackgroundBrush" Color="Transparent" />
                             <SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />
+                            <Thickness x:Key="ExpanderContentPadding">20,0,0,0</Thickness>
+                            <Thickness x:Key="ExpanderMinHeight">1</Thickness>
+                            <Thickness x:Key="GridViewHeaderPadding">12,8,12,0</Thickness>
+                            <Thickness x:Key="GridViewHeaderMinHeight">0</Thickness>
+                            <Thickness x:Key="GridViewHeaderItemMinHeight">0</Thickness>
+                            <Thickness x:Key="ListViewRowPadding">8,0,8,8</Thickness>
+                            <Thickness x:Key="ListViewHeaderGridHeight">38</Thickness>
+                            <Thickness x:Key="ListedItemPadding">10,0</Thickness>
+                            <Thickness x:Key="ListedItemHeight">32</Thickness>
+                            <Thickness x:Key="ListViewMinHeight">1</Thickness>
+                            <Thickness x:Key="ListViewHeight">36</Thickness>
+                            <Thickness x:Key="ListViewItemMinHeight">1</Thickness>
+                            <Thickness x:Key="ListViewHeaderItemPadding">12,8,12,0</Thickness>
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="Dark">
                             <Color x:Key="SolidBackgroundAcrylic">#2C2C2C</Color>
@@ -104,6 +117,19 @@
                             <StaticResource x:Key="SidebarContentBackgroundBrush" ResourceKey="LayerFillColorDefaultBrush" />
                             <SolidColorBrush x:Key="TitlebarContentBackgroundBrush" Color="Transparent" />
                             <SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />
+                            <Thickness x:Key="ExpanderContentPadding">20,0,0,0</Thickness>
+                            <Thickness x:Key="ExpanderMinHeight">1</Thickness>
+                            <Thickness x:Key="GridViewHeaderPadding">12,8,12,0</Thickness>
+                            <Thickness x:Key="GridViewHeaderMinHeight">0</Thickness>
+                            <Thickness x:Key="GridViewHeaderItemMinHeight">0</Thickness>
+                            <Thickness x:Key="ListViewRowPadding">8,0,8,8</Thickness>
+                            <Thickness x:Key="ListViewHeaderGridHeight">38</Thickness>
+                            <Thickness x:Key="ListedItemPadding">10,0</Thickness>
+                            <Thickness x:Key="ListedItemHeight">32</Thickness>
+                            <Thickness x:Key="ListViewMinHeight">1</Thickness>
+                            <Thickness x:Key="ListViewHeight">36</Thickness>
+                            <Thickness x:Key="ListViewItemMinHeight">1</Thickness>
+                            <Thickness x:Key="ListViewHeaderItemPadding">12,8,12,0</Thickness>
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="HighContrast">
                             <SolidColorBrush x:Key="ApplicationPageBackgroundThemeBrush" Color="{StaticResource SystemColorWindowColor}" />
@@ -152,6 +178,19 @@
                             <StaticResource x:Key="SidebarContentBackgroundBrush" ResourceKey="LayerFillColorDefaultBrush" />
                             <SolidColorBrush x:Key="TitlebarContentBackgroundBrush" Color="Transparent" />
                             <SolidColorBrush x:Key="NavigationViewContentBackground" Color="#0F000000" />
+                            <Thickness x:Key="ExpanderContentPadding">20,0,0,0</Thickness>
+                            <Thickness x:Key="ExpanderMinHeight">1</Thickness>
+                            <Thickness x:Key="GridViewHeaderPadding">12,8,12,0</Thickness>
+                            <Thickness x:Key="GridViewHeaderMinHeight">0</Thickness>
+                            <Thickness x:Key="GridViewHeaderItemMinHeight">0</Thickness>
+                            <Thickness x:Key="ListViewRowPadding">8,0,8,8</Thickness>
+                            <Thickness x:Key="ListViewHeaderGridHeight">38</Thickness>
+                            <Thickness x:Key="ListedItemPadding">10,0</Thickness>
+                            <Thickness x:Key="ListedItemHeight">32</Thickness>
+                            <Thickness x:Key="ListViewMinHeight">1</Thickness>
+                            <Thickness x:Key="ListViewHeight">36</Thickness>
+                            <Thickness x:Key="ListViewItemMinHeight">1</Thickness>
+                            <Thickness x:Key="ListViewHeaderItemPadding">12,8,12,0</Thickness>
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
                     <LinearGradientBrush x:Key="ControlElevationBorderBrush" MappingMode="Absolute" StartPoint="0,0" EndPoint="0,3">

--- a/src/Files/BaseLayout.cs
+++ b/src/Files/BaseLayout.cs
@@ -31,6 +31,7 @@ using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
@@ -317,6 +318,7 @@ namespace Files
         protected abstract void HookEvents();
 
         protected abstract void UnhookEvents();
+        protected abstract SelectorItem ContainerFromItem(ListedItem listedItem);
 
         private void HookBaseEvents()
         {
@@ -514,6 +516,32 @@ namespace Files
             }
             catch (Exception)
             {
+            }
+        }
+        public void UpdateAppearanceSettings()
+        {
+            foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.ToList())
+            {
+                try
+                {
+                    Control itemContainer = ContainerFromItem(listedItem);
+                    if (itemContainer != null)
+                    {
+                        // Doing it this way to keep Left and Right Margin and Padding for the selectedItem selector (the little blue bar)
+                        itemContainer.Margin = new Thickness(itemContainer.Margin.Left, listedItem.SpacingSize/2, itemContainer.Margin.Right, listedItem.SpacingSize/2);
+                        itemContainer.Padding = new Thickness(itemContainer.Padding.Left, listedItem.PaddingSize / 2, itemContainer.Padding.Right, listedItem.PaddingSize / 2);
+                        // Leaving this here in case we'll want to change the ListViewItem/GridViewItem children in the future
+                        //Grid itemGrid = itemContainer.FindDescendant<Grid>();
+                        //if (itemGrid != null)
+                        //{
+                        //    itemGrid.Padding = listedItem.PaddingSize;
+                        //}
+                    }
+                }
+                catch (Exception error)
+                {
+                    Debug.WriteLine(error.Message);
+                }
             }
         }
 

--- a/src/Files/Filesystem/ListedItem.cs
+++ b/src/Files/Filesystem/ListedItem.cs
@@ -27,15 +27,22 @@ namespace Files.Filesystem
         protected static IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
 
         // Need to access this in the DataTemplate to read the updated padding
-        // Need to access this in the DataTemplate to read the updated padding
-        public Thickness SpacingSize
+        public double SpacingSize
         {
-            get => new Thickness(0, UserSettingsService.AppearanceSettingsService.SpacingSizePx / 2, 0, UserSettingsService.AppearanceSettingsService.SpacingSizePx / 2);
+            get => UserSettingsService.AppearanceSettingsService.SpacingSizePx;
+            set
+            {
+                OnPropertyChanged(nameof(SpacingSize));
+            }
         }
 
-        public Thickness PaddingSize
+        public double PaddingSize
         {
-            get => new Thickness(0, UserSettingsService.AppearanceSettingsService.PaddingSizePx / 2, 0, UserSettingsService.AppearanceSettingsService.PaddingSizePx / 2);
+            get => UserSettingsService.AppearanceSettingsService.PaddingSizePx;
+            set
+            {
+                OnPropertyChanged(nameof(PaddingSize));
+            }
         }
 
 

--- a/src/Files/Filesystem/ListedItem.cs
+++ b/src/Files/Filesystem/ListedItem.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Windows.Storage;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media.Imaging;
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -24,6 +25,19 @@ namespace Files.Filesystem
     public class ListedItem : ObservableObject, IGroupableItem
     {
         protected static IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
+
+        // Need to access this in the DataTemplate to read the updated padding
+        // Need to access this in the DataTemplate to read the updated padding
+        public Thickness SpacingSize
+        {
+            get => new Thickness(0, UserSettingsService.AppearanceSettingsService.SpacingSizePx / 2, 0, UserSettingsService.AppearanceSettingsService.SpacingSizePx / 2);
+        }
+
+        public Thickness PaddingSize
+        {
+            get => new Thickness(0, UserSettingsService.AppearanceSettingsService.PaddingSizePx / 2, 0, UserSettingsService.AppearanceSettingsService.PaddingSizePx / 2);
+        }
+
 
         protected static IFileTagsSettingsService FileTagsSettingsService { get; } = Ioc.Default.GetService<IFileTagsSettingsService>();
 

--- a/src/Files/Helpers/RegistryToJsonSettingsMerger.cs
+++ b/src/Files/Helpers/RegistryToJsonSettingsMerger.cs
@@ -67,6 +67,8 @@ namespace Files.Helpers
                     userSettingsService.PreferencesSettingsService.OpenFoldersInNewTab = appSettings.Get(false, "OpenFoldersNewTab");
 
                     // Appearance
+                    userSettingsService.AppearanceSettingsService.SpacingSizePx = appSettings.Get(2d, "SpacingSizePx");
+                    userSettingsService.AppearanceSettingsService.PaddingSizePx = appSettings.Get(2d, "PaddingSizePx");
                     userSettingsService.AppearanceSettingsService.MoveOverflowMenuItemsToSubMenu = appSettings.Get(true, "MoveOverflowMenuItemsToSubMenu");
 
                     // Startup

--- a/src/Files/Services/IAppearanceSettingsService.cs
+++ b/src/Files/Services/IAppearanceSettingsService.cs
@@ -12,6 +12,16 @@ namespace Files.Services
         #region Internal Settings
 
         /// <summary>
+        /// Gets or sets a value indicating the spacing size in px of the items in list view.
+        /// </summary>
+        double SpacingSizePx { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating the padding size in px of the items in list view.
+        /// </summary>
+        double PaddingSizePx { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating the width of the sidebar pane when open.
         /// </summary>
         double SidebarWidth { get; set; }

--- a/src/Files/Services/Implementation/AppearanceSettingsService.cs
+++ b/src/Files/Services/Implementation/AppearanceSettingsService.cs
@@ -19,6 +19,16 @@ namespace Files.Services.Implementation
             get => Get(Math.Min(Math.Max(Get(255d), Constants.UI.MinimumSidebarWidth), 500d));
             set => Set(value);
         }
+        public double SpacingSizePx
+        {
+            get => Get(Math.Min(Math.Max(Get(100d), 2d), 50d));
+            set => Set(value);
+        }
+        public double PaddingSizePx
+        {
+            get => Get(Math.Min(Math.Max(Get(100d), 2d), 50d));
+            set => Set(value);
+        }
 
         public bool IsSidebarOpen
         {
@@ -81,6 +91,8 @@ namespace Files.Services.Implementation
             switch (e.settingName)
             {
                 case nameof(MoveOverflowMenuItemsToSubMenu):
+                case nameof(SpacingSizePx):
+                case nameof(PaddingSizePx):
                 case nameof(ShowFavoritesSection):
                 case nameof(ShowLibrarySection):
                 case nameof(ShowCloudDrivesSection):
@@ -98,6 +110,8 @@ namespace Files.Services.Implementation
         {
             Analytics.TrackEvent($"{nameof(MoveOverflowMenuItemsToSubMenu)}, {MoveOverflowMenuItemsToSubMenu}");
             Analytics.TrackEvent($"{nameof(ShowFavoritesSection)}, {ShowFavoritesSection}");
+            Analytics.TrackEvent($"{nameof(SpacingSizePx)}, {SpacingSizePx}");
+            Analytics.TrackEvent($"{nameof(PaddingSizePx)}, {PaddingSizePx}");
             Analytics.TrackEvent($"{nameof(ShowLibrarySection)}, {ShowLibrarySection}");
             Analytics.TrackEvent($"{nameof(ShowCloudDrivesSection)}, {ShowCloudDrivesSection}");
             Analytics.TrackEvent($"{nameof(ShowNetworkDrivesSection)}, {ShowNetworkDrivesSection}");

--- a/src/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files/UserControls/InnerNavigationToolbar.xaml
@@ -739,13 +739,13 @@
                                     <RowDefinition MinHeight="30" />
                                 </Grid.RowDefinitions>
                                 <TextBlock
-                                    x:Uid="NavToolbarSpacingScrollbarHeader"
+                                    x:Uid="NavToolbarSpacingSliderHeader"
                                     Grid.Row="0"
                                     Grid.Column="0"
                                     VerticalAlignment="Center"
                                     Text="Spacing" />
                                 <Slider 
-                                    x:Uid="NavToolbarSpacingScrollbar"  
+                                    x:Uid="NavToolbarSpacingSlider"
                                     Grid.Row="0"
                                     Grid.Column="1"
                                     Minimum="1" 
@@ -753,6 +753,7 @@
                                     TickFrequency="1"
                                     TickPlacement="BottomRight"   
                                     Value="{x:Bind UserSettingsService.AppearanceSettingsService.SpacingSizePx, Mode=TwoWay}"
+                                    ValueChanged="NavToolbarSpacingSlider_ValueChanged"
                                     />
                                 <TextBlock
                                     Grid.Row="0"
@@ -760,13 +761,13 @@
                                     VerticalAlignment="Center"
                                     Text="px " />
                                 <TextBlock
-                                    x:Uid="NavToolbarPaddingScrollbarHeader"
+                                    x:Uid="NavToolbarPaddingSliderHeader"
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     VerticalAlignment="Center"
                                     Text="Padding " />
                                 <Slider 
-                                    x:Uid="NavToolbarPaddingScrollbar"  
+                                    x:Uid="NavToolbarPaddingSlider"  
                                     Grid.Row="1"
                                     Grid.Column="1"
                                     Minimum="1" 
@@ -774,6 +775,7 @@
                                     TickFrequency="1"
                                     TickPlacement="BottomRight"   
                                     Value="{x:Bind UserSettingsService.AppearanceSettingsService.PaddingSizePx, Mode=TwoWay}"
+                                    ValueChanged="NavToolbarPaddingSlider_ValueChanged"
                                     />
                                 <TextBlock
                                     Grid.Row="1"

--- a/src/Files/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files/UserControls/InnerNavigationToolbar.xaml
@@ -705,24 +705,69 @@
                                 BorderBrush="{ThemeResource ControlStrokeColorDefault}"
                                 BorderThickness="1" />
 
-                            <Grid RowSpacing="4">
+                            <Grid RowSpacing="4" ColumnSpacing="5">                                
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="15" />
                                 </Grid.ColumnDefinitions>
                                 <Grid.RowDefinitions>
+                                    <RowDefinition MinHeight="40" />
+                                    <RowDefinition MinHeight="40" />
                                     <RowDefinition MinHeight="30" />
                                     <RowDefinition MinHeight="30" />
                                 </Grid.RowDefinitions>
                                 <TextBlock
-                                    x:Uid="NavToolbarShowHiddenItemsHeader"
+                                    x:Uid="NavToolbarSpacingScrollbarHeader"
                                     Grid.Row="0"
+                                    Grid.Column="0"
+                                    VerticalAlignment="Center"
+                                    Text="Spacing" />
+                                <Slider 
+                                    x:Uid="NavToolbarSpacingScrollbar"  
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    Minimum="1" 
+                                    Maximum="30"
+                                    TickFrequency="1"
+                                    TickPlacement="BottomRight"   
+                                    Value="{x:Bind UserSettingsService.AppearanceSettingsService.SpacingSizePx, Mode=TwoWay}"
+                                    />
+                                <TextBlock
+                                    Grid.Row="0"
+                                    Grid.Column="2"
+                                    VerticalAlignment="Center"
+                                    Text="px " />
+                                <TextBlock
+                                    x:Uid="NavToolbarPaddingScrollbarHeader"
+                                    Grid.Row="1"
+                                    Grid.Column="0"
+                                    VerticalAlignment="Center"
+                                    Text="Padding " />
+                                <Slider 
+                                    x:Uid="NavToolbarPaddingScrollbar"  
+                                    Grid.Row="1"
+                                    Grid.Column="1"
+                                    Minimum="1" 
+                                    Maximum="30"
+                                    TickFrequency="1"
+                                    TickPlacement="BottomRight"   
+                                    Value="{x:Bind UserSettingsService.AppearanceSettingsService.PaddingSizePx, Mode=TwoWay}"
+                                    />
+                                <TextBlock
+                                    Grid.Row="1"
+                                    Grid.Column="2"
+                                    VerticalAlignment="Center"
+                                    Text="px " />
+                                <TextBlock
+                                    x:Uid="NavToolbarShowHiddenItemsHeader"
+                                    Grid.Row="2"
                                     Grid.Column="0"
                                     VerticalAlignment="Center"
                                     Text="Show hidden items" />
                                 <ToggleSwitch
                                     x:Uid="NavToolbarShowHiddenItems"
-                                    Grid.Row="0"
+                                    Grid.Row="2"
                                     Grid.Column="1"
                                     HorizontalAlignment="Right"
                                     AutomationProperties.Name="Show hidden items"
@@ -731,13 +776,13 @@
 
                                 <TextBlock
                                     x:Uid="NavToolbarShowFileExtensionsHeader"
-                                    Grid.Row="1"
+                                    Grid.Row="3"
                                     Grid.Column="0"
                                     VerticalAlignment="Center"
                                     Text="Show file extensions" />
                                 <ToggleSwitch
                                     x:Uid="NavToolbarShowFileExtensions"
-                                    Grid.Row="1"
+                                    Grid.Row="3"
                                     Grid.Column="1"
                                     HorizontalAlignment="Right"
                                     AutomationProperties.Name="Show file extensions"

--- a/src/Files/UserControls/InnerNavigationToolbar.xaml.cs
+++ b/src/Files/UserControls/InnerNavigationToolbar.xaml.cs
@@ -191,6 +191,15 @@ namespace Files.UserControls
             }
         }
 
+        private void NavToolbarSpacingSlider_ValueChanged(object sender, Windows.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            UserSettingsService.AppearanceSettingsService.SpacingSizePx = e.NewValue;
+        }
+        private void NavToolbarPaddingSlider_ValueChanged(object sender, Windows.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs e)
+        {
+            UserSettingsService.AppearanceSettingsService.PaddingSizePx = e.NewValue;
+
+        }
         private void NavToolbarDetailsHeader_Tapped(object sender, TappedRoutedEventArgs e)
     => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView.Execute(true);
         private void NavToolbarTilesHeader_Tapped(object sender, TappedRoutedEventArgs e)

--- a/src/Files/UserControls/Settings/SettingsBlockControl.xaml
+++ b/src/Files/UserControls/Settings/SettingsBlockControl.xaml
@@ -30,8 +30,8 @@
             <Setter Property="BorderBrush" Value="{ThemeResource ExpanderHeaderBorderBrush}" />
             <Setter Property="BorderThickness" Value="{ThemeResource ExpanderHeaderBorderThickness}" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
-            <Setter Property="MinHeight" Value="{StaticResource ExpanderMinHeight}" />
-            <Setter Property="Padding" Value="{StaticResource ExpanderContentPadding}" />
+            <Setter Property="MinHeight" Value="{ThemeResource  ExpanderMinHeight}" />
+            <Setter Property="Padding" Value="{ThemeResource  ExpanderContentPadding}" />
             <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
         </Style>
 
@@ -44,8 +44,8 @@
             <Setter Property="BorderThickness" Value="{ThemeResource ExpanderHeaderBorderThickness}" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-            <Setter Property="Padding" Value="{StaticResource ExpanderContentPadding}" />
-            <Setter Property="MinHeight" Value="{StaticResource ExpanderMinHeight}" />
+            <Setter Property="Padding" Value="{ThemeResource  ExpanderContentPadding}" />
+            <Setter Property="MinHeight" Value="{ThemeResource  ExpanderMinHeight}" />
             <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
         </Style>
     </UserControl.Resources>

--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -36,6 +36,7 @@ using Windows.Foundation.Collections;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Search;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
@@ -383,6 +384,16 @@ namespace Files.ViewModels
         {
             switch (e.settingName)
             {
+                case nameof(UserSettingsService.AppearanceSettingsService.SpacingSizePx):
+                case nameof(UserSettingsService.AppearanceSettingsService.PaddingSizePx):
+                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
+                    {
+                        if (WorkingDirectory != "Home".GetLocalized())
+                        {
+                            DirectoryInfoUpdated?.Invoke(this, EventArgs.Empty);
+                        }
+                    });
+                    break;
                 case nameof(UserSettingsService.PreferencesSettingsService.ShowFileExtensions):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden):

--- a/src/Files/ViewModels/SettingsViewModels/AppearanceViewModel.cs
+++ b/src/Files/ViewModels/SettingsViewModels/AppearanceViewModel.cs
@@ -202,5 +202,31 @@ namespace Files.ViewModels.SettingsViewModels
                 }
             }
         }
+
+        public double SpacingSizePx
+        {
+            get => UserSettingsService.AppearanceSettingsService.SpacingSizePx;
+            set
+            {
+                if (value != UserSettingsService.AppearanceSettingsService.SpacingSizePx)
+                {
+                    UserSettingsService.AppearanceSettingsService.SpacingSizePx = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public double PaddingSizePx
+        {
+            get => UserSettingsService.AppearanceSettingsService.PaddingSizePx;
+            set
+            {
+                if (value != UserSettingsService.AppearanceSettingsService.PaddingSizePx)
+                {
+                    UserSettingsService.AppearanceSettingsService.PaddingSizePx = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
     }
 }

--- a/src/Files/Views/ColumnShellPage.xaml.cs
+++ b/src/Files/Views/ColumnShellPage.xaml.cs
@@ -538,6 +538,7 @@ namespace Files.Views
                     ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{FilesystemViewModel.FilesAndFolders.Count} {"ItemsCount/Text".GetLocalized()}";
                 }
             }
+            ContentPage.UpdateAppearanceSettings();
         }
 
         private void FilesystemViewModel_ListedItemAdded(object sender, ListedItemAddedEventArgs e)

--- a/src/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -178,7 +178,7 @@ namespace Files.Views.LayoutModes
             foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.ToList())
             {
                 listedItem.ItemPropertiesInitialized = false;
-                if (FileList.ContainerFromItem(listedItem) != null)
+                if (ContainerFromItem(listedItem) != null)
                 {
                     await ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(listedItem, 24);
                 }
@@ -193,7 +193,7 @@ namespace Files.Views.LayoutModes
                 return;
             }
             int extensionLength = RenamingItem.FileExtension?.Length ?? 0;
-            ListViewItem listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+            ListViewItem listViewItem = ContainerFromItem(RenamingItem) as ListViewItem;
             TextBox textBox = null;
             if (listViewItem == null)
             {
@@ -266,7 +266,7 @@ namespace Files.Views.LayoutModes
             else
             {
                 // Re-focus selected list item
-                ListViewItem listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+                ListViewItem listViewItem = ContainerFromItem(RenamingItem) as ListViewItem;
                 listViewItem?.Focus(FocusState.Programmatic);
 
                 textBox.Visibility = Visibility.Collapsed;
@@ -523,7 +523,7 @@ namespace Files.Views.LayoutModes
                 }
                 else if (IsRenamingItem)
                 {
-                    if (FileList.ContainerFromItem(RenamingItem) is ListViewItem listViewItem
+                    if (ContainerFromItem(RenamingItem) is ListViewItem listViewItem
                         && listViewItem.FindDescendant("ListViewTextBoxItemName") is TextBox textBox)
                     {
                         CommitRename(textBox);
@@ -625,6 +625,11 @@ namespace Files.Views.LayoutModes
                         break;
                 }
             }
+        }
+
+        protected override SelectorItem ContainerFromItem(ListedItem listedItem)
+        {
+            return (FileList.ContainerFromItem(listedItem) as SelectorItem);
         }
     }
 }

--- a/src/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -4,6 +4,7 @@ using Files.Helpers;
 using Files.Helpers.XamlHelpers;
 using Files.Interacts;
 using Files.UserControls.Selection;
+using Files.Services;
 using Microsoft.Toolkit.Uwp.UI;
 using System;
 using System.Collections.Generic;

--- a/src/Files/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
 
@@ -306,6 +307,11 @@ namespace Files.Views.LayoutModes
 
                 return ParentShellPageInstance;
             }
+        }
+
+        protected override SelectorItem ContainerFromItem(ListedItem listedItem)
+        {
+            return null;
         }
     }
 }

--- a/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -510,13 +510,11 @@
                     </ListView.Header>
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="local2:ListedItem">
-                            <!--Padding="{x:Bind PaddingSize, Mode=OneWay}"-->
-                            <Grid
+                            <Grid x:Name="ItemRow"
                                 HorizontalAlignment="Stretch"
                                 AutomationProperties.Name="{x:Bind ItemName, Mode=OneWay}"
                                 IsRightTapEnabled="True"
                                 Loaded="Grid_Loaded"
-                                Padding="{Binding PaddingSize, Mode=OneWay}"
                                 VerticalAlignment="Center"
                                 RightTapped="StackPanel_RightTapped"
                                 ToolTipService.ToolTip="{x:Bind ItemTooltipText, Mode=OneWay}">
@@ -783,7 +781,8 @@
                                 <Setter Property="ItemsPanel">
                                     <Setter.Value>
                                         <ItemsPanelTemplate>
-                                            <ItemsStackPanel Orientation="Vertical" />
+                                            <ItemsStackPanel
+                                                Orientation="Vertical"/>
                                         </ItemsPanelTemplate>
                                     </Setter.Value>
                                 </Setter>
@@ -818,7 +817,7 @@
                                                         </Grid.ColumnDefinitions>
                                                         <ItemsPresenter
                                                             Margin="0,0,12,0"
-                                                            Padding="{TemplateBinding Padding}"
+                                                            Padding="{TemplateBinding Padding}"                                                            
                                                             HorizontalAlignment="Stretch"
                                                             Footer="{TemplateBinding Footer}"
                                                             FooterTemplate="{TemplateBinding FooterTemplate}"
@@ -888,11 +887,15 @@
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                             <Setter Property="MinHeight" Value="1" />
                             <Setter Property="Height" Value="Auto" />
+                            <Setter Property="Margin" Value="{Binding SpacingSize}" />
                         </Style>
                     </ListView.ItemContainerStyle>
                     <ListView.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <ItemsStackPanel AreStickyGroupHeadersEnabled="False" Orientation="Vertical" />
+                            <ItemsStackPanel                                
+                                AreStickyGroupHeadersEnabled="False"
+                                Orientation="Vertical">
+                            </ItemsStackPanel>
                         </ItemsPanelTemplate>
                     </ListView.ItemsPanel>
                     <ListView.Footer>
@@ -981,7 +984,6 @@
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                             <Setter Property="MinHeight" Value="{ThemeResource ListViewMinHeight}" />
                             <Setter Property="Height" Value="{ThemeResource ListViewHeight}" />
-                            <Setter Property="Margin" Value="{Binding SpacingSize, Mode=OneWay}" />
                         </Style>
                     </ListView.ItemContainerStyle>
                 </ListView>

--- a/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -58,12 +58,14 @@
                 <Setter Property="Width" Value="1" />
                 <Setter Property="Margin" Value="0,4,0,4" />
                 <Setter Property="Opacity" Value="0.8" />
+                
             </Style>
 
             <Style TargetType="ListViewHeaderItem">
                 <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
                 <Setter Property="FontSize" Value="{ThemeResource GridViewHeaderItemThemeFontSize}" />
                 <Setter Property="Background" Value="{ThemeResource GridViewHeaderItemBackground}" />
+                <Setter Property="Padding" Value="{ThemeResource GridViewHeaderPadding}" />
                 <Setter Property="Margin" Value="0,0,0,4" />
                 <Setter Property="Padding" Value="12,8,12,0" />
                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -241,7 +243,7 @@
                     <ListView.Header>
                         <Grid
                             x:Name="HeaderGrid"
-                            Height="40"
+                            Height="{ThemeResource ListViewHeaderGridHeight}"
                             Padding="16,0,0,0"
                             Background="{ThemeResource FileBrowserHeaderBackgroundBrush}"
                             BorderBrush="{ThemeResource ControlStrokeColorDefault}"
@@ -508,11 +510,14 @@
                     </ListView.Header>
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="local2:ListedItem">
+                            <!--Padding="{x:Bind PaddingSize, Mode=OneWay}"-->
                             <Grid
                                 HorizontalAlignment="Stretch"
                                 AutomationProperties.Name="{x:Bind ItemName, Mode=OneWay}"
                                 IsRightTapEnabled="True"
                                 Loaded="Grid_Loaded"
+                                Padding="{Binding PaddingSize, Mode=OneWay}"
+                                VerticalAlignment="Center"
                                 RightTapped="StackPanel_RightTapped"
                                 ToolTipService.ToolTip="{x:Bind ItemTooltipText, Mode=OneWay}">
                                 <Grid.ColumnDefinitions>
@@ -885,7 +890,7 @@
                         <Style BasedOn="{StaticResource DefaultListViewItemStyle}" TargetType="ListViewItem">
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                             <Setter Property="MinHeight" Value="1" />
-                            <Setter Property="Height" Value="36" />
+                            <Setter Property="Height" Value="Auto" />
                         </Style>
                     </ListView.ItemContainerStyle>
                     <ListView.ItemsPanel>
@@ -897,6 +902,7 @@
                         <StackPanel
                             x:Name="SearchUnindexedItemsPanel"
                             HorizontalAlignment="Stretch"
+                            VerticalAlignment="Center" 
                             x:Load="{x:Bind InstanceViewModel.ShowSearchUnindexedItemsMessage, Mode=OneWay}"
                             Orientation="Vertical">
                             <TextBlock
@@ -976,6 +982,9 @@
                     <ListView.ItemContainerStyle>
                         <Style BasedOn="{StaticResource DefaultListViewItemStyle}" TargetType="ListViewItem">
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            <Setter Property="MinHeight" Value="{ThemeResource ListViewMinHeight}" />
+                            <Setter Property="Height" Value="{ThemeResource ListViewHeight}" />
+                            <Setter Property="Margin" Value="{Binding SpacingSize, Mode=OneWay}" />
                         </Style>
                     </ListView.ItemContainerStyle>
                 </ListView>

--- a/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -580,6 +580,7 @@ namespace Files.Views.LayoutModes
                 listedItem.ItemPropertiesInitialized = false;
                 if (FileList.ContainerFromItem(listedItem) != null)
                 {
+                    //FileList.ContainerFromItem(listedItem).dis
                     await ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(listedItem, currentIconSize);
                 }
             }

--- a/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -12,6 +12,7 @@ using Microsoft.Toolkit.Uwp.UI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Storage;
@@ -103,7 +104,7 @@ namespace Files.Views.LayoutModes
             if (SelectedItems.Any())
             {
                 FileList.ScrollIntoView(SelectedItems.Last());
-                (FileList.ContainerFromItem(SelectedItems.Last()) as ListViewItem)?.Focus(FocusState.Keyboard);
+                (ContainerFromItem(SelectedItems.Last()) as ListViewItem)?.Focus(FocusState.Keyboard);
             }
         }
 
@@ -258,6 +259,7 @@ namespace Files.Views.LayoutModes
             SyncStatusHeader.ColumnSortOption = FolderSettings.DirectorySortOption == SortOption.SyncStatus ? FolderSettings.DirectorySortDirection : (SortDirection?)null;
         }
 
+
         private void FilesystemViewModel_PageTypeUpdated(object sender, PageTypeUpdatedEventArgs e)
         {
             // This code updates which columns are hidden and which ones are shwn
@@ -338,7 +340,7 @@ namespace Files.Views.LayoutModes
                 return;
             }
             int extensionLength = RenamingItem.FileExtension?.Length ?? 0;
-            ListViewItem listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+            ListViewItem listViewItem = ContainerFromItem(RenamingItem) as ListViewItem;
             TextBox textBox = null;
             if (listViewItem == null)
             {
@@ -426,7 +428,7 @@ namespace Files.Views.LayoutModes
                 Grid.SetColumnSpan(parent, 1);
             }
 
-            ListViewItem listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+            ListViewItem listViewItem = ContainerFromItem(RenamingItem) as ListViewItem;
 
             if (textBox == null || listViewItem == null)
             {
@@ -578,9 +580,8 @@ namespace Files.Views.LayoutModes
             foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.ToList())
             {
                 listedItem.ItemPropertiesInitialized = false;
-                if (FileList.ContainerFromItem(listedItem) != null)
+                if (ContainerFromItem(listedItem) != null)
                 {
-                    //FileList.ContainerFromItem(listedItem).dis
                     await ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(listedItem, currentIconSize);
                 }
             }
@@ -617,7 +618,7 @@ namespace Files.Views.LayoutModes
                 }
                 else if (IsRenamingItem)
                 {
-                    ListViewItem listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+                    ListViewItem listViewItem = ContainerFromItem(RenamingItem) as ListViewItem;
                     if (listViewItem != null)
                     {
                         var textBox = listViewItem.FindDescendant("ItemNameTextBox") as TextBox;
@@ -807,6 +808,11 @@ namespace Files.Views.LayoutModes
         private void FileList_Loaded(object sender, RoutedEventArgs e)
         {
             ContentScroller = FileList.FindDescendant<ScrollViewer>(x => x.Name == "ScrollViewer");
+        }
+
+        protected override SelectorItem ContainerFromItem(ListedItem listedItem)
+        {
+            return (FileList.ContainerFromItem(listedItem) as SelectorItem);
         }
     }
 }

--- a/src/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -243,7 +243,7 @@
                 </StackPanel>
                 <Grid
                     Grid.Column="1"
-                    Height="60"
+                    Height="Auto"
                     Opacity="{x:Bind Opacity, Mode=OneWay}"
                     Tag="ItemImage">
                     <ContentPresenter

--- a/src/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -68,7 +68,7 @@ namespace Files.Views.LayoutModes
             if (SelectedItems.Any())
             {
                 FileList.ScrollIntoView(SelectedItems.Last());
-                (FileList.ContainerFromItem(SelectedItems.Last()) as GridViewItem)?.Focus(FocusState.Keyboard);
+                (ContainerFromItem(SelectedItems.Last()) as GridViewItem)?.Focus(FocusState.Keyboard);
             }
         }
 
@@ -243,7 +243,7 @@ namespace Files.Views.LayoutModes
                 return;
             }
             int extensionLength = RenamingItem.FileExtension?.Length ?? 0;
-            GridViewItem gridViewItem = FileList.ContainerFromItem(RenamingItem) as GridViewItem;
+            GridViewItem gridViewItem = ContainerFromItem(RenamingItem) as GridViewItem;
             TextBox textBox = null;
             if (gridViewItem == null)
             {
@@ -364,7 +364,7 @@ namespace Files.Views.LayoutModes
             IsRenamingItem = false;
 
             // Re-focus selected list item
-            GridViewItem gridViewItem = FileList.ContainerFromItem(RenamingItem) as GridViewItem;
+            GridViewItem gridViewItem = ContainerFromItem(RenamingItem) as GridViewItem;
             gridViewItem?.Focus(FocusState.Programmatic);
         }
 
@@ -489,7 +489,7 @@ namespace Files.Views.LayoutModes
             foreach (ListedItem listedItem in ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.ToList())
             {
                 listedItem.ItemPropertiesInitialized = false;
-                if (FileList.ContainerFromItem(listedItem) != null)
+                if (ContainerFromItem(listedItem) != null)
                 {
                     await ParentShellPageInstance.FilesystemViewModel.LoadExtendedItemProperties(listedItem, currentIconSize);
                 }
@@ -527,7 +527,7 @@ namespace Files.Views.LayoutModes
                 }
                 else if (IsRenamingItem)
                 {
-                    if (FileList.ContainerFromItem(RenamingItem) is GridViewItem gridViewItem)
+                    if (ContainerFromItem(RenamingItem) is GridViewItem gridViewItem)
                     {
                         if (FolderSettings.LayoutMode == FolderLayoutModes.GridView)
                         {
@@ -604,6 +604,11 @@ namespace Files.Views.LayoutModes
                     ParentShellPageInstance.FilesystemViewModel.CancelExtendedPropertiesLoadingForItem(item);
                 }
             }
+        }
+
+        protected override SelectorItem ContainerFromItem(ListedItem listedItem)
+        {
+            return (FileList.ContainerFromItem(listedItem) as SelectorItem);
         }
     }
 }

--- a/src/Files/Views/ModernShellPage.xaml.cs
+++ b/src/Files/Views/ModernShellPage.xaml.cs
@@ -580,6 +580,7 @@ namespace Files.Views
                 {
                     ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{FilesystemViewModel.FilesAndFolders.Count} {"ItemsCount/Text".GetLocalized()}";
                 }
+                ContentPage.UpdateAppearanceSettings();
             }
         }
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related #1940 

**Details of Changes**
Add details of changes here.
- Added a list of `ThemeResource` settings to `App.xaml` to make it easily modifiable (instead of being `StaticResource`s)
- Added two sliders Spacing and Padding to the Navbar setting dialog
- The sliders are linked to two settings `SpacingSizePx` and `PaddingSizePx` which I already reigstered to JSON and added them both to `UserSettingsService.AppearanceSettingsService`
-- The changes are updated LIVE through `ModernShellPage` and `ColumnShellPage` by calling a new abstract method in `BaseLayout` called `UpdateAppearanceSettings()`.
-- `UpdateAppearanceSettings()` then calls the method `ContainerFromItem()` implemented by the children classes such as `DetailsBrowserLayout` 
-- The new method `ContainerFromItem()` is abstract and located in `BaseLayout` so the inheriting layouts can implement it however they want to return whatever item they want from a `listedItem`.
-- All of this was needed to update Margin and Padding live since they are set in the item style template and wouldn't be updated otherwise
- Had to change some `Grid` elements' `Height` to `Auto` to automatically scale icons and avoid them getting clipped due to the `Padding` changes.

**Validation**
How did you test these changes?
- [ x] Built and ran the app
- [ x] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/6282055/150940376-7f98b259-903a-46f6-88fa-c8f60f5a23b8.png)
![image](https://user-images.githubusercontent.com/6282055/150940469-1f93e7e8-eebe-48c0-a426-0e2130a76dab.png)
