### PR TITLE
feat(VirtualStorageItem): instantiation from filesystem path

### DIFF
--- a/src/Files.Uwp/BaseLayout.cs
+++ b/src/Files.Uwp/BaseLayout.cs
@@ -844,9 +844,8 @@ namespace Files.Uwp
             try
             {
                 // Only support IStorageItem capable paths
-                var itemList = e.Items.OfType<ListedItem>().Where(x => !(x.IsHiddenItem && x.IsLinkItem && x.IsRecycleBinItem && x.IsShortcutItem)).Select(x => new VirtualStorageItem(x));
+                var itemList = e.Items.OfType<ListedItem>().Where(x => !(x.IsHiddenItem && x.IsLinkItem && x.IsRecycleBinItem && x.IsShortcutItem)).Select(x => VirtualStorageItem.FromListedItem(x));
                 e.Data.SetStorageItems(itemList, false);
-                //e.Data.RequestedOperation = DataPackageOperation.Move;
             }
             catch (Exception)
             {

--- a/src/Files.Uwp/BaseLayout.cs
+++ b/src/Files.Uwp/BaseLayout.cs
@@ -837,19 +837,14 @@ namespace Files.Uwp
             }
         }
 
-        protected async void FileList_DragItemsStarting(object sender, DragItemsStartingEventArgs e)
+        protected void FileList_DragItemsStarting(object sender, DragItemsStartingEventArgs e)
         {
-            // Only support IStorageItem capable paths
             e.Items.OfType<ListedItem>().ForEach(item => SelectedItems.Add(item));
 
             try
             {
-                // Get the log file to use its properties. For some reason the drag and drop operation
-                // requires a BasicProperties object even though does not seem to be used.
-                // We supply it regardless for every VirtualStorageItem because it is checked for
-                var fakeFilePropsItem = await StorageFile.GetFileFromPathAsync(Path.Combine(ApplicationData.Current.LocalFolder.Path, "debug.log"));
-                var props = await fakeFilePropsItem.GetBasicPropertiesAsync();
-                var itemList = e.Items.OfType<ListedItem>().Where(x => !(x.IsHiddenItem && x.IsLinkItem && x.IsRecycleBinItem && x.IsShortcutItem)).Select(x => new VirtualStorageItem(x, props));
+                // Only support IStorageItem capable paths
+                var itemList = e.Items.OfType<ListedItem>().Where(x => !(x.IsHiddenItem && x.IsLinkItem && x.IsRecycleBinItem && x.IsShortcutItem)).Select(x => new VirtualStorageItem(x));
                 e.Data.SetStorageItems(itemList, false);
                 //e.Data.RequestedOperation = DataPackageOperation.Move;
             }

--- a/src/Files.Uwp/Filesystem/StorageItems/VirtualStorageItem.cs
+++ b/src/Files.Uwp/Filesystem/StorageItems/VirtualStorageItem.cs
@@ -1,7 +1,7 @@
-﻿using Files.Uwp.Extensions;
-using Files.Uwp.Helpers;
+﻿using Files.Uwp.Helpers;
 using System;
 using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Storage;
@@ -17,46 +17,70 @@ namespace Files.Uwp.Filesystem.StorageItems
     /// </summary>
     public class VirtualStorageItem : IStorageItem
     {
-        private readonly ListedItem item;
         private static BasicProperties props;
 
-        public Windows.Storage.FileAttributes Attributes => item.PrimaryItemAttribute == StorageItemTypes.File ? Windows.Storage.FileAttributes.Normal : Windows.Storage.FileAttributes.Directory;
+        public Windows.Storage.FileAttributes Attributes { get; init; }
 
-        public DateTimeOffset DateCreated => item.ItemDateCreatedReal;
+        public DateTimeOffset DateCreated { get; init; }
 
-        public string Name => item.ItemName;
+        public string Name { get; init; }
 
-        public string Path => item.ItemPath;
+        public string Path { get; init; }
 
-        public VirtualStorageItem(ListedItem item)
+        private VirtualStorageItem() { }
+
+        public static VirtualStorageItem FromListedItem(ListedItem item)
         {
-            this.item = item;
-            SetBasicProperties();
+            return new VirtualStorageItem()
+            {
+                Name = item.ItemNameRaw,
+                Path = item.ItemPath,
+                DateCreated = item.ItemDateCreatedReal,
+                Attributes = item.IsZipItem || item.PrimaryItemAttribute == StorageItemTypes.File ? Windows.Storage.FileAttributes.Normal : Windows.Storage.FileAttributes.Directory
+            };
         }
 
-        public VirtualStorageItem(string path)
+        public static VirtualStorageItem FromPath(string path)
         {
             FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
             int additionalFlags = FIND_FIRST_EX_LARGE_FETCH;
-
-            IntPtr hFile = FindFirstFileExFromApp(path, findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero,
-                                                  additionalFlags);
+            IntPtr hFile = FindFirstFileExFromApp(path, findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, additionalFlags);
             if (hFile.ToInt64() != -1)
             {
-                this.item = GetListedItemFromFindData(findData);
-                SetBasicProperties();
+                // https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/c8e77b37-3909-4fe6-a4ea-2b9d423b1ee4
+                bool isReparsePoint = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.ReparsePoint) == System.IO.FileAttributes.ReparsePoint;
+                bool isSymlink = isReparsePoint && findData.dwReserved0 == NativeFileOperationsHelper.IO_REPARSE_TAG_SYMLINK;
+                bool isHidden = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.Hidden) == System.IO.FileAttributes.Hidden;
+                bool isDirectory = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.Directory) == System.IO.FileAttributes.Directory;
+
+                if (!(isHidden && isSymlink))
+                {
+                    DateTime itemCreatedDate;
+
+                    try
+                    {
+                        FileTimeToSystemTime(ref findData.ftCreationTime, out SYSTEMTIME systemCreatedDateOutput);
+                        itemCreatedDate = systemCreatedDateOutput.ToDateTime();
+                    }
+                    catch (ArgumentException)
+                    {
+                        // Invalid date means invalid findData, do not add to list
+                        return null;
+                    }
+
+                    return new VirtualStorageItem()
+                    {
+                        Name = findData.cFileName,
+                        Path = path,
+                        DateCreated = itemCreatedDate,
+                        Attributes = isDirectory ? Windows.Storage.FileAttributes.Directory : Windows.Storage.FileAttributes.Normal
+                    };
+                }
+
+                FindClose(hFile);
             }
 
-            FindClose(hFile);
-        }
-
-        private async void SetBasicProperties()
-        {
-            if (props is null)
-            {
-                var streamedFile = await StorageFile.CreateStreamedFileAsync(Name, StreamedFileWriter, null);
-                props = await streamedFile.GetBasicPropertiesAsync();
-            }
+            return null;
         }
 
         private async void StreamedFileWriter(StreamedFileDataRequest request)
@@ -64,9 +88,8 @@ namespace Files.Uwp.Filesystem.StorageItems
             try
             {
                 using (var stream = request.AsStreamForWrite())
-                using (var streamWriter = new StreamWriter(stream))
                 {
-                    await streamWriter.WriteLineAsync(Name);
+                    await stream.FlushAsync();
                 }
                 request.Dispose();
             }
@@ -98,54 +121,20 @@ namespace Files.Uwp.Filesystem.StorageItems
 
         public IAsyncOperation<BasicProperties> GetBasicPropertiesAsync()
         {
-            return Task.FromResult(props).AsAsyncOperation();
+            return AsyncInfo.Run(async (cancellationToken) => 
+            {
+                async Task<BasicProperties> GetFakeBasicProperties()
+                {
+                    var streamedFile = await StorageFile.CreateStreamedFileAsync(Name, StreamedFileWriter, null);
+                    return await streamedFile.GetBasicPropertiesAsync();
+                }
+                return props ?? (props = await GetFakeBasicProperties());
+            });
         }
 
         public bool IsOfType(StorageItemTypes type)
         {
-            return item.PrimaryItemAttribute == type;
-        }
-
-        private ListedItem GetListedItemFromFindData(WIN32_FIND_DATA findData)
-        {
-            bool isHidden = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.Hidden) == System.IO.FileAttributes.Hidden;
-
-            // https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/c8e77b37-3909-4fe6-a4ea-2b9d423b1ee4
-            bool isReparsePoint = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.ReparsePoint) == System.IO.FileAttributes.ReparsePoint;
-            bool isSymlink = isReparsePoint && findData.dwReserved0 == NativeFileOperationsHelper.IO_REPARSE_TAG_SYMLINK;
-
-            if (!(isHidden && isSymlink))
-            {
-                var itemPath = Path;
-                var itemName = findData.cFileName;
-                DateTime itemCreatedDate;
-                StorageItemTypes itemPrimaryType;
-
-                try
-                {
-                    FileTimeToSystemTime(ref findData.ftCreationTime, out SYSTEMTIME systemCreatedDateOutput);
-                    itemCreatedDate = systemCreatedDateOutput.ToDateTime();
-                }
-                catch (ArgumentException)
-                {
-                    // Invalid date means invalid findData, do not add to list
-                    return null;
-                }
-
-                itemPrimaryType = (System.IO.Path.HasExtension(Path)) ? StorageItemTypes.File : StorageItemTypes.Folder;
-
-                return new ListedItem(null, DateTimeExtensions.GetDateFormat(Shared.Enums.TimeStyle.System))
-                {
-                    PrimaryItemAttribute = itemPrimaryType,
-                    FileImage = null,
-                    ItemNameRaw = itemName,
-                    IsHiddenItem = isHidden,
-                    ItemDateCreatedReal = itemCreatedDate,
-                    ItemPath = itemPath,
-                };
-            }
-
-            return null;
+            return Attributes.HasFlag(Windows.Storage.FileAttributes.Directory) ? type == StorageItemTypes.Folder : type == StorageItemTypes.File;
         }
     }
 }


### PR DESCRIPTION
**Resolved / Related Issues**
N/A

**Details of Changes**
Expands the capability of our new VirtualStorageItem impl to support instantiation solely from a filesystem path. For this feature, we leverage the fast FindFirstFileExFromApp() method to get enough item properties to construct the backing ListedItem which is used to set the properties on the IStorageItem contract. 

Additionally, a static data field for BasicProperties is created on the VirtualStorageItem class and is set, only initially, from a simple streamed storage file. This makes the present use of VirtualStorageFile (in BaseLayout for drag and drop) more concise. 

Lastly, path instantiation will allow us to leverage VirtualStorageItem for all filesystem operations, instead of having to create a StorageFile/Folder n number of times. This will likely speed up paste for storage item operations like move and copy because we inspect the underlying FileDropList (dealing with filesystem paths) instead of the DataPackage itself as of https://github.com/files-community/Files/pull/9035.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
N/A