### PR TITLE
Fix FilesystemTasks error code

### DIFF
--- a/src/Files.Uwp/Filesystem/StorageFileHelpers/FilesystemResult.cs
+++ b/src/Files.Uwp/Filesystem/StorageFileHelpers/FilesystemResult.cs
@@ -60,13 +60,13 @@ namespace Files.Filesystem
             {
                 return FileSystemStatusCode.NotFound;
             }
-            else if (ex is IOException || ex is FileLoadException)
-            {
-                return FileSystemStatusCode.InUse;
-            }
             else if (ex is PathTooLongException)
             {
                 return FileSystemStatusCode.NameTooLong;
+            }
+            else if (ex is IOException || ex is FileLoadException)
+            {
+                return FileSystemStatusCode.InUse;
             }
             else if (ex is ArgumentException) // Item was invalid
             {


### PR DESCRIPTION
This pr fixes a small bug in the FilesystemTasks class. The NameTooLong error code is never returned because PathTooLongException is a subclass of IOException. The NameTooLong code is however tested by the caller. The order of the tests has been modified to manage the most specific in priority.

This function can still be improved: Unnecessary tests of FileLoadException and Generic, multiple casting of the same value, replacement by a switch expression, …. This pr only fixes the bug.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility