### PR TITLE
fix: BulkConcurrentObservableCollection::Remove returns false if item not found

### DIFF
--- a/src/Files.Uwp/Helpers/ItemListDisplayHelpers/BulkConcurrentObservableCollection.cs
+++ b/src/Files.Uwp/Helpers/ItemListDisplayHelpers/BulkConcurrentObservableCollection.cs
@@ -283,7 +283,7 @@ namespace Files.Uwp.Helpers
 
                 if (index == -1)
                 {
-                    return true;
+                    return false;
                 }
 
                 collection.RemoveAt(index);


### PR DESCRIPTION
**Resolved / Related Issues**
- N/A

**Details of Changes**
- `BulkConcurrentObservableCollection::Remove` should return `false` if the item was not found
- We currently have zero usages of `Remove`'s return value in the codebase, so this is to avoid bugs from arising in the future

**Validation**
How did you test these changes?
- [X] Built and ran the app
