### PR TITLE
Fix SearchBox height

### DIFF
--- a/src/Files/UserControls/NavigationToolbar.xaml
+++ b/src/Files/UserControls/NavigationToolbar.xaml
@@ -481,7 +481,7 @@
                 x:Name="SearchRegion"
                 Grid.Column="2"
                 Width="240"
-                Height="33"
+                Height="34"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Center"
                 Canvas.ZIndex="100"


### PR DESCRIPTION
**Resolved / Related Issues**
Adjust the SearchBox height. #8427

**Details of Changes**
Modifiy the searchbox height (34 instead of 33) to match the address bar.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![SearchHeight](https://user-images.githubusercontent.com/46631671/154975834-a03338c2-3342-4445-b882-dd59792d3e81.png)
