### PR TITLE
Fixes for item context menu in search page

### DIFF
--- a/src/Files.Uwp/Helpers/ContextFlyoutItemHelper.cs
+++ b/src/Files.Uwp/Helpers/ContextFlyoutItemHelper.cs
@@ -1004,6 +1004,7 @@ namespace Files.Uwp.Helpers
                 {
                     ItemType = ItemType.Separator,
                     Tag = "OverflowSeparator",
+                    ShowInSearchPage = true,
                     IsHidden = true,
                 },
                 new ContextMenuFlyoutItemViewModel()
@@ -1013,6 +1014,7 @@ namespace Files.Uwp.Helpers
                     Items = new List<ContextMenuFlyoutItemViewModel>(),
                     ID = "ItemOverflow",
                     Tag = "ItemOverflow",
+                    ShowInSearchPage = true,
                     IsHidden = true,
                 },
             };

--- a/src/Files.Uwp/ViewModels/CurrentInstanceViewModel.cs
+++ b/src/Files.Uwp/ViewModels/CurrentInstanceViewModel.cs
@@ -39,6 +39,7 @@ namespace Files.Uwp.ViewModels
                 OnPropertyChanged(nameof(CanCopyPathInPage));
                 OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
                 OnPropertyChanged(nameof(CanShareInPage));
+                OnPropertyChanged(nameof(CanTagFilesInPage));
             }
         }
 
@@ -84,6 +85,7 @@ namespace Files.Uwp.ViewModels
                 OnPropertyChanged(nameof(CanCopyPathInPage));
                 OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
                 OnPropertyChanged(nameof(CanShareInPage));
+                OnPropertyChanged(nameof(CanTagFilesInPage));
             }
         }
 
@@ -102,6 +104,7 @@ namespace Files.Uwp.ViewModels
                 OnPropertyChanged(nameof(CanCopyPathInPage));
                 OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
                 OnPropertyChanged(nameof(CanShareInPage));
+                OnPropertyChanged(nameof(CanTagFilesInPage));
             }
         }
 
@@ -120,6 +123,7 @@ namespace Files.Uwp.ViewModels
                 OnPropertyChanged(nameof(CanCopyPathInPage));
                 OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
                 OnPropertyChanged(nameof(CanShareInPage));
+                OnPropertyChanged(nameof(CanTagFilesInPage));
             }
         }
 
@@ -138,6 +142,7 @@ namespace Files.Uwp.ViewModels
                 OnPropertyChanged(nameof(CanCopyPathInPage));
                 OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
                 OnPropertyChanged(nameof(CanShareInPage));
+                OnPropertyChanged(nameof(CanTagFilesInPage));
             }
         }
 
@@ -156,6 +161,7 @@ namespace Files.Uwp.ViewModels
                 OnPropertyChanged(nameof(CanCopyPathInPage));
                 OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
                 OnPropertyChanged(nameof(CanShareInPage));
+                OnPropertyChanged(nameof(CanTagFilesInPage));
             }
         }
 
@@ -174,6 +180,7 @@ namespace Files.Uwp.ViewModels
                 OnPropertyChanged(nameof(CanCopyPathInPage));
                 OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
                 OnPropertyChanged(nameof(CanShareInPage));
+                OnPropertyChanged(nameof(CanTagFilesInPage));
             }
         }
 
@@ -192,6 +199,7 @@ namespace Files.Uwp.ViewModels
                 OnPropertyChanged(nameof(CanCopyPathInPage));
                 OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
                 OnPropertyChanged(nameof(CanShareInPage));
+                OnPropertyChanged(nameof(CanTagFilesInPage));
             }
         }
 
@@ -223,6 +231,11 @@ namespace Files.Uwp.ViewModels
         public bool CanShareInPage
         {
             get => !isPageTypeRecycleBin && isPageTypeNotHome && !isPageTypeFtp && !isPageTypeZipFolder;
+        }
+
+        public bool CanTagFilesInPage
+        {
+            get => !isPageTypeRecycleBin && !isPageTypeFtp && !isPageTypeZipFolder;
         }
     }
 }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #8986

**Details of Changes**
Add details of changes here.
- Show file tags menu in search page
- Fix overflow items not shown in search page

Currently right clicking on an item in search page shown a context menu where the last item is a separator, which is weird. Issue is that the "Overflow" menu item is hidden in search.

**Validation**
How did you test these changes?
- [x] Built and ran the app
