### PR TITLE
Fix crash when copy/move operation fails

### DIFF
--- a/src/Files.Uwp/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/src/Files.Uwp/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -341,21 +341,20 @@ namespace Files.Uwp.Filesystem
             ((IProgress<float>)banner.Progress).Report(100.0f);
             await Task.Yield();
 
-            foreach (var item in history.Source.Zip(history.Destination, (k, v) => new { Key = k, Value = v }).ToDictionary(k => k.Key, v => v.Value))
+            if (registerHistory && history != null && source.Any((item) => !string.IsNullOrWhiteSpace(item.Path)))
             {
-                foreach (var item2 in itemsResult)
+                foreach (var item in history.Source.Zip(history.Destination, (k, v) => new { Key = k, Value = v }).ToDictionary(k => k.Key, v => v.Value))
                 {
-                    if (!string.IsNullOrEmpty(item2.CustomName) && item2.SourcePath == item.Key.Path)
+                    foreach (var item2 in itemsResult)
                     {
-                        var renameHistory = await filesystemOperations.RenameAsync(item.Value, item2.CustomName, NameCollisionOption.FailIfExists, banner.ErrorCode, token);
+                        if (!string.IsNullOrEmpty(item2.CustomName) && item2.SourcePath == item.Key.Path)
+                        {
+                            var renameHistory = await filesystemOperations.RenameAsync(item.Value, item2.CustomName, NameCollisionOption.FailIfExists, banner.ErrorCode, token);
 
-                        history.Destination[history.Source.IndexOf(item.Key)] = renameHistory.Destination[0];
+                            history.Destination[history.Source.IndexOf(item.Key)] = renameHistory.Destination[0];
+                        }
                     }
                 }
-            }
-
-            if (registerHistory && source.Any((item) => !string.IsNullOrWhiteSpace(item.Path)))
-            {
                 App.HistoryWrapper.AddHistory(history);
             }
             var itemsCopied = history?.Source.Count() ?? 0;
@@ -497,21 +496,20 @@ namespace Files.Uwp.Filesystem
             ((IProgress<float>)banner.Progress).Report(100.0f);
             await Task.Yield();
 
-            foreach (var item in history.Source.Zip(history.Destination, (k, v) => new { Key = k, Value = v }).ToDictionary(k => k.Key, v => v.Value))
+            if (registerHistory && history != null && source.Any((item) => !string.IsNullOrWhiteSpace(item.Path)))
             {
-                foreach (var item2 in itemsResult)
+                foreach (var item in history.Source.Zip(history.Destination, (k, v) => new { Key = k, Value = v }).ToDictionary(k => k.Key, v => v.Value))
                 {
-                    if (!string.IsNullOrEmpty(item2.CustomName) && item2.SourcePath == item.Key.Path)
+                    foreach (var item2 in itemsResult)
                     {
-                        var renameHistory = await filesystemOperations.RenameAsync(item.Value, item2.CustomName, NameCollisionOption.FailIfExists, banner.ErrorCode, token);
+                        if (!string.IsNullOrEmpty(item2.CustomName) && item2.SourcePath == item.Key.Path)
+                        {
+                            var renameHistory = await filesystemOperations.RenameAsync(item.Value, item2.CustomName, NameCollisionOption.FailIfExists, banner.ErrorCode, token);
 
-                        history.Destination[history.Source.IndexOf(item.Key)] = renameHistory.Destination[0];
+                            history.Destination[history.Source.IndexOf(item.Key)] = renameHistory.Destination[0];
+                        }
                     }
                 }
-            }
-
-            if (registerHistory && source.Any((item) => !string.IsNullOrWhiteSpace(item.Path)))
-            {
                 App.HistoryWrapper.AddHistory(history);
             }
             int itemsMoved = history?.Source.Count() ?? 0;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes Appcenter [2806362965u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/2806362965u/overview), [2832023223u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/2806362965u/overview)

**Details of Changes**
Add details of changes here.
- Returned History can be null if the copy/move operations has failed -> added null check.

**Validation**
How did you test these changes?
- [x] Built and ran the app
