### PR TITLE
fix(sidebar): add items to favorites in a consistent order

### DIFF
--- a/src/Files.Uwp/Controllers/SidebarPinnedController.cs
+++ b/src/Files.Uwp/Controllers/SidebarPinnedController.cs
@@ -21,8 +21,6 @@ namespace Files.Uwp.Controllers
 
         private StorageFileQueryResult query;
 
-        private bool suppressChangeEvent;
-
         private string configContent;
 
         public string JsonFileName { get; } = "PinnedItems.json";
@@ -124,12 +122,6 @@ namespace Files.Uwp.Controllers
 
         private async void Query_ContentsChanged(IStorageQueryResultBase sender, object args)
         {
-            if (suppressChangeEvent)
-            {
-                suppressChangeEvent = false;
-                return;
-            }
-
             try
             {
                 var configFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appdata:///local/settings/PinnedItems.json"));
@@ -155,7 +147,6 @@ namespace Files.Uwp.Controllers
 
         public void SaveModel()
         {
-            suppressChangeEvent = true;
             try
             {
                 using (var file = File.CreateText(Path.Combine(folderPath, JsonFileName)))
@@ -163,10 +154,14 @@ namespace Files.Uwp.Controllers
                     JsonSerializer serializer = new JsonSerializer();
                     serializer.Formatting = Formatting.Indented;
                     serializer.Serialize(file, Model);
+
+                    // update local configContent to avoid unnecessary refreshes
+                    configContent = JsonConvert.SerializeObject(Model, Formatting.Indented);
                 }
             }
             catch
             {
+                // ignored
             }
         }
 

--- a/src/Files.Uwp/Controllers/TerminalController.cs
+++ b/src/Files.Uwp/Controllers/TerminalController.cs
@@ -22,8 +22,6 @@ namespace Files.Uwp.Controllers
 
         private StorageFileQueryResult query;
 
-        private bool suppressChangeEvent;
-
         private string configContent;
 
         public TerminalFileModel Model { get; set; }
@@ -103,12 +101,6 @@ namespace Files.Uwp.Controllers
 
         private async void Query_ContentsChanged(IStorageQueryResultBase sender, object args)
         {
-            if (suppressChangeEvent)
-            {
-                suppressChangeEvent = false;
-                return;
-            }
-
             try
             {
                 var configFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appdata:///local/settings/terminal.json"));
@@ -201,7 +193,6 @@ namespace Files.Uwp.Controllers
 
         public void SaveModel()
         {
-            suppressChangeEvent = true;
             try
             {
                 using (var file = File.CreateText(Path.Combine(folderPath, JsonFileName)))
@@ -209,10 +200,14 @@ namespace Files.Uwp.Controllers
                     JsonSerializer serializer = new JsonSerializer();
                     serializer.Formatting = Formatting.Indented;
                     serializer.Serialize(file, Model);
+
+                    // update local configContent to avoid unnecessary refreshes
+                    configContent = JsonConvert.SerializeObject(Model, Formatting.Indented);
                 }
             }
             catch
             {
+                // ignored
             }
         }
     }


### PR DESCRIPTION
**Resolved / Related Issues**
- Should resolve #8941

**Details of Changes**
- Make adds to `SidebarItems` (model) and `sidebarList` (UI list) atomic (otherwise model and UI desync)
- Eliminate unnecessary refreshes by serializing model to `configContent` after every save
   - `suppressChangeEvent` wasn't a good solution; `Query_ContentChanged` could be handled very late after many saves
- Refactor `AddItemToSidebarAsync`  to reuse existing methods

**Validation**
- [X] Built and ran the app
- [X] Tested the changes for accessibility

**Screenshots (optional)**

_(notice how add order is consistent instead of random)_
![Files-8941](https://user-images.githubusercontent.com/29434693/167269448-33b20a55-2160-40b4-89af-6943e0da367c.gif)

