### PR TITLE
Remove OpenProtectedFileForRead function

### DIFF
--- a/src/Files.App/Filesystem/StorageItems/ZipStorageFile.cs
+++ b/src/Files.App/Filesystem/StorageItems/ZipStorageFile.cs
@@ -462,16 +462,16 @@ namespace Files.App.Filesystem.StorageItems
                 : new ZipFileBasicProperties(entry);
         }
 
-        private IAsyncOperation<SevenZipExtractor> OpenZipFileAsync(bool openProtected = false)
+        private IAsyncOperation<SevenZipExtractor> OpenZipFileAsync()
         {
             return AsyncInfo.Run<SevenZipExtractor>(async (cancellationToken) =>
             {
-                var zipFile = await OpenZipFileAsync(FileAccessMode.Read, openProtected);
+                var zipFile = await OpenZipFileAsync(FileAccessMode.Read);
                 return zipFile is not null ? new SevenZipExtractor(zipFile) : null;
             });
         }
 
-        private IAsyncOperation<Stream> OpenZipFileAsync(FileAccessMode accessMode, bool openProtected = false)
+        private IAsyncOperation<Stream> OpenZipFileAsync(FileAccessMode accessMode)
         {
             return AsyncInfo.Run<Stream>(async (cancellationToken) =>
             {
@@ -482,9 +482,7 @@ namespace Files.App.Filesystem.StorageItems
                 }
                 else
                 {
-                    var hFile = openProtected ?
-                        NativeFileOperationsHelper.OpenProtectedFileForRead(containerPath) :
-                        NativeFileOperationsHelper.OpenFileForRead(containerPath, readWrite);
+                    var hFile = NativeFileOperationsHelper.OpenFileForRead(containerPath, readWrite);
                     if (hFile.IsInvalid)
                     {
                         return null;
@@ -500,9 +498,7 @@ namespace Files.App.Filesystem.StorageItems
             {
                 try
                 {
-                    // If called from here it fails with Access Denied?!
-                    //var hFile = NativeFileOperationsHelper.OpenFileForRead(ContainerPath);
-                    using SevenZipExtractor zipFile = await OpenZipFileAsync(openProtected: true);
+                    using SevenZipExtractor zipFile = await OpenZipFileAsync();
                     if (zipFile == null || zipFile.ArchiveFileData == null)
                     {
                         request.FailAndClose(StreamedFileFailureMode.CurrentlyUnavailable);

--- a/src/Files.App/Helpers/FileOperationsHelpers.cs
+++ b/src/Files.App/Helpers/FileOperationsHelpers.cs
@@ -31,21 +31,6 @@ namespace Files.App.Helpers
     {
         private static readonly ProgressHandler progressHandler = new();
 
-        public static long? GetFileHandle(string filePath, bool readWrite, int processId)
-        {
-            using var hFile = Kernel32.CreateFile(filePath, Kernel32.FileAccess.GENERIC_READ | (readWrite ? Kernel32.FileAccess.GENERIC_WRITE : 0), FileShare.ReadWrite, null, FileMode.Open, FileFlagsAndAttributes.FILE_ATTRIBUTE_NORMAL);
-            
-            if (hFile.IsInvalid)
-                return null;
-
-            using var uwpProces = System.Diagnostics.Process.GetProcessById(processId);
-
-            if (!Kernel32.DuplicateHandle(Kernel32.GetCurrentProcess(), hFile.DangerousGetHandle(), uwpProces.Handle, out var targetHandle, 0, false, Kernel32.DUPLICATE_HANDLE_OPTIONS.DUPLICATE_SAME_ACCESS))
-                return null;
-
-            return targetHandle.ToInt64();
-        }
-
         public static Task SetClipboard(string[] filesToCopy, DataPackageOperation operation)
         {
             return Win32API.StartSTATask(() =>

--- a/src/Files.App/Helpers/NativeFileOperationsHelper.cs
+++ b/src/Files.App/Helpers/NativeFileOperationsHelper.cs
@@ -465,13 +465,6 @@ namespace Files.App.Helpers
             return null;
         }
 
-        public static SafeFileHandle OpenProtectedFileForRead(string filePath, bool readWrite = false)
-        {
-            var handle = FileOperationsHelpers.GetFileHandle(filePath, readWrite, System.Diagnostics.Process.GetCurrentProcess().Id);
-
-            return new SafeFileHandle(new IntPtr(handle ?? -1), true);
-        }
-
         // https://github.com/rad1oactive/BetterExplorer/blob/master/Windows%20API%20Code%20Pack%201.1/source/WindowsAPICodePack/Shell/ReparsePoint.cs
         public static string ParseSymLink(string path)
         {


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Removes unnecessary OpenProtectedFileForRead function. The function was used when opening files from inside an archive due to UWP limitations but it's not necessary anymore.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Launch a file from inside an archive and check it still works
