### PR TITLE
Fix: Fixed issue where the progress bar wasn't shown when connecting new drives

### DIFF
--- a/src/Files.App/DataModels/NavigationControlItems/DriveItem.cs
+++ b/src/Files.App/DataModels/NavigationControlItems/DriveItem.cs
@@ -199,11 +199,15 @@ namespace Files.App.DataModels.NavigationControlItems
 					SpaceText = "DriveCapacityUnknown".GetLocalizedResource();
 					MaxSpace = SpaceUsed = FreeSpace = ByteSize.FromBytes(0);
 				}
+
+				OnPropertyChanged(nameof(ShowDriveDetails));
 			}
 			catch (Exception)
 			{
 				SpaceText = "DriveCapacityUnknown".GetLocalizedResource();
 				MaxSpace = SpaceUsed = FreeSpace = ByteSize.FromBytes(0);
+
+				OnPropertyChanged(nameof(ShowDriveDetails));
 			}
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
When you connect a new drive and the homepage is displayed, the drive widget is displayed but without the progressbar. You have to refresh the page to display it. This pr fixes this so that the progressbar always shows.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before/After
![ProgressBar1](https://user-images.githubusercontent.com/46631671/196987763-6c56f8e4-8102-4bdd-b0f2-4b90c5487cd0.png)
![ProgressBar2](https://user-images.githubusercontent.com/46631671/196987766-41618e28-0833-40fe-8f6c-1574899a833b.png)
