### PR TITLE
Fix: Fixed issue where the sidebars right click menu would sometimes get cut off

### DIFF
--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -553,7 +553,7 @@ namespace Files.App.UserControls
 
         private void NavigationViewItem_RightTapped(object sender, RightTappedRoutedEventArgs e)
         {
-			var itemContextMenuFlyout = new CommandBarFlyout{ Placement = FlyoutPlacementMode.Full };
+            var itemContextMenuFlyout = new CommandBarFlyout{ Placement = FlyoutPlacementMode.Full };
             var sidebarItem = sender as NavigationViewItem;
             var item = sidebarItem.DataContext as INavigationControlItem;
 
@@ -568,7 +568,7 @@ namespace Files.App.UserControls
             }
 
             secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
-			itemContextMenuFlyout.ShowAt(sidebarItem, new FlyoutShowOptions { Position = e.GetPosition(sidebarItem) });
+            itemContextMenuFlyout.ShowAt(sidebarItem, new FlyoutShowOptions { Position = e.GetPosition(sidebarItem) });
 
             if (item.MenuOptions.ShowShellItems)
             {

--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -553,7 +553,7 @@ namespace Files.App.UserControls
 
         private void NavigationViewItem_RightTapped(object sender, RightTappedRoutedEventArgs e)
         {
-            var itemContextMenuFlyout = new CommandBarFlyout();
+			var itemContextMenuFlyout = new CommandBarFlyout{ Placement = FlyoutPlacementMode.Full };
             var sidebarItem = sender as NavigationViewItem;
             var item = sidebarItem.DataContext as INavigationControlItem;
 
@@ -568,7 +568,7 @@ namespace Files.App.UserControls
             }
 
             secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
-            itemContextMenuFlyout.ShowAt(sidebarItem, new FlyoutShowOptions() { Position = e.GetPosition(sidebarItem) });
+			itemContextMenuFlyout.ShowAt(sidebarItem, new FlyoutShowOptions { Position = e.GetPosition(sidebarItem) });
 
             if (item.MenuOptions.ShowShellItems)
             {


### PR DESCRIPTION
**Resolved / Related Issues**
In the sidebar, the context menu may not be entirely visible. This pr changes its placement so that it is no longer obscured by the edge of the window.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before
![ContextBefore](https://user-images.githubusercontent.com/46631671/197817050-eacd8087-07db-45bb-b71f-3e196484c80a.png)
After
![ContextAfter](https://user-images.githubusercontent.com/46631671/197817043-79b91272-3925-4140-8906-02e10a70ef29.png)
