### PR TITLE
Feature: Hide minimize/maximize buttons on the properties window

### DIFF
--- a/src/Files.App/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Helpers/FilePropertiesHelpers.cs
@@ -59,8 +59,7 @@ namespace Files.App.Helpers
                     var propertiesWindow = new WinUIEx.WindowEx()
                     {
                         IsMaximizable = false,
-                        IsMinimizable = false,
-                        IsResizable = false
+                        IsMinimizable = false
                     };
                     var appWindow = propertiesWindow.AppWindow;
 

--- a/src/Files.App/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Helpers/FilePropertiesHelpers.cs
@@ -1,17 +1,18 @@
 using Files.App.Dialogs;
-using Files.App.Views;
 using Files.App.Extensions;
+using Files.App.Views;
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Animation;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.Foundation.Metadata;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media.Animation;
 using Windows.Graphics;
-using Microsoft.UI;
 using static Files.App.Views.Properties;
-using Microsoft.UI.Windowing;
+
+#nullable enable
 
 namespace Files.App.Helpers
 {
@@ -22,35 +23,25 @@ namespace Files.App.Helpers
             if (associatedInstance.SlimContentPage.IsItemSelected)
             {
                 if (associatedInstance.SlimContentPage.SelectedItems.Count > 1)
-                {
                     await OpenPropertiesWindowAsync(associatedInstance.SlimContentPage.SelectedItems, associatedInstance);
-                }
                 else
-                {
                     await OpenPropertiesWindowAsync(associatedInstance.SlimContentPage.SelectedItem, associatedInstance);
-                }
             }
             else
             {
-                if (!System.IO.Path.GetPathRoot(associatedInstance.FilesystemViewModel.CurrentFolder.ItemPath)
-                    .Equals(associatedInstance.FilesystemViewModel.CurrentFolder.ItemPath, StringComparison.OrdinalIgnoreCase))
-                {
+                var path = System.IO.Path.GetPathRoot(associatedInstance.FilesystemViewModel.CurrentFolder.ItemPath);
+                if (path is not null && path.Equals(associatedInstance.FilesystemViewModel.CurrentFolder.ItemPath, StringComparison.OrdinalIgnoreCase))
                     await OpenPropertiesWindowAsync(associatedInstance.FilesystemViewModel.CurrentFolder, associatedInstance);
-                }
                 else
-                {
                     await OpenPropertiesWindowAsync(App.DrivesManager.Drives
-                        .SingleOrDefault(x => x.Path.Equals(associatedInstance.FilesystemViewModel.CurrentFolder.ItemPath)), associatedInstance);
-                }
+                        .Single(x => x.Path.Equals(associatedInstance.FilesystemViewModel.CurrentFolder.ItemPath)), associatedInstance);
             }
         }
 
         public static async Task OpenPropertiesWindowAsync(object item, IShellPage associatedInstance)
         {
             if (item == null)
-            {
                 return;
-            }
 
             if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
             {
@@ -65,7 +56,12 @@ namespace Files.App.Helpers
                     }, new SuppressNavigationTransitionInfo());
 
                     // Initialize window
-                    var propertiesWindow = new WinUIEx.WindowEx();
+                    var propertiesWindow = new WinUIEx.WindowEx()
+                    {
+                        IsMaximizable = false,
+                        IsMinimizable = false,
+                        IsResizable = false
+                    };
                     var appWindow = propertiesWindow.AppWindow;
 
                     // Set content


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #9931 

**Changes**
- Now minimize and maximize buttons are hidden.
- Now the properties window can't be resized by the user

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![Screenshot (40)](https://user-images.githubusercontent.com/102259289/189212819-add7c6c5-0eb9-4aae-9f37-f5aa58fc991e.png)
