### PR TITLE
Manually get folder name in case of network share folder or drive

### DIFF
--- a/src/Files.Uwp/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
+++ b/src/Files.Uwp/ViewModels/Widgets/Bundles/BundleItemViewModel.cs
@@ -45,7 +45,23 @@ namespace Files.Uwp.ViewModels.Widgets.Bundles
         {
             get
             {
-                string fileName = System.IO.Path.GetFileName(this.Path);
+                string fileName;
+
+                // Network Share path
+                if (System.IO.Path.GetPathRoot(this.Path) == this.Path && this.Path.StartsWith(@"\\")) 
+                {
+                    fileName = this.Path.Substring(this.Path.LastIndexOf(@"\") + 1);
+                }
+                // Drive path
+                else if (System.IO.Path.GetPathRoot(this.Path) == this.Path)
+                {
+                    fileName = this.Path;
+                }
+                else
+                {
+                    fileName = System.IO.Path.GetFileName(this.Path);
+                }
+
 
                 if (fileName.EndsWith(".lnk", StringComparison.Ordinal) || fileName.EndsWith(".url", StringComparison.Ordinal))
                 {


### PR DESCRIPTION

**Resolved / Related Issues**
- Closes #7561 ...

**Details of Changes**
Starting from .Net 5 as mentioned [here](https://github.com/dotnet/runtime/issues/48039), `GetFileName` does not get the Share folder name, but gets an empty string instead, which is how the bug arose.
I added specific handling for UNC paths if it stops at the share level (ie : \\127.0.0.1\share), and for Drive folders.

**Validation**
How did you test these changes?
- [ X] Built and ran the app
- [ ] Tested the changes for accessibility
