### PR TITLE
Fix: Folder suggestions are not showing in the Address bar

### DIFF
--- a/src/Files.App/UserControls/AddressToolbar.xaml
+++ b/src/Files.App/UserControls/AddressToolbar.xaml
@@ -432,7 +432,7 @@
 				BorderBrush="{ThemeResource SystemBaseMediumLowColor}"
 				BorderThickness="{ThemeResource TextControlBorderThemeThickness}"
 				CornerRadius="{StaticResource ControlCornerRadius}"
-				DisplayMemberPath="ItemName"
+				DisplayMemberPath="Name"
 				FocusDisengaged="VisiblePath_LostFocus"
 				FontWeight="SemiBold"
 				ItemsSource="{x:Bind ViewModel.NavigationBarSuggestions, Mode=OneWay}"


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10150 

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Comments**
In #10116  the Property ItemName was removed. The property Name returns exactly the same value as ItemName did before.

**Screenshots (optional)**
Suggestions are displayed again
![image](https://user-images.githubusercontent.com/56681014/195165946-04d15644-d2bc-40f3-9122-464a79766784.png)
