### PR TITLE
Fix issue causing user settings to be repeatedly reloaded from file in some cases

### DIFF
--- a/src/Files.Uwp/App.xaml.cs
+++ b/src/Files.Uwp/App.xaml.cs
@@ -30,7 +30,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
@@ -54,7 +53,6 @@ namespace Files.Uwp
         private static bool ShowErrorNotification = false;
         private static string OutputPath = null;
 
-        public static SemaphoreSlim SemaphoreSlim = new SemaphoreSlim(1, 1);
         public static StorageHistoryWrapper HistoryWrapper = new StorageHistoryWrapper();
         public static SettingsViewModel AppSettings { get; private set; }
         public static MainViewModel MainViewModel { get; private set; }

--- a/src/Files.Uwp/Filesystem/StorageHistory/Helpers/StorageHistoryHelpers.cs
+++ b/src/Files.Uwp/Filesystem/StorageHistory/Helpers/StorageHistoryHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Shared.Enums;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Files.Uwp.Filesystem.FilesystemHistory
@@ -8,6 +9,8 @@ namespace Files.Uwp.Filesystem.FilesystemHistory
     {
         private IStorageHistoryOperations operations;
 
+        private static SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
+
         public StorageHistoryHelpers(IStorageHistoryOperations storageHistoryOperations)
             => operations = storageHistoryOperations;
 
@@ -15,7 +18,7 @@ namespace Files.Uwp.Filesystem.FilesystemHistory
         {
             if (App.HistoryWrapper.CanUndo())
             {
-                if (!await App.SemaphoreSlim.WaitAsync(0))
+                if (!await semaphore.WaitAsync(0))
                 {
                     return ReturnResult.InProgress;
                 }
@@ -26,7 +29,7 @@ namespace Files.Uwp.Filesystem.FilesystemHistory
                 finally
                 {
                     App.HistoryWrapper.DecreaseIndex();
-                    App.SemaphoreSlim.Release();
+                    semaphore.Release();
                 }
             }
 
@@ -37,7 +40,7 @@ namespace Files.Uwp.Filesystem.FilesystemHistory
         {
             if (App.HistoryWrapper.CanRedo())
             {
-                if (!await App.SemaphoreSlim.WaitAsync(0))
+                if (!await semaphore.WaitAsync(0))
                 {
                     return ReturnResult.InProgress;
                 }
@@ -48,7 +51,7 @@ namespace Files.Uwp.Filesystem.FilesystemHistory
                 }
                 finally
                 {
-                    App.SemaphoreSlim.Release();
+                    semaphore.Release();
                 }
             }
 

--- a/src/Files.Uwp/Serialization/Implementation/CachingJsonSettingsDatabase.cs
+++ b/src/Files.Uwp/Serialization/Implementation/CachingJsonSettingsDatabase.cs
@@ -25,7 +25,10 @@ namespace Files.Uwp.Serialization.Implementation
             }
             else
             {
-                base.SetValue(key, defaultValue);
+                if (base.SetValue(key, defaultValue))
+                {
+                    _settingsCache.Add(key, defaultValue);
+                }
                 return defaultValue;
             }
         }


### PR DESCRIPTION
**Details of Changes**
Add details of changes here.
- Fixed an issue causing settings to be repeatedly read from file in some cases
- Moved public SemaphoreSlim from App.cs to StorageHistoryHelpers (only place it's used)

**Validation**
How did you test these changes?
- [x] Built and ran the app
