### PR TITLE
Appcenter fixes for 2.3.5

### DIFF
--- a/src/Files.Shared/Extensions/LinqExtensions.cs
+++ b/src/Files.Shared/Extensions/LinqExtensions.cs
@@ -42,16 +42,16 @@ namespace Files.Shared.Extensions
             return defaultValue;
         }
 
-        public static async Task<TValue?> GetAsync<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, Func<Task<TValue?>> defaultValueFunc)
+        public static Task<TValue?> GetAsync<TKey, TValue>(this IDictionary<TKey, Task<TValue?>> dictionary, TKey key, Func<Task<TValue?>> defaultValueFunc)
         {
             if (dictionary is null || key is null)
             {
-                return await defaultValueFunc();
+                return defaultValueFunc();
             }
             if (!dictionary.ContainsKey(key))
             {
-                var defaultValue = await defaultValueFunc();
-                if (defaultValue is TValue value)
+                var defaultValue = defaultValueFunc();
+                if (defaultValue is Task<TValue?> value)
                 {
                     dictionary.Add(key, value);
                 }

--- a/src/Files.Uwp/Filesystem/StorageItems/ZipStorageFile.cs
+++ b/src/Files.Uwp/Filesystem/StorageItems/ZipStorageFile.cs
@@ -468,7 +468,8 @@ namespace Files.Uwp.Filesystem.StorageItems
         {
             return AsyncInfo.Run<SevenZipExtractor>(async (cancellationToken) =>
             {
-                return new SevenZipExtractor(await OpenZipFileAsync(FileAccessMode.Read, openProtected));
+                var zipFile = await OpenZipFileAsync(FileAccessMode.Read, openProtected);
+                return zipFile is not null ? new SevenZipExtractor(zipFile) : null;
             });
         }
 

--- a/src/Files.Uwp/Filesystem/StorageItems/ZipStorageFolder.cs
+++ b/src/Files.Uwp/Filesystem/StorageItems/ZipStorageFolder.cs
@@ -76,7 +76,7 @@ namespace Files.Uwp.Filesystem.StorageItems
             return (marker == path.Length && includeRoot) || (marker < path.Length && path[marker] is '\\');
         }
 
-        private static Dictionary<string, bool> defaultAppDict = new Dictionary<string, bool>();
+        private static Dictionary<string, Task<bool>> defaultAppDict = new Dictionary<string, Task<bool>>();
         public static async Task<bool> CheckDefaultZipApp(string filePath)
         {
             Func<Task<bool>> queryFileAssoc = async () =>

--- a/src/Files.Uwp/Filesystem/StorageItems/ZipStorageFolder.cs
+++ b/src/Files.Uwp/Filesystem/StorageItems/ZipStorageFolder.cs
@@ -487,7 +487,8 @@ namespace Files.Uwp.Filesystem.StorageItems
         {
             return AsyncInfo.Run<SevenZipExtractor>(async (cancellationToken) =>
             {
-                return new SevenZipExtractor(await OpenZipFileAsync(FileAccessMode.Read));
+                var zipFile = await OpenZipFileAsync(FileAccessMode.Read);
+                return zipFile is not null ? new SevenZipExtractor(zipFile) : null;
             });
         }
 

--- a/src/Files.Uwp/UserControls/Menus/FileTagsContextMenu.xaml.cs
+++ b/src/Files.Uwp/UserControls/Menus/FileTagsContextMenu.xaml.cs
@@ -57,7 +57,8 @@ namespace Files.Uwp.UserControls.Menus
                 var existingTags = selectedItem.FileTags ?? Array.Empty<string>();
                 if (existingTags.Contains(removed.Uid))
                 {
-                    selectedItem.FileTags = existingTags.Except(new[] { removed.Uid }).ToArray();
+                    var tagList = existingTags.Except(new[] { removed.Uid }).ToArray();
+                    selectedItem.FileTags = tagList.Any() ? tagList : null;
                 }
             }
         }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes [1163518263u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/1163518263u/overview) & friends
- Fixes [595421595u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/595421595u/overview)
- Fixes [2122662730u](https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/2122662730u/overview)

**Details of Changes**
Add details of changes here.
- 1163518263u -> crash when enumerating folder containing multiple zip files
- 595421595u -> crash when loading an archive and file could not be opened
- 2122662730u -> crash when removing last tag on a file

**Validation**
How did you test these changes?
- [x] Built and ran the app
