### PR TITLE
Removed x86 build from pipeline

### DIFF
--- a/builds/azure-pipelines-release.yml
+++ b/builds/azure-pipelines-release.yml
@@ -32,7 +32,7 @@ variables:
 - name: solution
   value: '**/*.sln'
 - name: buildPlatform
-  value: 'x86|x64|arm64'
+  value: 'x64|arm64'
 - name: buildConfiguration
   value: 'Release'
 - name: sideloadBuildConfiguration


### PR DESCRIPTION
**Details of Changes**
Add details of changes here.
Removed the x86 build from the pipeline, we should still support x86 but we no longer release x86 builds for users.

**Validation**
How did you test these changes?
- No testing required 

**Screenshots (optional)**
Add screenshots here.
