### PR TITLE
Fix refresh not working when doing some files operations in network drives

### DIFF
--- a/src/Files.FullTrust/Helpers/ShellFolderHelpers.cs
+++ b/src/Files.FullTrust/Helpers/ShellFolderHelpers.cs
@@ -29,6 +29,13 @@ namespace Files.FullTrust.Helpers
             return libraryItem;
         }
 
+        private static T TryGetProperty<T>(this ShellItemPropertyStore sip, Ole32.PROPERTYKEY key)
+        {
+            T value = default;
+            SafetyExtensions.IgnoreExceptions(() => sip.TryGetValue<T>(key, out value));
+            return value;
+        }
+
         public static ShellFileItem GetShellFileItem(ShellItem folderItem)
         {
             if (folderItem == null)
@@ -36,10 +43,6 @@ namespace Files.FullTrust.Helpers
                 return null;
             }
             bool isFolder = folderItem.IsFolder && !folderItem.Attributes.HasFlag(ShellItemAttribute.Stream);
-            if (folderItem.Properties == null)
-            {
-                return new ShellFileItem(isFolder, folderItem.FileSystemPath, Path.GetFileName(folderItem.Name), folderItem.Name, DateTime.Now, DateTime.Now, DateTime.Now, null, 0, null);
-            }
             var parsingPath = folderItem.GetDisplayName(ShellItemDisplayString.DesktopAbsoluteParsing);
             parsingPath ??= folderItem.FileSystemPath; // True path on disk
             if (parsingPath == null || !Path.IsPathRooted(parsingPath))
@@ -47,8 +50,7 @@ namespace Files.FullTrust.Helpers
                 // Use PIDL as path
                 parsingPath = $@"\\SHELL\{string.Join("\\", folderItem.PIDL.Select(x => x.GetBytes()).Select(x => Convert.ToBase64String(x, 0, x.Length)))}";
             }
-            folderItem.Properties.TryGetValue<string>(
-                Ole32.PROPERTYKEY.System.ItemNameDisplay, out var fileName);
+            var fileName = folderItem.Properties.TryGetProperty<string>(Ole32.PROPERTYKEY.System.ItemNameDisplay);
             fileName ??= Path.GetFileName(folderItem.Name); // Original file name
             string filePath = string.IsNullOrEmpty(Path.GetDirectoryName(parsingPath)) ? // Null if root
                 parsingPath : Path.Combine(Path.GetDirectoryName(parsingPath), folderItem.Name); // In recycle bin "Name" contains original file path + name
@@ -63,20 +65,18 @@ namespace Files.FullTrust.Helpers
                     filePath = $"{filePath}{realExtension}";
                 }
             }
-            folderItem.Properties.TryGetValue<System.Runtime.InteropServices.ComTypes.FILETIME?>(
-                Ole32.PROPERTYKEY.System.Recycle.DateDeleted, out var fileTime);
+            var fileTime = folderItem.Properties.TryGetProperty<System.Runtime.InteropServices.ComTypes.FILETIME?>(
+                Ole32.PROPERTYKEY.System.Recycle.DateDeleted);
             var recycleDate = fileTime?.ToDateTime().ToLocalTime() ?? DateTime.Now; // This is LocalTime
-            folderItem.Properties.TryGetValue<System.Runtime.InteropServices.ComTypes.FILETIME?>(
-                Ole32.PROPERTYKEY.System.DateModified, out fileTime);
+            fileTime = folderItem.Properties.TryGetProperty<System.Runtime.InteropServices.ComTypes.FILETIME?>(
+                Ole32.PROPERTYKEY.System.DateModified);
             var modifiedDate = fileTime?.ToDateTime().ToLocalTime() ?? DateTime.Now; // This is LocalTime
-            folderItem.Properties.TryGetValue<System.Runtime.InteropServices.ComTypes.FILETIME?>(
-                Ole32.PROPERTYKEY.System.DateCreated, out fileTime);
+            fileTime = folderItem.Properties.TryGetProperty<System.Runtime.InteropServices.ComTypes.FILETIME?>(
+                Ole32.PROPERTYKEY.System.DateCreated);
             var createdDate = fileTime?.ToDateTime().ToLocalTime() ?? DateTime.Now; // This is LocalTime
-            string fileSize = folderItem.Properties.TryGetValue<ulong?>(
-                Ole32.PROPERTYKEY.System.Size, out var fileSizeBytes) ?
-                folderItem.Properties.GetPropertyString(Ole32.PROPERTYKEY.System.Size) : null;
-            folderItem.Properties.TryGetValue<string>(
-                Ole32.PROPERTYKEY.System.ItemTypeText, out var fileType);
+            var fileSizeBytes = folderItem.Properties.TryGetProperty<ulong?>(Ole32.PROPERTYKEY.System.Size);
+            string fileSize = fileSizeBytes is not null ? folderItem.Properties.GetPropertyString(Ole32.PROPERTYKEY.System.Size) : null;
+            var fileType = folderItem.Properties.TryGetProperty<string>(Ole32.PROPERTYKEY.System.ItemTypeText);
             return new ShellFileItem(isFolder, parsingPath, fileName, filePath, recycleDate, modifiedDate, createdDate, fileSize, fileSizeBytes ?? 0, fileType);
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9294

**Details of Changes**
Add details of changes here.
- Catch exception if ShellItem has no property store

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Created a ".BMP" file from the "new file" toolbar menu in a network drive, file appears without refresh
