### PR TITLE
Hide triple-dot button from empty space context menu

### DIFF
--- a/src/Files.Uwp/BaseLayout.cs
+++ b/src/Files.Uwp/BaseLayout.cs
@@ -67,7 +67,10 @@ namespace Files.Uwp
         {
             AlwaysExpanded = true,
         };
-        public Microsoft.UI.Xaml.Controls.CommandBarFlyout BaseContextMenuFlyout { get; set; } = new Microsoft.UI.Xaml.Controls.CommandBarFlyout();
+        public Microsoft.UI.Xaml.Controls.CommandBarFlyout BaseContextMenuFlyout { get; set; } = new Microsoft.UI.Xaml.Controls.CommandBarFlyout()
+        {
+            AlwaysExpanded = true,
+        };
 
         public BaseLayoutCommandsViewModel CommandsViewModel { get; protected set; }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Hide triple-dot button from empty space context menu to match items context menu

**Details of Changes**
Add details of changes here.
- Set AlwaysExpanded to true for BaseContextMenuFlyout

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots (optional)**
Add screenshots here.

![image](https://user-images.githubusercontent.com/9673091/168451352-612bfe3b-6498-48fc-8067-530d9bfb8991.png)