### PR TITLE
Fix issues with drag&drop from special locations

### DIFF
--- a/src/Files.FullTrust/Win32API.cs
+++ b/src/Files.FullTrust/Win32API.cs
@@ -505,7 +505,7 @@ namespace Files.FullTrust
 
                 for (ushort count = 1; File.Exists(uniquePath); count++)
                 {
-                    if (countMatch != null)
+                    if (countMatch.Success)
                     {
                         uniquePath = Path.Combine(directory, $"{nameWithoutExt[..countMatch.Index]}({count}){extension}");
                     }
@@ -523,7 +523,7 @@ namespace Files.FullTrust
 
                 for (ushort Count = 1; Directory.Exists(uniquePath); Count++)
                 {
-                    if (countMatch != null)
+                    if (countMatch.Success)
                     {
                         uniquePath = Path.Combine(directory, $"{Name[..countMatch.Index]}({Count})");
                     }

--- a/src/Files.Shared/ShellOperationResult.cs
+++ b/src/Files.Shared/ShellOperationResult.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Files.Shared
 {
@@ -11,6 +12,9 @@ namespace Files.Shared
 
         public List<ShellOperationItemResult> Items { get; set; }
         public bool Succeeded { get; set; }
+
+        public List<ShellOperationItemResult> Final =>
+            Items.GroupBy(x => new { Src = x.Source, Dst = x.Destination }).Select(x => x.Last()).ToList();
     }
 
     public class ShellOperationItemResult

--- a/src/Files.Shared/ShellOperationResult.cs
+++ b/src/Files.Shared/ShellOperationResult.cs
@@ -10,9 +10,15 @@ namespace Files.Shared
             Items = new List<ShellOperationItemResult>();
         }
 
+        /// <summary>
+        /// File operation results: success and error code. Can contains multiple results for the same source file.
+        /// E.g. if the shell shows a "replace" confirmation dialog, results can be both COPYENGINE_S_PENDING and COPYENGINE_S_USER_IGNORED.
+        /// </summary>
         public List<ShellOperationItemResult> Items { get; set; }
-        public bool Succeeded { get; set; }
 
+        /// <summary>
+        /// Final results of a file operation. Contains last status for each source file.
+        /// </summary>
         public List<ShellOperationItemResult> Final =>
             Items.GroupBy(x => new { Src = x.Source, Dst = x.Destination }).Select(x => x.Last()).ToList();
     }

--- a/src/Files.Uwp/Filesystem/FilesystemOperations/FilesystemOperations.cs
+++ b/src/Files.Uwp/Filesystem/FilesystemOperations/FilesystemOperations.cs
@@ -195,7 +195,7 @@ namespace Files.Uwp.Filesystem
                 else
                 {
                     // CopyFileFromApp only works on file not directories
-                    var fsSourceFolder = await source.ToStorageItemResult(associatedInstance);
+                    var fsSourceFolder = await source.ToStorageItemResult();
                     var fsDestinationFolder = await associatedInstance.FilesystemViewModel.GetFolderFromPathAsync(PathNormalization.GetParentDir(destination));
                     var fsResult = (FilesystemResult)(fsSourceFolder.ErrorCode | fsDestinationFolder.ErrorCode);
 
@@ -241,7 +241,7 @@ namespace Files.Uwp.Filesystem
                     Debug.WriteLine(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
 
                     FilesystemResult<BaseStorageFolder> destinationResult = await associatedInstance.FilesystemViewModel.GetFolderFromPathAsync(PathNormalization.GetParentDir(destination));
-                    var sourceResult = await source.ToStorageItemResult(associatedInstance);
+                    var sourceResult = await source.ToStorageItemResult();
                     fsResult = sourceResult.ErrorCode | destinationResult.ErrorCode;
 
                     if (fsResult)
@@ -386,7 +386,7 @@ namespace Files.Uwp.Filesystem
                     {
                         Debug.WriteLine(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
 
-                        var fsSourceFolder = await source.ToStorageItemResult(associatedInstance);
+                        var fsSourceFolder = await source.ToStorageItemResult();
                         var fsDestinationFolder = await associatedInstance.FilesystemViewModel.GetFolderFromPathAsync(PathNormalization.GetParentDir(destination));
                         fsResult = fsSourceFolder.ErrorCode | fsDestinationFolder.ErrorCode;
 
@@ -435,7 +435,7 @@ namespace Files.Uwp.Filesystem
                     Debug.WriteLine(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
 
                     FilesystemResult<BaseStorageFolder> destinationResult = await associatedInstance.FilesystemViewModel.GetFolderFromPathAsync(PathNormalization.GetParentDir(destination));
-                    var sourceResult = await source.ToStorageItemResult(associatedInstance);
+                    var sourceResult = await source.ToStorageItemResult();
                     fsResult = sourceResult.ErrorCode | destinationResult.ErrorCode;
 
                     if (fsResult)
@@ -601,7 +601,7 @@ namespace Files.Uwp.Filesystem
                 && !FilesystemHelpers.ContainsRestrictedCharacters(newName)
                 && !FilesystemHelpers.ContainsRestrictedFileName(newName))
             {
-                var renamed = await source.ToStorageItemResult(associatedInstance)
+                var renamed = await source.ToStorageItemResult()
                     .OnSuccess(async (t) =>
                     {
                         if (t.Name.Equals(newName, StringComparison.CurrentCultureIgnoreCase))

--- a/src/Files.Uwp/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
+++ b/src/Files.Uwp/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
@@ -271,7 +271,7 @@ namespace Files.Uwp.Filesystem
                 if (createdSources.Any())
                 {
                     var item = StorageHelpers.FromPathAndType(createdSources.Single().Destination, source.ItemType);
-                    var storageItem = await item.ToStorageItem(associatedInstance);
+                    var storageItem = await item.ToStorageItem();
                     return (new StorageHistory(FileOperationType.CreateNew, item.CreateList(), null), storageItem);
                 }
                 return (null, null);

--- a/src/Files.Uwp/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
+++ b/src/Files.Uwp/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
@@ -109,7 +109,7 @@ namespace Files.Uwp.Filesystem
                 result &= (FilesystemResult)(status == AppServiceResponseStatus.Success
                     && response.Get("Success", false));
                 var shellOpResult = JsonConvert.DeserializeObject<ShellOperationResult>(response.Get("Result", ""));
-                copyResult.Items.AddRange(shellOpResult?.Items ?? Enumerable.Empty<ShellOperationItemResult>());
+                copyResult.Items.AddRange(shellOpResult?.Final ?? Enumerable.Empty<ShellOperationItemResult>());
             }
             if (sourceReplace.Any())
             {
@@ -126,7 +126,7 @@ namespace Files.Uwp.Filesystem
                 result &= (FilesystemResult)(status == AppServiceResponseStatus.Success
                     && response.Get("Success", false));
                 var shellOpResult = JsonConvert.DeserializeObject<ShellOperationResult>(response.Get("Result", ""));
-                copyResult.Items.AddRange(shellOpResult?.Items ?? Enumerable.Empty<ShellOperationItemResult>());
+                copyResult.Items.AddRange(shellOpResult?.Final ?? Enumerable.Empty<ShellOperationItemResult>());
             }
 
             if (connection != null)
@@ -260,7 +260,7 @@ namespace Files.Uwp.Filesystem
             var result = (FilesystemResult)(status == AppServiceResponseStatus.Success
                 && response.Get("Success", false));
             var shellOpResult = JsonConvert.DeserializeObject<ShellOperationResult>(response.Get("Result", ""));
-            createResult.Items.AddRange(shellOpResult?.Items ?? Enumerable.Empty<ShellOperationItemResult>());
+            createResult.Items.AddRange(shellOpResult?.Final ?? Enumerable.Empty<ShellOperationItemResult>());
 
             result &= (FilesystemResult)createResult.Items.All(x => x.Succeeded);
 
@@ -396,7 +396,7 @@ namespace Files.Uwp.Filesystem
             var result = (FilesystemResult)(status == AppServiceResponseStatus.Success
                 && response.Get("Success", false));
             var shellOpResult = JsonConvert.DeserializeObject<ShellOperationResult>(response.Get("Result", ""));
-            deleteResult.Items.AddRange(shellOpResult?.Items ?? Enumerable.Empty<ShellOperationItemResult>());
+            deleteResult.Items.AddRange(shellOpResult?.Final ?? Enumerable.Empty<ShellOperationItemResult>());
 
             if (connection != null)
             {
@@ -522,7 +522,7 @@ namespace Files.Uwp.Filesystem
                 result &= (FilesystemResult)(status == AppServiceResponseStatus.Success
                     && response.Get("Success", false));
                 var shellOpResult = JsonConvert.DeserializeObject<ShellOperationResult>(response.Get("Result", ""));
-                moveResult.Items.AddRange(shellOpResult?.Items ?? Enumerable.Empty<ShellOperationItemResult>());
+                moveResult.Items.AddRange(shellOpResult?.Final ?? Enumerable.Empty<ShellOperationItemResult>());
             }
             if (sourceReplace.Any())
             {
@@ -539,7 +539,7 @@ namespace Files.Uwp.Filesystem
                 result &= (FilesystemResult)(status == AppServiceResponseStatus.Success
                     && response.Get("Success", false));
                 var shellOpResult = JsonConvert.DeserializeObject<ShellOperationResult>(response.Get("Result", ""));
-                moveResult.Items.AddRange(shellOpResult?.Items ?? Enumerable.Empty<ShellOperationItemResult>());
+                moveResult.Items.AddRange(shellOpResult?.Final ?? Enumerable.Empty<ShellOperationItemResult>());
             }
 
             if (connection != null)
@@ -647,7 +647,7 @@ namespace Files.Uwp.Filesystem
             var result = (FilesystemResult)(status == AppServiceResponseStatus.Success
                 && response.Get("Success", false));
             var shellOpResult = JsonConvert.DeserializeObject<ShellOperationResult>(response.Get("Result", ""));
-            renameResult.Items.AddRange(shellOpResult?.Items ?? Enumerable.Empty<ShellOperationItemResult>());
+            renameResult.Items.AddRange(shellOpResult?.Final ?? Enumerable.Empty<ShellOperationItemResult>());
 
             result &= (FilesystemResult)renameResult.Items.All(x => x.Succeeded);
 
@@ -745,7 +745,7 @@ namespace Files.Uwp.Filesystem
             var result = (FilesystemResult)(status == AppServiceResponseStatus.Success
                 && response.Get("Success", false));
             var shellOpResult = JsonConvert.DeserializeObject<ShellOperationResult>(response.Get("Result", ""));
-            moveResult.Items.AddRange(shellOpResult?.Items ?? Enumerable.Empty<ShellOperationItemResult>());
+            moveResult.Items.AddRange(shellOpResult?.Final ?? Enumerable.Empty<ShellOperationItemResult>());
 
             if (connection != null)
             {

--- a/src/Files.Uwp/Helpers/StorageHelpers.cs
+++ b/src/Files.Uwp/Helpers/StorageHelpers.cs
@@ -15,12 +15,12 @@ namespace Files.Uwp.Helpers
     /// </summary>
     public static class StorageHelpers
     {
-        public static async Task<IStorageItem> ToStorageItem(this IStorageItemWithPath item, IShellPage associatedInstance = null)
+        public static async Task<IStorageItem> ToStorageItem(this IStorageItemWithPath item)
         {
-            return (await item.ToStorageItemResult(associatedInstance)).Result;
+            return (await item.ToStorageItemResult()).Result;
         }
 
-        public static async Task<TRequested> ToStorageItem<TRequested>(string path, IShellPage associatedInstance = null) where TRequested : IStorageItem
+        public static async Task<TRequested> ToStorageItem<TRequested>(string path) where TRequested : IStorageItem
         {
             FilesystemResult<BaseStorageFile> file = null;
             FilesystemResult<BaseStorageFolder> folder = null;
@@ -110,28 +110,14 @@ namespace Files.Uwp.Helpers
 
             async Task GetFile()
             {
-                if (associatedInstance == null || associatedInstance.FilesystemViewModel == null)
-                {
-                    var rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(path));
-                    file = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFileFromPathAsync(path, rootItem));
-                }
-                else
-                {
-                    file = await associatedInstance.FilesystemViewModel.GetFileFromPathAsync(path);
-                }
+                var rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(path));
+                file = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFileFromPathAsync(path, rootItem));
             }
 
             async Task GetFolder()
             {
-                if (associatedInstance == null)
-                {
-                    var rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(path));
-                    folder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(path, rootItem));
-                }
-                else
-                {
-                    folder = await associatedInstance?.FilesystemViewModel?.GetFolderFromPathAsync(path);
-                }
+                var rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(path));
+                folder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(path, rootItem));
             }
         }
 
@@ -141,18 +127,16 @@ namespace Files.Uwp.Helpers
             return (long)properties.Size;
         }
 
-        public static async Task<FilesystemResult<IStorageItem>> ToStorageItemResult(this IStorageItemWithPath item, IShellPage associatedInstance = null)
+        public static async Task<FilesystemResult<IStorageItem>> ToStorageItemResult(this IStorageItemWithPath item)
         {
             var returnedItem = new FilesystemResult<IStorageItem>(null, FileSystemStatusCode.Generic);
-            var rootItem = associatedInstance == null ? await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(item.Path)) : null;
+            var rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(item.Path));
             if (!string.IsNullOrEmpty(item.Path))
             {
                 returnedItem = (item.ItemType == FilesystemItemType.File) ?
-                    ToType<IStorageItem, BaseStorageFile>(associatedInstance != null ?
-                        await associatedInstance.FilesystemViewModel.GetFileFromPathAsync(item.Path) :
+                    ToType<IStorageItem, BaseStorageFile>(
                         await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFileFromPathAsync(item.Path, rootItem))) :
-                    ToType<IStorageItem, BaseStorageFolder>(associatedInstance != null ?
-                        await associatedInstance.FilesystemViewModel.GetFolderFromPathAsync(item.Path) :
+                    ToType<IStorageItem, BaseStorageFolder>(
                         await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(item.Path, rootItem)));
             }
             if (returnedItem.Result == null && item.Item != null)
@@ -169,9 +153,9 @@ namespace Files.Uwp.Helpers
                     (IStorageItemWithPath)new StorageFolderWithPath(null, customPath);
         }
 
-        public static async Task<FilesystemItemType> GetTypeFromPath(string path, IShellPage associatedInstance = null)
+        public static async Task<FilesystemItemType> GetTypeFromPath(string path)
         {
-            IStorageItem item = await ToStorageItem<IStorageItem>(path, associatedInstance);
+            IStorageItem item = await ToStorageItem<IStorageItem>(path);
 
             return item == null ? FilesystemItemType.File : (item.IsOfType(StorageItemTypes.Folder) ? FilesystemItemType.Directory : FilesystemItemType.File);
         }

--- a/src/Files.Uwp/Helpers/WallpaperHelpers.cs
+++ b/src/Files.Uwp/Helpers/WallpaperHelpers.cs
@@ -9,12 +9,12 @@ namespace Files.Uwp.Helpers
 {
     public static class WallpaperHelpers
     {
-        public static async void SetAsBackground(WallpaperType type, string filePath, IShellPage associatedInstance)
+        public static async void SetAsBackground(WallpaperType type, string filePath)
         {
             if (UserProfilePersonalizationSettings.IsSupported())
             {
                 // Get the path of the selected file
-                BaseStorageFile sourceFile = await StorageHelpers.ToStorageItem<BaseStorageFile>(filePath, associatedInstance);
+                BaseStorageFile sourceFile = await StorageHelpers.ToStorageItem<BaseStorageFile>(filePath);
                 if (sourceFile == null)
                 {
                     return;

--- a/src/Files.Uwp/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files.Uwp/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -107,7 +107,7 @@ namespace Files.Uwp.Interacts
 
         public virtual void SetAsLockscreenBackgroundItem(RoutedEventArgs e)
         {
-            WallpaperHelpers.SetAsBackground(WallpaperType.LockScreen, SlimContentPage.SelectedItem.ItemPath, associatedInstance);
+            WallpaperHelpers.SetAsBackground(WallpaperType.LockScreen, SlimContentPage.SelectedItem.ItemPath);
         }
 
         public virtual async void SetAsDesktopBackgroundItem(RoutedEventArgs e)
@@ -130,7 +130,7 @@ namespace Files.Uwp.Interacts
             }
             else
             {
-                WallpaperHelpers.SetAsBackground(WallpaperType.Desktop, SlimContentPage.SelectedItem.ItemPath, associatedInstance);
+                WallpaperHelpers.SetAsBackground(WallpaperType.Desktop, SlimContentPage.SelectedItem.ItemPath);
             }
         }
 
@@ -396,14 +396,14 @@ namespace Files.Uwp.Interacts
                     }
                     else if (item.PrimaryItemAttribute == StorageItemTypes.Folder && !item.IsZipItem)
                     {
-                        if (await StorageHelpers.ToStorageItem<BaseStorageFolder>(item.ItemPath, associatedInstance) is BaseStorageFolder folder)
+                        if (await StorageHelpers.ToStorageItem<BaseStorageFolder>(item.ItemPath) is BaseStorageFolder folder)
                         {
                             items.Add(folder);
                         }
                     }
                     else
                     {
-                        if (await StorageHelpers.ToStorageItem<BaseStorageFile>(item.ItemPath, associatedInstance) is BaseStorageFile file)
+                        if (await StorageHelpers.ToStorageItem<BaseStorageFile>(item.ItemPath) is BaseStorageFile file)
                         {
                             items.Add(file);
                         }

--- a/src/Files.Uwp/ViewModels/Properties/FileProperties.cs
+++ b/src/Files.Uwp/ViewModels/Properties/FileProperties.cs
@@ -356,7 +356,7 @@ namespace Files.Uwp.ViewModels.Properties
         private async Task<string> GetHashForFileAsync(ListedItem fileItem, string nameOfAlg, CancellationToken token, IProgress<float> progress, IShellPage associatedInstance)
         {
             HashAlgorithmProvider algorithmProvider = HashAlgorithmProvider.OpenAlgorithm(nameOfAlg);
-            BaseStorageFile file = await StorageHelpers.ToStorageItem<BaseStorageFile>((fileItem as ShortcutItem)?.TargetPath ?? fileItem.ItemPath, associatedInstance);
+            BaseStorageFile file = await StorageHelpers.ToStorageItem<BaseStorageFile>((fileItem as ShortcutItem)?.TargetPath ?? fileItem.ItemPath);
             if (file == null)
             {
                 return "";


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue preventing drag & drop from phone storage
- Fixes an issue causing a crash when dropping a file from a zip archive opened in Files and the destination already exists
- Fixes wrong filename when copy-pasting from a zip file opened in explorer and the destination already exists

**Details of Changes**
Add details of changes here.
- Fixed the GenerateUniquePath function so that a file named "test.txt" becomes "test (1).txt" instead of just "(1).txt" when copy-pasting from a zip file opened in explorer and the destination already exists.
- Take the most recent result for each source file at the end of a file operation. Fixes a crash due to duplicate key when calling "ToDictionary()" on file operation results.
- Removed dependency on `associatedInstance` from StorageHelpers. When drag&dropping the file does not come from the current instance. Fixes an issue preventing drag & drop from phone storage.

**Validation**
How did you test these changes?
- [x] Built and ran the app
