### PR TITLE
Improves the context menu of the sections

### DIFF
--- a/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
@@ -193,7 +193,7 @@ namespace Files.Uwp.UserControls
             bool showMoveItemUp = options.IsItemMovable && index > 0;
             bool showMoveItemDown = options.IsItemMovable && index < count - 1;
 
-            return new List<ContextMenuFlyoutItemViewModel>()
+            var items = new List<ContextMenuFlyoutItemViewModel>()
             {
                 new ContextMenuFlyoutItemViewModel()
                 {
@@ -280,13 +280,6 @@ namespace Files.Uwp.UserControls
                 },
                 new ContextMenuFlyoutItemViewModel()
                 {
-                    Text = string.Format("SideBarHideSectionFromSideBar/Text".GetLocalized(), rightClickedItem.Text),
-                    Glyph = "\uE77A",
-                    Command = HideSectionCommand,
-                    ShowItem = options.ShowHideSection
-                },
-                new ContextMenuFlyoutItemViewModel()
-                {
                     Text = "SideBarEjectDevice/Text".GetLocalized(),
                     Glyph = "\uF10B",
                     GlyphFontFamilyName = "CustomGlyph",
@@ -310,6 +303,44 @@ namespace Files.Uwp.UserControls
                     IsHidden = true,
                 }
             }.Where(x => x.ShowItem).ToList();
+
+            if (options.ShowHideSection)
+            {
+                if (items.Any())
+                {
+                    items.Add(new ContextMenuFlyoutItemViewModel { ItemType = ItemType.Separator });
+                }
+                items.Add(GetToggleItem("SidebarFavorites", ViewModel.ShowFavoritesSection,
+                    () => ViewModel.ShowFavoritesSection = !ViewModel.ShowFavoritesSection));
+                items.Add(GetToggleItem("SidebarLibraries", ViewModel.ShowLibrarySection,
+                    () => ViewModel.ShowLibrarySection = !ViewModel.ShowLibrarySection));
+                items.Add(GetToggleItem("Drives", ViewModel.ShowDrivesSection,
+                    () => ViewModel.ShowDrivesSection = !ViewModel.ShowDrivesSection));
+                items.Add(GetToggleItem("SidebarCloudDrives", ViewModel.ShowCloudDrivesSection,
+                    () => ViewModel.ShowCloudDrivesSection = !ViewModel.ShowCloudDrivesSection));
+                items.Add(GetToggleItem("SidebarNetworkDrives", ViewModel.ShowNetworkDrivesSection,
+                    () => ViewModel.ShowNetworkDrivesSection = !ViewModel.ShowNetworkDrivesSection));
+                items.Add(GetToggleItem("WSL", ViewModel.ShowWslSection,
+                    () => ViewModel.ShowWslSection = !ViewModel.ShowWslSection));
+                if (ViewModel.AreFileTagsEnabled)
+                {
+                    items.Add(GetToggleItem("FileTags", ViewModel.ShowFileTagsSection,
+                        () => ViewModel.ShowFileTagsSection = !ViewModel.ShowFileTagsSection));
+                }
+            }
+
+            return items;
+
+            static ContextMenuFlyoutItemViewModel GetToggleItem(string textKey, bool isEnabled, Action action)
+            {
+                return new()
+                {
+                    ItemType = ItemType.Toggle,
+                    Text = textKey.GetLocalized(),
+                    IsChecked = isEnabled,
+                    Command = new RelayCommand(action),
+                };
+            }
         }
 
         private void HideSection()


### PR DESCRIPTION
**Resolved / Related Issues**
The contextual menu of the sections of the sidebar only allows to hide the selected section. To add them, you must use the contextual menu of the sidebar outside of its elements. #9190

**Details of Changes**
Replaces the "Hide section" entry in the popup menu with the list of available section toggles, possibly after a separator. This only applies to section titles, not their elements, or Home.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before/After
![BeforeSection](https://user-images.githubusercontent.com/46631671/168624859-ce8ceb90-7a47-4938-8e50-4ab25b2022ab.png)
![Sections](https://user-images.githubusercontent.com/46631671/168624639-6957b608-3c74-466c-84b0-4e31628a9e5a.png)