### PR TITLE
Fix wrong foreground text color in zoomed-out Group headers

### DIFF
--- a/src/Files/Views/LayoutModes/ColumnViewBase.xaml
+++ b/src/Files/Views/LayoutModes/ColumnViewBase.xaml
@@ -419,7 +419,7 @@
                                         <TextBlock
                                             Margin="4,0,0,0"
                                             VerticalAlignment="Center"
-                                            Foreground="{StaticResource SystemControlPageTextBaseMediumBrush}"
+                                            Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                                             Style="{StaticResource BodyTextBlockStyle}"
                                             Text="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.CountText, Mode=OneWay}"
                                             Visibility="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.ShowCountTextBelow, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
@@ -427,13 +427,13 @@
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             FontSize="14"
-                                            Foreground="{StaticResource SystemControlPageTextBaseMediumBrush}"
+                                            Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                                             Style="{StaticResource SubheaderTextBlockStyle}"
                                             Text="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.Subtext, Mode=OneWay}"
                                             Visibility="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.ShowCountTextBelow, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
                                     </StackPanel>
                                     <TextBlock
-                                        Foreground="{StaticResource SystemControlPageTextBaseMediumBrush}"
+                                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                                         Style="{StaticResource BodyTextBlockStyle}"
                                         Text="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.CountText, Mode=OneWay}"
                                         Visibility="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.ShowCountTextBelow, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />

--- a/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -948,7 +948,7 @@
                                         <TextBlock
                                             Margin="4,0,0,0"
                                             VerticalAlignment="Center"
-                                            Foreground="{StaticResource SystemControlPageTextBaseMediumBrush}"
+                                            Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                                             Style="{StaticResource BodyTextBlockStyle}"
                                             Text="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.CountText, Mode=OneWay}"
                                             Visibility="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.ShowCountTextBelow, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
@@ -956,13 +956,13 @@
                                         <TextBlock
                                             VerticalAlignment="Center"
                                             FontSize="14"
-                                            Foreground="{StaticResource SystemControlPageTextBaseMediumBrush}"
+                                            Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                                             Style="{StaticResource SubheaderTextBlockStyle}"
                                             Text="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.Subtext, Mode=OneWay}"
                                             Visibility="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.ShowCountTextBelow, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
                                     </StackPanel>
                                     <TextBlock
-                                        Foreground="{StaticResource SystemControlPageTextBaseMediumBrush}"
+                                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                                         Style="{StaticResource BodyTextBlockStyle}"
                                         Text="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.CountText, Mode=OneWay}"
                                         Visibility="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.ShowCountTextBelow, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />

--- a/src/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -680,7 +680,7 @@
                                     Grid.Row="0"
                                     Grid.Column="2"
                                     VerticalAlignment="Center"
-                                    Foreground="{StaticResource SystemControlPageTextBaseMediumBrush}"
+                                    Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                                     Style="{StaticResource BodyTextBlockStyle}"
                                     Text="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.CountText, Mode=OneWay}"
                                     Visibility="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.ShowCountTextBelow, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
@@ -690,7 +690,7 @@
                                     Grid.Column="3"
                                     VerticalAlignment="Center"
                                     FontSize="14"
-                                    Foreground="{StaticResource SystemControlPageTextBaseMediumBrush}"
+                                    Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                                     Style="{StaticResource SubheaderTextBlockStyle}"
                                     Text="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.Subtext, Mode=OneWay}"
                                     Visibility="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.ShowCountTextBelow, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
@@ -699,7 +699,7 @@
                                     Grid.Row="1"
                                     Grid.Column="1"
                                     Grid.ColumnSpan="3"
-                                    Foreground="{StaticResource SystemControlPageTextBaseMediumBrush}"
+                                    Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                                     Style="{StaticResource BodyTextBlockStyle}"
                                     Text="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.CountText, Mode=OneWay}"
                                     Visibility="{x:Bind ((helpers:IGroupedCollectionHeader)Group).Model.ShowCountTextBelow, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />


### PR DESCRIPTION
**Details of Changes**
Add details of changes here.
- Fixed an issue where  switching theme would make the group headers unreadable until app restart

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots**

<img src="https://user-images.githubusercontent.com/9673091/155012372-76961026-6f56-443c-9622-f2382e52daa6.png" width="500"/>
