### PR TITLE
fix(recent-files): make recent files not reverse itself when loaded

### DIFF
--- a/src/Files.Uwp/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files.Uwp/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -81,7 +81,7 @@ namespace Files.Uwp.UserControls.Widgets
                     string mruToken = entry.Token;
                     var added = await FilesystemTasks.Wrap(async () =>
                     {
-                        IStorageItem item = await mostRecentlyUsed.GetItemAsync(mruToken, AccessCacheOptions.FastLocationsOnly);
+                        IStorageItem item = await mostRecentlyUsed.GetItemAsync(mruToken, AccessCacheOptions.FastLocationsOnly | AccessCacheOptions.SuppressAccessTimeUpdate);
                         await AddItemToRecentListAsync(item, entry);
                     });
                     if (added == FileSystemStatusCode.Unauthorized)

--- a/src/Files.Uwp/ViewModels/SettingsViewModels/PreferencesViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SettingsViewModels/PreferencesViewModel.cs
@@ -120,7 +120,7 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                     string mruToken = entry.Token;
                     var added = await FilesystemTasks.Wrap(async () =>
                     {
-                        IStorageItem item = await mostRecentlyUsed.GetItemAsync(mruToken, AccessCacheOptions.FastLocationsOnly);
+                        IStorageItem item = await mostRecentlyUsed.GetItemAsync(mruToken, AccessCacheOptions.FastLocationsOnly | AccessCacheOptions.SuppressAccessTimeUpdate);
                         if (item.IsOfType(StorageItemTypes.Folder))
                         {
                             menu.Items.Add(new MenuFlyoutItemViewModel(item.Name, string.IsNullOrEmpty(item.Path) ? entry.Metadata : item.Path, AddPageCommand));


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #5250

**Details of Changes**
Accessing an item from the MRU list via `GetItem/GetFiles/etc` while enumerating will update the access time
- Add `SuppressAccessTimeUpdate` flag when getting item to avoid update

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility

**Screenshots (optional)**

_**before:**_
![Files-5250-before](https://user-images.githubusercontent.com/29434693/167980310-0015f435-877d-47b2-88c9-1dc7b56245e8.gif)

---

_**after:**_
![Files-5250-after](https://user-images.githubusercontent.com/29434693/167980345-ddfb8fec-3449-4d84-953f-9dbff2d5b497.gif)

