### PR TITLE
Fix: Removed FluentUI reference

### DIFF
--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2319,12 +2319,6 @@
   <data name="SettingsPrivacy.Title" xml:space="preserve">
     <value>Privacy policy</value>
   </data>
-  <data name="SettingsFluentUISystemIconsLicenseButton.Content" xml:space="preserve">
-    <value>Fluent UI System Icons</value>
-  </data>
-  <data name="SettingsFluentUISystemIconsLicenseButton.AutomationProperties.Name" xml:space="preserve">
-    <value>Fluent UI System Icons</value>
-  </data>
   <data name="SettingsPrivacyPolicyMarkdownBlock.Text" xml:space="preserve">
     <value>
 We use App Center to track which settings are being used, find bugs, and fix crashes. Information sent to App Center is anonymous and free of any user or contextual data.

--- a/src/Files.App/Views/SettingsPages/About.xaml
+++ b/src/Files.App/Views/SettingsPages/About.xaml
@@ -283,11 +283,6 @@
 							AutomationProperties.Name="7-Zip (GNU LGPL)"
 							Content="7-Zip (GNU LGPL)"
 							NavigateUri="https://7-zip.org" />
-
-						<HyperlinkButton
-							AutomationProperties.Name="{helpers:ResourceString Name=SettingsFluentUISystemIconsLicenseButton/AutomationProperties/Name}"
-							Content="{helpers:ResourceString Name=SettingsFluentUISystemIconsLicenseButton/Content}"
-							NavigateUri="https://github.com/microsoft/fluentui-system-icons/blob/master/LICENSE" />
 					</StackPanel>
 				</local:SettingsBlockControl.ExpandableContent>
 			</local:SettingsBlockControl>


### PR DESCRIPTION
FluentUI isn't hard coded into Files so are no longer required to reference the license

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
