### PR TITLE
Improve JumpString behavior

### DIFF
--- a/src/Files/BaseLayout.cs
+++ b/src/Files/BaseLayout.cs
@@ -179,8 +179,7 @@ namespace Files
                     // starting with the same letter
                     if (value.Length == 1 && previouslySelectedItem != null)
                     {
-                        // Try to select item lexicographically bigger than the previous item
-                        jumpedToItem = candidateItems.FirstOrDefault(f => f.ItemName.CompareTo(previouslySelectedItem.ItemName) > 0);
+                        jumpedToItem = candidateItems.SkipWhile(x => x != previouslySelectedItem).Skip(1).FirstOrDefault();
                     }
                     if (jumpedToItem == null)
                     {

--- a/src/Files/BaseLayout.cs
+++ b/src/Files/BaseLayout.cs
@@ -167,22 +167,27 @@ namespace Files
                     ListedItem jumpedToItem = null;
                     ListedItem previouslySelectedItem = null;
 
-                    // Use FilesAndFolders because only displayed entries should be jumped to
-                    IEnumerable<ListedItem> candidateItems = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.Where(f => f.ItemName.Length >= value.Length && string.Equals(f.ItemName.Substring(0, value.Length), value, StringComparison.OrdinalIgnoreCase));
-
                     if (IsItemSelected)
                     {
                         previouslySelectedItem = SelectedItem;
                     }
 
-                    // If the user is trying to cycle through items
-                    // starting with the same letter
-                    if (value.Length == 1 && previouslySelectedItem != null)
+                    // Select first matching item after currently selected item
+                    if (previouslySelectedItem != null)
                     {
-                        jumpedToItem = candidateItems.SkipWhile(x => x != previouslySelectedItem).Skip(1).FirstOrDefault();
+                        // Use FilesAndFolders because only displayed entries should be jumped to
+                        IEnumerable<ListedItem> candidateItems = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders
+                            .SkipWhile(x => x != previouslySelectedItem)
+                            .Skip(value.Length == 1 ? 1 : 0) // User is trying to cycle through items starting with the same letter
+                            .Where(f => f.ItemName.Length >= value.Length && string.Equals(f.ItemName.Substring(0, value.Length), value, StringComparison.OrdinalIgnoreCase));
+                        jumpedToItem = candidateItems.FirstOrDefault();
                     }
+
                     if (jumpedToItem == null)
                     {
+                        // Use FilesAndFolders because only displayed entries should be jumped to
+                        IEnumerable<ListedItem> candidateItems = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders
+                            .Where(f => f.ItemName.Length >= value.Length && string.Equals(f.ItemName.Substring(0, value.Length), value, StringComparison.OrdinalIgnoreCase));
                         jumpedToItem = candidateItems.FirstOrDefault();
                     }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #8285

**Details of Changes**
Add details of changes here.
- Choose next item to be selected based on its position in the file list, not its lexicographical order (which causes some items to be skipped)
- Start looking for matching items after currently selected item

**Validation**
How did you test these changes?
- [x] Built and ran the app
