### PR TITLE
Fix: Fixed issue where columns sometimes had no width

### DIFF
--- a/src/Files.App/ServicesImplementation/Settings/FoldersSettingsService.cs
+++ b/src/Files.App/ServicesImplementation/Settings/FoldersSettingsService.cs
@@ -30,7 +30,11 @@ namespace Files.App.ServicesImplementation.Settings
 		public double TagColumnWidth
 		{
 			get => Get(200d);
-			set => Set(value);
+			set
+			{
+				if (ShowFileTagColumn)
+					Set(value);
+			}
 		}
 
 		public double NameColumnWidth
@@ -42,25 +46,41 @@ namespace Files.App.ServicesImplementation.Settings
 		public double DateModifiedColumnWidth
 		{
 			get => Get(200d);
-			set => Set(value);
+			set
+			{
+				if (ShowDateColumn)
+					Set(value);
+			}
 		}
 
 		public double TypeColumnWidth
 		{
 			get => Get(200d);
-			set => Set(value);
+			set
+			{
+				if (ShowTypeColumn)
+					Set(value);
+			}
 		}
 
 		public double DateCreatedColumnWidth
 		{
 			get => Get(200d);
-			set => Set(value);
+			set
+			{
+				if (ShowDateCreatedColumn)
+					Set(value);
+			}
 		}
 
 		public double SizeColumnWidth
 		{
 			get => Get(200d);
-			set => Set(value);
+			set
+			{
+				if (ShowSizeColumn)
+					Set(value);
+			}
 		}
 
 		public bool ShowDateColumn


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related #10117 #9867 

**Comments**
There was a bug involving hidden columns.
Steps to reproduce:
- Hide at least one column
- Set column widths as default
- Show one of the hidden columns
- See that its width is 0px

**Validation**
How did you test these changes?
- [x] Built and ran the app