### PR TITLE
Fixes an issue preventing icon for MTP device from appearing on Drives Widget

### DIFF
--- a/src/Files.Uwp/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.Uwp/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -46,14 +46,17 @@ namespace Files.Uwp.UserControls.Widgets
         {
             if (thumbnailData == null || thumbnailData.Length == 0)
             {
+                // Try load thumbnail using ListView mode
                 thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.Path, Convert.ToUInt32(overrideThumbnailSize), Windows.Storage.FileProperties.ThumbnailMode.ListView);
             }
             if (thumbnailData == null || thumbnailData.Length == 0)
             {
+                // Thumbnail is still null, use DriveItem icon (loaded using SingleItem mode)
                 thumbnailData = Item.IconData;
             }
             if (thumbnailData != null && thumbnailData.Length > 0)
             {
+                // Thumbnail data is valid, set the item icon
                 Thumbnail = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => thumbnailData.ToBitmapAsync(overrideThumbnailSize));
             }
         }

--- a/src/Files.Uwp/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.Uwp/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -20,7 +20,6 @@ using Windows.UI.Xaml.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.ApplicationModel.Core;
-using Files.Uwp.UserControls.Widgets;
 using System.Collections.Specialized;
 
 namespace Files.Uwp.UserControls.Widgets
@@ -48,10 +47,14 @@ namespace Files.Uwp.UserControls.Widgets
             if (thumbnailData == null || thumbnailData.Length == 0)
             {
                 thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.Path, Convert.ToUInt32(overrideThumbnailSize), Windows.Storage.FileProperties.ThumbnailMode.ListView);
-                if (thumbnailData != null && thumbnailData.Length > 0)
-                {
-                    Thumbnail = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => thumbnailData.ToBitmapAsync(overrideThumbnailSize));
-                }
+            }
+            if (thumbnailData == null || thumbnailData.Length == 0)
+            {
+                thumbnailData = Item.IconData;
+            }
+            if (thumbnailData != null && thumbnailData.Length > 0)
+            {
+                Thumbnail = await CoreApplication.MainView.DispatcherQueue.EnqueueAsync(() => thumbnailData.ToBitmapAsync(overrideThumbnailSize));
             }
         }
     }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9218

**Details of Changes**
Add details of changes here.
- Use DriveItem icon data if could not load thumbnail

**Validation**
How did you test these changes?
- [x] Built and ran the app
