### PR TITLE
Fix issue where clear all properties button wouldn't show any text

### DIFF
--- a/src/Files.Uwp/Views/Pages/PropertiesDetails.xaml
+++ b/src/Files.Uwp/Views/Pages/PropertiesDetails.xaml
@@ -89,7 +89,8 @@
                 <Button
                     x:Name="ClearPropertiesButton"
                     Margin="0,4,0,0"
-                    HorizontalAlignment="Stretch">
+                    HorizontalAlignment="Stretch"
+                    Content="{helpers:ResourceString Name=ClearPropertiesButton/Content}">
                     <Button.Flyout>
                         <Flyout x:Name="ClearPropertiesFlyout">
                             <StackPanel Orientation="Vertical" Spacing="4">


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->


**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...
- Related #issue...

**Details of Changes**
- bind button content to the string resource

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before:
![image](https://user-images.githubusercontent.com/59544401/163687873-05a07cf9-ab49-4e8d-8bee-fb563c6f498f.png)

After:
![image](https://user-images.githubusercontent.com/59544401/163687833-f6ef6074-8ab3-4b33-a5e1-4ec2b20fe030.png)


Side note, really like this new string resource system.