### PR TITLE
Fix folder size not shown for some items

### DIFF
--- a/src/Files.Uwp/Filesystem/FolderSizeProvider.cs
+++ b/src/Files.Uwp/Filesystem/FolderSizeProvider.cs
@@ -18,6 +18,7 @@ namespace Files.Uwp.Filesystem
 
         Task CleanCacheAsync();
         Task UpdateFolderAsync(string folderPath, CancellationToken cancellationToken);
+        bool GetCachedSize(string folderPath, out long cachedSize);
     }
 
     public class FolderSizeChangedEventArgs : EventArgs
@@ -63,6 +64,17 @@ namespace Files.Uwp.Filesystem
             return Task.CompletedTask;
         }
 
+        public bool GetCachedSize(string folderPath, out long cachedSize)
+        {
+            if (!preferencesSettingsService.ShowFolderSize)
+            {
+                cachedSize = default;
+                return false;
+            }
+
+            return cacheSizes.TryGetValue(folderPath, out cachedSize);
+        }
+
         public async Task UpdateFolderAsync(string folderPath, CancellationToken cancellationToken)
         {
             if (!preferencesSettingsService.ShowFolderSize)
@@ -71,9 +83,8 @@ namespace Files.Uwp.Filesystem
             }
 
             await Task.Yield();
-            if (cacheSizes.ContainsKey(folderPath))
+            if (cacheSizes.TryGetValue(folderPath, out var cachedSize))
             {
-                long cachedSize = cacheSizes[folderPath];
                 RaiseSizeChanged(folderPath, cachedSize);
             }
             else

--- a/src/Files.Uwp/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/src/Files.Uwp/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -96,6 +96,11 @@ namespace Files.Uwp.Filesystem.StorageEnumerators
 
                                 if (showFolderSize)
                                 {
+                                    if (folderSizeProvider.GetCachedSize(folder.ItemPath, out var size))
+                                    {
+                                        folder.FileSizeBytes = size;
+                                        folder.FileSize = size.ToSizeString();
+                                    }
                                     _ = folderSizeProvider.UpdateFolderAsync(folder.ItemPath, cancellationToken);
                                 }
                             }

--- a/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
@@ -590,6 +590,7 @@ namespace Files.Uwp.Views
                 {
                     ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{FilesystemViewModel.FilesAndFolders.Count} {"ItemsCount/Text".GetLocalized()}";
                 }
+                ContentPage.UpdateSelectionSize();
             }
         }
 

--- a/src/Files.Uwp/Views/ModernShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ModernShellPage.xaml.cs
@@ -630,6 +630,7 @@ namespace Files.Uwp.Views
                 {
                     ContentPage.DirectoryPropertiesViewModel.DirectoryItemCount = $"{FilesystemViewModel.FilesAndFolders.Count} {"ItemsCount/Text".GetLocalized()}";
                 }
+                ContentPage.UpdateSelectionSize();
             }
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue for which folder sizes are randomly not shown on some items
- Reduces occurrences of Appcenter [#97216821u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/97216821u/overview)

**Details of Changes**
Add details of changes here.
- Process folder size changed events after enumeration is complete to make sure the items has been added to the filesAndFolders collection

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots (optional)**
Add screenshots here.
![image](https://user-images.githubusercontent.com/9673091/167289481-37270c1a-1713-40e0-a6dd-ae40327935e4.png)
