### PR TITLE
Stretch drives widget to fit width

### DIFF
--- a/src/Files.Uwp/UserControls/Widgets/DrivesWidget.xaml
+++ b/src/Files.Uwp/UserControls/Widgets/DrivesWidget.xaml
@@ -10,9 +10,14 @@
     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
     mc:Ignorable="d">
     <Grid>
-        <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        
+        <Grid Grid.Column="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition />
+                <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
@@ -56,7 +61,7 @@
             ItemsSource="{x:Bind local:DrivesWidget.ItemsAdded, Mode=OneWay}">
             <muxc:ItemsRepeater.Layout>
                 <muxc:UniformGridLayout
-                    ItemsStretch="None"
+                    ItemsStretch="Fill"
                     MinColumnSpacing="8"
                     MinItemHeight="72"
                     MinItemWidth="240"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6398

**Details of Changes**
Add details of changes here.
- Change resize mode on the items repeater to fill
- Put more options button and drives widgets into separate folders

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/59544401/167205198-fdc1159b-dc57-497a-b03f-818191835bb9.png)
