### PR TITLE
Feat(recent-items): sync recent items with file explorer

### DIFF
--- a/src/Files.FullTrust/Helpers/ShellFolderHelpers.cs
+++ b/src/Files.FullTrust/Helpers/ShellFolderHelpers.cs
@@ -78,10 +78,10 @@ namespace Files.FullTrust.Helpers
             var recycleDate = fileTime?.ToDateTime().ToLocalTime() ?? DateTime.Now; // This is LocalTime
             fileTime = folderItem.Properties.TryGetProperty<System.Runtime.InteropServices.ComTypes.FILETIME?>(
                 Ole32.PROPERTYKEY.System.DateModified);
-            var modifiedDate = fileTime?.ToDateTime().ToLocalTime() ?? DateTime.Now; // This is LocalTime
+            var modifiedDate = fileTime?.ToDateTime().ToLocalTime() ?? folderItem.FileInfo?.LastWriteTime ?? DateTime.Now; // This is LocalTime
             fileTime = folderItem.Properties.TryGetProperty<System.Runtime.InteropServices.ComTypes.FILETIME?>(
                 Ole32.PROPERTYKEY.System.DateCreated);
-            var createdDate = fileTime?.ToDateTime().ToLocalTime() ?? DateTime.Now; // This is LocalTime
+            var createdDate = fileTime?.ToDateTime().ToLocalTime() ?? folderItem.FileInfo?.CreationTime ?? DateTime.Now; // This is LocalTime
             var fileSizeBytes = folderItem.Properties.TryGetProperty<ulong?>(Ole32.PROPERTYKEY.System.Size);
             string fileSize = fileSizeBytes is not null ? folderItem.Properties.GetPropertyString(Ole32.PROPERTYKEY.System.Size) : null;
             var fileType = folderItem.Properties.TryGetProperty<string>(Ole32.PROPERTYKEY.System.ItemTypeText);

--- a/src/Files.FullTrust/MessageHandlers/DriveHandler.cs
+++ b/src/Files.FullTrust/MessageHandlers/DriveHandler.cs
@@ -8,7 +8,7 @@ using Windows.Foundation.Collections;
 
 namespace Files.FullTrust.MessageHandlers
 {
-    [SupportedOSPlatform("Windows10.10240")]
+    [SupportedOSPlatform("Windows10.0.10240")]
     public class DriveHandler : Disposable, IMessageHandler
     {
         public void Initialize(PipeStream connection) {}

--- a/src/Files.FullTrust/MessageHandlers/RecentItemsHandler.cs
+++ b/src/Files.FullTrust/MessageHandlers/RecentItemsHandler.cs
@@ -1,0 +1,213 @@
+﻿using Files.FullTrust.Helpers;
+using Files.Shared;
+using Files.Shared.Enums;
+using Files.Shared.Extensions;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using Vanara.PInvoke;
+using Vanara.Windows.Shell;
+using Windows.Foundation.Collections;
+
+namespace Files.FullTrust.MessageHandlers
+{
+    [SupportedOSPlatform("Windows10.0.10240")]
+    public class RecentItemsHandler : Disposable, IMessageHandler
+    {
+        private const string QuickAccessJumpListFileName = "5f7b5f1e01b83767.automaticDestinations-ms";
+        private const string QuickAccessGuid = "::{679f85cb-0220-4080-b29b-5540cc05aab6}";
+        private static string RecentItemsPath = Environment.GetFolderPath(Environment.SpecialFolder.Recent);
+        private static string AutomaticDestinationsPath = Path.Combine(RecentItemsPath, "AutomaticDestinations");
+
+        private DateTime quickAccessLastReadTime = DateTime.MinValue;
+        private FileSystemWatcher quickAccessJumpListWatcher;
+        private PipeStream connection;
+
+        public void Initialize(PipeStream connection)
+        {
+            this.connection = connection;
+
+            StartQuickAccessJumpListWatcher();
+        }
+
+        /// <summary>
+        /// Watch the quick access jump list file for any changes.
+        /// Triggered by operations such as: added, accessed, removed from quick access, calls to SHAddToRecentDocs, etc..
+        /// </summary>
+        private void StartQuickAccessJumpListWatcher()
+        {
+            if (quickAccessJumpListWatcher is not null)
+            {
+                return;
+            }
+
+            quickAccessJumpListWatcher = new FileSystemWatcher
+            {
+                Path = AutomaticDestinationsPath,
+                Filter = QuickAccessJumpListFileName,
+                NotifyFilter = NotifyFilters.DirectoryName | NotifyFilters.FileName | NotifyFilters.LastWrite,
+            };
+            quickAccessJumpListWatcher.Changed += QuickAccessJumpList_Changed;
+            quickAccessJumpListWatcher.Deleted += QuickAccessJumpList_Changed;
+            quickAccessJumpListWatcher.EnableRaisingEvents = true;
+        }
+
+        public async Task ParseArgumentsAsync(PipeStream connection, Dictionary<string, object> message, string arguments)
+        {
+            switch (arguments)
+            {
+                case "ShellRecentItems":
+                    await HandleShellRecentItemsMessage(message);
+                    break;
+            }
+        }
+
+        private async void QuickAccessJumpList_Changed(object sender, FileSystemEventArgs e)
+        {
+            System.Diagnostics.Debug.WriteLine($"{nameof(QuickAccessJumpList_Changed)}: {e.ChangeType}, {e.FullPath}");
+
+            // skip if multiple events occurred for singular change
+            var lastWriteTime = File.GetLastWriteTime(e.FullPath);
+            if (quickAccessLastReadTime >= lastWriteTime)
+            {
+                return;
+            }
+            else
+            {
+                quickAccessLastReadTime = lastWriteTime;
+            }
+
+            if (connection?.IsConnected ?? false)
+            {
+                var response = new ValueSet()
+                {
+                    { "RecentItems", e.FullPath },
+                    { "ChangeType", "QuickAccessJumpListChanged" },
+                };
+
+                // send message to UWP app to refresh recent files
+                await Win32API.SendMessageAsync(connection, response);
+            }
+        }
+
+        private async Task HandleShellRecentItemsMessage(Dictionary<string, object> message)
+        {
+            var action = (string)message["action"];
+            var response = new ValueSet();
+
+            switch (action)
+            {
+                // enumerate `\Windows\Recent` for recent folders
+                // note: files are enumerated using (Win32MessageHandler: "ShellFolder") in RecentItemsManager
+                case "EnumerateFolders":
+                    var enumerateFoldersResponse = await Win32API.StartSTATask(() =>
+                    {
+                        try
+                        {
+                            var shellLinkItems = new List<ShellLinkItem>();
+                            var excludeMask = FileAttributes.Hidden;
+                            var linkFilePaths = Directory.EnumerateFiles(RecentItemsPath).Where(f => (new FileInfo(f).Attributes & excludeMask) == 0);
+                            
+                            foreach (var linkFilePath in linkFilePaths)
+                            {
+                                using var link = new ShellLink(linkFilePath, LinkResolution.NoUIWithMsgPump, null, TimeSpan.FromMilliseconds(100));
+
+                                try
+                                {
+                                    if (!string.IsNullOrEmpty(link.TargetPath) && link.Target.IsFolder)
+                                    {
+                                        var shellLinkItem = ShellFolderExtensions.GetShellLinkItem(link);
+                                        shellLinkItems.Add(shellLinkItem);
+                                    }
+                                }
+                                catch (FileNotFoundException)
+                                {
+                                    // occurs when shortcut or shortcut target is deleted and accessed (link.Target)
+                                    // consequently, we shouldn't include the item as a recent item
+                                }
+                            }
+
+                            response.Add("EnumerateFolders", JsonConvert.SerializeObject(shellLinkItems));
+                        }
+                        catch (Exception e)
+                        {
+                            Program.Logger.Warn(e);
+                        }
+                        return response;
+                    });
+                    await Win32API.SendMessageAsync(connection, enumerateFoldersResponse, message.Get("RequestID", (string)null));
+                    break;
+
+                case "Add":
+                    var addResponse = await Win32API.StartSTATask(() =>
+                    {
+                        try
+                        {
+                            var path = (string) message["Path"];
+                            Shell32.SHAddToRecentDocs(Shell32.SHARD.SHARD_PATHW, path);
+                        }
+                        catch (Exception e)
+                        {
+                            Program.Logger.Warn(e);
+                        }
+                        return response;
+                    });
+                    await Win32API.SendMessageAsync(connection, addResponse, message.Get("RequestID", (string)null));
+                    break;
+
+                case "Clear":
+                    var clearResponse = await Win32API.StartSTATask(() =>
+                    {
+                        try
+                        {
+                            Shell32.SHAddToRecentDocs(Shell32.SHARD.SHARD_PIDL, (string)null);
+                        }
+                        catch (Exception e)
+                        {
+                            Program.Logger.Warn(e);
+                        }
+                        return response;
+                    });
+                    await Win32API.SendMessageAsync(connection, clearResponse, message.Get("RequestID", (string)null));
+                    break;
+
+                // invoke 'remove' verb on the file to remove it from Quick Access
+                // note: for folders, we need to use the verb 'unpinfromhome' or 'removefromhome'
+                case "UnpinFile":
+                    var unpinFileResponse = await Win32API.StartSTATask(() =>
+                    {
+                        try
+                        {
+                            var path = (string)message["Path"];
+                            var command = $"-command \"((New-Object -ComObject Shell.Application).Namespace('shell:{QuickAccessGuid}\').Items() " +
+                                          $"| Where-Object {{ $_.Path -eq '{path}' }}).InvokeVerb('remove')\"";
+                            bool success = Win32API.RunPowershellCommand(command, false);
+
+                            response.Add("UnpinFile", path);
+                            response.Add("Success", success);
+                        }
+                        catch (Exception e)
+                        {
+                            Program.Logger.Warn(e);
+                        }
+                        return response;
+                    });
+                    await Win32API.SendMessageAsync(connection, unpinFileResponse, message.Get("RequestID", (string)null));
+                    break;
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                quickAccessJumpListWatcher?.Dispose();
+            }
+        }
+    }
+}

--- a/src/Files.FullTrust/Program.cs
+++ b/src/Files.FullTrust/Program.cs
@@ -54,7 +54,8 @@ namespace Files.FullTrust
                     new QuickLookHandler(),
                     new Win32MessageHandler(),
                     new InstallOperationsHandler(),
-                    new DesktopWallpaperHandler()
+                    new DesktopWallpaperHandler(),
+                    new RecentItemsHandler(),
                 };
 
                 // Connect to app service and wait until the connection gets closed

--- a/src/Files.Uwp/App.xaml.cs
+++ b/src/Files.Uwp/App.xaml.cs
@@ -59,6 +59,7 @@ namespace Files.Uwp
         public static PaneViewModel PaneViewModel { get; private set; }
         public static PreviewPaneViewModel PreviewPaneViewModel { get; private set; }
         public static JumpListManager JumpList { get; private set; }
+        public static RecentItemsManager RecentItemsManager { get; private set; }
         public static SidebarPinnedController SidebarPinnedController { get; private set; }
         public static TerminalController TerminalController { get; private set; }
         public static CloudDrivesManager CloudDrivesManager { get; private set; }
@@ -152,6 +153,7 @@ namespace Files.Uwp
             new AppearanceViewModel().SetCompactStyles(updateTheme: false);
 
             JumpList ??= new JumpListManager();
+            RecentItemsManager ??= new RecentItemsManager();
             MainViewModel ??= new MainViewModel();
             PaneViewModel ??= new PaneViewModel();
             PreviewPaneViewModel ??= new PreviewPaneViewModel();

--- a/src/Files.Uwp/Files.Uwp.csproj
+++ b/src/Files.Uwp/Files.Uwp.csproj
@@ -196,6 +196,8 @@
     <Compile Include="Filesystem\FileTagsHelper.cs" />
     <Compile Include="Filesystem\FileTagsManager.cs" />
     <Compile Include="Filesystem\FtpManager.cs" />
+    <Compile Include="Filesystem\RecentItem.cs" />
+    <Compile Include="Filesystem\RecentItemsManager.cs" />
     <Compile Include="Filesystem\Permissions\FilePermissionsManager.cs" />
     <Compile Include="Filesystem\Permissions\FileSystemAccessRule.cs" />
     <Compile Include="Filesystem\Permissions\FileSystemAccessRuleForUI.cs" />

--- a/src/Files.Uwp/Filesystem/RecentItem.cs
+++ b/src/Files.Uwp/Filesystem/RecentItem.cs
@@ -1,0 +1,118 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Files.Shared;
+using Files.Uwp.Helpers;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.Storage.FileProperties;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace Files.Uwp.Filesystem
+{
+    public class RecentItem : ObservableObject, IEquatable<RecentItem>
+    {
+        private BitmapImage _fileImg;
+        public BitmapImage FileImg 
+        {
+            get => _fileImg;
+            set => SetProperty(ref _fileImg, value);
+        }
+        public string LinkPath { get; set; }    // path of shortcut item (this is unique)
+        public string RecentPath { get; set; }  // path to target item
+        public string Name { get; set; }
+        public StorageItemTypes Type { get; set; }
+        public bool FolderImg { get; set; }
+        public bool EmptyImgVis { get; set; }
+        public bool FileIconVis { get; set; }
+        public bool IsFile { get => Type == StorageItemTypes.File; }
+        public DateTime LastModified { get; set; }
+
+        public RecentItem() 
+        {
+            EmptyImgVis = true; // defer icon load to LoadRecentItemIcon()
+        }
+
+        /// <summary>
+        /// Create a RecentItem instance from a link path.
+        /// This is usually needed if a shortcut is deleted -- the metadata is lost (i.e. the target item).
+        /// </summary>
+        /// <param name="linkPath">The location that shortcut lives/lived in</param>
+        public RecentItem(string linkPath) : base()
+        {
+            LinkPath = linkPath;
+        }
+
+        /// <summary>
+        /// Create a RecentItem from a ShellLinkItem (usually from shortcuts in `Windows\Recent`)
+        /// </summary>
+        public RecentItem(ShellLinkItem linkItem) : base()
+        {
+            LinkPath = linkItem.FilePath;
+            RecentPath = linkItem.TargetPath;
+            Name = NameOrPathWithoutExtension(linkItem.FileName);
+            Type = linkItem.IsFolder ? StorageItemTypes.Folder : StorageItemTypes.File;
+            FolderImg = linkItem.IsFolder;
+            FileIconVis = !linkItem.IsFolder;
+            LastModified = linkItem.ModifiedDate;
+        }
+
+        /// <summary>
+        /// Create a RecentItem from a ShellFileItem (usually from enumerating Quick Access directly).
+        /// </summary>
+        /// <param name="fileItem">The shell file item</param>
+        public RecentItem(ShellFileItem fileItem) : base()
+        {
+            LinkPath = fileItem.FilePath;   // intentionally the same
+            RecentPath = fileItem.FilePath; // intentionally the same
+            Name = NameOrPathWithoutExtension(fileItem.FileName);
+            Type = fileItem.IsFolder ? StorageItemTypes.Folder : StorageItemTypes.File;
+            FolderImg = fileItem.IsFolder;
+            FileIconVis = !fileItem.IsFolder;
+            LastModified = fileItem.ModifiedDate;
+        }
+
+        public async Task LoadRecentItemIcon()
+        {
+            var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(RecentPath, 24u, ThumbnailMode.ListView);
+            if (iconData == null)
+            {
+                EmptyImgVis = true;
+            }
+            else
+            {
+                EmptyImgVis = false;
+                FileImg = await iconData.ToBitmapAsync();
+            }
+        }
+
+        /// <summary>
+        /// Test equality for generic collection methods such as Remove(...)
+        /// </summary>
+        public bool Equals(RecentItem other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            // do not include LastModified or anything else here; otherwise, Remove(...) will fail since we lose metadata on deletion!
+            // when constructing a RecentItem from a deleted link, the only thing we have is the LinkPath (where the link use to be)
+            return LinkPath == other.LinkPath &&
+                   RecentPath == other.RecentPath;
+        }
+
+        /**
+         * Strips a name from an extension while aware of some edge cases.
+         * 
+         *   example.min.js => example.min
+         *   example.js     => example
+         *   .gitignore     => .gitignore
+         */
+        private static string NameOrPathWithoutExtension(string nameOrPath)
+        {
+            string strippedExtension = Path.GetFileNameWithoutExtension(nameOrPath);
+            return string.IsNullOrEmpty(strippedExtension) ? Path.GetFileName(nameOrPath) : strippedExtension;
+        }
+    }
+}

--- a/src/Files.Uwp/Filesystem/RecentItemsManager.cs
+++ b/src/Files.Uwp/Filesystem/RecentItemsManager.cs
@@ -1,0 +1,257 @@
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.Shared;
+using Files.Shared.Enums;
+using Files.Uwp.Helpers;
+using Microsoft.Toolkit.Uwp;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.AppService;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace Files.Uwp.Filesystem
+{
+    public class RecentItemsManager : IDisposable
+    {
+        private readonly ILogger logger = Ioc.Default.GetService<ILogger>();
+        private const string QuickAccessGuid = "::{679f85cb-0220-4080-b29b-5540cc05aab6}";
+
+        public EventHandler<NotifyCollectionChangedEventArgs> RecentFilesChanged;
+        public EventHandler<NotifyCollectionChangedEventArgs> RecentFoldersChanged;
+
+        // recent files
+        private readonly List<RecentItem> recentFiles = new();
+        public IReadOnlyList<RecentItem> RecentFiles    // already sorted
+        {
+            get
+            {
+                lock (recentFiles)
+                {
+                    return recentFiles.ToList().AsReadOnly();
+                }
+            }
+        }
+
+        // recent folders
+        private readonly List<RecentItem> recentFolders = new();
+        public IReadOnlyList<RecentItem> RecentFolders  // already sorted
+        {
+            get
+            {
+                lock (recentFolders)
+                {
+                    return recentFolders.ToList().AsReadOnly();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Refetch recent files to `recentFiles`.
+        /// </summary>
+        public async Task UpdateRecentFilesAsync()
+        {
+            // enumerate with fulltrust process
+            List<RecentItem> enumeratedFiles = await ListRecentFilesAsync();
+            if (enumeratedFiles != null)
+            {
+                lock (recentFiles)
+                {
+                    recentFiles.Clear();
+                    recentFiles.AddRange(enumeratedFiles);
+                    // do not sort here, enumeration order *is* the correct order since we get it from Quick Access
+                }
+
+                // todo: potentially optimize this and figure out if list changed by either (1) Add (2) Remove (3) Move
+                // this way the UI doesn't have to refresh the entire list everytime a change occurs
+                RecentFilesChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            }
+        }
+
+        /// <summary>
+        /// Refetch recent folders to `recentFolders`.
+        /// </summary>
+        public async Task UpdateRecentFoldersAsync()
+        {
+            // enumerate with fulltrust process
+            List<RecentItem> enumeratedFolders = await ListRecentFoldersAsync();
+            if (enumeratedFolders != null)
+            {
+                lock (recentFolders)
+                {
+                    recentFolders.Clear();
+                    recentFolders.AddRange(enumeratedFolders);
+
+                    // shortcut modifications in `Windows\Recent` consist of a delete + add operation;
+                    // thus, last modify date is reset and we can sort off it
+                    recentFolders.Sort((x, y) => y.LastModified.CompareTo(x.LastModified));
+                }
+
+                RecentFoldersChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            }
+        }
+
+        /// <summary>
+        /// Enumerate recently accessed files via `Quick Access`.
+        /// </summary>
+        public async Task<List<RecentItem>> ListRecentFilesAsync()
+        {
+            var connection = await AppServiceConnectionHelper.Instance;
+
+            if (connection != null)
+            {
+                // enumerate the Quick Access shell virtual path directly (handled via Win32MessageHandler)
+                ValueSet value = new ValueSet()
+                {
+                    { "Arguments", "ShellFolder" },
+                    { "action", "Enumerate" },
+                    { "folder", QuickAccessGuid }
+                };
+                var (status, response) = await connection.SendMessageForResponseAsync(value);
+
+                if (status == AppServiceResponseStatus.Success && response.ContainsKey("Enumerate"))
+                {
+                    var items = JsonConvert.DeserializeObject<List<ShellFileItem>>((string)response["Enumerate"])
+                                           .Select(link => new RecentItem(link)).ToList();
+                    return items;
+                }
+            }
+
+            return new();
+        }
+
+        /// <summary>
+        /// Enumerate recently accessed folders via `Windows\Recent`.
+        /// </summary>
+        public async Task<List<RecentItem>> ListRecentFoldersAsync()
+        {
+            List<RecentItem> linkItems = null;
+
+            var (status, response) = await SendRecentItemsActionForResponse("EnumerateFolders");
+            if (status == AppServiceResponseStatus.Success && response.ContainsKey("EnumerateFolders"))
+            {
+                linkItems = JsonConvert.DeserializeObject<List<ShellLinkItem>>((string) response["EnumerateFolders"])
+                                       .Select(link => new RecentItem(link)).ToList();
+            }
+
+            return linkItems;
+        }
+
+        /// <summary>
+        /// Adds a shortcut to `Windows\Recent`. The path can be to a file or folder.
+        /// It will update to `recentFiles` or `recentFolders` respectively.
+        /// </summary>
+        /// <param name="path">Path to a file or folder</param>
+        /// <returns>Whether the action was successfully handled or not</returns>
+        public async Task<bool> AddToRecentItems(string path)
+        {
+            var (status, _) = await SendRecentItemsActionForResponse("Add", new ValueSet 
+            { 
+                { "Path", path },
+            });
+            return status == AppServiceResponseStatus.Success;
+        }
+
+        /// <summary>
+        /// Clears both `recentFiles` and `recentFolders`.
+        /// This will also clear the Recent Files (and its jumplist) in File Explorer.
+        /// </summary>
+        /// <returns>Whether the action was successfully handled or not</returns>
+        public async Task<bool> ClearRecentItems()
+        {
+            var (status, _) = await SendRecentItemsActionForResponse("Clear");
+            return status == AppServiceResponseStatus.Success;
+        }
+
+        /// <summary>
+        /// Unpin (or remove) a file from `recentFiles`.
+        /// This will also unpin the item from the Recent Files in File Explorer.
+        /// </summary>
+        /// <returns>Whether the action was successfully handled or not</returns>
+        public async Task<bool> UnpinFromRecentFiles(string path)
+        {
+            var (status, response) = await SendRecentItemsActionForResponse("UnpinFile", new ValueSet
+            {
+                { "Path", path },
+            });
+            return status == AppServiceResponseStatus.Success &&
+                   response.TryGetValue("Success", out var success) &&
+                   (bool)success;
+        }
+
+        /// <summary>
+        /// Send an action for response with the argument `ShellRecentItems` which is handled by RecentItemsHandler.
+        /// </summary>
+        /// <param name="actionValue">The action to perform (e.g. "EnumerateFolders")</param>
+        /// <param name="extras">Any extra payload data needed (e.g. sending a path to enumerate)</param>
+        /// <returns>A tuple containing the response status and any additional payload data as key-value pairs</returns>
+        private async Task<(AppServiceResponseStatus Status, Dictionary<string, object> Data)> SendRecentItemsActionForResponse(string actionValue, ValueSet extras = null)
+        {
+            var connection = await AppServiceConnectionHelper.Instance;
+
+            if (connection == null)
+            {
+                return (AppServiceResponseStatus.Failure, null);
+            }
+
+            var valueSet = new ValueSet
+            {
+                { "Arguments", "ShellRecentItems" },
+                { "action", actionValue },
+            };
+
+            if (extras is not null)
+            {
+                foreach(var entry in extras)
+                {
+                    if (!valueSet.ContainsKey(entry.Key))
+                    {
+                        valueSet.Add(entry);
+                    }
+                }
+            }
+
+            return await connection.SendMessageForResponseAsync(valueSet);
+        }
+
+        /// <summary>
+        /// Handle any events received from the fulltrust process.
+        /// Events are only received when the user is on the home page (YourHomeViewModel is loaded).
+        /// </summary>
+        public async Task HandleWin32RecentItemsEvent(string changeType)
+        {
+            System.Diagnostics.Debug.WriteLine(nameof(HandleWin32RecentItemsEvent) + $": ({changeType})");
+
+            switch (changeType)
+            {
+                case "QuickAccessJumpListChanged":
+                    await UpdateRecentFilesAsync();
+                    break;
+
+                default:
+                    logger.Warn($"{nameof(HandleWin32RecentItemsEvent)}: Received invalid changeType of {changeType}");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Returns whether two RecentItem enumerables have the same order.
+        /// This function depends on `RecentItem` implementing IEquatable.
+        /// </summary>
+        private bool RecentItemsOrderEquals(IEnumerable<RecentItem> oldOrder, IEnumerable<RecentItem> newOrder)
+        {
+            if (oldOrder is null || newOrder is null)
+            {
+                return false;
+            }
+
+            return oldOrder.SequenceEqual(newOrder);
+        }
+
+        public void Dispose() {}
+    }
+}

--- a/src/Files.Uwp/Helpers/NavigationHelpers.cs
+++ b/src/Files.Uwp/Helpers/NavigationHelpers.cs
@@ -336,11 +336,10 @@ namespace Files.Uwp.Helpers
                 opened = await associatedInstance.FilesystemViewModel.GetFolderWithPathFromPathAsync(path)
                     .OnSuccess(async (childFolder) =>
                     {
-                        // Add location to MRU List
+                        // Add location to Recent Items List
                         if (childFolder.Item is SystemStorageFolder)
                         {
-                            var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
-                            mostRecentlyUsed.Add(await childFolder.Item.ToStorageFolderAsync(), childFolder.Path);
+                            await App.RecentItemsManager.AddToRecentItems(childFolder.Path);
                         }
                     });
                 if (!opened)
@@ -390,11 +389,10 @@ namespace Files.Uwp.Helpers
                         StorageFileWithPath childFile = await associatedInstance.FilesystemViewModel.GetFileWithPathFromPathAsync(shortcutInfo.TargetPath);
                         if (childFile != null)
                         {
-                            // Add location to MRU List
+                            // Add location to Recent Items List
                             if (childFile.Item is SystemStorageFile)
                             {
-                                var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
-                                mostRecentlyUsed.Add(await childFile.Item.ToStorageFileAsync(), childFile.Path);
+                                await App.RecentItemsManager.AddToRecentItems(childFile.Path);
                             }
                         }
                     }
@@ -411,11 +409,10 @@ namespace Files.Uwp.Helpers
                 opened = await associatedInstance.FilesystemViewModel.GetFileWithPathFromPathAsync(path)
                     .OnSuccess(async childFile =>
                     {
-                        // Add location to MRU List
+                        // Add location to Recent Items List
                         if (childFile.Item is SystemStorageFile)
                         {
-                            var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
-                            mostRecentlyUsed.Add(await childFile.Item.ToStorageFileAsync(), childFile.Path);
+                            await App.RecentItemsManager.AddToRecentItems(childFile.Path);
                         }
 
                         if (openViaApplicationPicker)

--- a/src/Files.Uwp/UserControls/Widgets/RecentFilesWidget.xaml
+++ b/src/Files.Uwp/UserControls/Widgets/RecentFilesWidget.xaml
@@ -4,6 +4,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:fs="using:Files.Uwp.Filesystem"
     xmlns:helpers="using:Files.Uwp.Helpers"
     xmlns:local="using:Files.Uwp.UserControls.Widgets"
     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
@@ -39,7 +40,7 @@
                 </Style>
             </ListView.ItemContainerStyle>
             <ListView.ItemTemplate>
-                <DataTemplate x:DataType="local:RecentItem">
+                <DataTemplate x:DataType="fs:RecentItem">
                     <Grid
                         Padding="2.5"
                         HorizontalAlignment="Stretch"
@@ -108,7 +109,7 @@
                             VerticalAlignment="Center"
                             x:Load="{x:Bind FileIconVis}"
                             x:Phase="1"
-                            Source="{x:Bind FileImg}"
+                            Source="{x:Bind FileImg, Mode=OneWay}"
                             Stretch="UniformToFill" />
 
                         <TextBlock

--- a/src/Files.Uwp/ViewModels/Pages/YourHomeViewModel.cs
+++ b/src/Files.Uwp/ViewModels/Pages/YourHomeViewModel.cs
@@ -7,6 +7,11 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Windows.Input;
 using Windows.UI.Xaml;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Files.Shared;
+using Files.Shared.Extensions;
 
 namespace Files.Uwp.ViewModels.Pages
 {
@@ -24,6 +29,25 @@ namespace Files.Uwp.ViewModels.Pages
 
         public ICommand LoadBundlesCommand { get; private set; }
 
+        private NamedPipeAsAppServiceConnection connection;
+
+        private NamedPipeAsAppServiceConnection Connection
+        {
+            get => connection;
+            set
+            {
+                if (connection != null)
+                {
+                    connection.RequestReceived -= Connection_RequestReceived;
+                }
+                connection = value;
+                if (connection != null)
+                {
+                    connection.RequestReceived += Connection_RequestReceived;
+                }
+            }
+        }
+
         public YourHomeViewModel(WidgetsListControlViewModel widgetsViewModel, IShellPage associatedInstance)
         {
             this.widgetsViewModel = widgetsViewModel;
@@ -32,6 +56,14 @@ namespace Files.Uwp.ViewModels.Pages
             // Create commands
             YourHomeLoadedCommand = new RelayCommand<RoutedEventArgs>(YourHomeLoaded);
             LoadBundlesCommand = new RelayCommand<BundlesViewModel>(LoadBundles);
+
+            _ = InitializeConnectionAsync(); // fire and forget
+            AppServiceConnectionHelper.ConnectionChanged += AppServiceConnectionHelper_ConnectionChanged;
+        }
+
+        private async Task InitializeConnectionAsync()
+        {
+            Connection ??= await AppServiceConnectionHelper.Instance;
         }
 
         public void ChangeAppInstance(IShellPage associatedInstance)
@@ -66,6 +98,20 @@ namespace Files.Uwp.ViewModels.Pages
             await NavigationHelpers.OpenPath(e.path, associatedInstance, e.itemType, e.openSilent, e.openViaApplicationPicker, e.selectItems);
         }
 
+        private async void AppServiceConnectionHelper_ConnectionChanged(object sender, Task<NamedPipeAsAppServiceConnection> e)
+        {
+            Connection = await e;
+        }
+
+        private async void Connection_RequestReceived(object sender, Dictionary<string, object> message)
+        {
+            if (message.ContainsKey("RecentItems"))
+            {
+                var changeType = message.Get("ChangeType", "");
+                await App.RecentItemsManager.HandleWin32RecentItemsEvent(changeType);
+            }
+        }
+
         #region IDisposable
 
         public void Dispose()
@@ -77,6 +123,13 @@ namespace Files.Uwp.ViewModels.Pages
             }
 
             widgetsViewModel?.Dispose();
+
+            if (connection != null)
+            {
+                connection.RequestReceived -= Connection_RequestReceived;
+            }
+
+            AppServiceConnectionHelper.ConnectionChanged -= AppServiceConnectionHelper_ConnectionChanged;
         }
 
         #endregion IDisposable

--- a/src/Files.Uwp/ViewModels/SettingsViewModels/PreferencesViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SettingsViewModels/PreferencesViewModel.cs
@@ -77,59 +77,41 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
 
             PagesOnStartupList.CollectionChanged += PagesOnStartupList_CollectionChanged;
 
+            _ = InitStartupSettingsRecentFoldersFlyout();
+            _ = DetectOpenFilesAtStartup();
+        }
+
+        private async Task InitStartupSettingsRecentFoldersFlyout()
+        {
             var recentsItem = new MenuFlyoutSubItemViewModel("JumpListRecentGroupHeader".GetLocalized());
             recentsItem.Items.Add(new MenuFlyoutItemViewModel("Home".GetLocalized(), "Home".GetLocalized(), AddPageCommand));
-            PopulateRecentItems(recentsItem).ContinueWith(_ =>
+
+            await App.RecentItemsManager.UpdateRecentFoldersAsync();    // ensure recent folders aren't stale since we don't update them with a watcher
+            await PopulateRecentItems(recentsItem).ContinueWith(_ =>
             {
                 AddFlyoutItemsSource = new ReadOnlyCollection<IMenuFlyoutItem>(new IMenuFlyoutItem[] {
                     new MenuFlyoutItemViewModel("Browse".GetLocalized(), null, AddPageCommand),
                     recentsItem,
                 });
             }, TaskScheduler.FromCurrentSynchronizationContext());
-
-            _ = DetectOpenFilesAtStartup();
         }
 
-        private async Task PopulateRecentItems(MenuFlyoutSubItemViewModel menu)
+        private Task PopulateRecentItems(MenuFlyoutSubItemViewModel menu)
         {
-            bool hasRecents = false;
-            menu.Items.Add(new MenuFlyoutSeparatorViewModel());
-
             try
             {
-                var mostRecentlyUsed = StorageApplicationPermissions.MostRecentlyUsedList;
+                var recentFolders = App.RecentItemsManager.RecentFolders;
 
-                foreach (AccessListEntry entry in mostRecentlyUsed.Entries)
+                // add separator
+                if (recentFolders.Any())
                 {
-                    string mruToken = entry.Token;
-                    var added = await FilesystemTasks.Wrap(async () =>
-                    {
-                        IStorageItem item = await mostRecentlyUsed.GetItemAsync(mruToken, AccessCacheOptions.FastLocationsOnly | AccessCacheOptions.SuppressAccessTimeUpdate);
-                        if (item.IsOfType(StorageItemTypes.Folder))
-                        {
-                            menu.Items.Add(new MenuFlyoutItemViewModel(item.Name, string.IsNullOrEmpty(item.Path) ? entry.Metadata : item.Path, AddPageCommand));
-                            hasRecents = true;
-                        }
-                    });
-                    if (added == FileSystemStatusCode.Unauthorized)
-                    {
-                        // Skip item until consent is provided
-                    }
-                    // Exceptions include but are not limited to:
-                    // COMException, FileNotFoundException, ArgumentException, DirectoryNotFoundException
-                    // 0x8007016A -> The cloud file provider is not running
-                    // 0x8000000A -> The data necessary to complete this operation is not yet available
-                    // 0x80004005 -> Unspecified error
-                    // 0x80270301 -> ?
-                    else if (!added)
-                    {
-                        await FilesystemTasks.Wrap(() =>
-                        {
-                            mostRecentlyUsed.Remove(mruToken);
-                            return Task.CompletedTask;
-                        });
-                        System.Diagnostics.Debug.WriteLine(added.ErrorCode);
-                    }
+                    menu.Items.Add(new MenuFlyoutSeparatorViewModel());
+                }
+
+                foreach (var recentFolder in recentFolders)
+                {
+                    var menuItem = new MenuFlyoutItemViewModel(recentFolder.Name, recentFolder.RecentPath, AddPageCommand);
+                    menu.Items.Add(menuItem);
                 }
             }
             catch (Exception ex)
@@ -137,10 +119,7 @@ namespace Files.Uwp.ViewModels.SettingsViewModels
                 App.Logger.Info(ex, "Could not fetch recent items");
             }
 
-            if (!hasRecents)
-            {
-                menu.Items.RemoveAt(menu.Items.Count - 1);
-            }
+            return Task.CompletedTask;
         }
 
         private void PagesOnStartupList_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
- Related #9153
- ~~Conflicts with #9163~~
   - ~~I need to (1) take the changes from the PR above (2) ensure the `dateCreated/Modified` fallback changes are kept~~
   - **Update:** conflicts should be resolved now

**Details of Changes**
* No longer utilize MRU; instead, directly **two-way** synchronize with the recent file list in File Explorer.
In summary, the domain knowledge was pretty intensive, there's _a lot_ of peculiar behavior from Files Explorer.
_**If interested, I can prepare a technical document describing peculiarities and decisions made behind them.**_
- Recent Files (in Home Page)
  - **Enumerating:** directly enumerate Quick Access
  - **Adding:** `SHAddToRecentDocs` API (invoked when opening a file)
  - **Unpin:** (Shell) invoke `remove` verb to directly modify Quick Access jump list file
- Recent Folders (in Settings > Preferences > Startup settings > Open a specific page or pages > [+ Add] > Browse) 
  - **Enumerating:** enumerate Recent Items (`Windows\Recent`)
  - **Adding:** `SHAddToRecentDocs` API (invoked when opening a folder)
- Shared
  - **Clearing** the recent items clears both Recent Files and Folders via the `SHAddToRecentDocs` API
  
**Validation**
- [X] Built and ran the app
- [X] Tested the changes for accessibility

**Screenshots (optional)**

_**(file explorer --> files)**_
https://user-images.githubusercontent.com/29434693/170891003-2ee0c3ae-04c3-413f-92da-d32edbe62430.mp4

---

_**(files --> file explorer)**_
https://user-images.githubusercontent.com/29434693/170891017-4ddde7a3-6c3e-4569-a617-a2d38c3d5013.mp4
