### PR TITLE
Feature: Improved the tooltip when hovering over drives

### DIFF
--- a/src/Files.App/DataModels/NavigationControlItems/DriveItem.cs
+++ b/src/Files.App/DataModels/NavigationControlItems/DriveItem.cs
@@ -46,11 +46,23 @@ namespace Files.App.DataModels.NavigationControlItems
 		public bool IsNetwork => Type == DriveType.Network;
 		public bool IsPinned => App.SidebarPinnedController.Model.FavoriteItems.Contains(path);
 
+		public string MaxSpaceText => MaxSpace.ToSizeString();
+		public string FreeSpaceText => FreeSpace.ToSizeString();
+		public string UsedSpaceText => SpaceUsed.ToSizeString();
+
 		private ByteSize maxSpace;
 		public ByteSize MaxSpace
 		{
 			get => maxSpace;
-			set => SetProperty(ref maxSpace, value);
+			set
+			{
+				if (SetProperty(ref maxSpace, value))
+				{
+					ToolTipText = GetSizeString();
+					OnPropertyChanged(nameof(MaxSpaceText));
+					OnPropertyChanged(nameof(ShowDriveDetails));
+				}
+			}
 		}
 
 		private ByteSize freeSpace;
@@ -59,8 +71,11 @@ namespace Files.App.DataModels.NavigationControlItems
 			get => freeSpace;
 			set
 			{
-				SetProperty(ref freeSpace, value);
-				ToolTipText = GetSizeString();
+				if (SetProperty(ref freeSpace, value))
+				{
+					ToolTipText = GetSizeString();
+					OnPropertyChanged(nameof(FreeSpaceText));
+				}
 			}
 		}
 
@@ -70,24 +85,16 @@ namespace Files.App.DataModels.NavigationControlItems
 			get => spaceUsed;
 			set
 			{
-				SetProperty(ref spaceUsed, value);
+				if (SetProperty(ref spaceUsed, value))
+				{
+					OnPropertyChanged(nameof(UsedSpaceText));
+				}
 			}
 		}
 
-		public bool ShowDriveDetails
-		{
-			get => MaxSpace.Bytes > 0d ? true : false;
-		}
+		public bool ShowDriveDetails => MaxSpace.Bytes > 0d;
 
-		private DriveType type;
-		public DriveType Type
-		{
-			get => type;
-			set
-			{
-				type = value;
-			}
-		}
+		public DriveType Type { get; set; }
 
 		private string text;
 		public string Text

--- a/src/Files.App/UserControls/SidebarControl.xaml
+++ b/src/Files.App/UserControls/SidebarControl.xaml
@@ -42,6 +42,7 @@
 	<NavigationView.Resources>
 		<ResourceDictionary>
 			<mconv:BoolNegationConverter x:Key="BoolNegationConverter" />
+			<mconv:StringFormatConverter x:Key="StringFormatConverter" />
 			<vc:ColorModelToColorConverter x:Key="ColorModelToColorConverter" />
 
 			<DataTemplate x:Key="LocationNavItem" x:DataType="navigationcontrolitems:LocationItem">
@@ -67,7 +68,7 @@
 					<NavigationViewItem.Icon>
 						<ImageIcon Source="{x:Bind Icon, Mode=OneWay}" />
 					</NavigationViewItem.Icon>
-					<!--  WINUI3  missing some styles -->
+					<!--  WINUI3  missing some styles  -->
 					<!--<NavigationViewItem.InfoBadge>
 						<InfoBadge Style="{ThemeResource CautionIconInfoBadgeStyle}" Visibility="{x:Bind IsInvalid, Mode=OneWay}" />
 					</NavigationViewItem.InfoBadge>-->
@@ -92,33 +93,165 @@
 					Visibility="{x:Bind ItemVisibility}">
 					<ToolTipService.ToolTip>
 						<ToolTip>
-							<Grid>
+							<Grid
+								x:Name="DriveTooltip"
+								Padding="0"
+								HorizontalAlignment="Stretch"
+								ColumnSpacing="8"
+								CornerRadius="4"
+								RowSpacing="8">
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="72" />
+									<ColumnDefinition
+										Width="Auto"
+										MinWidth="100"
+										MaxWidth="140" />
+									<ColumnDefinition Width="*" />
+									<ColumnDefinition Width="Auto" />
+								</Grid.ColumnDefinitions>
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+								</Grid.RowDefinitions>
+
 								<!--  Displays the drive name, this is hidden when the extended details are shown  -->
 								<TextBlock
 									x:Name="DriveNameTextBlock"
 									x:Load="{x:Bind ShowDriveDetails, Converter={StaticResource BoolNegationConverter}}"
 									Text="{x:Bind Text, Mode=OneWay}" />
 
-								<!--  Displays the drive name and extended details  -->
-								<StackPanel
-									x:Name="DriveDetailsStackPanel"
-									Padding="8"
+								<!--  Label  -->
+								<TextBlock
+									x:Name="DriveLabel"
+									Grid.ColumnSpan="3"
+									Padding="8,8,0,0"
+									VerticalAlignment="Center"
 									x:Load="{x:Bind ShowDriveDetails}"
-									Spacing="8">
+									FontSize="14"
+									FontWeight="Medium"
+									Text="{x:Bind Text, Mode=OneWay}" />
+
+								<!--  Space used progress  -->
+								<ProgressRing
+									x:Name="SpaceUserProgressRing"
+									Grid.Row="1"
+									Grid.RowSpan="3"
+									Grid.Column="0"
+									Width="60"
+									Height="60"
+									HorizontalAlignment="Left"
+									x:Load="{x:Bind ShowDriveDetails}"
+									IsIndeterminate="False"
+									Value="{x:Bind PercentageUsed, Mode=OneWay}">
+
+									<ProgressRing.Template>
+										<ControlTemplate TargetType="ProgressRing">
+											<Grid x:Name="LayoutRoot" Background="Transparent">
+												<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+													<TextBlock
+														Margin="0"
+														FontWeight="SemiBold"
+														Text="{Binding Value, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0}%', Mode=OneWay}"
+														TextAlignment="Center" />
+												</StackPanel>
+
+												<!--  AnimatedVisualPlayer for Lottie  -->
+												<AnimatedVisualPlayer
+													x:Name="LottiePlayer"
+													AutoPlay="false"
+													Opacity="1"
+													Stretch="fill" />
+
+												<VisualStateManager.VisualStateGroups>
+													<VisualStateGroup x:Name="CommonStates">
+														<VisualState x:Name="Inactive">
+															<VisualState.Setters>
+																<Setter Target="LayoutRoot.Opacity" Value="0" />
+															</VisualState.Setters>
+														</VisualState>
+														<VisualState x:Name="DeterminateActive" />
+														<VisualState x:Name="Active" />
+													</VisualStateGroup>
+												</VisualStateManager.VisualStateGroups>
+											</Grid>
+										</ControlTemplate>
+									</ProgressRing.Template>
+								</ProgressRing>
+
+								<!--  Disk used space  -->
+								<StackPanel
+									x:Name="UsedSpaceDrivePanel"
+									Grid.Row="1"
+									Grid.Column="1"
+									x:Load="{x:Bind ShowDriveDetails}"
+									Orientation="Horizontal">
+									<Rectangle
+										Width="15"
+										Height="15"
+										Margin="0,0,10,0"
+										Fill="{ThemeResource SystemAccentColorLight2}"
+										RadiusX="2"
+										RadiusY="2"
+										Stroke="{ThemeResource TextControlElevationBorderBrush}" />
 									<TextBlock
 										VerticalAlignment="Center"
-										FontSize="14"
-										FontWeight="Medium"
-										Text="{x:Bind Text, Mode=OneWay}" />
-
-									<ProgressBar
-										VerticalAlignment="Stretch"
-										VerticalContentAlignment="Stretch"
-										Maximum="{x:Bind MaxSpace.GigaBytes}"
-										Value="{x:Bind SpaceUsed.GigaBytes}" />
-
-									<TextBlock Text="{x:Bind ToolTipText, Mode=OneWay}" />
+										FontWeight="Bold"
+										Text="{helpers:ResourceString Name=PropertiesDriveUsedSpace/Text}" />
 								</StackPanel>
+								<TextBlock
+									x:Name="UsedSpaceDriveValue"
+									Grid.Row="1"
+									Grid.Column="2"
+									x:Load="{x:Bind ShowDriveDetails}"
+									Style="{StaticResource PropertyValueTextBlock}"
+									Text="{x:Bind UsedSpaceText, Mode=OneWay}" />
+
+								<!--  Disk free space  -->
+								<StackPanel
+									x:Name="FreeSpaceDrivePanel"
+									Grid.Row="2"
+									Grid.Column="1"
+									x:Load="{x:Bind ShowDriveDetails}"
+									Orientation="Horizontal">
+									<Rectangle
+										Width="15"
+										Height="15"
+										Margin="0,0,10,0"
+										Fill="{ThemeResource ProgressRingBackgroundThemeBrush}"
+										RadiusX="2"
+										RadiusY="2"
+										Stroke="{ThemeResource TextControlElevationBorderBrush}" />
+									<TextBlock
+										VerticalAlignment="Center"
+										FontWeight="Bold"
+										Text="{helpers:ResourceString Name=PropertiesDriveFreeSpace/Text}" />
+								</StackPanel>
+								<TextBlock
+									x:Name="FreeSpaceDriveValue"
+									Grid.Row="2"
+									Grid.Column="2"
+									x:Load="{x:Bind ShowDriveDetails}"
+									Style="{StaticResource PropertyValueTextBlock}"
+									Text="{x:Bind FreeSpaceText, Mode=OneWay}" />
+
+								<!--  Drive capacity  -->
+								<TextBlock
+									x:Name="MaxSpaceDriveLabel"
+									Grid.Row="3"
+									Grid.Column="1"
+									Padding="28,0,0,0"
+									x:Load="{x:Bind ShowDriveDetails}"
+									Style="{StaticResource PropertyName}"
+									Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />
+								<TextBlock
+									x:Name="MaxSpaceDriveValue"
+									Grid.Row="3"
+									Grid.Column="2"
+									x:Load="{x:Bind ShowDriveDetails}"
+									Style="{StaticResource PropertyValueTextBlock}"
+									Text="{x:Bind MaxSpaceText, Mode=OneWay}" />
 							</Grid>
 						</ToolTip>
 					</ToolTipService.ToolTip>
@@ -1067,6 +1200,11 @@
 					</Setter.Value>
 				</Setter>
 			</Style>
+
+			<ResourceDictionary.MergedDictionaries>
+				<ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml" />
+			</ResourceDictionary.MergedDictionaries>
+
 		</ResourceDictionary>
 	</NavigationView.Resources>
 

--- a/src/Files.App/UserControls/SidebarControl.xaml
+++ b/src/Files.App/UserControls/SidebarControl.xaml
@@ -241,7 +241,7 @@
 									x:Name="MaxSpaceDriveLabel"
 									Grid.Row="3"
 									Grid.Column="1"
-									Padding="28,0,0,0"
+									Padding="25,0,0,0"
 									x:Load="{x:Bind ShowDriveDetails}"
 									Style="{StaticResource PropertyName}"
 									Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />
@@ -1204,6 +1204,19 @@
 			<ResourceDictionary.MergedDictionaries>
 				<ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml" />
 			</ResourceDictionary.MergedDictionaries>
+			<ResourceDictionary.ThemeDictionaries>
+				<ResourceDictionary x:Key="Light">
+					<SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="#c3c3c3" />
+				</ResourceDictionary>
+
+				<ResourceDictionary x:Key="Dark">
+					<SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="#191919" />
+				</ResourceDictionary>
+
+				<ResourceDictionary x:Key="HighContrast">
+					<SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="#c3c3c3" />
+				</ResourceDictionary>
+			</ResourceDictionary.ThemeDictionaries>
 
 		</ResourceDictionary>
 	</NavigationView.Resources>

--- a/src/Files.App/Views/Pages/PropertiesGeneral.xaml
+++ b/src/Files.App/Views/Pages/PropertiesGeneral.xaml
@@ -441,7 +441,7 @@
 				x:Name="PropertiesDriveCapacity"
 				Grid.Row="2"
 				Grid.Column="1"
-				Padding="25,0,0,0"
+				Padding="28,0,0,0"
 				x:Load="{x:Bind ViewModel.DriveCapacityVisibility, Mode=OneWay}"
 				Style="{StaticResource PropertyName}"
 				Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />

--- a/src/Files.App/Views/Pages/PropertiesGeneral.xaml
+++ b/src/Files.App/Views/Pages/PropertiesGeneral.xaml
@@ -441,7 +441,7 @@
 				x:Name="PropertiesDriveCapacity"
 				Grid.Row="2"
 				Grid.Column="1"
-				Padding="28,0,0,0"
+				Padding="25,0,0,0"
 				x:Load="{x:Bind ViewModel.DriveCapacityVisibility, Mode=OneWay}"
 				Style="{StaticResource PropertyName}"
 				Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />


### PR DESCRIPTION
**Resolved / Related Issues**
Changes the sidebar drives template to match the property menu 
Closes #10214.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
![tooltip_light](https://user-images.githubusercontent.com/46631671/196221336-94b02413-3cba-42f8-8c8f-6f122d6cbd61.png)
![tooltip_dark](https://user-images.githubusercontent.com/46631671/196221327-d45c342f-3499-42a8-91aa-37d80a5a0b7d.png)

before/after
![fixbefore](https://user-images.githubusercontent.com/46631671/196224167-9879fd27-6b51-4616-8899-f029bdc4125b.png)
![fixafter](https://user-images.githubusercontent.com/46631671/196224164-40682f34-1a40-482a-8f8d-3a2fa1420fbc.png)