### PR TITLE
Fixed missing description in experimental settings page

### DIFF
--- a/src/Files/Views/SettingsPages/Experimental.xaml
+++ b/src/Files/Views/SettingsPages/Experimental.xaml
@@ -93,10 +93,9 @@
                 Text="{helpers:ResourceString Name=SettingsDefaultFilesManager}" />
 
             <local:SettingsBlockControl
+                HorizontalAlignment="Stretch" IsExpanded="True"
                 Title="{helpers:ResourceString Name=SettingsSetAsDefaultFileManager}"
-                HorizontalAlignment="Stretch"
-                Description="This option modifies the system registry and can have unexpected side effects on your device. Continue at your own risk."
-                IsExpanded="True">
+                Description="{helpers:ResourceString Name=SettingsSetAsDefaultFileManagerDescription}">
                 <local:SettingsBlockControl.Icon>
                     <FontIcon Glyph="&#xEC50;" />
                 </local:SettingsBlockControl.Icon>

--- a/src/Files/Views/SettingsPages/Experimental.xaml
+++ b/src/Files/Views/SettingsPages/Experimental.xaml
@@ -93,7 +93,8 @@
                 Text="{helpers:ResourceString Name=SettingsDefaultFilesManager}" />
 
             <local:SettingsBlockControl
-                HorizontalAlignment="Stretch" IsExpanded="True"
+                HorizontalAlignment="Stretch"
+                IsExpanded="True"
                 Title="{helpers:ResourceString Name=SettingsSetAsDefaultFileManager}"
                 Description="{helpers:ResourceString Name=SettingsSetAsDefaultFileManagerDescription}">
                 <local:SettingsBlockControl.Icon>


### PR DESCRIPTION
**Resolved / Related Issues**
The text SettingsSetAsDefaultFileManagerDescription is localized but not used.

**Details of Changes**
This pr uses the text SettingsSetAsDefaultFileManagerDescription in experimental settings.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility