### PR TITLE
Possibly fix app hung on start

### DIFF
--- a/src/Files.Uwp/Filesystem/Drives.cs
+++ b/src/Files.Uwp/Filesystem/Drives.cs
@@ -21,13 +21,12 @@ using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.UI.Core;
 using DriveType = Files.DataModels.NavigationControlItems.DriveType;
-using Files.Shared;
 
 namespace Files.Filesystem
 {
     public class DrivesManager : ObservableObject
     {
-        private static readonly IFolderSizeProvider folderSizeProvider = Ioc.Default.GetService<IFolderSizeProvider>();
+        private IFolderSizeProvider FolderSizeProvider { get; } = Ioc.Default.GetService<IFolderSizeProvider>();
 
         private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
 
@@ -106,7 +105,7 @@ namespace Files.Filesystem
         {
             System.Diagnostics.Debug.WriteLine("DeviceWatcher_EnumerationCompleted");
             await RefreshUI();
-            folderSizeProvider.CleanCache();
+            FolderSizeProvider.CleanCache();
         }
 
         private async Task RefreshUI()
@@ -250,7 +249,7 @@ namespace Files.Filesystem
                 {
                     return;
                 }
-            
+
                 Logger.Info($"Drive added: {driveItem.Path}, {driveItem.Type}");
 
                 drivesList.Add(driveItem);

--- a/src/Files.Uwp/Filesystem/FolderSizeProvider.cs
+++ b/src/Files.Uwp/Filesystem/FolderSizeProvider.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
-using Windows.UI.Core;
 using static Files.Helpers.NativeFindStorageItemHelper;
 
 namespace Files.Filesystem
@@ -34,8 +33,6 @@ namespace Files.Filesystem
     {
         private readonly IPreferencesSettingsService preferencesSettingsService = Ioc.Default.GetService<IPreferencesSettingsService>();
 
-        private readonly CoreDispatcher dispatcher = CoreApplication.MainView.CoreWindow.Dispatcher;
-
         private readonly IDictionary<string, long> cacheSizes = new Dictionary<string, long>();
 
         public event EventHandler<FolderSizeChangedEventArgs> FolderSizeChanged;
@@ -57,14 +54,14 @@ namespace Files.Filesystem
 
             var drives = DriveInfo.GetDrives().Select(drive => drive.Name).ToArray();
 
-            await dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+            await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
             {
                 var oldPaths = cacheSizes.Keys.Where(path => !drives.Any(drive => path.StartsWith(drive))).ToList();
                 foreach (var oldPath in oldPaths)
                 {
                     cacheSizes.Remove(oldPath);
                 }
-            });
+            }, Windows.System.DispatcherQueuePriority.Low);
         }
 
         public async void UpdateFolder(ListedItem folder, CancellationToken cancellationToken)
@@ -76,7 +73,7 @@ namespace Files.Filesystem
 
             if (folder.PrimaryItemAttribute == Windows.Storage.StorageItemTypes.Folder && folder.ContainsFilesOrFolders)
             {
-                await dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
                 {
                     if (cacheSizes.ContainsKey(folder.ItemPath))
                     {
@@ -90,17 +87,17 @@ namespace Files.Filesystem
                         folder.FileSize = "ItemSizeNotCalculated".GetLocalized();
                         RaiseSizeChanged(folder);
                     }
-                });
+                }, Windows.System.DispatcherQueuePriority.Low);
 
                 long size = await Calculate(folder.ItemPath);
 
-                await dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
                 {
                     cacheSizes[folder.ItemPath] = size;
                     folder.FileSizeBytes = size;
                     folder.FileSize = size.ToSizeString();
                     RaiseSizeChanged(folder);
-                });
+                }, Windows.System.DispatcherQueuePriority.Low);
             }
 
             async Task<long> Calculate(string folderPath, int level = 0)
@@ -135,7 +132,7 @@ namespace Files.Filesystem
 
                         if (level <= 3)
                         {
-                            await dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                            await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
                             {
                                 cacheSizes[localPath] = localSize;
 
@@ -145,7 +142,7 @@ namespace Files.Filesystem
                                     folder.FileSize = size.ToSizeString();
                                     RaiseSizeChanged(folder);
                                 };
-                            });
+                            }, Windows.System.DispatcherQueuePriority.Low);
                         }
 
                         if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue where the app occasionally hangs on start like:

<img width="500" src="https://user-images.githubusercontent.com/9673091/161434776-5d6841e8-3673-4fa1-8b23-ff9be06b11cc.png"/>

**Details of Changes**
Add details of changes here.
Debugger is showing the app hung on this line L37 in FolderSizeProvider.cs => `private readonly CoreDispatcher dispatcher = CoreApplication.MainView.CoreWindow.Dispatcher;`.
Hunch is that the line is called too early on app startup, being invoked as a consequence of a static initializer in Drives.cs => `private static readonly IFolderSizeProvider folderSizeProvider = Ioc.Default.GetService<IFolderSizeProvider>();`).
I'm not certain this PR fixes the issue as the bug is hard to reproduce, but at worst it won't change anything.

**Validation**
How did you test these changes?
- [x] Built and ran the app
