### PR TITLE
Do not load quick access icon

### DIFF
--- a/src/Files.Uwp/Helpers/UIHelpers.cs
+++ b/src/Files.Uwp/Helpers/UIHelpers.cs
@@ -104,27 +104,7 @@ namespace Files.Uwp.Helpers
                     Constants.ImageRes.Folder
                 }, 32);
 
-            const string shell32 = @"C:\Windows\System32\shell32.dll";
-            var shell32List = await UIHelpers.LoadSelectedIconsAsync(shell32, new List<int>() {
-                    Constants.Shell32.QuickAccess
-                }, 32);
-
-            if (shell32List != null && imageResList != null)
-            {
-                return imageResList.Concat(shell32List);
-            }
-            else if (shell32List != null && imageResList == null)
-            {
-                return shell32List;
-            }
-            else if (shell32List == null && imageResList != null)
-            {
-                return imageResList;
-            }
-            else
-            {
-                return null;
-            }
+            return imageResList;
         }
     }
 }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Not a bug fix, just a small optimization

**Details of Changes**
Add details of changes here.
- Since we now use a custom icon for the favorites section, there's no need to load the quick access icon from shell32 dll on start.

**Validation**
How did you test these changes?
- [x] Built and ran the app
