### PR TITLE
Fix: Fixed title bar drag area

### DIFF
--- a/src/Files.Uwp/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/src/Files.Uwp/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -560,6 +560,8 @@
         <muxc:TabView
             x:Name="HorizontalTabView"
             VerticalAlignment="Stretch"
+            Padding="0"
+            Margin="0,10,0,0"
             AddTabButtonClick="TabView_AddTabButtonClick"
             AllowDropTabs="True"
             Background="{x:Null}"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #8504

Fixed an issue preventing users from dragging the app window from the empty space on top of the tab view

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
