### PR TITLE
Fix up button

### DIFF
--- a/src/Files.Uwp/Views/ModernShellPage.xaml.cs
+++ b/src/Files.Uwp/Views/ModernShellPage.xaml.cs
@@ -404,7 +404,7 @@ namespace Files.Uwp.Views
         {
             FilesystemViewModel?.UpdateSortOptionStatus();
         }
-        
+
         private void AppSettings_SortDirectoriesAlongsideFilesPreferenceUpdated(object sender, bool e)
         {
             FilesystemViewModel?.UpdateSortDirectoriesAlongsideFiles();
@@ -681,7 +681,7 @@ namespace Files.Uwp.Views
             var ctrl = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Control);
             var shift = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
             var alt = args.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Menu);
-            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) || 
+            var tabInstance = CurrentPageType == typeof(DetailsLayoutBrowser) ||
                               CurrentPageType == typeof(GridViewBrowser);
 
             switch (c: ctrl, s: shift, a: alt, t: tabInstance, k: args.KeyboardAccelerator.Key)
@@ -958,6 +958,10 @@ namespace Files.Uwp.Views
                 if (lastSlashIndex != -1)
                 {
                     parentDirectoryOfPath = FilesystemViewModel.WorkingDirectory.Remove(lastSlashIndex);
+                }
+                if (parentDirectoryOfPath.EndsWith(":"))
+                {
+                    parentDirectoryOfPath += '\\';
                 }
 
                 SelectSidebarItemFromPath();


### PR DESCRIPTION
**Resolved / Related Issues**
Drive roots use a path such as "C:\\". This is the path that is used when opening a drive from the sidebar or other. But when the Up button needs to return to C:\\, it actually calls C:, it's that path in the address bar.

This leads to not finding the drive, for example when we want to display the properties of the disk.
Closes #9227

**Details of Changes**
This pr modifies the Up_Click method to add the trailing "\\" when the path ends with ":". This character is forbidden in paths, except to indicate the drive.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility