### PR TITLE
Add missing quick access

### DIFF
--- a/src/Files.Uwp/Helpers/ContextFlyoutItemHelper.cs
+++ b/src/Files.Uwp/Helpers/ContextFlyoutItemHelper.cs
@@ -484,6 +484,7 @@ namespace Files.Uwp.Helpers
                 new ContextMenuFlyoutItemViewModel()
                 {
                     Text = "BaseLayoutContextFlyoutPaste/Text".GetLocalized(),
+                    IsPrimary = true,
                     // Glyph = "\uF16D",
                     ShowInFtpPage = true,
                     ShowInZipPage = true,
@@ -568,6 +569,7 @@ namespace Files.Uwp.Helpers
                 new ContextMenuFlyoutItemViewModel()
                 {
                     Text = "BaseLayoutContextFlyoutPropertiesFolder/Text".GetLocalized(),
+                    IsPrimary = true,
                     ColoredIcon = new ColoredIconModel()
                     {
                         BaseLayerGlyph = "\uF031",


### PR DESCRIPTION
Add missing primary icons in the context menu of current folder.
The added icons are Paste and Properties. #9088

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Before/After
![MenuPaste](https://user-images.githubusercontent.com/46631671/167305938-ec22ef02-e269-4840-84ec-75a23abf1bde.png)![MenuAfter](https://user-images.githubusercontent.com/46631671/167305936-cb638b03-5d53-4743-bed0-eaf8784e9500.png)
