### PR TITLE
Fix: Fixed issue with the text alignment in the properties window

### DIFF
--- a/src/Files.App/UserControls/SidebarControl.xaml
+++ b/src/Files.App/UserControls/SidebarControl.xaml
@@ -188,9 +188,9 @@
 									x:Load="{x:Bind ShowDriveDetails}"
 									Orientation="Horizontal">
 									<Rectangle
-										Width="15"
-										Height="15"
-										Margin="0,0,10,0"
+										Width="16"
+										Height="16"
+										Margin="0,0,12,0"
 										Fill="{ThemeResource SystemAccentColorLight2}"
 										RadiusX="2"
 										RadiusY="2"
@@ -216,9 +216,9 @@
 									x:Load="{x:Bind ShowDriveDetails}"
 									Orientation="Horizontal">
 									<Rectangle
-										Width="15"
-										Height="15"
-										Margin="0,0,10,0"
+										Width="16"
+										Height="16"
+										Margin="0,0,12,0"
 										Fill="{ThemeResource ProgressRingBackgroundThemeBrush}"
 										RadiusX="2"
 										RadiusY="2"
@@ -241,7 +241,7 @@
 									x:Name="MaxSpaceDriveLabel"
 									Grid.Row="3"
 									Grid.Column="1"
-									Padding="25,0,0,0"
+									Padding="28,0,0,0"
 									x:Load="{x:Bind ShowDriveDetails}"
 									Style="{StaticResource PropertyName}"
 									Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />

--- a/src/Files.App/Views/Pages/PropertiesGeneral.xaml
+++ b/src/Files.App/Views/Pages/PropertiesGeneral.xaml
@@ -357,9 +357,9 @@
 				x:Load="{x:Bind ViewModel.DriveUsedSpaceVisibility, Mode=OneWay}"
 				Orientation="Horizontal">
 				<Rectangle
-					Width="15"
-					Height="15"
-					Margin="0,0,10,0"
+					Width="16"
+					Height="16"
+					Margin="0,0,12,0"
 					Fill="{ThemeResource SystemAccentColorLight2}"
 					RadiusX="2"
 					RadiusY="2"
@@ -401,9 +401,9 @@
 				x:Load="{x:Bind ViewModel.DriveFreeSpaceVisibility, Mode=OneWay}"
 				Orientation="Horizontal">
 				<Rectangle
-					Width="15"
-					Height="15"
-					Margin="0,0,10,0"
+					Width="16"
+					Height="16"
+					Margin="0,0,12,0"
 					Fill="{ThemeResource ProgressRingBackgroundThemeBrush}"
 					RadiusX="2"
 					RadiusY="2"
@@ -441,7 +441,7 @@
 				x:Name="PropertiesDriveCapacity"
 				Grid.Row="2"
 				Grid.Column="1"
-				Padding="25,0,0,0"
+				Padding="28,0,0,0"
 				x:Load="{x:Bind ViewModel.DriveCapacityVisibility, Mode=OneWay}"
 				Style="{StaticResource PropertyName}"
 				Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />

--- a/src/Files.App/Views/Pages/PropertiesGeneral.xaml
+++ b/src/Files.App/Views/Pages/PropertiesGeneral.xaml
@@ -441,7 +441,7 @@
 				x:Name="PropertiesDriveCapacity"
 				Grid.Row="2"
 				Grid.Column="1"
-				Padding="28,0,0,0"
+				Padding="25,0,0,0"
 				x:Load="{x:Bind ViewModel.DriveCapacityVisibility, Mode=OneWay}"
 				Style="{StaticResource PropertyName}"
 				Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />


### PR DESCRIPTION
**Resolved / Related Issues**
Fix the bad position of the text Capacity in the properties of drives.
The correct padding is 25, not 28, as the rectangle (width 15 + margin 10).

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before/After
![fixbefore](https://user-images.githubusercontent.com/46631671/196991222-b1b439c4-2a5a-4b98-9e63-b998818fd8ba.png)
![fixafter](https://user-images.githubusercontent.com/46631671/196991213-a11f65bd-337e-48d6-b920-3f66b07a95ee.png)