### PR TITLE
Show failed banner if any items failed in a file operation

### DIFF
--- a/src/Files.Shared/Enums/FileOperationType.cs
+++ b/src/Files.Shared/Enums/FileOperationType.cs
@@ -5,7 +5,6 @@ namespace Files.Shared.Enums
     /// <summary>
     /// Type of operation on Files filesystem that took place
     /// </summary>
-    [Flags]
     public enum FileOperationType : byte
     {
         /// <summary>

--- a/src/Files.Shared/Enums/ReturnResult.cs
+++ b/src/Files.Shared/Enums/ReturnResult.cs
@@ -5,7 +5,6 @@ namespace Files.Shared.Enums
     /// <summary>
     /// Contains all kinds of return status
     /// </summary>
-    [Flags]
     public enum ReturnResult : byte
     {
         /// <summary>

--- a/src/Files.Uwp/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/src/Files.Uwp/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -83,9 +83,9 @@ namespace Files.Uwp.Filesystem
 
         public async Task<(ReturnResult, IStorageItem)> CreateAsync(IStorageItemWithPath source, bool registerHistory)
         {
-            var returnCode = FileSystemStatusCode.InProgress;
+            var returnStatus = ReturnResult.InProgress;
             var errorCode = new Progress<FileSystemStatusCode>();
-            errorCode.ProgressChanged += (s, e) => returnCode = e;
+            errorCode.ProgressChanged += (s, e) => returnStatus = returnStatus < ReturnResult.Failed ? e.ToStatus() : returnStatus;
 
             var result = await filesystemOperations.CreateAsync(source, errorCode, cancellationToken);
 
@@ -95,7 +95,7 @@ namespace Files.Uwp.Filesystem
             }
 
             await Task.Yield();
-            return (returnCode.ToStatus(), result.Item2);
+            return (returnStatus, result.Item2);
         }
 
         #endregion Create
@@ -152,7 +152,7 @@ namespace Files.Uwp.Filesystem
 
             // post the status banner
             var banner = PostBannerHelpers.PostBanner_Delete(source, returnStatus, permanently, false, 0);
-            banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
+            banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = returnStatus < ReturnResult.Failed ? e.ToStatus() : returnStatus;
 
             var token = banner.CancellationToken;
 
@@ -218,9 +218,9 @@ namespace Files.Uwp.Filesystem
             source = await source.ToListAsync();
             destination = await destination.ToListAsync();
 
-            var returnCode = FileSystemStatusCode.InProgress;
+            var returnStatus = ReturnResult.InProgress;
             var errorCode = new Progress<FileSystemStatusCode>();
-            errorCode.ProgressChanged += (s, e) => returnCode = e;
+            errorCode.ProgressChanged += (s, e) => returnStatus = returnStatus < ReturnResult.Failed ? e.ToStatus() : returnStatus;
 
             var sw = new Stopwatch();
             sw.Start();
@@ -236,7 +236,7 @@ namespace Files.Uwp.Filesystem
 
             sw.Stop();
 
-            return returnCode.ToStatus();
+            return returnStatus;
         }
 
         #endregion Restore
@@ -320,7 +320,7 @@ namespace Files.Uwp.Filesystem
             var returnStatus = ReturnResult.InProgress;
 
             var banner = PostBannerHelpers.PostBanner_Copy(source, destination, returnStatus, false, 0);
-            banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
+            banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = returnStatus < ReturnResult.Failed ? e.ToStatus() : returnStatus;
 
             var token = banner.CancellationToken;
 
@@ -475,7 +475,7 @@ namespace Files.Uwp.Filesystem
             var destinationDir = PathNormalization.GetParentDir(destination.FirstOrDefault());
 
             var banner = PostBannerHelpers.PostBanner_Move(source, destination, returnStatus, false, 0);
-            banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = e.ToStatus();
+            banner.ErrorCode.ProgressChanged += (s, e) => returnStatus = returnStatus < ReturnResult.Failed ? e.ToStatus() : returnStatus;
 
             var token = banner.CancellationToken;
 
@@ -583,9 +583,9 @@ namespace Files.Uwp.Filesystem
 
         public async Task<ReturnResult> RenameAsync(IStorageItemWithPath source, string newName, NameCollisionOption collision, bool registerHistory)
         {
-            var returnCode = FileSystemStatusCode.InProgress;
+            var returnStatus = ReturnResult.InProgress;
             var errorCode = new Progress<FileSystemStatusCode>();
-            errorCode.ProgressChanged += (s, e) => returnCode = e;
+            errorCode.ProgressChanged += (s, e) => returnStatus = returnStatus < ReturnResult.Failed ? e.ToStatus() : returnStatus;
 
             IStorageHistory history = null;
 
@@ -627,7 +627,7 @@ namespace Files.Uwp.Filesystem
             App.JumpList.RemoveFolder(source.Path); // Remove items from jump list
 
             await Task.Yield();
-            return returnCode.ToStatus();
+            return returnStatus;
         }
 
         #endregion Rename
@@ -649,9 +649,9 @@ namespace Files.Uwp.Filesystem
                 return ReturnResult.Failed;
             }
 
-            var returnCode = FileSystemStatusCode.InProgress;
+            var returnStatus = ReturnResult.InProgress;
             var errorCode = new Progress<FileSystemStatusCode>();
-            errorCode.ProgressChanged += (s, e) => returnCode = e;
+            errorCode.ProgressChanged += (s, e) => returnStatus = returnStatus < ReturnResult.Failed ? e.ToStatus() : returnStatus;
 
             source = source.Where(x => !string.IsNullOrEmpty(x.Path));
             var dest = source.Select(x => Path.Combine(destination,
@@ -668,7 +668,7 @@ namespace Files.Uwp.Filesystem
             }
 
             await Task.Yield();
-            return returnCode.ToStatus();
+            return returnStatus;
         }
 
         public async Task<ReturnResult> RecycleItemsFromClipboard(DataPackageView packageView, string destination, bool showDialog, bool registerHistory)

--- a/src/Files.Uwp/Helpers/Convert/ErrorCodeConverter.cs
+++ b/src/Files.Uwp/Helpers/Convert/ErrorCodeConverter.cs
@@ -12,7 +12,7 @@ namespace Files.Uwp.Helpers
                     return ReturnResult.Success;
 
                 case FileSystemStatusCode.Generic:
-                    return ReturnResult.InProgress | ReturnResult.Cancelled;
+                    return ReturnResult.Failed;
 
                 case FileSystemStatusCode.Unauthorized:
                     return ReturnResult.AccessUnauthorized;
@@ -27,13 +27,13 @@ namespace Files.Uwp.Helpers
                     return ReturnResult.UnknownException;
 
                 case FileSystemStatusCode.AlreadyExists:
-                    return ReturnResult.Failed | ReturnResult.UnknownException;
+                    return ReturnResult.Failed;
 
                 case FileSystemStatusCode.NotAFolder:
-                    return ReturnResult.BadArgumentException | ReturnResult.IntegrityCheckFailed;
+                    return ReturnResult.BadArgumentException;
 
                 case FileSystemStatusCode.NotAFile:
-                    return ReturnResult.BadArgumentException | ReturnResult.IntegrityCheckFailed;
+                    return ReturnResult.BadArgumentException;
 
                 case FileSystemStatusCode.InProgress:
                     return ReturnResult.InProgress;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related #9159

**Details of Changes**
Add details of changes here.
- When using StorageAPI in file operations involving multiple items the last copy result overwrites the status shown in the banner. So if 29/30 operations fail but the 30th succeeds we show the "Success!" green banner, which is wrong.
- Changed callback function to only update the status if nothing has failed so far. 
- Remove the [Flags] attribute from enum whose values are not powers of 2 as required

**Validation**
How did you test these changes?
- [x] Built and ran the app
