### PR TITLE
Select next item after deletion and reduce code complexity

### DIFF
--- a/src/Files.Uwp/ViewModels/ItemViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ItemViewModel.cs
@@ -428,10 +428,18 @@ namespace Files.ViewModels
                             break;
 
                         case "Deleted":
+                            var nextOfMatchingItem = filesAndFolders
+                                .SkipWhile((x) => !x.ItemPath.Equals(itemPath)).Skip(1)
+                                .DefaultIfEmpty(filesAndFolders.TakeWhile((x) => !x.ItemPath.Equals(itemPath)).LastOrDefault())
+                                .FirstOrDefault();
                             var removedItem = await RemoveFileOrFolderAsync(itemPath);
                             if (removedItem != null)
                             {
                                 await ApplySingleFileChangeAsync(removedItem);
+                            }
+                            if (nextOfMatchingItem != null)
+                            {
+                                await RequestSelectionAsync(new List<ListedItem>() { nextOfMatchingItem });
                             }
                             break;
 

--- a/src/Files.Uwp/ViewModels/ItemViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ItemViewModel.cs
@@ -428,9 +428,12 @@ namespace Files.ViewModels
                             break;
 
                         case "Deleted":
+                            // get the item that immediately follows matching item to be removed
+                            // if the matching item is the last item, try to get the previous item; otherwise, null
+                            // case must be ignored since $Recycle.Bin != $RECYCLE.BIN
                             var nextOfMatchingItem = filesAndFolders
-                                .SkipWhile((x) => !x.ItemPath.Equals(itemPath)).Skip(1)
-                                .DefaultIfEmpty(filesAndFolders.TakeWhile((x) => !x.ItemPath.Equals(itemPath)).LastOrDefault())
+                                .SkipWhile((x) => !x.ItemPath.Equals(itemPath, StringComparison.OrdinalIgnoreCase)).Skip(1)
+                                .DefaultIfEmpty(filesAndFolders.TakeWhile((x) => !x.ItemPath.Equals(itemPath, StringComparison.OrdinalIgnoreCase)).LastOrDefault())
                                 .FirstOrDefault();
                             var removedItem = await RemoveFileOrFolderAsync(itemPath);
                             if (removedItem != null)

--- a/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
@@ -552,6 +552,8 @@ namespace Files.Views
 
         private void FilesystemViewModel_OnSelectionRequestedEvent(object sender, List<ListedItem> e)
         {
+            // set focus since selection might occur before the UI finishes updating
+            ContentPage.ItemManipulationModel.FocusFileList();
             ContentPage.ItemManipulationModel.SetSelectedItems(e);
         }
 

--- a/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
@@ -541,7 +541,6 @@ namespace Files.Views
             FilesystemViewModel.DirectoryInfoUpdated += FilesystemViewModel_DirectoryInfoUpdated;
             FilesystemViewModel.PageTypeUpdated += FilesystemViewModel_PageTypeUpdated;
             FilesystemViewModel.OnSelectionRequestedEvent += FilesystemViewModel_OnSelectionRequestedEvent;
-            FilesystemViewModel.ListedItemAdded += FilesystemViewModel_ListedItemAdded;
             OnNavigationParamsChanged();
             this.Loaded -= Page_Loaded;
         }
@@ -568,18 +567,6 @@ namespace Files.Views
                 {
                     ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{FilesystemViewModel.FilesAndFolders.Count} {"ItemsCount/Text".GetLocalized()}";
                 }
-            }
-        }
-
-        private void FilesystemViewModel_ListedItemAdded(object sender, ListedItemAddedEventArgs e)
-        {
-            ListedItem itemToSelect = e?.Item;
-            if (itemToSelect != null && ContentPage != null)
-            {
-                // set focus since selection might occur before the UI finishes updating
-                ContentPage.ItemManipulationModel.FocusFileList();
-                ContentPage.ItemManipulationModel.SetSelectedItem(itemToSelect);
-                ContentPage.ItemManipulationModel.ScrollIntoView(itemToSelect);
             }
         }
 
@@ -903,7 +890,6 @@ namespace Files.Views
                 FilesystemViewModel.DirectoryInfoUpdated -= FilesystemViewModel_DirectoryInfoUpdated;
                 FilesystemViewModel.PageTypeUpdated -= FilesystemViewModel_PageTypeUpdated;
                 FilesystemViewModel.OnSelectionRequestedEvent -= FilesystemViewModel_OnSelectionRequestedEvent;
-                FilesystemViewModel.ListedItemAdded -= FilesystemViewModel_ListedItemAdded;
                 FilesystemViewModel.Dispose();
             }
 

--- a/src/Files.Uwp/Views/ModernShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ModernShellPage.xaml.cs
@@ -584,7 +584,6 @@ namespace Files.Views
             FilesystemViewModel.DirectoryInfoUpdated += FilesystemViewModel_DirectoryInfoUpdated;
             FilesystemViewModel.PageTypeUpdated += FilesystemViewModel_PageTypeUpdated;
             FilesystemViewModel.OnSelectionRequestedEvent += FilesystemViewModel_OnSelectionRequestedEvent;
-            FilesystemViewModel.ListedItemAdded += FilesystemViewModel_ListedItemAdded;
             OnNavigationParamsChanged();
             this.Loaded -= Page_Loaded;
         }
@@ -611,18 +610,6 @@ namespace Files.Views
                 {
                     ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{FilesystemViewModel.FilesAndFolders.Count} {"ItemsCount/Text".GetLocalized()}";
                 }
-            }
-        }
-
-        private void FilesystemViewModel_ListedItemAdded(object sender, ListedItemAddedEventArgs e)
-        {
-            ListedItem itemToSelect = e?.Item;
-            if (itemToSelect != null && ContentPage != null)
-            {
-                // set focus since selection might occur before the UI finishes updating
-                ContentPage.ItemManipulationModel.FocusFileList();
-                ContentPage.ItemManipulationModel.SetSelectedItem(itemToSelect);
-                ContentPage.ItemManipulationModel.ScrollIntoView(itemToSelect);
             }
         }
 
@@ -1010,7 +997,6 @@ namespace Files.Views
                 FilesystemViewModel.DirectoryInfoUpdated -= FilesystemViewModel_DirectoryInfoUpdated;
                 FilesystemViewModel.PageTypeUpdated -= FilesystemViewModel_PageTypeUpdated;
                 FilesystemViewModel.OnSelectionRequestedEvent -= FilesystemViewModel_OnSelectionRequestedEvent;
-                FilesystemViewModel.ListedItemAdded -= FilesystemViewModel_ListedItemAdded;
                 FilesystemViewModel.Dispose();
             }
 

--- a/src/Files.Uwp/Views/ModernShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ModernShellPage.xaml.cs
@@ -595,6 +595,8 @@ namespace Files.Views
 
         private void FilesystemViewModel_OnSelectionRequestedEvent(object sender, List<ListedItem> e)
         {
+            // set focus since selection might occur before the UI finishes updating
+            ContentPage.ItemManipulationModel.FocusFileList();
             ContentPage.ItemManipulationModel.SetSelectedItems(e);
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #8418 

**Details of Changes**
- Select the item following the matched item to be deleted 
   - If the item was the last item, choose the item right before it
- Reduce code complexity with selecting newly created items by reusing `OnSelectionRequestedEvent` 
   - (I did this PR awhile back)

**Validation**
- [X] Built and ran the app

**Screenshots (optional)**
![Files-8418](https://user-images.githubusercontent.com/29434693/155646223-e1bc0953-00ad-4ac3-b465-77a71a87ac6c.gif)

