### PR TITLE
Show selected items size details when selecting by dragging the mouse

### DIFF
--- a/src/Files.Uwp/UserControls/Selection/RectangleSelection_ListViewBase.cs
+++ b/src/Files.Uwp/UserControls/Selection/RectangleSelection_ListViewBase.cs
@@ -21,6 +21,7 @@ namespace Files.Uwp.UserControls.Selection
         private Point originDragPoint;
         private Dictionary<object, System.Drawing.Rectangle> itemsPosition;
         private List<object> prevSelectedItems;
+        private List<object> prevSelectedItemsDrag;
         private ItemSelectionStrategy selectionStrategy;
 
         public RectangleSelection_ListViewBase(ListViewBase uiElement, Rectangle selectionRectangle, SelectionChangedEventHandler selectionChanged = null)
@@ -91,6 +92,17 @@ namespace Files.Uwp.UserControls.Selection
                     // Scroll up the list if pointer is at the top
                     var scrollIncrement = Math.Min(20 - currentPoint.Position.Y, 40);
                     scrollViewer.ChangeView(null, verticalOffset - scrollIncrement, null, false);
+                }
+
+                if (selectionChanged != null)
+                {
+                    var currentSelectedItemsDrag = uiElement.SelectedItems.Cast<object>().ToList();
+                    if (prevSelectedItemsDrag == null || !prevSelectedItemsDrag.SequenceEqual(currentSelectedItemsDrag))
+                    {
+                        // Trigger SelectionChanged event if the selection has changed
+                        selectionChanged(sender, null);
+                        prevSelectedItemsDrag = currentSelectedItemsDrag;
+                    }
                 }
             }
         }
@@ -194,6 +206,8 @@ namespace Files.Uwp.UserControls.Selection
 
             selectionStrategy = null;
             selectionState = SelectionState.Inactive;
+
+            prevSelectedItemsDrag = null;
 
             e.Handled = true;
         }


### PR DESCRIPTION
**Resolved / Related Issues**
Closes #9075 

**Details of Changes**
When selecting items by dragging the mouse, the selected items size details are now shown.

**Validation**
- [x] Built and ran the app

**Screenshots**

https://user-images.githubusercontent.com/25117425/171218690-a250daa4-0cda-43a4-b100-888ab0ccfa08.mp4


