### PR TITLE
Fix MainPage adaptive triggers

### DIFF
--- a/src/Files.OpenDialog/FilesLauncher/FilesLauncher.cpp
+++ b/src/Files.OpenDialog/FilesLauncher/FilesLauncher.cpp
@@ -340,7 +340,6 @@ bool OpenInExistingShellWindow(const TCHAR* folderPath)
 
 	bool opened = false;
 	IShellWindows* shellWindows;
-	long shellWindowsCount;
 	if (SUCCEEDED(CoCreateInstance(CLSID_ShellWindows, NULL, CLSCTX_LOCAL_SERVER, IID_IShellWindows, (void**)&shellWindows)))
 	{
 		VARIANT v;

--- a/src/Files.Uwp/BaseLayout.cs
+++ b/src/Files.Uwp/BaseLayout.cs
@@ -57,8 +57,6 @@ namespace Files
 
         public SelectedItemsPropertiesViewModel SelectedItemsPropertiesViewModel { get; }
 
-        public SettingsViewModel AppSettings => App.AppSettings;
-
         public FolderSettingsViewModel FolderSettings => ParentShellPageInstance.InstanceViewModel.FolderSettings;
 
         public CurrentInstanceViewModel InstanceViewModel => ParentShellPageInstance.InstanceViewModel;

--- a/src/Files.Uwp/Dialogs/PropertiesDialog.xaml.cs
+++ b/src/Files.Uwp/Dialogs/PropertiesDialog.xaml.cs
@@ -7,8 +7,6 @@ namespace Files.Dialogs
 {
     public sealed partial class PropertiesDialog : ContentDialog
     {
-        public SettingsViewModel AppSettings => App.AppSettings;
-
         public PropertiesDialog()
         {
             this.InitializeComponent();

--- a/src/Files.Uwp/Dialogs/SettingsDialog.xaml.cs
+++ b/src/Files.Uwp/Dialogs/SettingsDialog.xaml.cs
@@ -18,8 +18,6 @@ namespace Files.Dialogs
             set => DataContext = value;
         }
 
-        public SettingsViewModel AppSettings => App.AppSettings;
-
         // for some reason the requested theme wasn't being set on the content dialog, so this is used to manually bind to the requested app theme
         private FrameworkElement RootAppElement => Window.Current.Content as FrameworkElement;
 

--- a/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
@@ -38,8 +38,6 @@ namespace Files.UserControls
 
         public static BulkConcurrentObservableCollection<INavigationControlItem> SideBarItems { get; private set; } = new BulkConcurrentObservableCollection<INavigationControlItem>();
 
-        public SettingsViewModel AppSettings => App.AppSettings;
-
         public delegate void SidebarItemInvokedEventHandler(object sender, SidebarItemInvokedEventArgs e);
 
         public event SidebarItemInvokedEventHandler SidebarItemInvoked;

--- a/src/Files.Uwp/UserControls/StatusBarControl.xaml.cs
+++ b/src/Files.Uwp/UserControls/StatusBarControl.xaml.cs
@@ -8,8 +8,6 @@ namespace Files.UserControls
 {
     public sealed partial class StatusBarControl : UserControl, INotifyPropertyChanged
     {
-        public SettingsViewModel AppSettings => App.AppSettings;
-
         public MainViewModel MainViewModel => App.MainViewModel;
 
         public DirectoryPropertiesViewModel DirectoryPropertiesViewModel

--- a/src/Files.Uwp/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.Uwp/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -25,8 +25,6 @@ namespace Files.UserControls.Widgets
     {
         private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
 
-        public SettingsViewModel AppSettings => App.AppSettings;
-
         public delegate void DrivesWidgetInvokedEventHandler(object sender, DrivesWidgetInvokedEventArgs e);
 
         public event DrivesWidgetInvokedEventHandler DrivesWidgetInvoked;

--- a/src/Files.Uwp/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files.Uwp/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -34,7 +34,6 @@ namespace Files.UserControls.Widgets
 
         private ObservableCollection<RecentItem> recentItemsCollection = new ObservableCollection<RecentItem>();
         private EmptyRecentsText Empty { get; set; } = new EmptyRecentsText();
-        public SettingsViewModel AppSettings => App.AppSettings;
 
         public string WidgetName => nameof(RecentFilesWidget);
 

--- a/src/Files.Uwp/ViewModels/MainViewModel.cs
+++ b/src/Files.Uwp/ViewModels/MainViewModel.cs
@@ -18,8 +18,6 @@ namespace Files.ViewModels
 {
     public class MainViewModel : ObservableObject
     {
-        public SettingsViewModel AppSettings => App.AppSettings;
-
         public IPaneViewModel PaneViewModel { get; } = new PaneViewModel();
 
         public MainViewModel()

--- a/src/Files.Uwp/ViewModels/SettingsViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SettingsViewModel.cs
@@ -37,12 +37,6 @@ namespace Files.ViewModels
             }
 
             UpdateThemeElements = new RelayCommand(() => ThemeModeChanged?.Invoke(this, EventArgs.Empty));
-    }
-
-    public bool AreRegistrySettingsMergedToJson
-        {
-            get => Get(false);
-            set => Set(value);
         }
 
         public async Task DetectQuickLook()

--- a/src/Files.Uwp/Views/MainPage.xaml
+++ b/src/Files.Uwp/Views/MainPage.xaml
@@ -217,266 +217,269 @@
         </KeyboardAccelerator>
     </Page.KeyboardAccelerators>
 
-    <controls:SidebarControl
-        x:Name="SidebarControl"
-        HorizontalAlignment="Stretch"
-        HorizontalContentAlignment="Stretch"
-        Background="{ThemeResource RootBackgroundBrush}"
-        CanOpenInNewPane="{x:Bind SidebarAdaptiveViewModel.PaneHolder.IsMultiPaneEnabled, Mode=OneWay}"
-        DisplayModeChanged="{x:Bind SidebarAdaptiveViewModel.SidebarControl_DisplayModeChanged}"
-        EmptyRecycleBinCommand="{x:Bind SidebarAdaptiveViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
-        IsPaneOpen="{x:Bind SidebarAdaptiveViewModel.IsSidebarOpen, Mode=TwoWay}"
-        IsPaneToggleButtonVisible="False"
-        Loaded="SidebarControl_Loaded"
-        PaneDisplayMode="Left"
-        SelectedSidebarItem="{x:Bind SidebarAdaptiveViewModel.SidebarSelectedItem, Mode=TwoWay}"
-        ViewModel="{x:Bind SidebarAdaptiveViewModel}">
-        <controls:SidebarControl.TabContent>
+    <Border>
+        <controls:SidebarControl
+            x:Name="SidebarControl"
+            HorizontalAlignment="Stretch"
+            HorizontalContentAlignment="Stretch"
+            Background="{ThemeResource RootBackgroundBrush}"
+            CanOpenInNewPane="{x:Bind SidebarAdaptiveViewModel.PaneHolder.IsMultiPaneEnabled, Mode=OneWay}"
+            DisplayModeChanged="{x:Bind SidebarAdaptiveViewModel.SidebarControl_DisplayModeChanged}"
+            EmptyRecycleBinCommand="{x:Bind SidebarAdaptiveViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
+            IsPaneOpen="{x:Bind SidebarAdaptiveViewModel.IsSidebarOpen, Mode=TwoWay}"
+            IsPaneToggleButtonVisible="False"
+            Loaded="SidebarControl_Loaded"
+            PaneDisplayMode="Left"
+            SelectedSidebarItem="{x:Bind SidebarAdaptiveViewModel.SidebarSelectedItem, Mode=TwoWay}"
+            ViewModel="{x:Bind SidebarAdaptiveViewModel}">
+            <controls:SidebarControl.TabContent>
+                <Grid
+                    x:Name="RightMarginGrid"
+                    VerticalAlignment="Top"
+                    BorderBrush="{ThemeResource ControlStrokeColorDefault}"
+                    BorderThickness="0,0,0,1">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition x:Name="RightPaddingColumn" Width="0" />
+                    </Grid.ColumnDefinitions>
+
+                    <!--  This defines the drag area for the title bar  -->
+                    <Grid
+                        x:Name="DragArea"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
+                        Height="40"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Top"
+                        Background="Transparent"
+                        Loaded="DragArea_Loaded" />
+
+                    <usercontrols:HorizontalMultitaskingControl
+                        x:Name="horizontalMultitaskingControl"
+                        Grid.Column="0"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch"
+                        x:FieldModifier="public"
+                        x:Load="False"
+                        Loaded="HorizontalMultitaskingControl_Loaded"
+                        TabIndex="0"
+                        TabStripVisibility="Visible"
+                        Visibility="Visible">
+                        <usercontrols:HorizontalMultitaskingControl.ActionsControl>
+                            <StackPanel
+                                x:Name="ActionButtonsPanel"
+                                Grid.Column="1"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Bottom"
+                                Orientation="Horizontal"
+                                Spacing="4">
+                                <Button
+                                    x:Name="HorizontalMultitaskingControlAddButton"
+                                    x:Uid="HorizontalMultitaskingControlAddButton"
+                                    Width="32"
+                                    Height="32"
+                                    Padding="8"
+                                    AutomationProperties.Name="New tab (Ctrl+T)"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    BorderThickness="0"
+                                    Click="{x:Bind ViewModel.AddNewTab, Mode=OneWay}"
+                                    ToolTipService.ToolTip="New tab (Ctrl+T)">
+                                    <Button.Content>
+                                        <FontIcon
+                                            x:Name="HorizontalMultitaskingControlAddButtonIcon"
+                                            FontSize="12"
+                                            Glyph="&#xE710;" />
+                                    </Button.Content>
+                                </Button>
+                                <Button
+                                    x:Name="VerticalTabStripInvokeButton"
+                                    x:Uid="VerticalTabFlyout"
+                                    Width="32"
+                                    Height="32"
+                                    Padding="8"
+                                    HorizontalAlignment="Right"
+                                    x:Load="{x:Bind IsVerticalTabFlyoutEnabled, Mode=OneWay}"
+                                    AccessKey="T"
+                                    AllowDrop="True"
+                                    AutomationProperties.Name="Vertical tab flyout"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    BorderThickness="0"
+                                    DragEnter="VerticalTabStripInvokeButton_DragEnter"
+                                    IsTapEnabled="True"
+                                    Loaded="VerticalTabStripInvokeButton_Loaded"
+                                    Tapped="VerticalTabStrip_Tapped"
+                                    ToolTipService.ToolTip="Vertical tab flyout">
+                                    <Button.Content>
+                                        <FontIcon
+                                            x:Name="VerticalTabStripInvokeButtonIcon"
+                                            FontSize="12"
+                                            Glyph="&#xF5ED;" />
+                                    </Button.Content>
+                                    <Button.Flyout>
+                                        <Flyout
+                                            x:Name="VerticalTabViewFlyout"
+                                            contract8Present:ShouldConstrainToRootBounds="False"
+                                            Placement="Bottom">
+                                            <usercontrols:VerticalTabViewControl
+                                                x:Name="VerticalTabs"
+                                                HorizontalAlignment="Stretch"
+                                                VerticalAlignment="Stretch"
+                                                x:FieldModifier="public" />
+                                        </Flyout>
+                                    </Button.Flyout>
+                                </Button>
+                            </StackPanel>
+                        </usercontrols:HorizontalMultitaskingControl.ActionsControl>
+                    </usercontrols:HorizontalMultitaskingControl>
+
+                    <Grid
+                        x:Name="TabBorder"
+                        Grid.Column="1"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Bottom"
+                        BorderBrush="{ThemeResource CardStrokeColorDefault}"
+                        BorderThickness="0,0,0,1" />
+
+                    <controls:NavigationToolbar
+                        x:Name="NavToolbar"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch"
+                        x:Load="False"
+                        Loaded="NavToolbar_Loaded"
+                        OngoingTasksViewModel="{x:Bind OngoingTasksViewModel}"
+                        SettingsButtonCommand="{x:Bind MainViewModel.OpenSettingsCommand}"
+                        ShowOngoingTasks="True"
+                        ShowSearchBox="True"
+                        ShowSettingsButton="{x:Bind IsCompactOverlay, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+                        TabIndex="1" />
+                </Grid>
+            </controls:SidebarControl.TabContent>
+
             <Grid
-                x:Name="RightMarginGrid"
-                VerticalAlignment="Top"
-                BorderBrush="{ThemeResource ControlStrokeColorDefault}"
-                BorderThickness="0,0,0,1">
+                x:Name="RootGrid"
+                PreviewKeyDown="RootGrid_PreviewKeyDown"
+                SizeChanged="RootGrid_SizeChanged">
+
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" MinHeight="100" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition x:Name="PaneRow" Height="Auto" />
+                    <RowDefinition Height="32" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition x:Name="RightPaddingColumn" Width="0" />
+                    <ColumnDefinition Width="3*" MinWidth="100" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition x:Name="PaneColumn" Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <!--  This defines the drag area for the title bar  -->
-                <Grid
-                    x:Name="DragArea"
-                    Grid.Column="0"
-                    Grid.ColumnSpan="2"
-                    Height="40"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Top"
-                    Background="Transparent"
-                    Loaded="DragArea_Loaded" />
-
-                <usercontrols:HorizontalMultitaskingControl
-                    x:Name="horizontalMultitaskingControl"
-                    Grid.Column="0"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
-                    HorizontalContentAlignment="Stretch"
-                    x:FieldModifier="public"
+                <controls:InnerNavigationToolbar
+                    x:Name="InnerNavigationToolbar"
+                    Grid.ColumnSpan="3"
                     x:Load="False"
-                    Loaded="HorizontalMultitaskingControl_Loaded"
-                    TabIndex="0"
-                    TabStripVisibility="Visible"
-                    Visibility="Visible">
-                    <usercontrols:HorizontalMultitaskingControl.ActionsControl>
-                        <StackPanel
-                            x:Name="ActionButtonsPanel"
-                            Grid.Column="1"
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Bottom"
-                            Orientation="Horizontal"
-                            Spacing="4">
-                            <Button
-                                x:Name="HorizontalMultitaskingControlAddButton"
-                                x:Uid="HorizontalMultitaskingControlAddButton"
-                                Width="32"
-                                Height="32"
-                                Padding="8"
-                                AutomationProperties.Name="New tab (Ctrl+T)"
-                                Background="Transparent"
-                                BorderBrush="Transparent"
-                                BorderThickness="0"
-                                Click="{x:Bind ViewModel.AddNewTab, Mode=OneWay}"
-                                ToolTipService.ToolTip="New tab (Ctrl+T)">
-                                <Button.Content>
-                                    <FontIcon
-                                        x:Name="HorizontalMultitaskingControlAddButtonIcon"
-                                        FontSize="12"
-                                        Glyph="&#xE710;" />
-                                </Button.Content>
-                            </Button>
-                            <Button
-                                x:Name="VerticalTabStripInvokeButton"
-                                x:Uid="VerticalTabFlyout"
-                                Width="32"
-                                Height="32"
-                                Padding="8"
-                                HorizontalAlignment="Right"
-                                x:Load="{x:Bind IsVerticalTabFlyoutEnabled, Mode=OneWay}"
-                                AccessKey="T"
-                                AllowDrop="True"
-                                AutomationProperties.Name="Vertical tab flyout"
-                                Background="Transparent"
-                                BorderBrush="Transparent"
-                                BorderThickness="0"
-                                DragEnter="VerticalTabStripInvokeButton_DragEnter"
-                                IsTapEnabled="True"
-                                Loaded="VerticalTabStripInvokeButton_Loaded"
-                                Tapped="VerticalTabStrip_Tapped"
-                                ToolTipService.ToolTip="Vertical tab flyout">
-                                <Button.Content>
-                                    <FontIcon
-                                        x:Name="VerticalTabStripInvokeButtonIcon"
-                                        FontSize="12"
-                                        Glyph="&#xF5ED;" />
-                                </Button.Content>
-                                <Button.Flyout>
-                                    <Flyout
-                                        x:Name="VerticalTabViewFlyout"
-                                        contract8Present:ShouldConstrainToRootBounds="False"
-                                        Placement="Bottom">
-                                        <usercontrols:VerticalTabViewControl
-                                            x:Name="VerticalTabs"
-                                            HorizontalAlignment="Stretch"
-                                            VerticalAlignment="Stretch"
-                                            x:FieldModifier="public" />
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-                        </StackPanel>
-                    </usercontrols:HorizontalMultitaskingControl.ActionsControl>
-                </usercontrols:HorizontalMultitaskingControl>
+                    IsCompactOverlay="{x:Bind IsCompactOverlay, Mode=OneWay}"
+                    Loaded="NavToolbar_Loaded"
+                    SetCompactOverlayCommand="{x:Bind SetCompactOverlayCommand}"
+                    ShowPreviewPaneButton="{x:Bind IsPreviewPaneEnabled, Mode=OneWay}"
+                    TabIndex="2" />
 
-                <Grid
-                    x:Name="TabBorder"
-                    Grid.Column="1"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Bottom"
-                    BorderBrush="{ThemeResource CardStrokeColorDefault}"
-                    BorderThickness="0,0,0,1" />
-
-                <controls:NavigationToolbar
-                    x:Name="NavToolbar"
+                <ContentPresenter
                     Grid.Row="1"
                     Grid.Column="0"
-                    Grid.ColumnSpan="2"
                     HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Stretch"
+                    Content="{x:Bind ((viewmodels:MainPageViewModel)DataContext).SelectedTabItem.Control, Mode=OneWay}" />
+
+                <custom:GridSplitter
+                    x:Name="PaneSplitter"
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    x:Load="{x:Bind IsPaneEnabled, Mode=OneWay}"
+                    ManipulationCompleted="PaneSplitter_ManipulationCompleted"
+                    ResizeBehavior="BasedOnAlignment"
+                    Style="{StaticResource DefaultGridSplitterStyle}" />
+
+                <controls:PaneControl
+                    x:Name="Pane"
+                    Grid.Row="1"
+                    Grid.Column="2"
+                    HorizontalContentAlignment="Stretch"
+                    x:Load="{x:Bind IsPaneEnabled, Mode=OneWay}"
+                    Visibility="{x:Bind IsPaneEnabled, Mode=OneWay}" />
+
+                <controls:StatusBarControl
+                    x:Name="StatusBarControl"
+                    Grid.Row="4"
+                    Grid.ColumnSpan="3"
                     x:Load="False"
-                    Loaded="NavToolbar_Loaded"
-                    OngoingTasksViewModel="{x:Bind OngoingTasksViewModel}"
-                    SettingsButtonCommand="{x:Bind MainViewModel.OpenSettingsCommand}"
-                    ShowOngoingTasks="True"
-                    ShowSearchBox="True"
-                    ShowSettingsButton="{x:Bind IsCompactOverlay, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-                    TabIndex="1" />
+                    ShowInfoText="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePaneOrColumn.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}" />
             </Grid>
-        </controls:SidebarControl.TabContent>
+        </controls:SidebarControl>
 
-        <Grid
-            x:Name="RootGrid"
-            PreviewKeyDown="RootGrid_PreviewKeyDown"
-            SizeChanged="RootGrid_SizeChanged">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="MultitaskingControlStates">
+                <VisualState x:Name="NormalWindowWidth">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger x:Name="CollapseHorizontalTabViewTrigger" MinWindowWidth="500" />
+                    </VisualState.StateTriggers>
+                </VisualState>
+                <VisualState x:Name="HorizontalTabViewCollapsed">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="horizontalMultitaskingControl.TabStripVisibility" Value="Collapsed" />
 
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" MinHeight="100" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition x:Name="PaneRow" Height="Auto" />
-                <RowDefinition Height="32" />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="3*" MinWidth="100" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition x:Name="PaneColumn" Width="Auto" />
-            </Grid.ColumnDefinitions>
+                        <!--  Update the button size to match the pane toggle button size  -->
+                        <Setter Target="VerticalTabStripInvokeButton.Height" Value="36" />
+                        <Setter Target="VerticalTabStripInvokeButton.Width" Value="36" />
+                        <Setter Target="HorizontalMultitaskingControlAddButton.Visibility" Value="Collapsed" />
+                        <Setter Target="VerticalTabStripInvokeButtonIcon.FontSize" Value="16" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+            <VisualStateGroup>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger x:Name="CollapseSearchBoxAdaptiveTrigger" MinWindowWidth="750" />
+                    </VisualState.StateTriggers>
+                </VisualState>
+                <VisualState x:Name="CollapseSearchBoxState">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="NavToolbar.ShowSearchBox" Value="False" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
 
-            <controls:InnerNavigationToolbar
-                x:Name="InnerNavigationToolbar"
-                Grid.ColumnSpan="3"
-                x:Load="False"
-                IsCompactOverlay="{x:Bind IsCompactOverlay, Mode=OneWay}"
-                Loaded="NavToolbar_Loaded"
-                SetCompactOverlayCommand="{x:Bind SetCompactOverlayCommand}"
-                ShowPreviewPaneButton="{x:Bind IsPreviewPaneEnabled, Mode=OneWay}"
-                TabIndex="2" />
-
-            <ContentPresenter
-                Grid.Row="1"
-                Grid.Column="0"
-                HorizontalAlignment="Stretch"
-                HorizontalContentAlignment="Stretch"
-                Content="{x:Bind ((viewmodels:MainPageViewModel)DataContext).SelectedTabItem.Control, Mode=OneWay}" />
-
-            <custom:GridSplitter
-                x:Name="PaneSplitter"
-                Grid.Row="1"
-                Grid.Column="1"
-                x:Load="{x:Bind IsPaneEnabled, Mode=OneWay}"
-                ManipulationCompleted="PaneSplitter_ManipulationCompleted"
-                ResizeBehavior="BasedOnAlignment"
-                Style="{StaticResource DefaultGridSplitterStyle}" />
-
-            <controls:PaneControl
-                x:Name="Pane"
-                Grid.Row="1"
-                Grid.Column="2"
-                HorizontalContentAlignment="Stretch"
-                x:Load="{x:Bind IsPaneEnabled, Mode=OneWay}"
-                Visibility="{x:Bind IsPaneEnabled, Mode=OneWay}" />
-
-            <controls:StatusBarControl
-                x:Name="StatusBarControl"
-                Grid.Row="4"
-                Grid.ColumnSpan="3"
-                x:Load="False"
-                ShowInfoText="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePaneOrColumn.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}" />
-        </Grid>
-    </controls:SidebarControl>
-    <VisualStateManager.VisualStateGroups>
-        <VisualStateGroup x:Name="MultitaskingControlStates">
-            <VisualState x:Name="NormalWindowWidth">
-                <VisualState.StateTriggers>
-                    <AdaptiveTrigger x:Name="CollapseHorizontalTabViewTrigger" MinWindowWidth="500" />
-                </VisualState.StateTriggers>
-            </VisualState>
-            <VisualState x:Name="HorizontalTabViewCollapsed">
-                <VisualState.StateTriggers>
-                    <AdaptiveTrigger MinWindowWidth="0" />
-                </VisualState.StateTriggers>
-                <VisualState.Setters>
-                    <Setter Target="horizontalMultitaskingControl.TabStripVisibility" Value="Collapsed" />
-
-                    <!--  Update the button size to match the pane toggle button size  -->
-                    <Setter Target="VerticalTabStripInvokeButton.Height" Value="36" />
-                    <Setter Target="VerticalTabStripInvokeButton.Width" Value="36" />
-                    <Setter Target="HorizontalMultitaskingControlAddButton.Visibility" Value="Collapsed" />
-                    <Setter Target="VerticalTabStripInvokeButtonIcon.FontSize" Value="16" />
-                </VisualState.Setters>
-            </VisualState>
-        </VisualStateGroup>
-        <VisualStateGroup>
-            <VisualState>
-                <VisualState.StateTriggers>
-                    <AdaptiveTrigger x:Name="CollapseSearchBoxAdaptiveTrigger" MinWindowWidth="750" />
-                </VisualState.StateTriggers>
-            </VisualState>
-            <VisualState x:Name="CollapseSearchBoxState">
-                <VisualState.StateTriggers>
-                    <AdaptiveTrigger MinWindowWidth="0" />
-                </VisualState.StateTriggers>
-                <VisualState.Setters>
-                    <Setter Target="NavToolbar.ShowSearchBox" Value="False" />
-                </VisualState.Setters>
-            </VisualState>
-        </VisualStateGroup>
-
-        <VisualStateGroup>
-            <VisualState>
-                <VisualState.StateTriggers>
-                    <AdaptiveTrigger x:Name="MinimalSidebarAdaptiveTrigger" MinWindowWidth="641" />
-                </VisualState.StateTriggers>
-            </VisualState>
-            <VisualState x:Name="MinimalSidebarState">
-                <VisualState.StateTriggers>
-                    <AdaptiveTrigger MinWindowWidth="0" />
-                </VisualState.StateTriggers>
-                <VisualState.Setters>
-                    <Setter Target="SidebarControl.PaneDisplayMode" Value="LeftMinimal" />
-                    <Setter Target="SidebarControl.IsPaneToggleButtonVisible" Value="True" />
-                </VisualState.Setters>
-            </VisualState>
-        </VisualStateGroup>
-    </VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger x:Name="MinimalSidebarAdaptiveTrigger" MinWindowWidth="641" />
+                    </VisualState.StateTriggers>
+                </VisualState>
+                <VisualState x:Name="MinimalSidebarState">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="SidebarControl.PaneDisplayMode" Value="LeftMinimal" />
+                        <Setter Target="SidebarControl.IsPaneToggleButtonVisible" Value="True" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+    </Border>
 </Page>

--- a/src/Files.Uwp/Views/MainPage.xaml
+++ b/src/Files.Uwp/Views/MainPage.xaml
@@ -477,6 +477,7 @@
                     <VisualState.Setters>
                         <Setter Target="SidebarControl.PaneDisplayMode" Value="LeftMinimal" />
                         <Setter Target="SidebarControl.IsPaneToggleButtonVisible" Value="True" />
+                        <Setter Target="horizontalMultitaskingControl.Margin" Value="48,0,0,0" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Since #7939 adaptive triggers on MainPage do not work anymore (SearchBox does not collapse and Sidebar does not switch to minimal state).

**Details of Changes**
Add details of changes here.
- Adaptive triggers won't work if put on Page. Added back surrounding Border control.
- Fixed tabs  being drawn over Sidebar toggle button when in minimized state.
- Removed AppSettings where not referenced.

**Validation**
How did you test these changes?
- [x] Built and ran the app
