### PR TITLE
Fixed issue that causes a window to close when a tab is torn off

### DIFF
--- a/src/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
+++ b/src/Files/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
@@ -179,7 +179,7 @@ namespace Files.UserControls.MultitaskingControl
             }
             else
             {
-                CloseTab(args.Item as TabItem);
+                (args.Item as TabItem)?.Unload(); // Dispose tab arguments
             }
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #7246
- Probably related #7222

**Details of Changes**
Currently, when there are 2 tabs open and one of them is torn off, the first window is closed because CloseTab() is called after the tab has already been removed and it finds only one remaining tab.
This PR fixes the problem.

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots (optional)**