### PR TITLE
Fix: Fixed issue blocking properties window from opening

### DIFF
--- a/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -201,7 +201,10 @@ namespace Files.App.Interacts
 
         public virtual void ShowProperties(RoutedEventArgs e)
         {
-            SlimContentPage.ItemContextMenuFlyout.Closed += OpenProperties;
+            if (SlimContentPage.ItemContextMenuFlyout.IsOpen)
+                SlimContentPage.ItemContextMenuFlyout.Closed += OpenProperties;
+            else
+                FilePropertiesHelpers.ShowProperties(associatedInstance);
         }
 
         private void OpenProperties(object sender, object e)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related #9926 
- Related #9973 

**Changes**
Because of #9973 , users couldn't open properties clicking on `InfoButton`, this PR fixs that.

**Validation**
How did you test these changes?
- [x] Built and ran the app