### PR TITLE
Fixes duplicated themes when opening new tab using win + e

### DIFF
--- a/src/Files.Uwp/Helpers/ExternalResourcesHelper.cs
+++ b/src/Files.Uwp/Helpers/ExternalResourcesHelper.cs
@@ -54,12 +54,15 @@ namespace Files.Uwp.Helpers
         {
             foreach (var file in (await folder.GetFilesAsync()).Where(x => x.FileType == ".xaml"))
             {
-                Themes.Add(new AppTheme()
+                if(!Themes.Exists(t => t.AbsolutePath == file.Path))
                 {
-                    Name = file.Name.Replace(".xaml", "", StringComparison.Ordinal),
-                    Path = file.Name,
-                    AbsolutePath = file.Path,
-                });
+                    Themes.Add(new AppTheme()
+                    {
+                        Name = file.Name.Replace(".xaml", "", StringComparison.Ordinal),
+                        Path = file.Name,
+                        AbsolutePath = file.Path,
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
**Resolved / Related Issues**
Fixes #7851

**Details of Changes**
Fixes the issue, but I don't know if it is the proper fix. The issue existed because when using Win + E, `App.OnActivated()` function is called and it seems to initialize the whole app instead of just adding a new tab, so I don't know if this is the desired behaviour.

**Validation**
- [x] Built and ran the app

