### PR TITLE
[Refactor] Decouple *Manager classes from the Sidebar

### DIFF
--- a/src/Files.Shared/Extensions/LinqExtensions.cs
+++ b/src/Files.Shared/Extensions/LinqExtensions.cs
@@ -78,17 +78,17 @@ namespace Files.Shared.Extensions
                 action(value);
         }
 
-        public static IList<T> AddSorted<T>(this IList<T> list, T item) where T : IComparable<T>
+        public static int AddSorted<T>(this IList<T> list, T item) where T : IComparable<T>
         {
             if (!list.Any() || list.Last().CompareTo(item) <= 0)
             {
                 list.Add(item);
-                return list;
+                return list.Count;
             }
             if (list[0].CompareTo(item) >= 0)
             {
                 list.Insert(0, item);
-                return list;
+                return 0;
             }
             int index = list.ToList().BinarySearch(item);
             if (index < 0)
@@ -96,7 +96,7 @@ namespace Files.Shared.Extensions
                 index = ~index;
             }
             list.Insert(index, item);
-            return list;
+            return index;
         }
 
         /// <summary>

--- a/src/Files.Uwp/Controllers/SidebarPinnedController.cs
+++ b/src/Files.Uwp/Controllers/SidebarPinnedController.cs
@@ -11,12 +11,15 @@ using Windows.ApplicationModel.Core;
 using Windows.Storage;
 using Windows.Storage.Search;
 using Files.Shared.Extensions;
+using System.Collections.Specialized;
 
 namespace Files.Uwp.Controllers
 {
     public class SidebarPinnedController : IJson
     {
         public SidebarPinnedModel Model { get; set; }
+
+        public EventHandler<NotifyCollectionChangedEventArgs> DataChanged;
 
         private StorageFileQueryResult query;
 

--- a/src/Files.Uwp/DataModels/NavigationControlItems/INavigationControlItem.cs
+++ b/src/Files.Uwp/DataModels/NavigationControlItems/INavigationControlItem.cs
@@ -19,7 +19,6 @@ namespace Files.Uwp.Filesystem
 
     public enum NavigationControlItemType
     {
-        Header,
         Drive,
         LinuxDistro,
         Location,

--- a/src/Files.Uwp/DataModels/NavigationControlItems/LocationItem.cs
+++ b/src/Files.Uwp/DataModels/NavigationControlItems/LocationItem.cs
@@ -3,7 +3,6 @@ using Files.Uwp.Filesystem;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.Toolkit.Uwp;
 using System;
-using System.Collections.ObjectModel;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 using Files.Uwp.Helpers;
@@ -20,7 +19,7 @@ namespace Files.Uwp.DataModels.NavigationControlItems
             set => SetProperty(ref icon, value);
         }
 
-        public Uri IconSource { get; set; }
+        //public Uri IconSource { get; set; }
         public byte[] IconData { get; set; }
 
         public string Text { get; set; }

--- a/src/Files.Uwp/DataModels/NavigationControlItems/WslDistroItem.cs
+++ b/src/Files.Uwp/DataModels/NavigationControlItems/WslDistroItem.cs
@@ -25,7 +25,7 @@ namespace Files.Uwp.DataModels.NavigationControlItems
 
         public Uri Logo { get; set; }
 
-        public SectionType Section { get; private set; }
+        public SectionType Section { get; set; }
 
         public ContextMenuOptions MenuOptions { get; set; }
 

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -35,6 +35,7 @@ namespace Files.Uwp.DataModels
 
         private readonly List<INavigationControlItem> favoriteList = new List<INavigationControlItem>();
 
+        [JsonIgnore]
         public IReadOnlyList<INavigationControlItem> Favorites
         {
             get

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -4,7 +4,6 @@ using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Uwp.Filesystem;
 using Files.Uwp.Helpers;
 using Files.Backend.Services.Settings;
-using Files.Uwp.UserControls;
 using Files.Uwp.ViewModels;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Uwp;
@@ -18,6 +17,7 @@ using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.Storage;
 using Windows.UI.Xaml.Media.Imaging;
+using System.Collections.Specialized;
 
 namespace Files.Uwp.DataModels
 {
@@ -27,13 +27,24 @@ namespace Files.Uwp.DataModels
 
         private SidebarPinnedController controller;
 
-        private LocationItem favoriteSection;
-
         [JsonIgnore]
         public MainViewModel MainViewModel => App.MainViewModel;
 
         [JsonProperty("items")]
         public List<string> FavoriteItems { get; set; } = new List<string>();
+
+        private readonly List<INavigationControlItem> favoriteList = new List<INavigationControlItem>();
+
+        public IReadOnlyList<INavigationControlItem> Favorites
+        {
+            get
+            {
+                lock (favoriteList)
+                {
+                    return favoriteList.ToList().AsReadOnly();
+                }
+            }
+        }
 
         public void SetController(SidebarPinnedController controller)
         {
@@ -42,7 +53,6 @@ namespace Files.Uwp.DataModels
 
         public SidebarPinnedModel()
         {
-            favoriteSection = SidebarControl.SideBarItems.FirstOrDefault(x => x.Text == "SidebarFavorites".GetLocalized()) as LocationItem;
         }
 
         /// <summary>
@@ -55,32 +65,6 @@ namespace Files.Uwp.DataModels
             FavoriteItems.Add(CommonPaths.DesktopPath);
             FavoriteItems.Add(CommonPaths.DownloadsPath);
             FavoriteItems.Add(udp.Documents);
-        }
-
-        private void RemoveFavoritesSideBarSection()
-        {
-            try
-            {
-                var item = (from n in SidebarControl.SideBarItems where n.Text.Equals("SidebarFavorites".GetLocalized()) select n).FirstOrDefault();
-                if (!UserSettingsService.AppearanceSettingsService.ShowFavoritesSection && item != null)
-                {
-                    SidebarControl.SideBarItems.Remove(item);
-                }
-            }
-            catch (Exception)
-            { }
-        }
-
-        public async void UpdateFavoritesSectionVisibility()
-        {
-            if (UserSettingsService.AppearanceSettingsService.ShowFavoritesSection)
-            {
-                await AddAllItemsToSidebar();
-            }
-            else
-            {
-                RemoveFavoritesSideBarSection();
-            }
         }
 
         /// <summary>
@@ -97,20 +81,11 @@ namespace Files.Uwp.DataModels
         /// <param name="item">Item to remove</param>
         public async void AddItem(string item)
         {
-            await SidebarControl.SideBarItemsSemaphore.WaitAsync();
-
-            try
+            if (!string.IsNullOrEmpty(item) && !FavoriteItems.Contains(item))
             {
-                if (!string.IsNullOrEmpty(item) && !FavoriteItems.Contains(item))
-                {
-                    FavoriteItems.Add(item);
-                    await AddItemToSidebarAsync(item);
-                    Save();
-                }
-            }
-            finally
-            {
-                SidebarControl.SideBarItemsSemaphore.Release();
+                FavoriteItems.Add(item);
+                await AddItemToSidebarAsync(item);
+                Save();
             }
         }
 
@@ -134,18 +109,20 @@ namespace Files.Uwp.DataModels
                 };
                 // Add recycle bin to sidebar, title is read from LocalSettings (provided by the fulltrust process)
                 // TODO: the very first time the app is launched localized name not available
-                if (!favoriteSection.ChildItems.Any(x => x.Path == CommonPaths.RecycleBinPath))
+                if (!favoriteList.Any(x => x.Path == CommonPaths.RecycleBinPath))
                 {
-                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => favoriteSection.ChildItems.Add(recycleBinItem));
+                    favoriteList.Add(recycleBinItem);
+                    controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, recycleBinItem));
                 }
             }
             else
             {
-                foreach (INavigationControlItem item in favoriteSection.ChildItems.ToList())
+                foreach (INavigationControlItem item in favoriteList.ToList())
                 {
                     if (item is LocationItem && item.Path == CommonPaths.RecycleBinPath)
                     {
-                        await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => favoriteSection.ChildItems.Remove(item));
+                        favoriteList.Remove(item);
+                        controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item));
                     }
                 }
             }
@@ -188,16 +165,12 @@ namespace Files.Uwp.DataModels
                 {
                     FavoriteItems.RemoveAt(oldIndex - 1);
                     FavoriteItems.Insert(newIndex - 1, locationItem.Path);
-                    favoriteSection.ChildItems.RemoveAt(oldIndex);
-                    favoriteSection.ChildItems.Insert(newIndex, locationItem);
+                    favoriteList.RemoveAt(oldIndex);
+                    favoriteList.Insert(newIndex, locationItem);
+                    controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, locationItem, newIndex, oldIndex));
                     Save();
                 }
-                catch (Exception ex) when (
-                    ex is ArgumentException // Pinned item was invalid
-                    || ex is FileNotFoundException // Pinned item was deleted
-                    || ex is System.Runtime.InteropServices.COMException // Pinned item's drive was ejected
-                    || (uint)ex.HResult == 0x8007000F // The system cannot find the drive specified
-                    || (uint)ex.HResult == 0x800700A1) // The specified path is invalid (usually an mtp device was disconnected)
+                catch (Exception ex)
                 {
                     Debug.WriteLine($"An error occurred while moving pinned items in the Favorites sidebar section. {ex.Message}");
                     FavoriteItems = sidebarItemsBackup;
@@ -238,7 +211,7 @@ namespace Files.Uwp.DataModels
         /// <returns>Index of the item</returns>
         public int IndexOfItem(INavigationControlItem locationItem)
         {
-            return favoriteSection.ChildItems.IndexOf(locationItem);
+            return favoriteList.FindIndex(x => x.Path == locationItem.Path);
         }
 
         /// <summary>
@@ -266,8 +239,8 @@ namespace Files.Uwp.DataModels
         {
             var item = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(path));
             var res = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(path, item));
-            var lastItem = favoriteSection.ChildItems.LastOrDefault(x => x.ItemType == NavigationControlItemType.Location && !x.Path.Equals(CommonPaths.RecycleBinPath));
-            int insertIndex = lastItem != null ? favoriteSection.ChildItems.IndexOf(lastItem) + 1 : 0;
+            var lastItem = favoriteList.LastOrDefault(x => x.ItemType == NavigationControlItemType.Location && !x.Path.Equals(CommonPaths.RecycleBinPath));
+            int insertIndex = lastItem != null ? favoriteList.IndexOf(lastItem) + 1 : 0;
             var locationItem = new LocationItem
             {
                 Font = MainViewModel.FontName,
@@ -314,9 +287,10 @@ namespace Files.Uwp.DataModels
                 Debug.WriteLine($"Pinned item was invalid {res.ErrorCode}, item: {path}");
             }
 
-            if (!favoriteSection.ChildItems.Any(x => x.Path == locationItem.Path))
+            if (!favoriteList.Any(x => x.Path == locationItem.Path))
             {
-                await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => favoriteSection.ChildItems.Insert(insertIndex, locationItem));
+                favoriteList.Insert(insertIndex, locationItem);
+                controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, locationItem, insertIndex));
             }
         }
 
@@ -326,12 +300,13 @@ namespace Files.Uwp.DataModels
         /// <param name="section">The section.</param>
         private void AddLocationItemToSidebar(LocationItem section)
         {
-            var lastItem = favoriteSection.ChildItems.LastOrDefault(x => x.ItemType == NavigationControlItemType.Location && !x.Path.Equals(CommonPaths.RecycleBinPath));
-            int insertIndex = lastItem != null ? favoriteSection.ChildItems.IndexOf(lastItem) + 1 : 0;
+            var lastItem = favoriteList.LastOrDefault(x => x.ItemType == NavigationControlItemType.Location && !x.Path.Equals(CommonPaths.RecycleBinPath));
+            int insertIndex = lastItem != null ? favoriteList.IndexOf(lastItem) + 1 : 0;
 
-            if (!favoriteSection.ChildItems.Any(x => x.Section == section.Section))
+            if (!favoriteList.Any(x => x.Section == section.Section))
             {
-                favoriteSection.ChildItems.Insert(insertIndex, section);
+                favoriteList.Insert(insertIndex, section);
+                controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, section, insertIndex));
             }
         }
 
@@ -345,61 +320,28 @@ namespace Files.Uwp.DataModels
                 return;
             }
 
-            await SidebarControl.SideBarItemsSemaphore.WaitAsync();
-            try
+            var homeSection = new LocationItem()
             {
-                var homeSection = new LocationItem()
+                Text = "Home".GetLocalized(),
+                Section = SectionType.Home,
+                MenuOptions = new ContextMenuOptions
                 {
-                    Text = "Home".GetLocalized(),
-                    Section = SectionType.Home,
-                    MenuOptions = new ContextMenuOptions
-                    {
-                        IsLocationItem = true
-                    },
-                    Font = MainViewModel.FontName,
-                    IsDefaultLocation = true,
-                    Icon = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => new BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/Home.png"))),
-                    Path = "Home".GetLocalized()
-                };
-                favoriteSection ??= new LocationItem()
-                {
-                    Text = "SidebarFavorites".GetLocalized(),
-                    Section = SectionType.Favorites,
-                    MenuOptions = new ContextMenuOptions
-                    {
-                        ShowHideSection = true
-                    },
-                    SelectsOnInvoked = false,
-                    Icon = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => UIHelpers.GetIconResource(Constants.Shell32.QuickAccess)),
-                    Font = MainViewModel.FontName,
-                    ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
-                };
+                    IsLocationItem = true
+                },
+                Font = MainViewModel.FontName,
+                IsDefaultLocation = true,
+                Icon = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => new BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/Home.png"))),
+                Path = "Home".GetLocalized()
+            };
+            AddLocationItemToSidebar(homeSection);
 
-                if (homeSection != null)
-                {
-                    AddLocationItemToSidebar(homeSection);
-                }
-
-                if (!SidebarControl.SideBarItems.Any(x => x.Text == "SidebarFavorites".GetLocalized()))
-                {
-                    SidebarControl.SideBarItems.BeginBulkOperation();
-                    var index = 0; // First section
-                    SidebarControl.SideBarItems.Insert(index, favoriteSection);
-                    await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => SidebarControl.SideBarItems.EndBulkOperation());
-                }
-
-                for (int i = 0; i < FavoriteItems.Count; i++)
-                {
-                    string path = FavoriteItems[i];
-                    await AddItemToSidebarAsync(path);
-                }
-
-                await ShowHideRecycleBinItemAsync(UserSettingsService.AppearanceSettingsService.PinRecycleBinToSidebar);
-            }
-            finally
+            for (int i = 0; i < FavoriteItems.Count; i++)
             {
-                SidebarControl.SideBarItemsSemaphore.Release();
+                string path = FavoriteItems[i];
+                await AddItemToSidebarAsync(path);
             }
+
+            await ShowHideRecycleBinItemAsync(UserSettingsService.AppearanceSettingsService.PinRecycleBinToSidebar);
         }
 
         /// <summary>
@@ -409,17 +351,15 @@ namespace Files.Uwp.DataModels
         {
             // Remove unpinned items from sidebar
             // Reverse iteration to avoid skipping elements while removing
-            if (favoriteSection != null)
+            for (int i = favoriteList.Count - 1; i >= 0; i--)
             {
-                for (int i = favoriteSection.ChildItems.Count - 1; i >= 0; i--)
+                var childItem = favoriteList[i];
+                if (childItem is LocationItem item)
                 {
-                    var childItem = favoriteSection.ChildItems[i];
-                    if (childItem is LocationItem item)
+                    if (!item.IsDefaultLocation && !FavoriteItems.Contains(item.Path))
                     {
-                        if (!item.IsDefaultLocation && !FavoriteItems.Contains(item.Path))
-                        {
-                            favoriteSection.ChildItems.RemoveAt(i);
-                        }
+                        favoriteList.RemoveAt(i);
+                        controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item));
                     }
                 }
             }

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -350,7 +350,7 @@ namespace Files.Uwp.DataModels
         /// </summary>
         public void RemoveStaleSidebarItems()
         {
-            // Remove unpinned items from sidebar
+            // Remove unpinned items from favoriteList
             // Reverse iteration to avoid skipping elements while removing
             for (int i = favoriteList.Count - 1; i >= 0; i--)
             {
@@ -364,6 +364,9 @@ namespace Files.Uwp.DataModels
                     }
                 }
             }
+
+            // Remove unpinned items from sidebar
+            controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
     }
 }

--- a/src/Files.Uwp/Filesystem/CloudDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/CloudDrivesManager.cs
@@ -3,16 +3,14 @@ using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Uwp.Filesystem.Cloud;
 using Files.Uwp.Helpers;
 using Files.Backend.Services.Settings;
-using Files.Uwp.UserControls;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Uwp;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
-using Windows.UI.Core;
+using System.Collections.Specialized;
 
 namespace Files.Uwp.Filesystem
 {
@@ -22,6 +20,8 @@ namespace Files.Uwp.Filesystem
 
         private static readonly ILogger Logger = App.Logger;
         private readonly List<DriveItem> drivesList = new List<DriveItem>();
+
+        public EventHandler<NotifyCollectionChangedEventArgs> DataChanged;
 
         public IReadOnlyList<DriveItem> Drives
         {
@@ -77,103 +77,8 @@ namespace Files.Uwp.Filesystem
                         drivesList.Add(cloudProviderItem);
                     }
                 }
-            }
 
-            await RefreshUI();
-        }
-
-        private async Task RefreshUI()
-        {
-            try
-            {
-                await SyncSideBarItemsUI();
-            }
-            catch (Exception ex) // UI Thread not ready yet, so we defer the previous operation until it is.
-            {
-                Logger.Warn(ex, "UI thread not ready yet");
-                System.Diagnostics.Debug.WriteLine($"RefreshUI Exception");
-                // Defer because UI-thread is not ready yet (and DriveItem requires it?)
-                CoreApplication.MainView.Activated += RefreshUI;
-            }
-        }
-
-        private async void RefreshUI(CoreApplicationView sender, Windows.ApplicationModel.Activation.IActivatedEventArgs args)
-        {
-            CoreApplication.MainView.Activated -= RefreshUI;
-            await SyncSideBarItemsUI();
-        }
-
-        private async Task SyncSideBarItemsUI()
-        {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
-            {
-                await SidebarControl.SideBarItemsSemaphore.WaitAsync();
-                try
-                {
-                    var section = SidebarControl.SideBarItems.FirstOrDefault(x => x.Text == "SidebarCloudDrives".GetLocalized()) as LocationItem;
-                    if (UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection && section == null && Drives.Any())
-                    {
-                        section = new LocationItem()
-                        {
-                            Text = "SidebarCloudDrives".GetLocalized(),
-                            Section = SectionType.CloudDrives,
-                            MenuOptions = new ContextMenuOptions
-                            {
-                                ShowHideSection = true
-                            },
-                            SelectsOnInvoked = false,
-                            Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/CloudDrive.png")),
-                            ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
-                        };
-                        var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
-                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
-                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0); // After drives section
-                        SidebarControl.SideBarItems.BeginBulkOperation();
-                        SidebarControl.SideBarItems.Insert(Math.Min(index, SidebarControl.SideBarItems.Count), section);
-                        SidebarControl.SideBarItems.EndBulkOperation();
-                    }
-
-                    if (section != null)
-                    {
-                        foreach (DriveItem drive in Drives.ToList())
-                        {
-                            if (!section.ChildItems.Contains(drive))
-                            {
-                                section.ChildItems.Add(drive);
-                            }
-                        }
-                    }
-                }
-                finally
-                {
-                    SidebarControl.SideBarItemsSemaphore.Release();
-                }
-            });
-        }
-
-        private void RemoveCloudDrivesSideBarSection()
-        {
-            try
-            {
-                var item = (from n in SidebarControl.SideBarItems where n.Text.Equals("SidebarCloudDrives".GetLocalized()) select n).FirstOrDefault();
-                if (!UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection && item != null)
-                {
-                    SidebarControl.SideBarItems.Remove(item);
-                }
-            }
-            catch (Exception)
-            { }
-        }
-
-        public async void UpdateCloudDrivesSectionVisibility()
-        {
-            if (UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection)
-            {
-                await EnumerateDrivesAsync();
-            }
-            else
-            {
-                RemoveCloudDrivesSideBarSection();
+                DataChanged?.Invoke(SectionType.CloudDrives, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, cloudProviderItem));
             }
         }
     }

--- a/src/Files.Uwp/Filesystem/FileTagsManager.cs
+++ b/src/Files.Uwp/Filesystem/FileTagsManager.cs
@@ -1,17 +1,11 @@
 ﻿using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Backend.Services.Settings;
-using Files.Uwp.UserControls;
 using CommunityToolkit.Mvvm.DependencyInjection;
-using Microsoft.Toolkit.Uwp;
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Windows.ApplicationModel.Core;
-using Windows.UI.Core;
-using Files.Uwp.Helpers;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 
 namespace Files.Uwp.Filesystem
 {
@@ -21,114 +15,55 @@ namespace Files.Uwp.Filesystem
 
         private IFileTagsSettingsService FileTagsSettingsService { get; } = Ioc.Default.GetService<IFileTagsSettingsService>();
 
-        public async Task EnumerateFileTagsAsync()
+        private readonly List<FileTagItem> fileTagList = new List<FileTagItem>();
+
+        public EventHandler<NotifyCollectionChangedEventArgs> DataChanged;
+
+        public IReadOnlyList<FileTagItem> FileTags
         {
+            get
+            {
+                lock (fileTagList)
+                {
+                    return fileTagList.ToList().AsReadOnly();
+                }
+            }
+        }
+
+        public Task EnumerateFileTagsAsync()
+        {
+            if (!UserSettingsService.AppearanceSettingsService.ShowFileTagsSection)
+            {
+                return Task.CompletedTask;
+            }
+
             try
             {
-                await SyncSideBarItemsUI();
-            }
-            catch (Exception) // UI Thread not ready yet, so we defer the pervious operation until it is.
-            {
-                System.Diagnostics.Debug.WriteLine($"RefreshUI Exception");
-                // Defer because UI-thread is not ready yet
-                CoreApplication.MainView.Activated += EnumerateFileTagsAsync;
-            }
-        }
-
-        private async void EnumerateFileTagsAsync(CoreApplicationView sender, Windows.ApplicationModel.Activation.IActivatedEventArgs args)
-        {
-            await SyncSideBarItemsUI();
-            CoreApplication.MainView.Activated -= EnumerateFileTagsAsync;
-        }
-
-        private async Task SyncSideBarItemsUI()
-        {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
-            {
-                await SidebarControl.SideBarItemsSemaphore.WaitAsync();
-                try
+                foreach (var tag in FileTagsSettingsService.FileTagList)
                 {
-                    var section = SidebarControl.SideBarItems.FirstOrDefault(x => x.Text == "FileTags".GetLocalized()) as LocationItem;
-                    if (UserSettingsService.PreferencesSettingsService.AreFileTagsEnabled && UserSettingsService.AppearanceSettingsService.ShowFileTagsSection && section == null)
+                    if (!fileTagList.Any(x => x.Path == $"tag:{tag.TagName}"))
                     {
-                        section = new LocationItem()
+                        var tagItem = new FileTagItem()
                         {
-                            Text = "FileTags".GetLocalized(),
-                            Section = SectionType.FileTag,
+                            Text = tag.TagName,
+                            Path = $"tag:{tag.TagName}",
+                            FileTag = tag,
                             MenuOptions = new ContextMenuOptions
                             {
-                                ShowHideSection = true
-                            },
-                            SelectsOnInvoked = false,
-                            Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/FileTags.png")),
-                            ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
-                        };
-                        var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
-                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
-                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0) +
-                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.CloudDrives) ? 1 : 0) +
-                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Network) ? 1 : 0) +
-                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.WSL) ? 1 : 0); // After wsl section
-                        SidebarControl.SideBarItems.BeginBulkOperation();
-                        SidebarControl.SideBarItems.Insert(Math.Min(index, SidebarControl.SideBarItems.Count), section);
-                        SidebarControl.SideBarItems.EndBulkOperation();
-                    }
-
-                    if (section != null)
-                    {
-                        foreach (var tag in FileTagsSettingsService.FileTagList)
-                        {
-                            if (!section.ChildItems.Any(x => x.Path == $"tag:{tag.TagName}"))
-                            {
-                                section.ChildItems.Add(new FileTagItem()
-                                {
-                                    Text = tag.TagName,
-                                    Path = $"tag:{tag.TagName}",
-                                    FileTag = tag,
-                                    MenuOptions = new ContextMenuOptions
-                                    {
-                                        IsLocationItem = true
-                                    }
-                                });
+                                IsLocationItem = true
                             }
-                        }
+                        };
+                        fileTagList.Add(tagItem);
+                        DataChanged?.Invoke(SectionType.FileTag, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, tagItem));
                     }
                 }
-                catch (Exception ex)
-                {
-                    App.Logger.Warn(ex, "Error loading tags section.");
-                }
-                finally
-                {
-                    SidebarControl.SideBarItemsSemaphore.Release();
-                }
-            });
-        }
+            }
+            catch (Exception ex)
+            {
+                App.Logger.Warn(ex, "Error loading tags section.");
+            }
 
-        private void RemoveFileTagsSideBarSection()
-        {
-            try
-            {
-                var item = (from n in SidebarControl.SideBarItems where n.Text.Equals("FileTags".GetLocalized()) select n).FirstOrDefault();
-                if (!UserSettingsService.AppearanceSettingsService.ShowFileTagsSection && item != null)
-                {
-                    SidebarControl.SideBarItems.Remove(item);
-                }
-            }
-            catch (Exception)
-            { }
-        }
-
-        public async void UpdateFileTagsSectionVisibility()
-        {
-            if (UserSettingsService.AppearanceSettingsService.ShowFileTagsSection)
-            {
-                await EnumerateFileTagsAsync();
-            }
-            else
-            {
-                RemoveFileTagsSideBarSection();
-            }
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Files.Uwp/Filesystem/LibraryLocationItem.cs
+++ b/src/Files.Uwp/Filesystem/LibraryLocationItem.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Shared;
 using Files.Uwp.DataModels.NavigationControlItems;
+using Files.Uwp.Helpers;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
@@ -28,7 +29,6 @@ namespace Files.Uwp.Filesystem
             DefaultSaveFolder = shellLibrary.DefaultSaveFolder;
             Folders = shellLibrary.Folders == null ? null : new ReadOnlyCollection<string>(shellLibrary.Folders);
             IsDefaultLocation = shellLibrary.IsPinned;
-
         }
 
         public override bool Equals(object obj)
@@ -55,6 +55,15 @@ namespace Files.Uwp.Filesystem
                 res = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(DefaultSaveFolder, item));
             }
             return res;
+        }
+
+        public async Task LoadLibraryIcon()
+        {
+            IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Path, 24u);
+            if (IconData != null)
+            {
+                Icon = await IconData.ToBitmapAsync();
+            }
         }
     }
 }

--- a/src/Files.Uwp/Filesystem/LibraryManager.cs
+++ b/src/Files.Uwp/Filesystem/LibraryManager.cs
@@ -2,7 +2,6 @@
 using Files.Backend.Services.Settings;
 using Files.Uwp.Helpers;
 using Files.Shared;
-using Files.Shared.Extensions;
 using Files.Uwp.ViewModels;
 using Microsoft.Toolkit.Uwp;
 using System;
@@ -39,8 +38,6 @@ namespace Files.Uwp.Filesystem
         {
         }
 
-        private static bool IsLibraryOnSidebar(LibraryLocationItem item) => item != null && !item.IsEmpty && item.IsDefaultLocation;
-
         public void Dispose()
         {
         }
@@ -73,8 +70,8 @@ namespace Files.Uwp.Filesystem
             // library is null in case it was deleted
             if (library != null && !Libraries.Any(x => x.Path == library.FullPath))
             {
-                var index = librariesList.AddSorted(new LibraryLocationItem(library));
-                DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, library, index));
+                librariesList.Add(new LibraryLocationItem(library));
+                DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, library));
             }
             return Task.CompletedTask;
         }
@@ -99,8 +96,8 @@ namespace Files.Uwp.Filesystem
             var newLib = await LibraryHelper.CreateLibrary(name);
             if (newLib != null)
             {
-                var index = librariesList.AddSorted(newLib);
-                DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, newLib, index));
+                librariesList.Add(newLib);
+                DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, newLib));
                 return true;
             }
             return false;
@@ -115,7 +112,7 @@ namespace Files.Uwp.Filesystem
                 if (libItem != null)
                 {
                     librariesList[librariesList.IndexOf(libItem)] = newLib;
-                    DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newLib));
+                    DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newLib, libItem));
                 }
                 return newLib;
             }

--- a/src/Files.Uwp/Filesystem/LibraryManager.cs
+++ b/src/Files.Uwp/Filesystem/LibraryManager.cs
@@ -1,19 +1,16 @@
 ﻿using CommunityToolkit.Mvvm.DependencyInjection;
 using Files.Backend.Services.Settings;
-using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Uwp.Helpers;
 using Files.Shared;
 using Files.Shared.Extensions;
-using Files.Uwp.UserControls;
 using Files.Uwp.ViewModels;
 using Microsoft.Toolkit.Uwp;
 using System;
-using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Windows.ApplicationModel.Core;
-using Windows.UI.Core;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 
 namespace Files.Uwp.Filesystem
 {
@@ -23,210 +20,63 @@ namespace Files.Uwp.Filesystem
 
         public MainViewModel MainViewModel => App.MainViewModel;
 
-        private LocationItem librarySection;
+        private readonly List<LibraryLocationItem> librariesList = new List<LibraryLocationItem>();
 
-        public BulkConcurrentObservableCollection<LibraryLocationItem> Libraries { get; } = new BulkConcurrentObservableCollection<LibraryLocationItem>();
+        public EventHandler<NotifyCollectionChangedEventArgs> DataChanged;
+
+        public IReadOnlyList<LibraryLocationItem> Libraries
+        {
+            get
+            {
+                lock (librariesList)
+                {
+                    return librariesList.ToList().AsReadOnly();
+                }
+            }
+        }
 
         public LibraryManager()
         {
-            Libraries.CollectionChanged += Libraries_CollectionChanged;
-        }
-
-        private async void Libraries_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            if (!UserSettingsService.AppearanceSettingsService.ShowLibrarySection)
-            {
-                return;
-            }
-
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
-            {
-                await SidebarControl.SideBarItemsSemaphore.WaitAsync();
-                try
-                {
-                    switch (e.Action)
-                    {
-                        case NotifyCollectionChangedAction.Replace:
-                        case NotifyCollectionChangedAction.Remove:
-                            foreach (var lib in e.OldItems.Cast<LibraryLocationItem>())
-                            {
-                                librarySection.ChildItems.Remove(lib);
-                            }
-                            if (e.Action == NotifyCollectionChangedAction.Replace)
-                            {
-                                goto case NotifyCollectionChangedAction.Add;
-                            }
-                            break;
-
-                        case NotifyCollectionChangedAction.Reset:
-                            foreach (var lib in Libraries.Where(IsLibraryOnSidebar))
-                            {
-                                if (!librarySection.ChildItems.Any(x => x.Path == lib.Path))
-                                {
-                                    if (await lib.CheckDefaultSaveFolderAccess())
-                                    {
-                                        lib.Font = MainViewModel.FontName;
-                                        librarySection.ChildItems.AddSorted(lib);
-                                        this.LoadLibraryIcon(lib);
-                                    }
-                                }
-                            }
-                            foreach (var lib in librarySection.ChildItems.ToList())
-                            {
-                                if (!Libraries.Any(x => x.Path == lib.Path))
-                                {
-                                    librarySection.ChildItems.Remove(lib);
-                                }
-                            }
-                            break;
-
-                        case NotifyCollectionChangedAction.Add:
-                            foreach (var lib in e.NewItems.Cast<LibraryLocationItem>().Where(IsLibraryOnSidebar))
-                            {
-                                if (await lib.CheckDefaultSaveFolderAccess())
-                                {
-                                    lib.Font = MainViewModel.FontName;
-                                    librarySection.ChildItems.AddSorted(lib);
-                                    this.LoadLibraryIcon(lib);
-                                }
-                            }
-                            break;
-                    }
-                }
-                finally
-                {
-                    SidebarControl.SideBarItemsSemaphore.Release();
-                }
-            });
         }
 
         private static bool IsLibraryOnSidebar(LibraryLocationItem item) => item != null && !item.IsEmpty && item.IsDefaultLocation;
 
-        private async void LoadLibraryIcon(LibraryLocationItem lib)
-        {
-            lib.IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(lib.Path, 24u);
-            if (lib.IconData != null)
-            {
-                lib.Icon = await lib.IconData.ToBitmapAsync();
-            }
-        }
-
         public void Dispose()
         {
-            Libraries.CollectionChanged -= Libraries_CollectionChanged;
         }
 
         public async Task EnumerateLibrariesAsync()
         {
-            try
+            librariesList.Clear();
+            var libs = await LibraryHelper.ListUserLibraries();
+            if (libs != null)
             {
-                await SyncLibrarySideBarItemsUI();
+                libs.Sort();
+                librariesList.AddRange(libs);
             }
-            catch (Exception) // UI Thread not ready yet, so we defer the pervious operation until it is.
-            {
-                System.Diagnostics.Debug.WriteLine($"RefreshUI Exception");
-                // Defer because UI-thread is not ready yet (and DriveItem requires it?)
-                CoreApplication.MainView.Activated += EnumerateLibrariesAsync;
-            }
+            DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
-        private void RemoveLibrariesSideBarSection()
-        {
-            try
-            {
-                var item = (from n in SidebarControl.SideBarItems where n.Text.Equals("SidebarLibraries".GetLocalized()) select n).FirstOrDefault();
-                if (!UserSettingsService.AppearanceSettingsService.ShowLibrarySection && item != null)
-                {
-                    SidebarControl.SideBarItems.Remove(item);
-                }
-            }
-            catch (Exception) { }
-        }
-
-        public async void UpdateLibrariesSectionVisibility()
-        {
-            if (UserSettingsService.AppearanceSettingsService.ShowLibrarySection)
-            {
-                await EnumerateLibrariesAsync();
-            }
-            else
-            {
-                RemoveLibrariesSideBarSection();
-            }
-        }
-
-        private async void EnumerateLibrariesAsync(CoreApplicationView sender, Windows.ApplicationModel.Activation.IActivatedEventArgs args)
-        {
-            await SyncLibrarySideBarItemsUI();
-            CoreApplication.MainView.Activated -= EnumerateLibrariesAsync;
-        }
-
-        public async Task HandleWin32LibraryEvent(ShellLibraryItem library, string oldPath)
+        public Task HandleWin32LibraryEvent(ShellLibraryItem library, string oldPath)
         {
             string path = oldPath;
             if (string.IsNullOrEmpty(oldPath))
             {
                 path = library?.FullPath;
             }
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            var changedLibrary = Libraries.FirstOrDefault(l => string.Equals(l.Path, path, StringComparison.OrdinalIgnoreCase));
+            if (changedLibrary != null)
             {
-                var changedLibrary = Libraries.FirstOrDefault(l => string.Equals(l.Path, path, StringComparison.OrdinalIgnoreCase));
-                if (changedLibrary != null)
-                {
-                    Libraries.Remove(changedLibrary);
-                }
-                // library is null in case it was deleted
-                if (library != null && !Libraries.Any(x => x.Path == library.FullPath))
-                {
-                    Libraries.AddSorted(new LibraryLocationItem(library));
-                }
-            });
-        }
-
-        private async Task SyncLibrarySideBarItemsUI()
-        {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+                librariesList.Remove(changedLibrary);
+                DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, changedLibrary));
+            }
+            // library is null in case it was deleted
+            if (library != null && !Libraries.Any(x => x.Path == library.FullPath))
             {
-                await SidebarControl.SideBarItemsSemaphore.WaitAsync();
-                try
-                {
-                    var section = SidebarControl.SideBarItems.FirstOrDefault(x => x.Text == "SidebarLibraries".GetLocalized()) as LocationItem;
-                    if (UserSettingsService.AppearanceSettingsService.ShowLibrarySection && section == null)
-                    {
-                        librarySection = new LocationItem
-                        {
-                            Text = "SidebarLibraries".GetLocalized(),
-                            Section = SectionType.Library,
-                            MenuOptions = new ContextMenuOptions
-                            {
-                                IsLibrariesHeader = true,
-                                ShowHideSection = true
-                            },
-                            SelectsOnInvoked = false,
-                            Icon = await UIHelpers.GetIconResource(Constants.ImageRes.Libraries),
-                            ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
-                        };
-                        var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0); // After favorites section
-                        SidebarControl.SideBarItems.BeginBulkOperation();
-                        SidebarControl.SideBarItems.Insert(Math.Min(index, SidebarControl.SideBarItems.Count), librarySection);
-                        SidebarControl.SideBarItems.EndBulkOperation();
-                    }
-                }
-                finally
-                {
-                    SidebarControl.SideBarItemsSemaphore.Release();
-                }
-
-                Libraries.BeginBulkOperation();
-                Libraries.Clear();
-                var libs = await LibraryHelper.ListUserLibraries();
-                if (libs != null)
-                {
-                    libs.Sort();
-                    Libraries.AddRange(libs);
-                }
-                Libraries.EndBulkOperation();
-            });
+                var index = librariesList.AddSorted(new LibraryLocationItem(library));
+                DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, library, index));
+            }
+            return Task.CompletedTask;
         }
 
         public bool TryGetLibrary(string path, out LibraryLocationItem library)
@@ -249,7 +99,8 @@ namespace Files.Uwp.Filesystem
             var newLib = await LibraryHelper.CreateLibrary(name);
             if (newLib != null)
             {
-                Libraries.AddSorted(newLib);
+                var index = librariesList.AddSorted(newLib);
+                DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, newLib, index));
                 return true;
             }
             return false;
@@ -263,7 +114,8 @@ namespace Files.Uwp.Filesystem
                 var libItem = Libraries.FirstOrDefault(l => string.Equals(l.Path, libraryPath, StringComparison.OrdinalIgnoreCase));
                 if (libItem != null)
                 {
-                    Libraries[Libraries.IndexOf(libItem)] = newLib;
+                    librariesList[librariesList.IndexOf(libItem)] = newLib;
+                    DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newLib));
                 }
                 return newLib;
             }

--- a/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
@@ -100,7 +100,12 @@ namespace Files.Uwp.Filesystem
                                 drivesList.Add(networkItem);
                             }
                         }
-                        DataChanged?.Invoke(SectionType.Network, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, networkItem));
+                    }
+                    foreach (var drive in Drives
+                        .OrderByDescending(o => string.Equals(o.Text, "Network".GetLocalized(), StringComparison.OrdinalIgnoreCase))
+                        .ThenBy(o => o.Text))
+                    {
+                        DataChanged?.Invoke(SectionType.Network, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, drive));
                     }
                 }
             }

--- a/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
@@ -2,20 +2,16 @@
 using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Uwp.Helpers;
 using Files.Backend.Services.Settings;
-using Files.Uwp.UserControls;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Uwp;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.AppService;
-using Windows.ApplicationModel.Core;
 using Windows.Foundation.Collections;
-using Windows.UI.Core;
-using Files.Shared;
+using System.Collections.Specialized;
 
 namespace Files.Uwp.Filesystem
 {
@@ -24,6 +20,8 @@ namespace Files.Uwp.Filesystem
         private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
 
         private readonly List<DriveItem> drivesList = new List<DriveItem>();
+
+        public EventHandler<NotifyCollectionChangedEventArgs> DataChanged;
 
         public IReadOnlyList<DriveItem> Drives
         {
@@ -57,6 +55,7 @@ namespace Files.Uwp.Filesystem
             {
                 drivesList.Add(networkItem);
             }
+            DataChanged?.Invoke(SectionType.Network, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, networkItem));
         }
 
         public async Task EnumerateDrivesAsync()
@@ -101,117 +100,9 @@ namespace Files.Uwp.Filesystem
                                 drivesList.Add(networkItem);
                             }
                         }
+                        DataChanged?.Invoke(SectionType.Network, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, networkItem));
                     }
                 }
-            }
-
-            await RefreshUI();
-        }
-
-        private async Task RefreshUI()
-        {
-            try
-            {
-                await SyncSideBarItemsUI();
-            }
-            catch (Exception) // UI Thread not ready yet, so we defer the pervious operation until it is.
-            {
-                System.Diagnostics.Debug.WriteLine($"RefreshUI Exception");
-                // Defer because UI-thread is not ready yet (and DriveItem requires it?)
-                CoreApplication.MainView.Activated += RefreshUI;
-            }
-        }
-
-        private async void RefreshUI(CoreApplicationView sender, Windows.ApplicationModel.Activation.IActivatedEventArgs args)
-        {
-            await SyncSideBarItemsUI();
-            CoreApplication.MainView.Activated -= RefreshUI;
-        }
-
-        private async Task SyncSideBarItemsUI()
-        {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
-            {
-                await SidebarControl.SideBarItemsSemaphore.WaitAsync();
-                try
-                {
-                    var section = SidebarControl.SideBarItems.FirstOrDefault(x => x.Text == "SidebarNetworkDrives".GetLocalized()) as LocationItem;
-                    if (UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection && section == null)
-                    {
-                        section = new LocationItem()
-                        {
-                            Text = "SidebarNetworkDrives".GetLocalized(),
-                            Section = SectionType.Network,
-                            MenuOptions = new ContextMenuOptions
-                            {
-                                ShowHideSection = true
-                            },
-                            SelectsOnInvoked = false,
-                            Icon = await UIHelpers.GetIconResource(Constants.ImageRes.NetworkDrives),
-                            ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
-                        };
-                        var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
-                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
-                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0) +
-                                    (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.CloudDrives) ? 1 : 0); // After cloud section
-                        SidebarControl.SideBarItems.BeginBulkOperation();
-                        SidebarControl.SideBarItems.Insert(Math.Min(index, SidebarControl.SideBarItems.Count), section);
-                        SidebarControl.SideBarItems.EndBulkOperation();
-                    }
-
-                    if (section != null)
-                    {
-                        foreach (var drive in Drives.ToList()
-                        .OrderByDescending(o => string.Equals(o.Text, "Network".GetLocalized(), StringComparison.OrdinalIgnoreCase))
-                        .ThenBy(o => o.Text))
-                        {
-                            if (!string.IsNullOrEmpty(drive.DeviceID))
-                            {
-                                drive.IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(drive.DeviceID, 24);
-                            }
-                            if (drive.IconData == null)
-                            {
-                                var resource = await UIHelpers.GetIconResourceInfo(Constants.ImageRes.Folder);
-                                drive.IconData = resource?.IconDataBytes;
-                            }
-                            drive.Icon = await drive.IconData.ToBitmapAsync();
-                            if (!section.ChildItems.Contains(drive))
-                            {
-                                section.ChildItems.Add(drive);
-                            }
-                        }
-                    }
-                }
-                finally
-                {
-                    SidebarControl.SideBarItemsSemaphore.Release();
-                }
-            });
-        }
-
-        private void RemoveNetworkDrivesSideBarSection()
-        {
-            try
-            {
-                var item = (from n in SidebarControl.SideBarItems where n.Text.Equals("SidebarNetworkDrives".GetLocalized()) select n).FirstOrDefault();
-                if (!UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection && item != null)
-                {
-                    SidebarControl.SideBarItems.Remove(item);
-                }
-            }
-            catch (Exception)
-            { }
-        }
-
-        public async void UpdateNetworkDrivesSectionVisibility()
-        {
-            if (UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection)
-            {
-                await EnumerateDrivesAsync();
-            }
-            else
-            {
-                RemoveNetworkDrivesSideBarSection();
             }
         }
     }

--- a/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -33,7 +33,7 @@ namespace Files.Uwp.Filesystem
             }
             else if (component.Contains(":", StringComparison.Ordinal))
             {
-                var allDrives = SidebarControl.SideBarItems.Where(x => (x as LocationItem)?.ChildItems != null).SelectMany(x => (x as LocationItem).ChildItems);
+                var allDrives = App.DrivesManager.Drives.Concat(App.NetworkDrivesManager.Drives).Concat(App.CloudDrivesManager.Drives);
                 return new PathBoxItem()
                 {
                     Title = allDrives.FirstOrDefault(y => y.ItemType == NavigationControlItemType.Drive && y.Path.Contains(component, StringComparison.OrdinalIgnoreCase)) != null ?

--- a/src/Files.Uwp/Filesystem/WSLDistroManager.cs
+++ b/src/Files.Uwp/Filesystem/WSLDistroManager.cs
@@ -1,16 +1,12 @@
 ﻿using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Backend.Services.Settings;
-using Files.Uwp.UserControls;
 using CommunityToolkit.Mvvm.DependencyInjection;
-using Microsoft.Toolkit.Uwp;
 using System;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
-using Windows.ApplicationModel.Core;
 using Windows.Storage;
-using Windows.UI.Core;
-using Files.Uwp.Helpers;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 
 namespace Files.Uwp.Filesystem
 {
@@ -18,142 +14,79 @@ namespace Files.Uwp.Filesystem
     {
         private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
 
+        private readonly List<WslDistroItem> distroList = new List<WslDistroItem>();
+
+        public EventHandler<NotifyCollectionChangedEventArgs> DataChanged;
+
+        public IReadOnlyList<WslDistroItem> Distros
+        {
+            get
+            {
+                lock (distroList)
+                {
+                    return distroList.ToList().AsReadOnly();
+                }
+            }
+        }
+
         public async Task EnumerateDrivesAsync()
         {
+            if (!UserSettingsService.AppearanceSettingsService.ShowWslSection)
+            {
+                return;
+            }
+
             try
             {
-                await SyncSideBarItemsUI();
-            }
-            catch (Exception) // UI Thread not ready yet, so we defer the pervious operation until it is.
-            {
-                System.Diagnostics.Debug.WriteLine($"RefreshUI Exception");
-                // Defer because UI-thread is not ready yet (and DriveItem requires it?)
-                CoreApplication.MainView.Activated += EnumerateDrivesAsync;
-            }
-        }
-
-        private async void EnumerateDrivesAsync(CoreApplicationView sender, Windows.ApplicationModel.Activation.IActivatedEventArgs args)
-        {
-            await SyncSideBarItemsUI();
-            CoreApplication.MainView.Activated -= EnumerateDrivesAsync;
-        }
-
-        private async Task SyncSideBarItemsUI()
-        {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
-            {
-                await SidebarControl.SideBarItemsSemaphore.WaitAsync();
-                try
+                var distroFolder = await StorageFolder.GetFolderFromPathAsync(@"\\wsl$\");
+                foreach (StorageFolder folder in await distroFolder.GetFoldersAsync())
                 {
-                    var distroFolder = await StorageFolder.GetFolderFromPathAsync(@"\\wsl$\");
-                    if ((await distroFolder.GetFoldersAsync()).Count != 0)
+                    Uri logoURI = null;
+                    if (folder.DisplayName.Contains("ubuntu", StringComparison.OrdinalIgnoreCase))
                     {
-                        var section = SidebarControl.SideBarItems.FirstOrDefault(x => x.Text == "WSL".GetLocalized()) as LocationItem;
-                        if (UserSettingsService.AppearanceSettingsService.ShowWslSection && section == null)
-                        {
-                            section = new LocationItem()
-                            {
-                                Text = "WSL".GetLocalized(),
-                                Section = SectionType.WSL,
-                                MenuOptions = new ContextMenuOptions
-                                {
-                                    ShowHideSection = true
-                                },
-                                SelectsOnInvoked = false,
-                                Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/WSL/genericpng.png")),
-                                ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
-                            };
-                            var index = (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
-                                        (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
-                                        (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0) +
-                                        (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.CloudDrives) ? 1 : 0) +
-                                        (SidebarControl.SideBarItems.Any(item => item.Section == SectionType.Network) ? 1 : 0); // After network section
-                            SidebarControl.SideBarItems.BeginBulkOperation();
-                            SidebarControl.SideBarItems.Insert(Math.Min(index, SidebarControl.SideBarItems.Count), section);
-                            SidebarControl.SideBarItems.EndBulkOperation();
-                        }
-
-                        if (section != null)
-                        {
-                            foreach (StorageFolder folder in await distroFolder.GetFoldersAsync())
-                            {
-                                Uri logoURI = null;
-                                if (folder.DisplayName.Contains("ubuntu", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    logoURI = new Uri("ms-appx:///Assets/WSL/ubuntupng.png");
-                                }
-                                else if (folder.DisplayName.Contains("kali", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    logoURI = new Uri("ms-appx:///Assets/WSL/kalipng.png");
-                                }
-                                else if (folder.DisplayName.Contains("debian", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    logoURI = new Uri("ms-appx:///Assets/WSL/debianpng.png");
-                                }
-                                else if (folder.DisplayName.Contains("opensuse", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    logoURI = new Uri("ms-appx:///Assets/WSL/opensusepng.png");
-                                }
-                                else if (folder.DisplayName.Contains("alpine", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    logoURI = new Uri("ms-appx:///Assets/WSL/alpinepng.png");
-                                }
-                                else
-                                {
-                                    logoURI = new Uri("ms-appx:///Assets/WSL/genericpng.png");
-                                }
-
-                                if (!section.ChildItems.Any(x => x.Path == folder.Path))
-                                {
-                                    section.ChildItems.Add(new WslDistroItem()
-                                    {
-                                        Text = folder.DisplayName,
-                                        Path = folder.Path,
-                                        Logo = logoURI,
-                                        MenuOptions = new ContextMenuOptions
-                                        {
-                                            IsLocationItem = true
-                                        }
-                                    });
-                                }
-                            }
-                        }
+                        logoURI = new Uri("ms-appx:///Assets/WSL/ubuntupng.png");
                     }
-                }
-                catch (Exception)
-                {
-                    // WSL Not Supported/Enabled
-                }
-                finally
-                {
-                    SidebarControl.SideBarItemsSemaphore.Release();
-                }
-            });
-        }
+                    else if (folder.DisplayName.Contains("kali", StringComparison.OrdinalIgnoreCase))
+                    {
+                        logoURI = new Uri("ms-appx:///Assets/WSL/kalipng.png");
+                    }
+                    else if (folder.DisplayName.Contains("debian", StringComparison.OrdinalIgnoreCase))
+                    {
+                        logoURI = new Uri("ms-appx:///Assets/WSL/debianpng.png");
+                    }
+                    else if (folder.DisplayName.Contains("opensuse", StringComparison.OrdinalIgnoreCase))
+                    {
+                        logoURI = new Uri("ms-appx:///Assets/WSL/opensusepng.png");
+                    }
+                    else if (folder.DisplayName.Contains("alpine", StringComparison.OrdinalIgnoreCase))
+                    {
+                        logoURI = new Uri("ms-appx:///Assets/WSL/alpinepng.png");
+                    }
+                    else
+                    {
+                        logoURI = new Uri("ms-appx:///Assets/WSL/genericpng.png");
+                    }
 
-        private void RemoveWslSideBarSection()
-        {
-            try
-            {
-                var item = (from n in SidebarControl.SideBarItems where n.Text.Equals("WSL".GetLocalized()) select n).FirstOrDefault();
-                if (!UserSettingsService.AppearanceSettingsService.ShowWslSection && item != null)
-                {
-                    SidebarControl.SideBarItems.Remove(item);
+                    if (!distroList.Any(x => x.Path == folder.Path))
+                    {
+                        var distro = new WslDistroItem()
+                        {
+                            Text = folder.DisplayName,
+                            Path = folder.Path,
+                            Logo = logoURI,
+                            MenuOptions = new ContextMenuOptions
+                            {
+                                IsLocationItem = true
+                            }
+                        };
+                        distroList.Add(distro);
+                        DataChanged?.Invoke(SectionType.WSL, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, distro));
+                    }
                 }
             }
             catch (Exception)
-            { }
-        }
-
-        public async void UpdateWslSectionVisibility()
-        {
-            if (UserSettingsService.AppearanceSettingsService.ShowWslSection)
             {
-                await EnumerateDrivesAsync();
-            }
-            else
-            {
-                RemoveWslSideBarSection();
+                // WSL Not Supported/Enabled
             }
         }
     }

--- a/src/Files.Uwp/MultilingualResources/Files.af.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.af.xlf
@@ -334,10 +334,6 @@
           <source>Application</source>
           <target state="translated">Toepassing</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Stelsel</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Nuwe Omslag</target>
@@ -441,22 +437,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Het jy hierdie omslag geskrap?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Die lêer wat jy probeer skrap word tans deur 'n ander toepassing gebruik.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Lêer is in gebruik</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Probeer weer</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -965,10 +945,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Fout</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Probeer weer</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3528,6 +3504,46 @@ Ons gebruik App Center om tred te hou met programgebruik, foute te vind en ongel
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.ar.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.ar.xlf
@@ -275,10 +275,6 @@
           <source>Application</source>
           <target state="translated" state-qualifier="tm-suggestion">التطبيق</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated" state-qualifier="tm-suggestion">النظام</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated" state-qualifier="tm-suggestion">مجلد جديد</target>
@@ -389,22 +385,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">هل قمت بحذف هذا الملف؟</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">الملف الذي تحاول حذفه يتم حاليا استخذامه عبر برنامج اخر</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">الملف قيد الاستخدام</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated" state-qualifier="tm-suggestion">حاول مرة أخرى</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated" state-qualifier="tm-suggestion">موافق</target>
         </trans-unit>
         <trans-unit id="PropertiesDialogReadOnly.Text" translate="yes" xml:space="preserve">
           <source>Read-only</source>
@@ -873,10 +853,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated" state-qualifier="tm-suggestion">خطأ</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated" state-qualifier="tm-suggestion">إعادة المحاولة</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3542,6 +3518,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.bg.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.bg.xlf
@@ -334,10 +334,6 @@
           <source>Application</source>
           <target state="translated">Приложение</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Система</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Нова папка</target>
@@ -441,22 +437,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Изтрихте ли тази папка?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Файлът, който се опитвате да изтриете, в момента се използва от друго приложение.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Файлът се използва</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Опитай отново</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">Добре</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -967,10 +947,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Грешка</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Опитай отново</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3526,6 +3502,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.ca.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.ca.xlf
@@ -326,10 +326,6 @@
           <source>Application</source>
           <target state="translated">Aplicació</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Sistema</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Nova carpeta</target>
@@ -436,22 +432,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Vas esborrar aquesta carpeta?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">L'arxiu que intentes esborrar està en ús per una altra aplicació.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">L'arxiu està en ús</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Torna-ho a provar</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="new">OK</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -949,10 +929,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="new">Error</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Reintenta-ho</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3521,6 +3497,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.da-DK.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.da-DK.xlf
@@ -274,10 +274,6 @@
           <source>Application</source>
           <target state="translated">Applikation</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">System</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Ny mappe</target>
@@ -388,22 +384,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Har du slettet denne mappe?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Den fil, du prøver at slette, bruges i øjeblikket af et andet program.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Fil er i brug</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Prøv igen</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="PropertiesDialogReadOnly.Text" translate="yes" xml:space="preserve">
           <source>Read-only</source>
@@ -871,10 +851,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Fejl</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Forsøg igen</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3545,6 +3521,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.da.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.da.xlf
@@ -275,10 +275,6 @@
           <source>Application</source>
           <target state="translated">Applikation</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">System</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Ny mappe</target>
@@ -389,22 +385,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Har du slettet denne mappe?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Den fil, du prøver at slette, bruges i øjeblikket af et andet program.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Fil er i brug</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Prøv igen</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="PropertiesDialogReadOnly.Text" translate="yes" xml:space="preserve">
           <source>Read-only</source>
@@ -873,10 +853,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Fejl</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Forsøg igen</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3542,6 +3518,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.de-DE.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.de-DE.xlf
@@ -222,10 +222,6 @@
           <source>Application</source>
           <target state="translated">Anwendung</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">System</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Neuer Ordner</target>
@@ -369,22 +365,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Haben Sie diesen Ordner gelöscht?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Die Datei, die Sie löschen möchten, wird gerade von einer anderen Anwendung verwendet.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Datei wird bereits verwendet</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Erneut versuchen</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1262,10 +1242,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Fehler</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Wiederholen</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3531,6 +3507,46 @@ Wir benutzen das App Center, um einen Überblick über die Nutzung von Files zu 
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="translated">Tags anzeigen</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.el.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.el.xlf
@@ -326,10 +326,6 @@
           <source>Application</source>
           <target state="translated">Εφαρμογή</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Σύστημα</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Νέος φάκελος</target>
@@ -433,22 +429,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Διαγράψατε αυτόν τον φάκελο;</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Το αρχείο που προσπαθείτε να διαγράψετε χρησιμοποιείται επί του παρόντος από μια άλλη εφαρμογή.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Το αρχείο είναι σε χρήση</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Δοκιμάστε ξανά</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">Εντάξει</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -946,10 +926,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Σφάλμα</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Επανάληψη</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3523,6 +3499,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.en-GB.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.en-GB.xlf
@@ -330,10 +330,6 @@
           <source>Application</source>
           <target state="translated" state-qualifier="tm-suggestion">Application</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated" state-qualifier="tm-suggestion">System</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated" state-qualifier="tm-suggestion">New Folder</target>
@@ -437,22 +433,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Did you delete this folder?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">The file you're trying to delete is currently being used by an another application.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">File is in use</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated" state-qualifier="tm-suggestion">Try again</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated" state-qualifier="tm-suggestion">OK</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -961,10 +941,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated" state-qualifier="tm-suggestion">Error</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated" state-qualifier="tm-suggestion">Retry</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3526,6 +3502,46 @@ We use App Center to keep track of app usage, find bugs, and fix crashes. All in
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.es-419.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.es-419.xlf
@@ -298,10 +298,6 @@
           <source>Application</source>
           <target state="translated">Aplicación</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Sistema</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Nueva Carpeta</target>
@@ -405,22 +401,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">¿Ha eliminado esta carpeta?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">La acción no se puede completar porque otro programa tiene abierto el archivo.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Archivo en uso</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Reintentar</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">Aceptar</target>
         </trans-unit>
         <trans-unit id="NavToolbarSelectionOptions.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Selection options</source>
@@ -893,10 +873,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Error</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Reintentar</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3527,6 +3503,46 @@ Usamos App Center para realizar un seguimiento del uso de la aplicación, encont
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.es-ES.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.es-ES.xlf
@@ -222,10 +222,6 @@
           <source>Application</source>
           <target state="translated">Aplicación</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Sistema</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Nueva Carpeta</target>
@@ -369,22 +365,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">¿Has eliminado esta carpeta?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">La acción no se puede completar porque otro programa tiene abierto el archivo.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Archivo en uso</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Reintentar</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">Aceptar</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1261,10 +1241,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Error</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Reintentar</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3530,6 +3506,46 @@ Utilizamos App Center para hacer un seguimiento del uso de la aplicación, encon
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.fr-FR.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.fr-FR.xlf
@@ -1238,10 +1238,6 @@
           <source>Error</source>
           <target state="translated">Erreur</target>
         </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Réessayer</target>
-        </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
           <target state="translated" state-qualifier="tm-suggestion">Fermer quand même</target>
@@ -3527,6 +3523,14 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
           <source>Show thumbnails</source>
           <target state="translated">Afficher les vignettes</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.he-IL.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.he-IL.xlf
@@ -271,10 +271,6 @@
           <source>Application</source>
           <target state="translated" state-qualifier="tm-suggestion">אפליקציה</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated" state-qualifier="tm-suggestion">מערכת</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated" state-qualifier="tm-suggestion">תיקיה חדשה</target>
@@ -377,22 +373,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">האם מחקת תיקיה זו?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">הקובץ אותו אתה מנסה למחוק נמצא בשימוש של תוכנה אחרת</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">הקובץ בשימוש</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated" state-qualifier="tm-suggestion">נסה שוב</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated" state-qualifier="tm-suggestion">אישור</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1270,10 +1250,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated" state-qualifier="tm-suggestion">שגיאה</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated" state-qualifier="tm-suggestion">נסה שנית</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3530,6 +3506,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.hi-IN.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.hi-IN.xlf
@@ -275,10 +275,6 @@
           <source>Application</source>
           <target state="translated">एप्लिकेसन्</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">सिस्टम</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">नया फ़ोल्डर</target>
@@ -385,22 +381,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">क्या आपने इस फ़ोल्डर को हटा दिया?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">आप जिस फ़ाइल को हटाने की कोशिश कर रहे हैं, वह वर्तमान में किसी अन्य एप्लिकेशन द्वारा इस्तेमाल की जा रही है।</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">फ़ाइल उपयोग में है</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">फिर कोशिश करें</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">ठीक है</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1279,10 +1259,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">त्रुटि</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">पुनः प्रयास करें</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3536,6 +3512,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.hr-HR.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.hr-HR.xlf
@@ -330,10 +330,6 @@
           <source>Application</source>
           <target state="translated">Aplikacija</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Sustav</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Nova mapa</target>
@@ -437,22 +433,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Jeste li izbrisali ovu mapu?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Datoteku koju pokušavate izbrisati trenutno koristi druga aplikacija.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Datoteka je u upotrebi</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Pokušaj ponovno</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">U redu</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -961,10 +941,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Greška</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Pokušaj ponovno</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3528,6 +3504,46 @@ Koristimo App Center za praćenje korištenja aplikacija, pronalaženje grešaka
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.hu-HU.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.hu-HU.xlf
@@ -270,10 +270,6 @@
           <source>Application</source>
           <target state="translated">Alkalmazás</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Rendszer</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Új mappa</target>
@@ -373,22 +369,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Ön törölte ezt a mappát?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">A törölni kívánt fájl jelenleg használatban van.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">A fájl használatban van</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Újra</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1261,10 +1241,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Hiba</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Újra</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3528,6 +3504,46 @@ Az App Center szolgáltatásait használjuk az app használatának monitorozás�
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.id-ID.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.id-ID.xlf
@@ -282,10 +282,6 @@
           <source>Application</source>
           <target state="translated">Aplikasi</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Sistem</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Folder Baru</target>
@@ -389,22 +385,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Apakah Anda menghapus folder ini?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Berkas yang Anda coba hapus sedang digunakan oleh aplikasi lain.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Berkas sedang digunakan</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Coba lagi</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">Iya</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -881,10 +861,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Kesalahan</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Coba lagi</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3530,6 +3506,46 @@ Kami menggunakan Pusat App untuk melacak penggunaan aplikasi, menemukan bug, dan
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="translated">Tampilkan bagian penanda</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.ja-JP.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.ja-JP.xlf
@@ -266,10 +266,6 @@
           <source>Application</source>
           <target state="translated">アプリ</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">システム</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">新しいフォルダー</target>
@@ -369,22 +365,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">このフォルダーを削除しましたか?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">削除しようとしているファイルは他のプログラムによって使用されています。</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">ファイルは使用中です</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">再試行</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1261,10 +1241,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">エラー</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">再試行</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3521,6 +3497,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.ka.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.ka.xlf
@@ -322,10 +322,6 @@
           <source>Application</source>
           <target state="translated">აპლიკაცია</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">სისტემა</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">ახალი საქაღალდე</target>
@@ -429,22 +425,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">თქვენ წაშალეთ ეს საქაღალდე?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">ფაილი, რომლის წაშლასაც თქვენ ცდილობთ, ამჟამად სხვა პროგრამა იყენებს.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">ფაილი გამოიყენება</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">სცადეთ ხელახლა</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">კარგი</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -941,10 +921,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">შეცდომა</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">სცადეთ ხელახლა</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3529,6 +3505,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.ko-KR.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.ko-KR.xlf
@@ -222,10 +222,6 @@
           <source>Application</source>
           <target state="translated">응용 프로그램</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">시스템</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">새 폴더</target>
@@ -357,22 +353,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">폴더를 삭제하셨나요?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">파일이 다른 프로그램에서 사용되고 있어 삭제할 수 없습니다.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">파일이 사용 중</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">다시 시도</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">확인</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -865,10 +845,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">오류</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">다시 시도</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3521,6 +3497,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="translated">태그 섹션 보이기</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.lv-LV.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.lv-LV.xlf
@@ -282,10 +282,6 @@
           <source>Application</source>
           <target state="translated">Lietojumprogramma</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Sistēma</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Jauna mape</target>
@@ -389,22 +385,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Vai Jūs izdzēsāt šo mapi?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Fails, kuru mēģināt dzēst, tiek izmantots citā lietotnē.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Fails tiek lietots</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Mēģināt vēlreiz</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="PropertiesDialogReadOnly.Text" translate="yes" xml:space="preserve">
           <source>Read-only</source>
@@ -869,10 +849,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Kļūda</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Mēģināt vēlreiz</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3528,6 +3504,46 @@ Mēs lietojam App Center, lai sekotu līdzi programmas lietojumam, atrastu un no
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.nb-NO.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.nb-NO.xlf
@@ -274,10 +274,6 @@
           <source>Application</source>
           <target state="translated">Applikasjon</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">System</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Ny mappe</target>
@@ -381,22 +377,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Har du slettet denne mappen?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Filen du forsøker å slette er i bruk av en annen applikasjon.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Filen er i bruk</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Prøv igjen</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="PropertiesDialogReadOnly.Text" translate="yes" xml:space="preserve">
           <source>Read-only</source>
@@ -861,10 +841,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Feil</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Prøv igjen</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3528,6 +3504,46 @@ Vi bruker App Center for å spore app-bruk og for å finne/reparere feil. All in
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.nl-NL.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.nl-NL.xlf
@@ -222,10 +222,6 @@
           <source>Application</source>
           <target state="translated" state-qualifier="tm-suggestion">Toepassing</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated" state-qualifier="tm-suggestion">Systeem</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Nieuwe map</target>
@@ -372,22 +368,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Is deze map verwijderd?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Het bestand dat u probeert te verwijderen, wordt momenteel gebruikt door een andere toepassing.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Bestand in gebruik</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated" state-qualifier="tm-suggestion">Opnieuw proberen</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1265,10 +1245,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated" state-qualifier="tm-suggestion">Foutmelding</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated" state-qualifier="tm-suggestion">Opnieuw</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3546,6 +3522,46 @@ We gebruiken App Center om app-gebruik bij te houden, bugs te vinden en crashes 
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.or-IN.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.or-IN.xlf
@@ -275,10 +275,6 @@
           <source>Application</source>
           <target state="translated">ଆପ୍ଲିକେସନ</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">ସିଷ୍ଟମ୍</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">ନୂତନ ଫୋଲ୍ଡର</target>
@@ -385,22 +381,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">ଆପଣ ଏହି ଫୋଲ୍ଡରକୁ ଡିଲିଟ୍ କରିଛନ୍ତି କି?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">ଆପଣ ବିଲୋପ କରିବାକୁ ଚେଷ୍ଟା କରୁଥିବା ଫାଇଲ୍ ବର୍ତ୍ତମାନ ଅନ୍ୟ ଏକ ଆପ୍ଲିକେସନ ଦ୍ୱାରା ବ୍ୟବହୃତ ହେଉଛି |</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">ଫାଇଲ୍ ବ୍ୟବହାରରେ ଅଛି</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">ପୁଣିଥରେ ଚେଷ୍ଟା କରନ୍ତୁ</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">ଠିକ୍ ଅଛି</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1279,10 +1259,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">ତ୍ରୁଟି</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">ପୁନଃଚେଷ୍ଟା</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3535,6 +3511,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.pl-PL.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.pl-PL.xlf
@@ -222,10 +222,6 @@
           <source>Application</source>
           <target state="translated" state-qualifier="tm-suggestion">Aplikacja</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated" state-qualifier="tm-suggestion">Systemowy</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated" state-qualifier="tm-suggestion">Nowy folder</target>
@@ -369,22 +365,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Czy usunąłeś ten folder?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Plik, który próbujesz usunąć, jest obecnie używany przez inną aplikację.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Plik jest w użyciu</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Spróbuj ponownie</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1261,10 +1241,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Błąd</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Ponów</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3521,6 +3497,46 @@ Korzystamy z App Center, aby monitotować używane ustawienia, znajdować błęd
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.pt-BR.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.pt-BR.xlf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en-US" target-language="pt-BR" original="FILES.UWP/STRINGS/EN-US/RESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
     <header>
@@ -270,10 +270,6 @@
           <source>Application</source>
           <target state="translated">Aplicativo</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Sistema</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Nova pasta</target>
@@ -373,22 +369,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Você excluiu esta pasta?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">O arquivo que você está tentando excluir está sendo usado por outro aplicativo.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">O arquivo está sendo usado</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Tentar novamente</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1261,10 +1241,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Erro</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Repetir</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3517,6 +3493,46 @@ Usamos o App Center para rastrear quais configurações estão sendo usadas, enc
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="translated">Mostrar a seção de Etiquetas</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.pt-PT.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.pt-PT.xlf
@@ -270,10 +270,6 @@
           <source>Application</source>
           <target state="translated">Aplicação</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Sistema</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Nova Pasta</target>
@@ -373,22 +369,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Pretende eliminar esta pasta?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">O ficheiro que você está tentando eliminar está sendo utilizado por uma aplicação.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">O ficheiro está em uso</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Tentar novamente</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1261,10 +1241,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Erro</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Tentar Novamente</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3517,6 +3493,46 @@ Utilizamos o App Center para localizar as definições que estão a ser utilizad
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="translated">Mostrar secção Tags</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.ru-RU.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.ru-RU.xlf
@@ -222,10 +222,6 @@
           <source>Application</source>
           <target state="translated">По умолчанию</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Как в системе</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Новая папка</target>
@@ -369,22 +365,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Вы удалили эту папку?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Файл, который Вы пытаетесь удалить, в настоящее время используется другим приложением.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Файл используется</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Повторить</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1261,10 +1241,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Ошибка</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Повторить</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3518,6 +3494,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="translated">Показывать Секцию Меток</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.sk-SK.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.sk-SK.xlf
@@ -274,10 +274,6 @@
           <source>Application</source>
           <target state="translated">Aplikácia</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Systém</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Nový priečinok</target>
@@ -381,22 +377,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Odstránili ste tento priečinok?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Súbor, ktorý sa snažíte odstrániť používa iná aplikácia.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Súbor sa používa</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Skúsiť znova</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="PropertiesDialogReadOnly.Text" translate="yes" xml:space="preserve">
           <source>Read-only</source>
@@ -861,10 +841,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Chyba</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Skúsiť znova</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3529,6 +3505,46 @@ Centrum aplikácií používame na sledovanie používania aplikácií, vyhľad�
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.sv-SE.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.sv-SE.xlf
@@ -279,10 +279,6 @@
           <source>Application</source>
           <target state="translated">App</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">System</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Ny mapp</target>
@@ -393,22 +389,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Tog du bort den här mappen?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Filen som du försöker ta bort används av ett annat program.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Filen används</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Försök igen</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="PropertiesDialogReadOnly.Text" translate="yes" xml:space="preserve">
           <source>Read-only</source>
@@ -877,10 +857,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Fel</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Försök igen</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3543,6 +3519,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.ta.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.ta.xlf
@@ -266,10 +266,6 @@
           <source>Application</source>
           <target state="translated">பயன்பாடு</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">முறைமை</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">புதியக் கோப்புறை</target>
@@ -369,22 +365,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">நீங்கள் இந்தக் கோப்புறையை நீக்கீவிட்டீர்களா?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">நீங்கள் நீக்க முயற்சிக்கும் கோப்பானது தற்போது பயன்பாட்டில் உள்ளது.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">கோப்புப் பயன்பாட்டில் உள்ளது</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">மீண்டும் முயலவும்</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">சரி</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1263,10 +1243,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="needs-review-translation" state-qualifier="tm-suggestion">பிழை</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="needs-review-translation" state-qualifier="tm-suggestion">மறுமுயற்சி</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3519,6 +3495,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.tr-TR.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.tr-TR.xlf
@@ -222,10 +222,6 @@
           <source>Application</source>
           <target state="translated">Uygulama</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Sistem</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Yeni Klasör</target>
@@ -372,22 +368,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Bu klasörü sildiniz mi?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Silmeye çalıştığınız dosya şu anda başka bir uygulama tarafından kullanılıyor.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Dosya kullanılıyor</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Yeniden dene</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">Tamam</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1264,10 +1244,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Hata</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Yeniden Dene</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3542,6 +3518,46 @@ Uygulama kullanımını takip etmek, hataları bulmak ve çökmeleri düzeltmek 
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.uk-UA.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.uk-UA.xlf
@@ -223,10 +223,6 @@
           <source>Application</source>
           <target state="translated">За замовчуванням</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Системний</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Нова папка</target>
@@ -377,22 +373,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Ви видалили цю папку?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Файл, який ви намагаєтесь видалити, зараз використовується іншою програмою.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Файл використовується</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">Повторити</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
@@ -1274,10 +1254,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Помилка</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Повторити</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3543,6 +3519,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.vi.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.vi.xlf
@@ -326,10 +326,6 @@
           <source>Application</source>
           <target state="translated">Ứng dụng</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">Hệ thống</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">Thư mục Mới</target>
@@ -436,22 +432,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">Bạn có xóa bỏ thư mục này không?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">Tệp bạn đang cố gắng để xóa bỏ đang có ứng dụng khác sử dụng.</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">Tệp đang sử dụng</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated" state-qualifier="tm-suggestion">Thử lại</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">Đồng ý</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -949,10 +929,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">Lỗi</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">Thử lại</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3544,6 +3520,46 @@ Chúng tôi sử dụng Trung tâm ứng dụng để theo dõi việc sử dụ
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.zh-Hans.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.zh-Hans.xlf
@@ -342,10 +342,6 @@
           <source>Application</source>
           <target state="translated">应用</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">系统</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">新建文件夹</target>
@@ -449,22 +445,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">确实要删除此文件夹吗？</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">删除目标文件正被其他应用程序使用。</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">文件正在使用</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">重试</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">确定</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -973,10 +953,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">错误</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">重试</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3515,6 +3491,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="translated">显示标签</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/MultilingualResources/Files.zh-Hant.xlf
+++ b/src/Files.Uwp/MultilingualResources/Files.zh-Hant.xlf
@@ -342,10 +342,6 @@
           <source>Application</source>
           <target state="translated">應用程式</target>
         </trans-unit>
-        <trans-unit id="SystemTimeStye" translate="yes" xml:space="preserve">
-          <source>System</source>
-          <target state="translated">系統</target>
-        </trans-unit>
         <trans-unit id="NewFolder" translate="yes" xml:space="preserve">
           <source>New Folder</source>
           <target state="translated">新增資料夾</target>
@@ -449,22 +445,6 @@
         <trans-unit id="FolderNotFoundDialog.Title" translate="yes" xml:space="preserve">
           <source>Did you delete this folder?</source>
           <target state="translated">您把資料夾刪除了嗎?</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Text" translate="yes" xml:space="preserve">
-          <source>The file you're trying to delete is currently being used by an another application.</source>
-          <target state="translated">欲刪除的檔案正被其他應用程式使用。</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.Title" translate="yes" xml:space="preserve">
-          <source>File is in use</source>
-          <target state="translated">檔案使用中</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Try again</source>
-          <target state="translated">重試</target>
-        </trans-unit>
-        <trans-unit id="FileInUseDeleteDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
-          <source>OK</source>
-          <target state="translated">確定</target>
         </trans-unit>
         <trans-unit id="NavToolbarLayout.Text" translate="yes" xml:space="preserve">
           <source>Layout</source>
@@ -973,10 +953,6 @@
         <trans-unit id="PropertySaveErrorDialog.Title" translate="yes" xml:space="preserve">
           <source>Error</source>
           <target state="translated">錯誤</target>
-        </trans-unit>
-        <trans-unit id="PropertySaveErrorDialog.PrimaryButtonText" translate="yes" xml:space="preserve">
-          <source>Retry</source>
-          <target state="translated">重試</target>
         </trans-unit>
         <trans-unit id="PropertySaveErrorDialog.SecondaryButtonText" translate="yes" xml:space="preserve">
           <source>Close anyway</source>
@@ -3517,6 +3493,46 @@ We use App Center to track which settings are being used, find bugs, and fix cra
         <trans-unit id="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" translate="yes" xml:space="preserve">
           <source>Show Tags section</source>
           <target state="new">Show Tags section</target>
+        </trans-unit>
+        <trans-unit id="SystemTimeStyle" translate="yes" xml:space="preserve">
+          <source>System</source>
+          <target state="new">System</target>
+        </trans-unit>
+        <trans-unit id="FileInUseByDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by {0}</source>
+          <target state="new">The file you are attempting to access is currently being used by {0}</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Text" translate="yes" xml:space="preserve">
+          <source>The file you are attempting to access is currently being used by an another application</source>
+          <target state="new">The file you are attempting to access is currently being used by an another application</target>
+        </trans-unit>
+        <trans-unit id="FileInUseDialog.Title" translate="yes" xml:space="preserve">
+          <source>File is in use</source>
+          <target state="new">File is in use</target>
+        </trans-unit>
+        <trans-unit id="UseCompactStyles" translate="yes" xml:space="preserve">
+          <source>Use compact styles in the details layout</source>
+          <target state="new">Use compact styles in the details layout</target>
+        </trans-unit>
+        <trans-unit id="Universal" translate="yes" xml:space="preserve">
+          <source>Universal</source>
+          <target state="new">Universal</target>
+        </trans-unit>
+        <trans-unit id="DateFormatSample" translate="yes" xml:space="preserve">
+          <source>ex: {0}, {1}</source>
+          <target state="new">ex: {0}, {1}</target>
+        </trans-unit>
+        <trans-unit id="SettingsFilesAndFoldersShowThumbnails" translate="yes" xml:space="preserve">
+          <source>Show thumbnails</source>
+          <target state="new">Show thumbnails</target>
+        </trans-unit>
+        <trans-unit id="Retry" translate="yes" xml:space="preserve">
+          <source>Retry</source>
+          <target state="new">Retry</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogUnsupportedMoveOperation" translate="yes" xml:space="preserve">
+          <source>Move operation is not supported in this context. Do you want to copy the items instead?</source>
+          <target state="new">Move operation is not supported in this context. Do you want to copy the items instead?</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Files.Uwp/Strings/af/Resources.resw
+++ b/src/Files.Uwp/Strings/af/Resources.resw
@@ -258,9 +258,6 @@
   <data name="Application" xml:space="preserve">
     <value>Toepassing</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Stelsel</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nuwe Omslag</value>
   </data>
@@ -338,18 +335,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Het jy hierdie omslag geskrap?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Die lêer wat jy probeer skrap word tans deur 'n ander toepassing gebruik.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Lêer is in gebruik</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Probeer weer</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>Uitleg</value>
@@ -731,9 +716,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Fout</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Probeer weer</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Sluit in elk geval</value>

--- a/src/Files.Uwp/Strings/ar/Resources.resw
+++ b/src/Files.Uwp/Strings/ar/Resources.resw
@@ -213,9 +213,6 @@
   <data name="Application" xml:space="preserve">
     <value>التطبيق</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>النظام</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>مجلد جديد</value>
   </data>
@@ -290,18 +287,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>هل قمت بحذف هذا الملف؟</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>الملف الذي تحاول حذفه يتم حاليا استخذامه عبر برنامج اخر</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>الملف قيد الاستخدام</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>حاول مرة أخرى</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>موافق</value>
   </data>
   <data name="PropertiesDialogReadOnly.Text" xml:space="preserve">
     <value>للقراءة فقط</value>
@@ -650,9 +635,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>خطأ</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>إعادة المحاولة</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>إغلاق على أي حال</value>

--- a/src/Files.Uwp/Strings/bg/Resources.resw
+++ b/src/Files.Uwp/Strings/bg/Resources.resw
@@ -258,9 +258,6 @@
   <data name="Application" xml:space="preserve">
     <value>Приложение</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Система</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Нова папка</value>
   </data>
@@ -338,18 +335,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Изтрихте ли тази папка?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Файлът, който се опитвате да изтриете, в момента се използва от друго приложение.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Файлът се използва</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Опитай отново</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>Добре</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>Оформление</value>
@@ -725,9 +710,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Грешка</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Опитай отново</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Затвори въпреки това</value>

--- a/src/Files.Uwp/Strings/ca/Resources.resw
+++ b/src/Files.Uwp/Strings/ca/Resources.resw
@@ -243,9 +243,6 @@
   <data name="Application" xml:space="preserve">
     <value>Aplicació</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Sistema</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nova carpeta</value>
   </data>
@@ -320,15 +317,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Vas esborrar aquesta carpeta?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>L'arxiu que intentes esborrar està en ús per una altra aplicació.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>L'arxiu està en ús</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Torna-ho a provar</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>Diseny</value>
@@ -674,9 +662,6 @@
   </data>
   <data name="PropertySaveErrorMessage.Text" xml:space="preserve">
     <value>Ha hagut un problema desant algunes propietats.</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Reintenta-ho</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Tanca de totes maneres</value>

--- a/src/Files.Uwp/Strings/da-DK/Resources.resw
+++ b/src/Files.Uwp/Strings/da-DK/Resources.resw
@@ -213,9 +213,6 @@
   <data name="Application" xml:space="preserve">
     <value>Applikation</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>System</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Ny mappe</value>
   </data>
@@ -293,18 +290,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Har du slettet denne mappe?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Den fil, du prøver at slette, bruges i øjeblikket af et andet program.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Fil er i brug</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Prøv igen</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="PropertiesDialogReadOnly.Text" xml:space="preserve">
     <value>Skrivebeskyttet</value>
@@ -653,9 +638,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Fejl</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Forsøg igen</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Luk alligevel</value>

--- a/src/Files.Uwp/Strings/da/Resources.resw
+++ b/src/Files.Uwp/Strings/da/Resources.resw
@@ -213,9 +213,6 @@
   <data name="Application" xml:space="preserve">
     <value>Applikation</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>System</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Ny mappe</value>
   </data>
@@ -293,18 +290,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Har du slettet denne mappe?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Den fil, du prøver at slette, bruges i øjeblikket af et andet program.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Fil er i brug</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Prøv igen</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="PropertiesDialogReadOnly.Text" xml:space="preserve">
     <value>Skrivebeskyttet</value>
@@ -653,9 +638,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Fejl</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Forsøg igen</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Luk alligevel</value>

--- a/src/Files.Uwp/Strings/de-DE/Resources.resw
+++ b/src/Files.Uwp/Strings/de-DE/Resources.resw
@@ -174,9 +174,6 @@
   <data name="Application" xml:space="preserve">
     <value>Anwendung</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>System</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Neuer Ordner</value>
   </data>
@@ -284,18 +281,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Haben Sie diesen Ordner gelöscht?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Die Datei, die Sie löschen möchten, wird gerade von einer anderen Anwendung verwendet.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Datei wird bereits verwendet</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Erneut versuchen</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Papierkorb leeren</value>
@@ -953,9 +938,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Fehler</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Wiederholen</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Trotzdem schließen</value>
@@ -2628,5 +2610,26 @@ Wir benutzen das App Center, um einen Überblick über die Nutzung von Files zu 
   </data>
   <data name="PrepareInProgress" xml:space="preserve">
     <value>Objekte werden vorbereitet</value>
+  </data>
+  <data name="StatusCopyFailed" xml:space="preserve">
+    <value>Kopieren fehlgeschlagen</value>
+  </data>
+  <data name="StatusCopyFailedDetails_Plural" xml:space="preserve">
+    <value>Das Kopieren von {0} Objekten von {1} nach {2} ist fehlgeschlagen</value>
+  </data>
+  <data name="StatusCopyFailedDetails_Singular" xml:space="preserve">
+    <value>Das Kopieren von {0} von {1} nach {2} ist fehlgeschlagen</value>
+  </data>
+  <data name="StatusMoveFailed" xml:space="preserve">
+    <value>Verschieben fehlgeschlagen</value>
+  </data>
+  <data name="FileTags" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="SettingsShowFileTagsSection.Title" xml:space="preserve">
+    <value>Tags anzeigen</value>
+  </data>
+  <data name="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" xml:space="preserve">
+    <value>Tags anzeigen</value>
   </data>
 </root>

--- a/src/Files.Uwp/Strings/el/Resources.resw
+++ b/src/Files.Uwp/Strings/el/Resources.resw
@@ -252,9 +252,6 @@
   <data name="Application" xml:space="preserve">
     <value>Εφαρμογή</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Σύστημα</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Νέος φάκελος</value>
   </data>
@@ -332,18 +329,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Διαγράψατε αυτόν τον φάκελο;</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Το αρχείο που προσπαθείτε να διαγράψετε χρησιμοποιείται επί του παρόντος από μια άλλη εφαρμογή.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Το αρχείο είναι σε χρήση</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Δοκιμάστε ξανά</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>Εντάξει</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>Διάταξη</value>
@@ -716,9 +701,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Σφάλμα</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Επανάληψη</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Κλείσιμο ούτως ή άλλως</value>

--- a/src/Files.Uwp/Strings/en-GB/Resources.resw
+++ b/src/Files.Uwp/Strings/en-GB/Resources.resw
@@ -255,9 +255,6 @@
   <data name="Application" xml:space="preserve">
     <value>Application</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>System</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>New Folder</value>
   </data>
@@ -335,18 +332,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Did you delete this folder?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>The file you're trying to delete is currently being used by an another application.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>File is in use</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Try again</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>Layout</value>
@@ -728,9 +713,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Error</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Retry</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Close anyway</value>

--- a/src/Files.Uwp/Strings/es-419/Resources.resw
+++ b/src/Files.Uwp/Strings/es-419/Resources.resw
@@ -231,9 +231,6 @@
   <data name="Application" xml:space="preserve">
     <value>Aplicación</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Sistema</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nueva Carpeta</value>
   </data>
@@ -311,18 +308,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>¿Ha eliminado esta carpeta?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>La acción no se puede completar porque otro programa tiene abierto el archivo.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Archivo en uso</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Reintentar</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>Aceptar</value>
   </data>
   <data name="NavToolbarSelectionOptions.ToolTipService.ToolTip" xml:space="preserve">
     <value>Opciones de selección</value>
@@ -677,9 +662,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Error</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Reintentar</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Cerrar de todos modos</value>

--- a/src/Files.Uwp/Strings/es-ES/Resources.resw
+++ b/src/Files.Uwp/Strings/es-ES/Resources.resw
@@ -174,9 +174,6 @@
   <data name="Application" xml:space="preserve">
     <value>Aplicación</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Sistema</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nueva Carpeta</value>
   </data>
@@ -284,18 +281,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>¿Has eliminado esta carpeta?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>La acción no se puede completar porque otro programa tiene abierto el archivo.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Archivo en uso</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Reintentar</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>Aceptar</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Vaciar Papelera de reciclaje</value>
@@ -953,9 +938,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Error</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Reintentar</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Cerrar de todos modos</value>

--- a/src/Files.Uwp/Strings/fr-FR/Resources.resw
+++ b/src/Files.Uwp/Strings/fr-FR/Resources.resw
@@ -183,9 +183,6 @@
   <data name="Application" xml:space="preserve">
     <value>Application</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Système</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nouveau dossier</value>
   </data>
@@ -284,18 +281,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Avez-vous supprimé ce dossier ?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Le fichier que vous essayez de supprimer est actuellement utilisé par une autre application.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Le fichier en cours d'utilisation</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Réessayer</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Vider la Corbeille</value>
@@ -950,9 +935,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Erreur</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Réessayer</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Fermer quand même</value>
@@ -2457,6 +2439,9 @@
   <data name="ReducedColorMode" xml:space="preserve">
     <value>Mode couleurs réduites</value>
   </data>
+  <data name="RegisterForRestart" xml:space="preserve">
+    <value>Programmer un redémarrage</value>
+  </data>
   <data name="RunAsAdministrator" xml:space="preserve">
     <value>Exécuter en tant qu'administrateur</value>
   </data>
@@ -2639,5 +2624,29 @@
   </data>
   <data name="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" xml:space="preserve">
     <value>Afficher la section Étiquettes</value>
+  </data>
+  <data name="SystemTimeStyle" xml:space="preserve">
+    <value>Système</value>
+  </data>
+  <data name="FileInUseByDialog.Text" xml:space="preserve">
+    <value>Le fichier auquel vous tentez d'accéder est actuellement utilisé par {0}.</value>
+  </data>
+  <data name="FileInUseDialog.Text" xml:space="preserve">
+    <value>Le fichier auquel vous tentez d'accéder est actuellement utilisé par une autre application.</value>
+  </data>
+  <data name="FileInUseDialog.Title" xml:space="preserve">
+    <value>Le fichier est en cours d'utilisation</value>
+  </data>
+  <data name="UseCompactStyles" xml:space="preserve">
+    <value>Utiliser le style compact dans la vue Détails</value>
+  </data>
+  <data name="Universal" xml:space="preserve">
+    <value>Universel</value>
+  </data>
+  <data name="DateFormatSample" xml:space="preserve">
+    <value>ex: {0}, {1}</value>
+  </data>
+  <data name="SettingsFilesAndFoldersShowThumbnails" xml:space="preserve">
+    <value>Afficher les vignettes</value>
   </data>
 </root>

--- a/src/Files.Uwp/Strings/he-IL/Resources.resw
+++ b/src/Files.Uwp/Strings/he-IL/Resources.resw
@@ -201,9 +201,6 @@
   <data name="Application" xml:space="preserve">
     <value>אפליקציה</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>מערכת</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>תיקיה חדשה</value>
   </data>
@@ -257,18 +254,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>האם מחקת תיקיה זו?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>הקובץ אותו אתה מנסה למחוק נמצא בשימוש של תוכנה אחרת</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>הקובץ בשימוש</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>נסה שוב</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>אישור</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>רוקן את סל המיחזור</value>
@@ -806,9 +791,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>שגיאה</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>נסה שנית</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>סגור בכל זאת</value>

--- a/src/Files.Uwp/Strings/hi-IN/Resources.resw
+++ b/src/Files.Uwp/Strings/hi-IN/Resources.resw
@@ -210,9 +210,6 @@
   <data name="Application" xml:space="preserve">
     <value>एप्लिकेसन्</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>सिस्टम</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>नया फ़ोल्डर</value>
   </data>
@@ -287,18 +284,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>क्या आपने इस फ़ोल्डर को हटा दिया?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>आप जिस फ़ाइल को हटाने की कोशिश कर रहे हैं, वह वर्तमान में किसी अन्य एप्लिकेशन द्वारा इस्तेमाल की जा रही है।</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>फ़ाइल उपयोग में है</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>फिर कोशिश करें</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>ठीक है</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>रीसायकल बिन खाली करें</value>
@@ -752,9 +737,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>त्रुटि</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>पुनः प्रयास करें</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>फिर भी बंद करें</value>

--- a/src/Files.Uwp/Strings/hr-HR/Resources.resw
+++ b/src/Files.Uwp/Strings/hr-HR/Resources.resw
@@ -255,9 +255,6 @@
   <data name="Application" xml:space="preserve">
     <value>Aplikacija</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Sustav</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nova mapa</value>
   </data>
@@ -335,18 +332,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Jeste li izbrisali ovu mapu?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Datoteku koju pokušavate izbrisati trenutno koristi druga aplikacija.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Datoteka je u upotrebi</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Pokušaj ponovno</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>U redu</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>Raspored</value>
@@ -728,9 +713,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Greška</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Pokušaj ponovno</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Ipak zatvori</value>

--- a/src/Files.Uwp/Strings/hu-HU/Resources.resw
+++ b/src/Files.Uwp/Strings/hu-HU/Resources.resw
@@ -210,9 +210,6 @@
   <data name="Application" xml:space="preserve">
     <value>Alkalmazás</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Rendszer</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Új mappa</value>
   </data>
@@ -287,18 +284,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Ön törölte ezt a mappát?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>A törölni kívánt fájl jelenleg használatban van.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>A fájl használatban van</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Újra</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Lomtár ürítése</value>
@@ -953,9 +938,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Hiba</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Újra</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Bezárás mindenképpen</value>

--- a/src/Files.Uwp/Strings/id-ID/Resources.resw
+++ b/src/Files.Uwp/Strings/id-ID/Resources.resw
@@ -196,10 +196,10 @@
     <value>Untuk memulai, Anda harus memberi kami izin untuk menampilkan file Anda. Ini akan membuka halaman Pengaturan di mana Anda dapat memberi kami izin ini. Anda harus membuka kembali aplikasi setelah menyelesaikan langkah ini. </value>
   </data>
   <data name="FileFolderListItem" xml:space="preserve">
-    <value>Folder file</value>
+    <value>Folder berkas</value>
   </data>
   <data name="ItemTypeFile" xml:space="preserve">
-    <value>File</value>
+    <value>Berkas</value>
   </data>
   <data name="RenameDialog.Title" xml:space="preserve">
     <value>Masukkan nama benda</value>
@@ -218,9 +218,6 @@
   </data>
   <data name="Application" xml:space="preserve">
     <value>Aplikasi</value>
-  </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Sistem</value>
   </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Folder Baru</value>
@@ -253,7 +250,7 @@
     <value>Properti</value>
   </data>
   <data name="ItemAlreadyExistsDialogContent" xml:space="preserve">
-    <value>Item dengan nama ini sudah ada di direktori ini.</value>
+    <value>Item dengan nama ini sudah ada di katalog ini.</value>
   </data>
   <data name="ItemAlreadyExistsDialogSecondaryButtonText" xml:space="preserve">
     <value>Ganti item yang sudah ada</value>
@@ -274,7 +271,7 @@
     <value>Ikon Kecil</value>
   </data>
   <data name="PropertiesDialogOKButton.Content" xml:space="preserve">
-    <value>Oke</value>
+    <value>Iya</value>
   </data>
   <data name="AccessDeniedDeleteDialog.Text" xml:space="preserve">
     <value>Kami tidak dapat menghapus item ini</value>
@@ -299,18 +296,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Apakah Anda menghapus folder ini?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Berkas yang Anda coba hapus sedang digunakan oleh aplikasi lain.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Berkas sedang digunakan</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Coba lagi</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>Oke</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>Tata letak</value>
@@ -367,7 +352,7 @@
     <value>Nama item tidak boleh mengandung karakter berikut: \ / : * ? " &lt; &gt; |</value>
   </data>
   <data name="FileNameTeachingTip.CloseButtonContent" xml:space="preserve">
-    <value>Oke</value>
+    <value>Iya</value>
   </data>
   <data name="RenameDialogSymbolsTip.Text" xml:space="preserve">
     <value>Nama item tidak boleh mengandung karakter berikut: \ / : * ? " &lt; &gt; |</value>
@@ -511,7 +496,7 @@
     <value>Jenis pintasan:</value>
   </data>
   <data name="PropertiesShortcutItemWorkingDir.Text" xml:space="preserve">
-    <value>Direktori kerja:</value>
+    <value>Katalog kerja:</value>
   </data>
   <data name="PropertiesShortcutTypeFile" xml:space="preserve">
     <value>Berkas</value>
@@ -658,19 +643,16 @@
     <value>Target maju</value>
   </data>
   <data name="NavResfreshButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Segarkan direktori</value>
+    <value>Segarkan katalog</value>
   </data>
   <data name="NavUpButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Naik satu tingkat direktori</value>
+    <value>Naik satu tingkat dari katalog</value>
   </data>
   <data name="PropertySaveErrorMessage.Text" xml:space="preserve">
     <value>Terjadi masalah saat menyimpan beberapa properti.</value>
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Kesalahan</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Coba lagi</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Tetap tutup</value>
@@ -946,7 +928,7 @@
     <value>Audio</value>
   </data>
   <data name="PropertySectionMusic" xml:space="preserve">
-    <value>Musik</value>
+    <value>Lagu</value>
   </data>
   <data name="PropertySectionVideo" xml:space="preserve">
     <value>Tontonan</value>
@@ -1276,7 +1258,7 @@
     <value>Tidak diketahui</value>
   </data>
   <data name="DriveTypeVirtualDrive" xml:space="preserve">
-    <value>Penyimpanan Maya (Virtual)</value>
+    <value>Penyimpanan Maya</value>
   </data>
   <data name="DateCreated" xml:space="preserve">
     <value>Tanggal dibuat</value>
@@ -1756,7 +1738,7 @@
     <value>Kontrol penuh</value>
   </data>
   <data name="SecurityListDirectoryLabel.Text" xml:space="preserve">
-    <value>Daftar konten direktori</value>
+    <value>Daftar konten katalog</value>
   </data>
   <data name="SecurityModifyLabel.Text" xml:space="preserve">
     <value>Ubah</value>
@@ -1915,7 +1897,7 @@
     <value>Hapus</value>
   </data>
   <data name="SecurityDeleteSubdirectoriesAndFilesLabel.Text" xml:space="preserve">
-    <value>Hapus subdirektori dan berkas</value>
+    <value>Hapus subkatalog dan berkas</value>
   </data>
   <data name="SecurityExecuteFileLabel.Text" xml:space="preserve">
     <value>Eksekusi berkas</value>
@@ -2059,7 +2041,7 @@
     <value>Bahasa</value>
   </data>
   <data name="SettingsFilesAndFoldersShowFileExtensions" xml:space="preserve">
-    <value>Tampilkan ekstensi file pada file yang sudah diketahui</value>
+    <value>Tampilkan ekstensi pada berkas yang sudah diketahui</value>
   </data>
   <data name="SettingsFilesAndFoldersShowHiddenItems" xml:space="preserve">
     <value>Tampilkan berkas dan folder tersembunyi</value>
@@ -2071,13 +2053,13 @@
     <value>Buka menu dengan sekali klik</value>
   </data>
   <data name="SettingsListAndSortDirectoriesAlongsideFiles" xml:space="preserve">
-    <value>Daftar dan urutkan direktori berdampingan dengan berkas</value>
+    <value>Daftar dan urutkan katalog berdampingan dengan berkas</value>
   </data>
   <data name="SettingsSearchUnindexedItems" xml:space="preserve">
-    <value>Tampilkan item yang tidak terindeks ketika mencari berkas dan direktori (pencarian mungkin lebih lama)</value>
+    <value>Tampilkan item yang tidak terindeks ketika mencari berkas dan katalog (pencarian mungkin lebih lama)</value>
   </data>
   <data name="SettingsEnableLayoutPreferencesPerFolder" xml:space="preserve">
-    <value>Aktifkan preferensi individu untuk setiap direktori individu</value>
+    <value>Aktifkan preferensi individu untuk setiap katalog individu</value>
   </data>
   <data name="SettingsUsefulLinks.Title" xml:space="preserve">
     <value>Tautan yang berguna</value>
@@ -2261,7 +2243,7 @@ Kami menggunakan Pusat App untuk melacak penggunaan aplikasi, menemukan bug, dan
     <value>Bagian dari set</value>
   </data>
   <data name="AskCredentialDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Oke</value>
+    <value>Iya</value>
   </data>
   <data name="AskCredentialDialog.Title" xml:space="preserve">
     <value>Kredensial Diperlukan</value>
@@ -2477,7 +2459,7 @@ Kami menggunakan Pusat App untuk melacak penggunaan aplikasi, menemukan bug, dan
     <value>Gunakan pengaturan DPI monitor utama</value>
   </data>
   <data name="SettingsDefaultFilesManager" xml:space="preserve">
-    <value>Pengelola file bawaan</value>
+    <value>Pengelola berkas bawaan</value>
   </data>
   <data name="SettingsSetAsDefaultFileManager" xml:space="preserve">
     <value>Setel Files sebagai pengelola berkas bawaan</value>
@@ -2492,7 +2474,7 @@ Kami menggunakan Pusat App untuk melacak penggunaan aplikasi, menemukan bug, dan
     <value>Berkas dan folder</value>
   </data>
   <data name="OpenNewInstance" xml:space="preserve">
-    <value>Buka instance baru saat membuka direktori dari jumplist taskbar</value>
+    <value>Buka instance baru saat membuka katalog dari jumplist taskbar</value>
   </data>
   <data name="StartupSettings" xml:space="preserve">
     <value>Pengaturan startup</value>
@@ -2612,7 +2594,7 @@ Kami menggunakan Pusat App untuk melacak penggunaan aplikasi, menemukan bug, dan
     <value>Tutup halaman lainnya</value>
   </data>
   <data name="Music" xml:space="preserve">
-    <value>Musik</value>
+    <value>Lagu</value>
   </data>
   <data name="Pictures" xml:space="preserve">
     <value>Gambar</value>

--- a/src/Files.Uwp/Strings/it-IT/Resources.resw
+++ b/src/Files.Uwp/Strings/it-IT/Resources.resw
@@ -189,9 +189,6 @@
   <data name="Application" xml:space="preserve">
     <value>Applicazione</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Sistema</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nuova cartella</value>
   </data>
@@ -283,19 +280,7 @@
     <value>La cartella a cui stai tentando di accedere potrebbe essere stata spostata o eliminata.</value>
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
-    <value>Vuoi eliminare questa cartella?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Il file che stai tentando di eliminare è attualmente utilizzato da un'altra applicazione.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>File in uso</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Riprova</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
+    <value>Hai eliminato questa cartella?</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Svuota il cestino</value>
@@ -953,9 +938,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Errore</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Riprova</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Chiudi comunque</value>
@@ -2644,5 +2626,35 @@ Usiamo App Center per tenere traccia dell'utilizzo dell'app, trovare bug e risol
   </data>
   <data name="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" xml:space="preserve">
     <value>Mostra sezione Etichette</value>
+  </data>
+  <data name="UseCompactStyles" xml:space="preserve">
+    <value>Usa stile compatto per la visualizzazione Dettagli</value>
+  </data>
+  <data name="FileInUseByDialog.Text" xml:space="preserve">
+    <value>Il file a cui stai tentando di accedere è attualmente utilizzato da {0}</value>
+  </data>
+  <data name="FileInUseDialog.Text" xml:space="preserve">
+    <value>Il file a cui stai tentando di accedere è attualmente utilizzato da un'altra applicazione.</value>
+  </data>
+  <data name="FileInUseDialog.Title" xml:space="preserve">
+    <value>Il file è in uso</value>
+  </data>
+  <data name="SystemTimeStyle" xml:space="preserve">
+    <value>Sistema</value>
+  </data>
+  <data name="Universal" xml:space="preserve">
+    <value>Universale</value>
+  </data>
+  <data name="DateFormatSample" xml:space="preserve">
+    <value>eg: {0}, {1}</value>
+  </data>
+  <data name="SettingsFilesAndFoldersShowThumbnails" xml:space="preserve">
+    <value>Mostra anteprime</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Riprova</value>
+  </data>
+  <data name="ErrorDialogUnsupportedMoveOperation" xml:space="preserve">
+    <value>L'operazione di spostamento non è supportata in questo contesto. Vuoi copiare gli elementi?</value>
   </data>
 </root>

--- a/src/Files.Uwp/Strings/ja-JP/Resources.resw
+++ b/src/Files.Uwp/Strings/ja-JP/Resources.resw
@@ -207,9 +207,6 @@
   <data name="Application" xml:space="preserve">
     <value>アプリ</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>システム</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>新しいフォルダー</value>
   </data>
@@ -284,18 +281,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>このフォルダーを削除しましたか?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>削除しようとしているファイルは他のプログラムによって使用されています。</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>ファイルは使用中です</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>再試行</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>ごみ箱を空にする</value>
@@ -953,9 +938,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>エラー</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>再試行</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>閉じる</value>

--- a/src/Files.Uwp/Strings/ka/Resources.resw
+++ b/src/Files.Uwp/Strings/ka/Resources.resw
@@ -249,9 +249,6 @@
   <data name="Application" xml:space="preserve">
     <value>აპლიკაცია</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>სისტემა</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>ახალი საქაღალდე</value>
   </data>
@@ -329,18 +326,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>თქვენ წაშალეთ ეს საქაღალდე?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>ფაილი, რომლის წაშლასაც თქვენ ცდილობთ, ამჟამად სხვა პროგრამა იყენებს.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>ფაილი გამოიყენება</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>სცადეთ ხელახლა</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>კარგი</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>განლაგება</value>
@@ -713,9 +698,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>შეცდომა</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>სცადეთ ხელახლა</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>მაინც დახურვა</value>

--- a/src/Files.Uwp/Strings/ko-KR/Resources.resw
+++ b/src/Files.Uwp/Strings/ko-KR/Resources.resw
@@ -174,9 +174,6 @@
   <data name="Application" xml:space="preserve">
     <value>응용 프로그램</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>시스템</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>새 폴더</value>
   </data>
@@ -275,18 +272,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>폴더를 삭제하셨나요?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>파일이 다른 프로그램에서 사용되고 있어 삭제할 수 없습니다.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>파일이 사용 중</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>다시 시도</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>확인</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>휴지통 비우기</value>
@@ -656,9 +641,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>오류</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>다시 시도</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>무시하고 닫기</value>

--- a/src/Files.Uwp/Strings/lv-LV/Resources.resw
+++ b/src/Files.Uwp/Strings/lv-LV/Resources.resw
@@ -219,9 +219,6 @@
   <data name="Application" xml:space="preserve">
     <value>Lietojumprogramma</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Sistēma</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Jauna mape</value>
   </data>
@@ -299,18 +296,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Vai Jūs izdzēsāt šo mapi?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Fails, kuru mēģināt dzēst, tiek izmantots citā lietotnē.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Fails tiek lietots</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Mēģināt vēlreiz</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="PropertiesDialogReadOnly.Text" xml:space="preserve">
     <value>Tikai lasāms</value>
@@ -659,9 +644,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Kļūda</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Mēģināt vēlreiz</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Tomēr aizvērt</value>

--- a/src/Files.Uwp/Strings/nb-NO/Resources.resw
+++ b/src/Files.Uwp/Strings/nb-NO/Resources.resw
@@ -213,9 +213,6 @@
   <data name="Application" xml:space="preserve">
     <value>Applikasjon</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>System</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Ny mappe</value>
   </data>
@@ -293,18 +290,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Har du slettet denne mappen?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Filen du forsøker å slette er i bruk av en annen applikasjon.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Filen er i bruk</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Prøv igjen</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="PropertiesDialogReadOnly.Text" xml:space="preserve">
     <value>Skrivebeskyttet</value>
@@ -653,9 +638,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Feil</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Prøv igjen</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Lukk likevel</value>

--- a/src/Files.Uwp/Strings/nl-NL/Resources.resw
+++ b/src/Files.Uwp/Strings/nl-NL/Resources.resw
@@ -174,9 +174,6 @@
   <data name="Application" xml:space="preserve">
     <value>Toepassing</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Systeem</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nieuwe map</value>
   </data>
@@ -284,18 +281,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Is deze map verwijderd?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Het bestand dat u probeert te verwijderen, wordt momenteel gebruikt door een andere toepassing.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Bestand in gebruik</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Opnieuw proberen</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Prullenbak leegmaken</value>
@@ -953,9 +938,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Foutmelding</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Opnieuw</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Toch sluiten</value>

--- a/src/Files.Uwp/Strings/or-IN/Resources.resw
+++ b/src/Files.Uwp/Strings/or-IN/Resources.resw
@@ -210,9 +210,6 @@
   <data name="Application" xml:space="preserve">
     <value>ଆପ୍ଲିକେସନ</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>ସିଷ୍ଟମ୍</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>ନୂତନ ଫୋଲ୍ଡର</value>
   </data>
@@ -287,18 +284,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>ଆପଣ ଏହି ଫୋଲ୍ଡରକୁ ଡିଲିଟ୍ କରିଛନ୍ତି କି?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>ଆପଣ ବିଲୋପ କରିବାକୁ ଚେଷ୍ଟା କରୁଥିବା ଫାଇଲ୍ ବର୍ତ୍ତମାନ ଅନ୍ୟ ଏକ ଆପ୍ଲିକେସନ ଦ୍ୱାରା ବ୍ୟବହୃତ ହେଉଛି |</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>ଫାଇଲ୍ ବ୍ୟବହାରରେ ଅଛି</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>ପୁଣିଥରେ ଚେଷ୍ଟା କରନ୍ତୁ</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>ଠିକ୍ ଅଛି</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>ରିସାଇକ୍ଲବିନ୍ ଖାଲି କର</value>
@@ -719,9 +704,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>ତ୍ରୁଟି</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>ପୁନଃଚେଷ୍ଟା</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>ଯେକୌଣସିଭାବରେ ବନ୍ଦ କରିବା</value>

--- a/src/Files.Uwp/Strings/pl-PL/Resources.resw
+++ b/src/Files.Uwp/Strings/pl-PL/Resources.resw
@@ -174,9 +174,6 @@
   <data name="Application" xml:space="preserve">
     <value>Aplikacja</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Systemowy</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nowy folder</value>
   </data>
@@ -284,18 +281,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Czy usunąłeś ten folder?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Plik, który próbujesz usunąć, jest obecnie używany przez inną aplikację.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Plik jest w użyciu</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Spróbuj ponownie</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Opróżnij kosz</value>
@@ -953,9 +938,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Błąd</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Ponów</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Zamknij mimo to</value>

--- a/src/Files.Uwp/Strings/pt-BR/Resources.resw
+++ b/src/Files.Uwp/Strings/pt-BR/Resources.resw
@@ -210,9 +210,6 @@
   <data name="Application" xml:space="preserve">
     <value>Aplicativo</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Sistema</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nova pasta</value>
   </data>
@@ -287,18 +284,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Você excluiu esta pasta?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>O arquivo que você está tentando excluir está sendo usado por outro aplicativo.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>O arquivo está sendo usado</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Tentar novamente</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Esvaziar lixeira</value>
@@ -953,9 +938,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Erro</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Repetir</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Fechar mesmo assim</value>
@@ -2201,12 +2183,7 @@
   </data>
   <data name="SettingsPrivacyPolicyMarkdownBlock.Text" xml:space="preserve">
     <value>
-*Coleta de informações pessoais* 
-O Files não coleta, armazena, compartilha ou publica qualquer informação pessoal.
-
-*Coleta de informações não pessoais*
-
-Usamos o App Center para controlar o uso do aplicativo, encontrar bugs e corrigir falhas. Todas as informações enviadas para o App Center são anônimas e livres de qualquer dado de usuário ou contextual.
+Usamos o App Center para rastrear quais configurações estão sendo usadas, encontrar bugs e corrigir falhas. As informações enviadas ao App Center são anônimas e livres de quaisquer dados do usuário ou contextuais.
   </value>
   </data>
   <data name="NavToolbarArrangementOptionName.Text" xml:space="preserve">
@@ -2237,13 +2214,13 @@ Usamos o App Center para controlar o uso do aplicativo, encontrar bugs e corrigi
     <value>Desconhecida</value>
   </data>
   <data name="DetailsViewHeaderFlyout_ShowFileTag.Text" xml:space="preserve">
-    <value>Etiqueta de arquivo</value>
+    <value>Etiqueta</value>
   </data>
   <data name="SettingsEditFileTagsExpander.Title" xml:space="preserve">
-    <value>Editar etiquetas de arquivo</value>
+    <value>Editar etiquetas</value>
   </data>
   <data name="SettingsEnableFileTags.Title" xml:space="preserve">
-    <value>Habilitar etiquetas de arquivo</value>
+    <value>Habilitar etiquetas</value>
   </data>
   <data name="InsertDiscDialog.OpenDriveButton" xml:space="preserve">
     <value>Abrir Drive</value>
@@ -2318,7 +2295,7 @@ Usamos o App Center para controlar o uso do aplicativo, encontrar bugs e corrigi
     <value>Fixar lixeira nos Favoritos</value>
   </data>
   <data name="SettingsShowCloudDrivesSectionSwitch.AutomationProperties.Name" xml:space="preserve">
-    <value>Mostrar seção de Unidades na Nuvem</value>
+    <value>Mostrar seção de Unidades em Nuvem</value>
   </data>
   <data name="SettingsShowDrivesSectionSwitch.AutomationProperties.Name" xml:space="preserve">
     <value>Mostrar seção de Unidades</value>
@@ -2501,7 +2478,7 @@ Usamos o App Center para controlar o uso do aplicativo, encontrar bugs e corrigi
     <value>Licenças de terceiros</value>
   </data>
   <data name="SettingsSetAsDefaultFileManagerDescription" xml:space="preserve">
-    <value>Esta configuração modifica arquivos do sistema e pode ter efeitos colaterais inesperados no seu dispositivo. Os desenvolvedores não assumem nenhuma responsabilidade no caso de um problema ocorrer como resultado. Continuar com essa opção é um reconhecimento dos riscos envolvidos com essa ação. Observe que a desinstalação de arquivos não desinstalará essas alterações e poderá impedi-lo de abrir o explorador de arquivos, a menos que você desligue esta configuração antes de remover arquivos do seu dispositivo.</value>
+    <value>Esta opção modifica o registro do sistema e pode causar efeitos colaterais inesperados no seu dispositivo. Continue por sua conta e risco.</value>
   </data>
   <data name="ClearAll" xml:space="preserve">
     <value>Limpar todos</value>
@@ -2559,5 +2536,95 @@ Usamos o App Center para controlar o uso do aplicativo, encontrar bugs e corrigi
   </data>
   <data name="Bytes" xml:space="preserve">
     <value>Bytes</value>
+  </data>
+  <data name="Extract" xml:space="preserve">
+    <value>Extrair</value>
+  </data>
+  <data name="ExtractFiles" xml:space="preserve">
+    <value>Extrair arquivos</value>
+  </data>
+  <data name="ExtractHere" xml:space="preserve">
+    <value>Extrair aqui</value>
+  </data>
+  <data name="ExtractKeyboardAcceleratorTextOverride" xml:space="preserve">
+    <value>Ctrl+E</value>
+  </data>
+  <data name="ExtractToChildFolder" xml:space="preserve">
+    <value>Extrair para {0}</value>
+  </data>
+  <data name="RunScript" xml:space="preserve">
+    <value>Executar script</value>
+  </data>
+  <data name="RunWithPowerShell" xml:space="preserve">
+    <value>Executar com o PowerShell</value>
+  </data>
+  <data name="SetAsBackground" xml:space="preserve">
+    <value>Definir como fundo da área de trabalho</value>
+  </data>
+  <data name="ShowFolderSizesWarning" xml:space="preserve">
+    <value>O cálculo do tamanho de pastas consome muitos recursos e pode causar aumento no consumo de CPU e energia.</value>
+  </data>
+  <data name="OpenIn" xml:space="preserve">
+    <value>Abrir com</value>
+  </data>
+  <data name="RotateLeft" xml:space="preserve">
+    <value>Girar para a esquerda</value>
+  </data>
+  <data name="RotateRight" xml:space="preserve">
+    <value>Girar para a direita</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="CloseTabsToTheLeft" xml:space="preserve">
+    <value>Fechar guias à esquerda</value>
+  </data>
+  <data name="CloseTabsToTheRight" xml:space="preserve">
+    <value>Fechar guias à direita</value>
+  </data>
+  <data name="ShowDotFiles" xml:space="preserve">
+    <value>Mostrar arquivos "."</value>
+  </data>
+  <data name="CloseOtherTabs" xml:space="preserve">
+    <value>Fechar demais guias</value>
+  </data>
+  <data name="Music" xml:space="preserve">
+    <value>Músicas</value>
+  </data>
+  <data name="Pictures" xml:space="preserve">
+    <value>Imagens</value>
+  </data>
+  <data name="Videos" xml:space="preserve">
+    <value>Vídeos</value>
+  </data>
+  <data name="UpdateFiles" xml:space="preserve">
+    <value>Atualizar Arquivos</value>
+  </data>
+  <data name="StatusPreparingItemsDetails_Plural" xml:space="preserve">
+    <value>Preparando {0} itens</value>
+  </data>
+  <data name="PrepareInProgress" xml:space="preserve">
+    <value>Preparando itens</value>
+  </data>
+  <data name="StatusCopyFailed" xml:space="preserve">
+    <value>Falha ao copiar</value>
+  </data>
+  <data name="StatusCopyFailedDetails_Plural" xml:space="preserve">
+    <value>Falha ao copiar {0} itens de {1} para {2}</value>
+  </data>
+  <data name="StatusCopyFailedDetails_Singular" xml:space="preserve">
+    <value>Falha ao copiar {0} item de {1} para {2}</value>
+  </data>
+  <data name="StatusMoveFailed" xml:space="preserve">
+    <value>Falha ao mover</value>
+  </data>
+  <data name="FileTags" xml:space="preserve">
+    <value>Etiquetas</value>
+  </data>
+  <data name="SettingsShowFileTagsSection.Title" xml:space="preserve">
+    <value>Mostrar a seção de Etiquetas</value>
+  </data>
+  <data name="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" xml:space="preserve">
+    <value>Mostrar a seção de Etiquetas</value>
   </data>
 </root>

--- a/src/Files.Uwp/Strings/pt-PT/Resources.resw
+++ b/src/Files.Uwp/Strings/pt-PT/Resources.resw
@@ -210,9 +210,6 @@
   <data name="Application" xml:space="preserve">
     <value>Aplicação</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Sistema</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nova Pasta</value>
   </data>
@@ -287,18 +284,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Pretende eliminar esta pasta?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>O ficheiro que você está tentando eliminar está sendo utilizado por uma aplicação.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>O ficheiro está em uso</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Tentar novamente</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Esvaziar Reciclagem</value>
@@ -954,9 +939,6 @@
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Erro</value>
   </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Tentar Novamente</value>
-  </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Fechar mesmo assim</value>
   </data>
@@ -1000,7 +982,7 @@
     <value>Envie aos desenvolvedores um relatório de problema com mais informações</value>
   </data>
   <data name="SettingsAboutSupportUsListViewItem.AutomationProperties.Name" xml:space="preserve">
-    <value>Apoie-nos no PayPal</value>
+    <value>Apoie-nos no GitHub</value>
   </data>
   <data name="Details" xml:space="preserve">
     <value>Detalhes</value>
@@ -2068,13 +2050,13 @@
     <value>Ocultar ficheiros protegidos do sistema operativo (Recomendado)</value>
   </data>
   <data name="SettingsOpenFilesWithOneClick" xml:space="preserve">
-    <value>Abrir itens com um clique único</value>
+    <value>Abrir ficheiros com um clique único</value>
   </data>
   <data name="SettingsListAndSortDirectoriesAlongsideFiles" xml:space="preserve">
     <value>Listar e ordenar diretórios ao lado dos ficheiros</value>
   </data>
   <data name="SettingsSearchUnindexedItems" xml:space="preserve">
-    <value>Mostrar itens não indexados ao pesquisar ficheiros e pastas (as pesquisas podem demorar mais)</value>
+    <value>Mostrar itens não indexados ao pesquisar ficheiros e pastas</value>
   </data>
   <data name="SettingsEnableLayoutPreferencesPerFolder" xml:space="preserve">
     <value>Ligar preferências individuais para diretórios individuais</value>
@@ -2201,13 +2183,7 @@
   </data>
   <data name="SettingsPrivacyPolicyMarkdownBlock.Text" xml:space="preserve">
     <value>
-*Recolha de Informação Pessoal*
-
-Files não recolhe, guarda, partilha ou publica qualquer informação pessoal.
-
-*Recolha de Informação Não-pessoal*
-
-Nós utilizamos o App Center para acompanhar a utilização da aplicação, encontrar bugs, e corrigir falhas. Toda a informação enviada ao App Center é anónima e livre de qualquer utilizador ou dados contextuais.
+Utilizamos o App Center para localizar as definições que estão a ser utilizadas, encontrar bugs, e corrigir falhas. A informação enviada para o App Center é anónima e livre de qualquer utilizador ou dados contextuais.
   </value>
   </data>
   <data name="NavToolbarArrangementOptionName.Text" xml:space="preserve">
@@ -2238,13 +2214,13 @@ Nós utilizamos o App Center para acompanhar a utilização da aplicação, enco
     <value>Desconhecido</value>
   </data>
   <data name="DetailsViewHeaderFlyout_ShowFileTag.Text" xml:space="preserve">
-    <value>Tag do ficheiro</value>
+    <value>Tag</value>
   </data>
   <data name="SettingsEditFileTagsExpander.Title" xml:space="preserve">
-    <value>Editar tags dos ficheiros</value>
+    <value>Editar tags</value>
   </data>
   <data name="SettingsEnableFileTags.Title" xml:space="preserve">
-    <value>Ativar tags dos ficheiros</value>
+    <value>Ativar tags</value>
   </data>
   <data name="InsertDiscDialog.OpenDriveButton" xml:space="preserve">
     <value>Abrir Unidade</value>
@@ -2502,7 +2478,7 @@ Nós utilizamos o App Center para acompanhar a utilização da aplicação, enco
     <value>Licenças de terceiros</value>
   </data>
   <data name="SettingsSetAsDefaultFileManagerDescription" xml:space="preserve">
-    <value>Esta definição modifica os ficheiros do sistema e pode ter efeitos secundários inesperados no seu dispositivo. Os programadores não assumem qualquer responsabilidade no caso de ocorrer um problema como resultado. A continuação desta opção é um reconhecimento dos riscos envolvidos com esta ação. Note que a desinstalação de Files não desfaz estas alterações e pode impedi-lo de abrir o explorador de ficheiros, a menos que desligue esta definição antes de remover o Files do seu dispositivo.</value>
+    <value>Esta opção modifica o registo do sistema e pode ter efeitos secundários inesperados no seu dispositivo. Continue por sua conta e risco.</value>
   </data>
   <data name="ClearAll" xml:space="preserve">
     <value>Limpar tudo</value>
@@ -2536,5 +2512,119 @@ Nós utilizamos o App Center para acompanhar a utilização da aplicação, enco
   </data>
   <data name="SettingsOpenInLogin" xml:space="preserve">
     <value>Abrir Files no Início do Windows</value>
+  </data>
+  <data name="Attributes" xml:space="preserve">
+    <value>Atributos</value>
+  </data>
+  <data name="Hidden" xml:space="preserve">
+    <value>Oculto</value>
+  </data>
+  <data name="MoreDetails" xml:space="preserve">
+    <value>Mais detalhes</value>
+  </data>
+  <data name="ReadOnly" xml:space="preserve">
+    <value>Só de leitura</value>
+  </data>
+  <data name="CleanupDrive" xml:space="preserve">
+    <value>Limpe o conteúdo da sua unidade</value>
+  </data>
+  <data name="DiskCleanup" xml:space="preserve">
+    <value>Limpeza do disco</value>
+  </data>
+  <data name="Type" xml:space="preserve">
+    <value>Tipo:</value>
+  </data>
+  <data name="Bytes" xml:space="preserve">
+    <value>Bytes</value>
+  </data>
+  <data name="Extract" xml:space="preserve">
+    <value>Extrair</value>
+  </data>
+  <data name="ExtractFiles" xml:space="preserve">
+    <value>Extrair ficheiros</value>
+  </data>
+  <data name="ExtractHere" xml:space="preserve">
+    <value>Extrair aqui</value>
+  </data>
+  <data name="ExtractKeyboardAcceleratorTextOverride" xml:space="preserve">
+    <value>Ctrl+E</value>
+  </data>
+  <data name="ExtractToChildFolder" xml:space="preserve">
+    <value>Extrair para {0}</value>
+  </data>
+  <data name="RunScript" xml:space="preserve">
+    <value>Executar script</value>
+  </data>
+  <data name="RunWithPowerShell" xml:space="preserve">
+    <value>Executar com PowerShell</value>
+  </data>
+  <data name="SetAsBackground" xml:space="preserve">
+    <value>Definir como fundo do ambiente de trabalho</value>
+  </data>
+  <data name="ShowFolderSizesWarning" xml:space="preserve">
+    <value>O cálculo do tamanho das pastas exige muitos recursos e pode fazer aumentar a utilização da sua CPU.</value>
+  </data>
+  <data name="OpenIn" xml:space="preserve">
+    <value>Aberto no</value>
+  </data>
+  <data name="RotateLeft" xml:space="preserve">
+    <value>Rodar para a esquerda</value>
+  </data>
+  <data name="RotateRight" xml:space="preserve">
+    <value>Rodar para a direita</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="CloseTabsToTheLeft" xml:space="preserve">
+    <value>Fechar separadores à esquerda</value>
+  </data>
+  <data name="CloseTabsToTheRight" xml:space="preserve">
+    <value>Fechar separadores à direita</value>
+  </data>
+  <data name="ShowDotFiles" xml:space="preserve">
+    <value>Mostrar ficheiros ponto</value>
+  </data>
+  <data name="CloseOtherTabs" xml:space="preserve">
+    <value>Fechar outros separadores</value>
+  </data>
+  <data name="Music" xml:space="preserve">
+    <value>Música</value>
+  </data>
+  <data name="Pictures" xml:space="preserve">
+    <value>Imagens</value>
+  </data>
+  <data name="Videos" xml:space="preserve">
+    <value>Vídeos</value>
+  </data>
+  <data name="UpdateFiles" xml:space="preserve">
+    <value>Atualizar Files</value>
+  </data>
+  <data name="StatusPreparingItemsDetails_Plural" xml:space="preserve">
+    <value>Preparando {0} itens</value>
+  </data>
+  <data name="PrepareInProgress" xml:space="preserve">
+    <value>Preparando itens</value>
+  </data>
+  <data name="StatusCopyFailed" xml:space="preserve">
+    <value>Cópia falhada</value>
+  </data>
+  <data name="StatusCopyFailedDetails_Plural" xml:space="preserve">
+    <value>Falha em copiar {0} itens de {1} a {2}</value>
+  </data>
+  <data name="StatusCopyFailedDetails_Singular" xml:space="preserve">
+    <value>Falha em copiar {0} item de {1} para {2}</value>
+  </data>
+  <data name="StatusMoveFailed" xml:space="preserve">
+    <value>Mover falhou</value>
+  </data>
+  <data name="FileTags" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="SettingsShowFileTagsSection.Title" xml:space="preserve">
+    <value>Mostrar secção Tags</value>
+  </data>
+  <data name="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" xml:space="preserve">
+    <value>Mostrar secção Tags</value>
   </data>
 </root>

--- a/src/Files.Uwp/Strings/ru-RU/Resources.resw
+++ b/src/Files.Uwp/Strings/ru-RU/Resources.resw
@@ -174,9 +174,6 @@
   <data name="Application" xml:space="preserve">
     <value>По умолчанию</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Как в системе</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Новая папка</value>
   </data>
@@ -284,18 +281,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Вы удалили эту папку?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Файл, который Вы пытаетесь удалить, в настоящее время используется другим приложением.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Файл используется</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Повторить</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Очистить корзину</value>
@@ -953,9 +938,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Ошибка</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Повторить</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Закрыть</value>

--- a/src/Files.Uwp/Strings/sk-SK/Resources.resw
+++ b/src/Files.Uwp/Strings/sk-SK/Resources.resw
@@ -213,9 +213,6 @@
   <data name="Application" xml:space="preserve">
     <value>Aplikácia</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Systém</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Nový priečinok</value>
   </data>
@@ -293,18 +290,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Odstránili ste tento priečinok?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Súbor, ktorý sa snažíte odstrániť používa iná aplikácia.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Súbor sa používa</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Skúsiť znova</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="PropertiesDialogReadOnly.Text" xml:space="preserve">
     <value>Iba na čítanie</value>
@@ -653,9 +638,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Chyba</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Skúsiť znova</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Ajtak zatvoriť</value>

--- a/src/Files.Uwp/Strings/sv-SE/Resources.resw
+++ b/src/Files.Uwp/Strings/sv-SE/Resources.resw
@@ -216,9 +216,6 @@
   <data name="Application" xml:space="preserve">
     <value>App</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>System</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Ny mapp</value>
   </data>
@@ -296,18 +293,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Tog du bort den här mappen?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Filen som du försöker ta bort används av ett annat program.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Filen används</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Försök igen</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="PropertiesDialogReadOnly.Text" xml:space="preserve">
     <value>Skrivskyddad</value>
@@ -656,9 +641,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Fel</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Försök igen</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Stäng ändå</value>

--- a/src/Files.Uwp/Strings/ta/Resources.resw
+++ b/src/Files.Uwp/Strings/ta/Resources.resw
@@ -207,9 +207,6 @@
   <data name="Application" xml:space="preserve">
     <value>பயன்பாடு</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>முறைமை</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>புதியக் கோப்புறை</value>
   </data>
@@ -284,18 +281,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>நீங்கள் இந்தக் கோப்புறையை நீக்கீவிட்டீர்களா?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>நீங்கள் நீக்க முயற்சிக்கும் கோப்பானது தற்போது பயன்பாட்டில் உள்ளது.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>கோப்புப் பயன்பாட்டில் உள்ளது</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>மீண்டும் முயலவும்</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>சரி</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>மறுசுழற்சிக் கூடையைக் காலியாக்கு</value>
@@ -790,9 +775,6 @@
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>பிழை</value>
   </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>மறுமுயற்சி</value>
-  </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>எப்படியாயினும் மூடு</value>
   </data>
@@ -837,9 +819,6 @@
   </data>
   <data name="DateDeleted" xml:space="preserve">
     <value>தேதி நீக்கப்பட்டது</value>
-  </data>
-  <data name="BundlesWidgetRenameBundleDialogTitleText" xml:space="preserve">
-    <value>Rename "{0}"</value>
   </data>
   <data name="Confirm" xml:space="preserve">
     <value>உறுதிசெய்</value>

--- a/src/Files.Uwp/Strings/tr-TR/Resources.resw
+++ b/src/Files.Uwp/Strings/tr-TR/Resources.resw
@@ -174,9 +174,6 @@
   <data name="Application" xml:space="preserve">
     <value>Uygulama</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Sistem</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Yeni Klasör</value>
   </data>
@@ -284,18 +281,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Bu klasörü sildiniz mi?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Silmeye çalıştığınız dosya şu anda başka bir uygulama tarafından kullanılıyor.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Dosya kullanılıyor</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Yeniden dene</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>Tamam</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Geri dönüşüm kutusunu boşalt</value>
@@ -953,9 +938,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Hata</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Yeniden Dene</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Yine de kapat</value>

--- a/src/Files.Uwp/Strings/uk-UA/Resources.resw
+++ b/src/Files.Uwp/Strings/uk-UA/Resources.resw
@@ -174,9 +174,6 @@
   <data name="Application" xml:space="preserve">
     <value>За замовчуванням</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Системний</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Нова папка</value>
   </data>
@@ -284,18 +281,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Ви видалили цю папку?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Файл, який ви намагаєтесь видалити, зараз використовується іншою програмою.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Файл використовується</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Повторити</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>OK</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
     <value>Очистити кошик</value>
@@ -908,9 +893,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Помилка</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Повторити</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Закрити</value>

--- a/src/Files.Uwp/Strings/vi/Resources.resw
+++ b/src/Files.Uwp/Strings/vi/Resources.resw
@@ -252,9 +252,6 @@
   <data name="Application" xml:space="preserve">
     <value>Ứng dụng</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>Hệ thống</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>Thư mục Mới</value>
   </data>
@@ -332,18 +329,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>Bạn có xóa bỏ thư mục này không?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>Tệp bạn đang cố gắng để xóa bỏ đang có ứng dụng khác sử dụng.</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>Tệp đang sử dụng</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Thử lại</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>Đồng ý</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>Bố trí</value>
@@ -716,9 +701,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>Lỗi</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Thử lại</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>Vẫn đóng</value>

--- a/src/Files.Uwp/Strings/zh-Hans/Resources.resw
+++ b/src/Files.Uwp/Strings/zh-Hans/Resources.resw
@@ -264,9 +264,6 @@
   <data name="Application" xml:space="preserve">
     <value>应用</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>系统</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>新建文件夹</value>
   </data>
@@ -344,18 +341,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>确实要删除此文件夹吗？</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>删除目标文件正被其他应用程序使用。</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>文件正在使用</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>重试</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>确定</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>布局</value>
@@ -737,9 +722,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>错误</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>重试</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>仍然关闭</value>

--- a/src/Files.Uwp/Strings/zh-Hant/Resources.resw
+++ b/src/Files.Uwp/Strings/zh-Hant/Resources.resw
@@ -264,9 +264,6 @@
   <data name="Application" xml:space="preserve">
     <value>應用程式</value>
   </data>
-  <data name="SystemTimeStye" xml:space="preserve">
-    <value>系統</value>
-  </data>
   <data name="NewFolder" xml:space="preserve">
     <value>新增資料夾</value>
   </data>
@@ -344,18 +341,6 @@
   </data>
   <data name="FolderNotFoundDialog.Title" xml:space="preserve">
     <value>您把資料夾刪除了嗎?</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Text" xml:space="preserve">
-    <value>欲刪除的檔案正被其他應用程式使用。</value>
-  </data>
-  <data name="FileInUseDeleteDialog.Title" xml:space="preserve">
-    <value>檔案使用中</value>
-  </data>
-  <data name="FileInUseDeleteDialog.PrimaryButtonText" xml:space="preserve">
-    <value>重試</value>
-  </data>
-  <data name="FileInUseDeleteDialog.SecondaryButtonText" xml:space="preserve">
-    <value>確定</value>
   </data>
   <data name="NavToolbarLayout.Text" xml:space="preserve">
     <value>檢視</value>
@@ -737,9 +722,6 @@
   </data>
   <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
     <value>錯誤</value>
-  </data>
-  <data name="PropertySaveErrorDialog.PrimaryButtonText" xml:space="preserve">
-    <value>重試</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
     <value>仍要關閉</value>

--- a/src/Files.Uwp/UserControls/SidebarControl.xaml
+++ b/src/Files.Uwp/UserControls/SidebarControl.xaml
@@ -22,7 +22,7 @@
     DisplayModeChanged="SidebarControl_DisplayModeChanged"
     IsTitleBarAutoPaddingEnabled="False"
     ItemInvoked="Sidebar_ItemInvoked"
-    MenuItemsSource="{x:Bind local:SidebarControl.SideBarItems, Mode=OneWay}"
+    MenuItemsSource="{x:Bind ViewModel.SideBarItems, Mode=OneWay}"
     OpenPaneLength="{x:Bind UserSettingsService.AppearanceSettingsService.SidebarWidth, Mode=OneTime}"
     SelectedItem="{x:Bind SelectedSidebarItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
     mc:Ignorable="d">
@@ -92,7 +92,7 @@
                     ToolTipService.ToolTip="{x:Bind HoverDisplayText, Mode=OneWay}"
                     Visibility="{x:Bind ItemVisibility}">
                     <muxc:NavigationViewItem.Icon>
-                        <muxc:ImageIcon Source="{x:Bind Icon}" />
+                        <muxc:ImageIcon Source="{x:Bind Icon, Mode=OneWay}" />
                     </muxc:NavigationViewItem.Icon>
                 </muxc:NavigationViewItem>
             </DataTemplate>

--- a/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
@@ -315,31 +315,24 @@ namespace Files.Uwp.UserControls
             {
                 case SectionType.Favorites:
                     UserSettingsService.AppearanceSettingsService.ShowFavoritesSection = false;
-                    //App.SidebarPinnedController.Model.UpdateFavoritesSectionVisibility();
                     break;
                 case SectionType.Library:
                     UserSettingsService.AppearanceSettingsService.ShowLibrarySection = false;
-                    //App.LibraryManager.UpdateLibrariesSectionVisibility();
                     break;
                 case SectionType.CloudDrives:
                     UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection = false;
-                    //App.CloudDrivesManager.UpdateCloudDrivesSectionVisibility();
                     break;
                 case SectionType.Drives:
                     UserSettingsService.AppearanceSettingsService.ShowDrivesSection = false;
-                    //App.DrivesManager.UpdateDrivesSectionVisibility();
                     break;
                 case SectionType.Network:
                     UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection = false;
-                    //App.NetworkDrivesManager.UpdateNetworkDrivesSectionVisibility();
                     break;
                 case SectionType.WSL:
                     UserSettingsService.AppearanceSettingsService.ShowWslSection = false;
-                    //App.WSLDistroManager.UpdateWslSectionVisibility();
                     break;
                 case SectionType.FileTag:
                     UserSettingsService.AppearanceSettingsService.ShowFileTagsSection = false;
-                    //App.FileTagsManager.UpdateFileTagsSectionVisibility();
                     break;
             }
         }

--- a/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
@@ -34,10 +34,6 @@ namespace Files.Uwp.UserControls
     {
         public IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
 
-        public static SemaphoreSlim SideBarItemsSemaphore = new SemaphoreSlim(1, 1);
-
-        public static BulkConcurrentObservableCollection<INavigationControlItem> SideBarItems { get; private set; } = new BulkConcurrentObservableCollection<INavigationControlItem>();
-
         public delegate void SidebarItemInvokedEventHandler(object sender, SidebarItemInvokedEventArgs e);
 
         public event SidebarItemInvokedEventHandler SidebarItemInvoked;
@@ -319,31 +315,31 @@ namespace Files.Uwp.UserControls
             {
                 case SectionType.Favorites:
                     UserSettingsService.AppearanceSettingsService.ShowFavoritesSection = false;
-                    App.SidebarPinnedController.Model.UpdateFavoritesSectionVisibility();
+                    //App.SidebarPinnedController.Model.UpdateFavoritesSectionVisibility();
                     break;
                 case SectionType.Library:
                     UserSettingsService.AppearanceSettingsService.ShowLibrarySection = false;
-                    App.LibraryManager.UpdateLibrariesSectionVisibility();
+                    //App.LibraryManager.UpdateLibrariesSectionVisibility();
                     break;
                 case SectionType.CloudDrives:
                     UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection = false;
-                    App.CloudDrivesManager.UpdateCloudDrivesSectionVisibility();
+                    //App.CloudDrivesManager.UpdateCloudDrivesSectionVisibility();
                     break;
                 case SectionType.Drives:
                     UserSettingsService.AppearanceSettingsService.ShowDrivesSection = false;
-                    App.DrivesManager.UpdateDrivesSectionVisibility();
+                    //App.DrivesManager.UpdateDrivesSectionVisibility();
                     break;
                 case SectionType.Network:
                     UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection = false;
-                    App.NetworkDrivesManager.UpdateNetworkDrivesSectionVisibility();
+                    //App.NetworkDrivesManager.UpdateNetworkDrivesSectionVisibility();
                     break;
                 case SectionType.WSL:
                     UserSettingsService.AppearanceSettingsService.ShowWslSection = false;
-                    App.WSLDistroManager.UpdateWslSectionVisibility();
+                    //App.WSLDistroManager.UpdateWslSectionVisibility();
                     break;
                 case SectionType.FileTag:
                     UserSettingsService.AppearanceSettingsService.ShowFileTagsSection = false;
-                    App.FileTagsManager.UpdateFileTagsSectionVisibility();
+                    //App.FileTagsManager.UpdateFileTagsSectionVisibility();
                     break;
             }
         }
@@ -1234,7 +1230,7 @@ namespace Files.Uwp.UserControls
         private void NavigationView_PaneOpened(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
         {
             // Restore expanded state when pane is opened
-            foreach (var loc in SideBarItems.OfType<LocationItem>().Where(x => x.ChildItems != null))
+            foreach (var loc in ViewModel.SideBarItems.OfType<LocationItem>().Where(x => x.ChildItems != null))
             {
                 loc.IsExpanded = App.AppSettings.Get(loc.Text == "SidebarFavorites".GetLocalized(), $"section:{loc.Text.Replace('\\', '_')}");
             }
@@ -1243,7 +1239,7 @@ namespace Files.Uwp.UserControls
         private void NavigationView_PaneClosed(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
         {
             // Collapse all sections but do not store the state when pane is closed
-            foreach (var loc in SideBarItems.OfType<LocationItem>().Where(x => x.ChildItems != null))
+            foreach (var loc in ViewModel.SideBarItems.OfType<LocationItem>().Where(x => x.ChildItems != null))
             {
                 loc.IsExpanded = false;
             }
@@ -1328,9 +1324,6 @@ namespace Files.Uwp.UserControls
 
                     case NavigationControlItemType.FileTag:
                         return FileTagNavItemTemplate;
-
-                    case NavigationControlItemType.Header:
-                        return HeaderNavItemTemplate;
                 }
             }
             return null;

--- a/src/Files.Uwp/ViewModels/Properties/DriveProperties.cs
+++ b/src/Files.Uwp/ViewModels/Properties/DriveProperties.cs
@@ -24,9 +24,9 @@ namespace Files.Uwp.ViewModels.Properties
         {
             if (Drive != null)
             {
-                ViewModel.CustomIconSource = Drive.IconSource;
+                ViewModel.CustomIconSource = null; //Drive.IconSource;
                 ViewModel.IconData = Drive.IconData;
-                ViewModel.LoadCustomIcon = Drive.IconSource != null && Drive.IconData == null;
+                ViewModel.LoadCustomIcon = false; //Drive.IconSource != null && Drive.IconData == null;
                 ViewModel.LoadFileIcon = Drive.IconData != null;
                 ViewModel.ItemName = Drive.Text;
                 ViewModel.OriginalItemName = Drive.Text;

--- a/src/Files.Uwp/ViewModels/SettingsViewModels/AppearanceViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SettingsViewModels/AppearanceViewModel.cs
@@ -133,7 +133,6 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowFavoritesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowFavoritesSection = value;
-                    //App.SidebarPinnedController.Model.UpdateFavoritesSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -178,7 +177,6 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowLibrarySection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowLibrarySection = value;
-                    //App.LibraryManager.UpdateLibrariesSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -192,7 +190,6 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowDrivesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowDrivesSection = value;
-                    //App.DrivesManager.UpdateDrivesSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -206,7 +203,6 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection = value;
-                    //App.CloudDrivesManager.UpdateCloudDrivesSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -220,7 +216,6 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection = value;
-                    //App.NetworkDrivesManager.UpdateNetworkDrivesSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -234,7 +229,6 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowWslSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowWslSection = value;
-                    //App.WSLDistroManager.UpdateWslSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -250,7 +244,6 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowFileTagsSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowFileTagsSection = value;
-                    //App.FileTagsManager.UpdateFileTagsSectionVisibility();
                     OnPropertyChanged();
                 }
             }

--- a/src/Files.Uwp/ViewModels/SettingsViewModels/AppearanceViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SettingsViewModels/AppearanceViewModel.cs
@@ -133,7 +133,7 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowFavoritesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowFavoritesSection = value;
-                    App.SidebarPinnedController.Model.UpdateFavoritesSectionVisibility();
+                    //App.SidebarPinnedController.Model.UpdateFavoritesSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -178,7 +178,7 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowLibrarySection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowLibrarySection = value;
-                    App.LibraryManager.UpdateLibrariesSectionVisibility();
+                    //App.LibraryManager.UpdateLibrariesSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -192,7 +192,7 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowDrivesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowDrivesSection = value;
-                    App.DrivesManager.UpdateDrivesSectionVisibility();
+                    //App.DrivesManager.UpdateDrivesSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -206,7 +206,7 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection = value;
-                    App.CloudDrivesManager.UpdateCloudDrivesSectionVisibility();
+                    //App.CloudDrivesManager.UpdateCloudDrivesSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -220,7 +220,7 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection = value;
-                    App.NetworkDrivesManager.UpdateNetworkDrivesSectionVisibility();
+                    //App.NetworkDrivesManager.UpdateNetworkDrivesSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -234,7 +234,7 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowWslSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowWslSection = value;
-                    App.WSLDistroManager.UpdateWslSectionVisibility();
+                    //App.WSLDistroManager.UpdateWslSectionVisibility();
                     OnPropertyChanged();
                 }
             }
@@ -250,7 +250,7 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowFileTagsSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowFileTagsSection = value;
-                    App.FileTagsManager.UpdateFileTagsSectionVisibility();
+                    //App.FileTagsManager.UpdateFileTagsSectionVisibility();
                     OnPropertyChanged();
                 }
             }

--- a/src/Files.Uwp/ViewModels/SidebarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SidebarViewModel.cs
@@ -250,7 +250,7 @@ namespace Files.Uwp.ViewModels
             await dispatcherQueue.EnqueueAsync(async () =>
             {
                 var section = await GetOrCreateSection((SectionType)sender);
-                IReadOnlyList<INavigationControlItem> list = (SectionType)sender switch
+                Func<IReadOnlyList<INavigationControlItem>> getElements = () => (SectionType)sender switch
                 {
                     SectionType.Favorites => App.SidebarPinnedController.Model.Favorites,
                     SectionType.CloudDrives => App.CloudDrivesManager.Drives,
@@ -261,11 +261,11 @@ namespace Files.Uwp.ViewModels
                     SectionType.FileTag => App.FileTagsManager.FileTags,
                     _ => null
                 };
-                await SyncSidebarItems(section, list, e);
+                await SyncSidebarItems(section, getElements, e);
             });
         }
 
-        private async Task SyncSidebarItems(LocationItem section, IReadOnlyList<INavigationControlItem> elements, NotifyCollectionChangedEventArgs e)
+        private async Task SyncSidebarItems(LocationItem section, Func<IReadOnlyList<INavigationControlItem>> getElements, NotifyCollectionChangedEventArgs e)
         {
             if (section == null)
             {
@@ -300,13 +300,13 @@ namespace Files.Uwp.ViewModels
                     }
                 case NotifyCollectionChangedAction.Reset:
                     {
-                        foreach (INavigationControlItem elem in elements)
+                        foreach (INavigationControlItem elem in getElements())
                         {
                             await AddElementToSection(elem, section);
                         }
                         foreach (INavigationControlItem elem in section.ChildItems.ToList())
                         {
-                            if (!elements.Any(x => x.Path == elem.Path))
+                            if (!getElements().Any(x => x.Path == elem.Path))
                             {
                                 section.ChildItems.Remove(elem);
                             }

--- a/src/Files.Uwp/ViewModels/SidebarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SidebarViewModel.cs
@@ -549,6 +549,7 @@ namespace Files.Uwp.ViewModels
                     SectionType.Favorites => App.SidebarPinnedController.Model.AddAllItemsToSidebar,
                     _ => () => Task.CompletedTask
                 };
+                Manager_DataChanged(sectionType, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
                 await action();
             }
             else

--- a/src/Files.Uwp/ViewModels/SidebarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SidebarViewModel.cs
@@ -118,7 +118,6 @@ namespace Files.Uwp.ViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.IsSidebarOpen)
                 {
                     UserSettingsService.AppearanceSettingsService.IsSidebarOpen = value;
-                    OnPropertyChanged();
                 }
             }
         }
@@ -131,7 +130,6 @@ namespace Files.Uwp.ViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowFavoritesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowFavoritesSection = value;
-                    //App.SidebarPinnedController.Model.UpdateFavoritesSectionVisibility();
                 }
             }
         }
@@ -144,7 +142,6 @@ namespace Files.Uwp.ViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowLibrarySection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowLibrarySection = value;
-                    //App.LibraryManager.UpdateLibrariesSectionVisibility();
                 }
             }
         }
@@ -157,7 +154,6 @@ namespace Files.Uwp.ViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowDrivesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowDrivesSection = value;
-                    //App.DrivesManager.UpdateDrivesSectionVisibility();
                 }
             }
         }
@@ -170,7 +166,6 @@ namespace Files.Uwp.ViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection = value;
-                    //App.CloudDrivesManager.UpdateCloudDrivesSectionVisibility();
                 }
             }
         }
@@ -183,7 +178,6 @@ namespace Files.Uwp.ViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection = value;
-                    //App.NetworkDrivesManager.UpdateNetworkDrivesSectionVisibility();
                 }
             }
         }
@@ -196,7 +190,6 @@ namespace Files.Uwp.ViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowWslSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowWslSection = value;
-                    //App.WSLDistroManager.UpdateWslSectionVisibility();
                 }
             }
         }
@@ -209,7 +202,6 @@ namespace Files.Uwp.ViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.ShowFileTagsSection)
                 {
                     UserSettingsService.AppearanceSettingsService.ShowFileTagsSection = value;
-                    //App.FileTagsManager.UpdateFileTagsSectionVisibility();
                 }
             }
         }
@@ -542,6 +534,29 @@ namespace Files.Uwp.ViewModels
             }
         }
 
+        public async void UpdateSectionVisibility(SectionType sectionType, bool show)
+        {
+            if (show)
+            {
+                Func<Task> action = sectionType switch
+                {
+                    SectionType.CloudDrives => App.CloudDrivesManager.EnumerateDrivesAsync,
+                    SectionType.Drives => App.DrivesManager.EnumerateDrivesAsync,
+                    SectionType.Network => App.NetworkDrivesManager.EnumerateDrivesAsync,
+                    SectionType.WSL => App.WSLDistroManager.EnumerateDrivesAsync,
+                    SectionType.FileTag => App.FileTagsManager.EnumerateFileTagsAsync,
+                    SectionType.Library => App.LibraryManager.EnumerateLibrariesAsync,
+                    SectionType.Favorites => App.SidebarPinnedController.Model.AddAllItemsToSidebar,
+                    _ => () => Task.CompletedTask
+                };
+                await action();
+            }
+            else
+            {
+                SideBarItems.Remove(SideBarItems.FirstOrDefault(x => x.Section == sectionType));
+            }
+        }
+
         public async void EmptyRecycleBin(RoutedEventArgs e)
         {
             await RecycleBinHelpers.S_EmptyRecycleBin();
@@ -558,24 +573,31 @@ namespace Files.Uwp.ViewModels
                     }
                     break;
                 case nameof(UserSettingsService.AppearanceSettingsService.ShowFavoritesSection):
+                    UpdateSectionVisibility(SectionType.Favorites, ShowFavoritesSection);
                     OnPropertyChanged(nameof(ShowFavoritesSection));
                     break;
                 case nameof(UserSettingsService.AppearanceSettingsService.ShowLibrarySection):
+                    UpdateSectionVisibility(SectionType.Library, ShowLibrarySection);
                     OnPropertyChanged(nameof(ShowLibrarySection));
                     break;
                 case nameof(UserSettingsService.AppearanceSettingsService.ShowCloudDrivesSection):
+                    UpdateSectionVisibility(SectionType.CloudDrives, ShowCloudDrivesSection);
                     OnPropertyChanged(nameof(ShowCloudDrivesSection));
                     break;
                 case nameof(UserSettingsService.AppearanceSettingsService.ShowDrivesSection):
+                    UpdateSectionVisibility(SectionType.Drives, ShowDrivesSection);
                     OnPropertyChanged(nameof(ShowDrivesSection));
                     break;
                 case nameof(UserSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection):
+                    UpdateSectionVisibility(SectionType.Network, ShowNetworkDrivesSection);
                     OnPropertyChanged(nameof(ShowNetworkDrivesSection));
                     break;
                 case nameof(UserSettingsService.AppearanceSettingsService.ShowWslSection):
+                    UpdateSectionVisibility(SectionType.WSL, ShowWslSection);
                     OnPropertyChanged(nameof(ShowWslSection));
                     break;
                 case nameof(UserSettingsService.AppearanceSettingsService.ShowFileTagsSection):
+                    UpdateSectionVisibility(SectionType.FileTag, ShowFileTagsSection);
                     OnPropertyChanged(nameof(ShowFileTagsSection));
                     break;
                 case nameof(UserSettingsService.PreferencesSettingsService.AreFileTagsEnabled):

--- a/src/Files.Uwp/ViewModels/SidebarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SidebarViewModel.cs
@@ -285,7 +285,8 @@ namespace Files.Uwp.ViewModels
                     {
                         for (int i = 0; i < e.NewItems.Count; i++)
                         {
-                            await AddElementToSection((INavigationControlItem)e.NewItems[i], section, e.NewStartingIndex < 0 ? -1 : i + e.NewStartingIndex);
+                            var index = e.NewStartingIndex < 0 ? -1 : i + e.NewStartingIndex;
+                            await AddElementToSection((INavigationControlItem)e.NewItems[i], section, index);
                         }
                         break;
                     }
@@ -295,7 +296,8 @@ namespace Files.Uwp.ViewModels
                     {
                         foreach (INavigationControlItem elem in e.OldItems)
                         {
-                            section.ChildItems.Remove(elem);
+                            var match = section.ChildItems.FirstOrDefault(x => x.Path == elem.Path);
+                            section.ChildItems.Remove(match);
                         }
                         if (e.Action != NotifyCollectionChangedAction.Remove)
                         {
@@ -309,10 +311,9 @@ namespace Files.Uwp.ViewModels
                         {
                             await AddElementToSection(elem, section);
                         }
-
                         foreach (INavigationControlItem elem in section.ChildItems.ToList())
                         {
-                            if (!elements.Contains(elem))
+                            if (!elements.Any(x => x.Path == elem.Path))
                             {
                                 section.ChildItems.Remove(elem);
                             }

--- a/src/Files.Uwp/ViewModels/SidebarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SidebarViewModel.cs
@@ -118,6 +118,7 @@ namespace Files.Uwp.ViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.IsSidebarOpen)
                 {
                     UserSettingsService.AppearanceSettingsService.IsSidebarOpen = value;
+                    OnPropertyChanged();
                 }
             }
         }

--- a/src/Files.Uwp/ViewModels/SidebarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SidebarViewModel.cs
@@ -351,6 +351,7 @@ namespace Files.Uwp.ViewModels
 
         private async Task<LocationItem> GetOrCreateSection(SectionType sectionType)
         {
+            var sectionOrder = new[] { SectionType.Favorites, SectionType.Library, SectionType.Drives, SectionType.CloudDrives, SectionType.Network, SectionType.WSL, SectionType.FileTag };
             switch (sectionType)
             {
                 case SectionType.Favorites:
@@ -370,7 +371,7 @@ namespace Files.Uwp.ViewModels
                                 Font = App.MainViewModel.FontName,
                                 ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                             };
-                            var index = 0; // First section
+                            var index = sectionOrder.TakeWhile(x => x != sectionType).Select(x => SideBarItems.Any(item => item.Section == x) ? 1 : 0).Sum();
                             SideBarItems.Insert(Math.Min(index, SideBarItems.Count), section);
                             section.Icon = await UIHelpers.GetIconResource(Constants.Shell32.QuickAccess); // After insert
                         }
@@ -394,7 +395,7 @@ namespace Files.Uwp.ViewModels
                                 SelectsOnInvoked = false,
                                 ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                             };
-                            var index = (SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0); // After favorites section
+                            var index = sectionOrder.TakeWhile(x => x != sectionType).Select(x => SideBarItems.Any(item => item.Section == x) ? 1 : 0).Sum();
                             SideBarItems.Insert(Math.Min(index, SideBarItems.Count), section);
                             section.Icon = await UIHelpers.GetIconResource(Constants.ImageRes.Libraries); // After insert
                         }
@@ -417,8 +418,7 @@ namespace Files.Uwp.ViewModels
                                 SelectsOnInvoked = false,
                                 ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                             };
-                            var index = (SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0); // After libraries section
+                            var index = sectionOrder.TakeWhile(x => x != sectionType).Select(x => SideBarItems.Any(item => item.Section == x) ? 1 : 0).Sum();
                             SideBarItems.Insert(Math.Min(index, SideBarItems.Count), section);
                             section.Icon = await UIHelpers.GetIconResource(Constants.ImageRes.ThisPC); // After insert
                         }
@@ -442,9 +442,7 @@ namespace Files.Uwp.ViewModels
                                 Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/CloudDrive.png")),
                                 ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                             };
-                            var index = (SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0); // After drives section
+                            var index = sectionOrder.TakeWhile(x => x != sectionType).Select(x => SideBarItems.Any(item => item.Section == x) ? 1 : 0).Sum();
                             SideBarItems.Insert(Math.Min(index, SideBarItems.Count), section);
                         }
                         return section;
@@ -466,10 +464,7 @@ namespace Files.Uwp.ViewModels
                                 SelectsOnInvoked = false,
                                 ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                             };
-                            var index = (SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.CloudDrives) ? 1 : 0); // After cloud section
+                            var index = sectionOrder.TakeWhile(x => x != sectionType).Select(x => SideBarItems.Any(item => item.Section == x) ? 1 : 0).Sum();
                             SideBarItems.Insert(Math.Min(index, SideBarItems.Count), section);
                             section.Icon = await UIHelpers.GetIconResource(Constants.ImageRes.NetworkDrives); // After insert
                         }
@@ -493,11 +488,7 @@ namespace Files.Uwp.ViewModels
                                 Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/WSL/genericpng.png")),
                                 ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                             };
-                            var index = (SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.CloudDrives) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Network) ? 1 : 0); // After network section
+                            var index = sectionOrder.TakeWhile(x => x != sectionType).Select(x => SideBarItems.Any(item => item.Section == x) ? 1 : 0).Sum();
                             SideBarItems.Insert(Math.Min(index, SideBarItems.Count), section);
                         }
                         return section;
@@ -520,12 +511,7 @@ namespace Files.Uwp.ViewModels
                                 Icon = new Windows.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/FileTags.png")),
                                 ChildItems = new BulkConcurrentObservableCollection<INavigationControlItem>()
                             };
-                            var index = (SideBarItems.Any(item => item.Section == SectionType.Favorites) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Library) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Drives) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.CloudDrives) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.Network) ? 1 : 0) +
-                                        (SideBarItems.Any(item => item.Section == SectionType.WSL) ? 1 : 0); // After wsl section
+                            var index = sectionOrder.TakeWhile(x => x != sectionType).Select(x => SideBarItems.Any(item => item.Section == x) ? 1 : 0).Sum();
                             SideBarItems.Insert(Math.Min(index, SideBarItems.Count), section);
                         }
                         return section;


### PR DESCRIPTION
**Details of Changes**
Add details of changes here.

Refactored "Manager" classes (DrivesManager, CloudDrivesManager, FileTagsManager, LibraryManager, NetworkDrivesManager, WSLDistroManager, SidebarPinnedModel) so that they are decoupled from the Sidebar.
- Only SidebarViewModel should access sidebar items -> moved SidebarItems collection from SidebarControl to SidebarViewModel and made it non static
- The "Manager" classes only load the items -> the SidebarItems collection is updated by SidebarViewModel  through events
- Reduced code duplication -> removed duplicate SyncSideBarItemsUI(), Update\*SectionVisibility(), Remove\*SideBarSection() methods
- Removed the SidebarItemsSemaphore

**Validation**
How did you test these changes?
- [x] Built and ran the app
