### PR TITLE
Feature: Display drive letter of the connected network drives

### DIFF
--- a/src/Files.App/DataModels/NavigationControlItems/DriveItem.cs
+++ b/src/Files.App/DataModels/NavigationControlItems/DriveItem.cs
@@ -152,7 +152,7 @@ namespace Files.App.DataModels.NavigationControlItems
 			if (imageStream != null)
 				item.IconData = await imageStream.ToByteArrayAsync();
 
-			item.Text = root.DisplayName;
+			item.Text = type is DriveType.Network ? $"{root.DisplayName} ({deviceId})" : root.DisplayName;
 			item.Type = type;
 			item.MenuOptions = new ContextMenuOptions
 			{


### PR DESCRIPTION
**Resolved / Related Issues**
The access path of network disks which have a local access path is not displayed in their label, contrary to fixed disks. This is so in the item name received by .net and FileExplorer has the same problem. This pr adds this missing path for consistency and readability
Closes #10261.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before/After
![Drive1](https://user-images.githubusercontent.com/46631671/197211643-d8fcd598-67cf-4c4b-97c6-829e8ec34f36.png)
![fix2](https://user-images.githubusercontent.com/46631671/197211653-d8df414a-d0a3-4d33-b51f-439052d200ef.png)
![fix4](https://user-images.githubusercontent.com/46631671/197213363-70a16caf-57e0-4db7-bd52-79e6c366f626.png)
![fix5](https://user-images.githubusercontent.com/46631671/197213369-9c7d9817-3504-461d-afe2-f442b7458745.png)