### PR TITLE
Fix: Fixed issue where right clicking on sidebar items showed the wrong menu options

### DIFF
--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -196,8 +196,9 @@ namespace Files.App.UserControls
             int favoriteIndex = favoriteModel.IndexOfItem(item);
             int favoriteCount = favoriteModel.FavoriteItems.Count;
 
-            bool showMoveItemUp = favoriteIndex > 0 && item.Section == SectionType.Favorites;
-            bool showMoveItemDown = favoriteIndex < favoriteCount - 1 && item.Section == SectionType.Favorites;
+            bool isFavoriteItem = item.Section is SectionType.Favorites && favoriteIndex is not -1;
+            bool showMoveItemUp = isFavoriteItem && favoriteIndex > 0;
+            bool showMoveItemDown = isFavoriteItem && favoriteIndex < favoriteCount - 1;
 
             bool isDriveItem = item is DriveItem;
             bool isDriveItemPinned = isDriveItem && (item as DriveItem).IsPinned;


### PR DESCRIPTION
**Resolved / Related Issues**
The entries "Move on down" and "Move to bottom" of the favorites section is a bug (on the title, not on the items), without effect. This pr fix this. 
Fixes #10215

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before/After.
![section1](https://user-images.githubusercontent.com/46631671/195991511-4d0dbda9-b5f2-479c-bb9c-4f00db098cc4.png)
![section2](https://user-images.githubusercontent.com/46631671/195991448-eb77f97a-ac56-4f2f-9cca-2e9847d64479.png)