### PR TITLE
Fix spacing in status bar

### DIFF
--- a/src/Files.Uwp/UserControls/StatusBarControl.xaml
+++ b/src/Files.Uwp/UserControls/StatusBarControl.xaml
@@ -24,8 +24,7 @@
         Height="32"
         Padding="8,0"
         HorizontalAlignment="Stretch"
-        VerticalAlignment="Stretch"
-        ColumnSpacing="12">
+        VerticalAlignment="Stretch">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
@@ -38,12 +37,14 @@
             x:Name="DirectoryItemCount"
             Grid.Column="0"
             VerticalAlignment="Center"
+            Margin="0,0,12,0"
             x:Load="{x:Bind ShowInfoText, Mode=OneWay}"
             Text="{x:Bind DirectoryPropertiesViewModel.DirectoryItemCount, Mode=OneWay}" />
         <TextBlock
             x:Name="SelectedItemsCountString"
             Grid.Column="1"
             VerticalAlignment="Center"
+            Margin="0,0,12,0"
             x:Load="{x:Bind ShowInfoText, Mode=OneWay}"
             Text="{x:Bind SelectedItemsPropertiesViewModel.SelectedItemsCountString, Mode=OneWay}"
             Visibility="{x:Bind SelectedItemsPropertiesViewModel.IsItemSelected, Mode=OneWay}" />
@@ -51,6 +52,7 @@
             x:Name="ItemSize"
             Grid.Column="2"
             VerticalAlignment="Center"
+            Margin="0,0,12,0"
             x:Load="{x:Bind ShowInfoText, Mode=OneWay}"
             Text="{x:Bind SelectedItemsPropertiesViewModel.ItemSize, Mode=OneWay}"
             Visibility="{x:Bind SelectedItemsPropertiesViewModel.ItemSizeVisibility, Mode=OneWay}" />


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
This fixes a small issue where in the Status bar when no items are selected and folder size is enabled there's a 24px space (instead of 12px) between element count and size.

**Details of Changes**
Add details of changes here.
- Put margin on each column content instead of using ColumnSpacing property

**Validation**
How did you test these changes?
- [x] Built and ran the app
