### PR TITLE
refactor SettingsViewModel

### DIFF
--- a/src/Files/App.xaml.cs
+++ b/src/Files/App.xaml.cs
@@ -29,6 +29,7 @@ using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation.Metadata;
 using Windows.Storage;
+using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Notifications;
 using Windows.UI.ViewManagement;
@@ -462,9 +463,7 @@ namespace Files
                     var eventArgsForNotification = args as ToastNotificationActivatedEventArgs;
                     if (eventArgsForNotification.Argument == "report")
                     {
-                        // Launch the URI and open log files location
-                        //SettingsViewModel.OpenLogLocation();
-                        SettingsViewModel.ReportIssueOnGitHub();
+                        await Launcher.LaunchUriAsync(new Uri(Constants.GitHub.FeedbackUri));
                     }
                     break;
 

--- a/src/Files/Constants.cs
+++ b/src/Files/Constants.cs
@@ -169,5 +169,15 @@
 
             public const string CachedEmptyItemName = "fileicon_cache";
         }
+
+        public static class GitHub
+        {
+            public const string ContributorsUri = @"https://github.com/files-community/Files/graphs/contributors";
+            public const string DocumentationUri = @"https://files.community/docs";
+            public const string FeedbackUri = @"https://github.com/files-community/Files/issues/new/choose";
+            public const string PrivacyPolicyUri = @"https://github.com/files-community/Files/blob/main/Privacy.md";
+            public const string ReleaseNotesUri = @"https://github.com/files-community/Files/releases";
+            public const string SupportUsUri = @"https://github.com/sponsors/yaichenbaum";
+        }
     }
 }

--- a/src/Files/ViewModels/SettingsViewModel.cs
+++ b/src/Files/ViewModels/SettingsViewModel.cs
@@ -12,11 +12,9 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.AppService;
-using Windows.ApplicationModel.Core;
 using Windows.Foundation.Collections;
 using Windows.Globalization;
 using Windows.Storage;
-using Windows.System;
 
 namespace Files.ViewModels
 {
@@ -36,22 +34,6 @@ namespace Files.ViewModels
             {
                 DefaultLanguages.Add(new DefaultLanguageModel(lang));
             }
-        }
-
-        public static async void OpenLogLocation()
-        {
-            await Launcher.LaunchFolderAsync(ApplicationData.Current.LocalFolder);
-        }
-
-        public static async void OpenThemesFolder()
-        {
-            await CoreApplication.MainView.Dispatcher.YieldAsync();
-            await NavigationHelpers.OpenPathInNewTab(App.ExternalResourcesHelper.ImportedThemesFolder.Path);
-        }
-
-        public static async void ReportIssueOnGitHub()
-        {
-            await Launcher.LaunchUriAsync(new Uri(@"https://github.com/files-community/Files/issues/new/choose"));
         }
 
         public bool AreRegistrySettingsMergedToJson
@@ -188,7 +170,7 @@ namespace Files.ViewModels
 
         public event EventHandler ThemeModeChanged;
 
-        public RelayCommand UpdateThemeElements => new RelayCommand(() =>
+        public RelayCommand UpdateThemeElements => new(() =>
         {
             ThemeModeChanged?.Invoke(this, EventArgs.Empty);
         });
@@ -208,7 +190,7 @@ namespace Files.ViewModels
                 originalValue = Get(originalValue, propertyName);
 
                 localSettings.Values[propertyName] = value;
-                if (!base.SetProperty(ref originalValue, value, propertyName))
+                if (!SetProperty(ref originalValue, value, propertyName))
                 {
                     return false;
                 }
@@ -234,7 +216,7 @@ namespace Files.ViewModels
             {
                 var value = localSettings.Values[name];
 
-                if (!(value is TValue tValue))
+                if (value is not TValue tValue)
                 {
                     if (value is IConvertible)
                     {

--- a/src/Files/ViewModels/SettingsViewModels/AboutViewModel.cs
+++ b/src/Files/ViewModels/SettingsViewModels/AboutViewModel.cs
@@ -26,15 +26,14 @@ namespace Files.ViewModels.SettingsViewModels
         private IBundlesSettingsService BundlesSettingsService { get; } = Ioc.Default.GetService<IBundlesSettingsService>();
         protected IFileTagsSettingsService FileTagsSettingsService { get; } = Ioc.Default.GetService<IFileTagsSettingsService>();
 
-        public RelayCommand OpenLogLocationCommand => new RelayCommand(() => SettingsViewModel.OpenLogLocation());
-        public RelayCommand CopyVersionInfoCommand => new RelayCommand(() => CopyVersionInfo());
+        public RelayCommand OpenLogLocationCommand => new(OpenLogLocation);
+        public RelayCommand CopyVersionInfoCommand => new(CopyVersionInfo);
 
         public ICommand ExportSettingsCommand { get; }
 
         public ICommand ImportSettingsCommand { get; }
 
-        public RelayCommand<ItemClickEventArgs> ClickAboutFeedbackItemCommand =>
-            new RelayCommand<ItemClickEventArgs>(ClickAboutFeedbackItem);
+        public RelayCommand<ItemClickEventArgs> ClickAboutFeedbackItemCommand => new(ClickAboutFeedbackItem);
 
         public AboutViewModel()
         {
@@ -148,6 +147,8 @@ namespace Files.ViewModels.SettingsViewModels
             });
         }
 
+        public static async void OpenLogLocation() => await Launcher.LaunchFolderAsync(ApplicationData.Current.LocalFolder);
+
         public string Version
         {
             get
@@ -157,45 +158,24 @@ namespace Files.ViewModels.SettingsViewModels
             }
         }
 
-        public string AppName
-        {
-            get
-            {
-                return Package.Current.DisplayName;
-            }
-        }
+        public string AppName => Package.Current.DisplayName;
 
         private async void ClickAboutFeedbackItem(ItemClickEventArgs e)
         {
             var clickedItem = (StackPanel)e.ClickedItem;
-            switch (clickedItem.Tag)
+            var uri = clickedItem.Tag switch
             {
-                case "Feedback":
-                    SettingsViewModel.ReportIssueOnGitHub();
-                    break;
-
-                case "ReleaseNotes":
-                    await Launcher.LaunchUriAsync(new Uri(@"https://github.com/files-community/Files/releases"));
-                    break;
-
-                case "Documentation":
-                    await Launcher.LaunchUriAsync(new Uri(@"https://files.community/docs"));
-                    break;
-
-                case "Contributors":
-                    await Launcher.LaunchUriAsync(new Uri(@"https://github.com/files-community/Files/graphs/contributors"));
-                    break;
-
-                case "PrivacyPolicy":
-                    await Launcher.LaunchUriAsync(new Uri(@"https://github.com/files-community/Files/blob/main/Privacy.md"));
-                    break;
-
-                case "SupportUs":
-                    await Launcher.LaunchUriAsync(new Uri(@"https://github.com/sponsors/yaichenbaum"));
-                    break;
-
-                default:
-                    break;
+                "Contributors" => Constants.GitHub.ContributorsUri,
+                "Documentation" => Constants.GitHub.DocumentationUri,
+                "Feedback" => Constants.GitHub.FeedbackUri,
+                "PrivacyPolicy" => Constants.GitHub.PrivacyPolicyUri,
+                "ReleaseNotes" => Constants.GitHub.ReleaseNotesUri,
+                "SupportUs" => Constants.GitHub.SupportUsUri,
+                _ => null,
+            };
+            if (uri is not null)
+            {
+                await Launcher.LaunchUriAsync(new Uri(uri));
             }
         }
     }

--- a/src/Files/ViewModels/SettingsViewModels/AppearanceViewModel.cs
+++ b/src/Files/ViewModels/SettingsViewModels/AppearanceViewModel.cs
@@ -6,6 +6,7 @@ using Microsoft.Toolkit.Uwp;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
 using Windows.UI.Xaml;
 
 namespace Files.ViewModels.SettingsViewModels
@@ -201,6 +202,12 @@ namespace Files.ViewModels.SettingsViewModels
                     OnPropertyChanged();
                 }
             }
+        }
+
+        public async void OpenThemesFolder()
+        {
+            await CoreApplication.MainView.Dispatcher.YieldAsync();
+            await NavigationHelpers.OpenPathInNewTab(App.ExternalResourcesHelper.ImportedThemesFolder.Path);
         }
     }
 }

--- a/src/Files/Views/SettingsPages/Appearance.xaml.cs
+++ b/src/Files/Views/SettingsPages/Appearance.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using Files.Dialogs;
 using Files.Helpers.XamlHelpers;
 using Files.UserControls.Settings;
-using Files.ViewModels;
 using Microsoft.Toolkit.Uwp.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -36,7 +35,7 @@ namespace Files.SettingsPages
         {
             ThemesTeachingTip.IsOpen = false;
             this.FindAscendant<SettingsDialog>()?.Hide();
-            SettingsViewModel.OpenThemesFolder();
+            ViewModel.OpenThemesFolder();
         }
 
         private async void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
The class SettingsViewModel is obsolete. It is necessary to completely remove this class to no longer have warnings.

**Details of Changes**
This pr starts emptying SettingsViewModel of its content to get rid of it. Objective 0 warnings. As usual, this pr takes the opportunity to clean up the code when possible. It's a refactoring.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility