### PR TITLE
Fixed: Draging files over items select them

### DIFF
--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -790,8 +790,6 @@ namespace Files.App
 			{
 				deferral = e.GetDeferral();
 
-				ItemManipulationModel.SetSelectedItem(item);
-
 				if (dragOverItem != item)
 				{
 					dragOverItem = item;
@@ -800,8 +798,9 @@ namespace Files.App
 					{
 						if (dragOverItem != null && !dragOverItem.IsExecutable)
 						{
-							dragOverItem = null;
 							dragOverTimer.Stop();
+							ItemManipulationModel.SetSelectedItem(dragOverItem);
+							dragOverItem = null;
 							NavigationHelpers.OpenSelectedItems(ParentShellPageInstance!, false);
 						}
 					}, TimeSpan.FromMilliseconds(1000), false);


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related: #6768 

**Comments**
- I fixed the bug delaying the selection at the end of the timer. This way, the hovered item is selected just before it's opened.
- There's still a problem with `ColumnsLayout`, where items have `SelectedStyle` even when they're not. I believe the bug affects `ListViewBase` since the code is the same as in `GridViewBase`, where the feature is working.

**Validation**
How did you test these changes?
- [x] Built and ran the app