### PR TITLE
[Post v2.3] Improves pinned RecycleBin

### DIFF
--- a/src/Files.FullTrust/Helpers/ShellFolderHelpers.cs
+++ b/src/Files.FullTrust/Helpers/ShellFolderHelpers.cs
@@ -44,8 +44,14 @@ namespace Files.FullTrust.Helpers
             parsingPath ??= folderItem.FileSystemPath; // True path on disk
             if (parsingPath == null || !Path.IsPathRooted(parsingPath))
             {
-                // Use PIDL as path
-                parsingPath = $@"\\SHELL\{string.Join("\\", folderItem.PIDL.Select(x => x.GetBytes()).Select(x => Convert.ToBase64String(x, 0, x.Length)))}";
+                parsingPath = parsingPath switch
+                {
+                    "::{645FF040-5081-101B-9F08-00AA002F954E}" => "Shell:RecycleBinFolder",
+                    "::{F02C1A0D-BE21-4350-88B0-7367FC96EF3C}" => "Shell:NetworkPlacesFolder",
+                    "::{208D2C60-3AEA-1069-A2D7-08002B30309D}" => "Shell:NetworkPlacesFolder",
+                    // Use PIDL as path
+                    _ => $@"\\SHELL\{string.Join("\\", folderItem.PIDL.Select(x => x.GetBytes()).Select(x => Convert.ToBase64String(x, 0, x.Length)))}"
+                };
             }
             folderItem.Properties.TryGetValue<string>(
                 Ole32.PROPERTYKEY.System.ItemNameDisplay, out var fileName);

--- a/src/Files.Uwp/DataModels/NavigationControlItems/INavigationControlItem.cs
+++ b/src/Files.Uwp/DataModels/NavigationControlItems/INavigationControlItem.cs
@@ -48,8 +48,6 @@ namespace Files.Uwp.Filesystem
 
         public bool ShowUnpinItem { get; set; }
 
-        public bool IsItemMovable { get; set; }
-
         public bool ShowProperties { get; set; }
 
         public bool ShowEmptyRecycleBin { get; set; }

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -298,8 +298,8 @@ namespace Files.Uwp.DataModels
                 {
                     return;
                 }
-                var lastItem = favoriteList.LastOrDefault(x => x.ItemType == NavigationControlItemType.Location && !x.Path.Equals(CommonPaths.RecycleBinPath));
-                insertIndex = lastItem != null ? favoriteList.IndexOf(lastItem) + 1 : 0;
+                var lastItem = favoriteList.LastOrDefault(x => x.ItemType is NavigationControlItemType.Location);
+                insertIndex = lastItem is not null ? favoriteList.IndexOf(lastItem) + 1 : 0;
                 favoriteList.Insert(insertIndex, locationItem);
             }
             controller.DataChanged?.Invoke(SectionType.Favorites, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, locationItem, insertIndex));
@@ -310,18 +310,14 @@ namespace Files.Uwp.DataModels
         /// </summary>
         public async Task AddAllItemsToSidebar()
         {
-            if (!UserSettingsService.AppearanceSettingsService.ShowFavoritesSection)
+            if (UserSettingsService.AppearanceSettingsService.ShowFavoritesSection)
             {
-                return;
+                foreach (string path in FavoriteItems)
+                {
+                    await AddItemToSidebarAsync(path);
+                }
+                ShowHideRecycleBinItem(UserSettingsService.AppearanceSettingsService.PinRecycleBinToSidebar);
             }
-
-            for (int i = 0; i < FavoriteItems.Count; i++)
-            {
-                string path = FavoriteItems[i];
-                await AddItemToSidebarAsync(path);
-            }
-
-            ShowHideRecycleBinItem(UserSettingsService.AppearanceSettingsService.PinRecycleBinToSidebar);
         }
 
         /// <summary>

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -220,16 +220,6 @@ namespace Files.Uwp.DataModels
             {
                 RemoveItem(CommonPaths.RecycleBinPath);
             }
-
-            if (show)
-            {
-                var item = favoriteList.FirstOrDefault(x => x.Path == CommonPaths.RecycleBinPath);
-                if (item is not null)
-                {
-                    item.MenuOptions.ShowShellItems = true;
-                    item.MenuOptions.ShowEmptyRecycleBin = true;
-                }
-            }
         }
 
         /// <summary>

--- a/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.Uwp/DataModels/SidebarPinnedModel.cs
@@ -145,10 +145,12 @@ namespace Files.Uwp.DataModels
 
             try
             {
-                (FavoriteItems[oldIndex], FavoriteItems[newIndex]) = (FavoriteItems[newIndex], FavoriteItems[oldIndex]);
+                FavoriteItems.RemoveAt(oldIndex);
+                FavoriteItems.Insert(newIndex, locationItem.Path);
                 lock (favoriteList)
                 {
-                    (favoriteList[oldIndex], favoriteList[newIndex]) = (favoriteList[newIndex], favoriteList[oldIndex]);
+                    favoriteList.RemoveAt(oldIndex);
+                    favoriteList.Insert(newIndex, locationItem);
                 }
                 var e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, locationItem, newIndex, oldIndex);
                 controller.DataChanged?.Invoke(SectionType.Favorites, e);

--- a/src/Files.Uwp/Helpers/ContextFlyoutItemHelper.cs
+++ b/src/Files.Uwp/Helpers/ContextFlyoutItemHelper.cs
@@ -1,12 +1,12 @@
-﻿using Files.Shared;
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using CommunityToolkit.Mvvm.Input;
+using Files.Backend.Services.Settings;
+using Files.Shared;
 using Files.Shared.Enums;
 using Files.Uwp.Extensions;
 using Files.Uwp.Filesystem;
 using Files.Uwp.Interacts;
-using Files.Backend.Services.Settings;
 using Files.Uwp.ViewModels;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using CommunityToolkit.Mvvm.Input;
 using Microsoft.Toolkit.Uwp;
 using System;
 using System.Collections.Generic;
@@ -539,6 +539,7 @@ namespace Files.Uwp.Helpers
                     Command = commandsViewModel.PinDirectoryToFavoritesCommand,
                     ShowItem = !itemViewModel.CurrentFolder.IsPinned & userSettingsService.AppearanceSettingsService.ShowFavoritesSection,
                     ShowInFtpPage = true,
+                    ShowInRecycleBin = true,
                 },
                 new ContextMenuFlyoutItemViewModel()
                 {
@@ -547,6 +548,7 @@ namespace Files.Uwp.Helpers
                     Command = commandsViewModel.UnpinDirectoryFromFavoritesCommand,
                     ShowItem = itemViewModel.CurrentFolder.IsPinned & userSettingsService.AppearanceSettingsService.ShowFavoritesSection,
                     ShowInFtpPage = true,
+                    ShowInRecycleBin = true,
                 },
                 new ContextMenuFlyoutItemViewModel()
                 {

--- a/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
@@ -392,7 +392,7 @@ namespace Files.Uwp.UserControls
                 }
 
                 int oldIndex = App.SidebarPinnedController.Model.IndexOfItem(rightClickedItem);
-                App.SidebarPinnedController.Model.MoveItem(rightClickedItem, oldIndex, 1);
+                App.SidebarPinnedController.Model.MoveItem(rightClickedItem, oldIndex, 0);
 
                 if (isSelectedSidebarItem)
                 {
@@ -455,7 +455,7 @@ namespace Files.Uwp.UserControls
                 }
 
                 int oldIndex = App.SidebarPinnedController.Model.IndexOfItem(rightClickedItem);
-                App.SidebarPinnedController.Model.MoveItem(rightClickedItem, oldIndex, App.SidebarPinnedController.Model.FavoriteItems.Count);
+                App.SidebarPinnedController.Model.MoveItem(rightClickedItem, oldIndex, App.SidebarPinnedController.Model.FavoriteItems.Count - 1);
 
                 if (isSelectedSidebarItem)
                 {

--- a/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.Uwp/UserControls/SidebarControl.xaml.cs
@@ -186,12 +186,12 @@ namespace Files.Uwp.UserControls
         {
             ContextMenuOptions options = item.MenuOptions;
 
-            var model = App.SidebarPinnedController.Model;
-            int index = model.IndexOfItem(item);
-            int count = model.FavoriteItems.Count;
+            var favoriteModel = App.SidebarPinnedController.Model;
+            int favoriteIndex = favoriteModel.IndexOfItem(item);
+            int favoriteCount = favoriteModel.FavoriteItems.Count;
 
-            bool showMoveItemUp = options.IsItemMovable && index > 0;
-            bool showMoveItemDown = options.IsItemMovable && index < count - 1;
+            bool showMoveItemUp = favoriteIndex > 0;
+            bool showMoveItemDown = favoriteIndex < favoriteCount - 1;
 
             return new List<ContextMenuFlyoutItemViewModel>()
             {
@@ -372,7 +372,7 @@ namespace Files.Uwp.UserControls
             if (rightClickedItem.MenuOptions.ShowEmptyRecycleBin)
             {
                 UserSettingsService.AppearanceSettingsService.PinRecycleBinToSidebar = false;
-                _ = App.SidebarPinnedController.Model.ShowHideRecycleBinItemAsync(false);
+                App.SidebarPinnedController.Model.ShowHideRecycleBinItem(false);
             }
             else if (rightClickedItem.Section == SectionType.Favorites)
             {

--- a/src/Files.Uwp/ViewModels/SettingsViewModels/AppearanceViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SettingsViewModels/AppearanceViewModel.cs
@@ -1,7 +1,7 @@
-﻿using Files.Uwp.Helpers;
-using Files.Backend.Services.Settings;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.Backend.Services.Settings;
+using Files.Uwp.Helpers;
 using Microsoft.Toolkit.Uwp;
 using System;
 using System.Collections.Generic;
@@ -146,7 +146,7 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 if (value != UserSettingsService.AppearanceSettingsService.PinRecycleBinToSidebar)
                 {
                     UserSettingsService.AppearanceSettingsService.PinRecycleBinToSidebar = value;
-                    _ = App.SidebarPinnedController.Model.ShowHideRecycleBinItemAsync(value);
+                    App.SidebarPinnedController.Model.ShowHideRecycleBinItem(value);
                     OnPropertyChanged();
                 }
             }


### PR DESCRIPTION
**Resolved / Related Issues**
The favorite RecycleBin is particular. We can't move it. In the code, it is handled separately.
The context menu of the RecycleBin page does not offer an entry for Pin/Unpin.
- Closes #9191
- Closes #8227
- Related #9192

**Details of Changes**
The RecycleBin favorite becomes a favorite like any other, stored like any other. It can be moved and retains its specific menu entries.

The setting to display it is retained. He has priority at the start of the session to add/remove the favorite if necessary. This makes it possible not to break the user's current preferences.

The context menu of the RecycleBin page offers an entry for Pin/Unpin.

**Validation**
How did you test these changes?
- [x] Built and ran the app
