### PR TITLE
Fix: Fixed issue where renaming a shortcut that had a blank name would cause a crash

### DIFF
--- a/src/Files.App/Helpers/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UIFilesystemHelpers.cs
@@ -284,7 +284,7 @@ namespace Files.App.Helpers
 
         public static async void CreateFileFromDialogResultType(AddItemDialogItemType itemType, ShellNewEntry itemInfo, IShellPage associatedInstance)
         {
-            _ = await CreateFileFromDialogResultTypeForResult(itemType, itemInfo, associatedInstance);
+            await CreateFileFromDialogResultTypeForResult(itemType, itemInfo, associatedInstance);
         }
 
         // WINUI3

--- a/src/Files.App/Helpers/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UIFilesystemHelpers.cs
@@ -1,25 +1,23 @@
-using Files.Shared;
 using Files.App.Dialogs;
-using Files.Shared.Enums;
-using Files.Shared.Extensions;
 using Files.App.Filesystem;
 using Files.App.Filesystem.StorageItems;
 using Files.App.Interacts;
 using Files.App.ViewModels;
 using Files.App.Extensions;
+using Files.Backend.Enums;
+using Files.Shared;
+using Files.Shared.Enums;
+using Files.Shared.Extensions;
+using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Windows.ApplicationModel.AppService;
 using Windows.ApplicationModel.DataTransfer;
-using Windows.Foundation.Collections;
 using Windows.Storage;
-using Files.Backend.Enums;
 using Windows.System;
-using Microsoft.UI.Xaml.Controls;
 
 namespace Files.App.Helpers
 {

--- a/src/Files.App/Helpers/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UIFilesystemHelpers.cs
@@ -301,12 +301,11 @@ namespace Files.App.Helpers
             if (associatedInstance.SlimContentPage != null)
             {
                 currentPath = associatedInstance.FilesystemViewModel.WorkingDirectory;
-                if (App.LibraryManager.TryGetLibrary(currentPath, out var library))
-                {
-                    if (!library.IsEmpty && library.Folders.Count == 1) // TODO: handle libraries with multiple folders
-                    {
-                        currentPath = library.Folders.First();
-                    }
+                if (App.LibraryManager.TryGetLibrary(currentPath, out var library) &&
+                    !library.IsEmpty &&
+                    library.Folders.Count == 1) // TODO: handle libraries with multiple folders
+				{
+                    currentPath = library.Folders.First();
                 }
             }
 

--- a/src/Files.App/Helpers/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UIFilesystemHelpers.cs
@@ -255,10 +255,15 @@ namespace Files.App.Helpers
                     StringComparison.Ordinal);
                 newName = $"{ads.MainStreamName}:{newName}";
             }
+            else if (string.IsNullOrEmpty(item.Name))
+            {
+                newName = string.Concat(newName, item.FileExtension);
+            }
             else
             {
                 newName = item.ItemNameRaw.Replace(item.Name, newName, StringComparison.Ordinal);
             }
+
             if (item.ItemNameRaw == newName || string.IsNullOrEmpty(newName))
             {
                 return true;

--- a/src/Files.App/Helpers/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UIFilesystemHelpers.cs
@@ -269,17 +269,10 @@ namespace Files.App.Helpers
                 return true;
             }
 
+            FilesystemItemType itemType = (item.PrimaryItemAttribute == StorageItemTypes.Folder) ? FilesystemItemType.Directory : FilesystemItemType.File;
+
             ReturnResult renamed = ReturnResult.InProgress;
-            if (item.PrimaryItemAttribute == StorageItemTypes.Folder)
-            {
-                renamed = await associatedInstance.FilesystemHelpers.RenameAsync(StorageHelpers.FromPathAndType(item.ItemPath, FilesystemItemType.Directory),
-                    newName, NameCollisionOption.FailIfExists, true);
-            }
-            else
-            {
-                renamed = await associatedInstance.FilesystemHelpers.RenameAsync(StorageHelpers.FromPathAndType(item.ItemPath, FilesystemItemType.File),
-                    newName, NameCollisionOption.FailIfExists, true);
-            }
+            renamed = await associatedInstance.FilesystemHelpers.RenameAsync(StorageHelpers.FromPathAndType(item.ItemPath, itemType), newName, NameCollisionOption.FailIfExists, true);
 
             if (renamed == ReturnResult.Success)
             {


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #10157 

**What has been done**
- Fixed the crash : the `Replace` function could not handle when `item.Name` was empty.
- Did some minor refactoring.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
