### PR TITLE
Workaround for titlebar drag area on windows 10

### DIFF
--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -134,7 +134,18 @@ namespace Files.App.Views
 
 		private void HorizontalMultitaskingControl_Loaded(object sender, RoutedEventArgs e)
 		{
-			horizontalMultitaskingControl.DragArea.SizeChanged += (_, _) => SetRectDragRegion();
+            // WINUI3: bad workaround to be removed asap!
+            // SetDragRectangles() does not work on windows 10 with winappsdk "1.2.220902.1-preview1"
+            if (Environment.OSVersion.Version.Build >= 22000)
+			{
+                horizontalMultitaskingControl.DragArea.SizeChanged += (_, _) => SetRectDragRegion();
+            }
+			else
+			{
+				App.Window.AppWindow.TitleBar.ExtendsContentIntoTitleBar = false;
+				App.Window.ExtendsContentIntoTitleBar = true;
+				App.Window.SetTitleBar(horizontalMultitaskingControl.DragArea);
+			}
 
 			if (!(ViewModel.MultitaskingControl is HorizontalMultitaskingControl))
 			{

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -134,12 +134,12 @@ namespace Files.App.Views
 
 		private void HorizontalMultitaskingControl_Loaded(object sender, RoutedEventArgs e)
 		{
-            // WINUI3: bad workaround to be removed asap!
-            // SetDragRectangles() does not work on windows 10 with winappsdk "1.2.220902.1-preview1"
-            if (Environment.OSVersion.Version.Build >= 22000)
+			// WINUI3: bad workaround to be removed asap!
+			// SetDragRectangles() does not work on windows 10 with winappsdk "1.2.220902.1-preview1"
+			if (Environment.OSVersion.Version.Build >= 22000)
 			{
-                horizontalMultitaskingControl.DragArea.SizeChanged += (_, _) => SetRectDragRegion();
-            }
+				horizontalMultitaskingControl.DragArea.SizeChanged += (_, _) => SetRectDragRegion();
+			}
 			else
 			{
 				App.Window.AppWindow.TitleBar.ExtendsContentIntoTitleBar = false;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes dragging the window on windows 10

Despite the docs, SetDragRectangles() still does not work on win10 with winappsdk "1.2.220902.1-preview1" :/
Confirmed on Discord.
The workaround is kinda ugly, if you prefer to just wait for a fix from winappsdk I'm ok to not merge this. Does not change things on win11.

**Validation**
How did you test these changes?
- [x] Built and ran the app
