### PR TITLE
Fixed an issue where the tab control had the wrong color

### DIFF
--- a/src/Files.Uwp/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/src/Files.Uwp/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -325,7 +325,6 @@
                                                         <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible" />
                                                         <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible" />
                                                         <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
-                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
                                                         <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}" />
                                                         <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}" />
                                                         <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}" />
@@ -347,7 +346,6 @@
                                                         <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible" />
                                                         <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible" />
                                                         <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
-                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
                                                         <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}" />
                                                         <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}" />
                                                         <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}" />

--- a/src/Files.Uwp/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/src/Files.Uwp/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -1,14 +1,14 @@
 ﻿<local:BaseMultitaskingControl
     x:Class="Files.Uwp.UserControls.MultitaskingControl.HorizontalMultitaskingControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:local1="using:Files.Uwp"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="using:Files.Uwp.Helpers"
     xmlns:local="using:Files.Uwp.UserControls.MultitaskingControl"
-    xmlns:vm="using:Files.Uwp.ViewModels"
+    xmlns:local1="using:Files.Uwp"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:vm="using:Files.Uwp.ViewModels"
     d:DesignHeight="300"
     d:DesignWidth="400"
     mc:Ignorable="d">
@@ -78,6 +78,481 @@
                             </MenuFlyoutItem.KeyboardAccelerators>
                         </MenuFlyoutItem>
                     </MenuFlyout>
+
+                    <Style x:Key="TabViewCloseButtonStyle" TargetType="Button">
+                        <Setter Property="HorizontalContentAlignment" Value="Center" />
+                        <Setter Property="VerticalContentAlignment" Value="Center" />
+                        <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}" />
+                        <Setter Property="FontSize" Value="{ThemeResource TabViewItemHeaderCloseFontSize}" />
+                        <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+                        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                        <Setter Property="Width" Value="{ThemeResource TabViewItemHeaderCloseButtonWidth}" />
+                        <Setter Property="Height" Value="{ThemeResource TabViewItemHeaderCloseButtonHeight}" />
+                        <Setter Property="Background" Value="{ThemeResource TabViewItemHeaderCloseButtonBackground}" />
+                        <Setter Property="Foreground" Value="{ThemeResource TabViewItemHeaderCloseButtonForeground}" />
+                        <Setter Property="FocusVisualMargin" Value="-3" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="Button">
+                                    <ContentPresenter
+                                        x:Name="ContentPresenter"
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        AutomationProperties.AccessibilityView="Raw"
+                                        Background="{TemplateBinding Background}"
+                                        BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                        Content="{TemplateBinding Content}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        ContentTransitions="{TemplateBinding ContentTransitions}"
+                                        CornerRadius="{TemplateBinding CornerRadius}">
+                                        <VisualStateManager.VisualStateGroups>
+                                            <VisualStateGroup x:Name="CommonStates">
+                                                <VisualState x:Name="Normal" />
+                                                <VisualState x:Name="PointerOver">
+                                                    <Storyboard>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewItemHeaderCloseButtonBackgroundPointerOver}" />
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewItemHeaderCloseButtonForegroundPointerOver}" />
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                    </Storyboard>
+                                                </VisualState>
+                                                <VisualState x:Name="Pressed">
+                                                    <Storyboard>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewItemHeaderCloseButtonBackgroundPressed}" />
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TabViewItemHeaderCloseButtonForegroundPressed}" />
+                                                        </ObjectAnimationUsingKeyFrames>
+                                                    </Storyboard>
+                                                </VisualState>
+                                            </VisualStateGroup>
+                                        </VisualStateManager.VisualStateGroups>
+                                    </ContentPresenter>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+
+                    <Style x:Key="Local.TabViewItem" TargetType="muxc:TabViewItem">
+                        <Setter Property="Background" Value="{ThemeResource TabViewItemHeaderBackground}" />
+                        <Setter Property="HorizontalContentAlignment" Value="Left" />
+                        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                        <Setter Property="MinHeight" Value="{ThemeResource TabViewItemMinHeight}" />
+                        <Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
+                        <Setter Property="BorderThickness" Value="{ThemeResource TabViewItemBorderThickness}" />
+                        <Setter Property="BorderBrush" Value="{ThemeResource TabViewItemBorderBrush}" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="muxc:TabViewItem">
+                                    <Grid
+                                        x:Name="LayoutRoot"
+                                        Padding="{TemplateBinding Padding}"
+                                        UseLayoutRounding="False">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition x:Name="LeftColumn" Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition x:Name="RightColumn" Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <Grid.RenderTransform>
+                                            <ScaleTransform x:Name="LayoutRootScale" />
+                                        </Grid.RenderTransform>
+
+                                        <Border
+                                            x:Name="BottomBorderLine"
+                                            Grid.ColumnSpan="3"
+                                            Height="1"
+                                            VerticalAlignment="Bottom"
+                                            BorderBrush="{ThemeResource TabViewBorderBrush}"
+                                            BorderThickness="1" />
+
+                                        <Path
+                                            x:Name="LeftRadiusRenderArc"
+                                            Width="4"
+                                            Height="4"
+                                            Margin="-4,0,0,0"
+                                            VerticalAlignment="Bottom"
+                                            x:Load="False"
+                                            Data="M4 0C4 1.19469 3.47624 2.26706 2.64582 3H0C1.65685 3 3 1.65685 3 0H4Z"
+                                            Fill="{ThemeResource TabViewBorderBrush}"
+                                            Visibility="Collapsed" />
+
+                                        <Path
+                                            x:Name="RightRadiusRenderArc"
+                                            Grid.Column="2"
+                                            Width="4"
+                                            Height="4"
+                                            Margin="0,0,-4,0"
+                                            VerticalAlignment="Bottom"
+                                            x:Load="False"
+                                            Data="M0 0C0 1.19469 0.523755 2.26706 1.35418 3H4C2.34315 3 1 1.65685 1 0H0Z"
+                                            Fill="{ThemeResource TabViewBorderBrush}"
+                                            Visibility="Collapsed" />
+
+                                        <Path
+                                            x:Name="SelectedBackgroundPath"
+                                            Grid.ColumnSpan="3"
+                                            Margin="-4,0,-4,0"
+                                            VerticalAlignment="Bottom"
+                                            x:Load="False"
+                                            Data="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.TabGeometry}"
+                                            Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}"
+                                            Visibility="Collapsed" />
+
+                                        <Border
+                                            x:Name="TabSeparator"
+                                            Grid.Column="1"
+                                            Width="1"
+                                            Margin="{ThemeResource TabViewItemSeparatorMargin}"
+                                            HorizontalAlignment="Right"
+                                            BorderBrush="{ThemeResource TabViewItemSeparator}"
+                                            BorderThickness="1" />
+
+                                        <Grid
+                                            x:Name="TabContainer"
+                                            Grid.Column="1"
+                                            Padding="{ThemeResource TabViewItemHeaderPadding}"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                            Control.IsTemplateFocusTarget="True"
+                                            CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={StaticResource TopCornerRadiusFilterConverter}}"
+                                            FocusVisualMargin="{TemplateBinding FocusVisualMargin}">
+
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition x:Name="IconColumn" Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <Viewbox
+                                                x:Name="IconBox"
+                                                MaxWidth="{ThemeResource TabViewItemHeaderIconSize}"
+                                                MaxHeight="{ThemeResource TabViewItemHeaderIconSize}"
+                                                Margin="{ThemeResource TabViewItemHeaderIconMargin}">
+                                                <ContentControl
+                                                    x:Name="IconControl"
+                                                    Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.IconElement}"
+                                                    Foreground="{ThemeResource TabViewItemIconForeground}"
+                                                    HighContrastAdjustment="None"
+                                                    IsTabStop="False" />
+                                            </Viewbox>
+
+                                            <!--
+                                                If we template bind the ContentPresenter's Content property to the TabViewItem.Header property
+                                                we unfortunately run into the following issue if the header is [null] or empty:
+                                                The TabViewItem.Content property will be implictly bound to the Content property of the ContentPresenter.
+                                                To prevent this, we explicitly set a default empty content here and update the content in code behind.
+                                            -->
+                                            <ContentPresenter
+                                                x:Name="ContentPresenter"
+                                                Grid.Column="1"
+                                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                Content=""
+                                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                                ContentTransitions="{TemplateBinding ContentTransitions}"
+                                                FontSize="{ThemeResource TabViewItemHeaderFontSize}"
+                                                FontWeight="{TemplateBinding FontWeight}"
+                                                Foreground="{ThemeResource TabViewItemHeaderForeground}"
+                                                HighContrastAdjustment="None"
+                                                OpticalMarginAlignment="TrimSideBearings" />
+
+                                            <Button
+                                                x:Name="CloseButton"
+                                                Grid.Column="2"
+                                                Margin="{ThemeResource TabViewItemHeaderCloseMargin}"
+                                                Content="&#xE711;"
+                                                HighContrastAdjustment="None"
+                                                IsTabStop="False"
+                                                IsTextScaleFactorEnabled="False"
+                                                Style="{ThemeResource TabViewCloseButtonStyle}" />
+                                        </Grid>
+
+                                        <VisualStateManager.VisualStateGroups>
+                                            <VisualStateGroup x:Name="CommonStates">
+                                                <VisualState x:Name="Normal" />
+
+                                                <VisualState x:Name="PointerOver">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundPointerOver}" />
+                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundPointerOver}" />
+                                                        <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundPointerOver}" />
+                                                        <Setter Target="CloseButton.Background" Value="{ThemeResource TabViewItemHeaderPointerOverCloseButtonBackground}" />
+                                                        <Setter Target="CloseButton.Foreground" Value="{ThemeResource TabViewItemHeaderPointerOverCloseButtonForeground}" />
+                                                        <Setter Target="TabSeparator.Opacity" Value="0" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+
+                                                <VisualState x:Name="Pressed">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundPressed}" />
+                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundPressed}" />
+                                                        <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundPressed}" />
+                                                        <Setter Target="CloseButton.Background" Value="{ThemeResource TabViewItemHeaderPressedCloseButtonBackground}" />
+                                                        <Setter Target="CloseButton.Foreground" Value="{ThemeResource TabViewItemHeaderPressedCloseButtonForeground}" />
+                                                        <Setter Target="TabSeparator.Opacity" Value="0" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+
+                                                <VisualState x:Name="Selected">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="BottomBorderLine.Visibility" Value="Collapsed" />
+                                                        <Setter Target="RightRadiusRenderArc.Visibility" Value="Visible" />
+                                                        <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible" />
+                                                        <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible" />
+                                                        <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
+                                                        <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}" />
+                                                        <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}" />
+                                                        <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}" />
+                                                        <Setter Target="TabContainer.Padding" Value="{ThemeResource TabViewSelectedItemHeaderPadding}" />
+                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundSelected}" />
+                                                        <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundSelected}" />
+                                                        <Setter Target="CloseButton.Background" Value="{ThemeResource TabViewItemHeaderSelectedCloseButtonBackground}" />
+                                                        <Setter Target="CloseButton.Foreground" Value="{ThemeResource TabViewItemHeaderSelectedCloseButtonForeground}" />
+                                                        <Setter Target="LayoutRoot.Background" Value="Transparent" />
+                                                        <Setter Target="ContentPresenter.FontWeight" Value="SemiBold" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+
+                                                <VisualState x:Name="PointerOverSelected">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="BottomBorderLine.Visibility" Value="Collapsed" />
+                                                        <Setter Target="RightRadiusRenderArc.Visibility" Value="Visible" />
+                                                        <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible" />
+                                                        <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible" />
+                                                        <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
+                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
+                                                        <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}" />
+                                                        <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}" />
+                                                        <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}" />
+                                                        <Setter Target="TabContainer.Padding" Value="{ThemeResource TabViewSelectedItemHeaderPadding}" />
+                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundSelected}" />
+                                                        <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundSelected}" />
+                                                        <Setter Target="CloseButton.Background" Value="{ThemeResource TabViewItemHeaderSelectedCloseButtonBackground}" />
+                                                        <Setter Target="CloseButton.Foreground" Value="{ThemeResource TabViewItemHeaderSelectedCloseButtonForeground}" />
+
+                                                        <Setter Target="LayoutRoot.Background" Value="Transparent" />
+                                                        <Setter Target="ContentPresenter.FontWeight" Value="SemiBold" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+
+                                                <VisualState x:Name="PressedSelected">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="BottomBorderLine.Visibility" Value="Collapsed" />
+                                                        <Setter Target="RightRadiusRenderArc.Visibility" Value="Visible" />
+                                                        <Setter Target="LeftRadiusRenderArc.Visibility" Value="Visible" />
+                                                        <Setter Target="SelectedBackgroundPath.Visibility" Value="Visible" />
+                                                        <Setter Target="SelectedBackgroundPath.Fill" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
+                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundSelected}" />
+                                                        <Setter Target="TabContainer.Margin" Value="{ThemeResource TabViewSelectedItemHeaderMargin}" />
+                                                        <Setter Target="TabContainer.BorderBrush" Value="{ThemeResource TabViewSelectedItemBorderBrush}" />
+                                                        <Setter Target="TabContainer.BorderThickness" Value="{ThemeResource TabViewSelectedItemBorderThickness}" />
+                                                        <Setter Target="TabContainer.Padding" Value="{ThemeResource TabViewSelectedItemHeaderPadding}" />
+                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundSelected}" />
+                                                        <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemIconForegroundSelected}" />
+                                                        <Setter Target="CloseButton.Background" Value="{ThemeResource TabViewItemHeaderSelectedCloseButtonBackground}" />
+                                                        <Setter Target="CloseButton.Foreground" Value="{ThemeResource TabViewItemHeaderSelectedCloseButtonForeground}" />
+                                                        <Setter Target="LayoutRoot.Background" Value="Transparent" />
+                                                        <Setter Target="ContentPresenter.FontWeight" Value="SemiBold" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+
+                                            <VisualStateGroup x:Name="DisabledStates">
+                                                <VisualState x:Name="Enabled" />
+
+                                                <VisualState x:Name="Disabled">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="TabContainer.Background" Value="{ThemeResource TabViewItemHeaderBackgroundDisabled}" />
+                                                        <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundDisabled}" />
+                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TabViewItemHeaderForegroundDisabled}" />
+                                                        <Setter Target="IconControl.Foreground" Value="{ThemeResource TabViewButtonForegroundDisabled}" />
+                                                        <Setter Target="CloseButton.Background" Value="{ThemeResource TabViewItemHeaderDisabledCloseButtonBackground}" />
+                                                        <Setter Target="CloseButton.Foreground" Value="{ThemeResource TabViewItemHeaderDisabledCloseButtonForeground}" />
+                                                        <Setter Target="CloseButton.BorderBrush" Value="{ThemeResource TabViewItemHeaderCloseButtonBorderBrushDisabled}" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+
+                                            <VisualStateGroup x:Name="DataVirtualizationStates">
+                                                <VisualState x:Name="DataAvailable" />
+
+                                                <VisualState x:Name="DataPlaceholder" />
+                                            </VisualStateGroup>
+
+                                            <VisualStateGroup x:Name="ReorderHintStates">
+                                                <VisualState x:Name="NoReorderHint" />
+
+                                                <VisualState x:Name="BottomReorderHint">
+                                                    <Storyboard>
+                                                        <DragOverThemeAnimation
+                                                            Direction="Bottom"
+                                                            ToOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
+                                                            TargetName="LayoutRoot" />
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualState x:Name="TopReorderHint">
+                                                    <Storyboard>
+                                                        <DragOverThemeAnimation
+                                                            Direction="Top"
+                                                            ToOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
+                                                            TargetName="LayoutRoot" />
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualState x:Name="RightReorderHint">
+                                                    <Storyboard>
+                                                        <DragOverThemeAnimation
+                                                            Direction="Right"
+                                                            ToOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
+                                                            TargetName="LayoutRoot" />
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualState x:Name="LeftReorderHint">
+                                                    <Storyboard>
+                                                        <DragOverThemeAnimation
+                                                            Direction="Left"
+                                                            ToOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
+                                                            TargetName="LayoutRoot" />
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualStateGroup.Transitions>
+                                                    <VisualTransition GeneratedDuration="0:0:0.2" To="NoReorderHint" />
+                                                </VisualStateGroup.Transitions>
+                                            </VisualStateGroup>
+
+                                            <VisualStateGroup x:Name="DragStates">
+                                                <VisualState x:Name="NotDragging" />
+
+                                                <VisualState x:Name="Dragging">
+                                                    <Storyboard>
+                                                        <DoubleAnimation
+                                                            Storyboard.TargetName="LayoutRoot"
+                                                            Storyboard.TargetProperty="Opacity"
+                                                            To="{ThemeResource ListViewItemDragThemeOpacity}"
+                                                            Duration="0" />
+                                                        <DragItemThemeAnimation TargetName="LayoutRoot" />
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualState x:Name="DraggingTarget" />
+
+                                                <VisualState x:Name="MultipleDraggingPrimary" />
+
+                                                <VisualState x:Name="MultipleDraggingSecondary" />
+
+                                                <VisualState x:Name="DraggedPlaceholder" />
+
+                                                <VisualState x:Name="Reordering">
+                                                    <Storyboard>
+                                                        <DoubleAnimation
+                                                            Storyboard.TargetName="LayoutRoot"
+                                                            Storyboard.TargetProperty="Opacity"
+                                                            To="{ThemeResource ListViewItemReorderThemeOpacity}"
+                                                            Duration="0:0:0.240" />
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualState x:Name="ReorderingTarget">
+                                                    <Storyboard>
+                                                        <DoubleAnimation
+                                                            Storyboard.TargetName="LayoutRoot"
+                                                            Storyboard.TargetProperty="Opacity"
+                                                            To="{ThemeResource ListViewItemReorderTargetThemeOpacity}"
+                                                            Duration="0:0:0.240" />
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualState x:Name="MultipleReorderingPrimary" />
+
+                                                <VisualState x:Name="ReorderedPlaceholder">
+                                                    <Storyboard>
+                                                        <FadeOutThemeAnimation TargetName="LayoutRoot" />
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualState x:Name="DragOver">
+                                                    <Storyboard>
+                                                        <DropTargetItemThemeAnimation TargetName="LayoutRoot" />
+                                                    </Storyboard>
+                                                </VisualState>
+
+                                                <VisualStateGroup.Transitions>
+                                                    <VisualTransition GeneratedDuration="0:0:0.2" To="NotDragging" />
+                                                </VisualStateGroup.Transitions>
+                                            </VisualStateGroup>
+
+                                            <VisualStateGroup x:Name="IconStates">
+                                                <VisualState x:Name="Icon" />
+                                                <VisualState x:Name="NoIcon">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="IconBox.Visibility" Value="Collapsed" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+
+                                            <VisualStateGroup x:Name="TabWidthModes">
+                                                <VisualState x:Name="StandardWidth" />
+
+                                                <VisualState x:Name="Compact">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="IconBox.Margin" Value="0,0,0,0" />
+                                                        <Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
+                                                        <Setter Target="IconColumn.Width" Value="{ThemeResource TabViewItemHeaderIconSize}" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+
+                                            <VisualStateGroup x:Name="CloseIconStates">
+                                                <VisualState x:Name="CloseButtonVisible" />
+                                                <VisualState x:Name="CloseButtonCollapsed">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="CloseButton.Visibility" Value="Collapsed" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+
+                                            <VisualStateGroup>
+                                                <VisualState x:Name="ForegroundNotSet" />
+                                                <VisualState x:Name="ForegroundSet">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="IconControl.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}" />
+                                                        <Setter Target="ContentPresenter.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Foreground}" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+
+                                            <VisualStateGroup>
+                                                <VisualState x:Name="NormalBottomBorderLine" />
+                                                <VisualState x:Name="LeftOfSelectedTab">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="BottomBorderLine.Margin" Value="0,0,2,0" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                                <VisualState x:Name="RightOfSelectedTab">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="BottomBorderLine.Margin" Value="2,0,0,0" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                                <VisualState x:Name="NoBottomBorderLine">
+                                                    <VisualState.Setters>
+                                                        <Setter Target="BottomBorderLine.Visibility" Value="Collapsed" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+                                        </VisualStateManager.VisualStateGroups>
+                                    </Grid>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -114,6 +589,7 @@
                         Drop="TabViewItem_Drop"
                         Header="{x:Bind Header, Mode=OneWay}"
                         IconSource="{x:Bind IconSource, Mode=OneWay}"
+                        Style="{StaticResource Local.TabViewItem}"
                         ToolTipService.ToolTip="{x:Null}" />
                 </DataTemplate>
             </muxc:TabView.TabItemTemplate>


### PR DESCRIPTION
A recent WinUI update added a second layer of mica to the tab control causing it to have the wrong transparncy in Files. I worked around this by removing one of the visual states from the default template.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
