### PR TITLE
Fixed: Right click doesn't always select the file/folder hovered over

### DIFF
--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -1017,7 +1017,7 @@ namespace Files.App
 		protected void FileListItem_RightTapped(object sender, RightTappedRoutedEventArgs e)
 		{
 			var rightClickedItem = GetItemFromElement(sender);
-			if (rightClickedItem != null && !((ListViewItem)sender).IsSelected)
+			if (rightClickedItem != null && !((SelectorItem)sender).IsSelected)
 			{
 				ItemManipulationModel.SetSelectedItem(rightClickedItem);
 			}

--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -900,6 +900,7 @@ namespace Files.App
 			container.PointerPressed -= FileListItem_PointerPressed;
 			container.PointerEntered -= FileListItem_PointerEntered;
 			container.PointerExited -= FileListItem_PointerExited;
+			container.RightTapped -= FileListItem_RightTapped;
 
 			if (inRecycleQueue)
 			{
@@ -908,6 +909,7 @@ namespace Files.App
 			else
 			{
 				container.PointerPressed += FileListItem_PointerPressed;
+				container.RightTapped += FileListItem_RightTapped;
 				if (UserSettingsService.PreferencesSettingsService.SelectFilesOnHover)
 				{
 					container.PointerEntered += FileListItem_PointerEntered;
@@ -1010,6 +1012,15 @@ namespace Files.App
 
 			hoverTimer.Stop();
 			hoveredItem = null;
+		}
+
+		protected void FileListItem_RightTapped(object sender, RightTappedRoutedEventArgs e)
+		{
+			var rightClickedItem = GetItemFromElement(sender);
+			if (rightClickedItem != null && !((ListViewItem)sender).IsSelected)
+			{
+				ItemManipulationModel.SetSelectedItem(rightClickedItem);
+			}
 		}
 
 		private readonly RecycleBinHelpers recycleBinHelpers = new();

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml
@@ -192,7 +192,6 @@
 								CornerRadius="{StaticResource ControlCornerRadius}"
 								IsRightTapEnabled="True"
 								Loaded="Grid_Loaded"
-								RightTapped="StackPanel_RightTapped"
 								ToolTipService.ToolTip="{x:Bind ItemName, Mode=OneWay}">
 								<Grid.ColumnDefinitions>
 									<ColumnDefinition Width="24" />

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -550,17 +550,6 @@ namespace Files.App.Views.LayoutModes
 			}
 		}
 
-		private void StackPanel_RightTapped(object sender, RightTappedRoutedEventArgs e)
-		{
-			var parentContainer = DependencyObjectHelpers.FindParent<ListViewItem>(e.OriginalSource as DependencyObject);
-			
-			if (parentContainer.IsSelected)
-				return;
-
-			// The following code is only reachable when a user RightTapped an unselected row
-			ItemManipulationModel.SetSelectedItem(FileList.ItemFromContainer(parentContainer) as ListedItem);
-		}
-
 		private void Grid_Loaded(object sender, RoutedEventArgs e)
 		{
 			var itemContainer = (sender as Grid)?.FindAscendant<ListViewItem>();

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -507,7 +507,6 @@
 									AutomationProperties.Name="{x:Bind ItemName, Mode=OneWay}"
 									IsRightTapEnabled="True"
 									Loaded="Grid_Loaded"
-									RightTapped="StackPanel_RightTapped"
 									ToolTipService.ToolTip="{x:Bind ItemTooltipText, Mode=OneWay}">
 									<Grid.ColumnDefinitions>
 										<ColumnDefinition Width="{Binding ColumnsViewModel.IconColumn.LengthIncludingGridSplitter, ElementName=PageRoot, Mode=OneWay}" />

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -308,15 +308,6 @@ namespace Files.App.Views.LayoutModes
 		{
 		}
 
-		private void StackPanel_RightTapped(object sender, RightTappedRoutedEventArgs e)
-		{
-			var parentContainer = DependencyObjectHelpers.FindParent<ListViewItem>(e.OriginalSource as DependencyObject);
-			if (!parentContainer.IsSelected)
-			{
-				ItemManipulationModel.SetSelectedItem(FileList.ItemFromContainer(parentContainer) as ListedItem);
-			}
-		}
-
 		private async void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
 			SelectedItems = FileList.SelectedItems.Cast<ListedItem>().Where(x => x != null).ToList();

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
@@ -62,7 +62,6 @@
 				Background="Transparent"
 				IsRightTapEnabled="True"
 				Loaded="Grid_Loaded"
-				RightTapped="StackPanel_RightTapped"
 				ToolTipService.ToolTip="{x:Bind ItemTooltipText, Mode=OneWay}">
 				<Grid.RowDefinitions>
 					<RowDefinition Height="Auto" />
@@ -214,7 +213,6 @@
 				ColumnSpacing="4"
 				IsRightTapEnabled="True"
 				Loaded="Grid_Loaded"
-				RightTapped="StackPanel_RightTapped"
 				ToolTipService.ToolTip="{x:Bind ItemTooltipText, Mode=OneWay}">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="Auto" />

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -236,15 +236,6 @@ namespace Files.App.Views.LayoutModes
 			NotifyPropertyChanged(nameof(GridViewItemMinWidth));
 		}
 
-		private void StackPanel_RightTapped(object sender, RightTappedRoutedEventArgs e)
-		{
-			var parentContainer = DependencyObjectHelpers.FindParent<GridViewItem>(e.OriginalSource as DependencyObject);
-			if (!parentContainer.IsSelected)
-			{
-				ItemManipulationModel.SetSelectedItem(FileList.ItemFromContainer(parentContainer) as ListedItem);
-			}
-		}
-
 		private async void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
 			SelectedItems = FileList.SelectedItems.Cast<ListedItem>().Where(x => x != null).ToList();


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9834 

**Comments**
I changed `RightTapped` event-area, applying it to items' container (same as #9977 )
If you think this is ok, I'll proceed with code cleanup (remove nullable warnings)

**Validation**
How did you test these changes?
- [x] Built and ran the app
