### PR TITLE
Hoist TaskCompletionSource outside the loop

### DIFF
--- a/src/Files.Uwp/Helpers/AsyncManualResetEvent.cs
+++ b/src/Files.Uwp/Helpers/AsyncManualResetEvent.cs
@@ -46,11 +46,12 @@ namespace Files.Uwp.Helpers
 
         public void Reset()
         {
+            var newTcs = new TaskCompletionSource<bool>();
             while (true)
             {
                 var tcs = m_tcs;
                 if (!tcs.Task.IsCompleted ||
-                    Interlocked.CompareExchange(ref m_tcs, new TaskCompletionSource<bool>(), tcs) == tcs)
+                    Interlocked.CompareExchange(ref m_tcs, newTcs, tcs) == tcs)
                     return;
             }
         }


### PR DESCRIPTION
To avoid unnecessary allocations.