### PR TITLE
Fix new/rename dialog processing stale text

### DIFF
--- a/src/Files.Uwp/Helpers/DynamicDialogFactory.cs
+++ b/src/Files.Uwp/Helpers/DynamicDialogFactory.cs
@@ -72,9 +72,9 @@ namespace Files.Helpers
                 }
                 else
                 {
-                    dialog.ViewModel.AdditionalData = textBox.Text;
+                    dialog.ViewModel.AdditionalData = args.NewText;
 
-                    if (!string.IsNullOrWhiteSpace(textBox.Text))
+                    if (!string.IsNullOrWhiteSpace(args.NewText))
                     {
                         dialog.ViewModel.DynamicButtonsEnabled = DynamicDialogButtons.Primary | DynamicDialogButtons.Cancel;
                     }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #8765 
- Regression from #8204

**Details of Changes**
- Using `BeforeTextChanging` means that the textbox text is stale, `args.NewText` must be used instead

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility