### PR TITLE
Fix: Fixed issue where GridSplitter style was missing on the details layout

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -358,6 +358,8 @@
 									DoubleTapped="GridSplitter_DoubleTapped"
 									ManipulationCompleted="GridSplitter_ManipulationCompleted"
 									ManipulationDelta="GridSplitter_ManipulationDelta"
+									ManipulationStarting="GridSplitter_ManipulationStarting"
+									Loaded="GridSplitter_Loaded"
 									PreviewKeyUp="GridSplitter_PreviewKeyUp"
 									Style="{StaticResource HeaderGridSplitterStyle}" />
 
@@ -374,6 +376,8 @@
 									DoubleTapped="GridSplitter_DoubleTapped"
 									ManipulationCompleted="GridSplitter_ManipulationCompleted"
 									ManipulationDelta="GridSplitter_ManipulationDelta"
+									ManipulationStarting="GridSplitter_ManipulationStarting"
+									Loaded="GridSplitter_Loaded"
 									PreviewKeyUp="GridSplitter_PreviewKeyUp"
 									Style="{StaticResource HeaderGridSplitterStyle}"
 									Visibility="{x:Bind ColumnsViewModel.TagColumn.Visibility, Mode=OneWay}" />
@@ -391,6 +395,8 @@
 									DoubleTapped="GridSplitter_DoubleTapped"
 									ManipulationCompleted="GridSplitter_ManipulationCompleted"
 									ManipulationDelta="GridSplitter_ManipulationDelta"
+									ManipulationStarting="GridSplitter_ManipulationStarting"
+									Loaded="GridSplitter_Loaded"
 									PreviewKeyUp="GridSplitter_PreviewKeyUp"
 									Style="{StaticResource HeaderGridSplitterStyle}"
 									Visibility="{x:Bind ColumnsViewModel.OriginalPathColumn.Visibility, Mode=OneWay}" />
@@ -408,6 +414,8 @@
 									DoubleTapped="GridSplitter_DoubleTapped"
 									ManipulationCompleted="GridSplitter_ManipulationCompleted"
 									ManipulationDelta="GridSplitter_ManipulationDelta"
+									ManipulationStarting="GridSplitter_ManipulationStarting"
+									Loaded="GridSplitter_Loaded"
 									PreviewKeyUp="GridSplitter_PreviewKeyUp"
 									Style="{StaticResource HeaderGridSplitterStyle}"
 									Visibility="{x:Bind ColumnsViewModel.DateDeletedColumn.Visibility, Mode=OneWay}" />
@@ -425,6 +433,8 @@
 									DoubleTapped="GridSplitter_DoubleTapped"
 									ManipulationCompleted="GridSplitter_ManipulationCompleted"
 									ManipulationDelta="GridSplitter_ManipulationDelta"
+									ManipulationStarting="GridSplitter_ManipulationStarting"
+									Loaded="GridSplitter_Loaded"
 									PreviewKeyUp="GridSplitter_PreviewKeyUp"
 									Style="{StaticResource HeaderGridSplitterStyle}"
 									Visibility="{x:Bind ColumnsViewModel.DateModifiedColumn.Visibility, Mode=OneWay}" />
@@ -442,6 +452,8 @@
 									DoubleTapped="GridSplitter_DoubleTapped"
 									ManipulationCompleted="GridSplitter_ManipulationCompleted"
 									ManipulationDelta="GridSplitter_ManipulationDelta"
+									ManipulationStarting="GridSplitter_ManipulationStarting"
+									Loaded="GridSplitter_Loaded"
 									PreviewKeyUp="GridSplitter_PreviewKeyUp"
 									Style="{StaticResource HeaderGridSplitterStyle}"
 									Visibility="{x:Bind ColumnsViewModel.DateCreatedColumn.Visibility, Mode=OneWay}" />
@@ -459,6 +471,8 @@
 									DoubleTapped="GridSplitter_DoubleTapped"
 									ManipulationCompleted="GridSplitter_ManipulationCompleted"
 									ManipulationDelta="GridSplitter_ManipulationDelta"
+									ManipulationStarting="GridSplitter_ManipulationStarting"
+									Loaded="GridSplitter_Loaded"
 									PreviewKeyUp="GridSplitter_PreviewKeyUp"
 									Style="{StaticResource HeaderGridSplitterStyle}"
 									Visibility="{x:Bind ColumnsViewModel.ItemTypeColumn.Visibility, Mode=OneWay}" />
@@ -476,6 +490,8 @@
 									DoubleTapped="GridSplitter_DoubleTapped"
 									ManipulationCompleted="GridSplitter_ManipulationCompleted"
 									ManipulationDelta="GridSplitter_ManipulationDelta"
+									ManipulationStarting="GridSplitter_ManipulationStarting"
+									Loaded="GridSplitter_Loaded"
 									PreviewKeyUp="GridSplitter_PreviewKeyUp"
 									Style="{StaticResource HeaderGridSplitterStyle}"
 									Visibility="{x:Bind ColumnsViewModel.SizeColumn.Visibility, Mode=OneWay}" />
@@ -495,6 +511,8 @@
 									DoubleTapped="GridSplitter_DoubleTapped"
 									ManipulationCompleted="GridSplitter_ManipulationCompleted"
 									ManipulationDelta="GridSplitter_ManipulationDelta"
+									ManipulationStarting="GridSplitter_ManipulationStarting"
+									Loaded="GridSplitter_Loaded"
 									PreviewKeyUp="GridSplitter_PreviewKeyUp"
 									Style="{StaticResource HeaderGridSplitterStyle}"
 									Visibility="{x:Bind ColumnsViewModel.StatusColumn.Visibility, Mode=OneWay}" />

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -81,7 +81,6 @@ namespace Files.App.Views.LayoutModes
 
 			var selectionRectangle = RectangleSelection.Create(FileList, SelectionRectangle, FileList_SelectionChanged);
 			selectionRectangle.SelectionEnded += SelectionRectangle_SelectionEnded;
-			
 		}
 
 		protected override void HookEvents()

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -34,6 +34,7 @@ namespace Files.App.Views.LayoutModes
 		private uint currentIconSize;
 
 		private InputCursor arrowCursor = InputCursor.CreateFromCoreCursor(new CoreCursor(CoreCursorType.Arrow, 0));
+
 		private InputCursor resizeCursor = InputCursor.CreateFromCoreCursor(new CoreCursor(CoreCursorType.SizeWestEast, 1));
 
 		protected override uint IconSize => currentIconSize;

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -1,4 +1,5 @@
-using Files.Shared.Enums;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.WinUI.UI;
 using Files.App.EventArguments;
 using Files.App.Filesystem;
 using Files.App.Helpers;
@@ -7,21 +8,22 @@ using Files.App.Interacts;
 using Files.App.UserControls;
 using Files.App.UserControls.Selection;
 using Files.App.ViewModels;
-using CommunityToolkit.Mvvm.Input;
-using CommunityToolkit.WinUI.UI;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Windows.Foundation;
-using Windows.Storage;
-using Windows.System;
-using Windows.UI.Core;
+using Files.Shared.Enums;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UWPToWinAppSDKUpgradeHelpers;
+using Windows.Foundation;
+using Windows.Storage;
+using Windows.System;
+using Windows.UI.Core;
 
 using SortDirection = Files.Shared.Enums.SortDirection;
 
@@ -30,6 +32,9 @@ namespace Files.App.Views.LayoutModes
 	public sealed partial class DetailsLayoutBrowser : BaseLayout
 	{
 		private uint currentIconSize;
+
+		private InputCursor arrowCursor = InputCursor.CreateFromCoreCursor(new CoreCursor(CoreCursorType.Arrow, 0));
+		private InputCursor resizeCursor = InputCursor.CreateFromCoreCursor(new CoreCursor(CoreCursorType.SizeWestEast, 1));
 
 		protected override uint IconSize => currentIconSize;
 
@@ -76,6 +81,7 @@ namespace Files.App.Views.LayoutModes
 
 			var selectionRectangle = RectangleSelection.Create(FileList, SelectionRectangle, FileList_SelectionChanged);
 			selectionRectangle.SelectionEnded += SelectionRectangle_SelectionEnded;
+			
 		}
 
 		protected override void HookEvents()
@@ -657,9 +663,20 @@ namespace Files.App.Views.LayoutModes
 			MaxWidthForRenameTextbox = Math.Max(0, RootGrid.ActualWidth - 80);
 		}
 
+		private void GridSplitter_ManipulationStarting(object sender, ManipulationStartingRoutedEventArgs e)
+		{
+			this.ChangeCursor(resizeCursor);
+		}
+
 		private void GridSplitter_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
 		{
 			FolderSettings.ColumnsViewModel = ColumnsViewModel;
+			this.ChangeCursor(arrowCursor);
+		}
+
+		private void GridSplitter_Loaded(object sender, RoutedEventArgs e)
+		{
+			(sender as UIElement).ChangeCursor(resizeCursor);
 		}
 
 		private void ToggleMenuFlyoutItem_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9927 

**Comments**
It seems this is a <a href="https://github.com/microsoft/microsoft-ui-xaml/issues/4834">known bug</a> of WinUI3.
This is a workaround to fix that.

**Validation**
How did you test these changes?
- [x] Built and ran the app