### PR TITLE
Added an option to hide files starting with '.'

### DIFF
--- a/src/Files/Filesystem/Search/FolderSearch.cs
+++ b/src/Files/Filesystem/Search/FolderSearch.cs
@@ -207,9 +207,13 @@ namespace Files.Filesystem.Search
                 {
                     var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
                     var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
-
-                    bool shouldBeListed = !isHidden || (UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible && (!isSystem || !UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden));
-
+                    var startWithDot = findData.cFileName.StartsWith(".");
+                    
+                    bool shouldBeListed = (!isHidden || 
+                        (UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible && 
+                        (!isSystem || !UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden))) && 
+                        (!startWithDot || !UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden);
+                    
                     if (shouldBeListed)
                     {
                         var item = GetListedItemAsync(match.FilePath, findData);
@@ -297,10 +301,13 @@ namespace Files.Filesystem.Search
 
                         var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
                         var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
-                        bool shouldBeListed = hiddenOnly ?
-                            isHidden && (!isSystem || !UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden) :
-                            !isHidden || (UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible && (!isSystem || !UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden));
+                        var startWithDot = findData.cFileName.StartsWith(".");
 
+                        bool shouldBeListed = (hiddenOnly ?
+                            isHidden && (!isSystem || !UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden) :
+                            !isHidden || (UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible && (!isSystem || !UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden))) &&
+                            (!startWithDot || !UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden);
+                        
                         if (shouldBeListed)
                         {
                             var item = GetListedItemAsync(itemPath, findData);

--- a/src/Files/Filesystem/Search/FolderSearch.cs
+++ b/src/Files/Filesystem/Search/FolderSearch.cs
@@ -212,7 +212,7 @@ namespace Files.Filesystem.Search
                     bool shouldBeListed = (!isHidden || 
                         (UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible && 
                         (!isSystem || !UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden))) && 
-                        (!startWithDot || !UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden);
+                        (!startWithDot || UserSettingsService.PreferencesSettingsService.ShowDotFiles);
                     
                     if (shouldBeListed)
                     {
@@ -306,7 +306,7 @@ namespace Files.Filesystem.Search
                         bool shouldBeListed = (hiddenOnly ?
                             isHidden && (!isSystem || !UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden) :
                             !isHidden || (UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible && (!isSystem || !UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden))) &&
-                            (!startWithDot || !UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden);
+                            (!startWithDot || UserSettingsService.PreferencesSettingsService.ShowDotFiles);
                         
                         if (shouldBeListed)
                         {

--- a/src/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/src/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -53,7 +53,11 @@ namespace Files.Filesystem.StorageEnumerators
             {
                 var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
                 var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
-                if (!isHidden || (userSettingsService.PreferencesSettingsService.AreHiddenItemsVisible && (!isSystem || !userSettingsService.PreferencesSettingsService.AreSystemItemsHidden)))
+                var startWithDot = findData.cFileName.StartsWith(".");
+                if ((!isHidden ||
+                   (userSettingsService.PreferencesSettingsService.AreHiddenItemsVisible &&
+                   (!isSystem || !userSettingsService.PreferencesSettingsService.AreSystemItemsHidden))) &&
+                   (!startWithDot || !userSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden))
                 {
                     if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
                     {

--- a/src/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/src/Files/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -57,7 +57,7 @@ namespace Files.Filesystem.StorageEnumerators
                 if ((!isHidden ||
                    (userSettingsService.PreferencesSettingsService.AreHiddenItemsVisible &&
                    (!isSystem || !userSettingsService.PreferencesSettingsService.AreSystemItemsHidden))) &&
-                   (!startWithDot || !userSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden))
+                   (!startWithDot || userSettingsService.PreferencesSettingsService.ShowDotFiles))
                 {
                     if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
                     {

--- a/src/Files/Helpers/RegistryToJsonSettingsMerger.cs
+++ b/src/Files/Helpers/RegistryToJsonSettingsMerger.cs
@@ -31,7 +31,7 @@ namespace Files.Helpers
                     userSettingsService.PreferencesSettingsService.ShowFileExtensions = appSettings.Get(true, "ShowFileExtensions");
                     userSettingsService.PreferencesSettingsService.AreHiddenItemsVisible = appSettings.Get(false, "AreHiddenItemsVisible");
                     userSettingsService.PreferencesSettingsService.AreSystemItemsHidden = appSettings.Get(true, "AreSystemItemsHidden");
-                    userSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden = appSettings.Get(false, "AreItemsStartingWithDotHidden");
+                    userSettingsService.PreferencesSettingsService.ShowDotFiles = appSettings.Get(false, "ShowDotFiles");
                     userSettingsService.PreferencesSettingsService.ListAndSortDirectoriesAlongsideFiles = appSettings.Get(false, "ListAndSortDirectoriesAlongsideFiles");
                     userSettingsService.PreferencesSettingsService.OpenFilesWithOneClick = appSettings.Get(false, "OpenItemsWithOneClick");
                     userSettingsService.PreferencesSettingsService.OpenFoldersWithOneClick = appSettings.Get(false, "OpenItemsWithOneClick");

--- a/src/Files/Helpers/RegistryToJsonSettingsMerger.cs
+++ b/src/Files/Helpers/RegistryToJsonSettingsMerger.cs
@@ -31,6 +31,7 @@ namespace Files.Helpers
                     userSettingsService.PreferencesSettingsService.ShowFileExtensions = appSettings.Get(true, "ShowFileExtensions");
                     userSettingsService.PreferencesSettingsService.AreHiddenItemsVisible = appSettings.Get(false, "AreHiddenItemsVisible");
                     userSettingsService.PreferencesSettingsService.AreSystemItemsHidden = appSettings.Get(true, "AreSystemItemsHidden");
+                    userSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden = appSettings.Get(false, "AreItemsStartingWithDotHidden");
                     userSettingsService.PreferencesSettingsService.ListAndSortDirectoriesAlongsideFiles = appSettings.Get(false, "ListAndSortDirectoriesAlongsideFiles");
                     userSettingsService.PreferencesSettingsService.OpenFilesWithOneClick = appSettings.Get(false, "OpenItemsWithOneClick");
                     userSettingsService.PreferencesSettingsService.OpenFoldersWithOneClick = appSettings.Get(false, "OpenItemsWithOneClick");

--- a/src/Files/MultilingualResources/Files.es-ES.xlf
+++ b/src/Files/MultilingualResources/Files.es-ES.xlf
@@ -2778,10 +2778,14 @@
         <trans-unit id="SettingsFilesAndFoldersShowHiddenItems" translate="yes" xml:space="preserve">
           <source>Show hidden files and folders</source>
           <target state="translated">Mostrar archivos y carpetas ocultos</target>
-        </trans-unit>
+        </trans-unit>        
         <trans-unit id="SettingsFilesAndFoldersHideSystemItems" translate="yes" xml:space="preserve">
           <source>Hide protected operating system files (Recommended)</source>
           <target state="translated">Ocultar archivos protegidos del sistema operativo (recomendado)</target>
+        </trans-unit>
+        <trans-unit id="ShowDotFiles" translate="yes" xml:space="preserve">
+          <source>Show dot files</source>
+          <target state="translated">Mostrar archivos que comienzan con un punto</target>
         </trans-unit>
         <trans-unit id="SettingsOpenFilesWithOneClick" translate="yes" xml:space="preserve">
           <source>Open files with a single click</source>

--- a/src/Files/MultilingualResources/Files.it-IT.xlf
+++ b/src/Files/MultilingualResources/Files.it-IT.xlf
@@ -2783,9 +2783,9 @@
           <source>Hide protected operating system files (Recommended)</source>
           <target state="translated">Nascondi file protetti e di sistema (Raccomandato)</target>
         </trans-unit>
-        <trans-unit id="SettingsFilesAndFoldersHideItemsStartingWithDot" translate="yes" xml:space="preserve">
-          <source>Hide files and folders whose names start with a dot</source>
-          <target state="translated">Nascondi file e cartelle il cui nome inizia con un punto</target>
+        <trans-unit id="ShowDotFiles" translate="yes" xml:space="preserve">
+          <source>Show dot files</source>
+          <target state="translated">Mostra file e cartelle che iniziano con un punto</target>
         </trans-unit>
         <trans-unit id="SettingsOpenFilesWithOneClick" translate="yes" xml:space="preserve">
           <source>Open files with a single click</source>

--- a/src/Files/MultilingualResources/Files.it-IT.xlf
+++ b/src/Files/MultilingualResources/Files.it-IT.xlf
@@ -2783,6 +2783,10 @@
           <source>Hide protected operating system files (Recommended)</source>
           <target state="translated">Nascondi file protetti e di sistema (Raccomandato)</target>
         </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersHideItemsStartingWithDot" translate="yes" xml:space="preserve">
+          <source>Hide files and folders whose names start with a dot</source>
+          <target state="translated">Nascondi file e cartelle il cui nome inizia con un punto</target>
+        </trans-unit>
         <trans-unit id="SettingsOpenFilesWithOneClick" translate="yes" xml:space="preserve">
           <source>Open files with a single click</source>
           <target state="translated">Apri i file con un solo click</target>

--- a/src/Files/Services/IPreferencesSettingsService.cs
+++ b/src/Files/Services/IPreferencesSettingsService.cs
@@ -29,7 +29,12 @@ namespace Files.Services
         /// Gets or sets a value indicating whether or not system items should be visible.
         /// </summary>
         bool AreSystemItemsHidden { get; set; }
-
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether or not elements whose name begins with a dot should be visible.
+        /// </summary>
+        bool AreItemsStartingWithDotHidden { get; set; }
+        
         /// <summary>
         /// Gets or sets a value indicating whether or not files should be sorted together with folders.
         /// </summary>

--- a/src/Files/Services/IPreferencesSettingsService.cs
+++ b/src/Files/Services/IPreferencesSettingsService.cs
@@ -31,9 +31,9 @@ namespace Files.Services
         bool AreSystemItemsHidden { get; set; }
         
         /// <summary>
-        /// Gets or sets a value indicating whether or not elements whose name begins with a dot should be visible.
+        /// Gets or sets a value indicating whether or not to display dot files.
         /// </summary>
-        bool AreItemsStartingWithDotHidden { get; set; }
+        bool ShowDotFiles{ get; set; }
         
         /// <summary>
         /// Gets or sets a value indicating whether or not files should be sorted together with folders.

--- a/src/Files/Services/Implementation/PreferencesSettingsService.cs
+++ b/src/Files/Services/Implementation/PreferencesSettingsService.cs
@@ -41,6 +41,12 @@ namespace Files.Services.Implementation
             get => Get(true);
             set => Set(value);
         }
+        
+        public bool AreItemsStartingWithDotHidden
+        {
+            get => Get(false);
+            set => Set(value);
+        }
 
         public bool ListAndSortDirectoriesAlongsideFiles
         {
@@ -141,6 +147,7 @@ namespace Files.Services.Implementation
                 case nameof(ShowFileExtensions):
                 case nameof(AreHiddenItemsVisible):
                 case nameof(AreSystemItemsHidden):
+                case nameof(AreItemsStartingWithDotHidden):
                 case nameof(ListAndSortDirectoriesAlongsideFiles):
                 case nameof(OpenFilesWithOneClick):
                 case nameof(OpenFoldersWithOneClick):
@@ -167,6 +174,7 @@ namespace Files.Services.Implementation
             Analytics.TrackEvent($"{nameof(ShowFileExtensions)}, {ShowFileExtensions}");
             Analytics.TrackEvent($"{nameof(AreHiddenItemsVisible)}, {AreHiddenItemsVisible}");
             Analytics.TrackEvent($"{nameof(AreSystemItemsHidden)}, {AreSystemItemsHidden}");
+            Analytics.TrackEvent($"{nameof(AreItemsStartingWithDotHidden)}, {AreItemsStartingWithDotHidden}");
             Analytics.TrackEvent($"{nameof(ListAndSortDirectoriesAlongsideFiles)}, {ListAndSortDirectoriesAlongsideFiles}");
             Analytics.TrackEvent($"{nameof(OpenFilesWithOneClick)}, {OpenFilesWithOneClick}");
             Analytics.TrackEvent($"{nameof(OpenFoldersWithOneClick)}, {OpenFoldersWithOneClick}");

--- a/src/Files/Services/Implementation/PreferencesSettingsService.cs
+++ b/src/Files/Services/Implementation/PreferencesSettingsService.cs
@@ -147,7 +147,7 @@ namespace Files.Services.Implementation
                 case nameof(ShowFileExtensions):
                 case nameof(AreHiddenItemsVisible):
                 case nameof(AreSystemItemsHidden):
-                case nameof(AreItemsStartingWithDotHidden):
+                case nameof(ShowDotFiles):
                 case nameof(ListAndSortDirectoriesAlongsideFiles):
                 case nameof(OpenFilesWithOneClick):
                 case nameof(OpenFoldersWithOneClick):

--- a/src/Files/Services/Implementation/PreferencesSettingsService.cs
+++ b/src/Files/Services/Implementation/PreferencesSettingsService.cs
@@ -42,7 +42,7 @@ namespace Files.Services.Implementation
             set => Set(value);
         }
         
-        public bool AreItemsStartingWithDotHidden
+        public bool ShowDotFiles
         {
             get => Get(false);
             set => Set(value);

--- a/src/Files/Services/Implementation/PreferencesSettingsService.cs
+++ b/src/Files/Services/Implementation/PreferencesSettingsService.cs
@@ -174,7 +174,7 @@ namespace Files.Services.Implementation
             Analytics.TrackEvent($"{nameof(ShowFileExtensions)}, {ShowFileExtensions}");
             Analytics.TrackEvent($"{nameof(AreHiddenItemsVisible)}, {AreHiddenItemsVisible}");
             Analytics.TrackEvent($"{nameof(AreSystemItemsHidden)}, {AreSystemItemsHidden}");
-            Analytics.TrackEvent($"{nameof(AreItemsStartingWithDotHidden)}, {AreItemsStartingWithDotHidden}");
+            Analytics.TrackEvent($"{nameof(ShowDotFiles)}, {ShowDotFiles}");
             Analytics.TrackEvent($"{nameof(ListAndSortDirectoriesAlongsideFiles)}, {ListAndSortDirectoriesAlongsideFiles}");
             Analytics.TrackEvent($"{nameof(OpenFilesWithOneClick)}, {OpenFilesWithOneClick}");
             Analytics.TrackEvent($"{nameof(OpenFoldersWithOneClick)}, {OpenFoldersWithOneClick}");

--- a/src/Files/Strings/en-US/Resources.resw
+++ b/src/Files/Strings/en-US/Resources.resw
@@ -231,6 +231,9 @@
   <data name="SettingsFilesAndFoldersShowHiddenItems" xml:space="preserve">
     <value>Show hidden files and folders</value>
   </data>
+  <data name="SettingsFilesAndFoldersHideItemsStartingWithDot" xml:space="preserve">
+    <value>Hide files and folders whose names start with a dot</value>
+  </data>
   <data name="SettingsExperimentalTitle.Text" xml:space="preserve">
     <value>Experimental</value>
   </data>

--- a/src/Files/Strings/en-US/Resources.resw
+++ b/src/Files/Strings/en-US/Resources.resw
@@ -231,8 +231,8 @@
   <data name="SettingsFilesAndFoldersShowHiddenItems" xml:space="preserve">
     <value>Show hidden files and folders</value>
   </data>
-  <data name="SettingsFilesAndFoldersHideItemsStartingWithDot" xml:space="preserve">
-    <value>Hide files and folders whose names start with a dot</value>
+  <data name="ShowDotFiles" xml:space="preserve">
+    <value>Show dot files</value>
   </data>
   <data name="SettingsExperimentalTitle.Text" xml:space="preserve">
     <value>Experimental</value>

--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -386,6 +386,7 @@ namespace Files.ViewModels
                 case nameof(UserSettingsService.PreferencesSettingsService.ShowFileExtensions):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden):
+                case nameof(UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreFileTagsEnabled):
                 case nameof(UserSettingsService.PreferencesSettingsService.ShowFolderSize):
                     await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
@@ -2121,7 +2122,10 @@ namespace Files.ViewModels
 
             var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
             var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
-            if (isHidden && (!UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible || (isSystem && UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden)))
+            if ((isHidden &&
+               (!UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible ||
+               (isSystem && UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden))) ||
+               (startWithDot && UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden))
             {
                 // Do not add to file list if hidden/system attribute is set and system/hidden file are not to be shown
                 return null;

--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -386,7 +386,7 @@ namespace Files.ViewModels
                 case nameof(UserSettingsService.PreferencesSettingsService.ShowFileExtensions):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden):
-                case nameof(UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden):
+                case nameof(UserSettingsService.PreferencesSettingsService.ShowDotFiles):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreFileTagsEnabled):
                 case nameof(UserSettingsService.PreferencesSettingsService.ShowFolderSize):
                     await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>

--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -2122,6 +2122,7 @@ namespace Files.ViewModels
 
             var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
             var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
+            var startWithDot = findData.cFileName.StartsWith(".");
             if ((isHidden &&
                (!UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible ||
                (isSystem && UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden))) ||

--- a/src/Files/ViewModels/ItemViewModel.cs
+++ b/src/Files/ViewModels/ItemViewModel.cs
@@ -2126,7 +2126,7 @@ namespace Files.ViewModels
             if ((isHidden &&
                (!UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible ||
                (isSystem && UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden))) ||
-               (startWithDot && UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden))
+               (startWithDot && !UserSettingsService.PreferencesSettingsService.ShowDotFiles))
             {
                 // Do not add to file list if hidden/system attribute is set and system/hidden file are not to be shown
                 return null;

--- a/src/Files/ViewModels/SettingsViewModels/PreferencesViewModel.cs
+++ b/src/Files/ViewModels/SettingsViewModels/PreferencesViewModel.cs
@@ -529,14 +529,14 @@ namespace Files.ViewModels.SettingsViewModels
             }
         }
         
-        public bool AreItemsStartingWithDotHidden
+        public bool ShowDotFiles
         {
-            get => UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden;
+            get => UserSettingsService.PreferencesSettingsService.ShowDotFiles;
             set
             {
-                if (value != UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden)
+                if (value != UserSettingsService.PreferencesSettingsService.ShowDotFiles)
                 {
-                    UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden = value;
+                    UserSettingsService.PreferencesSettingsService.ShowDotFiles = value;
                     OnPropertyChanged();
                 }
             }

--- a/src/Files/ViewModels/SettingsViewModels/PreferencesViewModel.cs
+++ b/src/Files/ViewModels/SettingsViewModels/PreferencesViewModel.cs
@@ -528,6 +528,19 @@ namespace Files.ViewModels.SettingsViewModels
                 }
             }
         }
+        
+        public bool AreItemsStartingWithDotHidden
+        {
+            get => UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden;
+            set
+            {
+                if (value != UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden)
+                {
+                    UserSettingsService.PreferencesSettingsService.AreItemsStartingWithDotHidden = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         public bool ShowFileExtensions
         {

--- a/src/Files/Views/SettingsPages/Preferences.xaml
+++ b/src/Files/Views/SettingsPages/Preferences.xaml
@@ -168,7 +168,7 @@
                             </local:SettingsBlockControl.Icon>
                             <ToggleSwitch
                                 AutomationProperties.Name="{helpers:ResourceString Name=ShowDotFiles}"
-                                IsOn="{Binding AreItemsStartingWithDotHidden, Mode=TwoWay}"
+                                IsOn="{Binding ShowDotFiles, Mode=TwoWay}"
                                 Style="{StaticResource RightAlignedToggleSwitchStyle}" />
                         </local:SettingsBlockControl>
 

--- a/src/Files/Views/SettingsPages/Preferences.xaml
+++ b/src/Files/Views/SettingsPages/Preferences.xaml
@@ -162,7 +162,7 @@
                                 Style="{StaticResource RightAlignedToggleSwitchStyle}" />
                         </local:SettingsBlockControl>
                         
-                        <local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsFilesAndFoldersHideItemsStartingWithDot}" HorizontalAlignment="Stretch">
+                        <local:SettingsBlockControl Title="{helpers:ResourceString Name=ShowDotFiles}" HorizontalAlignment="Stretch">
                             <local:SettingsBlockControl.Icon>
                                 <FontIcon contract13NotPresent:Glyph="&#xE72E;" contract13Present:Glyph="&#xED1A;" />
                             </local:SettingsBlockControl.Icon>

--- a/src/Files/Views/SettingsPages/Preferences.xaml
+++ b/src/Files/Views/SettingsPages/Preferences.xaml
@@ -164,7 +164,7 @@
                         
                         <local:SettingsBlockControl Title="{helpers:ResourceString Name=ShowDotFiles}" HorizontalAlignment="Stretch">
                             <local:SettingsBlockControl.Icon>
-                                <FontIcon contract13NotPresent:Glyph="&#xE72E;" contract13Present:Glyph="&#xED1A;" />
+                                <FontIcon Glyph="&#xE7B3;" />
                             </local:SettingsBlockControl.Icon>
                             <ToggleSwitch
                                 AutomationProperties.Name="{helpers:ResourceString Name=ShowDotFiles}"

--- a/src/Files/Views/SettingsPages/Preferences.xaml
+++ b/src/Files/Views/SettingsPages/Preferences.xaml
@@ -161,6 +161,16 @@
                                 IsOn="{Binding AreSystemItemsHidden, Mode=TwoWay}"
                                 Style="{StaticResource RightAlignedToggleSwitchStyle}" />
                         </local:SettingsBlockControl>
+                        
+                        <local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsFilesAndFoldersHideItemsStartingWithDot}" HorizontalAlignment="Stretch">
+                            <local:SettingsBlockControl.Icon>
+                                <FontIcon contract13NotPresent:Glyph="&#xE72E;" contract13Present:Glyph="&#xED1A;" />
+                            </local:SettingsBlockControl.Icon>
+                            <ToggleSwitch
+                                AutomationProperties.Name="{helpers:ResourceString Name=SettingsFilesAndFoldersHideItemsStartingWithDot}"
+                                IsOn="{Binding AreItemsStartingWithDotHidden, Mode=TwoWay}"
+                                Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+                        </local:SettingsBlockControl>
 
                         <local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsFilesAndFoldersShowFileExtensions}" HorizontalAlignment="Stretch">
                             <local:SettingsBlockControl.Icon>

--- a/src/Files/Views/SettingsPages/Preferences.xaml
+++ b/src/Files/Views/SettingsPages/Preferences.xaml
@@ -151,16 +151,6 @@
                                 IsOn="{Binding AreHiddenItemsVisible, Mode=TwoWay}"
                                 Style="{StaticResource RightAlignedToggleSwitchStyle}" />
                         </local:SettingsBlockControl>
-
-                        <local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsFilesAndFoldersHideSystemItems}" HorizontalAlignment="Stretch">
-                            <local:SettingsBlockControl.Icon>
-                                <FontIcon contract13NotPresent:Glyph="&#xE72E;" contract13Present:Glyph="&#xED1A;" />
-                            </local:SettingsBlockControl.Icon>
-                            <ToggleSwitch
-                                AutomationProperties.Name="{helpers:ResourceString Name=SettingsFilesAndFoldersHideSystemItems}"
-                                IsOn="{Binding AreSystemItemsHidden, Mode=TwoWay}"
-                                Style="{StaticResource RightAlignedToggleSwitchStyle}" />
-                        </local:SettingsBlockControl>
                         
                         <local:SettingsBlockControl Title="{helpers:ResourceString Name=ShowDotFiles}" HorizontalAlignment="Stretch">
                             <local:SettingsBlockControl.Icon>
@@ -169,6 +159,16 @@
                             <ToggleSwitch
                                 AutomationProperties.Name="{helpers:ResourceString Name=ShowDotFiles}"
                                 IsOn="{Binding ShowDotFiles, Mode=TwoWay}"
+                                Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+                        </local:SettingsBlockControl>
+                        
+                        <local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsFilesAndFoldersHideSystemItems}" HorizontalAlignment="Stretch">
+                            <local:SettingsBlockControl.Icon>
+                                <FontIcon contract13NotPresent:Glyph="&#xE72E;" contract13Present:Glyph="&#xED1A;" />
+                            </local:SettingsBlockControl.Icon>
+                            <ToggleSwitch
+                                AutomationProperties.Name="{helpers:ResourceString Name=SettingsFilesAndFoldersHideSystemItems}"
+                                IsOn="{Binding AreSystemItemsHidden, Mode=TwoWay}"
                                 Style="{StaticResource RightAlignedToggleSwitchStyle}" />
                         </local:SettingsBlockControl>
 

--- a/src/Files/Views/SettingsPages/Preferences.xaml
+++ b/src/Files/Views/SettingsPages/Preferences.xaml
@@ -167,7 +167,7 @@
                                 <FontIcon contract13NotPresent:Glyph="&#xE72E;" contract13Present:Glyph="&#xED1A;" />
                             </local:SettingsBlockControl.Icon>
                             <ToggleSwitch
-                                AutomationProperties.Name="{helpers:ResourceString Name=SettingsFilesAndFoldersHideItemsStartingWithDot}"
+                                AutomationProperties.Name="{helpers:ResourceString Name=ShowDotFiles}"
                                 IsOn="{Binding AreItemsStartingWithDotHidden, Mode=TwoWay}"
                                 Style="{StaticResource RightAlignedToggleSwitchStyle}" />
                         </local:SettingsBlockControl>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Closes #2587.
This is a simple implementation. It doesn't include advanced options, if anyone wants to implement them I am open to suggestions, or we can always open another PR in the future after having defined details better.

**Details of Changes**
- Added an option to hide files and folders starting with a dot (off by default) in Settings>Preferences>Files and folders
- Changed some functions so that .*** files are hidden (even from search) when the new setting is enabled

**Validation**
How did you test these changes?
- [x] Built and ran the app