### PR TITLE
Fix dropping from 7zip to folder

### DIFF
--- a/src/Files.Uwp/BaseLayout.cs
+++ b/src/Files.Uwp/BaseLayout.cs
@@ -908,61 +908,58 @@ namespace Files.Uwp
                     var handledByFtp = await Filesystem.FilesystemHelpers.CheckDragNeedsFulltrust(e.DataView);
                     var draggedItems = await Filesystem.FilesystemHelpers.GetDraggedStorageItems(e.DataView);
 
-                    if (draggedItems.IsEmpty())
+                    if (draggedItems.Any(draggedItem => draggedItem.Path == item.ItemPath))
+                    {
+                        e.AcceptedOperation = DataPackageOperation.None;
+                    }
+                    else if (handledByFtp)
+                    {
+                        e.DragUIOverride.IsCaptionVisible = true;
+                        e.DragUIOverride.Caption = string.Format("CopyToFolderCaptionText".GetLocalized(), item.ItemName);
+                        e.AcceptedOperation = DataPackageOperation.Copy;
+                    }
+                    else if (!draggedItems.Any())
                     {
                         e.AcceptedOperation = DataPackageOperation.None;
                     }
                     else
                     {
-                        if (draggedItems.Any(draggedItem => draggedItem.Path == item.ItemPath))
+                        e.DragUIOverride.IsCaptionVisible = true;
+                        if (item.IsExecutable)
                         {
-                            e.AcceptedOperation = DataPackageOperation.None;
+                            e.DragUIOverride.Caption = $"{"OpenItemsWithCaptionText".GetLocalized()} {item.ItemName}";
+                            e.AcceptedOperation = DataPackageOperation.Link;
+                        } // Items from the same drive as this folder are dragged into this folder, so we move the items instead of copy
+                        else if (e.Modifiers.HasFlag(DragDropModifiers.Alt) || e.Modifiers.HasFlag(DragDropModifiers.Control | DragDropModifiers.Shift))
+                        {
+                            e.DragUIOverride.Caption = string.Format("LinkToFolderCaptionText".GetLocalized(), item.ItemName);
+                            e.AcceptedOperation = DataPackageOperation.Link;
                         }
-                        else if (handledByFtp)
+                        else if (e.Modifiers.HasFlag(DragDropModifiers.Control))
                         {
-                            e.DragUIOverride.IsCaptionVisible = true;
                             e.DragUIOverride.Caption = string.Format("CopyToFolderCaptionText".GetLocalized(), item.ItemName);
                             e.AcceptedOperation = DataPackageOperation.Copy;
                         }
+                        else if (e.Modifiers.HasFlag(DragDropModifiers.Shift))
+                        {
+                            e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalized(), item.ItemName);
+                            e.AcceptedOperation = DataPackageOperation.Move;
+                        }
+                        else if (draggedItems.Any(x => x.Item is ZipStorageFile || x.Item is ZipStorageFolder)
+                            || ZipStorageFolder.IsZipPath(item.ItemPath))
+                        {
+                            e.DragUIOverride.Caption = string.Format("CopyToFolderCaptionText".GetLocalized(), item.ItemName);
+                            e.AcceptedOperation = DataPackageOperation.Copy;
+                        }
+                        else if (draggedItems.AreItemsInSameDrive(item.ItemPath))
+                        {
+                            e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalized(), item.ItemName);
+                            e.AcceptedOperation = DataPackageOperation.Move;
+                        }
                         else
                         {
-                            e.DragUIOverride.IsCaptionVisible = true;
-                            if (item.IsExecutable)
-                            {
-                                e.DragUIOverride.Caption = $"{"OpenItemsWithCaptionText".GetLocalized()} {item.ItemName}";
-                                e.AcceptedOperation = DataPackageOperation.Link;
-                            } // Items from the same drive as this folder are dragged into this folder, so we move the items instead of copy
-                            else if (e.Modifiers.HasFlag(DragDropModifiers.Alt) || e.Modifiers.HasFlag(DragDropModifiers.Control | DragDropModifiers.Shift))
-                            {
-                                e.DragUIOverride.Caption = string.Format("LinkToFolderCaptionText".GetLocalized(), item.ItemName);
-                                e.AcceptedOperation = DataPackageOperation.Link;
-                            }
-                            else if (e.Modifiers.HasFlag(DragDropModifiers.Control))
-                            {
-                                e.DragUIOverride.Caption = string.Format("CopyToFolderCaptionText".GetLocalized(), item.ItemName);
-                                e.AcceptedOperation = DataPackageOperation.Copy;
-                            }
-                            else if (e.Modifiers.HasFlag(DragDropModifiers.Shift))
-                            {
-                                e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalized(), item.ItemName);
-                                e.AcceptedOperation = DataPackageOperation.Move;
-                            }
-                            else if (draggedItems.Any(x => x.Item is ZipStorageFile || x.Item is ZipStorageFolder)
-                                || ZipStorageFolder.IsZipPath(item.ItemPath))
-                            {
-                                e.DragUIOverride.Caption = string.Format("CopyToFolderCaptionText".GetLocalized(), item.ItemName);
-                                e.AcceptedOperation = DataPackageOperation.Copy;
-                            }
-                            else if (draggedItems.AreItemsInSameDrive(item.ItemPath))
-                            {
-                                e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalized(), item.ItemName);
-                                e.AcceptedOperation = DataPackageOperation.Move;
-                            }
-                            else
-                            {
-                                e.DragUIOverride.Caption = string.Format("CopyToFolderCaptionText".GetLocalized(), item.ItemName);
-                                e.AcceptedOperation = DataPackageOperation.Copy;
-                            }
+                            e.DragUIOverride.Caption = string.Format("CopyToFolderCaptionText".GetLocalized(), item.ItemName);
+                            e.AcceptedOperation = DataPackageOperation.Copy;
                         }
                     }
                 }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue preventing to drag&drop from 7zip/WinRar/etc to a folder in Files (dropping to the empty space already works, but not dropping into a folder)

**Details of Changes**
Add details of changes here.
- Match DragOver() if-checks to Item_DragOver(). The `handledByFtp` condition must be checked before `draggedItems.Any()`.

**Validation**
How did you test these changes?
- [x] Built and ran the app
