### PR TITLE
Remove unused class IsExternalInit

### DIFF
--- a/src/Files.App.Storage/IsExternalInit.cs
+++ b/src/Files.App.Storage/IsExternalInit.cs
@@ -1,7 +1,0 @@
-using System.ComponentModel;
-
-namespace System.Runtime.CompilerServices
-{
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal sealed class IsExternalInit {}
-}

--- a/src/Files.App/IsExternalInit.cs
+++ b/src/Files.App/IsExternalInit.cs
@@ -1,7 +1,0 @@
-using System.ComponentModel;
-
-namespace System.Runtime.CompilerServices
-{
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    internal sealed class IsExternalInit {}
-}


### PR DESCRIPTION
**Resolved / Related Issues**
IsExternalInit classes were added to handle the init keyword. These classes are no longer needed for .NET 6 because this keyword is natively managed. This pr removes these files for .net 6 projects only. This has no effect on the software.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility