### PR TITLE
Fix: Fixed issue where drives had the wrong order in the sidebar

### DIFF
--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -7,6 +7,7 @@ using Files.App.Helpers;
 using Files.App.Helpers.XamlHelpers;
 using Files.App.ViewModels.Widgets;
 using Files.Backend.Services.Settings;
+using Files.Shared.Extensions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -25,8 +26,8 @@ using Windows.UI.Core;
 
 namespace Files.App.UserControls.Widgets
 {
-    public class DriveCardItem : ObservableObject, IWidgetCardItem<DriveItem>
-    {
+    public class DriveCardItem : ObservableObject, IWidgetCardItem<DriveItem>, IComparable<DriveCardItem>
+	{
         private BitmapImage thumbnail;
         private byte[] thumbnailData;
 
@@ -61,7 +62,9 @@ namespace Files.App.UserControls.Widgets
                 Thumbnail = await App.Window.DispatcherQueue.EnqueueAsync(() => thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize));
             }
         }
-    }
+
+        public int CompareTo(DriveCardItem? other) => Item.Path.CompareTo(other?.Item?.Path);
+	}
 
     public sealed partial class DrivesWidget : UserControl, IWidgetItemModel, INotifyPropertyChanged
     {
@@ -122,7 +125,7 @@ namespace Files.App.UserControls.Widgets
                         if (drive.Type != DriveType.VirtualDrive)
                         {
                             var cardItem = new DriveCardItem(drive);
-                            ItemsAdded.Add(cardItem);
+                            ItemsAdded.AddSorted(cardItem);
                             await cardItem.LoadCardThumbnailAsync(); // After add
                         }
                     }

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -27,7 +27,7 @@ using Windows.UI.Core;
 namespace Files.App.UserControls.Widgets
 {
     public class DriveCardItem : ObservableObject, IWidgetCardItem<DriveItem>, IComparable<DriveCardItem>
-	{
+    {
         private BitmapImage thumbnail;
         private byte[] thumbnailData;
 

--- a/src/Files.App/ViewModels/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/SidebarViewModel.cs
@@ -3,17 +3,17 @@ using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI;
 using Files.App.DataModels.NavigationControlItems;
+using Files.App.Extensions;
 using Files.App.Filesystem;
 using Files.App.Helpers;
 using Files.App.UserControls;
-using Files.App.Extensions;
 using Files.Backend.Services.Settings;
 using Files.Shared.EventArguments;
 using Files.Shared.Extensions;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.UI.Dispatching;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -349,9 +349,15 @@ namespace Files.App.ViewModels
 			}
 			else if (elem is DriveItem drive)
 			{
-				if (!section.ChildItems.Any(x => x.Path == drive.Path))
+				string drivePath = drive.Path;
+				IList<string> paths = section.ChildItems.Select(item => item.Path).ToList();
+
+				if (!paths.Contains(drivePath))
 				{
-					section.ChildItems.Insert(index < 0 ? section.ChildItems.Count : Math.Min(index, section.ChildItems.Count), drive);
+					paths.AddSorted(drivePath);
+					int position = paths.IndexOf(drivePath);
+
+					section.ChildItems.Insert(position, drive);
 					await drive.LoadDriveIcon();
 				}
 			}


### PR DESCRIPTION
**Resolved / Related Issues**
Detected drives are always displayed at the end. It makes more sense to display them in order according to the path. Sometimes internal drives are not displayed in path order.  

Closes #10252.

This pr keeps drives sorted by path in the sidebar and homepage.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility