### PR TITLE
Fix folders sometimes using wrong grouping option

### DIFF
--- a/src/Files.Uwp/Helpers/LayoutPreferences/LayoutPreferences.cs
+++ b/src/Files.Uwp/Helpers/LayoutPreferences/LayoutPreferences.cs
@@ -55,6 +55,7 @@ namespace Files.Uwp.Helpers.LayoutPreferences
                 return (
                     prefs.LayoutMode == this.LayoutMode &&
                     prefs.GridViewSize == this.GridViewSize &&
+                    prefs.DirectoryGroupOption == this.DirectoryGroupOption &&
                     prefs.DirectorySortOption == this.DirectorySortOption &&
                     prefs.DirectorySortDirection == this.DirectorySortDirection &&
                     prefs.SortDirectoriesAlongsideFiles == this.SortDirectoriesAlongsideFiles &&
@@ -68,6 +69,7 @@ namespace Files.Uwp.Helpers.LayoutPreferences
         {
             var hashCode = LayoutMode.GetHashCode();
             hashCode = (hashCode * 397) ^ GridViewSize.GetHashCode();
+            hashCode = (hashCode * 397) ^ DirectoryGroupOption.GetHashCode();
             hashCode = (hashCode * 397) ^ DirectorySortOption.GetHashCode();
             hashCode = (hashCode * 397) ^ DirectorySortDirection.GetHashCode();
             hashCode = (hashCode * 397) ^ SortDirectoriesAlongsideFiles.GetHashCode();


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue sometimes causing folders to use the wrong grouping option

**Details of Changes**
Add details of changes here.
- Added missing group option check to Equals method

**Validation**
How did you test these changes?
- [x] Built and ran the app
