### PR TITLE
Notify when pinned items config changes

### DIFF
--- a/src/Files.Uwp/DataModels/NavigationControlItems/LocationItem.cs
+++ b/src/Files.Uwp/DataModels/NavigationControlItems/LocationItem.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.ObjectModel;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
+using Files.Helpers;
 
 namespace Files.DataModels.NavigationControlItems
 {
@@ -40,7 +41,7 @@ namespace Files.DataModels.NavigationControlItems
         public FontFamily Font { get; set; }
         public NavigationControlItemType ItemType => NavigationControlItemType.Location;
         public bool IsDefaultLocation { get; set; }
-        public ObservableCollection<INavigationControlItem> ChildItems { get; set; }
+        public BulkConcurrentObservableCollection<INavigationControlItem> ChildItems { get; set; }
 
         public bool SelectsOnInvoked { get; set; } = true;
 

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -376,11 +376,13 @@ namespace Files.DataModels
         public void RemoveStaleSidebarItems()
         {
             // Remove unpinned items from sidebar
-            for (int i = 0; i < favoriteSection.ChildItems.Count; i++)
+            // Reverse iteration to avoid skipping elements while removing
+            for (int i = favoriteSection.ChildItems.Count - 1; i >= 0; i--)
             {
-                if (favoriteSection.ChildItems[i] is LocationItem)
+                var childItem = favoriteSection.ChildItems[i];
+                if (childItem is LocationItem)
                 {
-                    var item = favoriteSection.ChildItems[i] as LocationItem;
+                    var item = childItem as LocationItem;
                     if (!item.IsDefaultLocation && !FavoriteItems.Contains(item.Path))
                     {
                         favoriteSection.ChildItems.RemoveAt(i);

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -97,11 +97,20 @@ namespace Files.DataModels
         /// <param name="item">Item to remove</param>
         public async void AddItem(string item)
         {
-            if (!string.IsNullOrEmpty(item) && !FavoriteItems.Contains(item))
+            await SidebarControl.SideBarItemsSemaphore.WaitAsync();
+
+            try
             {
-                FavoriteItems.Add(item);
-                await AddItemToSidebarAsync(item);
-                Save();
+                if (!string.IsNullOrEmpty(item) && !FavoriteItems.Contains(item))
+                {
+                    FavoriteItems.Add(item);
+                    await AddItemToSidebarAsync(item);
+                    Save();
+                }
+            }
+            finally
+            {
+                SidebarControl.SideBarItemsSemaphore.Release();
             }
         }
 

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -11,7 +11,6 @@ using Microsoft.Toolkit.Uwp;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -331,7 +330,7 @@ namespace Files.DataModels
                     IsDefaultLocation = true,
                     Icon = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => new BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/Home.png"))),
                     Path = "Home".GetLocalized(),
-                    ChildItems = new ObservableCollection<INavigationControlItem>()
+                    ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                 };
                 favoriteSection ??= new LocationItem()
                 {
@@ -340,7 +339,7 @@ namespace Files.DataModels
                     SelectsOnInvoked = false,
                     Icon = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => UIHelpers.GetIconResource(Constants.Shell32.QuickAccess)),
                     Font = MainViewModel.FontName,
-                    ChildItems = new ObservableCollection<INavigationControlItem>()
+                    ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                 };
 
                 if (homeSection != null)
@@ -355,19 +354,19 @@ namespace Files.DataModels
                     SidebarControl.SideBarItems.Insert(index, favoriteSection);
                     await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => SidebarControl.SideBarItems.EndBulkOperation());
                 }
+
+                for (int i = 0; i < FavoriteItems.Count; i++)
+                {
+                    string path = FavoriteItems[i];
+                    await AddItemToSidebarAsync(path);
+                }
+
+                await ShowHideRecycleBinItemAsync(UserSettingsService.AppearanceSettingsService.PinRecycleBinToSidebar);
             }
             finally
             {
                 SidebarControl.SideBarItemsSemaphore.Release();
             }
-
-            for (int i = 0; i < FavoriteItems.Count; i++)
-            {
-                string path = FavoriteItems[i];
-                await AddItemToSidebarAsync(path);
-            }
-
-            await ShowHideRecycleBinItemAsync(UserSettingsService.AppearanceSettingsService.PinRecycleBinToSidebar);
         }
 
         /// <summary>

--- a/src/Files.Uwp/Filesystem/CloudDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/CloudDrivesManager.cs
@@ -113,7 +113,7 @@ namespace Files.Filesystem
                             Section = SectionType.CloudDrives,
                             SelectsOnInvoked = false,
                             Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/CloudDrive.png")),
-                            ChildItems = new ObservableCollection<INavigationControlItem>()
+                            ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                         };
                         var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
                                     (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +

--- a/src/Files.Uwp/Filesystem/Drives.cs
+++ b/src/Files.Uwp/Filesystem/Drives.cs
@@ -145,7 +145,7 @@ namespace Files.Filesystem
                             Section = SectionType.Drives,
                             SelectsOnInvoked = false,
                             Icon = await UIHelpers.GetIconResource(Constants.ImageRes.ThisPC),
-                            ChildItems = new ObservableCollection<INavigationControlItem>()
+                            ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                         };
                         var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
                                     (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0); // After libraries section

--- a/src/Files.Uwp/Filesystem/FileTagsManager.cs
+++ b/src/Files.Uwp/Filesystem/FileTagsManager.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
+using Files.Helpers;
 
 namespace Files.Filesystem
 {
@@ -56,7 +57,7 @@ namespace Files.Filesystem
                             Section = SectionType.FileTag,
                             SelectsOnInvoked = false,
                             Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/FileTags.png")),
-                            ChildItems = new ObservableCollection<INavigationControlItem>()
+                            ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                         };
                         var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
                                     (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +

--- a/src/Files.Uwp/Filesystem/LibraryManager.cs
+++ b/src/Files.Uwp/Filesystem/LibraryManager.cs
@@ -200,7 +200,7 @@ namespace Files.Filesystem
                             Section = SectionType.Library,
                             SelectsOnInvoked = false,
                             Icon = await UIHelpers.GetIconResource(Constants.ImageRes.Libraries),
-                            ChildItems = new ObservableCollection<INavigationControlItem>()
+                            ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                         };
                         var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0); // After favorites section
                         SidebarControl.SideBarItems.BeginBulkOperation();

--- a/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
@@ -130,7 +130,7 @@ namespace Files.Filesystem
                             Section = SectionType.Network,
                             SelectsOnInvoked = false,
                             Icon = await UIHelpers.GetIconResource(Constants.ImageRes.NetworkDrives),
-                            ChildItems = new ObservableCollection<INavigationControlItem>()
+                            ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                         };
                         var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
                                     (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +

--- a/src/Files.Uwp/Filesystem/WSLDistroManager.cs
+++ b/src/Files.Uwp/Filesystem/WSLDistroManager.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.Storage;
 using Windows.UI.Core;
+using Files.Helpers;
 
 namespace Files.Filesystem
 {
@@ -56,7 +57,7 @@ namespace Files.Filesystem
                                 Section = SectionType.WSL,
                                 SelectsOnInvoked = false,
                                 Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/WSL/genericpng.png")),
-                                ChildItems = new ObservableCollection<INavigationControlItem>()
+                                ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                             };
                             var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
                                         (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +


### PR DESCRIPTION
**Resolved / Related Issues**
- Resolves #8556

**Details of Changes**
- Added watcher to pinned items config
- Fixed bug with items staying pinned when multiple items unpinned at once
    - Caused by incorrect iteration order when mutating list while enumerating
- Fixed bug with incorrect pin order when favoriting multiple items
- Synchronize updates to `ChildItems` by using `BulkConcurrentObservableCollection`
   - Watcher callback needs to marshal `RefreshAsync()` to UI thread which 
      implies that modification to `ChildItems` now needs to be thread-safe

**Validation**
- [X] Built and ran the app
- [X] Tested the changes for accessibility

**Screenshots (optional)**
![Files-8556](https://user-images.githubusercontent.com/29434693/159134647-93ffccc1-5cbf-450b-89cf-aaa9fb97aeb3.gif)

