### PR TITLE
Fix: Resolve full path for relative paths

### DIFF
--- a/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/src/Files.Uwp/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -172,6 +172,11 @@ namespace Files.Uwp.Filesystem
             return Environment.ExpandEnvironmentVariables(path);
         }
 
+        public static string GetResolvedPath(string path)
+        {            
+            return Path.GetFullPath(path);
+        }
+
         public async static Task<BaseStorageFile> DangerousGetFileFromPathAsync
             (string value, StorageFolderWithPath rootFolder = null, StorageFolderWithPath parentFolder = null)
                 => (await DangerousGetFileWithPathFromPathAsync(value, rootFolder, parentFolder)).Item;

--- a/src/Files.Uwp/ViewModels/ToolbarViewModel.cs
+++ b/src/Files.Uwp/ViewModels/ToolbarViewModel.cs
@@ -992,6 +992,7 @@ namespace Files.Uwp.ViewModels
                 else
                 {
                     currentInput = StorageFileExtensions.GetPathWithoutEnvironmentVariable(currentInput);
+                    currentInput = StorageFileExtensions.GetResolvedPath(currentInput);
                     if (currentSelectedPath == currentInput)
                     {
                         return;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clarified title
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9808 

**Details of Changes**
Add details of changes here.
- Resolve full path to handle relative path inputs

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots (optional)**
Screenshots

When the input is : `%appdata%\..\LocalLow`, Files resolve to the relative path:


![Te1](https://user-images.githubusercontent.com/24190373/186979313-1c9e7714-5a06-4e25-82d0-a0352a69ff6e.jpg)

