### PR TITLE
Fixed: Properties window opens behind main app window

### DIFF
--- a/src/Files.App/IBaseLayout.cs
+++ b/src/Files.App/IBaseLayout.cs
@@ -25,5 +25,6 @@ namespace Files.App
         public SelectedItemsPropertiesViewModel SelectedItemsPropertiesViewModel { get; }
         public DirectoryPropertiesViewModel DirectoryPropertiesViewModel { get; }
         public BaseLayoutCommandsViewModel CommandsViewModel { get; }
+        public Microsoft.UI.Xaml.Controls.CommandBarFlyout ItemContextMenuFlyout { get; set; }
     }
 }

--- a/src/Files.App/IBaseLayout.cs
+++ b/src/Files.App/IBaseLayout.cs
@@ -1,6 +1,7 @@
 using Files.App.Filesystem;
 using Files.App.Interacts;
 using Files.App.ViewModels;
+using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
 
@@ -25,6 +26,6 @@ namespace Files.App
         public SelectedItemsPropertiesViewModel SelectedItemsPropertiesViewModel { get; }
         public DirectoryPropertiesViewModel DirectoryPropertiesViewModel { get; }
         public BaseLayoutCommandsViewModel CommandsViewModel { get; }
-        public Microsoft.UI.Xaml.Controls.CommandBarFlyout ItemContextMenuFlyout { get; set; }
+        public CommandBarFlyout ItemContextMenuFlyout { get; set; }
     }
 }

--- a/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -194,11 +194,17 @@ namespace Files.App.Interacts
 
         public virtual void ShowFolderProperties(RoutedEventArgs e)
         {
-            FilePropertiesHelpers.ShowProperties(associatedInstance);
+            SlimContentPage.ItemContextMenuFlyout.Closed += OpenProperties;
         }
 
         public virtual void ShowProperties(RoutedEventArgs e)
         {
+            SlimContentPage.ItemContextMenuFlyout.Closed += OpenProperties;
+        }
+
+        private void OpenProperties(object sender, object e)
+        {
+            SlimContentPage.ItemContextMenuFlyout.Closed -= OpenProperties;
             FilePropertiesHelpers.ShowProperties(associatedInstance);
         }
 

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml
@@ -77,7 +77,8 @@
 						Tag="{x:Bind Item.Path}"
 						ToolTipService.ToolTip="{x:Bind Item.Text, Mode=OneWay}">
 						<Button.ContextFlyout>
-							<MenuFlyout Opening="MenuFlyout_Opening">
+							<MenuFlyout Opening="MenuFlyout_Opening"
+                                        Closed="MenuFlyout_Closed">
 								<MenuFlyout.Items>
 									<MenuFlyoutItem
 										x:Name="OpenInNewPane"

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -92,6 +92,8 @@ namespace Files.App.UserControls.Widgets
             }
         }
 
+        private DriveItem? propertiesItem = null;
+
         public string WidgetName => nameof(DrivesWidget);
 
         public string AutomationProperties => "DrivesWidgetAutomationProperties/Name".GetLocalizedResource();
@@ -189,8 +191,7 @@ namespace Files.App.UserControls.Widgets
 
         private async void OpenDriveProperties_Click(object sender, RoutedEventArgs e)
         {
-            var item = ((MenuFlyoutItem)sender).DataContext as DriveItem;
-            await FilePropertiesHelpers.OpenPropertiesWindowAsync(item, associatedInstance);
+            propertiesItem = ((MenuFlyoutItem)sender).DataContext as DriveItem;
         }
 
         private async void Button_Click(object sender, RoutedEventArgs e)
@@ -328,6 +329,14 @@ namespace Files.App.UserControls.Widgets
         public void Dispose()
         {
 
+        }
+
+        private async void MenuFlyout_Closed(object sender, object e)
+        {
+            if (propertiesItem is null)
+                return;
+            await FilePropertiesHelpers.OpenPropertiesWindowAsync(propertiesItem, associatedInstance);
+            propertiesItem = null;
         }
     }
 }

--- a/src/Files.App/UserControls/Widgets/FolderWidget.xaml
+++ b/src/Files.App/UserControls/Widgets/FolderWidget.xaml
@@ -39,7 +39,8 @@
 						PointerPressed="Button_PointerPressed"
 						Tag="{x:Bind Path}">
 						<Button.ContextFlyout>
-							<MenuFlyout Opening="MenuFlyout_Opening">
+							<MenuFlyout Opening="MenuFlyout_Opening"
+                                        Closed="MenuFlyout_Closed">
 								<MenuFlyout.Items>
 									<MenuFlyoutItem
 										x:Name="OpenInNewPane"

--- a/src/Files.App/UserControls/Widgets/FolderWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/FolderWidget.xaml.cs
@@ -88,6 +88,8 @@ namespace Files.App.UserControls.Widgets
         public BulkConcurrentObservableCollection<FolderCardItem> ItemsAdded = new BulkConcurrentObservableCollection<FolderCardItem>();
         private bool showMultiPaneControls;
 
+        private FolderCardItem? propertiesItem = null;
+
         public FolderWidget()
         {
             InitializeComponent();
@@ -239,11 +241,7 @@ namespace Files.App.UserControls.Widgets
 
         private void OpenLibraryProperties_Click(object sender, RoutedEventArgs e)
         {
-            var item = (sender as MenuFlyoutItem).DataContext as FolderCardItem;
-            if (item.IsLibrary)
-            {
-                LibraryCardPropertiesInvoked?.Invoke(this, new LibraryCardEventArgs { Library = item.Item as LibraryLocationItem });
-            }
+            propertiesItem = (sender as MenuFlyoutItem)?.DataContext as FolderCardItem;
         }
 
         private async Task OpenLibraryCard(FolderCardItem item)
@@ -276,6 +274,15 @@ namespace Files.App.UserControls.Widgets
         public void Dispose()
         {
 
+        }
+
+        private void MenuFlyout_Closed(object sender, object e)
+        {
+            if (propertiesItem is null || !propertiesItem.IsLibrary)
+                return;
+
+            LibraryCardPropertiesInvoked?.Invoke(this, new LibraryCardEventArgs { Library = (propertiesItem.Item as LibraryLocationItem)! });
+            propertiesItem = null;
         }
     }
 }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9926 

**Comments**
- The root of the problem was that, after the properties windows was opened, the focus returned to the main window because of the closing of the flyout context menu. I fixed the bug opening Properties after the menu gets closed
- If everything is ok, I'll proceed with code cleanup

**Validation**
How did you test these changes?
- [x] Built and ran the app
