### PR TITLE
Clean IStorageItemWithPath

### DIFF
--- a/src/Files.Uwp/Filesystem/StorageFileHelpers/IStorageItemWithPath.cs
+++ b/src/Files.Uwp/Filesystem/StorageFileHelpers/IStorageItemWithPath.cs
@@ -2,12 +2,12 @@
 
 namespace Files.Filesystem
 {
-    public interface IStorageItemWithPath // TODO: Maybe use here : IStorageItem instead of declaring a variable,
-                                          // and keep the Path property for it to override IStorageItem.Path ?
+    public interface IStorageItemWithPath
     {
         public string Name { get; }
-        public string Path { get; set; }
-        public IStorageItem Item { get; set; }
+        public string Path { get; }
+
+        public IStorageItem Item { get; }
         public FilesystemItemType ItemType { get; }
     }
 }

--- a/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Files.Shared;
-using Files.DataModels.NavigationControlItems;
+﻿using Files.DataModels.NavigationControlItems;
 using Files.Extensions;
 using Files.Filesystem.StorageItems;
 using Files.Helpers;
@@ -106,7 +105,7 @@ namespace Files.Filesystem
                 }
                 else if (parentFolder != null && value.IsSubPathOf(parentFolder.Path))
                 {
-                    var folder = parentFolder.Folder;
+                    var folder = parentFolder.Item;
                     var prevComponents = GetDirectoryPathComponents(parentFolder.Path);
                     var path = parentFolder.Path;
                     foreach (var component in currComponents.ExceptBy(prevComponents, c => c.Path))
@@ -118,7 +117,7 @@ namespace Files.Filesystem
                 }
                 else if (value.IsSubPathOf(rootFolder.Path))
                 {
-                    var folder = rootFolder.Folder;
+                    var folder = rootFolder.Item;
                     var path = rootFolder.Path;
                     foreach (var component in currComponents.Skip(1))
                     {
@@ -145,7 +144,7 @@ namespace Files.Filesystem
                                                                                 StorageFolderWithPath rootFolder = null,
                                                                                 StorageFolderWithPath parentFolder = null)
         {
-            return (await DangerousGetFolderWithPathFromPathAsync(value, rootFolder, parentFolder)).Folder;
+            return (await DangerousGetFolderWithPathFromPathAsync(value, rootFolder, parentFolder)).Item;
         }
 
         public async static Task<StorageFileWithPath> DangerousGetFileWithPathFromPathAsync(string value,
@@ -158,7 +157,7 @@ namespace Files.Filesystem
 
                 if (parentFolder != null && value.IsSubPathOf(parentFolder.Path))
                 {
-                    var folder = parentFolder.Folder;
+                    var folder = parentFolder.Item;
                     var prevComponents = GetDirectoryPathComponents(parentFolder.Path);
                     var path = parentFolder.Path;
                     foreach (var component in currComponents.ExceptBy(prevComponents, c => c.Path).SkipLast(1))
@@ -172,7 +171,7 @@ namespace Files.Filesystem
                 }
                 else if (value.IsSubPathOf(rootFolder.Path))
                 {
-                    var folder = rootFolder.Folder;
+                    var folder = rootFolder.Item;
                     var path = rootFolder.Path;
                     foreach (var component in currComponents.Skip(1).SkipLast(1))
                     {
@@ -201,18 +200,18 @@ namespace Files.Filesystem
                                                                             StorageFolderWithPath rootFolder = null,
                                                                             StorageFolderWithPath parentFolder = null)
         {
-            return (await DangerousGetFileWithPathFromPathAsync(value, rootFolder, parentFolder)).File;
+            return (await DangerousGetFileWithPathFromPathAsync(value, rootFolder, parentFolder)).Item;
         }
 
         public async static Task<IList<StorageFolderWithPath>> GetFoldersWithPathAsync(this StorageFolderWithPath parentFolder, uint maxNumberOfItems = uint.MaxValue)
         {
-            return (await parentFolder.Folder.GetFoldersAsync(CommonFolderQuery.DefaultQuery, 0, maxNumberOfItems))
+            return (await parentFolder.Item.GetFoldersAsync(CommonFolderQuery.DefaultQuery, 0, maxNumberOfItems))
                 .Select(x => new StorageFolderWithPath(x, PathNormalization.Combine(parentFolder.Path, x.Name))).ToList();
         }
 
         public async static Task<IList<StorageFileWithPath>> GetFilesWithPathAsync(this StorageFolderWithPath parentFolder, uint maxNumberOfItems = uint.MaxValue)
         {
-            return (await parentFolder.Folder.GetFilesAsync(CommonFileQuery.DefaultQuery, 0, maxNumberOfItems))
+            return (await parentFolder.Item.GetFilesAsync(CommonFileQuery.DefaultQuery, 0, maxNumberOfItems))
                 .Select(x => new StorageFileWithPath(x, PathNormalization.Combine(parentFolder.Path, x.Name))).ToList();
         }
 
@@ -225,7 +224,7 @@ namespace Files.Filesystem
 
             var queryOptions = new QueryOptions();
             queryOptions.ApplicationSearchFilter = $"System.FileName:{nameFilter}*";
-            BaseStorageFolderQueryResult queryResult = parentFolder.Folder.CreateFolderQueryWithOptions(queryOptions);
+            BaseStorageFolderQueryResult queryResult = parentFolder.Item.CreateFolderQueryWithOptions(queryOptions);
 
             return (await queryResult.GetFoldersAsync(0, maxNumberOfItems)).Select(x => new StorageFolderWithPath(x, PathNormalization.Combine(parentFolder.Path, x.Name))).ToList();
         }

--- a/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFileWithPath.cs
+++ b/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFileWithPath.cs
@@ -1,37 +1,22 @@
 ﻿using Files.Filesystem.StorageItems;
 using Windows.Storage;
+using IO = System.IO;
 
 namespace Files.Filesystem
 {
     public class StorageFileWithPath : IStorageItemWithPath
     {
-        public BaseStorageFile File
-        {
-            get
-            {
-                return (BaseStorageFile)Item;
-            }
-            set
-            {
-                Item = value;
-            }
-        }
+        public string Path { get; }
+        public string Name => Item?.Name ?? IO.Path.GetFileName(Path);
 
-        public string Path { get; set; }
-        public string Name => Item?.Name ?? System.IO.Path.GetFileName(Path);
-        public IStorageItem Item { get; set; }
-        public FilesystemItemType ItemType => FilesystemItemType.File;
+        IStorageItem IStorageItemWithPath.Item => Item;
+        public BaseStorageFile Item { get; }
+
+        public FilesystemItemType ItemType => FilesystemItemType.Directory;
 
         public StorageFileWithPath(BaseStorageFile file)
-        {
-            File = file;
-            Path = File.Path;
-        }
-
+            : this(file, file.Path) {}
         public StorageFileWithPath(BaseStorageFile file, string path)
-        {
-            File = file;
-            Path = path;
-        }
+            => (Item, Path) = (file, path);
     }
 }

--- a/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFileWithPath.cs
+++ b/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFileWithPath.cs
@@ -12,7 +12,7 @@ namespace Files.Filesystem
         IStorageItem IStorageItemWithPath.Item => Item;
         public BaseStorageFile Item { get; }
 
-        public FilesystemItemType ItemType => FilesystemItemType.Directory;
+        public FilesystemItemType ItemType => FilesystemItemType.File;
 
         public StorageFileWithPath(BaseStorageFile file)
             : this(file, file.Path) {}

--- a/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFolderWithPath.cs
+++ b/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFolderWithPath.cs
@@ -1,37 +1,22 @@
 ﻿using Files.Filesystem.StorageItems;
 using Windows.Storage;
+using IO = System.IO;
 
 namespace Files.Filesystem
 {
     public class StorageFolderWithPath : IStorageItemWithPath
     {
-        public BaseStorageFolder Folder
-        {
-            get
-            {
-                return (BaseStorageFolder)Item;
-            }
-            set
-            {
-                Item = value;
-            }
-        }
+        public string Path { get; }
+        public string Name => Item?.Name ?? IO.Path.GetFileName(Path);
 
-        public string Path { get; set; }
-        public string Name => Item?.Name ?? System.IO.Path.GetFileName(Path);
-        public IStorageItem Item { get; set; }
+        IStorageItem IStorageItemWithPath.Item => Item;
+        public BaseStorageFolder Item { get; }
+
         public FilesystemItemType ItemType => FilesystemItemType.Directory;
 
         public StorageFolderWithPath(BaseStorageFolder folder)
-        {
-            Folder = folder;
-            Path = folder.Path;
-        }
-
+            : this(folder, folder.Path) {}
         public StorageFolderWithPath(BaseStorageFolder folder, string path)
-        {
-            Folder = folder;
-            Path = path;
-        }
+            => (Item, Path) = (folder, path);
     }
 }

--- a/src/Files.Uwp/Helpers/NavigationHelpers.cs
+++ b/src/Files.Uwp/Helpers/NavigationHelpers.cs
@@ -1,11 +1,11 @@
-﻿using Files.Shared;
-using Files.Shared.Enums;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.Backend.Services.Settings;
 using Files.Filesystem;
 using Files.Filesystem.StorageItems;
-using Files.Backend.Services.Settings;
+using Files.Shared;
+using Files.Shared.Enums;
 using Files.ViewModels;
 using Files.Views;
-using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Uwp;
 using Newtonsoft.Json;
 using System;
@@ -342,10 +342,10 @@ namespace Files.Helpers
                     .OnSuccess(async (childFolder) =>
                     {
                         // Add location to MRU List
-                        if (childFolder.Folder is SystemStorageFolder)
+                        if (childFolder.Item is SystemStorageFolder)
                         {
                             var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
-                            mostRecentlyUsed.Add(await childFolder.Folder.ToStorageFolderAsync(), childFolder.Path);
+                            mostRecentlyUsed.Add(await childFolder.Item.ToStorageFolderAsync(), childFolder.Path);
                         }
                     });
                 if (!opened)
@@ -392,10 +392,10 @@ namespace Files.Helpers
                         if (childFile != null)
                         {
                             // Add location to MRU List
-                            if (childFile.File is SystemStorageFile)
+                            if (childFile.Item is SystemStorageFile)
                             {
                                 var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
-                                mostRecentlyUsed.Add(await childFile.File.ToStorageFileAsync(), childFile.Path);
+                                mostRecentlyUsed.Add(await childFile.Item.ToStorageFileAsync(), childFile.Path);
                             }
                         }
                     }
@@ -413,10 +413,10 @@ namespace Files.Helpers
                     .OnSuccess(async childFile =>
                     {
                         // Add location to MRU List
-                        if (childFile.File is SystemStorageFile)
+                        if (childFile.Item is SystemStorageFile)
                         {
                             var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
-                            mostRecentlyUsed.Add(await childFile.File.ToStorageFileAsync(), childFile.Path);
+                            mostRecentlyUsed.Add(await childFile.Item.ToStorageFileAsync(), childFile.Path);
                         }
 
                         if (openViaApplicationPicker)
@@ -425,7 +425,7 @@ namespace Files.Helpers
                             {
                                 DisplayApplicationPicker = true
                             };
-                            if (!await Launcher.LaunchFileAsync(childFile.File, options))
+                            if (!await Launcher.LaunchFileAsync(childFile.Item, options))
                             {
                                 var connection = await AppServiceConnectionHelper.Instance;
                                 if (connection != null)
@@ -512,7 +512,7 @@ namespace Files.Helpers
                                 }
 
                                 // Now launch file with options.
-                                launchSuccess = await Launcher.LaunchFileAsync(await childFile.File.ToStorageFileAsync(), options);
+                                launchSuccess = await Launcher.LaunchFileAsync(await childFile.Item.ToStorageFileAsync(), options);
                             }
 
                             if (!launchSuccess)

--- a/src/Files.Uwp/ViewModels/ItemViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ItemViewModel.cs
@@ -1309,7 +1309,7 @@ namespace Files.ViewModels
                     case 1: // Enumerated with StorageFolder
                         PageTypeUpdated?.Invoke(this, new PageTypeUpdatedEventArgs() { IsTypeCloudDrive = false });
                         currentStorageFolder ??= await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderWithPathFromPathAsync(path));
-                        WatchForStorageFolderChanges(currentStorageFolder?.Folder);
+                        WatchForStorageFolderChanges(currentStorageFolder?.Item);
                         break;
 
                     case 2: // Watch for changes using FTP in Box Drive folder (#7428) and network drives (#5869)
@@ -1527,7 +1527,7 @@ namespace Files.ViewModels
                     return -1;
                 }
                 currentStorageFolder = res.Result;
-                rootFolder = currentStorageFolder.Folder;
+                rootFolder = currentStorageFolder.Item;
                 enumFromStorageFolder = true;
             }
             else
@@ -1536,7 +1536,7 @@ namespace Files.ViewModels
                 if (res)
                 {
                     currentStorageFolder = res.Result;
-                    rootFolder = currentStorageFolder.Folder;
+                    rootFolder = currentStorageFolder.Item;
                 }
                 else if (res == FileSystemStatusCode.Unauthorized)
                 {

--- a/src/Files.Uwp/ViewModels/NavToolbarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/NavToolbarViewModel.cs
@@ -1,14 +1,16 @@
-﻿using Files.Shared.Extensions;
-using Files.Shared.Enums;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.Mvvm.Input;
+using Files.Backend.Services;
+using Files.Backend.Services.Settings;
 using Files.Filesystem;
 using Files.Filesystem.StorageItems;
 using Files.Helpers;
-using Files.Backend.Services.Settings;
+using Files.Shared.Enums;
+using Files.Shared.EventArguments;
+using Files.Shared.Extensions;
 using Files.UserControls;
 using Files.Views;
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using CommunityToolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp;
 using Microsoft.Toolkit.Uwp.UI;
 using System;
@@ -27,11 +29,9 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
-using Files.Backend.Services;
 using static Files.UserControls.INavigationToolbar;
 using SearchBox = Files.UserControls.SearchBox;
 using SortDirection = Files.Shared.Enums.SortDirection;
-using Files.Shared.EventArguments;
 
 namespace Files.ViewModels
 {
@@ -1055,7 +1055,7 @@ namespace Files.ViewModels
                         suggestions = currPath.Select(x => new ListedItem(null)
                         {
                             ItemPath = x.Path,
-                            ItemNameRaw = x.Folder.DisplayName
+                            ItemNameRaw = x.Item.DisplayName
                         }).ToList();
                     }
                     else if (currPath.Any())
@@ -1064,12 +1064,12 @@ namespace Files.ViewModels
                         suggestions = currPath.Select(x => new ListedItem(null)
                         {
                             ItemPath = x.Path,
-                            ItemNameRaw = x.Folder.DisplayName
+                            ItemNameRaw = x.Item.DisplayName
                         }).Concat(
                             subPath.Select(x => new ListedItem(null)
                             {
                                 ItemPath = x.Path,
-                                ItemNameRaw = PathNormalization.Combine(currPath.First().Folder.DisplayName, x.Folder.DisplayName)
+                                ItemNameRaw = PathNormalization.Combine(currPath.First().Item.DisplayName, x.Item.DisplayName)
                             })).ToList();
                     }
                     else


### PR DESCRIPTION
Tiny pr to clean up IStorageItemWithPath and its 2 implementations. Refactoring only.
- Deletes unused sets.
- Use 1 property instead of 2 which returns the same instance.
- More readable code.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility