### PR TITLE
Add indicator spacing in properties page & make security icon use up to date font

### DIFF
--- a/src/Files.Uwp/Views/Pages/Properties.xaml
+++ b/src/Files.Uwp/Views/Pages/Properties.xaml
@@ -99,7 +99,6 @@
                     AccessKey="G"
                     Content="{helpers:ResourceString Name=General}"
                     CornerRadius="0"
-                    d:IsSelected="True"
                     Tag="General">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE7C3;" />

--- a/src/Files.Uwp/Views/Pages/Properties.xaml
+++ b/src/Files.Uwp/Views/Pages/Properties.xaml
@@ -85,6 +85,11 @@
             SelectedItem="{x:Bind TabGeneral}"
             SelectionChanged="NavigationView_SelectionChanged"
             SelectionFollowsFocus="Disabled">
+			<muxc:NavigationView.Resources>
+				<Style TargetType="muxc:NavigationViewItem">
+					<Setter Target="SelectionIndicator" Property="Margin" Value="0,-8,0,0" />
+				</Style>
+			</muxc:NavigationView.Resources>
             <!--  SelectionFollowsFocus disabled to fix #5387  -->
 
             <!--  Tabs  -->
@@ -94,6 +99,7 @@
                     AccessKey="G"
                     Content="{helpers:ResourceString Name=General}"
                     CornerRadius="0"
+                    d:IsSelected="True"
                     Tag="General">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE7C3;" />
@@ -105,7 +111,7 @@
                     CornerRadius="0"
                     Tag="Security">
                     <muxc:NavigationViewItem.Icon>
-                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE730;" />
+                        <FontIcon Glyph="&#xE730;" />
                     </muxc:NavigationViewItem.Icon>
                 </muxc:NavigationViewItem>
                 <muxc:NavigationViewItem


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**

This was discussed in the Files discord and there wasn't any issue related to this as far as I know, but I was told I can open it anyway.

**Details of Changes**
- Tweaked the spacing between the indicator and the tabs
- Made security icon not always use MDL2 Assets (for consistency in 11)

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Will add soon. I don't have access to my PC at the time this PR was created.