### PR TITLE
Fix crash due to multiple dialogs opening

### DIFF
--- a/src/Files.Uwp/ServicesImplementation/DialogService.cs
+++ b/src/Files.Uwp/ServicesImplementation/DialogService.cs
@@ -52,10 +52,18 @@ namespace Files.Uwp.ServicesImplementation
             return dialog;
         }
 
-        public Task<DialogResult> ShowDialogAsync<TViewModel>(TViewModel viewModel)
+        public async Task<DialogResult> ShowDialogAsync<TViewModel>(TViewModel viewModel)
             where TViewModel : class, INotifyPropertyChanged
         {
-            return GetDialog<TViewModel>(viewModel).ShowAsync();
+            try
+            {
+                return await GetDialog(viewModel).ShowAsync();
+            }
+            catch (Exception)
+            {
+            }
+
+            return DialogResult.None;
         }
     }
 }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes Appcenter [371833548u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/371833548u/overview)

**Details of Changes**
Add details of changes here.
- Add try-catch around dialog ShowAsync in DialogService to match DialogDisplayHelper. Return "DialogResult.None" if a dialog is already open.

**Validation**
How did you test these changes?
- [x] Built and ran the app
