### PR TITLE
Enable shared connection for layout prefs DB

### DIFF
--- a/src/Files.Uwp/ViewModels/FolderSettingsViewModel.cs
+++ b/src/Files.Uwp/ViewModels/FolderSettingsViewModel.cs
@@ -20,7 +20,7 @@ namespace Files.Uwp.ViewModels
     {
         public static string LayoutSettingsDbPath => IO.Path.Combine(ApplicationData.Current.LocalFolder.Path, "user_settings.db");
 
-        private static readonly Lazy<LayoutPrefsDb> dbInstance = new(() => new LayoutPrefsDb(LayoutSettingsDbPath));
+        private static readonly Lazy<LayoutPrefsDb> dbInstance = new(() => new LayoutPrefsDb(LayoutSettingsDbPath, true));
         public static LayoutPrefsDb DbInstance => dbInstance.Value;
 
         public event EventHandler<LayoutPreferenceEventArgs> LayoutPreferencesUpdateRequired;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes Appcenter [3657153677u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/3657153677u/overview?q=ioexception&searchType=unhandlederror)

**Details of Changes**
Add details of changes here.
- Enable shared connection for layout prefs DB

Should fix the "System.IO.IOException: The process cannot access the file user_settings.db because it is being used by another process" error.

**Validation**
How did you test these changes?
- [x] Built and ran the app
