### PR TITLE
Add MaxWidth to PreviewPane

### DIFF
--- a/src/Files.Uwp/UserControls/Pane/PreviewPane.xaml.cs
+++ b/src/Files.Uwp/UserControls/Pane/PreviewPane.xaml.cs
@@ -26,12 +26,12 @@ namespace Files.Uwp.UserControls
             if (panelWidth > 700)
             {
                 Position = PanePositions.Right;
-                (MinWidth, MinHeight) = (150, 0);
+                (MinWidth, MaxWidth, MinHeight, MaxHeight) = (150, 500, 0, double.MaxValue);
             }
             else
             {
                 Position = PanePositions.Bottom;
-                (MinWidth, MinHeight) = (0, 140);
+                (MinWidth, MaxWidth, MinHeight, MaxHeight) = (0, double.MaxValue, 140, double.MaxValue);
             }
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
The preview pane has not MaxWidth. The panel saves the current size when you modify it with the spinner, but not when resizing the window or the sidebar. This causes bugs (#9093) that are difficult to fix. The panel protrudes from the screen and no longer adapts to the available size.

**Details of Changes**
Add MaxWidth = 500 to the preview pane.
That's enough and prevent the bug.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
MaxWidth
![MaxWidth](https://user-images.githubusercontent.com/46631671/167305359-d7afc918-5f2a-4841-a548-73c11d7bd37b.png)
