### PR TITLE
Show more file types in "New" context menu

### DIFF
--- a/src/Files.Launcher/Helpers/ShellNewMenuHelper.cs
+++ b/src/Files.Launcher/Helpers/ShellNewMenuHelper.cs
@@ -78,10 +78,6 @@ namespace FilesFullTrust.Helpers
 
             var extension = root.Name.Substring(root.Name.LastIndexOf('\\') + 1);
             var fileName = (string)key.GetValue("FileName");
-            if (!string.IsNullOrEmpty(fileName) && Path.GetExtension(fileName) != extension)
-            {
-                return null;
-            }
 
             byte[] data = null;
             var dataObj = key.GetValue("Data");


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Partially solves #8244 

**Details of Changes**
This PR removes a check that prevented some files like .accdb (Microsoft Access) that have a template with a different extension from appearing in the "New" menu. The final file is still created with the correct extension.

I wasn't able to fix .txt and .bmp entries in Windows 11 because they don't have a ShellNew entry (this is somewhat related to the new Notepad and Paint apps).

**Validation**
How did you test these changes?
- [x] Built and ran the app
