### PR TITLE
Feature: Support double click in the column layout #9704

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -453,10 +453,12 @@ namespace Files.App.Views.LayoutModes
         private void FileList_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
         {
             var clickedItem = e.OriginalSource as FrameworkElement;
-            if (clickedItem?.DataContext is ListedItem item
-                 && !UserSettingsService.PreferencesSettingsService.OpenFilesWithOneClick && item.PrimaryItemAttribute == StorageItemTypes.File)
+            if (clickedItem?.DataContext is ListedItem item)
             {
-                NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                if (!UserSettingsService.PreferencesSettingsService.OpenFilesWithOneClick && item.PrimaryItemAttribute == StorageItemTypes.File)
+                {
+                    NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                }
             }
             else
             {


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #9704 

**Details of Changes**
- I splitted the 'if' that checks if the item should be opened so that even if SelectedItem is a folder, the Up_Click() method is not called

**Validation**
- Built and ran the app
