### PR TITLE
Restore Windows default language

### DIFF
--- a/src/Files.App/ViewModels/SettingsViewModels/PreferencesViewModel.cs
+++ b/src/Files.App/ViewModels/SettingsViewModels/PreferencesViewModel.cs
@@ -130,7 +130,7 @@ namespace Files.App.ViewModels.SettingsViewModels
 		public PreferencesViewModel()
 		{
 			EditTerminalApplicationsCommand = new AsyncRelayCommand(LaunchTerminalsConfigFile);
-			OpenFilesAtStartupCommand = new AsyncRelayCommand(OpenFilesAtStartup);			
+			OpenFilesAtStartupCommand = new AsyncRelayCommand(OpenFilesAtStartup);
 			ChangePageCommand = new AsyncRelayCommand(ChangePage);
 			RemovePageCommand = new RelayCommand(RemovePage);
 			AddPageCommand = new RelayCommand<string>(async (path) => await AddPage(path));
@@ -168,14 +168,17 @@ namespace Files.App.ViewModels.SettingsViewModels
 
 		private void AddSupportedAppLanguages()
 		{
-			var supportedLanguages = ApplicationLanguages.ManifestLanguages;
+			var appLanguages = ApplicationLanguages.ManifestLanguages
+				.Append(string.Empty) // add default language id
+				.Select(language => new AppLanguageItem(language))
+				.OrderBy(language => language.LanguagID is not "") // default language on top
+				.ThenBy(language => language.LanguageName);
+			AppLanguages = new ObservableCollection<AppLanguageItem>(appLanguages);
 
-			AppLanguages = new ObservableCollection<AppLanguageItem> { };
-			foreach (var language in supportedLanguages)
-				AppLanguages.Add(new AppLanguageItem(language));
-
-			SelectedAppLanguageIndex = AppLanguages.IndexOf(AppLanguages.FirstOrDefault(dl => dl.LanguagID == ApplicationLanguages.PrimaryLanguageOverride) ?? AppLanguages.FirstOrDefault());
-		}
+			string languageID = ApplicationLanguages.PrimaryLanguageOverride;
+			SelectedAppLanguageIndex = AppLanguages
+				.IndexOf(AppLanguages.FirstOrDefault(dl => dl.LanguagID == languageID) ?? AppLanguages.First());
+			}
 
 		private async Task InitStartupSettingsRecentFoldersFlyout()
 		{


### PR DESCRIPTION
**Resolved / Related Issues**
This pr restores Windows default in the language selection. This option is by default.
The others languages are sorted by name, including English. #10220.

The current behavior is to select Windows default after installation, but display English in the options. It is no longer possible to return to Windows default after changing the language. This pr fixes that. Windows default should be English if the Windows language doesn't exist in Files, but I couldn't test.

The method AddSupportedAppLanguages in PreferencesViewModel is refactored.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![selector](https://user-images.githubusercontent.com/46631671/195996892-3072f66c-4359-4928-93c2-1619e2f4c535.png)