### PR TITLE
Allow to set file tags from command line

### DIFF
--- a/src/Files.Backend/Services/Settings/IFileTagsSettingsService.cs
+++ b/src/Files.Backend/Services/Settings/IFileTagsSettingsService.cs
@@ -14,6 +14,8 @@ namespace Files.Backend.Services.Settings
 
         IEnumerable<FileTagViewModel> GetTagsByName(string tagName);
 
+        IEnumerable<FileTagViewModel> SearchTagsByName(string tagName);
+
         object ExportSettings();
 
         bool ImportSettings(object import);

--- a/src/Files.Uwp/App.xaml.cs
+++ b/src/Files.Uwp/App.xaml.cs
@@ -392,7 +392,7 @@ namespace Files.Uwp
                                 var ppm = CommandLineParser.ParseUntrustedCommands(unescapedValue);
                                 if (ppm.IsEmpty())
                                 {
-                                    ppm = new ParsedCommands() { new ParsedCommand() { Type = ParsedCommandType.Unknown, Payload = "." } };
+                                    ppm = new ParsedCommands() { new ParsedCommand() { Type = ParsedCommandType.Unknown, Args = new() { "." } } };
                                 }
                                 await InitializeFromCmdLineArgs(rootFrame, ppm);
                                 break;

--- a/src/Files.Uwp/App.xaml.cs
+++ b/src/Files.Uwp/App.xaml.cs
@@ -495,6 +495,21 @@ namespace Files.Uwp
                         }
                         break;
 
+                    case ParsedCommandType.TagFiles:
+                        var tagService = Ioc.Default.GetService<IFileTagsSettingsService>();
+                        var tag = tagService.GetTagsByName(command.Payload).FirstOrDefault();
+                        foreach (var file in command.Args.Skip(1))
+                        {
+                            var fileFRN = await FilesystemTasks.Wrap(() => StorageHelpers.ToStorageItem<IStorageItem>(file))
+                                .OnSuccess(item => FileTagsHelper.GetFileFRN(item));
+                            if (fileFRN is not null)
+                            {
+                                FileTagsHelper.DbInstance.SetTag(file, fileFRN, tag?.Uid);
+                                FileTagsHelper.WriteFileTag(file, tag?.Uid);
+                            }
+                        }
+                        break;
+
                     case ParsedCommandType.Unknown:
                         if (command.Payload.Equals("."))
                         {

--- a/src/Files.Uwp/CommandLine/CommandLineParser.cs
+++ b/src/Files.Uwp/CommandLine/CommandLineParser.cs
@@ -32,24 +32,24 @@ namespace Files.Uwp.CommandLine
 
                 switch (kvp.Key)
                 {
-                    case string s when "-Directory".Equals(s, StringComparison.OrdinalIgnoreCase):
+                    case string s when "Directory".Equals(s, StringComparison.OrdinalIgnoreCase):
                         command.Type = ParsedCommandType.OpenDirectory;
                         break;
 
-                    case string s when "-OutputPath".Equals(s, StringComparison.OrdinalIgnoreCase):
+                    case string s when "OutputPath".Equals(s, StringComparison.OrdinalIgnoreCase):
                         command.Type = ParsedCommandType.OutputPath;
                         break;
 
-                    case string s when "-Select".Equals(s, StringComparison.OrdinalIgnoreCase):
+                    case string s when "Select".Equals(s, StringComparison.OrdinalIgnoreCase):
                         command.Type = ParsedCommandType.SelectItem;
                         break;
 
-                    case string s when "-Tag".Equals(s, StringComparison.OrdinalIgnoreCase):
+                    case string s when "Tag".Equals(s, StringComparison.OrdinalIgnoreCase):
                         command.Type = ParsedCommandType.TagFiles;
                         break;
 
                     default:
-                        //case "-Cmdless":
+                        //case "Cmdless":
                         try
                         {
                             if (kvp.Value[0].StartsWith("::{", StringComparison.Ordinal) || kvp.Value[0].StartsWith("shell:", StringComparison.OrdinalIgnoreCase))
@@ -144,7 +144,7 @@ namespace Files.Uwp.CommandLine
 
             if (parsedArgs.Count == 0 && args.Length >= 2)
             {
-                parsedArgs.Add(new KeyValuePair<string, string[]>("-Cmdless", new[] { string.Join(" ", args.Skip(1)).TrimStart() }));
+                parsedArgs.Add(new KeyValuePair<string, string[]>("Cmdless", new[] { string.Join(" ", args.Skip(1)).TrimStart() }));
             }
 
             return parsedArgs;
@@ -167,7 +167,7 @@ namespace Files.Uwp.CommandLine
                 }
                 else
                 {
-                    key = args[index];
+                    key = args[index].Substring(1);
                 }
 
                 int argIndex = 1 + index;

--- a/src/Files.Uwp/CommandLine/CommandLineParser.cs
+++ b/src/Files.Uwp/CommandLine/CommandLineParser.cs
@@ -20,7 +20,7 @@ namespace Files.Uwp.CommandLine
             return ParseSplitArguments(parsedArgs);
         }
 
-        private static ParsedCommands ParseSplitArguments(List<KeyValuePair<string, string>> parsedArgs)
+        private static ParsedCommands ParseSplitArguments(List<KeyValuePair<string, string[]>> parsedArgs)
         {
             var commands = new ParsedCommands();
 
@@ -44,15 +44,19 @@ namespace Files.Uwp.CommandLine
                         command.Type = ParsedCommandType.SelectItem;
                         break;
 
+                    case string s when "-Tag".Equals(s, StringComparison.OrdinalIgnoreCase):
+                        command.Type = ParsedCommandType.TagFiles;
+                        break;
+
                     default:
                         //case "-Cmdless":
                         try
                         {
-                            if (kvp.Value.StartsWith("::{", StringComparison.Ordinal) || kvp.Value.StartsWith("shell:", StringComparison.OrdinalIgnoreCase))
+                            if (kvp.Value[0].StartsWith("::{", StringComparison.Ordinal) || kvp.Value[0].StartsWith("shell:", StringComparison.OrdinalIgnoreCase))
                             {
                                 command.Type = ParsedCommandType.ExplorerShellCommand;
                             }
-                            else if (Path.IsPathRooted(kvp.Value))
+                            else if (Path.IsPathRooted(kvp.Value[0]))
                             {
                                 command.Type = ParsedCommandType.OpenPath;
                             }
@@ -69,7 +73,7 @@ namespace Files.Uwp.CommandLine
                         break;
                 }
 
-                command.Payload = kvp.Value;
+                command.Args.AddRange(kvp.Value);
                 commands.Add(command);
             }
 
@@ -104,9 +108,9 @@ namespace Files.Uwp.CommandLine
             }
         }
 
-        public static List<KeyValuePair<string, string>> Parse(string[] args = null)
+        public static List<KeyValuePair<string, string[]>> Parse(string[] args = null)
         {
-            var parsedArgs = new List<KeyValuePair<string, string>>();
+            var parsedArgs = new List<KeyValuePair<string, string[]>>();
             //Environment.GetCommandLineArgs() IS better but... I haven't tested this enough.
 
             if (args != null)
@@ -140,16 +144,16 @@ namespace Files.Uwp.CommandLine
 
             if (parsedArgs.Count == 0 && args.Length >= 2)
             {
-                parsedArgs.Add(new KeyValuePair<string, string>("-Cmdless", string.Join(" ", args.Skip(1)).TrimStart()));
+                parsedArgs.Add(new KeyValuePair<string, string[]>("-Cmdless", new[] { string.Join(" ", args.Skip(1)).TrimStart() }));
             }
 
             return parsedArgs;
         }
 
-        private static KeyValuePair<string, string> ParseData(string[] args, int index)
+        private static KeyValuePair<string, string[]> ParseData(string[] args, int index)
         {
             string key = null;
-            string val = null;
+            var val = new List<string>();
             if (args[index].StartsWith('-') || args[index].StartsWith('/'))
             {
                 if (args[index].Contains(":", StringComparison.Ordinal))
@@ -158,25 +162,22 @@ namespace Files.Uwp.CommandLine
                     int endIndex = argument.IndexOf(':');
                     key = argument.Substring(1, endIndex - 1);   // trim the '/' and the ':'.
                     int valueStart = endIndex + 1;
-                    val = valueStart < argument.Length ? argument.Substring(
-                        valueStart, argument.Length - valueStart) : null;
+                    val.Add(valueStart < argument.Length ? argument.Substring(
+                        valueStart, argument.Length - valueStart) : null);
                 }
                 else
                 {
                     key = args[index];
-                    int argIndex = 1 + index;
-                    if (argIndex < args.Length && !(args[argIndex].StartsWith('-') || args[argIndex].StartsWith('/')))
-                    {
-                        val = args[argIndex];
-                    }
-                    else
-                    {
-                        val = null;
-                    }
+                }
+
+                int argIndex = 1 + index;
+                while (argIndex < args.Length && !(args[argIndex].StartsWith('-') || args[argIndex].StartsWith('/')))
+                {
+                    val.Add(args[argIndex++]);
                 }
             }
 
-            return key != null ? new KeyValuePair<string, string>(key, val) : default;
+            return key != null ? new KeyValuePair<string, string[]>(key, val.ToArray()) : default;
         }
     }
 }

--- a/src/Files.Uwp/CommandLine/ParsedCommand.cs
+++ b/src/Files.Uwp/CommandLine/ParsedCommand.cs
@@ -1,9 +1,17 @@
-﻿namespace Files.Uwp.CommandLine
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Files.Uwp.CommandLine
 {
     internal class ParsedCommand
     {
         public ParsedCommandType Type { get; set; }
 
-        public string Payload { get; set; }
+        public string Payload => Args.FirstOrDefault();
+
+        public List<string> Args { get; set; }
+
+        public ParsedCommand() =>
+            Args = new List<string>();
     }
 }

--- a/src/Files.Uwp/CommandLine/ParsedCommandType.cs
+++ b/src/Files.Uwp/CommandLine/ParsedCommandType.cs
@@ -8,5 +8,6 @@
         ExplorerShellCommand,
         OutputPath,
         SelectItem,
+        TagFiles
     }
 }

--- a/src/Files.Uwp/Filesystem/Drives.cs
+++ b/src/Files.Uwp/Filesystem/Drives.cs
@@ -62,7 +62,7 @@ namespace Files.Uwp.Filesystem
             if (devicePath.StartsWith(@"\\?\", StringComparison.Ordinal)) // USB device
             {
                 // Check among already discovered drives
-                StorageFolder matchingDrive = App.DrivesManager.Drives.FirstOrDefault(x =>
+                StorageFolder matchingDrive = App.DrivesManager?.Drives.FirstOrDefault(x =>
                     Helpers.PathNormalization.NormalizePath(x.Path) == Helpers.PathNormalization.NormalizePath(rootPath))?.Root;
                 if (matchingDrive is null)
                 {

--- a/src/Files.Uwp/Filesystem/Drives.cs
+++ b/src/Files.Uwp/Filesystem/Drives.cs
@@ -62,7 +62,7 @@ namespace Files.Uwp.Filesystem
             if (devicePath.StartsWith(@"\\?\", StringComparison.Ordinal)) // USB device
             {
                 // Check among already discovered drives
-                StorageFolder matchingDrive = App.DrivesManager?.Drives.FirstOrDefault(x =>
+                StorageFolder matchingDrive = App.DrivesManager.Drives.FirstOrDefault(x =>
                     Helpers.PathNormalization.NormalizePath(x.Path) == Helpers.PathNormalization.NormalizePath(rootPath))?.Root;
                 if (matchingDrive is null)
                 {

--- a/src/Files.Uwp/Filesystem/Search/FolderSearch.cs
+++ b/src/Files.Uwp/Filesystem/Search/FolderSearch.cs
@@ -192,7 +192,7 @@ namespace Files.Uwp.Filesystem.Search
         {
             //var sampler = new IntervalSampler(500);
             var tagName = AQSQuery.Substring("tag:".Length);
-            var tags = FileTagsSettingsService.GetTagsByName(tagName);
+            var tags = FileTagsSettingsService.SearchTagsByName(tagName);
             if (!tags.Any())
             {
                 return;

--- a/src/Files.Uwp/Program.cs
+++ b/src/Files.Uwp/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Files.Uwp.CommandLine;
+using Files.Shared;
 using Files.Uwp.Helpers;
 using Files.Shared.Extensions;
 using System;

--- a/src/Files.Uwp/Program.cs
+++ b/src/Files.Uwp/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Files.Uwp.CommandLine;
-using Files.Shared;
 using Files.Uwp.Helpers;
 using Files.Shared.Extensions;
 using System;
@@ -9,8 +8,6 @@ using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Storage;
 using Windows.UI.Xaml;
-using Files.Uwp.ServicesImplementation.Settings;
-using Files.Uwp.Filesystem;
 
 namespace Files.Uwp
 {
@@ -85,21 +82,6 @@ namespace Files.Uwp
                                         await OpenShellCommandInExplorerAsync(command.Payload, proc.Id);
                                         return; // Exit
                                     }
-                                    break;
-                                case ParsedCommandType.TagFiles:
-                                    var tagService = new FileTagsSettingsService();
-                                    var tag = tagService.GetTagsByName(command.Payload).FirstOrDefault();
-                                    foreach (var file in command.Args.Skip(1))
-                                    {
-                                        var fileFRN = await FilesystemTasks.Wrap(() => StorageHelpers.ToStorageItem<IStorageItem>(file))
-                                            .OnSuccess(item => FileTagsHelper.GetFileFRN(item));
-                                        if (fileFRN is not null)
-                                        {
-                                            FileTagsHelper.DbInstance.SetTag(file, fileFRN, tag?.Uid);
-                                            FileTagsHelper.WriteFileTag(file, tag?.Uid);
-                                        }
-                                    }
-                                    await TerminateUwpAppInstance(proc.Id);
                                     break;
                                 default:
                                     break;

--- a/src/Files.Uwp/ServicesImplementation/Settings/FileTagsSettingsService.cs
+++ b/src/Files.Uwp/ServicesImplementation/Settings/FileTagsSettingsService.cs
@@ -57,6 +57,11 @@ namespace Files.Uwp.ServicesImplementation.Settings
 
         public IEnumerable<FileTagViewModel> GetTagsByName(string tagName)
         {
+            return FileTagList.Where(x => x.TagName.Equals(tagName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public IEnumerable<FileTagViewModel> SearchTagsByName(string tagName)
+        {
             return FileTagList.Where(x => x.TagName.StartsWith(tagName, StringComparison.OrdinalIgnoreCase));
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9033

**Details of Changes**
Add details of changes here.
- Added "-tag" command line argument to allow setting/removing file tags from the command line
E.g `files /tag:blue "file1" "file2" "file3"` or `files -tag "orange" "file1" "file2"`
- Fixed an issue preventing command line args written as "/command" instead of "-command" from working
- Fixed an issue preventing shell folders from opening in explorer when "AlwaysOpenANewInstance=true"

**Notes**
Issuing the "-tag" command results in a Files window opening (and staying open). Given that there's no way to prevent the splash screen from appearing when invoking Files from the command line, I think it's better to leave the window open instead of causing it to repeatedly flash open and closed.

**Validation**
How did you test these changes?
- [x] Built and ran the app
