### PR TITLE
Fix shortcuts to folders opening outside Files

### DIFF
--- a/src/Files.Shared/ShellFileItem.cs
+++ b/src/Files.Shared/ShellFileItem.cs
@@ -4,16 +4,16 @@ namespace Files.Shared
 {
     public class ShellFileItem
     {
-        public bool IsFolder;
-        public string RecyclePath;
-        public string FileName;
-        public string FilePath;
-        public DateTime RecycleDate;
-        public DateTime ModifiedDate;
-        public DateTime CreatedDate;
-        public string FileSize;
-        public ulong FileSizeBytes;
-        public string FileType;
+        public bool IsFolder { get; set; }
+        public string RecyclePath { get; set; }
+        public string FileName { get; set; }
+        public string FilePath { get; set; }
+        public DateTime RecycleDate { get; set; }
+        public DateTime ModifiedDate { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public string FileSize { get; set; }
+        public ulong FileSizeBytes { get; set; }
+        public string FileType { get; set; }
 
         public ShellFileItem()
         {

--- a/src/Files.Shared/ShellLibraryItem.cs
+++ b/src/Files.Shared/ShellLibraryItem.cs
@@ -15,7 +15,7 @@ namespace Files.Shared
         /// C:\Users\[username]\AppData\Roaming\Microsoft\Windows\Libraries\Documents.library-ms<br/>
         /// C:\Users\[username]\AppData\Roaming\Microsoft\Windows\Libraries\Custom library.library-ms
         /// </summary>
-        public string FullPath;
+        public string FullPath { get; set; }
 
         /// <summary>
         /// ShellItemDisplayString.DesktopAbsoluteParsing<br/>
@@ -23,7 +23,7 @@ namespace Files.Shared
         /// ::{031E4825-7B94-4DC3-B131-E946B44C8DD5}\Documents.library-ms<br/>
         /// C:\Users\[username]\AppData\Roaming\Microsoft\Windows\Libraries\Custom library.library-ms
         /// </summary>
-        public string AbsolutePath;
+        public string AbsolutePath { get; set; }
 
         /// <summary>
         /// ShellItemDisplayString.ParentRelativeParsing<br/>
@@ -31,7 +31,7 @@ namespace Files.Shared
         /// {7B0DB17D-9CD2-4A93-9733-46CC89022E7C}<br/>
         /// Custom library.library-ms
         /// </summary>
-        public string RelativePath;
+        public string RelativePath { get; set; }
 
         /// <summary>
         /// ShellItemDisplayString.NormalDisplay<br/>
@@ -39,11 +39,11 @@ namespace Files.Shared
         /// Documents (locale dependent based on desktop.ini file of the Libraries folder)<br/>
         /// Custom library (locale independent)
         /// </summary>
-        public string DisplayName;
+        public string DisplayName { get; set; }
 
-        public bool IsPinned;
-        public string DefaultSaveFolder;
-        public string[] Folders;
+        public bool IsPinned { get; set; }
+        public string DefaultSaveFolder { get; set; }
+        public string[] Folders { get; set; }
 
         public ShellLibraryItem()
         {

--- a/src/Files.Shared/ShellLinkItem.cs
+++ b/src/Files.Shared/ShellLinkItem.cs
@@ -2,10 +2,10 @@
 {
     public class ShellLinkItem : ShellFileItem
     {
-        public string TargetPath;
-        public string Arguments;
-        public string WorkingDirectory;
-        public bool RunAsAdmin;
+        public string TargetPath { get; set; }
+        public string Arguments { get; set; }
+        public string WorkingDirectory { get; set; }
+        public bool RunAsAdmin { get; set; }
 
         public ShellLinkItem()
         {


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue where lnk to folders open in explorer instead of Files

**Changes**
Change fields that must be serialized to json into properties. System.Text.Json.JsonSerializer does not serialize fields by default (unlike JsonConvert).

**Validation**
How did you test these changes?
- [x] Built and ran the app
