### PR TITLE
Fix the label of groupings by date

### DIFF
--- a/src/Files.Uwp/Extensions/DateTimeExtensions.cs
+++ b/src/Files.Uwp/Extensions/DateTimeExtensions.cs
@@ -122,7 +122,7 @@ namespace Files.Uwp.Extensions
                 return result;
             }
 
-            return (result.range, result.range, result.glyph, result.index);
+            return (result.text, result.text, result.glyph, result.index);
         }
 
         private static Calendar calendar = new CultureInfo(CultureInfo.CurrentUICulture.Name).Calendar;


### PR DESCRIPTION
The Application date format groups dates by periods (Today, This week, ...). The other formats use the same grouping but with a single date label (4/24/2022 for Last week). These labels misrepresent the content of the group.

This pr uses the same label as Application to group the other date formats. This does not change anything for the individual display of a file or folder.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before/After (System date format). 75 items have a date between 4/24/2022 and 4/30/2022.
![date_before](https://user-images.githubusercontent.com/46631671/166253930-320d302e-5960-4cd7-bb25-27bdcddf3978.png)
![date_after](https://user-images.githubusercontent.com/46631671/166253922-112be97c-1b8e-40df-bb29-09e39e5bc8f5.png)
