### PR TITLE
Fix crash when favorites section is hidden

### DIFF
--- a/src/Files.Uwp/Controllers/SidebarPinnedController.cs
+++ b/src/Files.Uwp/Controllers/SidebarPinnedController.cs
@@ -133,7 +133,6 @@ namespace Files.Controllers
             });
         }
 
-
         public void SaveModel()
         {
             suppressChangeEvent = true;

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -387,15 +387,18 @@ namespace Files.DataModels
         {
             // Remove unpinned items from sidebar
             // Reverse iteration to avoid skipping elements while removing
-            for (int i = favoriteSection.ChildItems.Count - 1; i >= 0; i--)
+            if (favoriteSection != null)
             {
-                var childItem = favoriteSection.ChildItems[i];
-                if (childItem is LocationItem)
+                for (int i = favoriteSection.ChildItems.Count - 1; i >= 0; i--)
                 {
-                    var item = childItem as LocationItem;
-                    if (!item.IsDefaultLocation && !FavoriteItems.Contains(item.Path))
+                    var childItem = favoriteSection.ChildItems[i];
+                    if (childItem is LocationItem)
                     {
-                        favoriteSection.ChildItems.RemoveAt(i);
+                        var item = childItem as LocationItem;
+                        if (!item.IsDefaultLocation && !FavoriteItems.Contains(item.Path))
+                        {
+                            favoriteSection.ChildItems.RemoveAt(i);
+                        }
                     }
                 }
             }

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -392,9 +392,8 @@ namespace Files.DataModels
                 for (int i = favoriteSection.ChildItems.Count - 1; i >= 0; i--)
                 {
                     var childItem = favoriteSection.ChildItems[i];
-                    if (childItem is LocationItem)
+                    if (childItem is LocationItem item)
                     {
-                        var item = childItem as LocationItem;
                         if (!item.IsDefaultLocation && !FavoriteItems.Contains(item.Path))
                         {
                             favoriteSection.ChildItems.RemoveAt(i);


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixed AppCenter [1010488437u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/1010488437u/overview)

**Details of Changes**
Add details of changes here.
- `favoritesSection` will be null if the favorites section is hidden. Added null check.

**Validation**
How did you test these changes?
- [x] Built and ran the app
