### PR TITLE
Fix EmptyRecycleBinButton state

### DIFF
--- a/src/Files.Uwp/ViewModels/ToolbarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ToolbarViewModel.cs
@@ -1129,7 +1129,7 @@ namespace Files.Uwp.ViewModels
             }
         }
 
-        private bool hasItem = true;
+        private bool hasItem = false;
         public bool HasItem
         {
             get => hasItem;


### PR DESCRIPTION
**Resolved / Related Issues**
When the RecycleBin is empty and appears at startup, the EmptyRecycleBin button can be active. This pr fixes this bug. This is visible with the "Continue where you left off" option when exiting Files on the RecycleBin tab.

**Details of Changes**
Changes the initial value of HasItem to False. This value is not modified when there is no element, this is the reason for the bug.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before/After
![RecycleBin_before](https://user-images.githubusercontent.com/46631671/166770384-bedadfbb-4f96-4d5b-b5fe-33e511bb8293.png)
![RecycleBin_after](https://user-images.githubusercontent.com/46631671/166744630-c7191553-bcd3-41e7-90aa-b8214460a3d5.png)