### PR TITLE
Use OPEN_EXISTING when opening a file for read

### DIFF
--- a/src/Files.Uwp/Helpers/NativeFileOperationsHelper.cs
+++ b/src/Files.Uwp/Helpers/NativeFileOperationsHelper.cs
@@ -85,7 +85,7 @@ namespace Files.Uwp.Helpers
         public static SafeFileHandle OpenFileForRead(string filePath, bool readWrite = false, uint flags = 0)
         {
             return new SafeFileHandle(CreateFileFromApp(filePath,
-                GENERIC_READ | (readWrite ? GENERIC_WRITE : 0), FILE_SHARE_READ | FILE_SHARE_WRITE, IntPtr.Zero, OPEN_ALWAYS, (uint)File_Attributes.BackupSemantics | flags, IntPtr.Zero), true);
+                GENERIC_READ | (readWrite ? GENERIC_WRITE : 0), FILE_SHARE_READ | (readWrite ? 0 :FILE_SHARE_WRITE), IntPtr.Zero, OPEN_EXISTING, (uint)File_Attributes.BackupSemantics | flags, IntPtr.Zero), true);
         }
 
         private const int MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 16 * 1024;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9271

**Details of Changes**
Add details of changes here.
- Replace open_always with open_existing when opening a file for read so it does not create a file when the files does not exist.

**Validation**
How did you test these changes?
- [x] Built and ran the app