### PR TITLE
Fix(translation): removed ampersand sign from Polish bundle's "Add Element"

### DIFF
--- a/src/Files.App/Strings/pl-PL/Resources.resw
+++ b/src/Files.App/Strings/pl-PL/Resources.resw
@@ -2233,7 +2233,7 @@
     <value>Dodaj folder</value>
   </data>
   <data name="BundleOptionsFlyoutAddItemMenuItem.Text" xml:space="preserve">
-    <value>&amp;Dodaj element</value>
+    <value>Dodaj element</value>
   </data>
   <data name="ConsentDialogTitle" xml:space="preserve">
     <value>Dostępne aktualizacje</value>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- Removes ampersand sign from "Add Element" translation in Polish language

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Here's how it looked before fix:
![ApplicationFrameHost_ukKJtLwljD](https://user-images.githubusercontent.com/22046158/194395153-c49bd3dd-de80-4a1b-b84a-5ab9237ace71.png)
