### PR TITLE
Fix: Fixed issue where tags section showed "move" option

### DIFF
--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -196,8 +196,8 @@ namespace Files.App.UserControls
             int favoriteIndex = favoriteModel.IndexOfItem(item);
             int favoriteCount = favoriteModel.FavoriteItems.Count;
 
-            bool showMoveItemUp = favoriteIndex > 0;
-            bool showMoveItemDown = favoriteIndex < favoriteCount - 1;
+            bool showMoveItemUp = favoriteIndex > 0 && item.Section == SectionType.Favorites;
+            bool showMoveItemDown = favoriteIndex < favoriteCount - 1 && item.Section == SectionType.Favorites;
 
             bool isDriveItem = item is DriveItem;
             bool isDriveItemPinned = isDriveItem && (item as DriveItem).IsPinned;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9753 

**Comments**
I removed "move" option from all sidebar items that are not in the `Favourite Section` (I think this is the expected behavior)

**Validation**
How did you test these changes?
- [x] Built and ran the app
