### PR TITLE
Fix: Fixed issue where the option to leave compact overlay didn't work

### DIFF
--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml.cs
@@ -18,140 +18,140 @@ using System.Windows.Input;
 
 namespace Files.App.UserControls
 {
-    public sealed partial class InnerNavigationToolbar : UserControl
-    {
-        public InnerNavigationToolbar()
-        {
-            this.InitializeComponent();
-        }
+	public sealed partial class InnerNavigationToolbar : UserControl
+	{
+		public InnerNavigationToolbar()
+		{
+			this.InitializeComponent();
+		}
 
-        public IUserSettingsService UserSettingsService { get; } =
-            Ioc.Default.GetService<IUserSettingsService>()!;
+		public IUserSettingsService UserSettingsService { get; } =
+			Ioc.Default.GetService<IUserSettingsService>()!;
 
-        public AppModel AppModel => App.AppModel;
+		public AppModel AppModel => App.AppModel;
 
-        public ToolbarViewModel ViewModel
-        {
-            get => (ToolbarViewModel)GetValue(ViewModelProperty);
-            set => SetValue(ViewModelProperty, value);
-        }
+		public ToolbarViewModel ViewModel
+		{
+			get => (ToolbarViewModel)GetValue(ViewModelProperty);
+			set => SetValue(ViewModelProperty, value);
+		}
 
-        // Using a DependencyProperty as the backing store for ViewModel.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty ViewModelProperty =
-            DependencyProperty.Register(nameof(ViewModel), typeof(ToolbarViewModel), typeof(InnerNavigationToolbar), new PropertyMetadata(null));
+		// Using a DependencyProperty as the backing store for ViewModel.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty ViewModelProperty =
+			DependencyProperty.Register(nameof(ViewModel), typeof(ToolbarViewModel), typeof(InnerNavigationToolbar), new PropertyMetadata(null));
 
-        public bool ShowPreviewPaneButton
-        {
-            get { return (bool)GetValue(ShowPreviewPaneButtonProperty); }
-            set { SetValue(ShowPreviewPaneButtonProperty, value); }
-        }
+		public bool ShowPreviewPaneButton
+		{
+			get { return (bool)GetValue(ShowPreviewPaneButtonProperty); }
+			set { SetValue(ShowPreviewPaneButtonProperty, value); }
+		}
 
-        // Using a DependencyProperty as the backing store for ShowPreviewPaneButton.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty ShowPreviewPaneButtonProperty =
-            DependencyProperty.Register("ShowPreviewPaneButton", typeof(bool), typeof(AddressToolbar), new PropertyMetadata(null));
+		// Using a DependencyProperty as the backing store for ShowPreviewPaneButton.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty ShowPreviewPaneButtonProperty =
+			DependencyProperty.Register("ShowPreviewPaneButton", typeof(bool), typeof(AddressToolbar), new PropertyMetadata(null));
 
-        public bool ShowMultiPaneControls
-        {
-            get => (bool)GetValue(ShowMultiPaneControlsProperty);
-            set => SetValue(ShowMultiPaneControlsProperty, value);
-        }
+		public bool ShowMultiPaneControls
+		{
+			get => (bool)GetValue(ShowMultiPaneControlsProperty);
+			set => SetValue(ShowMultiPaneControlsProperty, value);
+		}
 
-        // Using a DependencyProperty as the backing store for ShowMultiPaneControls.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty ShowMultiPaneControlsProperty =
-            DependencyProperty.Register(nameof(ShowMultiPaneControls), typeof(bool), typeof(AddressToolbar), new PropertyMetadata(null));
+		// Using a DependencyProperty as the backing store for ShowMultiPaneControls.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty ShowMultiPaneControlsProperty =
+			DependencyProperty.Register(nameof(ShowMultiPaneControls), typeof(bool), typeof(AddressToolbar), new PropertyMetadata(null));
 
-        public bool IsMultiPaneActive
-        {
-            get { return (bool)GetValue(IsMultiPaneActiveProperty); }
-            set { SetValue(IsMultiPaneActiveProperty, value); }
-        }
+		public bool IsMultiPaneActive
+		{
+			get { return (bool)GetValue(IsMultiPaneActiveProperty); }
+			set { SetValue(IsMultiPaneActiveProperty, value); }
+		}
 
-        // Using a DependencyProperty as the backing store for IsMultiPaneActive.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty IsMultiPaneActiveProperty =
-            DependencyProperty.Register("IsMultiPaneActive", typeof(bool), typeof(AddressToolbar), new PropertyMetadata(false));
+		// Using a DependencyProperty as the backing store for IsMultiPaneActive.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty IsMultiPaneActiveProperty =
+			DependencyProperty.Register("IsMultiPaneActive", typeof(bool), typeof(AddressToolbar), new PropertyMetadata(false));
 
-        public bool IsCompactOverlay
-        {
-            get { return (bool)GetValue(IsCompactOverlayProperty); }
-            set { SetValue(IsCompactOverlayProperty, value); }
-        }
+		public bool IsCompactOverlay
+		{
+			get { return (bool)GetValue(IsCompactOverlayProperty); }
+			set { SetValue(IsCompactOverlayProperty, value); }
+		}
 
-        // Using a DependencyProperty as the backing store for IsCompactOverlay.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty IsCompactOverlayProperty =
-            DependencyProperty.Register("IsCompactOverlay", typeof(bool), typeof(AddressToolbar), new PropertyMetadata(null));
+		// Using a DependencyProperty as the backing store for IsCompactOverlay.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty IsCompactOverlayProperty =
+			DependencyProperty.Register("IsCompactOverlay", typeof(bool), typeof(AddressToolbar), new PropertyMetadata(null));
 
-        public ICommand SetCompactOverlayCommand
-        {
-            get { return (ICommand)GetValue(SetCompactOverlayCommandProperty); }
-            set { SetValue(SetCompactOverlayCommandProperty, value); }
-        }
+		public ICommand SetCompactOverlayCommand
+		{
+			get { return (ICommand)GetValue(SetCompactOverlayCommandProperty); }
+			set { SetValue(SetCompactOverlayCommandProperty, value); }
+		}
 
-        // Using a DependencyProperty as the backing store for ToggleCompactOverlayCommand.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty SetCompactOverlayCommandProperty =
-            DependencyProperty.Register("ToggleCompactOverlayCommand", typeof(ICommand), typeof(AddressToolbar), new PropertyMetadata(null));
+		// Using a DependencyProperty as the backing store for ToggleCompactOverlayCommand.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty SetCompactOverlayCommandProperty =
+			DependencyProperty.Register("ToggleCompactOverlayCommand", typeof(ICommand), typeof(AddressToolbar), new PropertyMetadata(null));
 
-        private void NewEmptySpace_Opening(object sender, object e)
-        {
-            if (!ViewModel.InstanceViewModel.CanCreateFileInPage)
-            {
-                var shell = NewEmptySpace.Items.Where(x => (x.Tag as string) == "CreateNewFile").Reverse().ToList();
-                shell.ForEach(x => NewEmptySpace.Items.Remove(x));
-                return;
-            }
-            var cachedNewContextMenuEntries = ContextFlyoutItemHelper.CachedNewContextMenuEntries.IsCompletedSuccessfully ? ContextFlyoutItemHelper.CachedNewContextMenuEntries.Result : null;
-            if (cachedNewContextMenuEntries == null)
-                return;
-            if (!NewEmptySpace.Items.Any(x => (x.Tag as string) == "CreateNewFile"))
-            {
-                var separatorIndex = NewEmptySpace.Items.IndexOf(NewEmptySpace.Items.Single(x => x.Name == "NewMenuFileFolderSeparator"));
-                foreach (var newEntry in Enumerable.Reverse(cachedNewContextMenuEntries))
-                {
-                    MenuFlyoutItem menuLayoutItem;
-                    if (!string.IsNullOrEmpty(newEntry.IconBase64))
-                    {
-                        byte[] bitmapData = Convert.FromBase64String(newEntry.IconBase64);
-                        using var ms = new MemoryStream(bitmapData);
-                        var image = new BitmapImage();
-                        _ = image.SetSourceAsync(ms.AsRandomAccessStream());
-                        menuLayoutItem = new MenuFlyoutItemWithImage()
-                        {
-                            Text = newEntry.Name,
-                            BitmapIcon = image,
-                            Tag = "CreateNewFile"
-                        };
-                    }
-                    else
-                    {
-                        menuLayoutItem = new MenuFlyoutItem()
-                        {
-                            Text = newEntry.Name,
-                            Icon = new FontIcon()
-                            {
-                                Glyph = "\xE7C3"
-                            },
-                            Tag = "CreateNewFile"
-                        };
-                    }
-                    menuLayoutItem.Command = ViewModel.CreateNewFileCommand;
-                    menuLayoutItem.CommandParameter = newEntry;
-                    NewEmptySpace.Items.Insert(separatorIndex + 1, menuLayoutItem);
-                }
-            }
-        }
+		private void NewEmptySpace_Opening(object sender, object e)
+		{
+			if (!ViewModel.InstanceViewModel.CanCreateFileInPage)
+			{
+				var shell = NewEmptySpace.Items.Where(x => (x.Tag as string) == "CreateNewFile").Reverse().ToList();
+				shell.ForEach(x => NewEmptySpace.Items.Remove(x));
+				return;
+			}
+			var cachedNewContextMenuEntries = ContextFlyoutItemHelper.CachedNewContextMenuEntries.IsCompletedSuccessfully ? ContextFlyoutItemHelper.CachedNewContextMenuEntries.Result : null;
+			if (cachedNewContextMenuEntries == null)
+				return;
+			if (!NewEmptySpace.Items.Any(x => (x.Tag as string) == "CreateNewFile"))
+			{
+				var separatorIndex = NewEmptySpace.Items.IndexOf(NewEmptySpace.Items.Single(x => x.Name == "NewMenuFileFolderSeparator"));
+				foreach (var newEntry in Enumerable.Reverse(cachedNewContextMenuEntries))
+				{
+					MenuFlyoutItem menuLayoutItem;
+					if (!string.IsNullOrEmpty(newEntry.IconBase64))
+					{
+						byte[] bitmapData = Convert.FromBase64String(newEntry.IconBase64);
+						using var ms = new MemoryStream(bitmapData);
+						var image = new BitmapImage();
+						_ = image.SetSourceAsync(ms.AsRandomAccessStream());
+						menuLayoutItem = new MenuFlyoutItemWithImage()
+						{
+							Text = newEntry.Name,
+							BitmapIcon = image,
+							Tag = "CreateNewFile"
+						};
+					}
+					else
+					{
+						menuLayoutItem = new MenuFlyoutItem()
+						{
+							Text = newEntry.Name,
+							Icon = new FontIcon()
+							{
+								Glyph = "\xE7C3"
+							},
+							Tag = "CreateNewFile"
+						};
+					}
+					menuLayoutItem.Command = ViewModel.CreateNewFileCommand;
+					menuLayoutItem.CommandParameter = newEntry;
+					NewEmptySpace.Items.Insert(separatorIndex + 1, menuLayoutItem);
+				}
+			}
+		}
 
-        private void NavToolbarDetailsHeader_Tapped(object sender, TappedRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView(true);
-        private void NavToolbarTilesHeader_Tapped(object sender, TappedRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTiles(true);
-        private void NavToolbarSmallIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmall(true);
-        private void NavToolbarMediumIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium(true);
-        private void NavToolbarLargeIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLarge(true);
-        private void NavToolbarColumnsHeader_Tapped(object sender, TappedRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnView(true);
-        private void NavToolbarAdaptiveHeader_Tapped(object sender, TappedRoutedEventArgs e)
-            => ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeAdaptive();
-    }
+		private void NavToolbarDetailsHeader_Tapped(object sender, TappedRoutedEventArgs e)
+			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView(true);
+		private void NavToolbarTilesHeader_Tapped(object sender, TappedRoutedEventArgs e)
+			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTiles(true);
+		private void NavToolbarSmallIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
+			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmall(true);
+		private void NavToolbarMediumIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
+			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium(true);
+		private void NavToolbarLargeIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
+			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLarge(true);
+		private void NavToolbarColumnsHeader_Tapped(object sender, TappedRoutedEventArgs e)
+			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnView(true);
+		private void NavToolbarAdaptiveHeader_Tapped(object sender, TappedRoutedEventArgs e)
+			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeAdaptive();
+	}
 }

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml.cs
@@ -1,19 +1,20 @@
 using CommunityToolkit.Mvvm.DependencyInjection;
-using Files.Backend.Services.Settings;
+using Files.App.DataModels;
 using Files.App.Helpers;
 using Files.App.ViewModels;
-using System;
-using System.IO;
-using System.Linq;
-using System.Windows.Input;
-using Windows.UI.ViewManagement;
+using Files.Backend.Services.Settings;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Files.App.DataModels;
+using System;
+using System.IO;
+using System.Linq;
+using System.Windows.Input;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+#nullable enable
 
 namespace Files.App.UserControls
 {
@@ -25,7 +26,7 @@ namespace Files.App.UserControls
         }
 
         public IUserSettingsService UserSettingsService { get; } =
-            Ioc.Default.GetService<IUserSettingsService>();
+            Ioc.Default.GetService<IUserSettingsService>()!;
 
         public AppModel AppModel => App.AppModel;
 
@@ -38,50 +39,6 @@ namespace Files.App.UserControls
         // Using a DependencyProperty as the backing store for ViewModel.  This enables animation, styling, binding, etc...
         public static readonly DependencyProperty ViewModelProperty =
             DependencyProperty.Register(nameof(ViewModel), typeof(ToolbarViewModel), typeof(InnerNavigationToolbar), new PropertyMetadata(null));
-
-        private void NavToolbarEnterCompactOverlay_Click(object sender, RoutedEventArgs e)
-        {
-            var appWindow = App.GetAppWindow(App.Window);
-            if (appWindow.Presenter.Kind == Microsoft.UI.Windowing.AppWindowPresenterKind.CompactOverlay)
-            {
-                appWindow.SetPresenter(Microsoft.UI.Windowing.AppWindowPresenterKind.Overlapped);
-                NavToolbarExitCompactOverlay.Visibility = Visibility.Collapsed;
-                NavToolbarEnterCompactOverlay.Visibility = Visibility.Visible;
-            }
-            else
-            {
-                appWindow.SetPresenter(Microsoft.UI.Windowing.AppWindowPresenterKind.CompactOverlay);
-                NavToolbarExitCompactOverlay.Visibility = Visibility.Visible;
-                NavToolbarEnterCompactOverlay.Visibility = Visibility.Collapsed;
-            }
-        }
-
-        private void SetAppBarButtonProps(ICommandBarElement e)
-        {
-            if (e is AppBarButton appBarButton)
-            {
-                if (appBarButton.Icon is FontIcon bFontIcon)
-                {
-                    bFontIcon.Style = Resources["AccentColorFontIconStyle"] as Style;
-                }
-                if (appBarButton.LabelPosition == CommandBarLabelPosition.Collapsed)
-                {
-                    appBarButton.Width = 48;
-                }
-            }
-            else if (e is AppBarToggleButton appBarToggleButton)
-            {
-                if (appBarToggleButton.Icon is FontIcon tFontIcon)
-                {
-                    tFontIcon.Style = Resources["AccentColorFontIconStyle"] as Style;
-                }
-
-                if (appBarToggleButton.LabelPosition == CommandBarLabelPosition.Collapsed)
-                {
-                    appBarToggleButton.Width = 48;
-                }
-            }
-        }
 
         public bool ShowPreviewPaneButton
         {
@@ -143,9 +100,7 @@ namespace Files.App.UserControls
             }
             var cachedNewContextMenuEntries = ContextFlyoutItemHelper.CachedNewContextMenuEntries.IsCompletedSuccessfully ? ContextFlyoutItemHelper.CachedNewContextMenuEntries.Result : null;
             if (cachedNewContextMenuEntries == null)
-            {
                 return;
-            }
             if (!NewEmptySpace.Items.Any(x => (x.Tag as string) == "CreateNewFile"))
             {
                 var separatorIndex = NewEmptySpace.Items.IndexOf(NewEmptySpace.Items.Single(x => x.Name == "NewMenuFileFolderSeparator"));

--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -28,476 +28,476 @@ using Windows.System;
 
 namespace Files.App.ViewModels
 {
-    public class MainPageViewModel : ObservableObject
-    {
-        private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>()!;
+	public class MainPageViewModel : ObservableObject
+	{
+		private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>()!;
 
-        public IMultitaskingControl? MultitaskingControl { get; set; }
-        public List<IMultitaskingControl> MultitaskingControls { get; } = new List<IMultitaskingControl>();
+		public IMultitaskingControl? MultitaskingControl { get; set; }
+		public List<IMultitaskingControl> MultitaskingControls { get; } = new List<IMultitaskingControl>();
 
-        public static ObservableCollection<TabItem> AppInstances { get; private set; } = new ObservableCollection<TabItem>();
-
-
-        private TabItem? selectedTabItem;
-        public TabItem? SelectedTabItem
-        {
-            get => selectedTabItem;
-            set => SetProperty(ref selectedTabItem, value);
-        }
-
-        private bool isWindowCompactOverlay;
-        public bool IsWindowCompactOverlay
-        {
-            get => isWindowCompactOverlay;
-            set => SetProperty(ref isWindowCompactOverlay, value);
-        }
-
-        public ICommand NavigateToNumberedTabKeyboardAcceleratorCommand { get; private set; }
-
-        public ICommand OpenNewWindowAcceleratorCommand { get; private set; }
-
-        public ICommand CloseSelectedTabKeyboardAcceleratorCommand { get; private set; }
-
-        public ICommand AddNewInstanceAcceleratorCommand { get; private set; }
-
-        public ICommand ReopenClosedTabAcceleratorCommand { get; private set; }
-
-        public ICommand OpenSettingsCommand { get; private set; }
-
-        public MainPageViewModel()
-        {
-            // Create commands
-            NavigateToNumberedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(NavigateToNumberedTabKeyboardAccelerator);
-            OpenNewWindowAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(OpenNewWindowAccelerator);
-            CloseSelectedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(CloseSelectedTabKeyboardAccelerator);
-            AddNewInstanceAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(AddNewInstanceAccelerator);
-            ReopenClosedTabAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(ReopenClosedTabAccelerator);
-            OpenSettingsCommand = new RelayCommand(OpenSettings);
-        }
-
-        private void NavigateToNumberedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
-        {
-            int indexToSelect = 0;
-            if (e is null)
-                return;
-            switch (e.KeyboardAccelerator.Key)
-            {
-                case VirtualKey.Number1:
-                    indexToSelect = 0;
-                    break;
-
-                case VirtualKey.Number2:
-                    indexToSelect = 1;
-                    break;
-
-                case VirtualKey.Number3:
-                    indexToSelect = 2;
-                    break;
-
-                case VirtualKey.Number4:
-                    indexToSelect = 3;
-                    break;
-
-                case VirtualKey.Number5:
-                    indexToSelect = 4;
-                    break;
-
-                case VirtualKey.Number6:
-                    indexToSelect = 5;
-                    break;
-
-                case VirtualKey.Number7:
-                    indexToSelect = 6;
-                    break;
-
-                case VirtualKey.Number8:
-                    indexToSelect = 7;
-                    break;
-
-                case VirtualKey.Number9:
-                    // Select the last tab
-                    indexToSelect = AppInstances.Count - 1;
-                    break;
-
-                case VirtualKey.Tab:
-                    bool shift = e.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
-
-                    if (!shift) // ctrl + tab, select next tab
-                    {
-                        if ((App.AppModel.TabStripSelectedIndex + 1) < AppInstances.Count)
-                            indexToSelect = App.AppModel.TabStripSelectedIndex + 1;
-                        else
-                            indexToSelect = 0;
-                    }
-                    else // ctrl + shift + tab, select previous tab
-                    {
-                        if ((App.AppModel.TabStripSelectedIndex - 1) >= 0)
-                            indexToSelect = App.AppModel.TabStripSelectedIndex - 1;
-                        else
-                            indexToSelect = AppInstances.Count - 1;
-                    }
-
-                    break;
-            }
-
-            // Only select the tab if it is in the list
-            if (indexToSelect < AppInstances.Count)
-                App.AppModel.TabStripSelectedIndex = indexToSelect;
-            e.Handled = true;
-        }
-
-        private async void OpenNewWindowAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
-        {
-            if (e is not null)
-                e.Handled = true;
-            Uri filesUWPUri = new Uri("files-uwp:");
-            await Launcher.LaunchUriAsync(filesUWPUri);
-        }
-
-        private void CloseSelectedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
-        {
-            if (App.AppModel.TabStripSelectedIndex >= AppInstances.Count)
-            {
-                TabItem tabItem = AppInstances[AppInstances.Count - 1];
-                MultitaskingControl?.CloseTab(tabItem);
-            }
-            else
-            {
-                TabItem tabItem = AppInstances[App.AppModel.TabStripSelectedIndex];
-                MultitaskingControl?.CloseTab(tabItem);
-            }
-            if (e is not null)
-                e.Handled = true;
-        }
-
-        private async void AddNewInstanceAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
-        {
-            await AddNewTabAsync();
-            if (e is not null)
-                e.Handled = true;
-        }
-
-        private void ReopenClosedTabAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
-        {
-            (MultitaskingControl as BaseMultitaskingControl)?.ReopenClosedTab(null, null);
-            if (e is not null)
-                e.Handled = true;
-        }
-
-        private async void OpenSettings()
-        {
-            var dialogService = Ioc.Default.GetRequiredService<IDialogService>();
-            var dialog = dialogService.GetDialog(new SettingsDialogViewModel());
-            await dialog.TryShowAsync();
-        }
+		public static ObservableCollection<TabItem> AppInstances { get; private set; } = new ObservableCollection<TabItem>();
 
 
-        public static async Task AddNewTabByPathAsync(Type type, string path, int atIndex = -1)
-        {
-            if (string.IsNullOrEmpty(path))
-                path = "Home".GetLocalizedResource();
+		private TabItem? selectedTabItem;
+		public TabItem? SelectedTabItem
+		{
+			get => selectedTabItem;
+			set => SetProperty(ref selectedTabItem, value);
+		}
 
-            // Support drives launched through jump list by stripping away the question mark at the end.
-            if (path.EndsWith("\\?"))
-                path = path.Remove(path.Length - 1);
+		private bool isWindowCompactOverlay;
+		public bool IsWindowCompactOverlay
+		{
+			get => isWindowCompactOverlay;
+			set => SetProperty(ref isWindowCompactOverlay, value);
+		}
 
-            TabItem tabItem = new TabItem()
-            {
-                Header = null,
-                IconSource = null,
-                Description = null,
-                ToolTipText = null
-            };
-            tabItem.Control.NavigationArguments = new TabItemArguments()
-            {
-                InitialPageType = type,
-                NavigationArg = path
-            };
-            tabItem.Control.ContentChanged += Control_ContentChanged;
-            await UpdateTabInfo(tabItem, path);
-            var index = atIndex == -1 ? AppInstances.Count : atIndex;
-            AppInstances.Insert(index, tabItem);
-            App.AppModel.TabStripSelectedIndex = index;
-        }
+		public ICommand NavigateToNumberedTabKeyboardAcceleratorCommand { get; private set; }
 
-        public async void UpdateInstanceProperties(object navigationArg)
-        {
-            string windowTitle = string.Empty;
-            if (navigationArg is PaneNavigationArguments paneArgs)
-            {
-                if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
-                {
-                    var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-                    var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
-                    windowTitle = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
-                }
-                else
-                {
-                    (windowTitle, _, _) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-                }
-            }
-            else if (navigationArg is string pathArgs)
-            {
-                (windowTitle, _, _) = await GetSelectedTabInfoAsync(pathArgs);
-            }
-            if (AppInstances.Count > 1)
-                windowTitle = $"{windowTitle} ({AppInstances.Count})";
-            if (navigationArg == SelectedTabItem?.TabItemArguments?.NavigationArg)
+		public ICommand OpenNewWindowAcceleratorCommand { get; private set; }
 
-                App.GetAppWindow(App.Window).Title = windowTitle;
-        }
+		public ICommand CloseSelectedTabKeyboardAcceleratorCommand { get; private set; }
 
-        public static async Task UpdateTabInfo(TabItem tabItem, object navigationArg)
-        {
-            tabItem.AllowStorageItemDrop = true;
-            if (navigationArg is PaneNavigationArguments paneArgs)
-            {
-                if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
-                {
-                    var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-                    var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
-                    tabItem.Header = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
-                    tabItem.IconSource = leftTabInfo.tabIcon;
-                }
-                else
-                {
-                    (tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-                }
-            }
-            else if (navigationArg is string pathArgs)
-            {
-                (tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = await GetSelectedTabInfoAsync(pathArgs);
-            }
-        }
+		public ICommand AddNewInstanceAcceleratorCommand { get; private set; }
 
-        public static async Task<(string tabLocationHeader, Microsoft.UI.Xaml.Controls.IconSource tabIcon, string toolTipText)> GetSelectedTabInfoAsync(string currentPath)
-        {
-            string? tabLocationHeader;
-            var iconSource = new Microsoft.UI.Xaml.Controls.ImageIconSource();
-            string toolTipText = currentPath;
+		public ICommand ReopenClosedTabAcceleratorCommand { get; private set; }
 
-            if (string.IsNullOrEmpty(currentPath) || currentPath == "Home".GetLocalizedResource())
-            {
-                tabLocationHeader = "Home".GetLocalizedResource();
-                iconSource.ImageSource = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/Home.png"));
-            }
-            else if (currentPath.Equals(CommonPaths.DesktopPath, StringComparison.OrdinalIgnoreCase))
-            {
-                tabLocationHeader = "Desktop".GetLocalizedResource();
-            }
-            else if (currentPath.Equals(CommonPaths.DownloadsPath, StringComparison.OrdinalIgnoreCase))
-            {
-                tabLocationHeader = "Downloads".GetLocalizedResource();
-            }
-            else if (currentPath.Equals(CommonPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
-            {
-                var localSettings = ApplicationData.Current.LocalSettings;
-                tabLocationHeader = localSettings.Values.Get("RecycleBin_Title", "Recycle Bin");
-            }
-            else if (currentPath.Equals(CommonPaths.NetworkFolderPath, StringComparison.OrdinalIgnoreCase))
-            {
-                tabLocationHeader = "SidebarNetworkDrives".GetLocalizedResource();
-            }
-            else if (App.LibraryManager.TryGetLibrary(currentPath, out LibraryLocationItem library))
-            {
-                var libName = System.IO.Path.GetFileNameWithoutExtension(library.Path).GetLocalizedResource();
-                // If localized string is empty use the library name.
-                tabLocationHeader = string.IsNullOrEmpty(libName) ? library.Text : libName;
-            }
-            else
-            {
-                var matchingCloudDrive = App.CloudDrivesManager.Drives.FirstOrDefault(x => PathNormalization.NormalizePath(currentPath).Equals(PathNormalization.NormalizePath(x.Path), StringComparison.OrdinalIgnoreCase));
-                if (matchingCloudDrive != null)
-                {
-                    tabLocationHeader = matchingCloudDrive.Text;
-                }
-                else if (PathNormalization.NormalizePath(PathNormalization.GetPathRoot(currentPath)) == PathNormalization.NormalizePath(currentPath)) // If path is a drive's root
-                {
-                    var matchingNetDrive = App.NetworkDrivesManager.Drives.FirstOrDefault(x => PathNormalization.NormalizePath(currentPath).Contains(PathNormalization.NormalizePath(x.Path), StringComparison.OrdinalIgnoreCase));
-                    if (matchingNetDrive != null)
-                        tabLocationHeader = matchingNetDrive.Text;
-                    else
-                        tabLocationHeader = PathNormalization.NormalizePath(currentPath);
-                }
-                else
-                {
-                    tabLocationHeader = currentPath.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar).Split('\\', StringSplitOptions.RemoveEmptyEntries).Last();
+		public ICommand OpenSettingsCommand { get; private set; }
 
-                    FilesystemResult<StorageFolderWithPath> rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(currentPath));
-                    if (rootItem)
-                    {
-                        BaseStorageFolder currentFolder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(currentPath, rootItem));
-                        if (currentFolder != null && !string.IsNullOrEmpty(currentFolder.DisplayName))
-                            tabLocationHeader = currentFolder.DisplayName;
-                    }
-                }
-            }
+		public MainPageViewModel()
+		{
+			// Create commands
+			NavigateToNumberedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(NavigateToNumberedTabKeyboardAccelerator);
+			OpenNewWindowAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(OpenNewWindowAccelerator);
+			CloseSelectedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(CloseSelectedTabKeyboardAccelerator);
+			AddNewInstanceAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(AddNewInstanceAccelerator);
+			ReopenClosedTabAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(ReopenClosedTabAccelerator);
+			OpenSettingsCommand = new RelayCommand(OpenSettings);
+		}
 
-            if (iconSource.ImageSource == null)
-            {
-                var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 24u, Windows.Storage.FileProperties.ThumbnailMode.ListView, true);
-                if (iconData != null)
-                    iconSource.ImageSource = await iconData.ToBitmapAsync();
-            }
+		private void NavigateToNumberedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+		{
+			int indexToSelect = 0;
+			if (e is null)
+				return;
+			switch (e.KeyboardAccelerator.Key)
+			{
+				case VirtualKey.Number1:
+					indexToSelect = 0;
+					break;
 
-            return (tabLocationHeader, iconSource, toolTipText);
-        }
+				case VirtualKey.Number2:
+					indexToSelect = 1;
+					break;
 
-        public async void OnNavigatedTo(NavigationEventArgs e)
-        {
-            if (e.NavigationMode == NavigationMode.Back)
-                return;
+				case VirtualKey.Number3:
+					indexToSelect = 2;
+					break;
 
-            //Initialize the static theme helper to capture a reference to this window
-            //to handle theme changes without restarting the app
-            ThemeHelper.Initialize();
+				case VirtualKey.Number4:
+					indexToSelect = 3;
+					break;
 
-            if (e.Parameter == null || (e.Parameter is string eventStr && string.IsNullOrEmpty(eventStr)))
-            {
-                try
-                {
-                    // add last session tabs to closed tabs stack if those tabs are not about to be opened
-                    if (!UserSettingsService.AppSettingsService.RestoreTabsOnStartup && !UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp && UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
-                    {
-                        var items = new TabItemArguments[UserSettingsService.PreferencesSettingsService.LastSessionTabList.Count];
-                        for (int i = 0; i < items.Length; i++)
-                        {
-                            var tabArgs = TabItemArguments.Deserialize(UserSettingsService.PreferencesSettingsService.LastSessionTabList[i]);
-                            items[i] = tabArgs;
-                        }
-                        BaseMultitaskingControl.RecentlyClosedTabs.Add(items);
-                    }
+				case VirtualKey.Number5:
+					indexToSelect = 4;
+					break;
 
-                    if (UserSettingsService.AppSettingsService.RestoreTabsOnStartup)
-                    {
-                        UserSettingsService.AppSettingsService.RestoreTabsOnStartup = false;
-                        if (UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
-                        {
-                            foreach (string tabArgsString in UserSettingsService.PreferencesSettingsService.LastSessionTabList)
-                            {
-                                var tabArgs = TabItemArguments.Deserialize(tabArgsString);
-                                await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
-                            }
-                        }
+				case VirtualKey.Number6:
+					indexToSelect = 5;
+					break;
 
-                        if (!UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp)
-                        {
-                            UserSettingsService.PreferencesSettingsService.LastSessionTabList = null;
-                        }
-                    }
-                    else if (UserSettingsService.PreferencesSettingsService.OpenSpecificPageOnStartup)
-                    {
-                        if (UserSettingsService.PreferencesSettingsService.TabsOnStartupList != null)
-                        {
-                            foreach (string path in UserSettingsService.PreferencesSettingsService.TabsOnStartupList)
-                                await AddNewTabByPathAsync(typeof(PaneHolderPage), path);
-                        }
-                        else
-                        {
-                            await AddNewTabAsync();
-                        }
-                    }
-                    else if (UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp)
-                    {
-                        if (UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
-                        {
-                            foreach (string tabArgsString in UserSettingsService.PreferencesSettingsService.LastSessionTabList)
-                            {
-                                var tabArgs = TabItemArguments.Deserialize(tabArgsString);
-                                await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
-                            }
-                            var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home".GetLocalizedResource() };
-                            UserSettingsService.PreferencesSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
-                        }
-                        else
-                        {
-                            await AddNewTabAsync();
-                        }
-                    }
-                    else
-                    {
-                        await AddNewTabAsync();
-                    }
-                }
-                catch (Exception)
-                {
-                    await AddNewTabAsync();
-                }
-            }
-            else
-            {
-                if (e.Parameter is string navArgs)
-                    await AddNewTabByPathAsync(typeof(PaneHolderPage), navArgs);
-                else if (e.Parameter is PaneNavigationArguments paneArgs)
-                    await AddNewTabByParam(typeof(PaneHolderPage), paneArgs);
-                else if (e.Parameter is TabItemArguments tabArgs)
-                    await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
-            }
-        }
+				case VirtualKey.Number7:
+					indexToSelect = 6;
+					break;
 
-        public static async Task AddNewTabAsync()
-        {
-            await AddNewTabByPathAsync(typeof(PaneHolderPage), "Home".GetLocalizedResource());
-        }
+				case VirtualKey.Number8:
+					indexToSelect = 7;
+					break;
 
-        public async void AddNewTab()
-        {
-            await AddNewTabAsync();
-        }
+				case VirtualKey.Number9:
+					// Select the last tab
+					indexToSelect = AppInstances.Count - 1;
+					break;
 
-        public static async void AddNewTabAtIndex(object sender, RoutedEventArgs e)
-        {
-            await AddNewTabAsync();
-        }
+				case VirtualKey.Tab:
+					bool shift = e.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
 
-        public static async void DuplicateTabAtIndex(object sender, RoutedEventArgs e)
-        {
-            var tabItem = (TabItem)((FrameworkElement)sender).DataContext;
-            var index = AppInstances.IndexOf(tabItem);
+					if (!shift) // ctrl + tab, select next tab
+					{
+						if ((App.AppModel.TabStripSelectedIndex + 1) < AppInstances.Count)
+							indexToSelect = App.AppModel.TabStripSelectedIndex + 1;
+						else
+							indexToSelect = 0;
+					}
+					else // ctrl + shift + tab, select previous tab
+					{
+						if ((App.AppModel.TabStripSelectedIndex - 1) >= 0)
+							indexToSelect = App.AppModel.TabStripSelectedIndex - 1;
+						else
+							indexToSelect = AppInstances.Count - 1;
+					}
 
-            if (AppInstances[index].TabItemArguments != null)
-            {
-                var tabArgs = AppInstances[index].TabItemArguments;
-                await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg, index + 1);
-            }
-            else
-            {
-                await AddNewTabByPathAsync(typeof(PaneHolderPage), "Home".GetLocalizedResource());
-            }
-        }
+					break;
+			}
 
-        public static async Task AddNewTabByParam(Type type, object tabViewItemArgs, int atIndex = -1)
-        {
-            TabItem tabItem = new TabItem()
-            {
-                Header = null,
-                IconSource = null,
-                Description = null,
-                ToolTipText = null
-            };
+			// Only select the tab if it is in the list
+			if (indexToSelect < AppInstances.Count)
+				App.AppModel.TabStripSelectedIndex = indexToSelect;
+			e.Handled = true;
+		}
 
-            tabItem.Control.NavigationArguments = new TabItemArguments()
-            {
-                InitialPageType = type,
-                NavigationArg = tabViewItemArgs
-            };
+		private async void OpenNewWindowAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+		{
+			if (e is not null)
+				e.Handled = true;
+			Uri filesUWPUri = new Uri("files-uwp:");
+			await Launcher.LaunchUriAsync(filesUWPUri);
+		}
 
-            tabItem.Control.ContentChanged += Control_ContentChanged;
-            await UpdateTabInfo(tabItem, tabViewItemArgs);
-            var index = atIndex == -1 ? AppInstances.Count : atIndex;
-            AppInstances.Insert(index, tabItem);
-            App.AppModel.TabStripSelectedIndex = index;
-        }
+		private void CloseSelectedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+		{
+			if (App.AppModel.TabStripSelectedIndex >= AppInstances.Count)
+			{
+				TabItem tabItem = AppInstances[AppInstances.Count - 1];
+				MultitaskingControl?.CloseTab(tabItem);
+			}
+			else
+			{
+				TabItem tabItem = AppInstances[App.AppModel.TabStripSelectedIndex];
+				MultitaskingControl?.CloseTab(tabItem);
+			}
+			if (e is not null)
+				e.Handled = true;
+		}
 
-        public static async void Control_ContentChanged(object? sender, TabItemArguments e)
-        {
-            if (sender == null)
-                return;
-            TabItem? matchingTabItem = AppInstances.SingleOrDefault(x => x.Control == (TabItemControl)sender);
-            if (matchingTabItem == null)
-                return;
+		private async void AddNewInstanceAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+		{
+			await AddNewTabAsync();
+			if (e is not null)
+				e.Handled = true;
+		}
 
-            await UpdateTabInfo(matchingTabItem, e.NavigationArg);
-        }
-    }
+		private void ReopenClosedTabAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+		{
+			(MultitaskingControl as BaseMultitaskingControl)?.ReopenClosedTab(null, null);
+			if (e is not null)
+				e.Handled = true;
+		}
+
+		private async void OpenSettings()
+		{
+			var dialogService = Ioc.Default.GetRequiredService<IDialogService>();
+			var dialog = dialogService.GetDialog(new SettingsDialogViewModel());
+			await dialog.TryShowAsync();
+		}
+
+
+		public static async Task AddNewTabByPathAsync(Type type, string path, int atIndex = -1)
+		{
+			if (string.IsNullOrEmpty(path))
+				path = "Home".GetLocalizedResource();
+
+			// Support drives launched through jump list by stripping away the question mark at the end.
+			if (path.EndsWith("\\?"))
+				path = path.Remove(path.Length - 1);
+
+			TabItem tabItem = new TabItem()
+			{
+				Header = null,
+				IconSource = null,
+				Description = null,
+				ToolTipText = null
+			};
+			tabItem.Control.NavigationArguments = new TabItemArguments()
+			{
+				InitialPageType = type,
+				NavigationArg = path
+			};
+			tabItem.Control.ContentChanged += Control_ContentChanged;
+			await UpdateTabInfo(tabItem, path);
+			var index = atIndex == -1 ? AppInstances.Count : atIndex;
+			AppInstances.Insert(index, tabItem);
+			App.AppModel.TabStripSelectedIndex = index;
+		}
+
+		public async void UpdateInstanceProperties(object navigationArg)
+		{
+			string windowTitle = string.Empty;
+			if (navigationArg is PaneNavigationArguments paneArgs)
+			{
+				if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
+				{
+					var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+					var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
+					windowTitle = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
+				}
+				else
+				{
+					(windowTitle, _, _) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+				}
+			}
+			else if (navigationArg is string pathArgs)
+			{
+				(windowTitle, _, _) = await GetSelectedTabInfoAsync(pathArgs);
+			}
+			if (AppInstances.Count > 1)
+				windowTitle = $"{windowTitle} ({AppInstances.Count})";
+			if (navigationArg == SelectedTabItem?.TabItemArguments?.NavigationArg)
+
+				App.GetAppWindow(App.Window).Title = windowTitle;
+		}
+
+		public static async Task UpdateTabInfo(TabItem tabItem, object navigationArg)
+		{
+			tabItem.AllowStorageItemDrop = true;
+			if (navigationArg is PaneNavigationArguments paneArgs)
+			{
+				if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
+				{
+					var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+					var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
+					tabItem.Header = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
+					tabItem.IconSource = leftTabInfo.tabIcon;
+				}
+				else
+				{
+					(tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+				}
+			}
+			else if (navigationArg is string pathArgs)
+			{
+				(tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = await GetSelectedTabInfoAsync(pathArgs);
+			}
+		}
+
+		public static async Task<(string tabLocationHeader, Microsoft.UI.Xaml.Controls.IconSource tabIcon, string toolTipText)> GetSelectedTabInfoAsync(string currentPath)
+		{
+			string? tabLocationHeader;
+			var iconSource = new Microsoft.UI.Xaml.Controls.ImageIconSource();
+			string toolTipText = currentPath;
+
+			if (string.IsNullOrEmpty(currentPath) || currentPath == "Home".GetLocalizedResource())
+			{
+				tabLocationHeader = "Home".GetLocalizedResource();
+				iconSource.ImageSource = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/Home.png"));
+			}
+			else if (currentPath.Equals(CommonPaths.DesktopPath, StringComparison.OrdinalIgnoreCase))
+			{
+				tabLocationHeader = "Desktop".GetLocalizedResource();
+			}
+			else if (currentPath.Equals(CommonPaths.DownloadsPath, StringComparison.OrdinalIgnoreCase))
+			{
+				tabLocationHeader = "Downloads".GetLocalizedResource();
+			}
+			else if (currentPath.Equals(CommonPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
+			{
+				var localSettings = ApplicationData.Current.LocalSettings;
+				tabLocationHeader = localSettings.Values.Get("RecycleBin_Title", "Recycle Bin");
+			}
+			else if (currentPath.Equals(CommonPaths.NetworkFolderPath, StringComparison.OrdinalIgnoreCase))
+			{
+				tabLocationHeader = "SidebarNetworkDrives".GetLocalizedResource();
+			}
+			else if (App.LibraryManager.TryGetLibrary(currentPath, out LibraryLocationItem library))
+			{
+				var libName = System.IO.Path.GetFileNameWithoutExtension(library.Path).GetLocalizedResource();
+				// If localized string is empty use the library name.
+				tabLocationHeader = string.IsNullOrEmpty(libName) ? library.Text : libName;
+			}
+			else
+			{
+				var matchingCloudDrive = App.CloudDrivesManager.Drives.FirstOrDefault(x => PathNormalization.NormalizePath(currentPath).Equals(PathNormalization.NormalizePath(x.Path), StringComparison.OrdinalIgnoreCase));
+				if (matchingCloudDrive != null)
+				{
+					tabLocationHeader = matchingCloudDrive.Text;
+				}
+				else if (PathNormalization.NormalizePath(PathNormalization.GetPathRoot(currentPath)) == PathNormalization.NormalizePath(currentPath)) // If path is a drive's root
+				{
+					var matchingNetDrive = App.NetworkDrivesManager.Drives.FirstOrDefault(x => PathNormalization.NormalizePath(currentPath).Contains(PathNormalization.NormalizePath(x.Path), StringComparison.OrdinalIgnoreCase));
+					if (matchingNetDrive != null)
+						tabLocationHeader = matchingNetDrive.Text;
+					else
+						tabLocationHeader = PathNormalization.NormalizePath(currentPath);
+				}
+				else
+				{
+					tabLocationHeader = currentPath.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar).Split('\\', StringSplitOptions.RemoveEmptyEntries).Last();
+
+					FilesystemResult<StorageFolderWithPath> rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(currentPath));
+					if (rootItem)
+					{
+						BaseStorageFolder currentFolder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(currentPath, rootItem));
+						if (currentFolder != null && !string.IsNullOrEmpty(currentFolder.DisplayName))
+							tabLocationHeader = currentFolder.DisplayName;
+					}
+				}
+			}
+
+			if (iconSource.ImageSource == null)
+			{
+				var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 24u, Windows.Storage.FileProperties.ThumbnailMode.ListView, true);
+				if (iconData != null)
+					iconSource.ImageSource = await iconData.ToBitmapAsync();
+			}
+
+			return (tabLocationHeader, iconSource, toolTipText);
+		}
+
+		public async void OnNavigatedTo(NavigationEventArgs e)
+		{
+			if (e.NavigationMode == NavigationMode.Back)
+				return;
+
+			//Initialize the static theme helper to capture a reference to this window
+			//to handle theme changes without restarting the app
+			ThemeHelper.Initialize();
+
+			if (e.Parameter == null || (e.Parameter is string eventStr && string.IsNullOrEmpty(eventStr)))
+			{
+				try
+				{
+					// add last session tabs to closed tabs stack if those tabs are not about to be opened
+					if (!UserSettingsService.AppSettingsService.RestoreTabsOnStartup && !UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp && UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
+					{
+						var items = new TabItemArguments[UserSettingsService.PreferencesSettingsService.LastSessionTabList.Count];
+						for (int i = 0; i < items.Length; i++)
+						{
+							var tabArgs = TabItemArguments.Deserialize(UserSettingsService.PreferencesSettingsService.LastSessionTabList[i]);
+							items[i] = tabArgs;
+						}
+						BaseMultitaskingControl.RecentlyClosedTabs.Add(items);
+					}
+
+					if (UserSettingsService.AppSettingsService.RestoreTabsOnStartup)
+					{
+						UserSettingsService.AppSettingsService.RestoreTabsOnStartup = false;
+						if (UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
+						{
+							foreach (string tabArgsString in UserSettingsService.PreferencesSettingsService.LastSessionTabList)
+							{
+								var tabArgs = TabItemArguments.Deserialize(tabArgsString);
+								await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
+							}
+						}
+
+						if (!UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp)
+						{
+							UserSettingsService.PreferencesSettingsService.LastSessionTabList = null;
+						}
+					}
+					else if (UserSettingsService.PreferencesSettingsService.OpenSpecificPageOnStartup)
+					{
+						if (UserSettingsService.PreferencesSettingsService.TabsOnStartupList != null)
+						{
+							foreach (string path in UserSettingsService.PreferencesSettingsService.TabsOnStartupList)
+								await AddNewTabByPathAsync(typeof(PaneHolderPage), path);
+						}
+						else
+						{
+							await AddNewTabAsync();
+						}
+					}
+					else if (UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp)
+					{
+						if (UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
+						{
+							foreach (string tabArgsString in UserSettingsService.PreferencesSettingsService.LastSessionTabList)
+							{
+								var tabArgs = TabItemArguments.Deserialize(tabArgsString);
+								await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
+							}
+							var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home".GetLocalizedResource() };
+							UserSettingsService.PreferencesSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
+						}
+						else
+						{
+							await AddNewTabAsync();
+						}
+					}
+					else
+					{
+						await AddNewTabAsync();
+					}
+				}
+				catch (Exception)
+				{
+					await AddNewTabAsync();
+				}
+			}
+			else
+			{
+				if (e.Parameter is string navArgs)
+					await AddNewTabByPathAsync(typeof(PaneHolderPage), navArgs);
+				else if (e.Parameter is PaneNavigationArguments paneArgs)
+					await AddNewTabByParam(typeof(PaneHolderPage), paneArgs);
+				else if (e.Parameter is TabItemArguments tabArgs)
+					await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
+			}
+		}
+
+		public static async Task AddNewTabAsync()
+		{
+			await AddNewTabByPathAsync(typeof(PaneHolderPage), "Home".GetLocalizedResource());
+		}
+
+		public async void AddNewTab()
+		{
+			await AddNewTabAsync();
+		}
+
+		public static async void AddNewTabAtIndex(object sender, RoutedEventArgs e)
+		{
+			await AddNewTabAsync();
+		}
+
+		public static async void DuplicateTabAtIndex(object sender, RoutedEventArgs e)
+		{
+			var tabItem = (TabItem)((FrameworkElement)sender).DataContext;
+			var index = AppInstances.IndexOf(tabItem);
+
+			if (AppInstances[index].TabItemArguments != null)
+			{
+				var tabArgs = AppInstances[index].TabItemArguments;
+				await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg, index + 1);
+			}
+			else
+			{
+				await AddNewTabByPathAsync(typeof(PaneHolderPage), "Home".GetLocalizedResource());
+			}
+		}
+
+		public static async Task AddNewTabByParam(Type type, object tabViewItemArgs, int atIndex = -1)
+		{
+			TabItem tabItem = new TabItem()
+			{
+				Header = null,
+				IconSource = null,
+				Description = null,
+				ToolTipText = null
+			};
+
+			tabItem.Control.NavigationArguments = new TabItemArguments()
+			{
+				InitialPageType = type,
+				NavigationArg = tabViewItemArgs
+			};
+
+			tabItem.Control.ContentChanged += Control_ContentChanged;
+			await UpdateTabInfo(tabItem, tabViewItemArgs);
+			var index = atIndex == -1 ? AppInstances.Count : atIndex;
+			AppInstances.Insert(index, tabItem);
+			App.AppModel.TabStripSelectedIndex = index;
+		}
+
+		public static async void Control_ContentChanged(object? sender, TabItemArguments e)
+		{
+			if (sender == null)
+				return;
+			TabItem? matchingTabItem = AppInstances.SingleOrDefault(x => x.Control == (TabItemControl)sender);
+			if (matchingTabItem == null)
+				return;
+
+			await UpdateTabInfo(matchingTabItem, e.NavigationArg);
+		}
+	}
 }

--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -78,9 +78,7 @@ namespace Files.App.ViewModels
 		private void NavigateToNumberedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
 		{
 			int indexToSelect = 0;
-			if (e is null)
-				return;
-			switch (e.KeyboardAccelerator.Key)
+			switch (e!.KeyboardAccelerator.Key)
 			{
 				case VirtualKey.Number1:
 					indexToSelect = 0;
@@ -148,10 +146,9 @@ namespace Files.App.ViewModels
 
 		private async void OpenNewWindowAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
 		{
-			if (e is not null)
-				e.Handled = true;
 			Uri filesUWPUri = new Uri("files-uwp:");
 			await Launcher.LaunchUriAsync(filesUWPUri);
+			e!.Handled = true;
 		}
 
 		private void CloseSelectedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
@@ -166,22 +163,19 @@ namespace Files.App.ViewModels
 				TabItem tabItem = AppInstances[App.AppModel.TabStripSelectedIndex];
 				MultitaskingControl?.CloseTab(tabItem);
 			}
-			if (e is not null)
-				e.Handled = true;
+			e!.Handled = true;
 		}
 
 		private async void AddNewInstanceAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
 		{
 			await AddNewTabAsync();
-			if (e is not null)
-				e.Handled = true;
+			e!.Handled = true;
 		}
 
 		private void ReopenClosedTabAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
 		{
 			(MultitaskingControl as BaseMultitaskingControl)?.ReopenClosedTab(null, null);
-			if (e is not null)
-				e.Handled = true;
+			e!.Handled = true;
 		}
 
 		private async void OpenSettings()

--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -24,510 +24,480 @@ using System.Windows.Input;
 using Windows.Storage;
 using Windows.System;
 
+#nullable enable
+
 namespace Files.App.ViewModels
 {
-	public class MainPageViewModel : ObservableObject
-	{
-		private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
+    public class MainPageViewModel : ObservableObject
+    {
+        private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>()!;
 
-		public IMultitaskingControl MultitaskingControl { get; set; }
-		public List<IMultitaskingControl> MultitaskingControls { get; } = new List<IMultitaskingControl>();
+        public IMultitaskingControl? MultitaskingControl { get; set; }
+        public List<IMultitaskingControl> MultitaskingControls { get; } = new List<IMultitaskingControl>();
 
-		public static ObservableCollection<TabItem> AppInstances { get; private set; } = new ObservableCollection<TabItem>();
-
-
-		private TabItem selectedTabItem;
-		public TabItem SelectedTabItem
-		{
-			get => selectedTabItem;
-			set => SetProperty(ref selectedTabItem, value);
-		}
-
-		private bool isWindowCompactOverlay;
-		public bool IsWindowCompactOverlay
-		{
-			get => isWindowCompactOverlay;
-			set
-			{
-				if (value != isWindowCompactOverlay)
-				{
-					isWindowCompactOverlay = value;
-					OnPropertyChanged(nameof(isWindowCompactOverlay));
-				}
-			}
-		}
-
-		public ICommand NavigateToNumberedTabKeyboardAcceleratorCommand { get; private set; }
-
-		public ICommand OpenNewWindowAcceleratorCommand { get; private set; }
-
-		public ICommand CloseSelectedTabKeyboardAcceleratorCommand { get; private set; }
-
-		public ICommand AddNewInstanceAcceleratorCommand { get; private set; }
-
-		public ICommand ReopenClosedTabAcceleratorCommand { get; private set; }
-
-		public ICommand OpenSettingsCommand { get; private set; }
-
-		public MainPageViewModel()
-		{
-			// Create commands
-			NavigateToNumberedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(NavigateToNumberedTabKeyboardAccelerator);
-			OpenNewWindowAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(OpenNewWindowAccelerator);
-			CloseSelectedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(CloseSelectedTabKeyboardAccelerator);
-			AddNewInstanceAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(AddNewInstanceAccelerator);
-			ReopenClosedTabAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(ReopenClosedTabAccelerator);
-			OpenSettingsCommand = new RelayCommand(OpenSettings);
-		}
-
-		private void NavigateToNumberedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs e)
-		{
-			int indexToSelect = 0;
-
-			switch (e.KeyboardAccelerator.Key)
-			{
-				case VirtualKey.Number1:
-					indexToSelect = 0;
-					break;
-
-				case VirtualKey.Number2:
-					indexToSelect = 1;
-					break;
-
-				case VirtualKey.Number3:
-					indexToSelect = 2;
-					break;
-
-				case VirtualKey.Number4:
-					indexToSelect = 3;
-					break;
-
-				case VirtualKey.Number5:
-					indexToSelect = 4;
-					break;
-
-				case VirtualKey.Number6:
-					indexToSelect = 5;
-					break;
-
-				case VirtualKey.Number7:
-					indexToSelect = 6;
-					break;
-
-				case VirtualKey.Number8:
-					indexToSelect = 7;
-					break;
-
-				case VirtualKey.Number9:
-					// Select the last tab
-					indexToSelect = AppInstances.Count - 1;
-					break;
-
-				case VirtualKey.Tab:
-					bool shift = e.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
-
-					if (!shift) // ctrl + tab, select next tab
-					{
-						if ((App.AppModel.TabStripSelectedIndex + 1) < AppInstances.Count)
-						{
-							indexToSelect = App.AppModel.TabStripSelectedIndex + 1;
-						}
-						else
-						{
-							indexToSelect = 0;
-						}
-					}
-					else // ctrl + shift + tab, select previous tab
-					{
-						if ((App.AppModel.TabStripSelectedIndex - 1) >= 0)
-						{
-							indexToSelect = App.AppModel.TabStripSelectedIndex - 1;
-						}
-						else
-						{
-							indexToSelect = AppInstances.Count - 1;
-						}
-					}
-
-					break;
-			}
-
-			// Only select the tab if it is in the list
-			if (indexToSelect < AppInstances.Count)
-			{
-				App.AppModel.TabStripSelectedIndex = indexToSelect;
-			}
-			e.Handled = true;
-		}
-
-		private async void OpenNewWindowAccelerator(KeyboardAcceleratorInvokedEventArgs e)
-		{
-			e.Handled = true;
-			Uri filesUWPUri = new Uri("files-uwp:");
-			await Launcher.LaunchUriAsync(filesUWPUri);
-		}
-
-		private void CloseSelectedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs e)
-		{
-			if (App.AppModel.TabStripSelectedIndex >= AppInstances.Count)
-			{
-				TabItem tabItem = AppInstances[AppInstances.Count - 1];
-				MultitaskingControl?.CloseTab(tabItem);
-			}
-			else
-			{
-				TabItem tabItem = AppInstances[App.AppModel.TabStripSelectedIndex];
-				MultitaskingControl?.CloseTab(tabItem);
-			}
-			e.Handled = true;
-		}
-
-		private async void AddNewInstanceAccelerator(KeyboardAcceleratorInvokedEventArgs e)
-		{
-			await AddNewTabAsync();
-			e.Handled = true;
-		}
-
-		private void ReopenClosedTabAccelerator(KeyboardAcceleratorInvokedEventArgs e)
-		{
-			((BaseMultitaskingControl)MultitaskingControl).ReopenClosedTab(null, null);
-			e.Handled = true;
-		}
-
-		private async void OpenSettings()
-		{
-			var dialogService = Ioc.Default.GetRequiredService<IDialogService>();
-			var dialog = dialogService.GetDialog(new SettingsDialogViewModel());
-			await dialog.TryShowAsync();
-		}
+        public static ObservableCollection<TabItem> AppInstances { get; private set; } = new ObservableCollection<TabItem>();
 
 
-		public static async Task AddNewTabByPathAsync(Type type, string path, int atIndex = -1)
-		{
-			if (string.IsNullOrEmpty(path))
-			{
-				path = "Home".GetLocalizedResource();
-			}
+        private TabItem? selectedTabItem;
+        public TabItem? SelectedTabItem
+        {
+            get => selectedTabItem;
+            set => SetProperty(ref selectedTabItem, value);
+        }
 
-			// Support drives launched through jump list by stripping away the question mark at the end.
-			if (path.EndsWith("\\?"))
-			{
-				path = path.Remove(path.Length - 1);
-			}
+        private bool isWindowCompactOverlay;
+        public bool IsWindowCompactOverlay
+        {
+            get => isWindowCompactOverlay;
+            set => SetProperty(ref isWindowCompactOverlay, value);
+        }
 
-			TabItem tabItem = new TabItem()
-			{
-				Header = null,
-				IconSource = null,
-				Description = null,
-				ToolTipText = null
-			};
-			tabItem.Control.NavigationArguments = new TabItemArguments()
-			{
-				InitialPageType = type,
-				NavigationArg = path
-			};
-			tabItem.Control.ContentChanged += Control_ContentChanged;
-			await UpdateTabInfo(tabItem, path);
-			var index = atIndex == -1 ? AppInstances.Count : atIndex;
-			AppInstances.Insert(index, tabItem);
-			App.AppModel.TabStripSelectedIndex = index;
-		}
+        public ICommand NavigateToNumberedTabKeyboardAcceleratorCommand { get; private set; }
 
-		public async void UpdateInstanceProperties(object navigationArg)
-		{
-			string windowTitle = string.Empty;
-			if (navigationArg is PaneNavigationArguments paneArgs)
-			{
-				if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
-				{
-					var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-					var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
-					windowTitle = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
-				}
-				else
-				{
-					(windowTitle, _, _) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-				}
-			}
-			else if (navigationArg is string pathArgs)
-			{
-				(windowTitle, _, _) = await GetSelectedTabInfoAsync(pathArgs);
-			}
-			if (AppInstances.Count > 1)
-			{
-				windowTitle = $"{windowTitle} ({AppInstances.Count})";
-			}
-			if (navigationArg == SelectedTabItem?.TabItemArguments?.NavigationArg)
-			{
+        public ICommand OpenNewWindowAcceleratorCommand { get; private set; }
 
-				App.GetAppWindow(App.Window).Title = windowTitle;
-			}
-		}
+        public ICommand CloseSelectedTabKeyboardAcceleratorCommand { get; private set; }
 
-		public static async Task UpdateTabInfo(TabItem tabItem, object navigationArg)
-		{
-			tabItem.AllowStorageItemDrop = true;
-			if (navigationArg is PaneNavigationArguments paneArgs)
-			{
-				if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
-				{
-					var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-					var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
-					tabItem.Header = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
-					tabItem.IconSource = leftTabInfo.tabIcon;
-				}
-				else
-				{
-					(tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-				}
-			}
-			else if (navigationArg is string pathArgs)
-			{
-				(tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = await GetSelectedTabInfoAsync(pathArgs);
-			}
-		}
+        public ICommand AddNewInstanceAcceleratorCommand { get; private set; }
 
-		public static async Task<(string tabLocationHeader, Microsoft.UI.Xaml.Controls.IconSource tabIcon, string toolTipText)> GetSelectedTabInfoAsync(string currentPath)
-		{
-			string tabLocationHeader;
-			var iconSource = new Microsoft.UI.Xaml.Controls.ImageIconSource();
-			string toolTipText = currentPath;
+        public ICommand ReopenClosedTabAcceleratorCommand { get; private set; }
 
-			if (string.IsNullOrEmpty(currentPath) || currentPath == "Home".GetLocalizedResource())
-			{
-				tabLocationHeader = "Home".GetLocalizedResource();
-				iconSource.ImageSource = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/Home.png"));
-			}
-			else if (currentPath.Equals(CommonPaths.DesktopPath, StringComparison.OrdinalIgnoreCase))
-			{
-				tabLocationHeader = "Desktop".GetLocalizedResource();
-			}
-			else if (currentPath.Equals(CommonPaths.DownloadsPath, StringComparison.OrdinalIgnoreCase))
-			{
-				tabLocationHeader = "Downloads".GetLocalizedResource();
-			}
-			else if (currentPath.Equals(CommonPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
-			{
-				var localSettings = ApplicationData.Current.LocalSettings;
-				tabLocationHeader = localSettings.Values.Get("RecycleBin_Title", "Recycle Bin");
-			}
-			else if (currentPath.Equals(CommonPaths.NetworkFolderPath, StringComparison.OrdinalIgnoreCase))
-			{
-				tabLocationHeader = "SidebarNetworkDrives".GetLocalizedResource();
-			}
-			else if (App.LibraryManager.TryGetLibrary(currentPath, out LibraryLocationItem library))
-			{
-				var libName = System.IO.Path.GetFileNameWithoutExtension(library.Path).GetLocalizedResource();
-				// If localized string is empty use the library name.
-				tabLocationHeader = string.IsNullOrEmpty(libName) ? library.Text : libName;
-			}
-			else
-			{
-				var matchingCloudDrive = App.CloudDrivesManager.Drives.FirstOrDefault(x => PathNormalization.NormalizePath(currentPath).Equals(PathNormalization.NormalizePath(x.Path), StringComparison.OrdinalIgnoreCase));
-				if (matchingCloudDrive != null)
-				{
-					tabLocationHeader = matchingCloudDrive.Text;
-				}
-				else if (PathNormalization.NormalizePath(PathNormalization.GetPathRoot(currentPath)) == PathNormalization.NormalizePath(currentPath)) // If path is a drive's root
-				{
-					var matchingNetDrive = App.NetworkDrivesManager.Drives.FirstOrDefault(x => PathNormalization.NormalizePath(currentPath).Contains(PathNormalization.NormalizePath(x.Path), StringComparison.OrdinalIgnoreCase));
-					if (matchingNetDrive != null)
-					{
-						tabLocationHeader = matchingNetDrive.Text;
-					}
-					else
-					{
-						tabLocationHeader = PathNormalization.NormalizePath(currentPath);
-					}
-				}
-				else
-				{
-					tabLocationHeader = currentPath.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar).Split('\\', StringSplitOptions.RemoveEmptyEntries).Last();
+        public ICommand OpenSettingsCommand { get; private set; }
 
-					FilesystemResult<StorageFolderWithPath> rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(currentPath));
-					if (rootItem)
-					{
-						BaseStorageFolder currentFolder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(currentPath, rootItem));
-						if (currentFolder != null && !string.IsNullOrEmpty(currentFolder.DisplayName))
-						{
-							tabLocationHeader = currentFolder.DisplayName;
-						}
-					}
-				}
-			}
+        public MainPageViewModel()
+        {
+            // Create commands
+            NavigateToNumberedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(NavigateToNumberedTabKeyboardAccelerator);
+            OpenNewWindowAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(OpenNewWindowAccelerator);
+            CloseSelectedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(CloseSelectedTabKeyboardAccelerator);
+            AddNewInstanceAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(AddNewInstanceAccelerator);
+            ReopenClosedTabAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(ReopenClosedTabAccelerator);
+            OpenSettingsCommand = new RelayCommand(OpenSettings);
+        }
 
-			if (iconSource.ImageSource == null)
-			{
-				var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 24u, Windows.Storage.FileProperties.ThumbnailMode.ListView, true);
-				if (iconData != null)
-				{
-					iconSource.ImageSource = await iconData.ToBitmapAsync();
-				}
-			}
+        private void NavigateToNumberedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+        {
+            int indexToSelect = 0;
+            if (e is null)
+                return;
+            switch (e.KeyboardAccelerator.Key)
+            {
+                case VirtualKey.Number1:
+                    indexToSelect = 0;
+                    break;
 
-			return (tabLocationHeader, iconSource, toolTipText);
-		}
+                case VirtualKey.Number2:
+                    indexToSelect = 1;
+                    break;
 
-		public async void OnNavigatedTo(NavigationEventArgs e)
-		{
-			if (e.NavigationMode == NavigationMode.Back)
-				return;
+                case VirtualKey.Number3:
+                    indexToSelect = 2;
+                    break;
 
-			//Initialize the static theme helper to capture a reference to this window
-			//to handle theme changes without restarting the app
-			ThemeHelper.Initialize();
+                case VirtualKey.Number4:
+                    indexToSelect = 3;
+                    break;
 
-			if (e.Parameter == null || (e.Parameter is string eventStr && string.IsNullOrEmpty(eventStr)))
-			{
-				try
-				{
-					// add last session tabs to closed tabs stack if those tabs are not about to be opened
-					if (!UserSettingsService.AppSettingsService.RestoreTabsOnStartup && !UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp && UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
-					{
-						var items = new TabItemArguments[UserSettingsService.PreferencesSettingsService.LastSessionTabList.Count];
-						for (int i = 0; i < items.Length; i++)
-						{
-							var tabArgs = TabItemArguments.Deserialize(UserSettingsService.PreferencesSettingsService.LastSessionTabList[i]);
-							items[i] = tabArgs;
-						}
-						BaseMultitaskingControl.RecentlyClosedTabs.Add(items);
-					}
+                case VirtualKey.Number5:
+                    indexToSelect = 4;
+                    break;
 
-					if (UserSettingsService.AppSettingsService.RestoreTabsOnStartup)
-					{
-						UserSettingsService.AppSettingsService.RestoreTabsOnStartup = false;
+                case VirtualKey.Number6:
+                    indexToSelect = 5;
+                    break;
 
-						foreach (string tabArgsString in UserSettingsService.PreferencesSettingsService.LastSessionTabList)
-						{
-							var tabArgs = TabItemArguments.Deserialize(tabArgsString);
-							await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
-						}
+                case VirtualKey.Number7:
+                    indexToSelect = 6;
+                    break;
 
-						if (!UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp)
-						{
-							UserSettingsService.PreferencesSettingsService.LastSessionTabList = null;
-						}
-					}
-					else if (UserSettingsService.PreferencesSettingsService.OpenSpecificPageOnStartup)
-					{
-						if (UserSettingsService.PreferencesSettingsService.TabsOnStartupList != null)
-						{
-							foreach (string path in UserSettingsService.PreferencesSettingsService.TabsOnStartupList)
-							{
-								await AddNewTabByPathAsync(typeof(PaneHolderPage), path);
-							}
-						}
-						else
-						{
-							await AddNewTabAsync();
-						}
-					}
-					else if (UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp)
-					{
-						if (UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
-						{
-							foreach (string tabArgsString in UserSettingsService.PreferencesSettingsService.LastSessionTabList)
-							{
-								var tabArgs = TabItemArguments.Deserialize(tabArgsString);
-								await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
-							}
-							var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home".GetLocalizedResource() };
-							UserSettingsService.PreferencesSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
-						}
-						else
-						{
-							await AddNewTabAsync();
-						}
-					}
-					else
-					{
-						await AddNewTabAsync();
-					}
-				}
-				catch (Exception)
-				{
-					await AddNewTabAsync();
-				}
-			}
-			else
-			{
-				if (e.Parameter is string navArgs)
-				{
-					await AddNewTabByPathAsync(typeof(PaneHolderPage), navArgs);
-				}
-				else if (e.Parameter is PaneNavigationArguments paneArgs)
-				{
-					await AddNewTabByParam(typeof(PaneHolderPage), paneArgs);
-				}
-				else if (e.Parameter is TabItemArguments tabArgs)
-				{
-					await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
-				}
-			}
-		}
+                case VirtualKey.Number8:
+                    indexToSelect = 7;
+                    break;
 
-		public static async Task AddNewTabAsync()
-		{
-			await AddNewTabByPathAsync(typeof(PaneHolderPage), "Home".GetLocalizedResource());
-		}
+                case VirtualKey.Number9:
+                    // Select the last tab
+                    indexToSelect = AppInstances.Count - 1;
+                    break;
 
-		public async void AddNewTab()
-		{
-			await AddNewTabAsync();
-		}
+                case VirtualKey.Tab:
+                    bool shift = e.KeyboardAccelerator.Modifiers.HasFlag(VirtualKeyModifiers.Shift);
 
-		public static async void AddNewTabAtIndex(object sender, RoutedEventArgs e)
-		{
-			await AddNewTabAsync();
-		}
+                    if (!shift) // ctrl + tab, select next tab
+                    {
+                        if ((App.AppModel.TabStripSelectedIndex + 1) < AppInstances.Count)
+                            indexToSelect = App.AppModel.TabStripSelectedIndex + 1;
+                        else
+                            indexToSelect = 0;
+                    }
+                    else // ctrl + shift + tab, select previous tab
+                    {
+                        if ((App.AppModel.TabStripSelectedIndex - 1) >= 0)
+                            indexToSelect = App.AppModel.TabStripSelectedIndex - 1;
+                        else
+                            indexToSelect = AppInstances.Count - 1;
+                    }
 
-		public static async void DuplicateTabAtIndex(object sender, RoutedEventArgs e)
-		{
-			var tabItem = ((FrameworkElement)sender).DataContext as TabItem;
-			var index = AppInstances.IndexOf(tabItem);
+                    break;
+            }
 
-			if (AppInstances[index].TabItemArguments != null)
-			{
-				var tabArgs = AppInstances[index].TabItemArguments;
-				await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg, index + 1);
-			}
-			else
-			{
-				await AddNewTabByPathAsync(typeof(PaneHolderPage), "Home".GetLocalizedResource());
-			}
-		}
+            // Only select the tab if it is in the list
+            if (indexToSelect < AppInstances.Count)
+                App.AppModel.TabStripSelectedIndex = indexToSelect;
+            e.Handled = true;
+        }
 
-		public static async Task AddNewTabByParam(Type type, object tabViewItemArgs, int atIndex = -1)
-		{
-			TabItem tabItem = new TabItem()
-			{
-				Header = null,
-				IconSource = null,
-				Description = null,
-				ToolTipText = null
-			};
+        private async void OpenNewWindowAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+        {
+            if (e is not null)
+                e.Handled = true;
+            Uri filesUWPUri = new Uri("files-uwp:");
+            await Launcher.LaunchUriAsync(filesUWPUri);
+        }
 
-			tabItem.Control.NavigationArguments = new TabItemArguments()
-			{
-				InitialPageType = type,
-				NavigationArg = tabViewItemArgs
-			};
+        private void CloseSelectedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+        {
+            if (App.AppModel.TabStripSelectedIndex >= AppInstances.Count)
+            {
+                TabItem tabItem = AppInstances[AppInstances.Count - 1];
+                MultitaskingControl?.CloseTab(tabItem);
+            }
+            else
+            {
+                TabItem tabItem = AppInstances[App.AppModel.TabStripSelectedIndex];
+                MultitaskingControl?.CloseTab(tabItem);
+            }
+            if (e is not null)
+                e.Handled = true;
+        }
 
-			tabItem.Control.ContentChanged += Control_ContentChanged;
-			await UpdateTabInfo(tabItem, tabViewItemArgs);
-			var index = atIndex == -1 ? AppInstances.Count : atIndex;
-			AppInstances.Insert(index, tabItem);
-			App.AppModel.TabStripSelectedIndex = index;
-		}
+        private async void AddNewInstanceAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+        {
+            await AddNewTabAsync();
+            if (e is not null)
+                e.Handled = true;
+        }
 
-		public static async void Control_ContentChanged(object sender, TabItemArguments e)
-		{
-			TabItem matchingTabItem = AppInstances.SingleOrDefault(x => x.Control == sender);
-			if (matchingTabItem == null)
-				return;
+        private void ReopenClosedTabAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+        {
+            (MultitaskingControl as BaseMultitaskingControl)?.ReopenClosedTab(null, null);
+            if (e is not null)
+                e.Handled = true;
+        }
 
-			await UpdateTabInfo(matchingTabItem, e.NavigationArg);
-		}
-	}
+        private async void OpenSettings()
+        {
+            var dialogService = Ioc.Default.GetRequiredService<IDialogService>();
+            var dialog = dialogService.GetDialog(new SettingsDialogViewModel());
+            await dialog.TryShowAsync();
+        }
+
+
+        public static async Task AddNewTabByPathAsync(Type type, string path, int atIndex = -1)
+        {
+            if (string.IsNullOrEmpty(path))
+                path = "Home".GetLocalizedResource();
+
+            // Support drives launched through jump list by stripping away the question mark at the end.
+            if (path.EndsWith("\\?"))
+                path = path.Remove(path.Length - 1);
+
+            TabItem tabItem = new TabItem()
+            {
+                Header = null,
+                IconSource = null,
+                Description = null,
+                ToolTipText = null
+            };
+            tabItem.Control.NavigationArguments = new TabItemArguments()
+            {
+                InitialPageType = type,
+                NavigationArg = path
+            };
+            tabItem.Control.ContentChanged += Control_ContentChanged;
+            await UpdateTabInfo(tabItem, path);
+            var index = atIndex == -1 ? AppInstances.Count : atIndex;
+            AppInstances.Insert(index, tabItem);
+            App.AppModel.TabStripSelectedIndex = index;
+        }
+
+        public async void UpdateInstanceProperties(object navigationArg)
+        {
+            string windowTitle = string.Empty;
+            if (navigationArg is PaneNavigationArguments paneArgs)
+            {
+                if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
+                {
+                    var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+                    var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
+                    windowTitle = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
+                }
+                else
+                {
+                    (windowTitle, _, _) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+                }
+            }
+            else if (navigationArg is string pathArgs)
+            {
+                (windowTitle, _, _) = await GetSelectedTabInfoAsync(pathArgs);
+            }
+            if (AppInstances.Count > 1)
+                windowTitle = $"{windowTitle} ({AppInstances.Count})";
+            if (navigationArg == SelectedTabItem?.TabItemArguments?.NavigationArg)
+
+                App.GetAppWindow(App.Window).Title = windowTitle;
+        }
+
+        public static async Task UpdateTabInfo(TabItem tabItem, object navigationArg)
+        {
+            tabItem.AllowStorageItemDrop = true;
+            if (navigationArg is PaneNavigationArguments paneArgs)
+            {
+                if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
+                {
+                    var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+                    var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
+                    tabItem.Header = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
+                    tabItem.IconSource = leftTabInfo.tabIcon;
+                }
+                else
+                {
+                    (tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+                }
+            }
+            else if (navigationArg is string pathArgs)
+            {
+                (tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = await GetSelectedTabInfoAsync(pathArgs);
+            }
+        }
+
+        public static async Task<(string tabLocationHeader, Microsoft.UI.Xaml.Controls.IconSource tabIcon, string toolTipText)> GetSelectedTabInfoAsync(string currentPath)
+        {
+            string? tabLocationHeader;
+            var iconSource = new Microsoft.UI.Xaml.Controls.ImageIconSource();
+            string toolTipText = currentPath;
+
+            if (string.IsNullOrEmpty(currentPath) || currentPath == "Home".GetLocalizedResource())
+            {
+                tabLocationHeader = "Home".GetLocalizedResource();
+                iconSource.ImageSource = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri("ms-appx:///Assets/FluentIcons/Home.png"));
+            }
+            else if (currentPath.Equals(CommonPaths.DesktopPath, StringComparison.OrdinalIgnoreCase))
+            {
+                tabLocationHeader = "Desktop".GetLocalizedResource();
+            }
+            else if (currentPath.Equals(CommonPaths.DownloadsPath, StringComparison.OrdinalIgnoreCase))
+            {
+                tabLocationHeader = "Downloads".GetLocalizedResource();
+            }
+            else if (currentPath.Equals(CommonPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
+            {
+                var localSettings = ApplicationData.Current.LocalSettings;
+                tabLocationHeader = localSettings.Values.Get("RecycleBin_Title", "Recycle Bin");
+            }
+            else if (currentPath.Equals(CommonPaths.NetworkFolderPath, StringComparison.OrdinalIgnoreCase))
+            {
+                tabLocationHeader = "SidebarNetworkDrives".GetLocalizedResource();
+            }
+            else if (App.LibraryManager.TryGetLibrary(currentPath, out LibraryLocationItem library))
+            {
+                var libName = System.IO.Path.GetFileNameWithoutExtension(library.Path).GetLocalizedResource();
+                // If localized string is empty use the library name.
+                tabLocationHeader = string.IsNullOrEmpty(libName) ? library.Text : libName;
+            }
+            else
+            {
+                var matchingCloudDrive = App.CloudDrivesManager.Drives.FirstOrDefault(x => PathNormalization.NormalizePath(currentPath).Equals(PathNormalization.NormalizePath(x.Path), StringComparison.OrdinalIgnoreCase));
+                if (matchingCloudDrive != null)
+                {
+                    tabLocationHeader = matchingCloudDrive.Text;
+                }
+                else if (PathNormalization.NormalizePath(PathNormalization.GetPathRoot(currentPath)) == PathNormalization.NormalizePath(currentPath)) // If path is a drive's root
+                {
+                    var matchingNetDrive = App.NetworkDrivesManager.Drives.FirstOrDefault(x => PathNormalization.NormalizePath(currentPath).Contains(PathNormalization.NormalizePath(x.Path), StringComparison.OrdinalIgnoreCase));
+                    if (matchingNetDrive != null)
+                        tabLocationHeader = matchingNetDrive.Text;
+                    else
+                        tabLocationHeader = PathNormalization.NormalizePath(currentPath);
+                }
+                else
+                {
+                    tabLocationHeader = currentPath.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar).Split('\\', StringSplitOptions.RemoveEmptyEntries).Last();
+
+                    FilesystemResult<StorageFolderWithPath> rootItem = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(currentPath));
+                    if (rootItem)
+                    {
+                        BaseStorageFolder currentFolder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(currentPath, rootItem));
+                        if (currentFolder != null && !string.IsNullOrEmpty(currentFolder.DisplayName))
+                            tabLocationHeader = currentFolder.DisplayName;
+                    }
+                }
+            }
+
+            if (iconSource.ImageSource == null)
+            {
+                var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 24u, Windows.Storage.FileProperties.ThumbnailMode.ListView, true);
+                if (iconData != null)
+                    iconSource.ImageSource = await iconData.ToBitmapAsync();
+            }
+
+            return (tabLocationHeader, iconSource, toolTipText);
+        }
+
+        public async void OnNavigatedTo(NavigationEventArgs e)
+        {
+            if (e.NavigationMode == NavigationMode.Back)
+                return;
+
+            //Initialize the static theme helper to capture a reference to this window
+            //to handle theme changes without restarting the app
+            ThemeHelper.Initialize();
+
+            if (e.Parameter == null || (e.Parameter is string eventStr && string.IsNullOrEmpty(eventStr)))
+            {
+                try
+                {
+                    // add last session tabs to closed tabs stack if those tabs are not about to be opened
+                    if (!UserSettingsService.AppSettingsService.RestoreTabsOnStartup && !UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp && UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
+                    {
+                        var items = new TabItemArguments[UserSettingsService.PreferencesSettingsService.LastSessionTabList.Count];
+                        for (int i = 0; i < items.Length; i++)
+                        {
+                            var tabArgs = TabItemArguments.Deserialize(UserSettingsService.PreferencesSettingsService.LastSessionTabList[i]);
+                            items[i] = tabArgs;
+                        }
+                        BaseMultitaskingControl.RecentlyClosedTabs.Add(items);
+                    }
+
+                    if (UserSettingsService.AppSettingsService.RestoreTabsOnStartup)
+                    {
+                        UserSettingsService.AppSettingsService.RestoreTabsOnStartup = false;
+                        if (UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
+                        {
+                            foreach (string tabArgsString in UserSettingsService.PreferencesSettingsService.LastSessionTabList)
+                            {
+                                var tabArgs = TabItemArguments.Deserialize(tabArgsString);
+                                await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
+                            }
+                        }
+
+                        if (!UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp)
+                        {
+                            UserSettingsService.PreferencesSettingsService.LastSessionTabList = null;
+                        }
+                    }
+                    else if (UserSettingsService.PreferencesSettingsService.OpenSpecificPageOnStartup)
+                    {
+                        if (UserSettingsService.PreferencesSettingsService.TabsOnStartupList != null)
+                        {
+                            foreach (string path in UserSettingsService.PreferencesSettingsService.TabsOnStartupList)
+                                await AddNewTabByPathAsync(typeof(PaneHolderPage), path);
+                        }
+                        else
+                        {
+                            await AddNewTabAsync();
+                        }
+                    }
+                    else if (UserSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp)
+                    {
+                        if (UserSettingsService.PreferencesSettingsService.LastSessionTabList != null)
+                        {
+                            foreach (string tabArgsString in UserSettingsService.PreferencesSettingsService.LastSessionTabList)
+                            {
+                                var tabArgs = TabItemArguments.Deserialize(tabArgsString);
+                                await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
+                            }
+                            var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home".GetLocalizedResource() };
+                            UserSettingsService.PreferencesSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
+                        }
+                        else
+                        {
+                            await AddNewTabAsync();
+                        }
+                    }
+                    else
+                    {
+                        await AddNewTabAsync();
+                    }
+                }
+                catch (Exception)
+                {
+                    await AddNewTabAsync();
+                }
+            }
+            else
+            {
+                if (e.Parameter is string navArgs)
+                    await AddNewTabByPathAsync(typeof(PaneHolderPage), navArgs);
+                else if (e.Parameter is PaneNavigationArguments paneArgs)
+                    await AddNewTabByParam(typeof(PaneHolderPage), paneArgs);
+                else if (e.Parameter is TabItemArguments tabArgs)
+                    await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
+            }
+        }
+
+        public static async Task AddNewTabAsync()
+        {
+            await AddNewTabByPathAsync(typeof(PaneHolderPage), "Home".GetLocalizedResource());
+        }
+
+        public async void AddNewTab()
+        {
+            await AddNewTabAsync();
+        }
+
+        public static async void AddNewTabAtIndex(object sender, RoutedEventArgs e)
+        {
+            await AddNewTabAsync();
+        }
+
+        public static async void DuplicateTabAtIndex(object sender, RoutedEventArgs e)
+        {
+            var tabItem = (TabItem)((FrameworkElement)sender).DataContext;
+            var index = AppInstances.IndexOf(tabItem);
+
+            if (AppInstances[index].TabItemArguments != null)
+            {
+                var tabArgs = AppInstances[index].TabItemArguments;
+                await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg, index + 1);
+            }
+            else
+            {
+                await AddNewTabByPathAsync(typeof(PaneHolderPage), "Home".GetLocalizedResource());
+            }
+        }
+
+        public static async Task AddNewTabByParam(Type type, object tabViewItemArgs, int atIndex = -1)
+        {
+            TabItem tabItem = new TabItem()
+            {
+                Header = null,
+                IconSource = null,
+                Description = null,
+                ToolTipText = null
+            };
+
+            tabItem.Control.NavigationArguments = new TabItemArguments()
+            {
+                InitialPageType = type,
+                NavigationArg = tabViewItemArgs
+            };
+
+            tabItem.Control.ContentChanged += Control_ContentChanged;
+            await UpdateTabInfo(tabItem, tabViewItemArgs);
+            var index = atIndex == -1 ? AppInstances.Count : atIndex;
+            AppInstances.Insert(index, tabItem);
+            App.AppModel.TabStripSelectedIndex = index;
+        }
+
+        public static async void Control_ContentChanged(object? sender, TabItemArguments e)
+        {
+            if (sender == null)
+                return;
+            TabItem? matchingTabItem = AppInstances.SingleOrDefault(x => x.Control == (TabItemControl)sender);
+            if (matchingTabItem == null)
+                return;
+
+            await UpdateTabInfo(matchingTabItem, e.NavigationArg);
+        }
+    }
 }

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -377,11 +377,8 @@ namespace Files.App.Views
 
 		private void ToggleSidebarCollapsedState(KeyboardAcceleratorInvokedEventArgs? e)
 		{
-			if (e is null)
-				return;
 			SidebarAdaptiveViewModel.IsSidebarOpen = !SidebarAdaptiveViewModel.IsSidebarOpen;
-
-			e.Handled = true;
+			e!.Handled = true;
 		}
 
 		private void SidebarControl_Loaded(object sender, RoutedEventArgs e)

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -31,498 +31,498 @@ using Windows.Storage;
 
 namespace Files.App.Views
 {
-    /// <summary>
-    /// The root page of Files
-    /// </summary>
-    public sealed partial class MainPage : Page, INotifyPropertyChanged
-    {
-        public IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>()!;
-
-        public AppModel AppModel => App.AppModel;
-
-        public MainPageViewModel ViewModel
-        {
-            get => (MainPageViewModel)DataContext;
-            set => DataContext = value;
-        }
-
-        public SidebarViewModel SidebarAdaptiveViewModel = new SidebarViewModel();
-
-        public OngoingTasksViewModel OngoingTasksViewModel => App.OngoingTasksViewModel;
-
-        public ICommand ToggleFullScreenAcceleratorCommand { get; }
-
-        private ICommand ToggleCompactOverlayCommand { get; }
-        private ICommand SetCompactOverlayCommand { get; }
-
-        private ICommand ToggleSidebarCollapsedStateCommand => new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(x => ToggleSidebarCollapsedState(x));
-
-        public MainPage()
-        {
-            InitializeComponent();
-
-            // TODO LayoutDirection is empty, might be an issue with WinAppSdk
-            var flowDirectionSetting = new Microsoft.Windows.ApplicationModel.Resources.ResourceManager().CreateResourceContext().QualifierValues["LayoutDirection"]; 
-            if (flowDirectionSetting == "RTL")
-                FlowDirection = FlowDirection.RightToLeft;
-
-            AllowDrop = true;
-
-            ToggleFullScreenAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(ToggleFullScreenAccelerator);
-            ToggleCompactOverlayCommand = new RelayCommand(ToggleCompactOverlay);
-            SetCompactOverlayCommand = new RelayCommand<bool>(SetCompactOverlay);
-
-            if (SystemInformation.Instance.TotalLaunchCount >= 15 & Package.Current.Id.Name == "49306atecsolution.FilesUWP" && !UserSettingsService.ApplicationSettingsService.WasPromptedToReview)
-            {
-                PromptForReview();
-                UserSettingsService.ApplicationSettingsService.WasPromptedToReview = true;
-            }
-
-            UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
-
-            LoadSelectedTheme();
-        }
-
-        private async void LoadSelectedTheme()
-        {
-            App.ExternalResourcesHelper.OverrideAppResources(UserSettingsService.AppearanceSettingsService.UseCompactStyles);
-            await App.ExternalResourcesHelper.LoadSelectedTheme();
-        }
-
-        private async void PromptForReview()
-        {
-            var AskForReviewDialog = new ContentDialog
-            {
-                Title = "ReviewFiles".ToLocalized(),
-                Content = "ReviewFilesContent".ToLocalized(),
-                PrimaryButtonText = "Yes".ToLocalized(),
-                SecondaryButtonText = "No".ToLocalized()
-            };
-
-            var result = await this.SetContentDialogRoot(AskForReviewDialog).ShowAsync();
-
-            if (result == ContentDialogResult.Primary)
-            {
-                try
-                {
-                    var storeContext = StoreContext.GetDefault();
-                    await storeContext.RequestRateAndReviewAppAsync();
-                }
-                catch (Exception) { }
-            }
-        }
-
-        // WINUI3
-        private ContentDialog SetContentDialogRoot(ContentDialog contentDialog)
-        {
-            if (Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
-                contentDialog.XamlRoot = App.Window.Content.XamlRoot;
-            return contentDialog;
-        }
-
-        private void UserSettingsService_OnSettingChangedEvent(object? sender, SettingChangedEventArgs e)
-        {
-            switch (e.SettingName)
-            {
-                case nameof(IPaneSettingsService.Content):
-                    LoadPaneChanged();
-                    break;
-            }
-        }
-
-        private void HorizontalMultitaskingControl_Loaded(object sender, RoutedEventArgs e)
-        {
-            // WINUI3: bad workaround to be removed asap!
-            // SetDragRectangles() does not work on windows 10 with winappsdk "1.2.220902.1-preview1"
-            if (Environment.OSVersion.Version.Build >= 22000)
-            {
-                horizontalMultitaskingControl.DragArea.SizeChanged += (_, _) => SetRectDragRegion();
-            }
-            else
-            {
-                App.Window.AppWindow.TitleBar.ExtendsContentIntoTitleBar = false;
-                App.Window.ExtendsContentIntoTitleBar = true;
-                App.Window.SetTitleBar(horizontalMultitaskingControl.DragArea);
-            }
-
-            if (!(ViewModel.MultitaskingControl is HorizontalMultitaskingControl))
-            {
-                ViewModel.MultitaskingControl = horizontalMultitaskingControl;
-                ViewModel.MultitaskingControls.Add(horizontalMultitaskingControl);
-                ViewModel.MultitaskingControl.CurrentInstanceChanged += MultitaskingControl_CurrentInstanceChanged;
-            }
-        }
-
-        private void SetRectDragRegion()
-        {
-            const uint MDT_Effective_DPI = 0;
-
-            var displayArea = DisplayArea.GetFromWindowId(App.Window.AppWindow.Id, DisplayAreaFallback.Primary);
-            var hMonitor = Win32Interop.GetMonitorFromDisplayId(displayArea.DisplayId);
-            var hr = NativeWinApiHelper.GetDpiForMonitor(hMonitor, MDT_Effective_DPI, out var dpiX, out _);
-            if (hr != 0)
-                return;
-
-            var scaleAdjustment = XamlRoot.RasterizationScale;
-            var dragArea = horizontalMultitaskingControl.DragArea;
-
-            var x = (int)((horizontalMultitaskingControl.ActualWidth - dragArea.ActualWidth) * scaleAdjustment);
-            var y = 0;
-            var width = (int)(dragArea.ActualWidth * scaleAdjustment);
-            var height = (int)(horizontalMultitaskingControl.TitlebarArea.ActualHeight * scaleAdjustment);
-
-            var dragRect = new RectInt32(x, y, width, height);
-            App.Window.AppWindow.TitleBar.SetDragRectangles(new[] { dragRect });
-        }
-
-        public void TabItemContent_ContentChanged(object? sender, TabItemArguments e)
-        {
-            if (SidebarAdaptiveViewModel.PaneHolder == null)
-                return;
-
-            var paneArgs = e.NavigationArg as PaneNavigationArguments;
-            SidebarAdaptiveViewModel.UpdateSidebarSelectedItemFromArgs(SidebarAdaptiveViewModel.PaneHolder.IsLeftPaneActive ?
-                paneArgs.LeftPaneNavPathParam : paneArgs.RightPaneNavPathParam);
-            UpdateStatusBarProperties();
-            LoadPaneChanged();
-            UpdateNavToolbarProperties();
-            ViewModel.UpdateInstanceProperties(paneArgs);
-        }
-
-        public void MultitaskingControl_CurrentInstanceChanged(object? sender, CurrentInstanceChangedEventArgs e)
-        {
-            if (SidebarAdaptiveViewModel.PaneHolder != null)
-                SidebarAdaptiveViewModel.PaneHolder.PropertyChanged -= PaneHolder_PropertyChanged;
-
-            var navArgs = e.CurrentInstance.TabItemArguments?.NavigationArg;
-            SidebarAdaptiveViewModel.PaneHolder = e.CurrentInstance as IPaneHolder;
-            SidebarAdaptiveViewModel.PaneHolder.PropertyChanged += PaneHolder_PropertyChanged;
-            SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged((navArgs as PaneNavigationArguments).LeftPaneNavPathParam);
-            UpdateStatusBarProperties();
-            UpdateNavToolbarProperties();
-            LoadPaneChanged();
-            ViewModel.UpdateInstanceProperties(navArgs);
-            e.CurrentInstance.ContentChanged -= TabItemContent_ContentChanged;
-            e.CurrentInstance.ContentChanged += TabItemContent_ContentChanged;
-        }
-
-        private void PaneHolder_PropertyChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged(SidebarAdaptiveViewModel.PaneHolder.ActivePane?.TabItemArguments?.NavigationArg?.ToString());
-            UpdateStatusBarProperties();
-            UpdateNavToolbarProperties();
-            LoadPaneChanged();
-        }
-
-        private void UpdateStatusBarProperties()
-        {
-            if (StatusBarControl != null)
-            {
-                StatusBarControl.DirectoryPropertiesViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.SlimContentPage?.DirectoryPropertiesViewModel;
-                StatusBarControl.SelectedItemsPropertiesViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.SlimContentPage?.SelectedItemsPropertiesViewModel;
-            }
-        }
-
-        private void UpdateNavToolbarProperties()
-        {
-            if (NavToolbar != null)
-                NavToolbar.ViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.ToolbarViewModel;
-
-            if (InnerNavigationToolbar != null)
-            {
-                InnerNavigationToolbar.ViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.ToolbarViewModel;
-                InnerNavigationToolbar.ShowMultiPaneControls = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneEnabled ?? false;
-                InnerNavigationToolbar.IsMultiPaneActive = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
-            }
-        }
-
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            ViewModel.OnNavigatedTo(e);
-            SidebarControl.SidebarItemInvoked += SidebarControl_SidebarItemInvoked;
-            SidebarControl.SidebarItemPropertiesInvoked += SidebarControl_SidebarItemPropertiesInvoked;
-            SidebarControl.SidebarItemDropped += SidebarControl_SidebarItemDropped;
-            SidebarControl.SidebarItemNewPaneInvoked += SidebarControl_SidebarItemNewPaneInvoked;
-        }
-
-        private async void SidebarControl_SidebarItemDropped(object sender, SidebarItemDroppedEventArgs e)
-        {
-            await SidebarAdaptiveViewModel.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.Package, e.ItemPath, false, true);
-            e.SignalEvent?.Set();
-        }
-
-        private async void SidebarControl_SidebarItemPropertiesInvoked(object sender, SidebarItemPropertiesInvokedEventArgs e)
-        {
-            if (e.InvokedItemDataContext is DriveItem)
-            {
-                await FilePropertiesHelpers.OpenPropertiesWindowAsync(e.InvokedItemDataContext, SidebarAdaptiveViewModel.PaneHolder.ActivePane);
-            }
-            else if (e.InvokedItemDataContext is LibraryLocationItem library)
-            {
-                await FilePropertiesHelpers.OpenPropertiesWindowAsync(new LibraryItem(library), SidebarAdaptiveViewModel.PaneHolder.ActivePane);
-            }
-            else if (e.InvokedItemDataContext is LocationItem locationItem)
-            {
-                ListedItem listedItem = new ListedItem(null!)
-                {
-                    ItemPath = locationItem.Path,
-                    ItemNameRaw = locationItem.Text,
-                    PrimaryItemAttribute = StorageItemTypes.Folder,
-                    ItemType = "FileFolderListItem".GetLocalizedResource(),
-                };
-                await FilePropertiesHelpers.OpenPropertiesWindowAsync(listedItem, SidebarAdaptiveViewModel.PaneHolder.ActivePane);
-            }
-        }
-
-        private void SidebarControl_SidebarItemNewPaneInvoked(object sender, SidebarItemNewPaneInvokedEventArgs e)
-        {
-            if (e.InvokedItemDataContext is INavigationControlItem navItem)
-                SidebarAdaptiveViewModel.PaneHolder.OpenPathInNewPane(navItem.Path);
-        }
-
-        private void SidebarControl_SidebarItemInvoked(object sender, SidebarItemInvokedEventArgs e)
-        {
-            var invokedItemContainer = e.InvokedItemContainer;
-
-            string? navigationPath; // path to navigate
-            Type? sourcePageType = null; // type of page to navigate
-
-            switch ((invokedItemContainer.DataContext as INavigationControlItem)?.ItemType)
-            {
-                case NavigationControlItemType.Location:
-                    {
-                        var ItemPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
-
-                        if (string.IsNullOrEmpty(ItemPath)) // Section item
-                        {
-                            navigationPath = invokedItemContainer.Tag?.ToString();
-                        }
-                        else if (ItemPath.Equals("Home".GetLocalizedResource(), StringComparison.OrdinalIgnoreCase)) // Home item
-                        {
-                            if (ItemPath.Equals(SidebarAdaptiveViewModel.SidebarSelectedItem?.Path, StringComparison.OrdinalIgnoreCase))
-                                return; // return if already selected
-
-                            navigationPath = "Home".GetLocalizedResource();
-                            sourcePageType = typeof(WidgetsPage);
-                        }
-                        else // Any other item
-                        {
-                            navigationPath = invokedItemContainer.Tag?.ToString();
-                        }
-
-                        break;
-                    }
-
-                case NavigationControlItemType.FileTag:
-                    var tagPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
-                    if (SidebarAdaptiveViewModel.PaneHolder?.ActivePane is IShellPage shp)
-                    {
-                        shp.NavigateToPath(tagPath, new NavigationArguments()
-                        {
-                            IsSearchResultPage = true,
-                            SearchPathParam = "Home".GetLocalizedResource(),
-                            SearchQuery = tagPath,
-                            AssociatedTabInstance = shp,
-                            NavPathParam = tagPath
-                        });
-                    }
-                    return;
-
-                default:
-                    {
-                        navigationPath = invokedItemContainer.Tag?.ToString();
-                        break;
-                    }
-            }
-
-            if (SidebarAdaptiveViewModel.PaneHolder?.ActivePane is IShellPage shellPage)
-                shellPage.NavigateToPath(navigationPath, sourcePageType);
-        }
-
-        private void Page_Loaded(object sender, RoutedEventArgs e)
-        {
-            // Defers the status bar loading until after the page has loaded to improve startup perf
-            FindName(nameof(StatusBarControl));
-            FindName(nameof(InnerNavigationToolbar));
-            FindName(nameof(horizontalMultitaskingControl));
-            FindName(nameof(NavToolbar));
-        }
-
-        private void Page_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            switch (Pane?.Position)
-            {
-                case PanePositions.Right when ContentColumn.ActualWidth == ContentColumn.MinWidth:
-                    UserSettingsService.PaneSettingsService.VerticalSizePx += e.NewSize.Width - e.PreviousSize.Width;
-                    UpdatePositioning();
-                    break;
-                case PanePositions.Bottom when ContentRow.ActualHeight == ContentRow.MinHeight:
-                    UserSettingsService.PaneSettingsService.HorizontalSizePx += e.NewSize.Height - e.PreviousSize.Height;
-                    UpdatePositioning();
-                    break;
-            }
-        }
-
-        private void ToggleFullScreenAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
-        {
-            var view = App.GetAppWindow(App.Window);
-
-            if (view.Presenter.Kind == AppWindowPresenterKind.FullScreen)
-                view.SetPresenter(AppWindowPresenterKind.Overlapped);
-            else
-                view.SetPresenter(AppWindowPresenterKind.FullScreen);
-            if (e != null)
-            e.Handled = true;
-        }
-
-        private void ToggleSidebarCollapsedState(KeyboardAcceleratorInvokedEventArgs? e)
-        {
-            if (e is null)
-                return;
-            SidebarAdaptiveViewModel.IsSidebarOpen = !SidebarAdaptiveViewModel.IsSidebarOpen;
-
-            e.Handled = true;
-        }
-
-        private void SidebarControl_Loaded(object sender, RoutedEventArgs e)
-        {
-            SidebarAdaptiveViewModel.UpdateTabControlMargin(); // Set the correct tab margin on startup
-        }
-
-        private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e) => LoadPaneChanged();
-
-        /// <summary>
-        /// Call this function to update the positioning of the preview pane.
-        /// This is a workaround as the VisualStateManager causes problems.
-        /// </summary>
-        private void UpdatePositioning()
-        {
-            if (Pane is null || !IsPaneEnabled)
-            {
-                PaneRow.MinHeight = 0;
-                PaneRow.MaxHeight = double.MaxValue;
-                PaneRow.Height = new GridLength(0);
-                PaneColumn.MinWidth = 0;
-                PaneColumn.MaxWidth = double.MaxValue;
-                PaneColumn.Width = new GridLength(0);
-            }
-            else
-            {
-                Pane.UpdatePosition(RootGrid.ActualWidth, RootGrid.ActualHeight);
-                switch (Pane.Position)
-                {
-                    case PanePositions.None:
-                        PaneRow.MinHeight = 0;
-                        PaneRow.Height = new GridLength(0);
-                        PaneColumn.MinWidth = 0;
-                        PaneColumn.Width = new GridLength(0);
-                        break;
-                    case PanePositions.Right:
-                        Pane.SetValue(Grid.RowProperty, 1);
-                        Pane.SetValue(Grid.ColumnProperty, 2);
-                        PaneSplitter.SetValue(Grid.RowProperty, 1);
-                        PaneSplitter.SetValue(Grid.ColumnProperty, 1);
-                        PaneSplitter.Width = 2;
-                        PaneSplitter.Height = RootGrid.ActualHeight;
-                        PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeWestEast;
-                        PaneColumn.MinWidth = Pane.MinWidth;
-                        PaneColumn.MaxWidth = Pane.MaxWidth;
-                        PaneColumn.Width = new GridLength(UserSettingsService.PaneSettingsService.VerticalSizePx, GridUnitType.Pixel);
-                        PaneRow.MinHeight = 0;
-                        PaneRow.MaxHeight = double.MaxValue;
-                        PaneRow.Height = new GridLength(0);
-                        break;
-                    case PanePositions.Bottom:
-                        Pane.SetValue(Grid.RowProperty, 3);
-                        Pane.SetValue(Grid.ColumnProperty, 0);
-                        PaneSplitter.SetValue(Grid.RowProperty, 2);
-                        PaneSplitter.SetValue(Grid.ColumnProperty, 0);
-                        PaneSplitter.Height = 2;
-                        PaneSplitter.Width = RootGrid.ActualWidth;
-                        PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeNorthSouth;
-                        PaneColumn.MinWidth = 0;
-                        PaneColumn.MaxWidth = double.MaxValue;
-                        PaneColumn.Width = new GridLength(0);
-                        PaneRow.MinHeight = Pane.MinHeight;
-                        PaneRow.MaxHeight = Pane.MaxHeight;
-                        PaneRow.Height = new GridLength(UserSettingsService.PaneSettingsService.HorizontalSizePx, GridUnitType.Pixel);
-                        break;
-                }
-            }
-        }
-
-        private void PaneSplitter_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
-        {
-            switch (Pane?.Position)
-            {
-                case PanePositions.Right:
-                    UserSettingsService.PaneSettingsService.VerticalSizePx = Pane.ActualWidth;
-                    break;
-                case PanePositions.Bottom:
-                    UserSettingsService.PaneSettingsService.HorizontalSizePx = Pane.ActualHeight;
-                    break;
-            }
-        }
-
-        public bool IsPaneEnabled => UserSettingsService.PaneSettingsService.Content switch
-        {
-            PaneContents.Preview => IsPreviewPaneEnabled,
-            _ => false,
-        };
-
-        public bool IsPreviewPaneEnabled
-        {
-            get
-            {
-                var isHomePage = !(SidebarAdaptiveViewModel.PaneHolder?.ActivePane?.InstanceViewModel?.IsPageTypeNotHome ?? false);
-                var isMultiPane = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
-                var isBigEnough = App.Window.Bounds.Width > 450 && App.Window.Bounds.Height > 400;
-                var isEnabled = (!isHomePage || isMultiPane) && isBigEnough;
-
-                return isEnabled;
-            }
-        }
-
-        private void LoadPaneChanged()
-        {
-            OnPropertyChanged(nameof(IsPaneEnabled));
-            OnPropertyChanged(nameof(IsPreviewPaneEnabled));
-            UpdatePositioning();
-        }
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-
-        private void OnPropertyChanged([CallerMemberName] string propertyName = "")
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        private void ToggleCompactOverlay() => SetCompactOverlay(App.GetAppWindow(App.Window).Presenter.Kind != AppWindowPresenterKind.CompactOverlay);
-
-        private void SetCompactOverlay(bool isCompact)
-        {
-            var view = App.GetAppWindow(App.Window);
-
-            if (!isCompact)
-            {
-                ViewModel.IsWindowCompactOverlay = false;
-                view.SetPresenter(AppWindowPresenterKind.Overlapped);
-            }
-            else
-            {
-                ViewModel.IsWindowCompactOverlay = true;
-                view.SetPresenter(AppWindowPresenterKind.CompactOverlay);
-                view.Resize(new SizeInt32(400, 350));
-            }
-        }
-
-        private void RootGrid_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
-        {
-            // prevents the arrow key events from navigating the list instead of switching compact overlay
-            if (EnterCompactOverlayKeyboardAccelerator.CheckIsPressed() || ExitCompactOverlayKeyboardAccelerator.CheckIsPressed())
-                Focus(FocusState.Keyboard);
-        }
-
-        private void NavToolbar_Loaded(object sender, RoutedEventArgs e) => UpdateNavToolbarProperties();
-    }
+	/// <summary>
+	/// The root page of Files
+	/// </summary>
+	public sealed partial class MainPage : Page, INotifyPropertyChanged
+	{
+		public IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>()!;
+
+		public AppModel AppModel => App.AppModel;
+
+		public MainPageViewModel ViewModel
+		{
+			get => (MainPageViewModel)DataContext;
+			set => DataContext = value;
+		}
+
+		public SidebarViewModel SidebarAdaptiveViewModel = new SidebarViewModel();
+
+		public OngoingTasksViewModel OngoingTasksViewModel => App.OngoingTasksViewModel;
+
+		public ICommand ToggleFullScreenAcceleratorCommand { get; }
+
+		private ICommand ToggleCompactOverlayCommand { get; }
+		private ICommand SetCompactOverlayCommand { get; }
+
+		private ICommand ToggleSidebarCollapsedStateCommand => new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(x => ToggleSidebarCollapsedState(x));
+
+		public MainPage()
+		{
+			InitializeComponent();
+
+			// TODO LayoutDirection is empty, might be an issue with WinAppSdk
+			var flowDirectionSetting = new Microsoft.Windows.ApplicationModel.Resources.ResourceManager().CreateResourceContext().QualifierValues["LayoutDirection"];
+			if (flowDirectionSetting == "RTL")
+				FlowDirection = FlowDirection.RightToLeft;
+
+			AllowDrop = true;
+
+			ToggleFullScreenAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(ToggleFullScreenAccelerator);
+			ToggleCompactOverlayCommand = new RelayCommand(ToggleCompactOverlay);
+			SetCompactOverlayCommand = new RelayCommand<bool>(SetCompactOverlay);
+
+			if (SystemInformation.Instance.TotalLaunchCount >= 15 & Package.Current.Id.Name == "49306atecsolution.FilesUWP" && !UserSettingsService.ApplicationSettingsService.WasPromptedToReview)
+			{
+				PromptForReview();
+				UserSettingsService.ApplicationSettingsService.WasPromptedToReview = true;
+			}
+
+			UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
+
+			LoadSelectedTheme();
+		}
+
+		private async void LoadSelectedTheme()
+		{
+			App.ExternalResourcesHelper.OverrideAppResources(UserSettingsService.AppearanceSettingsService.UseCompactStyles);
+			await App.ExternalResourcesHelper.LoadSelectedTheme();
+		}
+
+		private async void PromptForReview()
+		{
+			var AskForReviewDialog = new ContentDialog
+			{
+				Title = "ReviewFiles".ToLocalized(),
+				Content = "ReviewFilesContent".ToLocalized(),
+				PrimaryButtonText = "Yes".ToLocalized(),
+				SecondaryButtonText = "No".ToLocalized()
+			};
+
+			var result = await this.SetContentDialogRoot(AskForReviewDialog).ShowAsync();
+
+			if (result == ContentDialogResult.Primary)
+			{
+				try
+				{
+					var storeContext = StoreContext.GetDefault();
+					await storeContext.RequestRateAndReviewAppAsync();
+				}
+				catch (Exception) { }
+			}
+		}
+
+		// WINUI3
+		private ContentDialog SetContentDialogRoot(ContentDialog contentDialog)
+		{
+			if (Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+				contentDialog.XamlRoot = App.Window.Content.XamlRoot;
+			return contentDialog;
+		}
+
+		private void UserSettingsService_OnSettingChangedEvent(object? sender, SettingChangedEventArgs e)
+		{
+			switch (e.SettingName)
+			{
+				case nameof(IPaneSettingsService.Content):
+					LoadPaneChanged();
+					break;
+			}
+		}
+
+		private void HorizontalMultitaskingControl_Loaded(object sender, RoutedEventArgs e)
+		{
+			// WINUI3: bad workaround to be removed asap!
+			// SetDragRectangles() does not work on windows 10 with winappsdk "1.2.220902.1-preview1"
+			if (Environment.OSVersion.Version.Build >= 22000)
+			{
+				horizontalMultitaskingControl.DragArea.SizeChanged += (_, _) => SetRectDragRegion();
+			}
+			else
+			{
+				App.Window.AppWindow.TitleBar.ExtendsContentIntoTitleBar = false;
+				App.Window.ExtendsContentIntoTitleBar = true;
+				App.Window.SetTitleBar(horizontalMultitaskingControl.DragArea);
+			}
+
+			if (!(ViewModel.MultitaskingControl is HorizontalMultitaskingControl))
+			{
+				ViewModel.MultitaskingControl = horizontalMultitaskingControl;
+				ViewModel.MultitaskingControls.Add(horizontalMultitaskingControl);
+				ViewModel.MultitaskingControl.CurrentInstanceChanged += MultitaskingControl_CurrentInstanceChanged;
+			}
+		}
+
+		private void SetRectDragRegion()
+		{
+			const uint MDT_Effective_DPI = 0;
+
+			var displayArea = DisplayArea.GetFromWindowId(App.Window.AppWindow.Id, DisplayAreaFallback.Primary);
+			var hMonitor = Win32Interop.GetMonitorFromDisplayId(displayArea.DisplayId);
+			var hr = NativeWinApiHelper.GetDpiForMonitor(hMonitor, MDT_Effective_DPI, out var dpiX, out _);
+			if (hr != 0)
+				return;
+
+			var scaleAdjustment = XamlRoot.RasterizationScale;
+			var dragArea = horizontalMultitaskingControl.DragArea;
+
+			var x = (int)((horizontalMultitaskingControl.ActualWidth - dragArea.ActualWidth) * scaleAdjustment);
+			var y = 0;
+			var width = (int)(dragArea.ActualWidth * scaleAdjustment);
+			var height = (int)(horizontalMultitaskingControl.TitlebarArea.ActualHeight * scaleAdjustment);
+
+			var dragRect = new RectInt32(x, y, width, height);
+			App.Window.AppWindow.TitleBar.SetDragRectangles(new[] { dragRect });
+		}
+
+		public void TabItemContent_ContentChanged(object? sender, TabItemArguments e)
+		{
+			if (SidebarAdaptiveViewModel.PaneHolder == null)
+				return;
+
+			var paneArgs = e.NavigationArg as PaneNavigationArguments;
+			SidebarAdaptiveViewModel.UpdateSidebarSelectedItemFromArgs(SidebarAdaptiveViewModel.PaneHolder.IsLeftPaneActive ?
+				paneArgs.LeftPaneNavPathParam : paneArgs.RightPaneNavPathParam);
+			UpdateStatusBarProperties();
+			LoadPaneChanged();
+			UpdateNavToolbarProperties();
+			ViewModel.UpdateInstanceProperties(paneArgs);
+		}
+
+		public void MultitaskingControl_CurrentInstanceChanged(object? sender, CurrentInstanceChangedEventArgs e)
+		{
+			if (SidebarAdaptiveViewModel.PaneHolder != null)
+				SidebarAdaptiveViewModel.PaneHolder.PropertyChanged -= PaneHolder_PropertyChanged;
+
+			var navArgs = e.CurrentInstance.TabItemArguments?.NavigationArg;
+			SidebarAdaptiveViewModel.PaneHolder = e.CurrentInstance as IPaneHolder;
+			SidebarAdaptiveViewModel.PaneHolder.PropertyChanged += PaneHolder_PropertyChanged;
+			SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged((navArgs as PaneNavigationArguments).LeftPaneNavPathParam);
+			UpdateStatusBarProperties();
+			UpdateNavToolbarProperties();
+			LoadPaneChanged();
+			ViewModel.UpdateInstanceProperties(navArgs);
+			e.CurrentInstance.ContentChanged -= TabItemContent_ContentChanged;
+			e.CurrentInstance.ContentChanged += TabItemContent_ContentChanged;
+		}
+
+		private void PaneHolder_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged(SidebarAdaptiveViewModel.PaneHolder.ActivePane?.TabItemArguments?.NavigationArg?.ToString());
+			UpdateStatusBarProperties();
+			UpdateNavToolbarProperties();
+			LoadPaneChanged();
+		}
+
+		private void UpdateStatusBarProperties()
+		{
+			if (StatusBarControl != null)
+			{
+				StatusBarControl.DirectoryPropertiesViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.SlimContentPage?.DirectoryPropertiesViewModel;
+				StatusBarControl.SelectedItemsPropertiesViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.SlimContentPage?.SelectedItemsPropertiesViewModel;
+			}
+		}
+
+		private void UpdateNavToolbarProperties()
+		{
+			if (NavToolbar != null)
+				NavToolbar.ViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.ToolbarViewModel;
+
+			if (InnerNavigationToolbar != null)
+			{
+				InnerNavigationToolbar.ViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.ToolbarViewModel;
+				InnerNavigationToolbar.ShowMultiPaneControls = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneEnabled ?? false;
+				InnerNavigationToolbar.IsMultiPaneActive = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
+			}
+		}
+
+		protected override void OnNavigatedTo(NavigationEventArgs e)
+		{
+			ViewModel.OnNavigatedTo(e);
+			SidebarControl.SidebarItemInvoked += SidebarControl_SidebarItemInvoked;
+			SidebarControl.SidebarItemPropertiesInvoked += SidebarControl_SidebarItemPropertiesInvoked;
+			SidebarControl.SidebarItemDropped += SidebarControl_SidebarItemDropped;
+			SidebarControl.SidebarItemNewPaneInvoked += SidebarControl_SidebarItemNewPaneInvoked;
+		}
+
+		private async void SidebarControl_SidebarItemDropped(object sender, SidebarItemDroppedEventArgs e)
+		{
+			await SidebarAdaptiveViewModel.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.Package, e.ItemPath, false, true);
+			e.SignalEvent?.Set();
+		}
+
+		private async void SidebarControl_SidebarItemPropertiesInvoked(object sender, SidebarItemPropertiesInvokedEventArgs e)
+		{
+			if (e.InvokedItemDataContext is DriveItem)
+			{
+				await FilePropertiesHelpers.OpenPropertiesWindowAsync(e.InvokedItemDataContext, SidebarAdaptiveViewModel.PaneHolder.ActivePane);
+			}
+			else if (e.InvokedItemDataContext is LibraryLocationItem library)
+			{
+				await FilePropertiesHelpers.OpenPropertiesWindowAsync(new LibraryItem(library), SidebarAdaptiveViewModel.PaneHolder.ActivePane);
+			}
+			else if (e.InvokedItemDataContext is LocationItem locationItem)
+			{
+				ListedItem listedItem = new ListedItem(null!)
+				{
+					ItemPath = locationItem.Path,
+					ItemNameRaw = locationItem.Text,
+					PrimaryItemAttribute = StorageItemTypes.Folder,
+					ItemType = "FileFolderListItem".GetLocalizedResource(),
+				};
+				await FilePropertiesHelpers.OpenPropertiesWindowAsync(listedItem, SidebarAdaptiveViewModel.PaneHolder.ActivePane);
+			}
+		}
+
+		private void SidebarControl_SidebarItemNewPaneInvoked(object sender, SidebarItemNewPaneInvokedEventArgs e)
+		{
+			if (e.InvokedItemDataContext is INavigationControlItem navItem)
+				SidebarAdaptiveViewModel.PaneHolder.OpenPathInNewPane(navItem.Path);
+		}
+
+		private void SidebarControl_SidebarItemInvoked(object sender, SidebarItemInvokedEventArgs e)
+		{
+			var invokedItemContainer = e.InvokedItemContainer;
+
+			string? navigationPath; // path to navigate
+			Type? sourcePageType = null; // type of page to navigate
+
+			switch ((invokedItemContainer.DataContext as INavigationControlItem)?.ItemType)
+			{
+				case NavigationControlItemType.Location:
+					{
+						var ItemPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
+
+						if (string.IsNullOrEmpty(ItemPath)) // Section item
+						{
+							navigationPath = invokedItemContainer.Tag?.ToString();
+						}
+						else if (ItemPath.Equals("Home".GetLocalizedResource(), StringComparison.OrdinalIgnoreCase)) // Home item
+						{
+							if (ItemPath.Equals(SidebarAdaptiveViewModel.SidebarSelectedItem?.Path, StringComparison.OrdinalIgnoreCase))
+								return; // return if already selected
+
+							navigationPath = "Home".GetLocalizedResource();
+							sourcePageType = typeof(WidgetsPage);
+						}
+						else // Any other item
+						{
+							navigationPath = invokedItemContainer.Tag?.ToString();
+						}
+
+						break;
+					}
+
+				case NavigationControlItemType.FileTag:
+					var tagPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
+					if (SidebarAdaptiveViewModel.PaneHolder?.ActivePane is IShellPage shp)
+					{
+						shp.NavigateToPath(tagPath, new NavigationArguments()
+						{
+							IsSearchResultPage = true,
+							SearchPathParam = "Home".GetLocalizedResource(),
+							SearchQuery = tagPath,
+							AssociatedTabInstance = shp,
+							NavPathParam = tagPath
+						});
+					}
+					return;
+
+				default:
+					{
+						navigationPath = invokedItemContainer.Tag?.ToString();
+						break;
+					}
+			}
+
+			if (SidebarAdaptiveViewModel.PaneHolder?.ActivePane is IShellPage shellPage)
+				shellPage.NavigateToPath(navigationPath, sourcePageType);
+		}
+
+		private void Page_Loaded(object sender, RoutedEventArgs e)
+		{
+			// Defers the status bar loading until after the page has loaded to improve startup perf
+			FindName(nameof(StatusBarControl));
+			FindName(nameof(InnerNavigationToolbar));
+			FindName(nameof(horizontalMultitaskingControl));
+			FindName(nameof(NavToolbar));
+		}
+
+		private void Page_SizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			switch (Pane?.Position)
+			{
+				case PanePositions.Right when ContentColumn.ActualWidth == ContentColumn.MinWidth:
+					UserSettingsService.PaneSettingsService.VerticalSizePx += e.NewSize.Width - e.PreviousSize.Width;
+					UpdatePositioning();
+					break;
+				case PanePositions.Bottom when ContentRow.ActualHeight == ContentRow.MinHeight:
+					UserSettingsService.PaneSettingsService.HorizontalSizePx += e.NewSize.Height - e.PreviousSize.Height;
+					UpdatePositioning();
+					break;
+			}
+		}
+
+		private void ToggleFullScreenAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+		{
+			var view = App.GetAppWindow(App.Window);
+
+			if (view.Presenter.Kind == AppWindowPresenterKind.FullScreen)
+				view.SetPresenter(AppWindowPresenterKind.Overlapped);
+			else
+				view.SetPresenter(AppWindowPresenterKind.FullScreen);
+			if (e != null)
+				e.Handled = true;
+		}
+
+		private void ToggleSidebarCollapsedState(KeyboardAcceleratorInvokedEventArgs? e)
+		{
+			if (e is null)
+				return;
+			SidebarAdaptiveViewModel.IsSidebarOpen = !SidebarAdaptiveViewModel.IsSidebarOpen;
+
+			e.Handled = true;
+		}
+
+		private void SidebarControl_Loaded(object sender, RoutedEventArgs e)
+		{
+			SidebarAdaptiveViewModel.UpdateTabControlMargin(); // Set the correct tab margin on startup
+		}
+
+		private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e) => LoadPaneChanged();
+
+		/// <summary>
+		/// Call this function to update the positioning of the preview pane.
+		/// This is a workaround as the VisualStateManager causes problems.
+		/// </summary>
+		private void UpdatePositioning()
+		{
+			if (Pane is null || !IsPaneEnabled)
+			{
+				PaneRow.MinHeight = 0;
+				PaneRow.MaxHeight = double.MaxValue;
+				PaneRow.Height = new GridLength(0);
+				PaneColumn.MinWidth = 0;
+				PaneColumn.MaxWidth = double.MaxValue;
+				PaneColumn.Width = new GridLength(0);
+			}
+			else
+			{
+				Pane.UpdatePosition(RootGrid.ActualWidth, RootGrid.ActualHeight);
+				switch (Pane.Position)
+				{
+					case PanePositions.None:
+						PaneRow.MinHeight = 0;
+						PaneRow.Height = new GridLength(0);
+						PaneColumn.MinWidth = 0;
+						PaneColumn.Width = new GridLength(0);
+						break;
+					case PanePositions.Right:
+						Pane.SetValue(Grid.RowProperty, 1);
+						Pane.SetValue(Grid.ColumnProperty, 2);
+						PaneSplitter.SetValue(Grid.RowProperty, 1);
+						PaneSplitter.SetValue(Grid.ColumnProperty, 1);
+						PaneSplitter.Width = 2;
+						PaneSplitter.Height = RootGrid.ActualHeight;
+						PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeWestEast;
+						PaneColumn.MinWidth = Pane.MinWidth;
+						PaneColumn.MaxWidth = Pane.MaxWidth;
+						PaneColumn.Width = new GridLength(UserSettingsService.PaneSettingsService.VerticalSizePx, GridUnitType.Pixel);
+						PaneRow.MinHeight = 0;
+						PaneRow.MaxHeight = double.MaxValue;
+						PaneRow.Height = new GridLength(0);
+						break;
+					case PanePositions.Bottom:
+						Pane.SetValue(Grid.RowProperty, 3);
+						Pane.SetValue(Grid.ColumnProperty, 0);
+						PaneSplitter.SetValue(Grid.RowProperty, 2);
+						PaneSplitter.SetValue(Grid.ColumnProperty, 0);
+						PaneSplitter.Height = 2;
+						PaneSplitter.Width = RootGrid.ActualWidth;
+						PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeNorthSouth;
+						PaneColumn.MinWidth = 0;
+						PaneColumn.MaxWidth = double.MaxValue;
+						PaneColumn.Width = new GridLength(0);
+						PaneRow.MinHeight = Pane.MinHeight;
+						PaneRow.MaxHeight = Pane.MaxHeight;
+						PaneRow.Height = new GridLength(UserSettingsService.PaneSettingsService.HorizontalSizePx, GridUnitType.Pixel);
+						break;
+				}
+			}
+		}
+
+		private void PaneSplitter_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
+		{
+			switch (Pane?.Position)
+			{
+				case PanePositions.Right:
+					UserSettingsService.PaneSettingsService.VerticalSizePx = Pane.ActualWidth;
+					break;
+				case PanePositions.Bottom:
+					UserSettingsService.PaneSettingsService.HorizontalSizePx = Pane.ActualHeight;
+					break;
+			}
+		}
+
+		public bool IsPaneEnabled => UserSettingsService.PaneSettingsService.Content switch
+		{
+			PaneContents.Preview => IsPreviewPaneEnabled,
+			_ => false,
+		};
+
+		public bool IsPreviewPaneEnabled
+		{
+			get
+			{
+				var isHomePage = !(SidebarAdaptiveViewModel.PaneHolder?.ActivePane?.InstanceViewModel?.IsPageTypeNotHome ?? false);
+				var isMultiPane = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
+				var isBigEnough = App.Window.Bounds.Width > 450 && App.Window.Bounds.Height > 400;
+				var isEnabled = (!isHomePage || isMultiPane) && isBigEnough;
+
+				return isEnabled;
+			}
+		}
+
+		private void LoadPaneChanged()
+		{
+			OnPropertyChanged(nameof(IsPaneEnabled));
+			OnPropertyChanged(nameof(IsPreviewPaneEnabled));
+			UpdatePositioning();
+		}
+
+		public event PropertyChangedEventHandler? PropertyChanged;
+
+		private void OnPropertyChanged([CallerMemberName] string propertyName = "")
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		private void ToggleCompactOverlay() => SetCompactOverlay(App.GetAppWindow(App.Window).Presenter.Kind != AppWindowPresenterKind.CompactOverlay);
+
+		private void SetCompactOverlay(bool isCompact)
+		{
+			var view = App.GetAppWindow(App.Window);
+
+			if (!isCompact)
+			{
+				ViewModel.IsWindowCompactOverlay = false;
+				view.SetPresenter(AppWindowPresenterKind.Overlapped);
+			}
+			else
+			{
+				ViewModel.IsWindowCompactOverlay = true;
+				view.SetPresenter(AppWindowPresenterKind.CompactOverlay);
+				view.Resize(new SizeInt32(400, 350));
+			}
+		}
+
+		private void RootGrid_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+		{
+			// prevents the arrow key events from navigating the list instead of switching compact overlay
+			if (EnterCompactOverlayKeyboardAccelerator.CheckIsPressed() || ExitCompactOverlayKeyboardAccelerator.CheckIsPressed())
+				Focus(FocusState.Keyboard);
+		}
+
+		private void NavToolbar_Loaded(object sender, RoutedEventArgs e) => UpdateNavToolbarProperties();
+	}
 }

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -31,514 +31,498 @@ using Windows.Storage;
 
 namespace Files.App.Views
 {
-	/// <summary>
-	/// The root page of Files
-	/// </summary>
-	public sealed partial class MainPage : Page, INotifyPropertyChanged
-	{
-		public IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>();
-
-		public AppModel AppModel => App.AppModel;
-
-		public MainPageViewModel ViewModel
-		{
-			get => (MainPageViewModel)DataContext;
-			set => DataContext = value;
-		}
-
-		public SidebarViewModel SidebarAdaptiveViewModel = new SidebarViewModel();
-
-		public OngoingTasksViewModel OngoingTasksViewModel => App.OngoingTasksViewModel;
-
-		public ICommand ToggleFullScreenAcceleratorCommand { get; }
-
-		private ICommand ToggleCompactOverlayCommand { get; }
-		private ICommand SetCompactOverlayCommand { get; }
-
-		private ICommand ToggleSidebarCollapsedStateCommand => new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(x => ToggleSidebarCollapsedState(x));
-
-		public MainPage()
-		{
-			InitializeComponent();
-
-			// TODO LayoutDirection is empty, might be an issue with WinAppSdk
-			var flowDirectionSetting = new Microsoft.Windows.ApplicationModel.Resources.ResourceManager().CreateResourceContext().QualifierValues["LayoutDirection"]; 
-			if (flowDirectionSetting == "RTL")
-				FlowDirection = FlowDirection.RightToLeft;
-
-			AllowDrop = true;
-
-			ToggleFullScreenAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(ToggleFullScreenAccelerator);
-			ToggleCompactOverlayCommand = new RelayCommand(ToggleCompactOverlay);
-			SetCompactOverlayCommand = new RelayCommand<bool>(SetCompactOverlay);
-
-			if (SystemInformation.Instance.TotalLaunchCount >= 15 & Package.Current.Id.Name == "49306atecsolution.FilesUWP" && !UserSettingsService.ApplicationSettingsService.WasPromptedToReview)
-			{
-				PromptForReview();
-				UserSettingsService.ApplicationSettingsService.WasPromptedToReview = true;
-			}
-
-			UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
-
-			LoadSelectedTheme();
-		}
-
-		private async void LoadSelectedTheme()
-		{
-			App.ExternalResourcesHelper.OverrideAppResources(UserSettingsService.AppearanceSettingsService.UseCompactStyles);
-			await App.ExternalResourcesHelper.LoadSelectedTheme();
-		}
-
-		private async void PromptForReview()
-		{
-			var AskForReviewDialog = new ContentDialog
-			{
-				Title = "ReviewFiles".ToLocalized(),
-				Content = "ReviewFilesContent".ToLocalized(),
-				PrimaryButtonText = "Yes".ToLocalized(),
-				SecondaryButtonText = "No".ToLocalized()
-			};
-
-			var result = await this.SetContentDialogRoot(AskForReviewDialog).ShowAsync();
-
-			if (result == ContentDialogResult.Primary)
-			{
-				try
-				{
-					var storeContext = StoreContext.GetDefault();
-					await storeContext.RequestRateAndReviewAppAsync();
-				}
-				catch (Exception) { }
-			}
-		}
-
-		// WINUI3
-		private ContentDialog SetContentDialogRoot(ContentDialog contentDialog)
-		{
-			if (Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
-			{
-				contentDialog.XamlRoot = App.Window.Content.XamlRoot;
-			}
-			return contentDialog;
-		}
-
-		private void UserSettingsService_OnSettingChangedEvent(object sender, SettingChangedEventArgs e)
-		{
-			switch (e.SettingName)
-			{
-				case nameof(IPaneSettingsService.Content):
-					LoadPaneChanged();
-					break;
-			}
-		}
-
-		private void HorizontalMultitaskingControl_Loaded(object sender, RoutedEventArgs e)
-		{
-			// WINUI3: bad workaround to be removed asap!
-			// SetDragRectangles() does not work on windows 10 with winappsdk "1.2.220902.1-preview1"
-			if (Environment.OSVersion.Version.Build >= 22000)
-			{
-				horizontalMultitaskingControl.DragArea.SizeChanged += (_, _) => SetRectDragRegion();
-			}
-			else
-			{
-				App.Window.AppWindow.TitleBar.ExtendsContentIntoTitleBar = false;
-				App.Window.ExtendsContentIntoTitleBar = true;
-				App.Window.SetTitleBar(horizontalMultitaskingControl.DragArea);
-			}
-
-			if (!(ViewModel.MultitaskingControl is HorizontalMultitaskingControl))
-			{
-				ViewModel.MultitaskingControl = horizontalMultitaskingControl;
-				ViewModel.MultitaskingControls.Add(horizontalMultitaskingControl);
-				ViewModel.MultitaskingControl.CurrentInstanceChanged += MultitaskingControl_CurrentInstanceChanged;
-			}
-		}
-
-		private void SetRectDragRegion()
-		{
-			const uint MDT_Effective_DPI = 0;
-
-			var displayArea = DisplayArea.GetFromWindowId(App.Window.AppWindow.Id, DisplayAreaFallback.Primary);
-			var hMonitor = Win32Interop.GetMonitorFromDisplayId(displayArea.DisplayId);
-			var hr = NativeWinApiHelper.GetDpiForMonitor(hMonitor, MDT_Effective_DPI, out var dpiX, out _);
-			if (hr != 0)
-				return;
-
-			var scaleAdjustment = XamlRoot.RasterizationScale;
-			var dragArea = horizontalMultitaskingControl.DragArea;
-
-			var x = (int)((horizontalMultitaskingControl.ActualWidth - dragArea.ActualWidth) * scaleAdjustment);
-			var y = 0;
-			var width = (int)(dragArea.ActualWidth * scaleAdjustment);
-			var height = (int)(horizontalMultitaskingControl.TitlebarArea.ActualHeight * scaleAdjustment);
-
-			var dragRect = new RectInt32(x, y, width, height);
-			App.Window.AppWindow.TitleBar.SetDragRectangles(new[] { dragRect });
-		}
-
-		public void TabItemContent_ContentChanged(object sender, TabItemArguments e)
-		{
-			if (SidebarAdaptiveViewModel.PaneHolder == null)
-				return;
-
-			var paneArgs = e.NavigationArg as PaneNavigationArguments;
-			SidebarAdaptiveViewModel.UpdateSidebarSelectedItemFromArgs(SidebarAdaptiveViewModel.PaneHolder.IsLeftPaneActive ?
-				paneArgs.LeftPaneNavPathParam : paneArgs.RightPaneNavPathParam);
-			UpdateStatusBarProperties();
-			LoadPaneChanged();
-			UpdateNavToolbarProperties();
-			ViewModel.UpdateInstanceProperties(paneArgs);
-		}
-
-		public void MultitaskingControl_CurrentInstanceChanged(object sender, CurrentInstanceChangedEventArgs e)
-		{
-			if (SidebarAdaptiveViewModel.PaneHolder != null)
-			{
-				SidebarAdaptiveViewModel.PaneHolder.PropertyChanged -= PaneHolder_PropertyChanged;
-			}
-
-			var navArgs = e.CurrentInstance.TabItemArguments?.NavigationArg;
-			SidebarAdaptiveViewModel.PaneHolder = e.CurrentInstance as IPaneHolder;
-			SidebarAdaptiveViewModel.PaneHolder.PropertyChanged += PaneHolder_PropertyChanged;
-			SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged((navArgs as PaneNavigationArguments).LeftPaneNavPathParam);
-			UpdateStatusBarProperties();
-			UpdateNavToolbarProperties();
-			LoadPaneChanged();
-			ViewModel.UpdateInstanceProperties(navArgs);
-			e.CurrentInstance.ContentChanged -= TabItemContent_ContentChanged;
-			e.CurrentInstance.ContentChanged += TabItemContent_ContentChanged;
-		}
-
-		private void PaneHolder_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-		{
-			SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged(SidebarAdaptiveViewModel.PaneHolder.ActivePane?.TabItemArguments?.NavigationArg?.ToString());
-			UpdateStatusBarProperties();
-			UpdateNavToolbarProperties();
-			LoadPaneChanged();
-		}
-
-		private void UpdateStatusBarProperties()
-		{
-			if (StatusBarControl != null)
-			{
-				StatusBarControl.DirectoryPropertiesViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.SlimContentPage?.DirectoryPropertiesViewModel;
-				StatusBarControl.SelectedItemsPropertiesViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.SlimContentPage?.SelectedItemsPropertiesViewModel;
-			}
-		}
-
-		private void UpdateNavToolbarProperties()
-		{
-			if (NavToolbar != null)
-			{
-				NavToolbar.ViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.ToolbarViewModel;
-			}
-
-			if (InnerNavigationToolbar != null)
-			{
-				InnerNavigationToolbar.ViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.ToolbarViewModel;
-				InnerNavigationToolbar.ShowMultiPaneControls = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneEnabled ?? false;
-				InnerNavigationToolbar.IsMultiPaneActive = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
-			}
-		}
-
-		protected override void OnNavigatedTo(NavigationEventArgs e)
-		{
-			ViewModel.OnNavigatedTo(e);
-			SidebarControl.SidebarItemInvoked += SidebarControl_SidebarItemInvoked;
-			SidebarControl.SidebarItemPropertiesInvoked += SidebarControl_SidebarItemPropertiesInvoked;
-			SidebarControl.SidebarItemDropped += SidebarControl_SidebarItemDropped;
-			SidebarControl.SidebarItemNewPaneInvoked += SidebarControl_SidebarItemNewPaneInvoked;
-		}
-
-		private async void SidebarControl_SidebarItemDropped(object sender, SidebarItemDroppedEventArgs e)
-		{
-			await SidebarAdaptiveViewModel.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.Package, e.ItemPath, false, true);
-			e.SignalEvent?.Set();
-		}
-
-		private async void SidebarControl_SidebarItemPropertiesInvoked(object sender, SidebarItemPropertiesInvokedEventArgs e)
-		{
-			if (e.InvokedItemDataContext is DriveItem)
-			{
-				await FilePropertiesHelpers.OpenPropertiesWindowAsync(e.InvokedItemDataContext, SidebarAdaptiveViewModel.PaneHolder.ActivePane);
-			}
-			else if (e.InvokedItemDataContext is LibraryLocationItem library)
-			{
-				await FilePropertiesHelpers.OpenPropertiesWindowAsync(new LibraryItem(library), SidebarAdaptiveViewModel.PaneHolder.ActivePane);
-			}
-			else if (e.InvokedItemDataContext is LocationItem locationItem)
-			{
-				ListedItem listedItem = new ListedItem(null)
-				{
-					ItemPath = locationItem.Path,
-					ItemNameRaw = locationItem.Text,
-					PrimaryItemAttribute = StorageItemTypes.Folder,
-					ItemType = "FileFolderListItem".GetLocalizedResource(),
-				};
-				await FilePropertiesHelpers.OpenPropertiesWindowAsync(listedItem, SidebarAdaptiveViewModel.PaneHolder.ActivePane);
-			}
-		}
-
-		private void SidebarControl_SidebarItemNewPaneInvoked(object sender, SidebarItemNewPaneInvokedEventArgs e)
-		{
-			if (e.InvokedItemDataContext is INavigationControlItem navItem)
-			{
-				SidebarAdaptiveViewModel.PaneHolder.OpenPathInNewPane(navItem.Path);
-			}
-		}
-
-		private void SidebarControl_SidebarItemInvoked(object sender, SidebarItemInvokedEventArgs e)
-		{
-			var invokedItemContainer = e.InvokedItemContainer;
-
-			string navigationPath; // path to navigate
-			Type sourcePageType = null; // type of page to navigate
-
-			switch ((invokedItemContainer.DataContext as INavigationControlItem).ItemType)
-			{
-				case NavigationControlItemType.Location:
-					{
-						var ItemPath = (invokedItemContainer.DataContext as INavigationControlItem).Path; // Get the path of the invoked item
-
-						if (string.IsNullOrEmpty(ItemPath)) // Section item
-						{
-							navigationPath = invokedItemContainer.Tag?.ToString();
-						}
-						else if (ItemPath.Equals("Home".GetLocalizedResource(), StringComparison.OrdinalIgnoreCase)) // Home item
-						{
-							if (ItemPath.Equals(SidebarAdaptiveViewModel.SidebarSelectedItem?.Path, StringComparison.OrdinalIgnoreCase))
-							{
-								return; // return if already selected
-							}
-
-							navigationPath = "Home".GetLocalizedResource();
-							sourcePageType = typeof(WidgetsPage);
-						}
-						else // Any other item
-						{
-							navigationPath = invokedItemContainer.Tag?.ToString();
-						}
-
-						break;
-					}
-
-				case NavigationControlItemType.FileTag:
-					var tagPath = (invokedItemContainer.DataContext as INavigationControlItem).Path; // Get the path of the invoked item
-					if (SidebarAdaptiveViewModel.PaneHolder?.ActivePane is IShellPage shp)
-					{
-						shp.NavigateToPath(tagPath, new NavigationArguments()
-						{
-							IsSearchResultPage = true,
-							SearchPathParam = "Home".GetLocalizedResource(),
-							SearchQuery = tagPath,
-							AssociatedTabInstance = shp,
-							NavPathParam = tagPath
-						});
-					}
-					return;
-
-				default:
-					{
-						navigationPath = invokedItemContainer.Tag?.ToString();
-						break;
-					}
-			}
-
-			if (SidebarAdaptiveViewModel.PaneHolder?.ActivePane is IShellPage shellPage)
-			{
-				shellPage.NavigateToPath(navigationPath, sourcePageType);
-			}
-		}
-
-		private void Page_Loaded(object sender, RoutedEventArgs e)
-		{
-			// Defers the status bar loading until after the page has loaded to improve startup perf
-			FindName(nameof(StatusBarControl));
-			FindName(nameof(InnerNavigationToolbar));
-			FindName(nameof(horizontalMultitaskingControl));
-			FindName(nameof(NavToolbar));
-		}
-
-		private void Page_SizeChanged(object sender, SizeChangedEventArgs e)
-		{
-			switch (Pane?.Position)
-			{
-				case PanePositions.Right when ContentColumn.ActualWidth == ContentColumn.MinWidth:
-					UserSettingsService.PaneSettingsService.VerticalSizePx += e.NewSize.Width - e.PreviousSize.Width;
-					UpdatePositioning();
-					break;
-				case PanePositions.Bottom when ContentRow.ActualHeight == ContentRow.MinHeight:
-					UserSettingsService.PaneSettingsService.HorizontalSizePx += e.NewSize.Height - e.PreviousSize.Height;
-					UpdatePositioning();
-					break;
-			}
-		}
-
-		private void ToggleFullScreenAccelerator(KeyboardAcceleratorInvokedEventArgs e)
-		{
-			var view = App.GetAppWindow(App.Window);
-
-			if (view.Presenter.Kind == AppWindowPresenterKind.FullScreen)
-			{
-				view.SetPresenter(AppWindowPresenterKind.Overlapped);
-			}
-			else
-			{
-				view.SetPresenter(AppWindowPresenterKind.FullScreen);
-			}
-
-			e.Handled = true;
-		}
-
-		private void ToggleSidebarCollapsedState(KeyboardAcceleratorInvokedEventArgs e)
-		{
-			SidebarAdaptiveViewModel.IsSidebarOpen = !SidebarAdaptiveViewModel.IsSidebarOpen;
-
-			e.Handled = true;
-		}
-
-		private void SidebarControl_Loaded(object sender, RoutedEventArgs e)
-		{
-			SidebarAdaptiveViewModel.UpdateTabControlMargin(); // Set the correct tab margin on startup
-		}
-
-		private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e) => LoadPaneChanged();
-
-		/// <summary>
-		/// Call this function to update the positioning of the preview pane.
-		/// This is a workaround as the VisualStateManager causes problems.
-		/// </summary>
-		private void UpdatePositioning()
-		{
-			if (Pane is null || !IsPaneEnabled)
-			{
-				PaneRow.MinHeight = 0;
-				PaneRow.MaxHeight = double.MaxValue;
-				PaneRow.Height = new GridLength(0);
-				PaneColumn.MinWidth = 0;
-				PaneColumn.MaxWidth = double.MaxValue;
-				PaneColumn.Width = new GridLength(0);
-			}
-			else
-			{
-				Pane.UpdatePosition(RootGrid.ActualWidth, RootGrid.ActualHeight);
-				switch (Pane.Position)
-				{
-					case PanePositions.None:
-						PaneRow.MinHeight = 0;
-						PaneRow.Height = new GridLength(0);
-						PaneColumn.MinWidth = 0;
-						PaneColumn.Width = new GridLength(0);
-						break;
-					case PanePositions.Right:
-						Pane.SetValue(Grid.RowProperty, 1);
-						Pane.SetValue(Grid.ColumnProperty, 2);
-						PaneSplitter.SetValue(Grid.RowProperty, 1);
-						PaneSplitter.SetValue(Grid.ColumnProperty, 1);
-						PaneSplitter.Width = 2;
-						PaneSplitter.Height = RootGrid.ActualHeight;
-						PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeWestEast;
-						PaneColumn.MinWidth = Pane.MinWidth;
-						PaneColumn.MaxWidth = Pane.MaxWidth;
-						PaneColumn.Width = new GridLength(UserSettingsService.PaneSettingsService.VerticalSizePx, GridUnitType.Pixel);
-						PaneRow.MinHeight = 0;
-						PaneRow.MaxHeight = double.MaxValue;
-						PaneRow.Height = new GridLength(0);
-						break;
-					case PanePositions.Bottom:
-						Pane.SetValue(Grid.RowProperty, 3);
-						Pane.SetValue(Grid.ColumnProperty, 0);
-						PaneSplitter.SetValue(Grid.RowProperty, 2);
-						PaneSplitter.SetValue(Grid.ColumnProperty, 0);
-						PaneSplitter.Height = 2;
-						PaneSplitter.Width = RootGrid.ActualWidth;
-						PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeNorthSouth;
-						PaneColumn.MinWidth = 0;
-						PaneColumn.MaxWidth = double.MaxValue;
-						PaneColumn.Width = new GridLength(0);
-						PaneRow.MinHeight = Pane.MinHeight;
-						PaneRow.MaxHeight = Pane.MaxHeight;
-						PaneRow.Height = new GridLength(UserSettingsService.PaneSettingsService.HorizontalSizePx, GridUnitType.Pixel);
-						break;
-				}
-			}
-		}
-
-		private void PaneSplitter_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
-		{
-			switch (Pane?.Position)
-			{
-				case PanePositions.Right:
-					UserSettingsService.PaneSettingsService.VerticalSizePx = Pane.ActualWidth;
-					break;
-				case PanePositions.Bottom:
-					UserSettingsService.PaneSettingsService.HorizontalSizePx = Pane.ActualHeight;
-					break;
-			}
-		}
-
-		public bool IsPaneEnabled => UserSettingsService.PaneSettingsService.Content switch
-		{
-			PaneContents.Preview => IsPreviewPaneEnabled,
-			_ => false,
-		};
-
-		public bool IsPreviewPaneEnabled
-		{
-			get
-			{
-				var isHomePage = !(SidebarAdaptiveViewModel.PaneHolder?.ActivePane?.InstanceViewModel?.IsPageTypeNotHome ?? false);
-				var isMultiPane = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
-				var isBigEnough = App.Window.Bounds.Width > 450 && App.Window.Bounds.Height > 400;
-				var isEnabled = (!isHomePage || isMultiPane) && isBigEnough;
-
-				return isEnabled;
-			}
-		}
-
-		private void LoadPaneChanged()
-		{
-			OnPropertyChanged(nameof(IsPaneEnabled));
-			OnPropertyChanged(nameof(IsPreviewPaneEnabled));
-			UpdatePositioning();
-		}
-
-		public event PropertyChangedEventHandler PropertyChanged;
-
-		private void OnPropertyChanged([CallerMemberName] string propertyName = "")
-		{
-			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-		}
-
-		private void ToggleCompactOverlay() => SetCompactOverlay(App.GetAppWindow(App.Window).Presenter.Kind != AppWindowPresenterKind.CompactOverlay);
-
-		private void SetCompactOverlay(bool isCompact)
-		{
-			var view = App.GetAppWindow(App.Window);
-
-			if (!isCompact)
-			{
-				ViewModel.IsWindowCompactOverlay = true;
-				view.SetPresenter(AppWindowPresenterKind.Overlapped);
-			}
-			else
-			{
-				ViewModel.IsWindowCompactOverlay = false;
-				view.SetPresenter(AppWindowPresenterKind.CompactOverlay);
-				view.Resize(new SizeInt32(400, 350));
-			}
-		}
-
-		private void RootGrid_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
-		{
-			// prevents the arrow key events from navigating the list instead of switching compact overlay
-			if (EnterCompactOverlayKeyboardAccelerator.CheckIsPressed() || ExitCompactOverlayKeyboardAccelerator.CheckIsPressed())
-			{
-				Focus(FocusState.Keyboard);
-			}
-		}
-
-		private void NavToolbar_Loaded(object sender, RoutedEventArgs e) => UpdateNavToolbarProperties();
-	}
+    /// <summary>
+    /// The root page of Files
+    /// </summary>
+    public sealed partial class MainPage : Page, INotifyPropertyChanged
+    {
+        public IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetService<IUserSettingsService>()!;
+
+        public AppModel AppModel => App.AppModel;
+
+        public MainPageViewModel ViewModel
+        {
+            get => (MainPageViewModel)DataContext;
+            set => DataContext = value;
+        }
+
+        public SidebarViewModel SidebarAdaptiveViewModel = new SidebarViewModel();
+
+        public OngoingTasksViewModel OngoingTasksViewModel => App.OngoingTasksViewModel;
+
+        public ICommand ToggleFullScreenAcceleratorCommand { get; }
+
+        private ICommand ToggleCompactOverlayCommand { get; }
+        private ICommand SetCompactOverlayCommand { get; }
+
+        private ICommand ToggleSidebarCollapsedStateCommand => new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(x => ToggleSidebarCollapsedState(x));
+
+        public MainPage()
+        {
+            InitializeComponent();
+
+            // TODO LayoutDirection is empty, might be an issue with WinAppSdk
+            var flowDirectionSetting = new Microsoft.Windows.ApplicationModel.Resources.ResourceManager().CreateResourceContext().QualifierValues["LayoutDirection"]; 
+            if (flowDirectionSetting == "RTL")
+                FlowDirection = FlowDirection.RightToLeft;
+
+            AllowDrop = true;
+
+            ToggleFullScreenAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(ToggleFullScreenAccelerator);
+            ToggleCompactOverlayCommand = new RelayCommand(ToggleCompactOverlay);
+            SetCompactOverlayCommand = new RelayCommand<bool>(SetCompactOverlay);
+
+            if (SystemInformation.Instance.TotalLaunchCount >= 15 & Package.Current.Id.Name == "49306atecsolution.FilesUWP" && !UserSettingsService.ApplicationSettingsService.WasPromptedToReview)
+            {
+                PromptForReview();
+                UserSettingsService.ApplicationSettingsService.WasPromptedToReview = true;
+            }
+
+            UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
+
+            LoadSelectedTheme();
+        }
+
+        private async void LoadSelectedTheme()
+        {
+            App.ExternalResourcesHelper.OverrideAppResources(UserSettingsService.AppearanceSettingsService.UseCompactStyles);
+            await App.ExternalResourcesHelper.LoadSelectedTheme();
+        }
+
+        private async void PromptForReview()
+        {
+            var AskForReviewDialog = new ContentDialog
+            {
+                Title = "ReviewFiles".ToLocalized(),
+                Content = "ReviewFilesContent".ToLocalized(),
+                PrimaryButtonText = "Yes".ToLocalized(),
+                SecondaryButtonText = "No".ToLocalized()
+            };
+
+            var result = await this.SetContentDialogRoot(AskForReviewDialog).ShowAsync();
+
+            if (result == ContentDialogResult.Primary)
+            {
+                try
+                {
+                    var storeContext = StoreContext.GetDefault();
+                    await storeContext.RequestRateAndReviewAppAsync();
+                }
+                catch (Exception) { }
+            }
+        }
+
+        // WINUI3
+        private ContentDialog SetContentDialogRoot(ContentDialog contentDialog)
+        {
+            if (Windows.Foundation.Metadata.ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+                contentDialog.XamlRoot = App.Window.Content.XamlRoot;
+            return contentDialog;
+        }
+
+        private void UserSettingsService_OnSettingChangedEvent(object? sender, SettingChangedEventArgs e)
+        {
+            switch (e.SettingName)
+            {
+                case nameof(IPaneSettingsService.Content):
+                    LoadPaneChanged();
+                    break;
+            }
+        }
+
+        private void HorizontalMultitaskingControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            // WINUI3: bad workaround to be removed asap!
+            // SetDragRectangles() does not work on windows 10 with winappsdk "1.2.220902.1-preview1"
+            if (Environment.OSVersion.Version.Build >= 22000)
+            {
+                horizontalMultitaskingControl.DragArea.SizeChanged += (_, _) => SetRectDragRegion();
+            }
+            else
+            {
+                App.Window.AppWindow.TitleBar.ExtendsContentIntoTitleBar = false;
+                App.Window.ExtendsContentIntoTitleBar = true;
+                App.Window.SetTitleBar(horizontalMultitaskingControl.DragArea);
+            }
+
+            if (!(ViewModel.MultitaskingControl is HorizontalMultitaskingControl))
+            {
+                ViewModel.MultitaskingControl = horizontalMultitaskingControl;
+                ViewModel.MultitaskingControls.Add(horizontalMultitaskingControl);
+                ViewModel.MultitaskingControl.CurrentInstanceChanged += MultitaskingControl_CurrentInstanceChanged;
+            }
+        }
+
+        private void SetRectDragRegion()
+        {
+            const uint MDT_Effective_DPI = 0;
+
+            var displayArea = DisplayArea.GetFromWindowId(App.Window.AppWindow.Id, DisplayAreaFallback.Primary);
+            var hMonitor = Win32Interop.GetMonitorFromDisplayId(displayArea.DisplayId);
+            var hr = NativeWinApiHelper.GetDpiForMonitor(hMonitor, MDT_Effective_DPI, out var dpiX, out _);
+            if (hr != 0)
+                return;
+
+            var scaleAdjustment = XamlRoot.RasterizationScale;
+            var dragArea = horizontalMultitaskingControl.DragArea;
+
+            var x = (int)((horizontalMultitaskingControl.ActualWidth - dragArea.ActualWidth) * scaleAdjustment);
+            var y = 0;
+            var width = (int)(dragArea.ActualWidth * scaleAdjustment);
+            var height = (int)(horizontalMultitaskingControl.TitlebarArea.ActualHeight * scaleAdjustment);
+
+            var dragRect = new RectInt32(x, y, width, height);
+            App.Window.AppWindow.TitleBar.SetDragRectangles(new[] { dragRect });
+        }
+
+        public void TabItemContent_ContentChanged(object? sender, TabItemArguments e)
+        {
+            if (SidebarAdaptiveViewModel.PaneHolder == null)
+                return;
+
+            var paneArgs = e.NavigationArg as PaneNavigationArguments;
+            SidebarAdaptiveViewModel.UpdateSidebarSelectedItemFromArgs(SidebarAdaptiveViewModel.PaneHolder.IsLeftPaneActive ?
+                paneArgs.LeftPaneNavPathParam : paneArgs.RightPaneNavPathParam);
+            UpdateStatusBarProperties();
+            LoadPaneChanged();
+            UpdateNavToolbarProperties();
+            ViewModel.UpdateInstanceProperties(paneArgs);
+        }
+
+        public void MultitaskingControl_CurrentInstanceChanged(object? sender, CurrentInstanceChangedEventArgs e)
+        {
+            if (SidebarAdaptiveViewModel.PaneHolder != null)
+                SidebarAdaptiveViewModel.PaneHolder.PropertyChanged -= PaneHolder_PropertyChanged;
+
+            var navArgs = e.CurrentInstance.TabItemArguments?.NavigationArg;
+            SidebarAdaptiveViewModel.PaneHolder = e.CurrentInstance as IPaneHolder;
+            SidebarAdaptiveViewModel.PaneHolder.PropertyChanged += PaneHolder_PropertyChanged;
+            SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged((navArgs as PaneNavigationArguments).LeftPaneNavPathParam);
+            UpdateStatusBarProperties();
+            UpdateNavToolbarProperties();
+            LoadPaneChanged();
+            ViewModel.UpdateInstanceProperties(navArgs);
+            e.CurrentInstance.ContentChanged -= TabItemContent_ContentChanged;
+            e.CurrentInstance.ContentChanged += TabItemContent_ContentChanged;
+        }
+
+        private void PaneHolder_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            SidebarAdaptiveViewModel.NotifyInstanceRelatedPropertiesChanged(SidebarAdaptiveViewModel.PaneHolder.ActivePane?.TabItemArguments?.NavigationArg?.ToString());
+            UpdateStatusBarProperties();
+            UpdateNavToolbarProperties();
+            LoadPaneChanged();
+        }
+
+        private void UpdateStatusBarProperties()
+        {
+            if (StatusBarControl != null)
+            {
+                StatusBarControl.DirectoryPropertiesViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.SlimContentPage?.DirectoryPropertiesViewModel;
+                StatusBarControl.SelectedItemsPropertiesViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.SlimContentPage?.SelectedItemsPropertiesViewModel;
+            }
+        }
+
+        private void UpdateNavToolbarProperties()
+        {
+            if (NavToolbar != null)
+                NavToolbar.ViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.ToolbarViewModel;
+
+            if (InnerNavigationToolbar != null)
+            {
+                InnerNavigationToolbar.ViewModel = SidebarAdaptiveViewModel.PaneHolder?.ActivePaneOrColumn.ToolbarViewModel;
+                InnerNavigationToolbar.ShowMultiPaneControls = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneEnabled ?? false;
+                InnerNavigationToolbar.IsMultiPaneActive = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
+            }
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.OnNavigatedTo(e);
+            SidebarControl.SidebarItemInvoked += SidebarControl_SidebarItemInvoked;
+            SidebarControl.SidebarItemPropertiesInvoked += SidebarControl_SidebarItemPropertiesInvoked;
+            SidebarControl.SidebarItemDropped += SidebarControl_SidebarItemDropped;
+            SidebarControl.SidebarItemNewPaneInvoked += SidebarControl_SidebarItemNewPaneInvoked;
+        }
+
+        private async void SidebarControl_SidebarItemDropped(object sender, SidebarItemDroppedEventArgs e)
+        {
+            await SidebarAdaptiveViewModel.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.Package, e.ItemPath, false, true);
+            e.SignalEvent?.Set();
+        }
+
+        private async void SidebarControl_SidebarItemPropertiesInvoked(object sender, SidebarItemPropertiesInvokedEventArgs e)
+        {
+            if (e.InvokedItemDataContext is DriveItem)
+            {
+                await FilePropertiesHelpers.OpenPropertiesWindowAsync(e.InvokedItemDataContext, SidebarAdaptiveViewModel.PaneHolder.ActivePane);
+            }
+            else if (e.InvokedItemDataContext is LibraryLocationItem library)
+            {
+                await FilePropertiesHelpers.OpenPropertiesWindowAsync(new LibraryItem(library), SidebarAdaptiveViewModel.PaneHolder.ActivePane);
+            }
+            else if (e.InvokedItemDataContext is LocationItem locationItem)
+            {
+                ListedItem listedItem = new ListedItem(null!)
+                {
+                    ItemPath = locationItem.Path,
+                    ItemNameRaw = locationItem.Text,
+                    PrimaryItemAttribute = StorageItemTypes.Folder,
+                    ItemType = "FileFolderListItem".GetLocalizedResource(),
+                };
+                await FilePropertiesHelpers.OpenPropertiesWindowAsync(listedItem, SidebarAdaptiveViewModel.PaneHolder.ActivePane);
+            }
+        }
+
+        private void SidebarControl_SidebarItemNewPaneInvoked(object sender, SidebarItemNewPaneInvokedEventArgs e)
+        {
+            if (e.InvokedItemDataContext is INavigationControlItem navItem)
+                SidebarAdaptiveViewModel.PaneHolder.OpenPathInNewPane(navItem.Path);
+        }
+
+        private void SidebarControl_SidebarItemInvoked(object sender, SidebarItemInvokedEventArgs e)
+        {
+            var invokedItemContainer = e.InvokedItemContainer;
+
+            string? navigationPath; // path to navigate
+            Type? sourcePageType = null; // type of page to navigate
+
+            switch ((invokedItemContainer.DataContext as INavigationControlItem)?.ItemType)
+            {
+                case NavigationControlItemType.Location:
+                    {
+                        var ItemPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
+
+                        if (string.IsNullOrEmpty(ItemPath)) // Section item
+                        {
+                            navigationPath = invokedItemContainer.Tag?.ToString();
+                        }
+                        else if (ItemPath.Equals("Home".GetLocalizedResource(), StringComparison.OrdinalIgnoreCase)) // Home item
+                        {
+                            if (ItemPath.Equals(SidebarAdaptiveViewModel.SidebarSelectedItem?.Path, StringComparison.OrdinalIgnoreCase))
+                                return; // return if already selected
+
+                            navigationPath = "Home".GetLocalizedResource();
+                            sourcePageType = typeof(WidgetsPage);
+                        }
+                        else // Any other item
+                        {
+                            navigationPath = invokedItemContainer.Tag?.ToString();
+                        }
+
+                        break;
+                    }
+
+                case NavigationControlItemType.FileTag:
+                    var tagPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
+                    if (SidebarAdaptiveViewModel.PaneHolder?.ActivePane is IShellPage shp)
+                    {
+                        shp.NavigateToPath(tagPath, new NavigationArguments()
+                        {
+                            IsSearchResultPage = true,
+                            SearchPathParam = "Home".GetLocalizedResource(),
+                            SearchQuery = tagPath,
+                            AssociatedTabInstance = shp,
+                            NavPathParam = tagPath
+                        });
+                    }
+                    return;
+
+                default:
+                    {
+                        navigationPath = invokedItemContainer.Tag?.ToString();
+                        break;
+                    }
+            }
+
+            if (SidebarAdaptiveViewModel.PaneHolder?.ActivePane is IShellPage shellPage)
+                shellPage.NavigateToPath(navigationPath, sourcePageType);
+        }
+
+        private void Page_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Defers the status bar loading until after the page has loaded to improve startup perf
+            FindName(nameof(StatusBarControl));
+            FindName(nameof(InnerNavigationToolbar));
+            FindName(nameof(horizontalMultitaskingControl));
+            FindName(nameof(NavToolbar));
+        }
+
+        private void Page_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            switch (Pane?.Position)
+            {
+                case PanePositions.Right when ContentColumn.ActualWidth == ContentColumn.MinWidth:
+                    UserSettingsService.PaneSettingsService.VerticalSizePx += e.NewSize.Width - e.PreviousSize.Width;
+                    UpdatePositioning();
+                    break;
+                case PanePositions.Bottom when ContentRow.ActualHeight == ContentRow.MinHeight:
+                    UserSettingsService.PaneSettingsService.HorizontalSizePx += e.NewSize.Height - e.PreviousSize.Height;
+                    UpdatePositioning();
+                    break;
+            }
+        }
+
+        private void ToggleFullScreenAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
+        {
+            var view = App.GetAppWindow(App.Window);
+
+            if (view.Presenter.Kind == AppWindowPresenterKind.FullScreen)
+                view.SetPresenter(AppWindowPresenterKind.Overlapped);
+            else
+                view.SetPresenter(AppWindowPresenterKind.FullScreen);
+            if (e != null)
+            e.Handled = true;
+        }
+
+        private void ToggleSidebarCollapsedState(KeyboardAcceleratorInvokedEventArgs? e)
+        {
+            if (e is null)
+                return;
+            SidebarAdaptiveViewModel.IsSidebarOpen = !SidebarAdaptiveViewModel.IsSidebarOpen;
+
+            e.Handled = true;
+        }
+
+        private void SidebarControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            SidebarAdaptiveViewModel.UpdateTabControlMargin(); // Set the correct tab margin on startup
+        }
+
+        private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e) => LoadPaneChanged();
+
+        /// <summary>
+        /// Call this function to update the positioning of the preview pane.
+        /// This is a workaround as the VisualStateManager causes problems.
+        /// </summary>
+        private void UpdatePositioning()
+        {
+            if (Pane is null || !IsPaneEnabled)
+            {
+                PaneRow.MinHeight = 0;
+                PaneRow.MaxHeight = double.MaxValue;
+                PaneRow.Height = new GridLength(0);
+                PaneColumn.MinWidth = 0;
+                PaneColumn.MaxWidth = double.MaxValue;
+                PaneColumn.Width = new GridLength(0);
+            }
+            else
+            {
+                Pane.UpdatePosition(RootGrid.ActualWidth, RootGrid.ActualHeight);
+                switch (Pane.Position)
+                {
+                    case PanePositions.None:
+                        PaneRow.MinHeight = 0;
+                        PaneRow.Height = new GridLength(0);
+                        PaneColumn.MinWidth = 0;
+                        PaneColumn.Width = new GridLength(0);
+                        break;
+                    case PanePositions.Right:
+                        Pane.SetValue(Grid.RowProperty, 1);
+                        Pane.SetValue(Grid.ColumnProperty, 2);
+                        PaneSplitter.SetValue(Grid.RowProperty, 1);
+                        PaneSplitter.SetValue(Grid.ColumnProperty, 1);
+                        PaneSplitter.Width = 2;
+                        PaneSplitter.Height = RootGrid.ActualHeight;
+                        PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeWestEast;
+                        PaneColumn.MinWidth = Pane.MinWidth;
+                        PaneColumn.MaxWidth = Pane.MaxWidth;
+                        PaneColumn.Width = new GridLength(UserSettingsService.PaneSettingsService.VerticalSizePx, GridUnitType.Pixel);
+                        PaneRow.MinHeight = 0;
+                        PaneRow.MaxHeight = double.MaxValue;
+                        PaneRow.Height = new GridLength(0);
+                        break;
+                    case PanePositions.Bottom:
+                        Pane.SetValue(Grid.RowProperty, 3);
+                        Pane.SetValue(Grid.ColumnProperty, 0);
+                        PaneSplitter.SetValue(Grid.RowProperty, 2);
+                        PaneSplitter.SetValue(Grid.ColumnProperty, 0);
+                        PaneSplitter.Height = 2;
+                        PaneSplitter.Width = RootGrid.ActualWidth;
+                        PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeNorthSouth;
+                        PaneColumn.MinWidth = 0;
+                        PaneColumn.MaxWidth = double.MaxValue;
+                        PaneColumn.Width = new GridLength(0);
+                        PaneRow.MinHeight = Pane.MinHeight;
+                        PaneRow.MaxHeight = Pane.MaxHeight;
+                        PaneRow.Height = new GridLength(UserSettingsService.PaneSettingsService.HorizontalSizePx, GridUnitType.Pixel);
+                        break;
+                }
+            }
+        }
+
+        private void PaneSplitter_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
+        {
+            switch (Pane?.Position)
+            {
+                case PanePositions.Right:
+                    UserSettingsService.PaneSettingsService.VerticalSizePx = Pane.ActualWidth;
+                    break;
+                case PanePositions.Bottom:
+                    UserSettingsService.PaneSettingsService.HorizontalSizePx = Pane.ActualHeight;
+                    break;
+            }
+        }
+
+        public bool IsPaneEnabled => UserSettingsService.PaneSettingsService.Content switch
+        {
+            PaneContents.Preview => IsPreviewPaneEnabled,
+            _ => false,
+        };
+
+        public bool IsPreviewPaneEnabled
+        {
+            get
+            {
+                var isHomePage = !(SidebarAdaptiveViewModel.PaneHolder?.ActivePane?.InstanceViewModel?.IsPageTypeNotHome ?? false);
+                var isMultiPane = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
+                var isBigEnough = App.Window.Bounds.Width > 450 && App.Window.Bounds.Height > 400;
+                var isEnabled = (!isHomePage || isMultiPane) && isBigEnough;
+
+                return isEnabled;
+            }
+        }
+
+        private void LoadPaneChanged()
+        {
+            OnPropertyChanged(nameof(IsPaneEnabled));
+            OnPropertyChanged(nameof(IsPreviewPaneEnabled));
+            UpdatePositioning();
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = "")
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private void ToggleCompactOverlay() => SetCompactOverlay(App.GetAppWindow(App.Window).Presenter.Kind != AppWindowPresenterKind.CompactOverlay);
+
+        private void SetCompactOverlay(bool isCompact)
+        {
+            var view = App.GetAppWindow(App.Window);
+
+            if (!isCompact)
+            {
+                ViewModel.IsWindowCompactOverlay = false;
+                view.SetPresenter(AppWindowPresenterKind.Overlapped);
+            }
+            else
+            {
+                ViewModel.IsWindowCompactOverlay = true;
+                view.SetPresenter(AppWindowPresenterKind.CompactOverlay);
+                view.Resize(new SizeInt32(400, 350));
+            }
+        }
+
+        private void RootGrid_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            // prevents the arrow key events from navigating the list instead of switching compact overlay
+            if (EnterCompactOverlayKeyboardAccelerator.CheckIsPressed() || ExitCompactOverlayKeyboardAccelerator.CheckIsPressed())
+                Focus(FocusState.Keyboard);
+        }
+
+        private void NavToolbar_Loaded(object sender, RoutedEventArgs e) => UpdateNavToolbarProperties();
+    }
 }


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9928 

**Changes**
- Removed unused methods in `InnerNavigationToolbar.caml.cs` (`NavToolbarEnterCompactOverlay_Click()` and `SetAppBarButtonProps()`)
- Changed `Setter` of `IsWindowCompactOverlay` (`MainPageViewModel.cs`) as the existing one was not affecting the backing `DependencyProperty`
- Fixed logic-error in `SetCompactOverlay()` (`MainPage.xaml.cs`) line@ 508 and 513

**Validation**
How did you test these changes?
- [x] Built and ran the app
