### PR TITLE
Setting Show the thumbnails for media files

### DIFF
--- a/src/Files.Backend/Services/Settings/IPreferencesSettingsService.cs
+++ b/src/Files.Backend/Services/Settings/IPreferencesSettingsService.cs
@@ -21,6 +21,11 @@ namespace Files.Backend.Services.Settings
         bool ShowFileExtensions { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not media thumbnails should be visible.
+        /// </summary>
+        bool ShowThumbnails { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not hidden items should be visible.
         /// </summary>
         bool AreHiddenItemsVisible { get; set; }

--- a/src/Files.Uwp/ServicesImplementation/Settings/PreferencesSettingsService.cs
+++ b/src/Files.Uwp/ServicesImplementation/Settings/PreferencesSettingsService.cs
@@ -32,6 +32,12 @@ namespace Files.Uwp.ServicesImplementation.Settings
             set => Set(value);
         }
 
+        public bool ShowThumbnails
+        {
+            get => Get(true);
+            set => Set(value);
+        }
+
         public bool AreHiddenItemsVisible
         {
             get => Get(false);
@@ -43,7 +49,7 @@ namespace Files.Uwp.ServicesImplementation.Settings
             get => Get(true);
             set => Set(value);
         }
-        
+
         public bool ShowDotFiles
         {
             get => Get(true);

--- a/src/Files.Uwp/Strings/en-US/Resources.resw
+++ b/src/Files.Uwp/Strings/en-US/Resources.resw
@@ -2757,6 +2757,6 @@ We use App Center to track which settings are being used, find bugs, and fix cra
     <value>ex: {0}, {1}</value>
   </data>
   <data name="SettingsFilesAndFoldersShowThumbnails" xml:space="preserve">
-    <value>Show the thumbnails for media files</value>
+    <value>Show thumbnails for media files</value>
   </data>
 </root>

--- a/src/Files.Uwp/Strings/en-US/Resources.resw
+++ b/src/Files.Uwp/Strings/en-US/Resources.resw
@@ -2757,6 +2757,6 @@ We use App Center to track which settings are being used, find bugs, and fix cra
     <value>ex: {0}, {1}</value>
   </data>
   <data name="SettingsFilesAndFoldersShowThumbnails" xml:space="preserve">
-    <value>Show thumbnails for media files</value>
+    <value>Show thumbnails</value>
   </data>
 </root>

--- a/src/Files.Uwp/Strings/en-US/Resources.resw
+++ b/src/Files.Uwp/Strings/en-US/Resources.resw
@@ -2753,7 +2753,10 @@ We use App Center to track which settings are being used, find bugs, and fix cra
   <data name="Universal" xml:space="preserve">
     <value>Universal</value>
   </data>
-    <data name="DateFormatSample" xml:space="preserve">
+  <data name="DateFormatSample" xml:space="preserve">
     <value>ex: {0}, {1}</value>
+  </data>
+  <data name="SettingsFilesAndFoldersShowThumbnails" xml:space="preserve">
+    <value>Show the thumbnails for media files</value>
   </data>
 </root>

--- a/src/Files.Uwp/ViewModels/ItemViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ItemViewModel.cs
@@ -69,6 +69,7 @@ namespace Files.ViewModels
         private SettingsViewModel AppSettings => App.AppSettings;
         private FolderSettingsViewModel folderSettings = null;
         private bool shouldDisplayFileExtensions = false;
+        private bool shouldDisplayThumbnails = false;
         public ListedItem CurrentFolder { get; private set; }
         public CollectionViewSource viewSource;
         private CancellationTokenSource addFilesCTS, semaphoreCTS, loadPropsCTS, watcherCTS;
@@ -365,6 +366,7 @@ namespace Files.ViewModels
             operationEvent = new AsyncManualResetEvent();
             enumFolderSemaphore = new SemaphoreSlim(1, 1);
             shouldDisplayFileExtensions = UserSettingsService.PreferencesSettingsService.ShowFileExtensions;
+            shouldDisplayThumbnails = UserSettingsService.PreferencesSettingsService.ShowThumbnails;
 
             UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
             FileTagsSettingsService.OnSettingImportedEvent += FileTagsSettingsService_OnSettingImportedEvent;
@@ -387,6 +389,7 @@ namespace Files.ViewModels
             switch (e.SettingName)
             {
                 case nameof(UserSettingsService.PreferencesSettingsService.ShowFileExtensions):
+                case nameof(UserSettingsService.PreferencesSettingsService.ShowThumbnails):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden):
                 case nameof(UserSettingsService.PreferencesSettingsService.ShowDotFiles):
@@ -394,6 +397,7 @@ namespace Files.ViewModels
                 case nameof(UserSettingsService.PreferencesSettingsService.ShowFolderSize):
                     await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() =>
                     {
+                        shouldDisplayThumbnails = UserSettingsService.PreferencesSettingsService.ShowThumbnails;
                         if (WorkingDirectory != "Home".GetLocalized())
                         {
                             RefreshItems(null);
@@ -847,7 +851,7 @@ namespace Files.ViewModels
             var wasIconLoaded = false;
             if (item.IsLibraryItem || item.PrimaryItemAttribute == StorageItemTypes.File || item.IsZipItem)
             {
-                if (!item.IsShortcutItem && !item.IsHiddenItem && !FtpHelpers.IsFtpPath(item.ItemPath))
+                if (shouldDisplayThumbnails && !item.IsShortcutItem && !item.IsHiddenItem && !FtpHelpers.IsFtpPath(item.ItemPath))
                 {
                     var matchingStorageFile = matchingStorageItem.AsBaseStorageFile() ?? await GetFileFromPathAsync(item.ItemPath);
                     if (matchingStorageFile != null)

--- a/src/Files.Uwp/ViewModels/SettingsViewModels/PreferencesViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SettingsViewModels/PreferencesViewModel.cs
@@ -580,6 +580,19 @@ namespace Files.ViewModels.SettingsViewModels
             }
         }
 
+        public bool ShowThumbnails
+        {
+            get => UserSettingsService.PreferencesSettingsService.ShowThumbnails;
+            set
+            {
+                if (value != UserSettingsService.PreferencesSettingsService.ShowThumbnails)
+                {
+                    UserSettingsService.PreferencesSettingsService.ShowThumbnails = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         public bool OpenFilesWithOneClick
         {
             get => UserSettingsService.PreferencesSettingsService.OpenFilesWithOneClick;

--- a/src/Files.Uwp/Views/SettingsPages/Preferences.xaml
+++ b/src/Files.Uwp/Views/SettingsPages/Preferences.xaml
@@ -185,6 +185,16 @@
                                 Style="{StaticResource RightAlignedToggleSwitchStyle}" />
                         </local:SettingsBlockControl>
 
+                        <local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsFilesAndFoldersShowThumbnails}" HorizontalAlignment="Stretch">
+                            <local:SettingsBlockControl.Icon>
+                                <FontIcon Glyph="&#xE91B;" />
+                            </local:SettingsBlockControl.Icon>
+                            <ToggleSwitch
+                                AutomationProperties.Name="{helpers:ResourceString Name=SettingsFilesAndFoldersShowThumbnails}"
+                                IsOn="{Binding ShowThumbnails, Mode=TwoWay}"
+                                Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+                        </local:SettingsBlockControl>
+
                         <local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsOpenFilesWithOneClick}" HorizontalAlignment="Stretch">
                             <local:SettingsBlockControl.Icon>
                                 <FontIcon Glyph="&#xE8B0;" />


### PR DESCRIPTION
Add new setting "Show the thumbnails for media files".
When the settings is disabled, the media files show the file type icon.
Closes #6421 #8234 #8257 #8305

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![ShowThumbnails1](https://user-images.githubusercontent.com/46631671/162562081-ebacba81-6c5a-4e49-90e0-039867e9c6c5.png)
![ShowThumbnails2](https://user-images.githubusercontent.com/46631671/162562083-fb981909-76c3-4d4f-b03e-718f589e9e45.png)
![ShowThumbnails3](https://user-images.githubusercontent.com/46631671/162562086-e322aa55-a93d-490b-9e86-09767a20a57c.png)

