### PR TITLE
Move the Home item outside the favorites section

### DIFF
--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -1,11 +1,11 @@
-﻿using Files.Shared.Extensions;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.Backend.Services.Settings;
+using Files.Shared.Extensions;
 using Files.Uwp.Controllers;
 using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Uwp.Filesystem;
 using Files.Uwp.Helpers;
-using Files.Backend.Services.Settings;
 using Files.Uwp.ViewModels;
-using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.Toolkit.Uwp;
 using Newtonsoft.Json;
 using System;
@@ -18,7 +18,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.Storage;
-using Windows.UI.Xaml.Media.Imaging;
 
 namespace Files.Uwp.DataModels
 {
@@ -345,21 +344,6 @@ namespace Files.Uwp.DataModels
             {
                 return;
             }
-
-            var homeSection = new LocationItem()
-            {
-                Text = "Home".GetLocalized(),
-                Section = SectionType.Home,
-                MenuOptions = new ContextMenuOptions
-                {
-                    IsLocationItem = true
-                },
-                Font = MainViewModel.FontName,
-                IsDefaultLocation = true,
-                Icon = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => new BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/Home.png"))),
-                Path = "Home".GetLocalized()
-            };
-            AddLocationItemToSidebar(homeSection);
 
             for (int i = 0; i < FavoriteItems.Count; i++)
             {

--- a/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
@@ -1,13 +1,13 @@
 ﻿using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using Files.Backend.Services.Settings;
+using Files.Shared.Extensions;
 using Files.Uwp.DataModels;
 using Files.Uwp.DataModels.NavigationControlItems;
 using Files.Uwp.Filesystem;
 using Files.Uwp.Filesystem.StorageItems;
 using Files.Uwp.Helpers;
 using Files.Uwp.Helpers.ContextFlyouts;
-using Files.Shared.Extensions;
 using Files.Uwp.ViewModels;
 using Microsoft.Toolkit.Uwp;
 using Microsoft.Toolkit.Uwp.UI;
@@ -16,7 +16,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Windows.ApplicationModel.DataTransfer;
@@ -187,8 +186,8 @@ namespace Files.Uwp.UserControls
         {
             ContextMenuOptions options = item.MenuOptions;
 
-            bool showMoveItemUp = options.IsItemMovable ? App.SidebarPinnedController.Model.IndexOfItem(item) > 1 : false;
-            bool showMoveItemDown = options.IsItemMovable ? App.SidebarPinnedController.Model.IndexOfItem(item) < App.SidebarPinnedController.Model.FavoriteItems.Count : false;
+            bool showMoveItemUp = options.IsItemMovable && App.SidebarPinnedController.Model.IndexOfItem(item) > 1;
+            bool showMoveItemDown = options.IsItemMovable && App.SidebarPinnedController.Model.IndexOfItem(item) < App.SidebarPinnedController.Model.FavoriteItems.Count;
 
             return new List<ContextMenuFlyoutItemViewModel>()
             {

--- a/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
@@ -186,8 +186,12 @@ namespace Files.Uwp.UserControls
         {
             ContextMenuOptions options = item.MenuOptions;
 
-            bool showMoveItemUp = options.IsItemMovable && App.SidebarPinnedController.Model.IndexOfItem(item) > 1;
-            bool showMoveItemDown = options.IsItemMovable && App.SidebarPinnedController.Model.IndexOfItem(item) < App.SidebarPinnedController.Model.FavoriteItems.Count;
+            var model = App.SidebarPinnedController.Model;
+            int index = model.IndexOfItem(item);
+            int count = model.FavoriteItems.Count;
+
+            bool showMoveItemUp = options.IsItemMovable && index > 0;
+            bool showMoveItemDown = options.IsItemMovable && index < count - 1;
 
             return new List<ContextMenuFlyoutItemViewModel>()
             {


### PR DESCRIPTION
Move the Home item outside the favorites section.
Had to fix the commands to move Favorites, as it assumed the first item was Home.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
![Home](https://user-images.githubusercontent.com/46631671/168464996-7e00f7a1-fe3b-4af7-9a82-acd2312c2a9a.png)