### PR TITLE
Focus on new folder by default when using ctrl + shift + n (#9704)

### DIFF
--- a/src/Files.Uwp/Dialogs/AddItemDialog.xaml
+++ b/src/Files.Uwp/Dialogs/AddItemDialog.xaml
@@ -1,12 +1,12 @@
 ﻿<ContentDialog
     x:Class="Files.Uwp.Dialogs.AddItemDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:vm="using:Files.Backend.ViewModels.Dialogs.AddItemDialog"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="using:Files.Uwp.Helpers"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vc="using:Files.Uwp.ValueConverters"
+    xmlns:vm="using:Files.Backend.ViewModels.Dialogs.AddItemDialog"
     x:Name="AddDialog"
     Title="{helpers:ResourceString Name=AddDialog/Title}"
     Grid.RowSpan="4"
@@ -45,7 +45,10 @@
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="vm:AddItemDialogListItemViewModel">
                         <Grid Height="50">
-                            <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
+                            <StackPanel
+                                VerticalAlignment="Center"
+                                Loaded="AddItemListViewItem_Loaded"
+                                Orientation="Horizontal">
                                 <Grid Margin="0,0,10,0" VerticalAlignment="Center">
                                     <Viewbox
                                         x:Name="IconRoot"

--- a/src/Files.Uwp/Dialogs/AddItemDialog.xaml.cs
+++ b/src/Files.Uwp/Dialogs/AddItemDialog.xaml.cs
@@ -38,5 +38,14 @@ namespace Files.Uwp.Dialogs
             var itemTypes = await ShellNewEntryExtensions.GetNewContextMenuEntries();
             await ViewModel.AddItemsToList(itemTypes); // TODO(i): This is a very cheap way of doing it, consider adding a service to retrieve the itemTypes list.
         }
+
+        private void AddItemListViewItem_Loaded(object sender, RoutedEventArgs e)
+        {
+            ListViewItem file = AddItemsListView.ContainerFromIndex(0) as ListViewItem;
+            if (file != null)
+            {
+                file.Focus(FocusState.Keyboard);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Focus on "Folder" when using shortcut "Ctrl + Shift + N"

- Closes [https://github.com/files-community/Files/issues/9610](https://github.com/files-community/Files/issues/9610)

**Details of Changes**
- Added Method on `AddItemDialog.xaml.cs` that sets Focus on first ListViewItem which is "Folder"
- Added Loaded event on `AddItemDialog.xaml` to execute Focus function.

**Validation**
- [x] Built and ran the app
- [x] Tested the changes for accessibility 
