### PR TITLE
Remove invalid characters in conflicts dialog

### DIFF
--- a/src/Files.Uwp/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files.Uwp/Dialogs/FilesystemOperationDialog.xaml
@@ -184,7 +184,7 @@
 
     <Grid x:Name="ContainerGrid">
         <StackPanel Spacing="16">
-            <Grid x:Name="ApplyToAll" x:Load="{x:Bind ViewModel.FileSystemDialogMode.IsInDeleteMode, Converter={StaticResource BoolNegationConverter}}">
+            <Grid x:Name="ApplyToAll" x:Load="{x:Bind ViewModel.FileSystemDialogMode.ConflictsExist}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />

--- a/src/Files.Uwp/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files.Uwp/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -11,6 +11,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Files.Uwp.Helpers.XamlHelpers;
 using Windows.UI.Core;
+using Files.Uwp.Filesystem;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -152,6 +153,8 @@ namespace Files.Uwp.Dialogs
         {
             if ((sender as FrameworkElement)?.DataContext is FileSystemDialogConflictItemViewModel conflictItem)
             {
+                conflictItem.CustomName = FilesystemHelpers.FilterRestrictedCharacters(conflictItem.CustomName);
+
                 if (ViewModel.IsNameAvailableForItem(conflictItem, conflictItem.CustomName!))
                 {
                     conflictItem.IsTextBoxVisible = false;


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #9059 

**Details of Changes**
- Manually renaming items in conflicts dialog will remove any invalid file name characters. This PR also fixes the issue where aggregate conflict resolve option was visible in file in use dialog

**Validation**
How did you test these changes?
- [x] Built and ran the app
