### PR TITLE
Change preview pane play media toggle to 'ctrl + space'

### DIFF
--- a/src/Files.Uwp/UserControls/FilePreviews/MediaPreview.xaml
+++ b/src/Files.Uwp/UserControls/FilePreviews/MediaPreview.xaml
@@ -11,9 +11,9 @@
     mc:Ignorable="d">
     <UserControl.KeyboardAccelerators>
         <KeyboardAccelerator
-            Key="P"
+            Key="Space"
             Invoked="TogglePlaybackAcceleratorInvoked"
-            Modifiers="Control,Menu" />
+            Modifiers="Control" />
     </UserControl.KeyboardAccelerators>
     <Grid CornerRadius="{StaticResource ControlCornerRadius}">
         <MediaPlayerElement

--- a/src/Files.Uwp/UserControls/FilePreviews/MediaPreview.xaml.cs
+++ b/src/Files.Uwp/UserControls/FilePreviews/MediaPreview.xaml.cs
@@ -39,9 +39,9 @@ namespace Files.UserControls.FilePreviews
             }
         }
 
-        private void TogglePlaybackRequestInvoked(object sender, EventArgs e) 
+        private void TogglePlaybackRequestInvoked(object sender, EventArgs e)
         {
-            if (PlayerContext.MediaPlayer.PlaybackSession.PlaybackState is not MediaPlaybackState.Playing) 
+            if (PlayerContext.MediaPlayer.PlaybackSession.PlaybackState is not MediaPlaybackState.Playing)
             {
                 PlayerContext.MediaPlayer.Play();
             }

--- a/src/Files.Uwp/UserControls/FilePreviews/MediaPreview.xaml.cs
+++ b/src/Files.Uwp/UserControls/FilePreviews/MediaPreview.xaml.cs
@@ -5,6 +5,7 @@ using Windows.Media.Playback;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using System;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
@@ -27,6 +28,7 @@ namespace Files.UserControls.FilePreviews
         {
             PlayerContext.MediaPlayer.Volume = UserSettingsService.PaneSettingsService.MediaVolume;
             PlayerContext.MediaPlayer.VolumeChanged += MediaPlayer_VolumeChanged;
+            ViewModel.TogglePlaybackRequested += TogglePlaybackRequestInvoked;
         }
 
         private void MediaPlayer_VolumeChanged(MediaPlayer sender, object args)
@@ -37,16 +39,21 @@ namespace Files.UserControls.FilePreviews
             }
         }
 
-        private void TogglePlaybackAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        private void TogglePlaybackRequestInvoked(object sender, EventArgs e) 
         {
-            if (PlayerContext.MediaPlayer.PlaybackSession.PlaybackState is not MediaPlaybackState.Playing)
+            if (PlayerContext.MediaPlayer.PlaybackSession.PlaybackState is not MediaPlaybackState.Playing) 
             {
                 PlayerContext.MediaPlayer.Play();
             }
-            else
+            else 
             {
                 PlayerContext.MediaPlayer.Pause();
             }
+        }
+
+        private void TogglePlaybackAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            TogglePlaybackRequestInvoked(sender, null);
         }
     }
 }

--- a/src/Files.Uwp/UserControls/FilePreviews/MediaPreview.xaml.cs
+++ b/src/Files.Uwp/UserControls/FilePreviews/MediaPreview.xaml.cs
@@ -45,7 +45,7 @@ namespace Files.UserControls.FilePreviews
             {
                 PlayerContext.MediaPlayer.Play();
             }
-            else 
+            else
             {
                 PlayerContext.MediaPlayer.Pause();
             }

--- a/src/Files.Uwp/ViewModels/Previews/MediaPreviewViewModel.cs
+++ b/src/Files.Uwp/ViewModels/Previews/MediaPreviewViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Filesystem;
 using Files.ViewModels.Properties;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Windows.Media.Core;
@@ -9,6 +10,8 @@ namespace Files.ViewModels.Previews
 {
     public class MediaPreviewViewModel : BasePreviewModel
     {
+        public event EventHandler TogglePlaybackRequested;
+
         private MediaSource source;
 
         public MediaPreviewViewModel(ListedItem item) : base(item)
@@ -38,6 +41,10 @@ namespace Files.ViewModels.Previews
         {
             Source = null;
             base.PreviewControlBase_Unloaded(sender, e);
+        }
+
+        public void TogglePlayback() {
+            TogglePlaybackRequested?.Invoke(this, null);
         }
     }
 }

--- a/src/Files.Uwp/Views/ColumnShellPage.xaml
+++ b/src/Files.Uwp/Views/ColumnShellPage.xaml
@@ -81,11 +81,6 @@
             IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
             Modifiers="None" />
         <KeyboardAccelerator
-            Key="Space"
-            Invoked="KeyboardAccelerator_Invoked"
-            IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-            Modifiers="None" />
-        <KeyboardAccelerator
             Key="R"
             Invoked="KeyboardAccelerator_Invoked"
             IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"

--- a/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
@@ -206,8 +206,8 @@ namespace Files.Views
         private async void ColumnShellPage_PreviewKeyDown(object sender, KeyRoutedEventArgs args)
         {
             var ctrl = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            var alt = Window.Current.CoreWindow.GetKeyState(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
             var shift = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+            var alt = Window.Current.CoreWindow.GetKeyState(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
             var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) ||
                               CurrentPageType == typeof(GridViewBrowser) ||
                               CurrentPageType == typeof(ColumnViewBrowser) ||
@@ -625,12 +625,12 @@ namespace Files.Views
         {
             args.Handled = true;
             var ctrl = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Control);
-            var alt = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Menu);
             var shift = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
-            var tabInstance = CurrentPageType == (typeof(DetailsLayoutBrowser))
-                || CurrentPageType == typeof(GridViewBrowser)
-                || CurrentPageType == typeof(ColumnViewBrowser)
-                || CurrentPageType == typeof(ColumnViewBase);
+            var alt = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Menu);
+            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) ||
+                              CurrentPageType == typeof(GridViewBrowser) ||
+                              CurrentPageType == typeof(ColumnViewBrowser) ||
+                              CurrentPageType == typeof(ColumnViewBase);
 
             switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.KeyboardAccelerator.Key)
             {

--- a/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
@@ -213,12 +213,12 @@ namespace Files.Views
                               CurrentPageType == typeof(ColumnViewBrowser) ||
                               CurrentPageType == typeof(ColumnViewBase);
 
-            switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.Key) 
+            switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.Key)
             {
                 case (true, false, false, true, (VirtualKey) 192): // ctrl + ` (accent key), open terminal
                     // Check if there is a folder selected, if not use the current directory.
                     string path = FilesystemViewModel.WorkingDirectory;
-                    if (SlimContentPage?.SelectedItem?.PrimaryItemAttribute == StorageItemTypes.Folder) 
+                    if (SlimContentPage?.SelectedItem?.PrimaryItemAttribute == StorageItemTypes.Folder)
                     {
                         path = SlimContentPage.SelectedItem.ItemPath;
                     }

--- a/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
@@ -199,27 +199,44 @@ namespace Files.Views
             PreviewKeyDown += ColumnShellPage_PreviewKeyDown;
         }
 
-        private async void ColumnShellPage_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+        /**
+         * Some keys are overriden by control built-in defaults (e.g. 'Space').
+         * They must be handled here since they're not propagated to KeyboardAccelerator.
+         */
+        private async void ColumnShellPage_PreviewKeyDown(object sender, KeyRoutedEventArgs args)
         {
-            var ctrlPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) || CurrentPageType == typeof(GridViewBrowser);
+            var ctrl = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            var alt = Window.Current.CoreWindow.GetKeyState(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
+            var shift = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) ||
+                              CurrentPageType == typeof(GridViewBrowser) ||
+                              CurrentPageType == typeof(ColumnViewBrowser) ||
+                              CurrentPageType == typeof(ColumnViewBase);
 
-            if (tabInstance && e.Key == (VirtualKey)192 && ctrlPressed) // VirtualKey for ` (accent key)
+            switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.Key) 
             {
-                string path;
-                // Check if there is a folder selected, if not use the current directory.
-                if (SlimContentPage?.SelectedItem is not null &&
-                    SlimContentPage?.SelectedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
-                {
-                    path = SlimContentPage.SelectedItem.ItemPath;
-                }
-                else
-                {
-                    path = FilesystemViewModel.WorkingDirectory;
-                }
+                case (true, false, false, true, (VirtualKey) 192): // ctrl + ` (accent key), open terminal
+                    // Check if there is a folder selected, if not use the current directory.
+                    string path = FilesystemViewModel.WorkingDirectory;
+                    if (SlimContentPage?.SelectedItem?.PrimaryItemAttribute == StorageItemTypes.Folder) 
+                    {
+                        path = SlimContentPage.SelectedItem.ItemPath;
+                    }
+                    await NavigationHelpers.OpenDirectoryInTerminal(path);
+                    args.Handled = true;
+                    break;
 
-                await NavigationHelpers.OpenDirectoryInTerminal(path);
-                e.Handled = true;
+                case (false, false, false, true, VirtualKey.Space): // space, quick look
+                    // handled in `CurrentPageType`::FileList_PreviewKeyDown
+                    break;
+
+                case (true, false, false, true, VirtualKey.Space): // ctrl + space, toggle media playback
+                    if (App.PreviewPaneViewModel.PreviewPaneContent is UserControls.FilePreviews.MediaPreview mediaPreviewContent)
+                    {
+                        mediaPreviewContent.ViewModel.TogglePlayback();
+                        args.Handled = true;
+                    }
+                    break;
             }
         }
 
@@ -721,14 +738,7 @@ namespace Files.Views
 
                     break;
 
-                case (false, false, false, true, VirtualKey.Space): // space, quick look
-                    if (!NavToolbarViewModel.IsEditModeEnabled && !NavToolbarViewModel.IsSearchBoxVisible)
-                    {
-                        await QuickLookHelpers.ToggleQuickLook(this);
-                    }
-                    break;
-
-                case (true, false, false, true, VirtualKey.P):
+                case (true, false, false, true, VirtualKey.P): // ctrl + p, toggle preview pane
                     App.PaneViewModel.IsPreviewSelected = !App.PaneViewModel.IsPreviewSelected;
                     break;
 

--- a/src/Files.Uwp/Views/ModernShellPage.xaml
+++ b/src/Files.Uwp/Views/ModernShellPage.xaml
@@ -79,11 +79,6 @@
             IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
             Modifiers="None" />
         <KeyboardAccelerator
-            Key="Space"
-            Invoked="KeyboardAccelerator_Invoked"
-            IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-            Modifiers="None" />
-        <KeyboardAccelerator
             Key="R"
             Invoked="KeyboardAccelerator_Invoked"
             IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"

--- a/src/Files.Uwp/Views/ModernShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ModernShellPage.xaml.cs
@@ -194,27 +194,40 @@ namespace Files.Views
             PreviewKeyDown += ModernShellPage_PreviewKeyDown;
         }
 
-        private async void ModernShellPage_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+        /**
+         * Some keys are overriden by control built-in defaults (e.g. 'Space').
+         * They must be handled here since they're not propagated to KeyboardAccelerator.
+         */
+        private async void ModernShellPage_PreviewKeyDown(object sender, KeyRoutedEventArgs args)
         {
-            var ctrlPressed = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            var ctrl = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            var alt = Window.Current.CoreWindow.GetKeyState(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
+            var shift = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
             var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) || CurrentPageType == typeof(GridViewBrowser);
 
-            if (tabInstance && e.Key == (VirtualKey)192 && ctrlPressed) // VirtualKey for ` (accent key)
-            {
-                string path;
-                // Check if there is a folder selected, if not use the current directory.
-                if (SlimContentPage?.SelectedItem is not null &&
-                    SlimContentPage?.SelectedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
-                {
-                    path = SlimContentPage.SelectedItem.ItemPath;
-                }
-                else
-                {
-                    path = FilesystemViewModel.WorkingDirectory;
-                }
+            switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.Key) {
+                case (true, false, false, true, (VirtualKey) 192): // ctrl + ` (accent key), open terminal
+                    // Check if there is a folder selected, if not use the current directory.
+                    string path = FilesystemViewModel.WorkingDirectory;
+                    if (SlimContentPage?.SelectedItem?.PrimaryItemAttribute == StorageItemTypes.Folder) 
+                    {
+                        path = SlimContentPage.SelectedItem.ItemPath;
+                    }
+                    await NavigationHelpers.OpenDirectoryInTerminal(path);
+                    args.Handled = true;
+                    break;
 
-                await NavigationHelpers.OpenDirectoryInTerminal(path);
-                e.Handled = true;
+                case (false, false, false, true, VirtualKey.Space): // space, quick look
+                    // handled in `CurrentPageType`::FileList_PreviewKeyDown
+                    break;
+
+                case (true, false, false, true, VirtualKey.Space): // ctrl + space, toggle media playback
+                    if (App.PreviewPaneViewModel.PreviewPaneContent is UserControls.FilePreviews.MediaPreview mediaPreviewContent)
+                    {
+                        mediaPreviewContent.ViewModel.TogglePlayback();
+                        args.Handled = true;
+                    }
+                    break;
             }
         }
 
@@ -773,17 +786,7 @@ namespace Files.Views
 
                     break;
 
-                case (false, false, false, true, VirtualKey.Space): // space, quick look
-                    if (!NavToolbarViewModel.IsEditModeEnabled && !NavToolbarViewModel.IsSearchBoxVisible)
-                    {
-                        if (MainViewModel.IsQuickLookEnabled)
-                        {
-                            await QuickLookHelpers.ToggleQuickLook(this);
-                        }
-                    }
-                    break;
-
-                case (true, false, false, true, VirtualKey.P):
+                case (true, false, false, true, VirtualKey.P): // ctrl + p, toggle preview pane
                     App.PaneViewModel.IsPreviewSelected = !App.PaneViewModel.IsPreviewSelected;
                     break;
 

--- a/src/Files.Uwp/Views/ModernShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ModernShellPage.xaml.cs
@@ -201,9 +201,10 @@ namespace Files.Views
         private async void ModernShellPage_PreviewKeyDown(object sender, KeyRoutedEventArgs args)
         {
             var ctrl = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            var alt = Window.Current.CoreWindow.GetKeyState(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
             var shift = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
-            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) || CurrentPageType == typeof(GridViewBrowser);
+            var alt = Window.Current.CoreWindow.GetKeyState(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
+            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) || 
+                              CurrentPageType == typeof(GridViewBrowser);
 
             switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.Key) {
                 case (true, false, false, true, (VirtualKey) 192): // ctrl + ` (accent key), open terminal
@@ -672,10 +673,10 @@ namespace Files.Views
         {
             args.Handled = true;
             var ctrl = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Control);
-            var alt = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Menu);
             var shift = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
-            var tabInstance = CurrentPageType == (typeof(DetailsLayoutBrowser))
-                || CurrentPageType == typeof(GridViewBrowser);
+            var alt = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Menu);
+            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) || 
+                              CurrentPageType == typeof(GridViewBrowser);
 
             switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.KeyboardAccelerator.Key)
             {

--- a/src/Files.Uwp/Views/ModernShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ModernShellPage.xaml.cs
@@ -203,14 +203,14 @@ namespace Files.Views
             var ctrl = Window.Current.CoreWindow.GetKeyState(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
             var shift = Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
             var alt = Window.Current.CoreWindow.GetKeyState(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
-            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) || 
+            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) ||
                               CurrentPageType == typeof(GridViewBrowser);
 
             switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.Key) {
                 case (true, false, false, true, (VirtualKey) 192): // ctrl + ` (accent key), open terminal
                     // Check if there is a folder selected, if not use the current directory.
                     string path = FilesystemViewModel.WorkingDirectory;
-                    if (SlimContentPage?.SelectedItem?.PrimaryItemAttribute == StorageItemTypes.Folder) 
+                    if (SlimContentPage?.SelectedItem?.PrimaryItemAttribute == StorageItemTypes.Folder)
                     {
                         path = SlimContentPage.SelectedItem.ItemPath;
                     }


### PR DESCRIPTION
**Resolved / Related Issues**
- Resolves #7705
- Resolves #8108

**Details of Changes**
- Shortcut to toggle playback (`TogglePlaybackAccelerator`) is now `ctrl + space`
- Add code-behind to allow toggle in details/column layout
- `Space` was being suppressed and not propagated in `KeyboardAccelerator`, now handled in `PreviewKeyDown`
- Refactor `PreviewKeyDown` to be similar in structure with `KeyboardAccelerator_Invoked`

**Validation**
- [X] Built and ran the app
- [X] Tested the changes for accessibility
  - `` ctrl + ` `` still works as expected (open terminal with correct path) after refactor
  - `ctrl + space` works as expected (item selected, preview pane shown)
  - `space` key works when renaming and isn't disabled
  - **QuickLook** works as expected with `space` and as well as all the same interactions listed above