### PR TITLE
Fix: Fixed progress ring style in drive tooltip

### DIFF
--- a/src/Files.App/UserControls/SidebarControl.xaml
+++ b/src/Files.App/UserControls/SidebarControl.xaml
@@ -111,9 +111,9 @@
 								</Grid.ColumnDefinitions>
 								<Grid.RowDefinitions>
 									<RowDefinition Height="Auto" />
-									<RowDefinition Height="*" />
-									<RowDefinition Height="*" />
-									<RowDefinition Height="*" />
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
 								</Grid.RowDefinitions>
 
 								<!--  Displays the drive name, this is hidden when the extended details are shown  -->

--- a/src/Files.App/UserControls/SidebarControl.xaml
+++ b/src/Files.App/UserControls/SidebarControl.xaml
@@ -111,9 +111,9 @@
 								</Grid.ColumnDefinitions>
 								<Grid.RowDefinitions>
 									<RowDefinition Height="Auto" />
-									<RowDefinition Height="Auto" />
-									<RowDefinition Height="Auto" />
-									<RowDefinition Height="Auto" />
+									<RowDefinition Height="*" />
+									<RowDefinition Height="*" />
+									<RowDefinition Height="*" />
 								</Grid.RowDefinitions>
 
 								<!--  Displays the drive name, this is hidden when the extended details are shown  -->
@@ -144,7 +144,8 @@
 									HorizontalAlignment="Left"
 									x:Load="{x:Bind ShowDriveDetails}"
 									IsIndeterminate="False"
-									Value="{x:Bind PercentageUsed, Mode=OneWay}">
+									Value="{x:Bind PercentageUsed, Mode=OneWay}"
+									Background="{ThemeResource ProgressRingBackgroundThemeBrush}">
 
 									<ProgressRing.Template>
 										<ControlTemplate TargetType="ProgressRing">
@@ -191,7 +192,7 @@
 										Width="16"
 										Height="16"
 										Margin="0,0,12,0"
-										Fill="{ThemeResource SystemAccentColorLight2}"
+										Fill="{Binding Foreground, ElementName=SpaceUserProgressRing}"
 										RadiusX="2"
 										RadiusY="2"
 										Stroke="{ThemeResource TextControlElevationBorderBrush}" />
@@ -242,8 +243,9 @@
 									Grid.Row="3"
 									Grid.Column="1"
 									Padding="28,0,0,0"
+									VerticalAlignment="Center"
 									x:Load="{x:Bind ShowDriveDetails}"
-									Style="{StaticResource PropertyName}"
+									FontWeight="Bold"
 									Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />
 								<TextBlock
 									x:Name="MaxSpaceDriveValue"
@@ -1208,11 +1210,9 @@
 				<ResourceDictionary x:Key="Light">
 					<SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="#c3c3c3" />
 				</ResourceDictionary>
-
 				<ResourceDictionary x:Key="Dark">
 					<SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="#191919" />
 				</ResourceDictionary>
-
 				<ResourceDictionary x:Key="HighContrast">
 					<SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="#c3c3c3" />
 				</ResourceDictionary>

--- a/src/Files.App/Views/Pages/PropertiesGeneral.xaml
+++ b/src/Files.App/Views/Pages/PropertiesGeneral.xaml
@@ -21,11 +21,9 @@
 				<ResourceDictionary x:Key="Light">
 					<SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="#c3c3c3" />
 				</ResourceDictionary>
-
 				<ResourceDictionary x:Key="Dark">
 					<SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="#191919" />
 				</ResourceDictionary>
-
 				<ResourceDictionary x:Key="HighContrast">
 					<SolidColorBrush x:Key="ProgressRingBackgroundThemeBrush" Color="#c3c3c3" />
 				</ResourceDictionary>
@@ -293,12 +291,13 @@
 				<ColumnDefinition Width="Auto" />
 			</Grid.ColumnDefinitions>
 			<Grid.RowDefinitions>
-				<RowDefinition Height="Auto" />
-				<RowDefinition Height="Auto" />
-				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+				<RowDefinition Height="*" />
+				<RowDefinition Height="*" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 			</Grid.RowDefinitions>
+
 			<!--  Space used progress  -->
 			<ProgressRing
 				x:Name="SpaceUserProgressRing"
@@ -310,7 +309,8 @@
 				HorizontalAlignment="Left"
 				x:Load="{x:Bind ViewModel.DriveCapacityVisibility, Mode=OneWay}"
 				IsIndeterminate="False"
-				Value="{x:Bind ViewModel.DrivePercentageValue, Mode=OneWay}">
+				Value="{x:Bind ViewModel.DrivePercentageValue, Mode=OneWay}"
+				Background="{ThemeResource ProgressRingBackgroundThemeBrush}">
 
 				<ProgressRing.Template>
 					<ControlTemplate TargetType="ProgressRing">
@@ -360,7 +360,7 @@
 					Width="16"
 					Height="16"
 					Margin="0,0,12,0"
-					Fill="{ThemeResource SystemAccentColorLight2}"
+					Fill="{Binding Foreground, ElementName=SpaceUserProgressRing}"
 					RadiusX="2"
 					RadiusY="2"
 					Stroke="{ThemeResource TextControlElevationBorderBrush}" />
@@ -391,7 +391,6 @@
 					</Flyout>
 				</Button.Flyout>
 			</Button>
-
 
 			<!--  Disk free space  -->
 			<StackPanel
@@ -442,8 +441,9 @@
 				Grid.Row="2"
 				Grid.Column="1"
 				Padding="28,0,0,0"
+				VerticalAlignment="Center"
 				x:Load="{x:Bind ViewModel.DriveCapacityVisibility, Mode=OneWay}"
-				Style="{StaticResource PropertyName}"
+				FontWeight="SemiBold"
 				Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />
 			<TextBlock
 				x:Name="DriveCapacityValue"

--- a/src/Files.App/Views/Pages/PropertiesGeneral.xaml
+++ b/src/Files.App/Views/Pages/PropertiesGeneral.xaml
@@ -291,9 +291,9 @@
 				<ColumnDefinition Width="Auto" />
 			</Grid.ColumnDefinitions>
 			<Grid.RowDefinitions>
-				<RowDefinition Height="*" />
-				<RowDefinition Height="*" />
-				<RowDefinition Height="*" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 			</Grid.RowDefinitions>


### PR DESCRIPTION
**Resolved / Related Issues**
This pr fixes the style of displaying drive sizes (Property and Tooltip).
- In the tooltip, the background of the ring was missing.
- In the tooltip, the 3 texts did not use exactly the same style.
- In light mode, the color of the free space legend did not match the color used by the ring. The color of the ring has been used because it is more readable and this corresponds to the progressbar of the Drive widget.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before Property
![Before_Property_Dark](https://user-images.githubusercontent.com/46631671/197348372-e143a791-9387-47d3-b65e-56dd6c636cca.png)
![Before_Property_Light](https://user-images.githubusercontent.com/46631671/197348374-c5fa2e68-bf13-4582-923b-fb4ccbd62098.png)
After Property
![After_Property_Dark](https://user-images.githubusercontent.com/46631671/197348360-2939e80f-0e94-4e3e-ac7b-8bd0d7cb4291.png)
![After_Property_Light](https://user-images.githubusercontent.com/46631671/197348364-3b957e28-bb07-4c26-b98f-d6a573543773.png)
Before Tooltip
![Before_Tooltip_Dark](https://user-images.githubusercontent.com/46631671/197348376-59838403-71e2-439d-b9ae-56477b4a8a37.png)
![Before_Tooltip_Light](https://user-images.githubusercontent.com/46631671/197348378-2e239262-7cf1-485f-9c30-543071b2d6aa.png)
After Tooltip
![After_Tooltip_Dark](https://user-images.githubusercontent.com/46631671/197348367-a8957f0f-a197-402f-85f1-fc0781dc3edd.png)
![After_Tooltip_Light](https://user-images.githubusercontent.com/46631671/197348370-771c0697-669c-441a-a001-32e742e8f1e1.png)