### PR TITLE
Fixed missing icon for network folder

### DIFF
--- a/src/Files.Uwp/DataModels/NavigationControlItems/DriveItem.cs
+++ b/src/Files.Uwp/DataModels/NavigationControlItems/DriveItem.cs
@@ -237,7 +237,7 @@ namespace Files.Uwp.DataModels.NavigationControlItems
             {
                 if (!string.IsNullOrEmpty(DeviceID))
                 {
-                    IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(DeviceID, 24);
+                    IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(DeviceID, 24, true);
                 }
                 if (IconData == null)
                 {

--- a/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
@@ -9,6 +9,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.AppService;
+using Windows.ApplicationModel.Core;
 using Windows.Foundation.Collections;
 
 namespace Files.Uwp.Filesystem
@@ -47,11 +48,24 @@ namespace Files.Uwp.Filesystem
                 ShowProperties = true
             };
 
+            SetIconAsync(networkItem);
+
             lock (drives)
             {
                 drives.Add(networkItem);
             }
             DataChanged?.Invoke(SectionType.Network, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, networkItem));
+        }
+
+        private static async void SetIconAsync(DriveItem networkItem)
+        {
+            var iconData = await UIHelpers.GetIconResourceInfo(Constants.ImageRes.Folder);
+            if (iconData is not null)
+            {
+                networkItem.IconData = iconData.IconDataBytes;
+                await CoreApplication.MainView.CoreWindow.DispatcherQueue
+                    .EnqueueAsync(async () => networkItem.Icon = await iconData.IconDataBytes.ToBitmapAsync());
+            }
         }
 
         public async Task UpdateDrivesAsync()

--- a/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
+++ b/src/Files.Uwp/Filesystem/NetworkDrivesManager.cs
@@ -9,7 +9,6 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.AppService;
-using Windows.ApplicationModel.Core;
 using Windows.Foundation.Collections;
 
 namespace Files.Uwp.Filesystem
@@ -48,24 +47,11 @@ namespace Files.Uwp.Filesystem
                 ShowProperties = true
             };
 
-            SetIconAsync(networkItem);
-
             lock (drives)
             {
                 drives.Add(networkItem);
             }
             DataChanged?.Invoke(SectionType.Network, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, networkItem));
-        }
-
-        private static async void SetIconAsync(DriveItem networkItem)
-        {
-            var iconData = await UIHelpers.GetIconResourceInfo(Constants.ImageRes.Folder);
-            if (iconData is not null)
-            {
-                networkItem.IconData = iconData.IconDataBytes;
-                await CoreApplication.MainView.CoreWindow.DispatcherQueue
-                    .EnqueueAsync(async () => networkItem.Icon = await iconData.IconDataBytes.ToBitmapAsync());
-            }
         }
 
         public async Task UpdateDrivesAsync()


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9715 

**Details of Changes**

- When adding a network drive item to drives section, so far we didn't attach an icon for it. 
- Fixed by adding an icon for the network folder

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots**
Before: 

![image](https://user-images.githubusercontent.com/24190373/185192181-b9c24aeb-3ede-4caf-9d79-225ef6a8c183.png)

After: 

![image](https://user-images.githubusercontent.com/24190373/185191931-d523969f-1af7-4aab-a001-ceadc7b9fedb.png)

