### PR TITLE
Fix crash when using "apply to all" menu item in conflicts dialog

### DIFF
--- a/src/Files.Uwp/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files.Uwp/Dialogs/FilesystemOperationDialog.xaml
@@ -46,7 +46,7 @@
                 <MenuFlyoutItem
                     x:Name="ApplyToAllOption"
                     Click="MenuFlyoutItem_Click"
-                    Tag="{helpers:ResourceString Name=ConfictingItemsDialogOptionApplyToAll.Tag}"
+                    Tag="All"
                     Text="{helpers:ResourceString Name=ConfictingItemsDialogOptionApplyToAll/Text}" />
             </MenuFlyout>
         </ResourceDictionary>
@@ -202,9 +202,7 @@
                                     <muxc:SplitButton.Flyout>
                                         <MenuFlyout>
                                             <MenuFlyoutItem Command="{Binding GenerateNewNameCommand}" Text="{helpers:ResourceString Name=GenerateNewName}" />
-                                            <MenuFlyoutItem
-                                                Command="{Binding ReplaceExistingCommand}"
-                                                Text="{helpers:ResourceString Name=ConflictingItemsDialogItemOptionReplaceExisting/Text}" />
+                                            <MenuFlyoutItem Command="{Binding ReplaceExistingCommand}" Text="{helpers:ResourceString Name=ConflictingItemsDialogItemOptionReplaceExisting/Text}" />
                                             <MenuFlyoutItem Command="{Binding SkipCommand}" Text="{helpers:ResourceString Name=Skip}" />
                                         </MenuFlyout>
                                     </muxc:SplitButton.Flyout>

--- a/src/Files.Uwp/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files.Uwp/Dialogs/FilesystemOperationDialog.xaml
@@ -8,7 +8,6 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:icore="using:Microsoft.Xaml.Interactions.Core"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
-    Loaded="RootDialog_Loaded"
     x:Name="RootDialog"
     Title="{x:Bind ViewModel.Title, Mode=OneWay}"
     Closing="RootDialog_Closing"

--- a/src/Files.Uwp/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files.Uwp/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -18,7 +18,15 @@ namespace Files.Dialogs
         public FilesystemOperationDialogViewModel ViewModel
         {
             get => (FilesystemOperationDialogViewModel)DataContext;
-            set => DataContext = value;
+            set
+            {
+                if (value != null)
+                {
+                    value.View = this;
+                    value.LoadedCommand.Execute(null);
+                }
+                DataContext = value;
+            }
         }
 
         public IList<object> SelectedItems => DetailsGrid.SelectedItems;
@@ -112,12 +120,6 @@ namespace Files.Dialogs
         private void RootDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
             ViewModel.ClosingCommand.Execute(null);
-        }
-
-        private void RootDialog_Loaded(object sender, RoutedEventArgs e)
-        {
-            ViewModel.View = this;
-            ViewModel.LoadedCommand.Execute(null);
         }
     }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fix crash when using "apply to all" menu item in conflicts dialog
- Closes #8834

**Details of Changes**
Add details of changes here.
- "Apply to all" menu item Tag was incorrect (after #8792)
- Enable dialog primary button before the dialog is loaded (when the ViewModel is set)

**Validation**
How did you test these changes?
- [x] Built and ran the app
