### PR TITLE
Move the home button to the address bar

### DIFF
--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -1,11 +1,11 @@
-﻿using Files.Shared.Extensions;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.Backend.Services.Settings;
+using Files.Shared.Extensions;
 using Files.Uwp.Controllers;
 using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Uwp.Filesystem;
 using Files.Uwp.Helpers;
-using Files.Backend.Services.Settings;
 using Files.Uwp.ViewModels;
-using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Uwp;
 using Newtonsoft.Json;
 using System;
@@ -18,7 +18,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.Storage;
-using Windows.UI.Xaml.Media.Imaging;
 
 namespace Files.Uwp.DataModels
 {
@@ -345,21 +344,6 @@ namespace Files.Uwp.DataModels
             {
                 return;
             }
-
-            var homeSection = new LocationItem()
-            {
-                Text = "Home".GetLocalized(),
-                Section = SectionType.Home,
-                MenuOptions = new ContextMenuOptions
-                {
-                    IsLocationItem = true
-                },
-                Font = MainViewModel.FontName,
-                IsDefaultLocation = true,
-                Icon = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => new BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/Home.png"))),
-                Path = "Home".GetLocalized()
-            };
-            AddLocationItemToSidebar(homeSection);
 
             for (int i = 0; i < FavoriteItems.Count; i++)
             {

--- a/src/Files.Uwp/UserControls/AddressToolbar.xaml
+++ b/src/Files.Uwp/UserControls/AddressToolbar.xaml
@@ -410,11 +410,10 @@
                     Width="36"
                     Height="32"
                     x:FieldModifier="public"
-                    AccessKey="R"
                     AutomationProperties.Name="{helpers:ResourceString Name=Home}"
                     Background="Transparent"
+                    PointerPressed="Home_PointerPressed"
                     Command="{x:Bind ViewModel.GoHomeCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
                     Style="{StaticResource ToolBarButtonStyle}"
                     ToolTipService.ToolTip="{helpers:ResourceString Name=Home}">
                     <FontIcon FontSize="14" Glyph="&#xE80F;" />

--- a/src/Files.Uwp/UserControls/AddressToolbar.xaml
+++ b/src/Files.Uwp/UserControls/AddressToolbar.xaml
@@ -356,7 +356,7 @@
                     AccessKey="B"
                     AutomationProperties.Name="{helpers:ResourceString Name=NavBackButton/AutomationProperties/Name}"
                     Background="Transparent"
-                    Command="{x:Bind ViewModel.BackClickCommand, Mode=OneWay}"
+                    Command="{x:Bind ViewModel.BackCommand, Mode=OneWay}"
                     IsEnabled="{x:Bind ViewModel.CanGoBack, Mode=OneWay}"
                     Style="{StaticResource ToolBarButtonStyle}"
                     ToolTipService.ToolTip="{helpers:ResourceString Name=NavBackButton/ToolTipService/ToolTip}">
@@ -376,7 +376,7 @@
                     AccessKey="F"
                     AutomationProperties.Name="{helpers:ResourceString Name=NavForwardButton/AutomationProperties/Name}"
                     Background="Transparent"
-                    Command="{x:Bind ViewModel.ForwardClickCommand, Mode=OneWay}"
+                    Command="{x:Bind ViewModel.ForwardCommand, Mode=OneWay}"
                     IsEnabled="{x:Bind ViewModel.CanGoForward, Mode=OneWay}"
                     Style="{StaticResource ToolBarButtonStyle}"
                     ToolTipService.ToolTip="{helpers:ResourceString Name=NavForwardButton/ToolTipService/ToolTip}">
@@ -395,7 +395,7 @@
                     AccessKey="U"
                     AutomationProperties.Name="{helpers:ResourceString Name=NavUpButton/AutomationProperties/Name}"
                     Background="Transparent"
-                    Command="{x:Bind ViewModel.UpClickCommand, Mode=OneWay}"
+                    Command="{x:Bind ViewModel.UpCommand, Mode=OneWay}"
                     IsEnabled="{x:Bind ViewModel.CanNavigateToParent, Mode=OneWay}"
                     Style="{StaticResource ToolBarButtonStyle}"
                     ToolTipService.ToolTip="{helpers:ResourceString Name=NavUpButton/ToolTipService/ToolTip}">
@@ -406,6 +406,21 @@
                 </Button>
 
                 <Button
+                    x:Name="Home"
+                    Width="36"
+                    Height="32"
+                    x:FieldModifier="public"
+                    AccessKey="R"
+                    AutomationProperties.Name="{helpers:ResourceString Name=Home}"
+                    Background="Transparent"
+                    Command="{x:Bind ViewModel.GoHomeCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+                    Style="{StaticResource ToolBarButtonStyle}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=Home}">
+                    <FontIcon FontSize="14" Glyph="&#xE80F;" />
+                </Button>
+
+                <Button
                     x:Name="Refresh"
                     Width="36"
                     Height="32"
@@ -413,7 +428,7 @@
                     AccessKey="R"
                     AutomationProperties.Name="{helpers:ResourceString Name=NavRefreshButton/AutomationProperties/Name}"
                     Background="Transparent"
-                    Command="{x:Bind ViewModel.RefreshClickCommand, Mode=OneWay}"
+                    Command="{x:Bind ViewModel.RefreshCommand, Mode=OneWay}"
                     IsEnabled="{x:Bind ViewModel.CanRefresh, Mode=OneWay}"
                     Style="{StaticResource ToolBarButtonStyle}"
                     ToolTipService.ToolTip="{helpers:ResourceString Name=NavRefreshButton/ToolTipService/ToolTip}">

--- a/src/Files.Uwp/UserControls/AddressToolbar.xaml.cs
+++ b/src/Files.Uwp/UserControls/AddressToolbar.xaml.cs
@@ -1,7 +1,10 @@
 using Files.Uwp.Helpers.XamlHelpers;
 using Files.Uwp.ViewModels;
+using System.Threading.Tasks;
 using System.Windows.Input;
+using Windows.Devices.Input;
 using Windows.System;
+using Windows.UI.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -66,9 +69,9 @@ namespace Files.Uwp.UserControls
 
         private void ManualPathEntryItem_Click(object sender, PointerRoutedEventArgs e)
         {
-            if (e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Mouse)
+            if (e.Pointer.PointerDeviceType is PointerDeviceType.Mouse)
             {
-                Windows.UI.Input.PointerPoint ptrPt = e.GetCurrentPoint(NavToolbar);
+                PointerPoint ptrPt = e.GetCurrentPoint(NavToolbar);
                 if (ptrPt.Properties.IsMiddleButtonPressed)
                 {
                     return;
@@ -125,6 +128,18 @@ namespace Files.Uwp.UserControls
 
         public void SetShellCommandBarContextItems()
         {
+        }
+
+        private async void Home_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            if (e.Pointer.PointerDeviceType is PointerDeviceType.Mouse)
+            {
+                PointerPoint ptrPt = e.GetCurrentPoint(NavToolbar);
+                if (ptrPt.Properties.IsMiddleButtonPressed)
+                {
+                    await MainPageViewModel.AddNewTabAsync();
+                }
+            }
         }
 
         public bool ShowSearchBox

--- a/src/Files.Uwp/ViewModels/ToolbarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ToolbarViewModel.cs
@@ -3,12 +3,12 @@ using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using Files.Backend.Services;
 using Files.Backend.Services.Settings;
-using Files.Uwp.Filesystem;
-using Files.Uwp.Filesystem.StorageItems;
-using Files.Uwp.Helpers;
 using Files.Shared.Enums;
 using Files.Shared.EventArguments;
 using Files.Shared.Extensions;
+using Files.Uwp.Filesystem;
+using Files.Uwp.Filesystem.StorageItems;
+using Files.Uwp.Helpers;
 using Files.Uwp.UserControls;
 using Files.Uwp.Views;
 using Microsoft.Toolkit.Uwp;
@@ -73,6 +73,8 @@ namespace Files.Uwp.ViewModels
 
         public event EventHandler UpRequested;
 
+        public event EventHandler GoHomeRequested;
+
         public event EventHandler RefreshRequested;
 
         public event EventHandler RefreshWidgetsRequested;
@@ -90,7 +92,7 @@ namespace Files.Uwp.ViewModels
             get => InstanceViewModel?.FolderSettings.DirectorySortDirection == SortDirection.Descending;
             set { if (value) InstanceViewModel.FolderSettings.DirectorySortDirection = SortDirection.Descending; }
         }
-        
+
         public bool AreDirectoriesSortedAlongsideFiles
         {
             get => InstanceViewModel.FolderSettings.SortDirectoriesAlongsideFiles;
@@ -339,10 +341,11 @@ namespace Files.Uwp.ViewModels
 
         public ToolbarViewModel()
         {
-            BackClickCommand = new RelayCommand<RoutedEventArgs>(e => BackRequested?.Invoke(this, EventArgs.Empty));
-            ForwardClickCommand = new RelayCommand<RoutedEventArgs>(e => ForwardRequested?.Invoke(this, EventArgs.Empty));
-            UpClickCommand = new RelayCommand<RoutedEventArgs>(e => UpRequested?.Invoke(this, EventArgs.Empty));
-            RefreshClickCommand = new RelayCommand<RoutedEventArgs>(e => RefreshRequested?.Invoke(this, EventArgs.Empty));
+            BackCommand = new RelayCommand<RoutedEventArgs>(e => BackRequested?.Invoke(this, EventArgs.Empty));
+            ForwardCommand = new RelayCommand<RoutedEventArgs>(e => ForwardRequested?.Invoke(this, EventArgs.Empty));
+            UpCommand = new RelayCommand<RoutedEventArgs>(e => UpRequested?.Invoke(this, EventArgs.Empty));
+            GoHomeCommand = new RelayCommand<RoutedEventArgs>(e => GoHomeRequested?.Invoke(this, EventArgs.Empty));
+            RefreshCommand = new RelayCommand<RoutedEventArgs>(e => RefreshRequested?.Invoke(this, EventArgs.Empty));
 
             dispatcherQueue = DispatcherQueue.GetForCurrentThread();
             dragOverTimer = dispatcherQueue.CreateTimer();
@@ -380,7 +383,6 @@ namespace Files.Uwp.ViewModels
         public SearchBoxViewModel SearchBoxViewModel => SearchBox as SearchBoxViewModel;
 
         public bool IsSingleItemOverride { get; set; } = false;
-
         private string dragOverPath = null;
 
         public void UpdateSortAndGroupOptions()
@@ -409,7 +411,7 @@ namespace Files.Uwp.ViewModels
             OnPropertyChanged(nameof(IsSortedByDateDeleted));
             OnPropertyChanged(nameof(IsSortedByFileTag));
         }
-        
+
         private void FolderSettings_SortDirectoriesAlongsideFilesPreferenceUpdated(object sender, bool e)
         {
             OnPropertyChanged(nameof(AreDirectoriesSortedAlongsideFiles));
@@ -608,10 +610,11 @@ namespace Files.Uwp.ViewModels
             set => SetProperty(ref pathControlDisplayText, value);
         }
 
-        public ICommand BackClickCommand { get; }
-        public ICommand ForwardClickCommand { get; }
-        public ICommand UpClickCommand { get; }
-        public ICommand RefreshClickCommand { get; }
+        public ICommand BackCommand { get; }
+        public ICommand ForwardCommand { get; }
+        public ICommand UpCommand { get; }
+        public ICommand GoHomeCommand { get; }
+        public ICommand RefreshCommand { get; }
 
         public void PathItemSeparator_DataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
         {

--- a/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
@@ -175,7 +175,8 @@ namespace Files.Uwp.Views
             ToolbarViewModel.ForwardRequested += ColumnShellPage_ForwardNavRequested;
             ToolbarViewModel.UpRequested += ColumnShellPage_UpNavRequested;
             ToolbarViewModel.GoHomeRequested += ColumnShellPage_GoHomeRequested;
-            ToolbarViewModel.RefreshRequested += ColumnShellPage_RefreshRequested;            ToolbarViewModel.EditModeEnabled += NavigationToolbar_EditModeEnabled;
+            ToolbarViewModel.RefreshRequested += ColumnShellPage_RefreshRequested;
+            ToolbarViewModel.EditModeEnabled += NavigationToolbar_EditModeEnabled;
             ToolbarViewModel.ItemDraggedOverPathItem += ColumnShellPage_NavigationRequested;
             ToolbarViewModel.PathBoxQuerySubmitted += NavigationToolbar_QuerySubmitted;
             ToolbarViewModel.SearchBox.TextChanged += ColumnShellPage_TextChanged;
@@ -995,7 +996,7 @@ namespace Files.Uwp.Views
 
         public void NavigateHome()
         {
-            throw new NotImplementedException("Can't show Home page in Column View");
+            NavigateToPath("Home".GetLocalized());
         }
 
         public void RemoveLastPageFromBackStack()

--- a/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ColumnShellPage.xaml.cs
@@ -1,18 +1,21 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.Mvvm.Input;
+using Files.Backend.Enums;
+using Files.Backend.Services;
+using Files.Backend.Services.Settings;
+using Files.Backend.ViewModels.Dialogs.AddItemDialog;
 using Files.Shared;
-using Files.Uwp.Dialogs;
 using Files.Shared.Enums;
+using Files.Uwp.Dialogs;
 using Files.Uwp.EventArguments;
 using Files.Uwp.Filesystem;
 using Files.Uwp.Filesystem.FilesystemHistory;
 using Files.Uwp.Filesystem.Search;
 using Files.Uwp.Helpers;
-using Files.Backend.Services.Settings;
 using Files.Uwp.UserControls;
 using Files.Uwp.UserControls.MultitaskingControl;
 using Files.Uwp.ViewModels;
 using Files.Uwp.Views.LayoutModes;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using CommunityToolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp;
 using Microsoft.Toolkit.Uwp.UI;
 using System;
@@ -32,11 +35,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
-using Files.Uwp.Interacts;
 using SortDirection = Files.Shared.Enums.SortDirection;
-using Files.Backend.Enums;
-using Files.Backend.Services;
-using Files.Backend.ViewModels.Dialogs.AddItemDialog;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -173,10 +172,10 @@ namespace Files.Uwp.Views
             ToolbarViewModel.AddressBarTextEntered += ColumnShellPage_AddressBarTextEntered;
             ToolbarViewModel.PathBoxItemDropped += ColumnShellPage_PathBoxItemDropped;
             ToolbarViewModel.BackRequested += ColumnShellPage_BackNavRequested;
-            ToolbarViewModel.UpRequested += ColumnShellPage_UpNavRequested;
-            ToolbarViewModel.RefreshRequested += ColumnShellPage_RefreshRequested;
             ToolbarViewModel.ForwardRequested += ColumnShellPage_ForwardNavRequested;
-            ToolbarViewModel.EditModeEnabled += NavigationToolbar_EditModeEnabled;
+            ToolbarViewModel.UpRequested += ColumnShellPage_UpNavRequested;
+            ToolbarViewModel.GoHomeRequested += ColumnShellPage_GoHomeRequested;
+            ToolbarViewModel.RefreshRequested += ColumnShellPage_RefreshRequested;            ToolbarViewModel.EditModeEnabled += NavigationToolbar_EditModeEnabled;
             ToolbarViewModel.ItemDraggedOverPathItem += ColumnShellPage_NavigationRequested;
             ToolbarViewModel.PathBoxQuerySubmitted += NavigationToolbar_QuerySubmitted;
             ToolbarViewModel.SearchBox.TextChanged += ColumnShellPage_TextChanged;
@@ -350,25 +349,11 @@ namespace Files.Uwp.Views
             }
         }
 
-        private void ColumnShellPage_RefreshRequested(object sender, EventArgs e)
-        {
-            Refresh_Click();
-        }
-
-        private void ColumnShellPage_UpNavRequested(object sender, EventArgs e)
-        {
-            Up_Click();
-        }
-
-        private void ColumnShellPage_ForwardNavRequested(object sender, EventArgs e)
-        {
-            Forward_Click();
-        }
-
-        private void ColumnShellPage_BackNavRequested(object sender, EventArgs e)
-        {
-            Back_Click();
-        }
+        private void ColumnShellPage_BackNavRequested(object sender, EventArgs e) => Back_Click();
+        private void ColumnShellPage_ForwardNavRequested(object sender, EventArgs e) => Forward_Click();
+        private void ColumnShellPage_UpNavRequested(object sender, EventArgs e) => Up_Click();
+        private void ColumnShellPage_GoHomeRequested(object sender, EventArgs e) => NavigateHome();
+        private void ColumnShellPage_RefreshRequested(object sender, EventArgs e) => Refresh_Click();
 
         protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
         {
@@ -886,9 +871,10 @@ namespace Files.Uwp.Views
             ToolbarViewModel.AddressBarTextEntered -= ColumnShellPage_AddressBarTextEntered;
             ToolbarViewModel.PathBoxItemDropped -= ColumnShellPage_PathBoxItemDropped;
             ToolbarViewModel.BackRequested -= ColumnShellPage_BackNavRequested;
-            ToolbarViewModel.UpRequested -= ColumnShellPage_UpNavRequested;
-            ToolbarViewModel.RefreshRequested -= ColumnShellPage_RefreshRequested;
             ToolbarViewModel.ForwardRequested -= ColumnShellPage_ForwardNavRequested;
+            ToolbarViewModel.UpRequested -= ColumnShellPage_UpNavRequested;
+            ToolbarViewModel.GoHomeRequested -= ColumnShellPage_GoHomeRequested;
+            ToolbarViewModel.RefreshRequested -= ColumnShellPage_RefreshRequested;
             ToolbarViewModel.EditModeEnabled -= NavigationToolbar_EditModeEnabled;
             ToolbarViewModel.ItemDraggedOverPathItem -= ColumnShellPage_NavigationRequested;
             ToolbarViewModel.PathBoxQuerySubmitted -= NavigationToolbar_QuerySubmitted;

--- a/src/Files.Uwp/Views/ModernShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ModernShellPage.xaml.cs
@@ -1,18 +1,21 @@
-﻿using Files.Shared;
-using Files.Uwp.Dialogs;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.Mvvm.Input;
+using Files.Backend.Enums;
+using Files.Backend.Services;
+using Files.Backend.Services.Settings;
+using Files.Backend.ViewModels.Dialogs.AddItemDialog;
+using Files.Shared;
 using Files.Shared.Enums;
+using Files.Uwp.Dialogs;
 using Files.Uwp.EventArguments;
 using Files.Uwp.Filesystem;
 using Files.Uwp.Filesystem.FilesystemHistory;
 using Files.Uwp.Filesystem.Search;
 using Files.Uwp.Helpers;
-using Files.Backend.Services.Settings;
 using Files.Uwp.UserControls;
 using Files.Uwp.UserControls.MultitaskingControl;
 using Files.Uwp.ViewModels;
 using Files.Uwp.Views.LayoutModes;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using CommunityToolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp;
 using System;
 using System.Collections.Generic;
@@ -33,9 +36,6 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
 using SortDirection = Files.Shared.Enums.SortDirection;
-using Files.Backend.Enums;
-using Files.Backend.Services;
-using Files.Backend.ViewModels.Dialogs.AddItemDialog;
 
 namespace Files.Uwp.Views
 {
@@ -174,9 +174,10 @@ namespace Files.Uwp.Views
             ToolbarViewModel.AddressBarTextEntered += ModernShellPage_AddressBarTextEntered;
             ToolbarViewModel.PathBoxItemDropped += ModernShellPage_PathBoxItemDropped;
             ToolbarViewModel.BackRequested += ModernShellPage_BackNavRequested;
-            ToolbarViewModel.UpRequested += ModernShellPage_UpNavRequested;
-            ToolbarViewModel.RefreshRequested += ModernShellPage_RefreshRequested;
             ToolbarViewModel.ForwardRequested += ModernShellPage_ForwardNavRequested;
+            ToolbarViewModel.UpRequested += ModernShellPage_UpNavRequested;
+            ToolbarViewModel.GoHomeRequested += ModernShellPage_GoHomeRequested;
+            ToolbarViewModel.RefreshRequested += ModernShellPage_RefreshRequested;
             ToolbarViewModel.EditModeEnabled += NavigationToolbar_EditModeEnabled;
             ToolbarViewModel.ItemDraggedOverPathItem += ModernShellPage_NavigationRequested;
             ToolbarViewModel.PathBoxQuerySubmitted += NavigationToolbar_QuerySubmitted;
@@ -362,25 +363,11 @@ namespace Files.Uwp.Views
             });
         }
 
-        private void ModernShellPage_RefreshRequested(object sender, EventArgs e)
-        {
-            Refresh_Click();
-        }
-
-        private void ModernShellPage_UpNavRequested(object sender, EventArgs e)
-        {
-            Up_Click();
-        }
-
-        private void ModernShellPage_ForwardNavRequested(object sender, EventArgs e)
-        {
-            Forward_Click();
-        }
-
-        private void ModernShellPage_BackNavRequested(object sender, EventArgs e)
-        {
-            Back_Click();
-        }
+        private void ModernShellPage_BackNavRequested(object sender, EventArgs e) => Back_Click();
+        private void ModernShellPage_ForwardNavRequested(object sender, EventArgs e) => Forward_Click();
+        private void ModernShellPage_UpNavRequested(object sender, EventArgs e) => Up_Click();
+        private void ModernShellPage_GoHomeRequested(object sender, EventArgs e) => NavigateHome();
+        private void ModernShellPage_RefreshRequested(object sender, EventArgs e) => Refresh_Click();
 
         protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
         {
@@ -404,7 +391,7 @@ namespace Files.Uwp.Views
         {
             FilesystemViewModel?.UpdateSortOptionStatus();
         }
-        
+
         private void AppSettings_SortDirectoriesAlongsideFilesPreferenceUpdated(object sender, bool e)
         {
             FilesystemViewModel?.UpdateSortDirectoriesAlongsideFiles();
@@ -681,7 +668,7 @@ namespace Files.Uwp.Views
             var ctrl = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Control);
             var shift = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
             var alt = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Menu);
-            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) || 
+            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) ||
                               CurrentPageType == typeof(GridViewBrowser);
 
             switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.KeyboardAccelerator.Key)
@@ -992,9 +979,10 @@ namespace Files.Uwp.Views
             ToolbarViewModel.AddressBarTextEntered -= ModernShellPage_AddressBarTextEntered;
             ToolbarViewModel.PathBoxItemDropped -= ModernShellPage_PathBoxItemDropped;
             ToolbarViewModel.BackRequested -= ModernShellPage_BackNavRequested;
-            ToolbarViewModel.UpRequested -= ModernShellPage_UpNavRequested;
-            ToolbarViewModel.RefreshRequested -= ModernShellPage_RefreshRequested;
             ToolbarViewModel.ForwardRequested -= ModernShellPage_ForwardNavRequested;
+            ToolbarViewModel.UpRequested -= ModernShellPage_UpNavRequested;
+            ToolbarViewModel.GoHomeRequested -= ModernShellPage_GoHomeRequested;
+            ToolbarViewModel.RefreshRequested -= ModernShellPage_RefreshRequested;
             ToolbarViewModel.EditModeEnabled -= NavigationToolbar_EditModeEnabled;
             ToolbarViewModel.ItemDraggedOverPathItem -= ModernShellPage_NavigationRequested;
             ToolbarViewModel.PathBoxQuerySubmitted -= NavigationToolbar_QuerySubmitted;


### PR DESCRIPTION
Moves the Home button to the navigation bar, which is its most logical place. The MiddleClick opens a new tab. For this reason, this button is always active, even on the home page. #9147

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
![Home](https://user-images.githubusercontent.com/46631671/168439482-e771aec1-fa06-4e40-b520-d24e7b8ed63e.png)
