### PR TITLE
Fix crash due to concurrent edits of sidebar lists

### DIFF
--- a/src/Files.Uwp/BaseLayout.cs
+++ b/src/Files.Uwp/BaseLayout.cs
@@ -367,7 +367,7 @@ namespace Files.Uwp
                 return;
             }
 
-            foreach (var item in items.ToList()) // ToList() is necessary
+            foreach (var item in items)
             {
                 if (item != null)
                 {

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -110,19 +110,26 @@ namespace Files.Uwp.DataModels
                 };
                 // Add recycle bin to sidebar, title is read from LocalSettings (provided by the fulltrust process)
                 // TODO: the very first time the app is launched localized name not available
-                if (!favoriteList.Any(x => x.Path == CommonPaths.RecycleBinPath))
+                lock (favoriteList)
                 {
+                    if (favoriteList.Any(x => x.Path == CommonPaths.RecycleBinPath))
+                    {
+                        return;
+                    }
                     favoriteList.Add(recycleBinItem);
-                    controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, recycleBinItem));
                 }
+                controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, recycleBinItem));
             }
             else
             {
-                foreach (INavigationControlItem item in favoriteList.ToList())
+                foreach (INavigationControlItem item in Favorites)
                 {
                     if (item is LocationItem && item.Path == CommonPaths.RecycleBinPath)
                     {
-                        favoriteList.Remove(item);
+                        lock (favoriteList)
+                        {
+                            favoriteList.Remove(item);
+                        }
                         controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item));
                     }
                 }
@@ -166,8 +173,11 @@ namespace Files.Uwp.DataModels
                 {
                     FavoriteItems.RemoveAt(oldIndex - 1);
                     FavoriteItems.Insert(newIndex - 1, locationItem.Path);
-                    favoriteList.RemoveAt(oldIndex);
-                    favoriteList.Insert(newIndex, locationItem);
+                    lock (favoriteList)
+                    {
+                        favoriteList.RemoveAt(oldIndex);
+                        favoriteList.Insert(newIndex, locationItem);
+                    }
                     controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, locationItem, newIndex, oldIndex));
                     Save();
                 }
@@ -212,7 +222,10 @@ namespace Files.Uwp.DataModels
         /// <returns>Index of the item</returns>
         public int IndexOfItem(INavigationControlItem locationItem)
         {
-            return favoriteList.FindIndex(x => x.Path == locationItem.Path);
+            lock (favoriteList)
+            {
+                return favoriteList.FindIndex(x => x.Path == locationItem.Path);
+            }
         }
 
         /// <summary>
@@ -240,8 +253,6 @@ namespace Files.Uwp.DataModels
         {
             var item = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(path));
             var res = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(path, item));
-            var lastItem = favoriteList.LastOrDefault(x => x.ItemType == NavigationControlItemType.Location && !x.Path.Equals(CommonPaths.RecycleBinPath));
-            int insertIndex = lastItem != null ? favoriteList.IndexOf(lastItem) + 1 : 0;
             var locationItem = new LocationItem
             {
                 Font = MainViewModel.FontName,
@@ -288,11 +299,18 @@ namespace Files.Uwp.DataModels
                 Debug.WriteLine($"Pinned item was invalid {res.ErrorCode}, item: {path}");
             }
 
-            if (!favoriteList.Any(x => x.Path == locationItem.Path))
+            int insertIndex = -1;
+            lock (favoriteList)
             {
+                if (favoriteList.Any(x => x.Path == locationItem.Path))
+                {
+                    return;
+                }
+                var lastItem = favoriteList.LastOrDefault(x => x.ItemType == NavigationControlItemType.Location && !x.Path.Equals(CommonPaths.RecycleBinPath));
+                insertIndex = lastItem != null ? favoriteList.IndexOf(lastItem) + 1 : 0;
                 favoriteList.Insert(insertIndex, locationItem);
-                controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, locationItem, insertIndex));
             }
+            controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, locationItem, insertIndex));
         }
 
         /// <summary>
@@ -301,14 +319,18 @@ namespace Files.Uwp.DataModels
         /// <param name="section">The section.</param>
         private void AddLocationItemToSidebar(LocationItem section)
         {
-            var lastItem = favoriteList.LastOrDefault(x => x.ItemType == NavigationControlItemType.Location && !x.Path.Equals(CommonPaths.RecycleBinPath));
-            int insertIndex = lastItem != null ? favoriteList.IndexOf(lastItem) + 1 : 0;
-
-            if (!favoriteList.Any(x => x.Section == section.Section))
+            int insertIndex = -1;
+            lock (favoriteList)
             {
+                if (favoriteList.Any(x => x.Section == section.Section))
+                {
+                    return;
+                }
+                var lastItem = favoriteList.LastOrDefault(x => x.ItemType == NavigationControlItemType.Location && !x.Path.Equals(CommonPaths.RecycleBinPath));
+                insertIndex = lastItem != null ? favoriteList.IndexOf(lastItem) + 1 : 0;
                 favoriteList.Insert(insertIndex, section);
-                controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, section, insertIndex));
             }
+            controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, section, insertIndex));
         }
 
         /// <summary>
@@ -351,15 +373,16 @@ namespace Files.Uwp.DataModels
         public void RemoveStaleSidebarItems()
         {
             // Remove unpinned items from favoriteList
-            // Reverse iteration to avoid skipping elements while removing
-            for (int i = favoriteList.Count - 1; i >= 0; i--)
+            foreach (var childItem in Favorites)
             {
-                var childItem = favoriteList[i];
                 if (childItem is LocationItem item)
                 {
                     if (!item.IsDefaultLocation && !FavoriteItems.Contains(item.Path))
                     {
-                        favoriteList.RemoveAt(i);
+                        lock (favoriteList)
+                        {
+                            favoriteList.Remove(item);
+                        }
                         controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item));
                     }
                 }

--- a/src/Files.Uwp/Filesystem/CloudDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/CloudDrivesManager.cs
@@ -72,10 +72,11 @@ namespace Files.Uwp.Filesystem
 
                 lock (drivesList)
                 {
-                    if (!drivesList.Any(x => x.Path == cloudProviderItem.Path))
+                    if (drivesList.Any(x => x.Path == cloudProviderItem.Path))
                     {
-                        drivesList.Add(cloudProviderItem);
+                        continue;
                     }
+                    drivesList.Add(cloudProviderItem);
                 }
 
                 DataChanged?.Invoke(SectionType.CloudDrives, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, cloudProviderItem));

--- a/src/Files.Uwp/Filesystem/Drives.cs
+++ b/src/Files.Uwp/Filesystem/Drives.cs
@@ -175,7 +175,7 @@ namespace Files.Uwp.Filesystem
             // Flag set if any drive throws UnauthorizedAccessException
             bool unauthorizedAccessDetected = false;
 
-            var drives = DriveInfo.GetDrives().ToList();
+            var drives = DriveInfo.GetDrives();
 
             foreach (var drive in drives)
             {

--- a/src/Files.Uwp/Filesystem/FileTagsManager.cs
+++ b/src/Files.Uwp/Filesystem/FileTagsManager.cs
@@ -41,21 +41,26 @@ namespace Files.Uwp.Filesystem
             {
                 foreach (var tag in FileTagsSettingsService.FileTagList)
                 {
-                    if (!fileTagList.Any(x => x.Path == $"tag:{tag.TagName}"))
+                    var tagItem = new FileTagItem()
                     {
-                        var tagItem = new FileTagItem()
+                        Text = tag.TagName,
+                        Path = $"tag:{tag.TagName}",
+                        FileTag = tag,
+                        MenuOptions = new ContextMenuOptions
                         {
-                            Text = tag.TagName,
-                            Path = $"tag:{tag.TagName}",
-                            FileTag = tag,
-                            MenuOptions = new ContextMenuOptions
-                            {
-                                IsLocationItem = true
-                            }
-                        };
+                            IsLocationItem = true
+                        }
+                    };
+
+                    lock (fileTagList)
+                    {
+                        if (fileTagList.Any(x => x.Path == $"tag:{tag.TagName}"))
+                        {
+                            continue;
+                        }
                         fileTagList.Add(tagItem);
-                        DataChanged?.Invoke(SectionType.FileTag, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, tagItem));
                     }
+                    DataChanged?.Invoke(SectionType.FileTag, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, tagItem));
                 }
             }
             catch (Exception ex)

--- a/src/Files.Uwp/Filesystem/LibraryManager.cs
+++ b/src/Files.Uwp/Filesystem/LibraryManager.cs
@@ -44,12 +44,18 @@ namespace Files.Uwp.Filesystem
 
         public async Task EnumerateLibrariesAsync()
         {
-            librariesList.Clear();
+            lock (librariesList)
+            {
+                librariesList.Clear();
+            }
             var libs = await LibraryHelper.ListUserLibraries();
             if (libs != null)
             {
                 libs.Sort();
-                librariesList.AddRange(libs);
+                lock (librariesList)
+                {
+                    librariesList.AddRange(libs);
+                }
             }
             DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
@@ -64,13 +70,19 @@ namespace Files.Uwp.Filesystem
             var changedLibrary = Libraries.FirstOrDefault(l => string.Equals(l.Path, path, StringComparison.OrdinalIgnoreCase));
             if (changedLibrary != null)
             {
-                librariesList.Remove(changedLibrary);
+                lock (librariesList)
+                {
+                    librariesList.Remove(changedLibrary);
+                }
                 DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, changedLibrary));
             }
             // library is null in case it was deleted
             if (library != null && !Libraries.Any(x => x.Path == library.FullPath))
             {
-                librariesList.Add(new LibraryLocationItem(library));
+                lock (librariesList)
+                {
+                    librariesList.Add(new LibraryLocationItem(library));
+                }
                 DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, library));
             }
             return Task.CompletedTask;
@@ -96,7 +108,10 @@ namespace Files.Uwp.Filesystem
             var newLib = await LibraryHelper.CreateLibrary(name);
             if (newLib != null)
             {
-                librariesList.Add(newLib);
+                lock (librariesList)
+                {
+                    librariesList.Add(newLib);
+                }
                 DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, newLib));
                 return true;
             }
@@ -111,7 +126,10 @@ namespace Files.Uwp.Filesystem
                 var libItem = Libraries.FirstOrDefault(l => string.Equals(l.Path, libraryPath, StringComparison.OrdinalIgnoreCase));
                 if (libItem != null)
                 {
-                    librariesList[librariesList.IndexOf(libItem)] = newLib;
+                    lock (librariesList)
+                    {
+                        librariesList[librariesList.IndexOf(libItem)] = newLib;
+                    }
                     DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newLib, libItem));
                 }
                 return newLib;

--- a/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
@@ -95,10 +95,11 @@ namespace Files.Uwp.Filesystem
                         };
                         lock (drivesList)
                         {
-                            if (!drivesList.Any(x => x.Path == networkItem.Path))
+                            if (drivesList.Any(x => x.Path == networkItem.Path))
                             {
-                                drivesList.Add(networkItem);
+                                continue;
                             }
+                            drivesList.Add(networkItem);
                         }
                     }
                     foreach (var drive in Drives

--- a/src/Files.Uwp/Filesystem/WSLDistroManager.cs
+++ b/src/Files.Uwp/Filesystem/WSLDistroManager.cs
@@ -67,21 +67,26 @@ namespace Files.Uwp.Filesystem
                         logoURI = new Uri("ms-appx:///Assets/WSL/genericpng.png");
                     }
 
-                    if (!distroList.Any(x => x.Path == folder.Path))
+                    var distro = new WslDistroItem()
                     {
-                        var distro = new WslDistroItem()
+                        Text = folder.DisplayName,
+                        Path = folder.Path,
+                        Logo = logoURI,
+                        MenuOptions = new ContextMenuOptions
                         {
-                            Text = folder.DisplayName,
-                            Path = folder.Path,
-                            Logo = logoURI,
-                            MenuOptions = new ContextMenuOptions
-                            {
-                                IsLocationItem = true
-                            }
-                        };
+                            IsLocationItem = true
+                        }
+                    };
+
+                    lock (distroList)
+                    {
+                        if (distroList.Any(x => x.Path == folder.Path))
+                        {
+                            continue;
+                        }
                         distroList.Add(distro);
-                        DataChanged?.Invoke(SectionType.WSL, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, distro));
                     }
+                    DataChanged?.Invoke(SectionType.WSL, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, distro));
                 }
             }
             catch (Exception)

--- a/src/Files.Uwp/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.Uwp/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -108,7 +108,7 @@ namespace Files.Uwp.UserControls.Widgets
         {
             await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
             {
-                foreach (DriveItem drive in App.DrivesManager.Drives.ToList())
+                foreach (DriveItem drive in App.DrivesManager.Drives)
                 {
                     if (!ItemsAdded.Any(x => x.Item == drive))
                     {


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
PR #8952 introduced a bug for which sometimes the app crashes on start due to the favorites list being concurrently modified.

**Details of Changes**
Add details of changes here.
- Add proper lock() statements when modifying favorites and other sidebar sections related lists (like was already the case with Drives)
- Remove a couple of extra "ToList()" calls when safe to do so.

**Validation**
How did you test these changes?
- [x] Built and ran the app
