### PR TITLE
 Feature - Add uncompressed size for viewing zip properties #8990

### DIFF
--- a/src/Files.Uwp/Filesystem/ListedItem.cs
+++ b/src/Files.Uwp/Filesystem/ListedItem.cs
@@ -558,6 +558,22 @@ namespace Files.Uwp.Filesystem
             }
         }
 
+        private string uncompressedFileSize;
+
+        public string UncompressedFileSize
+        {
+            get => uncompressedFileSize;
+            set
+            {
+                SetProperty(ref uncompressedFileSize, value);
+                OnPropertyChanged(nameof(UncompressedFileSizeDisplay));
+            }
+        }
+
+        public string UncompressedFileSizeDisplay => string.IsNullOrEmpty(UncompressedFileSize) ? "ItemSizeNotCalculated".GetLocalized() : UncompressedFileSize;
+
+        public long UncompressedFileSizeBytes { get; set; }
+
         // Parameterless constructor for JsonConvert
         public ZipItem() : base()
         { }

--- a/src/Files.Uwp/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
+++ b/src/Files.Uwp/Filesystem/StorageEnumerators/Win32StorageEnumerator.cs
@@ -370,6 +370,7 @@ namespace Files.Uwp.Filesystem.StorageEnumerators
             {
                 if (ZipStorageFolder.IsZipPath(itemPath) && await ZipStorageFolder.CheckDefaultZipApp(itemPath))
                 {
+                    long uncompressedSizeBytes = await ZipStorageFolder.GetUncompressedSize(itemPath);
                     return new ZipItem(null)
                     {
                         PrimaryItemAttribute = StorageItemTypes.Folder, // Treat zip files as folders
@@ -385,7 +386,9 @@ namespace Files.Uwp.Filesystem.StorageEnumerators
                         ItemType = itemType,
                         ItemPath = itemPath,
                         FileSize = itemSize,
-                        FileSizeBytes = itemSizeBytes
+                        FileSizeBytes = itemSizeBytes,
+                        UncompressedFileSizeBytes = uncompressedSizeBytes,
+                        UncompressedFileSize = uncompressedSizeBytes.ToSizeString()
                     };
                 }
                 else

--- a/src/Files.Uwp/Strings/en-US/Resources.resw
+++ b/src/Files.Uwp/Strings/en-US/Resources.resw
@@ -165,6 +165,9 @@
   <data name="PropertiesItemSize.Text" xml:space="preserve">
     <value>Size:</value>
   </data>
+  <data name="PropertiesUncompressedItemSize.Text" xml:space="preserve">
+    <value>Uncompressed Size:</value>
+  </data>
   <data name="ErrorDialogThisActionCannotBeDone" xml:space="preserve">
     <value>This action cannot be done</value>
   </data>

--- a/src/Files.Uwp/ViewModels/Properties/FileProperties.cs
+++ b/src/Files.Uwp/ViewModels/Properties/FileProperties.cs
@@ -108,6 +108,12 @@ namespace Files.Uwp.ViewModels.Properties
             ViewModel.ItemSizeVisibility = true;
             ViewModel.ItemSize = Item.FileSizeBytes.ToLongSizeString();
 
+            if (Item.IsZipItem)
+            {
+                ViewModel.UncompressedItemSizeVisibility = true;
+                ViewModel.UncompressedItemSize = ((ZipItem)Item).UncompressedFileSizeBytes.ToLongSizeString();
+            }
+
             var fileIconData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.ItemPath, 80, Windows.Storage.FileProperties.ThumbnailMode.DocumentsView, false);
             if (fileIconData != null)
             {

--- a/src/Files.Uwp/ViewModels/Properties/FileProperties.cs
+++ b/src/Files.Uwp/ViewModels/Properties/FileProperties.cs
@@ -112,6 +112,7 @@ namespace Files.Uwp.ViewModels.Properties
             {
                 ViewModel.UncompressedItemSizeVisibility = true;
                 ViewModel.UncompressedItemSize = ((ZipItem)Item).UncompressedFileSizeBytes.ToLongSizeString();
+                ViewModel.UncompressedItemSizeBytes = ((ZipItem)Item).UncompressedFileSizeBytes;
             }
 
             var fileIconData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.ItemPath, 80, Windows.Storage.FileProperties.ThumbnailMode.DocumentsView, false);

--- a/src/Files.Uwp/ViewModels/SelectedItemsPropertiesViewModel.cs
+++ b/src/Files.Uwp/ViewModels/SelectedItemsPropertiesViewModel.cs
@@ -168,12 +168,29 @@ namespace Files.Uwp.ViewModels
             set => SetProperty(ref itemSize, value);
         }
 
+        private string uncompresseditemSize;
+
+        public string UncompressedItemSize
+        {
+            get => uncompresseditemSize;
+            set => SetProperty(ref uncompresseditemSize, value);
+        }
+
+
         private bool itemSizeVisibility = false;
 
         public bool ItemSizeVisibility
         {
             get => itemSizeVisibility;
             set => SetProperty(ref itemSizeVisibility, value);
+        }
+
+        private bool uncompresseditemSizeVisibility = false;
+
+        public bool UncompressedItemSizeVisibility
+        {
+            get => uncompresseditemSizeVisibility;
+            set => SetProperty(ref uncompresseditemSizeVisibility, value);
         }
 
         private long itemSizeBytes;
@@ -184,12 +201,28 @@ namespace Files.Uwp.ViewModels
             set => SetProperty(ref itemSizeBytes, value);
         }
 
+        private long uncompresseditemSizeBytes;
+
+        public long UncompressedItemSizeBytes
+        {
+            get => uncompresseditemSizeBytes;
+            set => SetProperty(ref uncompresseditemSizeBytes, value);
+        }
+
         private bool itemSizeProgressVisibility = false;
 
         public bool ItemSizeProgressVisibility
         {
             get => itemSizeProgressVisibility;
             set => SetProperty(ref itemSizeProgressVisibility, value);
+        }
+
+        private bool uncompresseditemSizeProgressVisibility = false;
+
+        public bool UncompressedItemSizeProgressVisibility
+        {
+            get => uncompresseditemSizeProgressVisibility;
+            set => SetProperty(ref uncompresseditemSizeProgressVisibility, value);
         }
 
         public string itemMD5Hash;

--- a/src/Files.Uwp/Views/Pages/PropertiesGeneral.xaml
+++ b/src/Files.Uwp/Views/Pages/PropertiesGeneral.xaml
@@ -199,6 +199,36 @@
                             Visibility="{x:Bind ViewModel.ItemSizeProgressVisibility, Mode=OneWay}" />
                     </Grid>
 
+                    <!--  Uncompressed Item size  -->
+                    <TextBlock
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        HorizontalAlignment="Left"
+                        Style="{StaticResource PropertyName}"
+                        Text="{helpers:ResourceString Name=PropertiesUncompressedItemSize/Text}"
+                        Visibility="{x:Bind ViewModel.UncompressedItemSizeVisibility, Mode=OneWay}" />
+                    <Grid
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Style="{StaticResource PropertyValueGrid}"
+                        Visibility="{x:Bind ViewModel.UncompressedItemSizeVisibility, Mode=OneWay}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" MinWidth="100" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            x:Name="UncompresseditemSizeValue"
+                            Grid.Column="0"
+                            IsTextSelectionEnabled="True"
+                            Text="{x:Bind ViewModel.UncompressedItemSize, Mode=OneWay}" />
+                        <muxc:ProgressBar
+                            x:Name="UncompressedItemSizeProgress"
+                            Grid.Column="1"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            Visibility="{x:Bind ViewModel.UncompressedItemSizeProgressVisibility, Mode=OneWay}" />
+                    </Grid>
+
                     <MenuFlyoutSeparator
                         Grid.Row="2"
                         Grid.Column="0"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #8990

**Details of Changes**
- In Properties General: Added new display
- In Resources.resw (en-US): Added new item for uncompressed prompt
- In ZipStorageFolder: Add function using SevenZipSharp to extract the zip by file path, and then loop through the extracted data summing the size

**Validation**
How did you test these changes?
- Built and ran the app
- Tested the changes and compared the result to what the file size is if you extract

**Screenshots (optional)**
![image](https://user-images.githubusercontent.com/16448374/185783699-a282ee09-2a2d-4afa-a16f-23010b6206ec.png)
![image](https://user-images.githubusercontent.com/16448374/185783725-d9689ff6-85fe-4cfa-b800-7574fb5da59d.png)
