### PR TITLE
Add cast from IDictionary to ConcurrentDictionary

### DIFF
--- a/src/Files.Shared/Extensions/LinqExtensions.cs
+++ b/src/Files.Shared/Extensions/LinqExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -53,7 +54,14 @@ namespace Files.Shared.Extensions
                 var defaultValue = defaultValueFunc();
                 if (defaultValue is Task<TValue?> value)
                 {
-                    dictionary.Add(key, value);
+                    if (dictionary is ConcurrentDictionary<TKey, Task<TValue?>> cDict)
+                    {
+                        cDict.TryAdd(key, value);
+                    }
+                    else
+                    {
+                        dictionary.Add(key, value);
+                    }
                 }
                 return defaultValue;
             }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes Appcenter 2855768364u

**Details of Changes**
Add details of changes here.
- Calling Add() on a ConcurrentDictionary cast to IDictionary breaks concurrency. Need to cast it to ConcurrentDictionary and call TryAdd explicitly.

**Validation**
How did you test these changes?
- [x] Built and ran the app
