### PR TITLE
Move default SortDirectoriesAlongsideFiles to LayoutSettingsService

### DIFF
--- a/src/Files.Backend/Services/Settings/IPreferencesSettingsService.cs
+++ b/src/Files.Backend/Services/Settings/IPreferencesSettingsService.cs
@@ -34,16 +34,11 @@ namespace Files.Backend.Services.Settings
         /// Gets or sets a value indicating whether or not system items should be visible.
         /// </summary>
         bool AreSystemItemsHidden { get; set; }
-        
+
         /// <summary>
         /// Gets or sets a value indicating whether or not to display dot files.
         /// </summary>
         bool ShowDotFiles{ get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether or not files should be sorted together with folders.
-        /// </summary>
-        bool ListAndSortDirectoriesAlongsideFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not files should open with one click.

--- a/src/Files.Uwp/ServicesImplementation/Settings/LayoutSettingsService.cs
+++ b/src/Files.Uwp/ServicesImplementation/Settings/LayoutSettingsService.cs
@@ -6,14 +6,10 @@ namespace Files.Uwp.ServicesImplementation.Settings
 {
     internal sealed class LayoutSettingsService : BaseObservableJsonSettings, ILayoutSettingsService
     {
-        private readonly IUserSettingsService userSettingsService;
-
         public LayoutSettingsService(ISettingsSharingContext settingsSharingContext)
         {
             // Register root
             RegisterSettingsContext(settingsSharingContext);
-
-            userSettingsService = settingsSharingContext as IUserSettingsService;
         }
 
         public bool ShowDateColumn
@@ -72,7 +68,7 @@ namespace Files.Uwp.ServicesImplementation.Settings
         
         public bool DefaultSortDirectoriesAlongsideFiles
         {
-            get => Get(userSettingsService.PreferencesSettingsService.ListAndSortDirectoriesAlongsideFiles);
+            get => Get(false);
             set => Set(value);
         }
 

--- a/src/Files.Uwp/ServicesImplementation/Settings/PreferencesSettingsService.cs
+++ b/src/Files.Uwp/ServicesImplementation/Settings/PreferencesSettingsService.cs
@@ -56,12 +56,6 @@ namespace Files.Uwp.ServicesImplementation.Settings
             set => Set(value);
         }
 
-        public bool ListAndSortDirectoriesAlongsideFiles
-        {
-            get => Get(false);
-            set => Set(value);
-        }
-
         public bool OpenFilesWithOneClick
         {
             get => Get(false);
@@ -156,7 +150,6 @@ namespace Files.Uwp.ServicesImplementation.Settings
                 case nameof(AreHiddenItemsVisible):
                 case nameof(AreSystemItemsHidden):
                 case nameof(ShowDotFiles):
-                case nameof(ListAndSortDirectoriesAlongsideFiles):
                 case nameof(OpenFilesWithOneClick):
                 case nameof(OpenFoldersWithOneClick):
                 case nameof(SearchUnindexedItems):
@@ -183,7 +176,6 @@ namespace Files.Uwp.ServicesImplementation.Settings
             Analytics.TrackEvent($"{nameof(AreHiddenItemsVisible)}, {AreHiddenItemsVisible}");
             Analytics.TrackEvent($"{nameof(AreSystemItemsHidden)}, {AreSystemItemsHidden}");
             Analytics.TrackEvent($"{nameof(ShowDotFiles)}, {ShowDotFiles}");
-            Analytics.TrackEvent($"{nameof(ListAndSortDirectoriesAlongsideFiles)}, {ListAndSortDirectoriesAlongsideFiles}");
             Analytics.TrackEvent($"{nameof(OpenFilesWithOneClick)}, {OpenFilesWithOneClick}");
             Analytics.TrackEvent($"{nameof(OpenFoldersWithOneClick)}, {OpenFoldersWithOneClick}");
             Analytics.TrackEvent($"{nameof(SearchUnindexedItems)}, {SearchUnindexedItems}");

--- a/src/Files.Uwp/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.Uwp/UserControls/InnerNavigationToolbar.xaml
@@ -507,8 +507,8 @@
                         <MenuFlyoutSeparator />
                         <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedAscending, Mode=TwoWay}" Text="{helpers:ResourceString Name=Ascending}" />
                         <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedDescending, Mode=TwoWay}" Text="{helpers:ResourceString Name=Descending}" />
-                         <MenuFlyoutSeparator />
-                         <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.AreDirectoriesSortedAlongsideFiles, Mode=TwoWay}" Text="{helpers:ResourceString Name=SettingsListAndSortDirectoriesAlongsideFiles}" />
+                        <MenuFlyoutSeparator />
+                        <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.AreDirectoriesSortedAlongsideFiles, Mode=TwoWay}" Text="{helpers:ResourceString Name=SettingsListAndSortDirectoriesAlongsideFiles}" />
                     </MenuFlyout>
                 </AppBarButton.Flyout>
             </AppBarButton>

--- a/src/Files.Uwp/ViewModels/FolderSettingsViewModel.cs
+++ b/src/Files.Uwp/ViewModels/FolderSettingsViewModel.cs
@@ -324,9 +324,7 @@ namespace Files.Uwp.ViewModels
         {
             get
             {
-                return UserSettingsService.PreferencesSettingsService.AreLayoutPreferencesPerFolder ?                
-                LayoutPreference.SortDirectoriesAlongsideFiles : 
-                UserSettingsService.PreferencesSettingsService.ListAndSortDirectoriesAlongsideFiles;
+                return LayoutPreference.SortDirectoriesAlongsideFiles;
             }
             set
             {
@@ -334,10 +332,6 @@ namespace Files.Uwp.ViewModels
                 {
                    LayoutPreferencesUpdateRequired?.Invoke(this, new LayoutPreferenceEventArgs(LayoutPreference));
                    SortDirectoriesAlongsideFilesPreferenceUpdated?.Invoke(this, SortDirectoriesAlongsideFiles);
-                   if (!UserSettingsService.PreferencesSettingsService.AreLayoutPreferencesPerFolder)
-                   {
-                       UserSettingsService.PreferencesSettingsService.ListAndSortDirectoriesAlongsideFiles = value;
-                   }
                 }
             }
         }
@@ -792,6 +786,20 @@ namespace Files.Uwp.ViewModels
         }
 
         private void ChangeGroupOption(GroupOption option) => DirectoryGroupOption = option;
+
+        public void OnDefaultPreferencesChanged(string folderPath, string settingsName)
+        {
+            var prefs = GetLayoutPreferencesForPath(folderPath);
+            switch (settingsName)
+            {
+                case nameof(UserSettingsService.LayoutSettingsService.DefaultSortDirectoriesAlongsideFiles):
+                    SortDirectoriesAlongsideFiles = prefs.SortDirectoriesAlongsideFiles;
+                    break;
+                case nameof(UserSettingsService.PreferencesSettingsService.AreLayoutPreferencesPerFolder):
+                    LayoutPreference = prefs;
+                    break;
+            }
+        }
     }
 
     public class FolderLayoutInformation

--- a/src/Files.Uwp/ViewModels/ItemViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ItemViewModel.cs
@@ -453,21 +453,23 @@ namespace Files.Uwp.ViewModels
                 case nameof(UserSettingsService.PreferencesSettingsService.AreHiddenItemsVisible):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreSystemItemsHidden):
                 case nameof(UserSettingsService.PreferencesSettingsService.ShowDotFiles):
-                case nameof(UserSettingsService.PreferencesSettingsService.ListAndSortDirectoriesAlongsideFiles):
-                case nameof(UserSettingsService.PreferencesSettingsService.AreLayoutPreferencesPerFolder):
                 case nameof(UserSettingsService.PreferencesSettingsService.AreFileTagsEnabled):
                 case nameof(UserSettingsService.PreferencesSettingsService.ShowFolderSize):
                     await dispatcherQueue.EnqueueAsync(() =>
                     {
                         shouldDisplayThumbnails = UserSettingsService.PreferencesSettingsService.ShowThumbnails;
-                        if (!UserSettingsService.PreferencesSettingsService.AreLayoutPreferencesPerFolder)
-                        {
-                            folderSettings.SortDirectoriesAlongsideFiles = UserSettingsService.PreferencesSettingsService.ListAndSortDirectoriesAlongsideFiles;
-                        }
                         if (WorkingDirectory != "Home".GetLocalized())
                         {
                             RefreshItems(null);
                         }
+                    });
+                    break;
+                case nameof(UserSettingsService.LayoutSettingsService.DefaultSortDirectoriesAlongsideFiles):
+                case nameof(UserSettingsService.PreferencesSettingsService.AreLayoutPreferencesPerFolder):
+                    await dispatcherQueue.EnqueueAsync(() =>
+                    {
+                        folderSettings.OnDefaultPreferencesChanged(WorkingDirectory, e.SettingName);
+                        UpdateSortDirectoriesAlongsideFiles();
                     });
                     break;
             }

--- a/src/Files.Uwp/ViewModels/SettingsViewModels/PreferencesViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SettingsViewModels/PreferencesViewModel.cs
@@ -612,12 +612,12 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
 
         public bool ListAndSortDirectoriesAlongsideFiles
         {
-            get => UserSettingsService.PreferencesSettingsService.ListAndSortDirectoriesAlongsideFiles;
+            get => UserSettingsService.LayoutSettingsService.DefaultSortDirectoriesAlongsideFiles;
             set
             {
-                if (value != UserSettingsService.PreferencesSettingsService.ListAndSortDirectoriesAlongsideFiles)
+                if (value != UserSettingsService.LayoutSettingsService.DefaultSortDirectoriesAlongsideFiles)
                 {
-                    UserSettingsService.PreferencesSettingsService.ListAndSortDirectoriesAlongsideFiles = value;
+                    UserSettingsService.LayoutSettingsService.DefaultSortDirectoriesAlongsideFiles = value;
                     OnPropertyChanged();
                 }
             }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Small improvement over #9098

**Details of Changes**
Add details of changes here.
- Move default SortDirectoriesAlongsideFiles from PreferencesSettingsService to LayoutSettingsService so we don't have a duplicate setting
- Refresh sort order in current folder when the global setting changes

**Validation**
How did you test these changes?
- [x] Built and ran the app
