### PR TITLE
Fixed an issue where the preview pane grid splitter sometimes used the wrong cursor 

### DIFF
--- a/src/Files.Uwp/Views/MainPage.xaml.cs
+++ b/src/Files.Uwp/Views/MainPage.xaml.cs
@@ -1,16 +1,17 @@
-﻿using Files.Uwp.DataModels.NavigationControlItems;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.Mvvm.Input;
+using Files.Backend.Services.Settings;
 using Files.Shared.Enums;
-using Files.Uwp.EventArguments;
+using Files.Shared.EventArguments;
+using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Uwp.Extensions;
 using Files.Uwp.Filesystem;
 using Files.Uwp.Helpers;
-using Files.Backend.Services.Settings;
 using Files.Uwp.UserControls;
 using Files.Uwp.UserControls.MultitaskingControl;
 using Files.Uwp.ViewModels;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using CommunityToolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp;
+using Microsoft.Toolkit.Uwp.UI.Controls;
 using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -23,7 +24,6 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Navigation;
-using Files.Shared.EventArguments;
 
 namespace Files.Uwp.Views
 {
@@ -412,6 +412,7 @@ namespace Files.Uwp.Views
                         PaneSplitter.SetValue(Grid.ColumnProperty, 1);
                         PaneSplitter.Width = 2;
                         PaneSplitter.Height = RootGrid.ActualHeight;
+                        PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeWestEast;
                         PaneColumn.MinWidth = Pane.MinWidth;
                         PaneColumn.MaxWidth = Pane.MaxWidth;
                         PaneColumn.Width = new GridLength(UserSettingsService.PaneSettingsService.VerticalSizePx, GridUnitType.Pixel);
@@ -426,6 +427,7 @@ namespace Files.Uwp.Views
                         PaneSplitter.SetValue(Grid.ColumnProperty, 0);
                         PaneSplitter.Height = 2;
                         PaneSplitter.Width = RootGrid.ActualWidth;
+                        PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeNorthSouth;
                         PaneColumn.MinWidth = 0;
                         PaneColumn.MaxWidth = double.MaxValue;
                         PaneColumn.Width = new GridLength(0);


### PR DESCRIPTION
**Resolved / Related Issues**
The PreviewPane splitter sometimes shows the wrong cursor after changing direction (horizontal/vertical).

**Details of Changes**
Change the cursor when the splitter changes of direction.
The property CursorBehavior="ChangeOnSplitterHover" of GridSplitter is not used because it does not work.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
The bug.
![cursor](https://user-images.githubusercontent.com/46631671/167452425-34309874-a8fb-4f09-8919-9c51347ec7c3.jpg)

