### PR TITLE
Avoid crash when creating a library

### DIFF
--- a/src/Files.Uwp/Filesystem/LibraryManager.cs
+++ b/src/Files.Uwp/Filesystem/LibraryManager.cs
@@ -63,11 +63,12 @@ namespace Files.Uwp.Filesystem
             // library is null in case it was deleted
             if (library is not null && !Libraries.Any(x => x.Path == library.FullPath))
             {
+                var libItem = new LibraryLocationItem(library);
                 lock (libraries)
                 {
-                    libraries.Add(new LibraryLocationItem(library));
+                    libraries.Add(libItem);
                 }
-                DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, library));
+                DataChanged?.Invoke(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, libItem));
             }
             return Task.CompletedTask;
         }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes Appcenter [2408931032u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/2408931032u/overview)

**Details of Changes**
Add details of changes here.
- Sidebar update event was being passed the wrong type of item

**Validation**
How did you test these changes?
- [x] Built and ran the app
