### PR TITLE
fix: file list randomly scrolling to top

### DIFF
--- a/src/Files.Uwp/ViewModels/ItemViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ItemViewModel.cs
@@ -1975,6 +1975,24 @@ namespace Files.Uwp.ViewModels
             ListedItem nextOfLastItemRemoved = null;
             var rand = Guid.NewGuid();
 
+            // call when any edits have occurred
+            async Task HandleChangesOccurredAsync()
+            {
+                await OrderFilesAndFoldersAsync();
+                await ApplyFilesAndFoldersChangesAsync();
+                if (lastItemAdded != null)
+                {
+                    await RequestSelectionAsync(new List<ListedItem>() { lastItemAdded });
+                    lastItemAdded = null;
+                }
+                if (nextOfLastItemRemoved != null)
+                {
+                    await RequestSelectionAsync(new List<ListedItem>() { nextOfLastItemRemoved });
+                    nextOfLastItemRemoved = null;
+                }
+                anyEdits = false;
+            }
+
             try
             {
                 while (!cancellationToken.IsCancellationRequested)
@@ -2030,19 +2048,7 @@ namespace Files.Uwp.ViewModels
 
                             if (anyEdits && sampler.CheckNow())
                             {
-                                await OrderFilesAndFoldersAsync();
-                                await ApplyFilesAndFoldersChangesAsync();
-                                if (lastItemAdded != null)
-                                {
-                                    await RequestSelectionAsync(new List<ListedItem>() { lastItemAdded });
-                                    lastItemAdded = null;
-                                }
-                                if (nextOfLastItemRemoved != null)
-                                {
-                                    await RequestSelectionAsync(new List<ListedItem>() { nextOfLastItemRemoved });
-                                    nextOfLastItemRemoved = null;
-                                }
-                                anyEdits = false;
+                                await HandleChangesOccurredAsync();
                             }
                         }
 
@@ -2069,19 +2075,7 @@ namespace Files.Uwp.ViewModels
 
                     if (anyEdits && sampler.CheckNow())
                     {
-                        await OrderFilesAndFoldersAsync();
-                        await ApplyFilesAndFoldersChangesAsync();
-                        if (lastItemAdded != null)
-                        {
-                            await RequestSelectionAsync(new List<ListedItem>() { lastItemAdded });
-                            lastItemAdded = null;
-                        }
-                        if (nextOfLastItemRemoved != null)
-                        {
-                            await RequestSelectionAsync(new List<ListedItem>() { nextOfLastItemRemoved });
-                            nextOfLastItemRemoved = null;
-                        }
-                        anyEdits = false;
+                        await HandleChangesOccurredAsync();
                     }
                 }
             }

--- a/src/Files.Uwp/ViewModels/ItemViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ItemViewModel.cs
@@ -498,10 +498,8 @@ namespace Files.Uwp.ViewModels
                             // get the item that immediately follows matching item to be removed
                             // if the matching item is the last item, try to get the previous item; otherwise, null
                             // case must be ignored since $Recycle.Bin != $RECYCLE.BIN
-                            var nextOfMatchingItem = filesAndFolders
-                                .SkipWhile((x) => !x.ItemPath.Equals(itemPath, StringComparison.OrdinalIgnoreCase)).Skip(1)
-                                .DefaultIfEmpty(filesAndFolders.TakeWhile((x) => !x.ItemPath.Equals(itemPath, StringComparison.OrdinalIgnoreCase)).LastOrDefault())
-                                .FirstOrDefault();
+                            var itemRemovedIndex = filesAndFolders.FindIndex(x => x.ItemPath.Equals(itemPath, StringComparison.OrdinalIgnoreCase));
+                            var nextOfMatchingItem = filesAndFolders.ElementAtOrDefault(itemRemovedIndex + 1 < filesAndFolders.Count() ? itemRemovedIndex + 1 : itemRemovedIndex - 1);
                             var removedItem = await RemoveFileOrFolderAsync(itemPath);
                             if (removedItem != null)
                             {
@@ -2027,17 +2025,21 @@ namespace Files.Uwp.ViewModels
                                     case FILE_ACTION_REMOVED:
                                         // get the item that immediately follows matching item to be removed
                                         // if the matching item is the last item, try to get the previous item; otherwise, null
-                                        nextOfLastItemRemoved = filesAndFolders
-                                            .SkipWhile(x => !x.ItemPath.Equals(operation.FileName)).Skip(1)
-                                            .DefaultIfEmpty(filesAndFolders.TakeWhile(x => !x.ItemPath.Equals(operation.FileName)).LastOrDefault())
-                                            .FirstOrDefault();
-                                        await RemoveFileOrFolderAsync(operation.FileName);
-                                        anyEdits = true;
+                                        var itemRemovedIndex = filesAndFolders.FindIndex(x => x.ItemPath.Equals(operation.FileName));
+                                        nextOfLastItemRemoved = filesAndFolders.ElementAtOrDefault(itemRemovedIndex + 1 < filesAndFolders.Count() ? itemRemovedIndex + 1 : itemRemovedIndex - 1);
+                                        var itemRemoved = await RemoveFileOrFolderAsync(operation.FileName);
+                                        if (itemRemoved != null)
+                                        {
+                                            anyEdits = true;
+                                        }
                                         break;
 
                                     case FILE_ACTION_RENAMED_OLD_NAME:
-                                        await RemoveFileOrFolderAsync(operation.FileName);
-                                        anyEdits = true;
+                                        var itemRenamedOld = await RemoveFileOrFolderAsync(operation.FileName);
+                                        if (itemRenamedOld != null)
+                                        {
+                                            anyEdits = true;
+                                        }
                                         break;
                                 }
                             }

--- a/src/Files.Uwp/ViewModels/ItemViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ItemViewModel.cs
@@ -1991,16 +1991,12 @@ namespace Files.Uwp.ViewModels
                                 switch (operation.Action)
                                 {
                                     case FILE_ACTION_ADDED:
+                                    case FILE_ACTION_RENAMED_NEW_NAME:
                                         lastItemAdded = await AddFileOrFolderAsync(operation.FileName, returnformat);
                                         if (lastItemAdded != null)
                                         {
                                             anyEdits = true;
                                         }
-                                        break;
-
-                                    case FILE_ACTION_RENAMED_NEW_NAME:
-                                        await AddFileOrFolderAsync(operation.FileName, returnformat);
-                                        anyEdits = true;
                                         break;
 
                                     case FILE_ACTION_MODIFIED:


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #8159

**Details of Changes**
File list randomly scrolls to top on renaming and deleting* (_especially_ if no confirmation dialog when deleting is on)
\* _deleting was fixed with (#8503), so couldn't reproduce on `main`_
- Select renamed files/folders (reuse code from selecting newly created items)
- Deduplicate code for handling changes `(anyEdits)` in operation queue
- Improve performance of finding selection item by only enumerating once

**Validation**
- [X] Built and ran the app
- [X] Tested the changes for accessibility

**Screenshots (optional)**
![Files-8159](https://user-images.githubusercontent.com/29434693/167527009-37d49761-37c1-4edf-9159-ccfebce59f6b.gif)

