### PR TITLE
Refactor EnumerateDrives

### DIFF
--- a/src/Files.Uwp/Filesystem/CloudDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/CloudDrivesManager.cs
@@ -1,5 +1,4 @@
 using CommunityToolkit.Mvvm.DependencyInjection;
-using Files.Backend.Services.Settings;
 using Files.Shared;
 using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Uwp.Filesystem.Cloud;
@@ -17,7 +16,6 @@ namespace Files.Uwp.Filesystem
     public class CloudDrivesManager
     {
         private readonly ILogger logger = Ioc.Default.GetService<ILogger>();
-        private readonly IUserSettingsService userSettingsService = Ioc.Default.GetService<IUserSettingsService>();
 
         public EventHandler<NotifyCollectionChangedEventArgs> DataChanged;
 
@@ -33,13 +31,8 @@ namespace Files.Uwp.Filesystem
             }
         }
 
-        public async Task EnumerateDrivesAsync()
+        public async Task UpdateDrivesAsync()
         {
-            if (!userSettingsService.AppearanceSettingsService.ShowCloudDrivesSection)
-            {
-                return;
-            }
-
             var cloudProviderController = new CloudProviderController();
             var cloudProviders = await cloudProviderController.DetectInstalledCloudProvidersAsync();
 

--- a/src/Files.Uwp/Filesystem/Drives.cs
+++ b/src/Files.Uwp/Filesystem/Drives.cs
@@ -101,7 +101,7 @@ namespace Files.Uwp.Filesystem
             return null;
         }
 
-        public async Task EnumerateDrivesAsync()
+        public async Task UpdateDrivesAsync()
         {
             isDriveEnumInProgress = true;
 

--- a/src/Files.Uwp/Filesystem/FileTagsManager.cs
+++ b/src/Files.Uwp/Filesystem/FileTagsManager.cs
@@ -13,7 +13,6 @@ namespace Files.Uwp.Filesystem
     public class FileTagsManager
     {
         private readonly ILogger logger = Ioc.Default.GetService<ILogger>();
-        private readonly IUserSettingsService userSettingsService = Ioc.Default.GetService<IUserSettingsService>();
         private readonly IFileTagsSettingsService fileTagsSettingsService = Ioc.Default.GetService<IFileTagsSettingsService>();
 
         public EventHandler<NotifyCollectionChangedEventArgs> DataChanged;
@@ -30,13 +29,8 @@ namespace Files.Uwp.Filesystem
             }
         }
 
-        public Task EnumerateFileTagsAsync()
+        public Task UpdateFileTagsAsync()
         {
-            if (!userSettingsService.AppearanceSettingsService.ShowFileTagsSection)
-            {
-                return Task.CompletedTask;
-            }
-
             try
             {
                 foreach (var tag in fileTagsSettingsService.FileTagList)

--- a/src/Files.Uwp/Filesystem/LibraryManager.cs
+++ b/src/Files.Uwp/Filesystem/LibraryManager.cs
@@ -26,7 +26,7 @@ namespace Files.Uwp.Filesystem
             }
         }
 
-        public async Task EnumerateLibrariesAsync()
+        public async Task UpdateLibrariesAsync()
         {
             lock (libraries)
             {

--- a/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
@@ -1,6 +1,4 @@
-﻿using CommunityToolkit.Mvvm.DependencyInjection;
-using Files.Backend.Services.Settings;
-using Files.Shared;
+﻿using Files.Shared;
 using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Uwp.Helpers;
 using Microsoft.Toolkit.Uwp;
@@ -17,8 +15,6 @@ namespace Files.Uwp.Filesystem
 {
     public class NetworkDrivesManager
     {
-        private readonly IUserSettingsService userSettingsService = Ioc.Default.GetService<IUserSettingsService>();
-
         public EventHandler<NotifyCollectionChangedEventArgs> DataChanged;
 
         private readonly List<DriveItem> drives = new();
@@ -58,13 +54,8 @@ namespace Files.Uwp.Filesystem
             DataChanged?.Invoke(SectionType.Network, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, networkItem));
         }
 
-        public async Task EnumerateDrivesAsync()
+        public async Task UpdateDrivesAsync()
         {
-            if (!userSettingsService.AppearanceSettingsService.ShowNetworkDrivesSection)
-            {
-                return;
-            }
-
             var connection = await AppServiceConnectionHelper.Instance;
             if (connection is not null)
             {

--- a/src/Files.Uwp/Filesystem/WSLDistroManager.cs
+++ b/src/Files.Uwp/Filesystem/WSLDistroManager.cs
@@ -1,6 +1,4 @@
-﻿using CommunityToolkit.Mvvm.DependencyInjection;
-using Files.Backend.Services.Settings;
-using Files.Uwp.DataModels.NavigationControlItems;
+﻿using Files.Uwp.DataModels.NavigationControlItems;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -12,8 +10,6 @@ namespace Files.Uwp.Filesystem
 {
     public class WSLDistroManager
     {
-        private readonly IUserSettingsService userSettingsService = Ioc.Default.GetService<IUserSettingsService>();
-
         public EventHandler<NotifyCollectionChangedEventArgs> DataChanged;
 
         private readonly List<WslDistroItem> distros = new();
@@ -28,13 +24,8 @@ namespace Files.Uwp.Filesystem
             }
         }
 
-        public async Task EnumerateDrivesAsync()
+        public async Task UpdateDrivesAsync()
         {
-            if (!userSettingsService.AppearanceSettingsService.ShowWslSection)
-            {
-                return;
-            }
-
             try
             {
                 var distroFolder = await StorageFolder.GetFolderFromPathAsync(@"\\wsl$\");

--- a/src/Files.Uwp/Helpers/LibraryHelper.cs
+++ b/src/Files.Uwp/Helpers/LibraryHelper.cs
@@ -1,6 +1,6 @@
 ﻿using Files.Shared;
-using Files.Uwp.Dialogs;
 using Files.Shared.Enums;
+using Files.Uwp.Dialogs;
 using Files.Uwp.Filesystem;
 using Files.Uwp.ViewModels.Dialogs;
 using Microsoft.Toolkit.Uwp;
@@ -166,7 +166,7 @@ namespace Files.Uwp.Helpers
                             { "Verb", "restorelibraries" }
                         });
                     }
-                    await App.LibraryManager.EnumerateLibrariesAsync();
+                    await App.LibraryManager.UpdateLibrariesAsync();
                 },
                 CloseButtonAction = (vm, e) => vm.HideDialog(),
                 KeyDownAction = (vm, e) =>

--- a/src/Files.Uwp/ViewModels/SidebarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SidebarViewModel.cs
@@ -1,24 +1,24 @@
-﻿using Files.Uwp.DataModels.NavigationControlItems;
-using Files.Uwp.Filesystem;
-using Files.Uwp.Helpers;
-using Files.Backend.Services.Settings;
-using Files.Uwp.UserControls;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
+using Files.Backend.Services.Settings;
+using Files.Shared.EventArguments;
+using Files.Shared.Extensions;
+using Files.Uwp.DataModels.NavigationControlItems;
+using Files.Uwp.Filesystem;
+using Files.Uwp.Helpers;
+using Files.Uwp.UserControls;
 using Microsoft.Toolkit.Uwp;
 using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
-using System.Windows.Input;
-using Windows.UI.Xaml;
-using Files.Shared.EventArguments;
-using Files.Shared.Extensions;
-using System.Collections.Specialized;
-using Windows.System;
 using System.Threading.Tasks;
+using System.Windows.Input;
+using Windows.System;
+using Windows.UI.Xaml;
 
 namespace Files.Uwp.ViewModels
 {
@@ -531,14 +531,16 @@ namespace Files.Uwp.ViewModels
         {
             if (show)
             {
+                var appearanceSettingsService = UserSettingsService.AppearanceSettingsService;
+
                 Func<Task> action = sectionType switch
                 {
-                    SectionType.CloudDrives => App.CloudDrivesManager.EnumerateDrivesAsync,
-                    SectionType.Drives => App.DrivesManager.EnumerateDrivesAsync,
-                    SectionType.Network => App.NetworkDrivesManager.EnumerateDrivesAsync,
-                    SectionType.WSL => App.WSLDistroManager.EnumerateDrivesAsync,
-                    SectionType.FileTag => App.FileTagsManager.EnumerateFileTagsAsync,
-                    SectionType.Library => App.LibraryManager.EnumerateLibrariesAsync,
+                    SectionType.CloudDrives when appearanceSettingsService.ShowCloudDrivesSection => App.CloudDrivesManager.UpdateDrivesAsync,
+                    SectionType.Drives => App.DrivesManager.UpdateDrivesAsync,
+                    SectionType.Network when appearanceSettingsService.ShowNetworkDrivesSection => App.NetworkDrivesManager.UpdateDrivesAsync,
+                    SectionType.WSL when appearanceSettingsService.ShowWslSection => App.WSLDistroManager.UpdateDrivesAsync,
+                    SectionType.FileTag when appearanceSettingsService.ShowFileTagsSection => App.FileTagsManager.UpdateFileTagsAsync,
+                    SectionType.Library => App.LibraryManager.UpdateLibrariesAsync,
                     SectionType.Favorites => App.SidebarPinnedController.Model.AddAllItemsToSidebar,
                     _ => () => Task.CompletedTask
                 };


### PR DESCRIPTION
Storage class EnumerateThingAsync methods have 2 issues fixed here.

1) The name assumes it returns an enumerable, but it returns nothing. It updates a property. I renamed it UpdateThingAsync for clarity.
2) The method reads the parameters to run or not according to user preferences. It is not the role of storage to handle this, but the role of the front. I moved this role to the caller which removes the dependency on UserSettingsService.

This is to move Storage to Backend, which should not depend on settings.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility