### PR TITLE
Fix: Remove icons from extract flyout

### DIFF
--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -1,935 +1,924 @@
 ﻿<UserControl
-	x:Class="Files.App.UserControls.InnerNavigationToolbar"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
-	xmlns:converters="using:Files.App.Converters"
-	xmlns:converters1="using:CommunityToolkit.WinUI.UI.Converters"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:helpers="using:Files.App.Helpers"
-	xmlns:local="using:Files.App.UserControls"
-	xmlns:local1="using:Files.App"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:xh="using:Files.App.Helpers.XamlHelpers"
-	d:DesignHeight="40"
-	d:DesignWidth="400"
-	mc:Ignorable="d">
-	<UserControl.Resources>
-		<ResourceDictionary>
-			<Style x:Key="AccentColorFontIconStyle" TargetType="FontIcon" />
-			<converters1:BoolNegationConverter x:Key="BoolNegationConverter" />
-			<converters1:BoolToVisibilityConverter
-				x:Key="NegatedBoolToVisibilityConverter"
-				FalseValue="Visible"
-				TrueValue="Collapsed" />
-			<converters:IntToGroupOption x:Key="IntToGroupOption" />
-			<converters:IntToSortOption x:Key="IntToSortOption" />
-			<converters:IntToSortDirection x:Key="IntToSortDirection" />
-			<x:Boolean x:Key="True">True</x:Boolean>
-			<x:Boolean x:Key="False">False</x:Boolean>
-			<ResourceDictionary.MergedDictionaries>
-				<ResourceDictionary Source="/ResourceDictionaries/ToolbarButtonStyle.xaml" />
-				<ResourceDictionary Source="/ResourceDictionaries/PathIcons.xaml" />
-				<ResourceDictionary Source="/ResourceDictionaries/RightAlignedToggleSwitchStyle.xaml" />
-			</ResourceDictionary.MergedDictionaries>
-		</ResourceDictionary>
-	</UserControl.Resources>
-	<Grid BorderBrush="{ThemeResource ControlStrokeColorDefault}" BorderThickness="0,0,0,1">
-		<Grid.ColumnDefinitions>
-			<ColumnDefinition Width="*" />
-			<ColumnDefinition Width="Auto" />
-		</Grid.ColumnDefinitions>
-		<CommandBar
-			x:Name="ContextCommandBar"
-			Grid.Column="0"
-			HorizontalAlignment="Left"
-			VerticalAlignment="Stretch"
-			DefaultLabelPosition="Right">
-			<CommandBar.Resources>
-				<ResourceDictionary>
-					<SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
-					<SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
-				</ResourceDictionary>
-			</CommandBar.Resources>
-			<CommandBar.PrimaryCommands>
-				<AppBarButton
-					x:Name="NewEmptySpaceAppBarButton"
-					AccessKey="W"
-					IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsCreateButtonEnabledInPage, Mode=OneWay, FallbackValue=False}"
-					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=BaseLayoutContextFlyoutNew/KeyboardAcceleratorTextOverride}"
-					Label="{helpers:ResourceString Name=BaseLayoutContextFlyoutNew/Label}"
-					Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}">
-					<AppBarButton.KeyboardAccelerators>
-						<KeyboardAccelerator
-							Key="N"
-							IsEnabled="False"
-							Modifiers="Control,Shift" />
-					</AppBarButton.KeyboardAccelerators>
-					<AppBarButton.Flyout>
-						<MenuFlyout x:Name="NewEmptySpace" Opening="NewEmptySpace_Opening">
-							<MenuFlyoutItem
-								x:Name="ToolbarNewFolderItem"
-								Command="{x:Bind ViewModel.CreateNewFolderCommand, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=Folder}">
-								<MenuFlyoutItem.Icon>
-									<FontIcon Glyph="&#xE8B7;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutItem
-								x:Name="NewFile"
-								Command="{x:Bind ViewModel.CreateNewFileCommand, Mode=OneWay}"
-								CommandParameter="{x:Null}"
-								IsEnabled="{x:Bind ViewModel.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=BaseLayoutContextFlyoutNewFile/Text}">
-								<MenuFlyoutItem.Icon>
-									<FontIcon Glyph="&#xE7C3;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutSeparator x:Name="NewMenuFileFolderSeparator" />
-						</MenuFlyout>
-					</AppBarButton.Flyout>
+    x:Class="Files.App.UserControls.InnerNavigationToolbar"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
+    xmlns:converters="using:Files.App.Converters"
+    xmlns:converters1="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Files.App.Helpers"
+    xmlns:local="using:Files.App.UserControls"
+    xmlns:local1="using:Files.App"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:xh="using:Files.App.Helpers.XamlHelpers"
+    d:DesignHeight="40"
+    d:DesignWidth="400"
+    mc:Ignorable="d">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <Style x:Key="AccentColorFontIconStyle" TargetType="FontIcon" />
+            <converters1:BoolNegationConverter x:Key="BoolNegationConverter" />
+            <converters1:BoolToVisibilityConverter
+                x:Key="NegatedBoolToVisibilityConverter"
+                FalseValue="Visible"
+                TrueValue="Collapsed" />
+            <converters:IntToGroupOption x:Key="IntToGroupOption" />
+            <converters:IntToSortOption x:Key="IntToSortOption" />
+            <converters:IntToSortDirection x:Key="IntToSortDirection" />
+            <x:Boolean x:Key="True">True</x:Boolean>
+            <x:Boolean x:Key="False">False</x:Boolean>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/ResourceDictionaries/ToolbarButtonStyle.xaml" />
+                <ResourceDictionary Source="/ResourceDictionaries/PathIcons.xaml" />
+                <ResourceDictionary Source="/ResourceDictionaries/RightAlignedToggleSwitchStyle.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid BorderBrush="{ThemeResource ControlStrokeColorDefault}" BorderThickness="0,0,0,1">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <CommandBar
+            x:Name="ContextCommandBar"
+            Grid.Column="0"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Stretch"
+            DefaultLabelPosition="Right">
+            <CommandBar.Resources>
+                <ResourceDictionary>
+                    <SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
+                    <SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
+                </ResourceDictionary>
+            </CommandBar.Resources>
+            <CommandBar.PrimaryCommands>
+                <AppBarButton
+                    x:Name="NewEmptySpaceAppBarButton"
+                    AccessKey="W"
+                    IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsCreateButtonEnabledInPage, Mode=OneWay, FallbackValue=False}"
+                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=BaseLayoutContextFlyoutNew/KeyboardAcceleratorTextOverride}"
+                    Label="{helpers:ResourceString Name=BaseLayoutContextFlyoutNew/Label}"
+                    Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}">
+                    <AppBarButton.KeyboardAccelerators>
+                        <KeyboardAccelerator
+                            Key="N"
+                            IsEnabled="False"
+                            Modifiers="Control,Shift" />
+                    </AppBarButton.KeyboardAccelerators>
+                    <AppBarButton.Flyout>
+                        <MenuFlyout x:Name="NewEmptySpace" Opening="NewEmptySpace_Opening">
+                            <MenuFlyoutItem
+                                x:Name="ToolbarNewFolderItem"
+                                Command="{x:Bind ViewModel.CreateNewFolderCommand, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=Folder}">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE8B7;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem
+                                x:Name="NewFile"
+                                Command="{x:Bind ViewModel.CreateNewFileCommand, Mode=OneWay}"
+                                CommandParameter="{x:Null}"
+                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=BaseLayoutContextFlyoutNewFile/Text}">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE7C3;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutSeparator x:Name="NewMenuFileFolderSeparator" />
+                        </MenuFlyout>
+                    </AppBarButton.Flyout>
 
-					<local:ColoredIcon
-						Margin="0,1,0,-1"
-						BaseLayerGlyph="&#xF037;"
-						OverlayLayerGlyph="&#xF038;" />
-				</AppBarButton>
-				<AppBarSeparator />
-				<AppBarButton
-					x:Name="CutButton"
-					Width="Auto"
-					MinWidth="40"
-					AccessKey="X"
-					Command="{x:Bind ViewModel.CutCommand, Mode=OneWay}"
-					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
-					Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutCut/Text}"
-					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutCut/Text}">
-					<AppBarButton.Content>
-						<local:ColoredIcon BaseLayerGlyph="&#xF03D;" OverlayLayerGlyph="&#xF03E;" />
-					</AppBarButton.Content>
-				</AppBarButton>
-				<AppBarButton
-					Width="Auto"
-					MinWidth="40"
-					AccessKey="C"
-					Command="{x:Bind ViewModel.CopyCommand, Mode=OneWay}"
-					IsEnabled="{x:Bind ViewModel.CanCopy, Mode=OneWay, FallbackValue=False}"
-					Label="{helpers:ResourceString Name=Copy}"
-					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=Copy}">
-					<local:ColoredIcon BaseLayerGlyph="&#xF021;" OverlayLayerGlyph="&#xF022;" />
-				</AppBarButton>
-				<AppBarButton
-					x:Name="PasteButton"
-					Width="Auto"
-					MinWidth="40"
-					AccessKey="P"
-					Command="{x:Bind ViewModel.PasteItemsFromClipboardCommand, Mode=OneWay}"
-					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.InstanceViewModel.CanPasteInPage, local1:App.AppModel.IsPasteEnabled), Mode=OneWay, FallbackValue=False}"
-					Label="{helpers:ResourceString Name=NavigationToolbarPaste/Label}"
-					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutContextFlyoutPaste/Text}">
-					<AppBarButton.KeyboardAccelerators>
-						<KeyboardAccelerator
-							Key="V"
-							IsEnabled="False"
-							Modifiers="Control" />
-					</AppBarButton.KeyboardAccelerators>
-					<local:ColoredIcon BaseLayerGlyph="&#xF023;" OverlayLayerGlyph="&#xF024;" />
-				</AppBarButton>
-				<AppBarButton
-					x:Name="RenameButton"
-					Width="Auto"
-					MinWidth="40"
-					AccessKey="M"
-					Command="{x:Bind ViewModel.Rename, Mode=OneWay}"
-					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanRename, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
-					Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutRename/Text}"
-					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutRename/Text}">
-					<AppBarButton.Content>
-						<local:ColoredIcon BaseLayerGlyph="&#xF027;" OverlayLayerGlyph="&#xF028;" />
-					</AppBarButton.Content>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="ShareButton"
-					Width="Auto"
-					MinWidth="40"
-					AccessKey="H"
-					Command="{x:Bind ViewModel.Share, Mode=OneWay}"
-					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanShare, ViewModel.InstanceViewModel.CanShareInPage), Mode=OneWay, FallbackValue=False}"
-					Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutShare/Text}"
-					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutShare/Text}">
-					<AppBarButton.Content>
-						<local:ColoredIcon BaseLayerGlyph="&#xF025;" OverlayLayerGlyph="&#xF026;" />
-					</AppBarButton.Content>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="DeleteButton"
-					Width="Auto"
-					MinWidth="40"
-					Command="{x:Bind ViewModel.DeleteCommand, Mode=OneWay}"
-					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
-					Label="{helpers:ResourceString Name=Delete}"
-					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=Delete}">
-					<AppBarButton.Content>
-						<local:ColoredIcon BaseLayerGlyph="&#xF035;" OverlayLayerGlyph="&#xF036;" />
-					</AppBarButton.Content>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="PropertiesButton"
-					Width="Auto"
-					MinWidth="40"
-					AccessKey="O"
-					AutomationProperties.Name="{helpers:ResourceString Name=PropertiesTitle}"
-					Command="{x:Bind ViewModel.PropertiesCommand, Mode=OneWay}"
-					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanViewProperties, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
-					Label="{helpers:ResourceString Name=PropertiesTitle}"
-					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=PropertiesTitle}">
-					<AppBarButton.Content>
-						<local:ColoredIcon BaseLayerGlyph="&#xF031;" OverlayLayerGlyph="&#xF032;" />
-					</AppBarButton.Content>
-				</AppBarButton>
-				<AppBarSeparator x:Name="AdditionalActionSeparator" x:Load="{x:Bind ViewModel.HasAdditionalAction, Mode=OneWay}" />
-				<AppBarButton
-					x:Name="EmptyRecycleBinButton"
-					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
-					AccessKey="B"
-					Command="{x:Bind ViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
-					IsEnabled="{x:Bind ViewModel.CanEmptyRecycleBin, Mode=OneWay}"
-					Label="{helpers:ResourceString Name=EmptyRecycleBin}"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=EmptyRecycleBin}">
-					<AppBarButton.Icon>
-						<FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="RestoreRecycleBinButton"
-					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
-					AccessKey="R"
-					Command="{x:Bind ViewModel.RestoreRecycleBinCommand, Mode=OneWay}"
-					IsEnabled="{x:Bind ViewModel.CanRestoreRecycleBin, Mode=OneWay}"
-					Label="{helpers:ResourceString Name=RestoreAllItems}"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=RestoreAllItems}"
-					Visibility="{x:Bind ViewModel.CanRestoreRecycleBin, Mode=OneWay}">
-					<AppBarButton.Icon>
-						<FontIcon Glyph="&#xE777;" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="RestoreSelectionRecycleBinButton"
-					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
-					AccessKey="R"
-					Command="{x:Bind ViewModel.RestoreSelectionRecycleBinCommand, Mode=OneWay}"
-					IsEnabled="{x:Bind ViewModel.CanRestoreSelectionRecycleBin, Mode=OneWay}"
-					Label="{helpers:ResourceString Name=RestoreSelection}"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=RestoreSelection}"
-					Visibility="{x:Bind ViewModel.CanRestoreSelectionRecycleBin, Mode=OneWay}">
-					<AppBarButton.Icon>
-						<FontIcon Glyph="&#xE777;" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="ExtractButton"
-					Width="Auto"
-					MinWidth="40"
-					x:Load="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
-					AccessKey="Z"
-					IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
-					Label="{helpers:ResourceString Name=Extract}"
-					LabelPosition="Default"
-					Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}">
-					<AppBarButton.Content>
-						<local:ColoredIcon BaseLayerGlyph="&#xF03F;" OverlayLayerGlyph="&#xF040;" />
-					</AppBarButton.Content>
-					<AppBarButton.Flyout>
-						<MenuFlyout helpers:MenuFlyoutHelper.IsVisible="{x:Bind ViewModel.CanExtract, Mode=OneWay}" Placement="Bottom">
-							<MenuFlyoutItem
-								x:Name="ExtractSingle"
-								x:Load="{x:Bind ViewModel.IsMultipleArchivesSelected, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-								Command="{x:Bind ViewModel.ExtractCommand, Mode=OneWay}"
-								IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
-								KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=ExtractKeyboardAcceleratorTextOverride}"
-								Text="{helpers:ResourceString Name=ExtractFiles}">
-								<MenuFlyoutItem.KeyboardAccelerators>
-									<KeyboardAccelerator
-										Key="E"
-										IsEnabled="False"
-										Modifiers="Control" />
-								</MenuFlyoutItem.KeyboardAccelerators>
-								<MenuFlyoutItem.Icon>
-									<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF11A;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutItem
-								x:Name="ExtractHere"
-								x:Load="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-								Command="{x:Bind ViewModel.ExtractHereCommand, Mode=OneWay}"
-								IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
-								Text="{helpers:ResourceString Name=ExtractHere}">
-								<MenuFlyoutItem.Icon>
-									<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF11A;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutItem
-								x:Name="ExtractTo"
-								x:Load="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-								Command="{x:Bind ViewModel.ExtractToCommand, Mode=OneWay}"
-								IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
-								Text="{x:Bind ViewModel.ExtractToText, Mode=OneWay}">
-								<MenuFlyoutItem.Icon>
-									<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF11A;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-						</MenuFlyout>
-					</AppBarButton.Flyout>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="RunWithPowerShellButton"
-					Width="Auto"
-					MinWidth="40"
-					x:Load="{x:Bind ViewModel.IsPowerShellScript, Mode=OneWay, FallbackValue=False}"
-					AutomationProperties.Name="RunWithPowerShell"
-					Command="{x:Bind ViewModel.RunWithPowerShellCommand, Mode=OneWay}"
-					Label="{helpers:ResourceString Name=RunScript}"
-					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=RunWithPowerShell}">
-					<AppBarButton.Icon>
-						<FontIcon Glyph="&#xE756;" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="SetAsBackgroundButton"
-					Width="Auto"
-					MinWidth="40"
-					x:Load="{x:Bind converters:MultiBooleanConverter.AndNotConvert(ViewModel.IsImage, ViewModel.IsMultipleImageSelected), Mode=OneWay}"
-					Label="{helpers:ResourceString Name=SetAsBackgroundFlyout}"
-					LabelPosition="Default"
-					Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsBackgroundFlyout}">
-					<AppBarButton.Icon>
-						<FontIcon Glyph="&#xE91B;" />
-					</AppBarButton.Icon>
-					<AppBarButton.Flyout>
-						<MenuFlyout Placement="Bottom">
-							<MenuFlyoutItem
-								x:Name="SetAsBackgroundFlyoutItem"
-								Command="{x:Bind ViewModel.SetAsBackgroundCommand, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=Desktop}">
-								<MenuFlyoutItem.Icon>
-									<FontIcon Glyph="&#xE91B;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutItem
-								x:Name="SetAsLockscreenFlyoutItem"
-								Command="{x:Bind ViewModel.SetAsLockscreenBackgroundCommand, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=Lockscreen}">
-								<MenuFlyoutItem.Icon>
-									<FontIcon Glyph="&#xEE3F;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-						</MenuFlyout>
-					</AppBarButton.Flyout>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="SetAsSlideshowButton"
-					Width="Auto"
-					MinWidth="40"
-					x:Load="{x:Bind ViewModel.IsMultipleImageSelected, Mode=OneWay, FallbackValue=False}"
-					Command="{x:Bind ViewModel.SetAsSlideshowCommand, Mode=OneWay}"
-					Label="{helpers:ResourceString Name=SetAsSlideshow}"
-					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsSlideshow}">
-					<AppBarButton.Icon>
-						<FontIcon Glyph="&#xE91B;" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="InstallInfButton"
-					x:Load="{x:Bind ViewModel.IsInfFile, Mode=OneWay, FallbackValue=False}"
-					AutomationProperties.Name="InstallInf"
-					Command="{x:Bind ViewModel.InstallInfCommand, Mode=OneWay}"
-					Label="{helpers:ResourceString Name=Install}"
-					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
-					<AppBarButton.Icon>
-						<FontIcon Glyph="&#xE9F5;" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="RotateImageLeftButton"
-					x:Load="{x:Bind ViewModel.IsImage, Mode=OneWay, FallbackValue=False}"
-					Command="{x:Bind ViewModel.RotateImageLeftCommand, Mode=OneWay}"
-					Label="{helpers:ResourceString Name=RotateLeft}"
-					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=RotateLeft}">
-					<AppBarButton.Content>
-						<local:ColoredIcon BaseLayerGlyph="&#xF043;" OverlayLayerGlyph="&#xF044;" />
-					</AppBarButton.Content>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="RotateImageRightButton"
-					x:Load="{x:Bind ViewModel.IsImage, Mode=OneWay, FallbackValue=False}"
-					Command="{x:Bind ViewModel.RotateImageRightCommand, Mode=OneWay}"
-					Label="{helpers:ResourceString Name=RotateRight}"
-					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=RotateRight}">
-					<AppBarButton.Content>
-						<local:ColoredIcon BaseLayerGlyph="&#xF045;" OverlayLayerGlyph="&#xF046;" />
-					</AppBarButton.Content>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="InstallFontButton"
-					x:Load="{x:Bind ViewModel.IsFont, Mode=OneWay, FallbackValue=False}"
-					Command="{x:Bind ViewModel.InstallFontCommand, Mode=OneWay}"
-					Label="{helpers:ResourceString Name=Install}"
-					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
-					<AppBarButton.Content>
-						<local:ColoredIcon BaseLayerGlyph="&#xF041;" OverlayLayerGlyph="&#xF042;" />
-					</AppBarButton.Content>
-				</AppBarButton>
-			</CommandBar.PrimaryCommands>
-		</CommandBar>
-		<CommandBar
-			x:Name="BaseCommandBar"
-			Grid.Column="1"
-			HorizontalAlignment="Stretch"
-			VerticalAlignment="Center"
-			DefaultLabelPosition="Right">
-			<CommandBar.Resources>
-				<ResourceDictionary>
-					<SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
-					<SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
-				</ResourceDictionary>
-			</CommandBar.Resources>
-			<AppBarButton
-				x:Name="SelectionOptions"
-				Width="Auto"
-				MinWidth="40"
-				x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-				AccessKey="S"
-				AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSelectionOptions/AutomationProperties/Name}"
-				Label="{helpers:ResourceString Name=NavToolbarSelectionOptions/Label}"
-				LabelPosition="Collapsed"
-				Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
-				ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSelectionOptions/ToolTipService/ToolTip}">
-				<AppBarButton.Flyout>
-					<MenuFlyout Placement="Bottom">
-						<ToggleMenuFlyoutItem
-							x:Name="MultiselectMFI"
-							IsChecked="{x:Bind AppModel.MultiselectEnabled, Mode=TwoWay}"
-							Text="{helpers:ResourceString Name=NavToolbarMultiselect/Text}">
-							<MenuFlyoutItem.Icon>
-								<FontIcon Glyph="&#xE762;" />
-							</MenuFlyoutItem.Icon>
-						</ToggleMenuFlyoutItem>
-						<MenuFlyoutItem
-							x:Name="SelectAllMFI"
-							Command="{x:Bind ViewModel.SelectAllContentPageItemsCommand, Mode=OneWay}"
-							Text="{helpers:ResourceString Name=NavToolbarSelectAll/Text}">
-							<MenuFlyoutItem.Icon>
-								<FontIcon Glyph="&#xE8B3;" />
-							</MenuFlyoutItem.Icon>
-							<MenuFlyoutItem.KeyboardAccelerators>
-								<KeyboardAccelerator
-									Key="A"
-									IsEnabled="False"
-									Modifiers="Control" />
-							</MenuFlyoutItem.KeyboardAccelerators>
-						</MenuFlyoutItem>
-						<MenuFlyoutItem
-							x:Name="InvertSelectionMFI"
-							Command="{x:Bind ViewModel.InvertContentPageSelctionCommand, Mode=OneWay}"
-							Text="{helpers:ResourceString Name=NavToolbarInvertSelection/Text}">
-							<MenuFlyoutItem.Icon>
-								<FontIcon Glyph="&#xE746;" />
-							</MenuFlyoutItem.Icon>
-						</MenuFlyoutItem>
-						<MenuFlyoutItem
-							x:Name="ClearSelectionMFI"
-							Command="{x:Bind ViewModel.ClearContentPageSelectionCommand, Mode=OneWay}"
-							Text="{helpers:ResourceString Name=NavToolbarClearSelection/Text}">
-							<MenuFlyoutItem.Icon>
-								<FontIcon Glyph="&#xE8E6;" />
-							</MenuFlyoutItem.Icon>
-						</MenuFlyoutItem>
-					</MenuFlyout>
-				</AppBarButton.Flyout>
+                    <local:ColoredIcon
+                        Margin="0,1,0,-1"
+                        BaseLayerGlyph="&#xF037;"
+                        OverlayLayerGlyph="&#xF038;" />
+                </AppBarButton>
+                <AppBarSeparator />
+                <AppBarButton
+                    x:Name="CutButton"
+                    Width="Auto"
+                    MinWidth="40"
+                    AccessKey="X"
+                    Command="{x:Bind ViewModel.CutCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
+                    Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutCut/Text}"
+                    LabelPosition="Collapsed"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutCut/Text}">
+                    <AppBarButton.Content>
+                        <local:ColoredIcon BaseLayerGlyph="&#xF03D;" OverlayLayerGlyph="&#xF03E;" />
+                    </AppBarButton.Content>
+                </AppBarButton>
+                <AppBarButton
+                    Width="Auto"
+                    MinWidth="40"
+                    AccessKey="C"
+                    Command="{x:Bind ViewModel.CopyCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind ViewModel.CanCopy, Mode=OneWay, FallbackValue=False}"
+                    Label="{helpers:ResourceString Name=Copy}"
+                    LabelPosition="Collapsed"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=Copy}">
+                    <local:ColoredIcon BaseLayerGlyph="&#xF021;" OverlayLayerGlyph="&#xF022;" />
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="PasteButton"
+                    Width="Auto"
+                    MinWidth="40"
+                    AccessKey="P"
+                    Command="{x:Bind ViewModel.PasteItemsFromClipboardCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.InstanceViewModel.CanPasteInPage, local1:App.AppModel.IsPasteEnabled), Mode=OneWay, FallbackValue=False}"
+                    Label="{helpers:ResourceString Name=NavigationToolbarPaste/Label}"
+                    LabelPosition="Collapsed"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutContextFlyoutPaste/Text}">
+                    <AppBarButton.KeyboardAccelerators>
+                        <KeyboardAccelerator
+                            Key="V"
+                            IsEnabled="False"
+                            Modifiers="Control" />
+                    </AppBarButton.KeyboardAccelerators>
+                    <local:ColoredIcon BaseLayerGlyph="&#xF023;" OverlayLayerGlyph="&#xF024;" />
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="RenameButton"
+                    Width="Auto"
+                    MinWidth="40"
+                    AccessKey="M"
+                    Command="{x:Bind ViewModel.Rename, Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanRename, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
+                    Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutRename/Text}"
+                    LabelPosition="Collapsed"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutRename/Text}">
+                    <AppBarButton.Content>
+                        <local:ColoredIcon BaseLayerGlyph="&#xF027;" OverlayLayerGlyph="&#xF028;" />
+                    </AppBarButton.Content>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="ShareButton"
+                    Width="Auto"
+                    MinWidth="40"
+                    AccessKey="H"
+                    Command="{x:Bind ViewModel.Share, Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanShare, ViewModel.InstanceViewModel.CanShareInPage), Mode=OneWay, FallbackValue=False}"
+                    Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutShare/Text}"
+                    LabelPosition="Collapsed"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutShare/Text}">
+                    <AppBarButton.Content>
+                        <local:ColoredIcon BaseLayerGlyph="&#xF025;" OverlayLayerGlyph="&#xF026;" />
+                    </AppBarButton.Content>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="DeleteButton"
+                    Width="Auto"
+                    MinWidth="40"
+                    Command="{x:Bind ViewModel.DeleteCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
+                    Label="{helpers:ResourceString Name=Delete}"
+                    LabelPosition="Collapsed"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=Delete}">
+                    <AppBarButton.Content>
+                        <local:ColoredIcon BaseLayerGlyph="&#xF035;" OverlayLayerGlyph="&#xF036;" />
+                    </AppBarButton.Content>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="PropertiesButton"
+                    Width="Auto"
+                    MinWidth="40"
+                    AccessKey="O"
+                    AutomationProperties.Name="{helpers:ResourceString Name=PropertiesTitle}"
+                    Command="{x:Bind ViewModel.PropertiesCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanViewProperties, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
+                    Label="{helpers:ResourceString Name=PropertiesTitle}"
+                    LabelPosition="Collapsed"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=PropertiesTitle}">
+                    <AppBarButton.Content>
+                        <local:ColoredIcon BaseLayerGlyph="&#xF031;" OverlayLayerGlyph="&#xF032;" />
+                    </AppBarButton.Content>
+                </AppBarButton>
+                <AppBarSeparator x:Name="AdditionalActionSeparator" x:Load="{x:Bind ViewModel.HasAdditionalAction, Mode=OneWay}" />
+                <AppBarButton
+                    x:Name="EmptyRecycleBinButton"
+                    x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
+                    AccessKey="B"
+                    Command="{x:Bind ViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind ViewModel.CanEmptyRecycleBin, Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=EmptyRecycleBin}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=EmptyRecycleBin}">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="RestoreRecycleBinButton"
+                    x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
+                    AccessKey="R"
+                    Command="{x:Bind ViewModel.RestoreRecycleBinCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind ViewModel.CanRestoreRecycleBin, Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=RestoreAllItems}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=RestoreAllItems}"
+                    Visibility="{x:Bind ViewModel.CanRestoreRecycleBin, Mode=OneWay}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE777;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="RestoreSelectionRecycleBinButton"
+                    x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
+                    AccessKey="R"
+                    Command="{x:Bind ViewModel.RestoreSelectionRecycleBinCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind ViewModel.CanRestoreSelectionRecycleBin, Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=RestoreSelection}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=RestoreSelection}"
+                    Visibility="{x:Bind ViewModel.CanRestoreSelectionRecycleBin, Mode=OneWay}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE777;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="ExtractButton"
+                    Width="Auto"
+                    MinWidth="40"
+                    x:Load="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
+                    AccessKey="Z"
+                    IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
+                    Label="{helpers:ResourceString Name=Extract}"
+                    LabelPosition="Default"
+                    Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}">
+                    <AppBarButton.Content>
+                        <local:ColoredIcon BaseLayerGlyph="&#xF03F;" OverlayLayerGlyph="&#xF040;" />
+                    </AppBarButton.Content>
+                    <AppBarButton.Flyout>
+                        <MenuFlyout helpers:MenuFlyoutHelper.IsVisible="{x:Bind ViewModel.CanExtract, Mode=OneWay}" Placement="Bottom">
+                            <MenuFlyoutItem
+                                x:Name="ExtractSingle"
+                                x:Load="{x:Bind ViewModel.IsMultipleArchivesSelected, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+                                Command="{x:Bind ViewModel.ExtractCommand, Mode=OneWay}"
+                                IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
+                                KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=ExtractKeyboardAcceleratorTextOverride}"
+                                Text="{helpers:ResourceString Name=ExtractFiles}">
+                                <MenuFlyoutItem.KeyboardAccelerators>
+                                    <KeyboardAccelerator
+                                        Key="E"
+                                        IsEnabled="False"
+                                        Modifiers="Control" />
+                                </MenuFlyoutItem.KeyboardAccelerators>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem
+                                x:Name="ExtractHere"
+                                x:Load="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+                                Command="{x:Bind ViewModel.ExtractHereCommand, Mode=OneWay}"
+                                IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
+                                Text="{helpers:ResourceString Name=ExtractHere}" />
+                            <MenuFlyoutItem
+                                x:Name="ExtractTo"
+                                x:Load="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+                                Command="{x:Bind ViewModel.ExtractToCommand, Mode=OneWay}"
+                                IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
+                                Text="{x:Bind ViewModel.ExtractToText, Mode=OneWay}" />
+                        </MenuFlyout>
+                    </AppBarButton.Flyout>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="RunWithPowerShellButton"
+                    Width="Auto"
+                    MinWidth="40"
+                    x:Load="{x:Bind ViewModel.IsPowerShellScript, Mode=OneWay, FallbackValue=False}"
+                    AutomationProperties.Name="RunWithPowerShell"
+                    Command="{x:Bind ViewModel.RunWithPowerShellCommand, Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=RunScript}"
+                    LabelPosition="Default"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=RunWithPowerShell}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE756;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="SetAsBackgroundButton"
+                    Width="Auto"
+                    MinWidth="40"
+                    x:Load="{x:Bind converters:MultiBooleanConverter.AndNotConvert(ViewModel.IsImage, ViewModel.IsMultipleImageSelected), Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=SetAsBackgroundFlyout}"
+                    LabelPosition="Default"
+                    Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsBackgroundFlyout}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE91B;" />
+                    </AppBarButton.Icon>
+                    <AppBarButton.Flyout>
+                        <MenuFlyout Placement="Bottom">
+                            <MenuFlyoutItem
+                                x:Name="SetAsBackgroundFlyoutItem"
+                                Command="{x:Bind ViewModel.SetAsBackgroundCommand, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=Desktop}">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE91B;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem
+                                x:Name="SetAsLockscreenFlyoutItem"
+                                Command="{x:Bind ViewModel.SetAsLockscreenBackgroundCommand, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=Lockscreen}">
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xEE3F;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                        </MenuFlyout>
+                    </AppBarButton.Flyout>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="SetAsSlideshowButton"
+                    Width="Auto"
+                    MinWidth="40"
+                    x:Load="{x:Bind ViewModel.IsMultipleImageSelected, Mode=OneWay, FallbackValue=False}"
+                    Command="{x:Bind ViewModel.SetAsSlideshowCommand, Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=SetAsSlideshow}"
+                    LabelPosition="Default"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsSlideshow}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE91B;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="InstallInfButton"
+                    x:Load="{x:Bind ViewModel.IsInfFile, Mode=OneWay, FallbackValue=False}"
+                    AutomationProperties.Name="InstallInf"
+                    Command="{x:Bind ViewModel.InstallInfCommand, Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=Install}"
+                    LabelPosition="Default"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE9F5;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="RotateImageLeftButton"
+                    x:Load="{x:Bind ViewModel.IsImage, Mode=OneWay, FallbackValue=False}"
+                    Command="{x:Bind ViewModel.RotateImageLeftCommand, Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=RotateLeft}"
+                    LabelPosition="Default"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=RotateLeft}">
+                    <AppBarButton.Content>
+                        <local:ColoredIcon BaseLayerGlyph="&#xF043;" OverlayLayerGlyph="&#xF044;" />
+                    </AppBarButton.Content>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="RotateImageRightButton"
+                    x:Load="{x:Bind ViewModel.IsImage, Mode=OneWay, FallbackValue=False}"
+                    Command="{x:Bind ViewModel.RotateImageRightCommand, Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=RotateRight}"
+                    LabelPosition="Default"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=RotateRight}">
+                    <AppBarButton.Content>
+                        <local:ColoredIcon BaseLayerGlyph="&#xF045;" OverlayLayerGlyph="&#xF046;" />
+                    </AppBarButton.Content>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="InstallFontButton"
+                    x:Load="{x:Bind ViewModel.IsFont, Mode=OneWay, FallbackValue=False}"
+                    Command="{x:Bind ViewModel.InstallFontCommand, Mode=OneWay}"
+                    Label="{helpers:ResourceString Name=Install}"
+                    LabelPosition="Default"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
+                    <AppBarButton.Content>
+                        <local:ColoredIcon BaseLayerGlyph="&#xF041;" OverlayLayerGlyph="&#xF042;" />
+                    </AppBarButton.Content>
+                </AppBarButton>
+            </CommandBar.PrimaryCommands>
+        </CommandBar>
+        <CommandBar
+            x:Name="BaseCommandBar"
+            Grid.Column="1"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Center"
+            DefaultLabelPosition="Right">
+            <CommandBar.Resources>
+                <ResourceDictionary>
+                    <SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
+                    <SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
+                </ResourceDictionary>
+            </CommandBar.Resources>
+            <AppBarButton
+                x:Name="SelectionOptions"
+                Width="Auto"
+                MinWidth="40"
+                x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+                AccessKey="S"
+                AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSelectionOptions/AutomationProperties/Name}"
+                Label="{helpers:ResourceString Name=NavToolbarSelectionOptions/Label}"
+                LabelPosition="Collapsed"
+                Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
+                ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSelectionOptions/ToolTipService/ToolTip}">
+                <AppBarButton.Flyout>
+                    <MenuFlyout Placement="Bottom">
+                        <ToggleMenuFlyoutItem
+                            x:Name="MultiselectMFI"
+                            IsChecked="{x:Bind AppModel.MultiselectEnabled, Mode=TwoWay}"
+                            Text="{helpers:ResourceString Name=NavToolbarMultiselect/Text}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE762;" />
+                            </MenuFlyoutItem.Icon>
+                        </ToggleMenuFlyoutItem>
+                        <MenuFlyoutItem
+                            x:Name="SelectAllMFI"
+                            Command="{x:Bind ViewModel.SelectAllContentPageItemsCommand, Mode=OneWay}"
+                            Text="{helpers:ResourceString Name=NavToolbarSelectAll/Text}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8B3;" />
+                            </MenuFlyoutItem.Icon>
+                            <MenuFlyoutItem.KeyboardAccelerators>
+                                <KeyboardAccelerator
+                                    Key="A"
+                                    IsEnabled="False"
+                                    Modifiers="Control" />
+                            </MenuFlyoutItem.KeyboardAccelerators>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            x:Name="InvertSelectionMFI"
+                            Command="{x:Bind ViewModel.InvertContentPageSelctionCommand, Mode=OneWay}"
+                            Text="{helpers:ResourceString Name=NavToolbarInvertSelection/Text}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE746;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            x:Name="ClearSelectionMFI"
+                            Command="{x:Bind ViewModel.ClearContentPageSelectionCommand, Mode=OneWay}"
+                            Text="{helpers:ResourceString Name=NavToolbarClearSelection/Text}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8E6;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                    </MenuFlyout>
+                </AppBarButton.Flyout>
 
-				<local:ColoredIcon BaseLayerGlyph="&#xF02B;" OverlayLayerGlyph="&#xF02C;" />
-			</AppBarButton>
-			<AppBarButton
-				x:Name="ArrangementOptions"
-				Width="Auto"
-				MinWidth="40"
-				x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-				AccessKey="A"
-				AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSortOptionsButton/AutomationProperties/Name}"
-				Label="{helpers:ResourceString Name=NavToolbarSortOptionsButton/Label}"
-				LabelPosition="Collapsed"
-				Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
-				ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSortOptionsButton/ToolTipService/ToolTip}">
-				<AppBarButton.Content>
-					<local:ColoredIcon BaseLayerGlyph="&#xF029;" OverlayLayerGlyph="&#xF02A;" />
-				</AppBarButton.Content>
-				<AppBarButton.Flyout>
-					<MenuFlyout contract8Present:ShouldConstrainToRootBounds="False" Placement="Bottom">
-						<MenuFlyoutSubItem Text="{helpers:ResourceString Name=NavToolbarSortByRadioButtons/Text}">
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByName, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionName/Text}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByDateModified, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateModifiedLowerCase}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByDateCreated, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateCreated}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedBySize, Mode=TwoWay}" Text="{helpers:ResourceString Name=Size}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByType, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionType/Text}" />
-							<ToggleMenuFlyoutItem
-								IsChecked="{x:Bind ViewModel.IsSortedBySyncStatus, Mode=TwoWay}"
-								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeCloudDrive, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=SyncStatus}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByFileTag, Mode=TwoWay}" Text="{helpers:ResourceString Name=FileTags}" />
-							<ToggleMenuFlyoutItem
-								IsChecked="{x:Bind ViewModel.IsSortedByOriginalFolder, Mode=TwoWay}"
-								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=NavToolbarArrangementOptionOriginalFolder/Text}" />
-							<ToggleMenuFlyoutItem
-								IsChecked="{x:Bind ViewModel.IsSortedByDateDeleted, Mode=TwoWay}"
-								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=DateDeleted}" />
-						</MenuFlyoutSubItem>
-						<MenuFlyoutSubItem Text="{helpers:ResourceString Name=NavToolbarGroupByRadioButtons/Text}">
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByNone, Mode=TwoWay}" Text="{helpers:ResourceString Name=None}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByName, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionName/Text}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByDateModified, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateModifiedLowerCase}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByDateCreated, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateCreated}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedBySize, Mode=TwoWay}" Text="{helpers:ResourceString Name=Size}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByType, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionType/Text}" />
-							<ToggleMenuFlyoutItem
-								IsChecked="{x:Bind ViewModel.IsGroupedBySyncStatus, Mode=TwoWay}"
-								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeCloudDrive, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=SyncStatus}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByFileTag, Mode=TwoWay}" Text="{helpers:ResourceString Name=FileTags}" />
-							<ToggleMenuFlyoutItem
-								IsChecked="{x:Bind ViewModel.IsGroupedByOriginalFolder, Mode=TwoWay}"
-								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=NavToolbarArrangementOptionOriginalFolder/Text}" />
-							<ToggleMenuFlyoutItem
-								IsChecked="{x:Bind ViewModel.IsGroupedByDateDeleted, Mode=TwoWay}"
-								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=DateDeleted}" />
-							<ToggleMenuFlyoutItem
-								IsChecked="{x:Bind ViewModel.IsGroupedByFolderPath, Mode=TwoWay}"
-								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeLibrary, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=NavToolbarArrangementOptionFolderPath/Text}" />
-						</MenuFlyoutSubItem>
-						<MenuFlyoutSeparator />
-						<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedAscending, Mode=TwoWay}" Text="{helpers:ResourceString Name=Ascending}" />
-						<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedDescending, Mode=TwoWay}" Text="{helpers:ResourceString Name=Descending}" />
-						<MenuFlyoutSeparator />
-						<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.AreDirectoriesSortedAlongsideFiles, Mode=TwoWay}" Text="{helpers:ResourceString Name=SettingsListAndSortDirectoriesAlongsideFiles}" />
-					</MenuFlyout>
-				</AppBarButton.Flyout>
-			</AppBarButton>
-			<AppBarButton
-				x:Name="LayoutOptionsButton"
-				Width="Auto"
-				MinWidth="40"
-				x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-				AccessKey="L"
-				AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/AutomationProperties/Name}"
-				Label="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/Label}"
-				LabelPosition="Collapsed"
-				Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
-				ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/ToolTipService/ToolTip}">
-				<AppBarButton.Icon>
-					<FontIcon FontSize="10" Glyph="&#xE152;" />
-				</AppBarButton.Icon>
-				<AppBarButton.Flyout>
-					<Flyout contract8Present:ShouldConstrainToRootBounds="False" Placement="Bottom">
-						<StackPanel Spacing="12">
-							<TextBlock FontWeight="Medium" Text="{helpers:ResourceString Name=NavToolbarLayout/Text}" />
+                <local:ColoredIcon BaseLayerGlyph="&#xF02B;" OverlayLayerGlyph="&#xF02C;" />
+            </AppBarButton>
+            <AppBarButton
+                x:Name="ArrangementOptions"
+                Width="Auto"
+                MinWidth="40"
+                x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+                AccessKey="A"
+                AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSortOptionsButton/AutomationProperties/Name}"
+                Label="{helpers:ResourceString Name=NavToolbarSortOptionsButton/Label}"
+                LabelPosition="Collapsed"
+                Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
+                ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSortOptionsButton/ToolTipService/ToolTip}">
+                <AppBarButton.Content>
+                    <local:ColoredIcon BaseLayerGlyph="&#xF029;" OverlayLayerGlyph="&#xF02A;" />
+                </AppBarButton.Content>
+                <AppBarButton.Flyout>
+                    <MenuFlyout contract8Present:ShouldConstrainToRootBounds="False" Placement="Bottom">
+                        <MenuFlyoutSubItem Text="{helpers:ResourceString Name=NavToolbarSortByRadioButtons/Text}">
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByName, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionName/Text}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByDateModified, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateModifiedLowerCase}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByDateCreated, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateCreated}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedBySize, Mode=TwoWay}" Text="{helpers:ResourceString Name=Size}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByType, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionType/Text}" />
+                            <ToggleMenuFlyoutItem
+                                IsChecked="{x:Bind ViewModel.IsSortedBySyncStatus, Mode=TwoWay}"
+                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeCloudDrive, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=SyncStatus}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByFileTag, Mode=TwoWay}" Text="{helpers:ResourceString Name=FileTags}" />
+                            <ToggleMenuFlyoutItem
+                                IsChecked="{x:Bind ViewModel.IsSortedByOriginalFolder, Mode=TwoWay}"
+                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=NavToolbarArrangementOptionOriginalFolder/Text}" />
+                            <ToggleMenuFlyoutItem
+                                IsChecked="{x:Bind ViewModel.IsSortedByDateDeleted, Mode=TwoWay}"
+                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=DateDeleted}" />
+                        </MenuFlyoutSubItem>
+                        <MenuFlyoutSubItem Text="{helpers:ResourceString Name=NavToolbarGroupByRadioButtons/Text}">
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByNone, Mode=TwoWay}" Text="{helpers:ResourceString Name=None}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByName, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionName/Text}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByDateModified, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateModifiedLowerCase}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByDateCreated, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateCreated}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedBySize, Mode=TwoWay}" Text="{helpers:ResourceString Name=Size}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByType, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionType/Text}" />
+                            <ToggleMenuFlyoutItem
+                                IsChecked="{x:Bind ViewModel.IsGroupedBySyncStatus, Mode=TwoWay}"
+                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeCloudDrive, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=SyncStatus}" />
+                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByFileTag, Mode=TwoWay}" Text="{helpers:ResourceString Name=FileTags}" />
+                            <ToggleMenuFlyoutItem
+                                IsChecked="{x:Bind ViewModel.IsGroupedByOriginalFolder, Mode=TwoWay}"
+                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=NavToolbarArrangementOptionOriginalFolder/Text}" />
+                            <ToggleMenuFlyoutItem
+                                IsChecked="{x:Bind ViewModel.IsGroupedByDateDeleted, Mode=TwoWay}"
+                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=DateDeleted}" />
+                            <ToggleMenuFlyoutItem
+                                IsChecked="{x:Bind ViewModel.IsGroupedByFolderPath, Mode=TwoWay}"
+                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeLibrary, Mode=OneWay}"
+                                Text="{helpers:ResourceString Name=NavToolbarArrangementOptionFolderPath/Text}" />
+                        </MenuFlyoutSubItem>
+                        <MenuFlyoutSeparator />
+                        <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedAscending, Mode=TwoWay}" Text="{helpers:ResourceString Name=Ascending}" />
+                        <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedDescending, Mode=TwoWay}" Text="{helpers:ResourceString Name=Descending}" />
+                        <MenuFlyoutSeparator />
+                        <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.AreDirectoriesSortedAlongsideFiles, Mode=TwoWay}" Text="{helpers:ResourceString Name=SettingsListAndSortDirectoriesAlongsideFiles}" />
+                    </MenuFlyout>
+                </AppBarButton.Flyout>
+            </AppBarButton>
+            <AppBarButton
+                x:Name="LayoutOptionsButton"
+                Width="Auto"
+                MinWidth="40"
+                x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+                AccessKey="L"
+                AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/AutomationProperties/Name}"
+                Label="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/Label}"
+                LabelPosition="Collapsed"
+                Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
+                ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/ToolTipService/ToolTip}">
+                <AppBarButton.Icon>
+                    <FontIcon FontSize="10" Glyph="&#xE152;" />
+                </AppBarButton.Icon>
+                <AppBarButton.Flyout>
+                    <Flyout contract8Present:ShouldConstrainToRootBounds="False" Placement="Bottom">
+                        <StackPanel Spacing="12">
+                            <TextBlock FontWeight="Medium" Text="{helpers:ResourceString Name=NavToolbarLayout/Text}" />
 
-							<Grid ColumnSpacing="8" RowSpacing="8">
-								<Grid.RowDefinitions>
-									<RowDefinition MinHeight="30" />
-									<RowDefinition MinHeight="30" />
-									<RowDefinition MinHeight="30" />
-									<RowDefinition MinHeight="30" />
-								</Grid.RowDefinitions>
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="40" />
-									<ColumnDefinition MaxWidth="100" />
-									<ColumnDefinition Width="40" />
-									<ColumnDefinition Width="40" />
-									<ColumnDefinition MaxWidth="100" />
-								</Grid.ColumnDefinitions>
+                            <Grid ColumnSpacing="8" RowSpacing="8">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition MinHeight="30" />
+                                    <RowDefinition MinHeight="30" />
+                                    <RowDefinition MinHeight="30" />
+                                    <RowDefinition MinHeight="30" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="40" />
+                                    <ColumnDefinition MaxWidth="100" />
+                                    <ColumnDefinition Width="40" />
+                                    <ColumnDefinition Width="40" />
+                                    <ColumnDefinition MaxWidth="100" />
+                                </Grid.ColumnDefinitions>
 
-								<RadioButton
-									Grid.Row="0"
-									Grid.Column="0"
-									Width="36"
-									Height="32"
-									MinWidth="0"
-									Padding="0"
-									HorizontalContentAlignment="Center"
-									VerticalContentAlignment="Center"
-									AutomationProperties.Name="{helpers:ResourceString Name=Details}"
-									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsViewCommand, Mode=OneWay}"
-									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-									CornerRadius="{StaticResource ControlCornerRadius}"
-									IsChecked="{x:Bind ViewModel.IsLayoutDetailsView, Mode=OneWay}"
-									Style="{StaticResource DefaultToggleButtonStyle}"
-									ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarDetails/ToolTipService/ToolTip}">
-									<FontIcon FontSize="16" Glyph="&#xE179;" />
-								</RadioButton>
+                                <RadioButton
+                                    Grid.Row="0"
+                                    Grid.Column="0"
+                                    Width="36"
+                                    Height="32"
+                                    MinWidth="0"
+                                    Padding="0"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    AutomationProperties.Name="{helpers:ResourceString Name=Details}"
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsViewCommand, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    CornerRadius="{StaticResource ControlCornerRadius}"
+                                    IsChecked="{x:Bind ViewModel.IsLayoutDetailsView, Mode=OneWay}"
+                                    Style="{StaticResource DefaultToggleButtonStyle}"
+                                    ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarDetails/ToolTipService/ToolTip}">
+                                    <FontIcon FontSize="16" Glyph="&#xE179;" />
+                                </RadioButton>
 
-								<TextBlock
-									x:Name="NavToolbarDetailsHeader"
-									Grid.Row="0"
-									Grid.Column="1"
-									VerticalAlignment="Center"
-									Tapped="NavToolbarDetailsHeader_Tapped"
-									Text="{helpers:ResourceString Name=Details}" />
+                                <TextBlock
+                                    x:Name="NavToolbarDetailsHeader"
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    Tapped="NavToolbarDetailsHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=Details}" />
 
-								<RadioButton
-									Grid.Row="1"
-									Grid.Column="0"
-									Width="36"
-									Height="32"
-									MinWidth="0"
-									Padding="0"
-									HorizontalContentAlignment="Center"
-									VerticalContentAlignment="Center"
-									AutomationProperties.Name="{helpers:ResourceString Name=Tiles}"
-									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTilesCommand, Mode=OneWay}"
-									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-									CornerRadius="{StaticResource ControlCornerRadius}"
-									IsChecked="{x:Bind ViewModel.IsLayoutTilesView, Mode=OneWay}"
-									Style="{StaticResource DefaultToggleButtonStyle}"
-									ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarTiles/ToolTipService/ToolTip}">
-									<FontIcon FontSize="16" Glyph="&#xE15C;" />
-								</RadioButton>
+                                <RadioButton
+                                    Grid.Row="1"
+                                    Grid.Column="0"
+                                    Width="36"
+                                    Height="32"
+                                    MinWidth="0"
+                                    Padding="0"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    AutomationProperties.Name="{helpers:ResourceString Name=Tiles}"
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTilesCommand, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    CornerRadius="{StaticResource ControlCornerRadius}"
+                                    IsChecked="{x:Bind ViewModel.IsLayoutTilesView, Mode=OneWay}"
+                                    Style="{StaticResource DefaultToggleButtonStyle}"
+                                    ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarTiles/ToolTipService/ToolTip}">
+                                    <FontIcon FontSize="16" Glyph="&#xE15C;" />
+                                </RadioButton>
 
-								<TextBlock
-									x:Name="NavToolbarTilesHeader"
-									Grid.Row="1"
-									Grid.Column="1"
-									VerticalAlignment="Center"
-									Tapped="NavToolbarTilesHeader_Tapped"
-									Text="{helpers:ResourceString Name=Tiles}" />
+                                <TextBlock
+                                    x:Name="NavToolbarTilesHeader"
+                                    Grid.Row="1"
+                                    Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    Tapped="NavToolbarTilesHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=Tiles}" />
 
-								<RadioButton
-									Grid.Row="2"
-									Grid.Column="0"
-									Width="36"
-									Height="32"
-									MinWidth="0"
-									Padding="0"
-									HorizontalContentAlignment="Center"
-									VerticalContentAlignment="Center"
-									AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSmallIcons/AutomationProperties/Name}"
-									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmallCommand, Mode=OneWay}"
-									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-									CornerRadius="{StaticResource ControlCornerRadius}"
-									IsChecked="{x:Bind ViewModel.IsLayoutGridViewSmall, Mode=OneWay}"
-									Style="{StaticResource DefaultToggleButtonStyle}"
-									ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSmallIcons/ToolTipService/ToolTip}">
-									<FontIcon FontSize="16" Glyph="&#xE80A;" />
-								</RadioButton>
+                                <RadioButton
+                                    Grid.Row="2"
+                                    Grid.Column="0"
+                                    Width="36"
+                                    Height="32"
+                                    MinWidth="0"
+                                    Padding="0"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSmallIcons/AutomationProperties/Name}"
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmallCommand, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    CornerRadius="{StaticResource ControlCornerRadius}"
+                                    IsChecked="{x:Bind ViewModel.IsLayoutGridViewSmall, Mode=OneWay}"
+                                    Style="{StaticResource DefaultToggleButtonStyle}"
+                                    ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSmallIcons/ToolTipService/ToolTip}">
+                                    <FontIcon FontSize="16" Glyph="&#xE80A;" />
+                                </RadioButton>
 
-								<TextBlock
-									x:Name="NavToolbarSmallIconsHeader"
-									Grid.Row="2"
-									Grid.Column="1"
-									VerticalAlignment="Center"
-									Tapped="NavToolbarSmallIconsHeader_Tapped"
-									Text="{helpers:ResourceString Name=SmallIcons}" />
+                                <TextBlock
+                                    x:Name="NavToolbarSmallIconsHeader"
+                                    Grid.Row="2"
+                                    Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    Tapped="NavToolbarSmallIconsHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=SmallIcons}" />
 
-								<RadioButton
-									Grid.Row="3"
-									Grid.Column="0"
-									Width="36"
-									Height="32"
-									MinWidth="0"
-									Padding="0"
-									HorizontalContentAlignment="Center"
-									VerticalContentAlignment="Center"
-									AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarMediumIcons/AutomationProperties/Name}"
-									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMediumCommand, Mode=OneWay}"
-									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-									CornerRadius="{StaticResource ControlCornerRadius}"
-									IsChecked="{x:Bind ViewModel.IsLayoutGridViewMedium, Mode=OneWay}"
-									Style="{StaticResource DefaultToggleButtonStyle}"
-									ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarMediumIcons/ToolTipService/ToolTip}">
-									<FontIcon FontSize="16" Glyph="&#xF0E2;" />
-								</RadioButton>
+                                <RadioButton
+                                    Grid.Row="3"
+                                    Grid.Column="0"
+                                    Width="36"
+                                    Height="32"
+                                    MinWidth="0"
+                                    Padding="0"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarMediumIcons/AutomationProperties/Name}"
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMediumCommand, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    CornerRadius="{StaticResource ControlCornerRadius}"
+                                    IsChecked="{x:Bind ViewModel.IsLayoutGridViewMedium, Mode=OneWay}"
+                                    Style="{StaticResource DefaultToggleButtonStyle}"
+                                    ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarMediumIcons/ToolTipService/ToolTip}">
+                                    <FontIcon FontSize="16" Glyph="&#xF0E2;" />
+                                </RadioButton>
 
-								<TextBlock
-									x:Name="NavToolbarMediumIconsHeader"
-									Grid.Row="3"
-									Grid.Column="1"
-									VerticalAlignment="Center"
-									Tapped="NavToolbarMediumIconsHeader_Tapped"
-									Text="{helpers:ResourceString Name=MediumIcons}" />
+                                <TextBlock
+                                    x:Name="NavToolbarMediumIconsHeader"
+                                    Grid.Row="3"
+                                    Grid.Column="1"
+                                    VerticalAlignment="Center"
+                                    Tapped="NavToolbarMediumIconsHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=MediumIcons}" />
 
-								<Border
-									Grid.RowSpan="4"
-									Grid.Column="2"
-									Height="120"
-									HorizontalAlignment="Center"
-									VerticalAlignment="Center"
-									BorderBrush="{ThemeResource ControlStrokeColorDefault}"
-									BorderThickness="1" />
+                                <Border
+                                    Grid.RowSpan="4"
+                                    Grid.Column="2"
+                                    Height="120"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    BorderBrush="{ThemeResource ControlStrokeColorDefault}"
+                                    BorderThickness="1" />
 
-								<RadioButton
-									Grid.Row="0"
-									Grid.Column="3"
-									Width="36"
-									Height="32"
-									MinWidth="0"
-									Padding="0"
-									HorizontalContentAlignment="Center"
-									VerticalContentAlignment="Center"
-									AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarLargeIcons/AutomationProperties/Name}"
-									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLargeCommand, Mode=OneWay}"
-									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-									CornerRadius="{StaticResource ControlCornerRadius}"
-									IsChecked="{x:Bind ViewModel.IsLayoutGridViewLarge, Mode=OneWay}"
-									Style="{StaticResource DefaultToggleButtonStyle}"
-									ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarLargeIcons/ToolTipService/ToolTip}">
-									<FontIcon FontSize="16" Glyph="&#xE739;" />
-								</RadioButton>
+                                <RadioButton
+                                    Grid.Row="0"
+                                    Grid.Column="3"
+                                    Width="36"
+                                    Height="32"
+                                    MinWidth="0"
+                                    Padding="0"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarLargeIcons/AutomationProperties/Name}"
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLargeCommand, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    CornerRadius="{StaticResource ControlCornerRadius}"
+                                    IsChecked="{x:Bind ViewModel.IsLayoutGridViewLarge, Mode=OneWay}"
+                                    Style="{StaticResource DefaultToggleButtonStyle}"
+                                    ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarLargeIcons/ToolTipService/ToolTip}">
+                                    <FontIcon FontSize="16" Glyph="&#xE739;" />
+                                </RadioButton>
 
-								<TextBlock
-									x:Name="NavToolbarLargeIconsHeader"
-									Grid.Row="0"
-									Grid.Column="4"
-									VerticalAlignment="Center"
-									Tapped="NavToolbarLargeIconsHeader_Tapped"
-									Text="{helpers:ResourceString Name=LargeIcons}" />
+                                <TextBlock
+                                    x:Name="NavToolbarLargeIconsHeader"
+                                    Grid.Row="0"
+                                    Grid.Column="4"
+                                    VerticalAlignment="Center"
+                                    Tapped="NavToolbarLargeIconsHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=LargeIcons}" />
 
-								<RadioButton
-									Grid.Row="1"
-									Grid.Column="3"
-									Width="36"
-									Height="32"
-									MinWidth="0"
-									Padding="0"
-									HorizontalContentAlignment="Center"
-									VerticalContentAlignment="Center"
-									AutomationProperties.Name="{helpers:ResourceString Name=Columns}"
-									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnViewCommand, Mode=OneWay}"
-									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-									CornerRadius="{StaticResource ControlCornerRadius}"
-									IsChecked="{x:Bind ViewModel.IsLayoutColumnsView, Mode=OneWay}"
-									Style="{StaticResource DefaultToggleButtonStyle}"
-									ToolTipService.ToolTip="{helpers:ResourceString Name=ColumnsShortcutTooltip}">
-									<FontIcon
-										FontFamily="{StaticResource CustomGlyph}"
-										FontSize="16"
-										Glyph="&#xF115;" />
-								</RadioButton>
+                                <RadioButton
+                                    Grid.Row="1"
+                                    Grid.Column="3"
+                                    Width="36"
+                                    Height="32"
+                                    MinWidth="0"
+                                    Padding="0"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    AutomationProperties.Name="{helpers:ResourceString Name=Columns}"
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnViewCommand, Mode=OneWay}"
+                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+                                    CornerRadius="{StaticResource ControlCornerRadius}"
+                                    IsChecked="{x:Bind ViewModel.IsLayoutColumnsView, Mode=OneWay}"
+                                    Style="{StaticResource DefaultToggleButtonStyle}"
+                                    ToolTipService.ToolTip="{helpers:ResourceString Name=ColumnsShortcutTooltip}">
+                                    <FontIcon
+                                        FontFamily="{StaticResource CustomGlyph}"
+                                        FontSize="16"
+                                        Glyph="&#xF115;" />
+                                </RadioButton>
 
-								<TextBlock
-									x:Name="NavToolbarColumnsHeader"
-									Grid.Row="1"
-									Grid.Column="4"
-									VerticalAlignment="Center"
-									Tapped="NavToolbarColumnsHeader_Tapped"
-									Text="{helpers:ResourceString Name=Columns}" />
+                                <TextBlock
+                                    x:Name="NavToolbarColumnsHeader"
+                                    Grid.Row="1"
+                                    Grid.Column="4"
+                                    VerticalAlignment="Center"
+                                    Tapped="NavToolbarColumnsHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=Columns}" />
 
-								<RadioButton
-									Grid.Row="2"
-									Grid.Column="3"
-									Width="36"
-									Height="32"
-									MinWidth="0"
-									Padding="0"
-									HorizontalContentAlignment="Center"
-									VerticalContentAlignment="Center"
-									AutomationProperties.Name="{helpers:ResourceString Name=Adaptive}"
-									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeAdaptiveCommand, Mode=OneWay}"
-									CornerRadius="{StaticResource ControlCornerRadius}"
-									IsChecked="{x:Bind ViewModel.IsLayoutAdaptive, Mode=OneWay}"
-									IsEnabled="{x:Bind ViewModel.IsAdaptiveLayoutEnabled, Mode=OneWay}"
-									Style="{StaticResource DefaultToggleButtonStyle}"
-									ToolTipService.ToolTip="{helpers:ResourceString Name=AdaptiveShortcutTooltip}">
-									<FontIcon FontSize="16" Glyph="&#xF576;" />
-								</RadioButton>
+                                <RadioButton
+                                    Grid.Row="2"
+                                    Grid.Column="3"
+                                    Width="36"
+                                    Height="32"
+                                    MinWidth="0"
+                                    Padding="0"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    AutomationProperties.Name="{helpers:ResourceString Name=Adaptive}"
+                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeAdaptiveCommand, Mode=OneWay}"
+                                    CornerRadius="{StaticResource ControlCornerRadius}"
+                                    IsChecked="{x:Bind ViewModel.IsLayoutAdaptive, Mode=OneWay}"
+                                    IsEnabled="{x:Bind ViewModel.IsAdaptiveLayoutEnabled, Mode=OneWay}"
+                                    Style="{StaticResource DefaultToggleButtonStyle}"
+                                    ToolTipService.ToolTip="{helpers:ResourceString Name=AdaptiveShortcutTooltip}">
+                                    <FontIcon FontSize="16" Glyph="&#xF576;" />
+                                </RadioButton>
 
-								<TextBlock
-									x:Name="NavToolbarAdaptiveHeader"
-									Grid.Row="2"
-									Grid.Column="4"
-									VerticalAlignment="Center"
-									Tapped="NavToolbarAdaptiveHeader_Tapped"
-									Text="{helpers:ResourceString Name=Adaptive}" />
-							</Grid>
+                                <TextBlock
+                                    x:Name="NavToolbarAdaptiveHeader"
+                                    Grid.Row="2"
+                                    Grid.Column="4"
+                                    VerticalAlignment="Center"
+                                    Tapped="NavToolbarAdaptiveHeader_Tapped"
+                                    Text="{helpers:ResourceString Name=Adaptive}" />
+                            </Grid>
 
-							<Border
-								Margin="-20,0"
-								HorizontalAlignment="Stretch"
-								BorderBrush="{ThemeResource ControlStrokeColorDefault}"
-								BorderThickness="1" />
+                            <Border
+                                Margin="-20,0"
+                                HorizontalAlignment="Stretch"
+                                BorderBrush="{ThemeResource ControlStrokeColorDefault}"
+                                BorderThickness="1" />
 
-							<Grid RowSpacing="4">
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*" />
-									<ColumnDefinition Width="Auto" />
-								</Grid.ColumnDefinitions>
-								<Grid.RowDefinitions>
-									<RowDefinition MinHeight="30" />
-									<RowDefinition MinHeight="30" />
-								</Grid.RowDefinitions>
-								<TextBlock
-									Grid.Row="0"
-									Grid.Column="0"
-									VerticalAlignment="Center"
-									Text="{helpers:ResourceString Name=NavToolbarShowHiddenItemsHeader/Text}" />
-								<ToggleSwitch
-									Grid.Row="0"
-									Grid.Column="1"
-									HorizontalAlignment="Right"
-									AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarShowHiddenItems/AutomationProperties/Name}"
-									IsOn="{x:Bind UserSettingsService.FoldersSettingsService.ShowHiddenItems, Mode=TwoWay}"
-									Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+                            <Grid RowSpacing="4">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition MinHeight="30" />
+                                    <RowDefinition MinHeight="30" />
+                                </Grid.RowDefinitions>
+                                <TextBlock
+                                    Grid.Row="0"
+                                    Grid.Column="0"
+                                    VerticalAlignment="Center"
+                                    Text="{helpers:ResourceString Name=NavToolbarShowHiddenItemsHeader/Text}" />
+                                <ToggleSwitch
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    HorizontalAlignment="Right"
+                                    AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarShowHiddenItems/AutomationProperties/Name}"
+                                    IsOn="{x:Bind UserSettingsService.FoldersSettingsService.ShowHiddenItems, Mode=TwoWay}"
+                                    Style="{StaticResource RightAlignedToggleSwitchStyle}" />
 
-								<TextBlock
-									Grid.Row="1"
-									Grid.Column="0"
-									VerticalAlignment="Center"
-									Text="{helpers:ResourceString Name=NavToolbarShowFileExtensionsHeader/Text}" />
-								<ToggleSwitch
-									Grid.Row="1"
-									Grid.Column="1"
-									HorizontalAlignment="Right"
-									AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarShowFileExtensions/AutomationProperties/Name}"
-									IsOn="{x:Bind UserSettingsService.PreferencesSettingsService.ShowFileExtensions, Mode=TwoWay}"
-									Rotation="1"
-									Style="{StaticResource RightAlignedToggleSwitchStyle}" />
-							</Grid>
-						</StackPanel>
-					</Flyout>
-				</AppBarButton.Flyout>
-			</AppBarButton>
-			<AppBarToggleButton
-				x:Name="PreviewPane"
-				Width="Auto"
-				MinWidth="40"
-				AccessKey="P"
-				AutomationProperties.Name="{helpers:ResourceString Name=PreviewPaneToggle/AutomationProperties/Name}"
-				IsChecked="{x:Bind AppModel.PaneViewModel.IsPreviewSelected, Mode=TwoWay}"
-				IsEnabled="{x:Bind ShowPreviewPaneButton, Mode=OneWay}"
-				Label="{helpers:ResourceString Name=PreviewPaneToggle/Label}"
-				LabelPosition="Collapsed"
-				ToolTipService.ToolTip="{helpers:ResourceString Name=PreviewPaneToggle/ToolTipService/ToolTip}"
-				Visibility="{x:Bind ShowPreviewPaneButton, Mode=OneWay}">
-				<AppBarToggleButton.Content>
-					<local:ColoredIcon BaseLayerGlyph="&#xF03b;" OverlayLayerGlyph="&#xF03c;" />
-				</AppBarToggleButton.Content>
-			</AppBarToggleButton>
-			<CommandBar.SecondaryCommands>
-				<AppBarButton
-					x:Name="NavToolbarNewPane"
-					x:Load="{x:Bind converters:MultiBooleanConverter.AndNotConvert(ShowMultiPaneControls, IsMultiPaneActive), Mode=OneWay}"
-					Command="{x:Bind ViewModel.OpenNewPaneCommand, Mode=OneWay}"
-					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarNewPane/KeyboardAcceleratorTextOverride}"
-					Label="{helpers:ResourceString Name=NavigationToolbarNewPane/Label}">
-					<AppBarButton.Icon>
-						<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF117;" />
-					</AppBarButton.Icon>
-					<AppBarButton.KeyboardAccelerators>
-						<KeyboardAccelerator
-							Key="Add"
-							IsEnabled="False"
-							Modifiers="Menu,Shift" />
-					</AppBarButton.KeyboardAccelerators>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="NavToolbarClosePane"
-					x:Load="{x:Bind IsMultiPaneActive, Mode=OneWay}"
-					Command="{x:Bind ViewModel.ClosePaneCommand, Mode=OneWay}"
-					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarClosePane/KeyboardAcceleratorTextOverride}"
-					Label="{helpers:ResourceString Name=NavigationToolbarClosePane/Label}">
-					<AppBarButton.Icon>
-						<FontIcon Glyph="&#xE89F;" />
-					</AppBarButton.Icon>
-					<AppBarButton.KeyboardAccelerators>
-						<KeyboardAccelerator
-							Key="W"
-							IsEnabled="False"
-							Modifiers="Control,Shift" />
-					</AppBarButton.KeyboardAccelerators>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="NavToolbarNewWindow"
-					Command="{x:Bind ViewModel.OpenNewWindowCommand, Mode=OneWay}"
-					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarNewWindow/KeyboardAcceleratorTextOverride}"
-					Label="{helpers:ResourceString Name=NavigationToolbarNewWindow/Label}">
-					<AppBarButton.Icon>
-						<FontIcon Glyph="&#xE737;" />
-					</AppBarButton.Icon>
-					<AppBarButton.KeyboardAccelerators>
-						<KeyboardAccelerator
-							Key="N"
-							IsEnabled="False"
-							Modifiers="Control" />
-					</AppBarButton.KeyboardAccelerators>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="NavToolbarEnterCompactOverlay"
-					Command="{x:Bind SetCompactOverlayCommand}"
-					CommandParameter="{StaticResource True}"
-					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarEnterCompactOverlay/KeyboardAcceleratorTextOverride}"
-					Label="{helpers:ResourceString Name=NavigationToolbarEnterCompactOverlay/Label}"
-					Visibility="{x:Bind IsCompactOverlay, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
-					<AppBarButton.KeyboardAccelerators>
-						<KeyboardAccelerator
-							Key="Up"
-							IsEnabled="False"
-							Modifiers="Menu,Control" />
-					</AppBarButton.KeyboardAccelerators>
-					<AppBarButton.Icon>
-						<PathIcon
-							HorizontalAlignment="Center"
-							VerticalAlignment="Center"
-							Data="{StaticResource EnterCompactOverlay}" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-				<AppBarButton
-					x:Name="NavToolbarExitCompactOverlay"
-					Command="{x:Bind SetCompactOverlayCommand}"
-					CommandParameter="{StaticResource False}"
-					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarExitCompactOverlay/KeyboardAcceleratorTextOverride}"
-					Label="{helpers:ResourceString Name=NavigationToolbarExitCompactOverlay/Label}"
-					Visibility="{x:Bind IsCompactOverlay, Mode=OneWay}">
-					<AppBarButton.Icon>
-						<PathIcon
-							HorizontalAlignment="Center"
-							VerticalAlignment="Center"
-							Data="{StaticResource ExitCompactOverlay}" />
-					</AppBarButton.Icon>
-					<AppBarButton.KeyboardAccelerators>
-						<KeyboardAccelerator
-							Key="Down"
-							IsEnabled="False"
-							Modifiers="Menu,Control" />
-					</AppBarButton.KeyboardAccelerators>
-				</AppBarButton>
-				<AppBarSeparator x:Name="SeparatorBar" x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}" />
-				<AppBarButton
-					x:Name="OpenInTerminalButton"
-					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-					Command="{x:Bind ViewModel.OpenDirectoryInDefaultTerminalCommand, Mode=OneWay}"
-					IsEnabled="{x:Bind ViewModel.InstanceViewModel.CanOpenTerminalInPage, Mode=OneWay}"
-					Label="{x:Bind ViewModel.OpenInTerminal, Mode=OneWay}">
-					<AppBarButton.Icon>
-						<FontIcon Glyph="&#xE756;" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-			</CommandBar.SecondaryCommands>
-		</CommandBar>
-	</Grid>
+                                <TextBlock
+                                    Grid.Row="1"
+                                    Grid.Column="0"
+                                    VerticalAlignment="Center"
+                                    Text="{helpers:ResourceString Name=NavToolbarShowFileExtensionsHeader/Text}" />
+                                <ToggleSwitch
+                                    Grid.Row="1"
+                                    Grid.Column="1"
+                                    HorizontalAlignment="Right"
+                                    AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarShowFileExtensions/AutomationProperties/Name}"
+                                    IsOn="{x:Bind UserSettingsService.PreferencesSettingsService.ShowFileExtensions, Mode=TwoWay}"
+                                    Rotation="1"
+                                    Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+                            </Grid>
+                        </StackPanel>
+                    </Flyout>
+                </AppBarButton.Flyout>
+            </AppBarButton>
+            <AppBarToggleButton
+                x:Name="PreviewPane"
+                Width="Auto"
+                MinWidth="40"
+                AccessKey="P"
+                AutomationProperties.Name="{helpers:ResourceString Name=PreviewPaneToggle/AutomationProperties/Name}"
+                IsChecked="{x:Bind AppModel.PaneViewModel.IsPreviewSelected, Mode=TwoWay}"
+                IsEnabled="{x:Bind ShowPreviewPaneButton, Mode=OneWay}"
+                Label="{helpers:ResourceString Name=PreviewPaneToggle/Label}"
+                LabelPosition="Collapsed"
+                ToolTipService.ToolTip="{helpers:ResourceString Name=PreviewPaneToggle/ToolTipService/ToolTip}"
+                Visibility="{x:Bind ShowPreviewPaneButton, Mode=OneWay}">
+                <AppBarToggleButton.Content>
+                    <local:ColoredIcon BaseLayerGlyph="&#xF03b;" OverlayLayerGlyph="&#xF03c;" />
+                </AppBarToggleButton.Content>
+            </AppBarToggleButton>
+            <CommandBar.SecondaryCommands>
+                <AppBarButton
+                    x:Name="NavToolbarNewPane"
+                    x:Load="{x:Bind converters:MultiBooleanConverter.AndNotConvert(ShowMultiPaneControls, IsMultiPaneActive), Mode=OneWay}"
+                    Command="{x:Bind ViewModel.OpenNewPaneCommand, Mode=OneWay}"
+                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarNewPane/KeyboardAcceleratorTextOverride}"
+                    Label="{helpers:ResourceString Name=NavigationToolbarNewPane/Label}">
+                    <AppBarButton.Icon>
+                        <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF117;" />
+                    </AppBarButton.Icon>
+                    <AppBarButton.KeyboardAccelerators>
+                        <KeyboardAccelerator
+                            Key="Add"
+                            IsEnabled="False"
+                            Modifiers="Menu,Shift" />
+                    </AppBarButton.KeyboardAccelerators>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="NavToolbarClosePane"
+                    x:Load="{x:Bind IsMultiPaneActive, Mode=OneWay}"
+                    Command="{x:Bind ViewModel.ClosePaneCommand, Mode=OneWay}"
+                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarClosePane/KeyboardAcceleratorTextOverride}"
+                    Label="{helpers:ResourceString Name=NavigationToolbarClosePane/Label}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE89F;" />
+                    </AppBarButton.Icon>
+                    <AppBarButton.KeyboardAccelerators>
+                        <KeyboardAccelerator
+                            Key="W"
+                            IsEnabled="False"
+                            Modifiers="Control,Shift" />
+                    </AppBarButton.KeyboardAccelerators>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="NavToolbarNewWindow"
+                    Command="{x:Bind ViewModel.OpenNewWindowCommand, Mode=OneWay}"
+                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarNewWindow/KeyboardAcceleratorTextOverride}"
+                    Label="{helpers:ResourceString Name=NavigationToolbarNewWindow/Label}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE737;" />
+                    </AppBarButton.Icon>
+                    <AppBarButton.KeyboardAccelerators>
+                        <KeyboardAccelerator
+                            Key="N"
+                            IsEnabled="False"
+                            Modifiers="Control" />
+                    </AppBarButton.KeyboardAccelerators>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="NavToolbarEnterCompactOverlay"
+                    Command="{x:Bind SetCompactOverlayCommand}"
+                    CommandParameter="{StaticResource True}"
+                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarEnterCompactOverlay/KeyboardAcceleratorTextOverride}"
+                    Label="{helpers:ResourceString Name=NavigationToolbarEnterCompactOverlay/Label}"
+                    Visibility="{x:Bind IsCompactOverlay, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
+                    <AppBarButton.KeyboardAccelerators>
+                        <KeyboardAccelerator
+                            Key="Up"
+                            IsEnabled="False"
+                            Modifiers="Menu,Control" />
+                    </AppBarButton.KeyboardAccelerators>
+                    <AppBarButton.Icon>
+                        <PathIcon
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Data="{StaticResource EnterCompactOverlay}" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+                <AppBarButton
+                    x:Name="NavToolbarExitCompactOverlay"
+                    Command="{x:Bind SetCompactOverlayCommand}"
+                    CommandParameter="{StaticResource False}"
+                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarExitCompactOverlay/KeyboardAcceleratorTextOverride}"
+                    Label="{helpers:ResourceString Name=NavigationToolbarExitCompactOverlay/Label}"
+                    Visibility="{x:Bind IsCompactOverlay, Mode=OneWay}">
+                    <AppBarButton.Icon>
+                        <PathIcon
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Data="{StaticResource ExitCompactOverlay}" />
+                    </AppBarButton.Icon>
+                    <AppBarButton.KeyboardAccelerators>
+                        <KeyboardAccelerator
+                            Key="Down"
+                            IsEnabled="False"
+                            Modifiers="Menu,Control" />
+                    </AppBarButton.KeyboardAccelerators>
+                </AppBarButton>
+                <AppBarSeparator x:Name="SeparatorBar" x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}" />
+                <AppBarButton
+                    x:Name="OpenInTerminalButton"
+                    x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+                    Command="{x:Bind ViewModel.OpenDirectoryInDefaultTerminalCommand, Mode=OneWay}"
+                    IsEnabled="{x:Bind ViewModel.InstanceViewModel.CanOpenTerminalInPage, Mode=OneWay}"
+                    Label="{x:Bind ViewModel.OpenInTerminal, Mode=OneWay}">
+                    <AppBarButton.Icon>
+                        <FontIcon Glyph="&#xE756;" />
+                    </AppBarButton.Icon>
+                </AppBarButton>
+            </CommandBar.SecondaryCommands>
+        </CommandBar>
+    </Grid>
 </UserControl>

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -1,924 +1,924 @@
 ﻿<UserControl
-    x:Class="Files.App.UserControls.InnerNavigationToolbar"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
-    xmlns:converters="using:Files.App.Converters"
-    xmlns:converters1="using:CommunityToolkit.WinUI.UI.Converters"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:helpers="using:Files.App.Helpers"
-    xmlns:local="using:Files.App.UserControls"
-    xmlns:local1="using:Files.App"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:xh="using:Files.App.Helpers.XamlHelpers"
-    d:DesignHeight="40"
-    d:DesignWidth="400"
-    mc:Ignorable="d">
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <Style x:Key="AccentColorFontIconStyle" TargetType="FontIcon" />
-            <converters1:BoolNegationConverter x:Key="BoolNegationConverter" />
-            <converters1:BoolToVisibilityConverter
-                x:Key="NegatedBoolToVisibilityConverter"
-                FalseValue="Visible"
-                TrueValue="Collapsed" />
-            <converters:IntToGroupOption x:Key="IntToGroupOption" />
-            <converters:IntToSortOption x:Key="IntToSortOption" />
-            <converters:IntToSortDirection x:Key="IntToSortDirection" />
-            <x:Boolean x:Key="True">True</x:Boolean>
-            <x:Boolean x:Key="False">False</x:Boolean>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/ResourceDictionaries/ToolbarButtonStyle.xaml" />
-                <ResourceDictionary Source="/ResourceDictionaries/PathIcons.xaml" />
-                <ResourceDictionary Source="/ResourceDictionaries/RightAlignedToggleSwitchStyle.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </UserControl.Resources>
-    <Grid BorderBrush="{ThemeResource ControlStrokeColorDefault}" BorderThickness="0,0,0,1">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <CommandBar
-            x:Name="ContextCommandBar"
-            Grid.Column="0"
-            HorizontalAlignment="Left"
-            VerticalAlignment="Stretch"
-            DefaultLabelPosition="Right">
-            <CommandBar.Resources>
-                <ResourceDictionary>
-                    <SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
-                    <SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
-                </ResourceDictionary>
-            </CommandBar.Resources>
-            <CommandBar.PrimaryCommands>
-                <AppBarButton
-                    x:Name="NewEmptySpaceAppBarButton"
-                    AccessKey="W"
-                    IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsCreateButtonEnabledInPage, Mode=OneWay, FallbackValue=False}"
-                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=BaseLayoutContextFlyoutNew/KeyboardAcceleratorTextOverride}"
-                    Label="{helpers:ResourceString Name=BaseLayoutContextFlyoutNew/Label}"
-                    Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}">
-                    <AppBarButton.KeyboardAccelerators>
-                        <KeyboardAccelerator
-                            Key="N"
-                            IsEnabled="False"
-                            Modifiers="Control,Shift" />
-                    </AppBarButton.KeyboardAccelerators>
-                    <AppBarButton.Flyout>
-                        <MenuFlyout x:Name="NewEmptySpace" Opening="NewEmptySpace_Opening">
-                            <MenuFlyoutItem
-                                x:Name="ToolbarNewFolderItem"
-                                Command="{x:Bind ViewModel.CreateNewFolderCommand, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=Folder}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE8B7;" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                            <MenuFlyoutItem
-                                x:Name="NewFile"
-                                Command="{x:Bind ViewModel.CreateNewFileCommand, Mode=OneWay}"
-                                CommandParameter="{x:Null}"
-                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=BaseLayoutContextFlyoutNewFile/Text}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE7C3;" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                            <MenuFlyoutSeparator x:Name="NewMenuFileFolderSeparator" />
-                        </MenuFlyout>
-                    </AppBarButton.Flyout>
+	x:Class="Files.App.UserControls.InnerNavigationToolbar"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
+	xmlns:converters="using:Files.App.Converters"
+	xmlns:converters1="using:CommunityToolkit.WinUI.UI.Converters"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:helpers="using:Files.App.Helpers"
+	xmlns:local="using:Files.App.UserControls"
+	xmlns:local1="using:Files.App"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xh="using:Files.App.Helpers.XamlHelpers"
+	d:DesignHeight="40"
+	d:DesignWidth="400"
+	mc:Ignorable="d">
+	<UserControl.Resources>
+		<ResourceDictionary>
+			<Style x:Key="AccentColorFontIconStyle" TargetType="FontIcon" />
+			<converters1:BoolNegationConverter x:Key="BoolNegationConverter" />
+			<converters1:BoolToVisibilityConverter
+				x:Key="NegatedBoolToVisibilityConverter"
+				FalseValue="Visible"
+				TrueValue="Collapsed" />
+			<converters:IntToGroupOption x:Key="IntToGroupOption" />
+			<converters:IntToSortOption x:Key="IntToSortOption" />
+			<converters:IntToSortDirection x:Key="IntToSortDirection" />
+			<x:Boolean x:Key="True">True</x:Boolean>
+			<x:Boolean x:Key="False">False</x:Boolean>
+			<ResourceDictionary.MergedDictionaries>
+				<ResourceDictionary Source="/ResourceDictionaries/ToolbarButtonStyle.xaml" />
+				<ResourceDictionary Source="/ResourceDictionaries/PathIcons.xaml" />
+				<ResourceDictionary Source="/ResourceDictionaries/RightAlignedToggleSwitchStyle.xaml" />
+			</ResourceDictionary.MergedDictionaries>
+		</ResourceDictionary>
+	</UserControl.Resources>
+	<Grid BorderBrush="{ThemeResource ControlStrokeColorDefault}" BorderThickness="0,0,0,1">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="Auto" />
+		</Grid.ColumnDefinitions>
+		<CommandBar
+			x:Name="ContextCommandBar"
+			Grid.Column="0"
+			HorizontalAlignment="Left"
+			VerticalAlignment="Stretch"
+			DefaultLabelPosition="Right">
+			<CommandBar.Resources>
+				<ResourceDictionary>
+					<SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
+					<SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
+				</ResourceDictionary>
+			</CommandBar.Resources>
+			<CommandBar.PrimaryCommands>
+				<AppBarButton
+					x:Name="NewEmptySpaceAppBarButton"
+					AccessKey="W"
+					IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsCreateButtonEnabledInPage, Mode=OneWay, FallbackValue=False}"
+					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=BaseLayoutContextFlyoutNew/KeyboardAcceleratorTextOverride}"
+					Label="{helpers:ResourceString Name=BaseLayoutContextFlyoutNew/Label}"
+					Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}">
+					<AppBarButton.KeyboardAccelerators>
+						<KeyboardAccelerator
+							Key="N"
+							IsEnabled="False"
+							Modifiers="Control,Shift" />
+					</AppBarButton.KeyboardAccelerators>
+					<AppBarButton.Flyout>
+						<MenuFlyout x:Name="NewEmptySpace" Opening="NewEmptySpace_Opening">
+							<MenuFlyoutItem
+								x:Name="ToolbarNewFolderItem"
+								Command="{x:Bind ViewModel.CreateNewFolderCommand, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=Folder}">
+								<MenuFlyoutItem.Icon>
+									<FontIcon Glyph="&#xE8B7;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+							<MenuFlyoutItem
+								x:Name="NewFile"
+								Command="{x:Bind ViewModel.CreateNewFileCommand, Mode=OneWay}"
+								CommandParameter="{x:Null}"
+								IsEnabled="{x:Bind ViewModel.InstanceViewModel.CanCreateFileInPage, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=BaseLayoutContextFlyoutNewFile/Text}">
+								<MenuFlyoutItem.Icon>
+									<FontIcon Glyph="&#xE7C3;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+							<MenuFlyoutSeparator x:Name="NewMenuFileFolderSeparator" />
+						</MenuFlyout>
+					</AppBarButton.Flyout>
 
-                    <local:ColoredIcon
-                        Margin="0,1,0,-1"
-                        BaseLayerGlyph="&#xF037;"
-                        OverlayLayerGlyph="&#xF038;" />
-                </AppBarButton>
-                <AppBarSeparator />
-                <AppBarButton
-                    x:Name="CutButton"
-                    Width="Auto"
-                    MinWidth="40"
-                    AccessKey="X"
-                    Command="{x:Bind ViewModel.CutCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
-                    Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutCut/Text}"
-                    LabelPosition="Collapsed"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutCut/Text}">
-                    <AppBarButton.Content>
-                        <local:ColoredIcon BaseLayerGlyph="&#xF03D;" OverlayLayerGlyph="&#xF03E;" />
-                    </AppBarButton.Content>
-                </AppBarButton>
-                <AppBarButton
-                    Width="Auto"
-                    MinWidth="40"
-                    AccessKey="C"
-                    Command="{x:Bind ViewModel.CopyCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind ViewModel.CanCopy, Mode=OneWay, FallbackValue=False}"
-                    Label="{helpers:ResourceString Name=Copy}"
-                    LabelPosition="Collapsed"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=Copy}">
-                    <local:ColoredIcon BaseLayerGlyph="&#xF021;" OverlayLayerGlyph="&#xF022;" />
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="PasteButton"
-                    Width="Auto"
-                    MinWidth="40"
-                    AccessKey="P"
-                    Command="{x:Bind ViewModel.PasteItemsFromClipboardCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.InstanceViewModel.CanPasteInPage, local1:App.AppModel.IsPasteEnabled), Mode=OneWay, FallbackValue=False}"
-                    Label="{helpers:ResourceString Name=NavigationToolbarPaste/Label}"
-                    LabelPosition="Collapsed"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutContextFlyoutPaste/Text}">
-                    <AppBarButton.KeyboardAccelerators>
-                        <KeyboardAccelerator
-                            Key="V"
-                            IsEnabled="False"
-                            Modifiers="Control" />
-                    </AppBarButton.KeyboardAccelerators>
-                    <local:ColoredIcon BaseLayerGlyph="&#xF023;" OverlayLayerGlyph="&#xF024;" />
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="RenameButton"
-                    Width="Auto"
-                    MinWidth="40"
-                    AccessKey="M"
-                    Command="{x:Bind ViewModel.Rename, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanRename, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
-                    Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutRename/Text}"
-                    LabelPosition="Collapsed"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutRename/Text}">
-                    <AppBarButton.Content>
-                        <local:ColoredIcon BaseLayerGlyph="&#xF027;" OverlayLayerGlyph="&#xF028;" />
-                    </AppBarButton.Content>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="ShareButton"
-                    Width="Auto"
-                    MinWidth="40"
-                    AccessKey="H"
-                    Command="{x:Bind ViewModel.Share, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanShare, ViewModel.InstanceViewModel.CanShareInPage), Mode=OneWay, FallbackValue=False}"
-                    Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutShare/Text}"
-                    LabelPosition="Collapsed"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutShare/Text}">
-                    <AppBarButton.Content>
-                        <local:ColoredIcon BaseLayerGlyph="&#xF025;" OverlayLayerGlyph="&#xF026;" />
-                    </AppBarButton.Content>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="DeleteButton"
-                    Width="Auto"
-                    MinWidth="40"
-                    Command="{x:Bind ViewModel.DeleteCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
-                    Label="{helpers:ResourceString Name=Delete}"
-                    LabelPosition="Collapsed"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=Delete}">
-                    <AppBarButton.Content>
-                        <local:ColoredIcon BaseLayerGlyph="&#xF035;" OverlayLayerGlyph="&#xF036;" />
-                    </AppBarButton.Content>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="PropertiesButton"
-                    Width="Auto"
-                    MinWidth="40"
-                    AccessKey="O"
-                    AutomationProperties.Name="{helpers:ResourceString Name=PropertiesTitle}"
-                    Command="{x:Bind ViewModel.PropertiesCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanViewProperties, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
-                    Label="{helpers:ResourceString Name=PropertiesTitle}"
-                    LabelPosition="Collapsed"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=PropertiesTitle}">
-                    <AppBarButton.Content>
-                        <local:ColoredIcon BaseLayerGlyph="&#xF031;" OverlayLayerGlyph="&#xF032;" />
-                    </AppBarButton.Content>
-                </AppBarButton>
-                <AppBarSeparator x:Name="AdditionalActionSeparator" x:Load="{x:Bind ViewModel.HasAdditionalAction, Mode=OneWay}" />
-                <AppBarButton
-                    x:Name="EmptyRecycleBinButton"
-                    x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
-                    AccessKey="B"
-                    Command="{x:Bind ViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind ViewModel.CanEmptyRecycleBin, Mode=OneWay}"
-                    Label="{helpers:ResourceString Name=EmptyRecycleBin}"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=EmptyRecycleBin}">
-                    <AppBarButton.Icon>
-                        <FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />
-                    </AppBarButton.Icon>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="RestoreRecycleBinButton"
-                    x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
-                    AccessKey="R"
-                    Command="{x:Bind ViewModel.RestoreRecycleBinCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind ViewModel.CanRestoreRecycleBin, Mode=OneWay}"
-                    Label="{helpers:ResourceString Name=RestoreAllItems}"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=RestoreAllItems}"
-                    Visibility="{x:Bind ViewModel.CanRestoreRecycleBin, Mode=OneWay}">
-                    <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE777;" />
-                    </AppBarButton.Icon>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="RestoreSelectionRecycleBinButton"
-                    x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
-                    AccessKey="R"
-                    Command="{x:Bind ViewModel.RestoreSelectionRecycleBinCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind ViewModel.CanRestoreSelectionRecycleBin, Mode=OneWay}"
-                    Label="{helpers:ResourceString Name=RestoreSelection}"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=RestoreSelection}"
-                    Visibility="{x:Bind ViewModel.CanRestoreSelectionRecycleBin, Mode=OneWay}">
-                    <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE777;" />
-                    </AppBarButton.Icon>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="ExtractButton"
-                    Width="Auto"
-                    MinWidth="40"
-                    x:Load="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
-                    AccessKey="Z"
-                    IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
-                    Label="{helpers:ResourceString Name=Extract}"
-                    LabelPosition="Default"
-                    Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}">
-                    <AppBarButton.Content>
-                        <local:ColoredIcon BaseLayerGlyph="&#xF03F;" OverlayLayerGlyph="&#xF040;" />
-                    </AppBarButton.Content>
-                    <AppBarButton.Flyout>
-                        <MenuFlyout helpers:MenuFlyoutHelper.IsVisible="{x:Bind ViewModel.CanExtract, Mode=OneWay}" Placement="Bottom">
-                            <MenuFlyoutItem
-                                x:Name="ExtractSingle"
-                                x:Load="{x:Bind ViewModel.IsMultipleArchivesSelected, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-                                Command="{x:Bind ViewModel.ExtractCommand, Mode=OneWay}"
-                                IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
-                                KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=ExtractKeyboardAcceleratorTextOverride}"
-                                Text="{helpers:ResourceString Name=ExtractFiles}">
-                                <MenuFlyoutItem.KeyboardAccelerators>
-                                    <KeyboardAccelerator
-                                        Key="E"
-                                        IsEnabled="False"
-                                        Modifiers="Control" />
-                                </MenuFlyoutItem.KeyboardAccelerators>
-                            </MenuFlyoutItem>
-                            <MenuFlyoutItem
-                                x:Name="ExtractHere"
-                                x:Load="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-                                Command="{x:Bind ViewModel.ExtractHereCommand, Mode=OneWay}"
-                                IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
-                                Text="{helpers:ResourceString Name=ExtractHere}" />
-                            <MenuFlyoutItem
-                                x:Name="ExtractTo"
-                                x:Load="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-                                Command="{x:Bind ViewModel.ExtractToCommand, Mode=OneWay}"
-                                IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
-                                Text="{x:Bind ViewModel.ExtractToText, Mode=OneWay}" />
-                        </MenuFlyout>
-                    </AppBarButton.Flyout>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="RunWithPowerShellButton"
-                    Width="Auto"
-                    MinWidth="40"
-                    x:Load="{x:Bind ViewModel.IsPowerShellScript, Mode=OneWay, FallbackValue=False}"
-                    AutomationProperties.Name="RunWithPowerShell"
-                    Command="{x:Bind ViewModel.RunWithPowerShellCommand, Mode=OneWay}"
-                    Label="{helpers:ResourceString Name=RunScript}"
-                    LabelPosition="Default"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=RunWithPowerShell}">
-                    <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE756;" />
-                    </AppBarButton.Icon>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="SetAsBackgroundButton"
-                    Width="Auto"
-                    MinWidth="40"
-                    x:Load="{x:Bind converters:MultiBooleanConverter.AndNotConvert(ViewModel.IsImage, ViewModel.IsMultipleImageSelected), Mode=OneWay}"
-                    Label="{helpers:ResourceString Name=SetAsBackgroundFlyout}"
-                    LabelPosition="Default"
-                    Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsBackgroundFlyout}">
-                    <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE91B;" />
-                    </AppBarButton.Icon>
-                    <AppBarButton.Flyout>
-                        <MenuFlyout Placement="Bottom">
-                            <MenuFlyoutItem
-                                x:Name="SetAsBackgroundFlyoutItem"
-                                Command="{x:Bind ViewModel.SetAsBackgroundCommand, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=Desktop}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xE91B;" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                            <MenuFlyoutItem
-                                x:Name="SetAsLockscreenFlyoutItem"
-                                Command="{x:Bind ViewModel.SetAsLockscreenBackgroundCommand, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=Lockscreen}">
-                                <MenuFlyoutItem.Icon>
-                                    <FontIcon Glyph="&#xEE3F;" />
-                                </MenuFlyoutItem.Icon>
-                            </MenuFlyoutItem>
-                        </MenuFlyout>
-                    </AppBarButton.Flyout>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="SetAsSlideshowButton"
-                    Width="Auto"
-                    MinWidth="40"
-                    x:Load="{x:Bind ViewModel.IsMultipleImageSelected, Mode=OneWay, FallbackValue=False}"
-                    Command="{x:Bind ViewModel.SetAsSlideshowCommand, Mode=OneWay}"
-                    Label="{helpers:ResourceString Name=SetAsSlideshow}"
-                    LabelPosition="Default"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsSlideshow}">
-                    <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE91B;" />
-                    </AppBarButton.Icon>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="InstallInfButton"
-                    x:Load="{x:Bind ViewModel.IsInfFile, Mode=OneWay, FallbackValue=False}"
-                    AutomationProperties.Name="InstallInf"
-                    Command="{x:Bind ViewModel.InstallInfCommand, Mode=OneWay}"
-                    Label="{helpers:ResourceString Name=Install}"
-                    LabelPosition="Default"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
-                    <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE9F5;" />
-                    </AppBarButton.Icon>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="RotateImageLeftButton"
-                    x:Load="{x:Bind ViewModel.IsImage, Mode=OneWay, FallbackValue=False}"
-                    Command="{x:Bind ViewModel.RotateImageLeftCommand, Mode=OneWay}"
-                    Label="{helpers:ResourceString Name=RotateLeft}"
-                    LabelPosition="Default"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=RotateLeft}">
-                    <AppBarButton.Content>
-                        <local:ColoredIcon BaseLayerGlyph="&#xF043;" OverlayLayerGlyph="&#xF044;" />
-                    </AppBarButton.Content>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="RotateImageRightButton"
-                    x:Load="{x:Bind ViewModel.IsImage, Mode=OneWay, FallbackValue=False}"
-                    Command="{x:Bind ViewModel.RotateImageRightCommand, Mode=OneWay}"
-                    Label="{helpers:ResourceString Name=RotateRight}"
-                    LabelPosition="Default"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=RotateRight}">
-                    <AppBarButton.Content>
-                        <local:ColoredIcon BaseLayerGlyph="&#xF045;" OverlayLayerGlyph="&#xF046;" />
-                    </AppBarButton.Content>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="InstallFontButton"
-                    x:Load="{x:Bind ViewModel.IsFont, Mode=OneWay, FallbackValue=False}"
-                    Command="{x:Bind ViewModel.InstallFontCommand, Mode=OneWay}"
-                    Label="{helpers:ResourceString Name=Install}"
-                    LabelPosition="Default"
-                    ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
-                    <AppBarButton.Content>
-                        <local:ColoredIcon BaseLayerGlyph="&#xF041;" OverlayLayerGlyph="&#xF042;" />
-                    </AppBarButton.Content>
-                </AppBarButton>
-            </CommandBar.PrimaryCommands>
-        </CommandBar>
-        <CommandBar
-            x:Name="BaseCommandBar"
-            Grid.Column="1"
-            HorizontalAlignment="Stretch"
-            VerticalAlignment="Center"
-            DefaultLabelPosition="Right">
-            <CommandBar.Resources>
-                <ResourceDictionary>
-                    <SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
-                    <SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
-                </ResourceDictionary>
-            </CommandBar.Resources>
-            <AppBarButton
-                x:Name="SelectionOptions"
-                Width="Auto"
-                MinWidth="40"
-                x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-                AccessKey="S"
-                AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSelectionOptions/AutomationProperties/Name}"
-                Label="{helpers:ResourceString Name=NavToolbarSelectionOptions/Label}"
-                LabelPosition="Collapsed"
-                Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
-                ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSelectionOptions/ToolTipService/ToolTip}">
-                <AppBarButton.Flyout>
-                    <MenuFlyout Placement="Bottom">
-                        <ToggleMenuFlyoutItem
-                            x:Name="MultiselectMFI"
-                            IsChecked="{x:Bind AppModel.MultiselectEnabled, Mode=TwoWay}"
-                            Text="{helpers:ResourceString Name=NavToolbarMultiselect/Text}">
-                            <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xE762;" />
-                            </MenuFlyoutItem.Icon>
-                        </ToggleMenuFlyoutItem>
-                        <MenuFlyoutItem
-                            x:Name="SelectAllMFI"
-                            Command="{x:Bind ViewModel.SelectAllContentPageItemsCommand, Mode=OneWay}"
-                            Text="{helpers:ResourceString Name=NavToolbarSelectAll/Text}">
-                            <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xE8B3;" />
-                            </MenuFlyoutItem.Icon>
-                            <MenuFlyoutItem.KeyboardAccelerators>
-                                <KeyboardAccelerator
-                                    Key="A"
-                                    IsEnabled="False"
-                                    Modifiers="Control" />
-                            </MenuFlyoutItem.KeyboardAccelerators>
-                        </MenuFlyoutItem>
-                        <MenuFlyoutItem
-                            x:Name="InvertSelectionMFI"
-                            Command="{x:Bind ViewModel.InvertContentPageSelctionCommand, Mode=OneWay}"
-                            Text="{helpers:ResourceString Name=NavToolbarInvertSelection/Text}">
-                            <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xE746;" />
-                            </MenuFlyoutItem.Icon>
-                        </MenuFlyoutItem>
-                        <MenuFlyoutItem
-                            x:Name="ClearSelectionMFI"
-                            Command="{x:Bind ViewModel.ClearContentPageSelectionCommand, Mode=OneWay}"
-                            Text="{helpers:ResourceString Name=NavToolbarClearSelection/Text}">
-                            <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xE8E6;" />
-                            </MenuFlyoutItem.Icon>
-                        </MenuFlyoutItem>
-                    </MenuFlyout>
-                </AppBarButton.Flyout>
+					<local:ColoredIcon
+						Margin="0,1,0,-1"
+						BaseLayerGlyph="&#xF037;"
+						OverlayLayerGlyph="&#xF038;" />
+				</AppBarButton>
+				<AppBarSeparator />
+				<AppBarButton
+					x:Name="CutButton"
+					Width="Auto"
+					MinWidth="40"
+					AccessKey="X"
+					Command="{x:Bind ViewModel.CutCommand, Mode=OneWay}"
+					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
+					Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutCut/Text}"
+					LabelPosition="Collapsed"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutCut/Text}">
+					<AppBarButton.Content>
+						<local:ColoredIcon BaseLayerGlyph="&#xF03D;" OverlayLayerGlyph="&#xF03E;" />
+					</AppBarButton.Content>
+				</AppBarButton>
+				<AppBarButton
+					Width="Auto"
+					MinWidth="40"
+					AccessKey="C"
+					Command="{x:Bind ViewModel.CopyCommand, Mode=OneWay}"
+					IsEnabled="{x:Bind ViewModel.CanCopy, Mode=OneWay, FallbackValue=False}"
+					Label="{helpers:ResourceString Name=Copy}"
+					LabelPosition="Collapsed"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=Copy}">
+					<local:ColoredIcon BaseLayerGlyph="&#xF021;" OverlayLayerGlyph="&#xF022;" />
+				</AppBarButton>
+				<AppBarButton
+					x:Name="PasteButton"
+					Width="Auto"
+					MinWidth="40"
+					AccessKey="P"
+					Command="{x:Bind ViewModel.PasteItemsFromClipboardCommand, Mode=OneWay}"
+					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.InstanceViewModel.CanPasteInPage, local1:App.AppModel.IsPasteEnabled), Mode=OneWay, FallbackValue=False}"
+					Label="{helpers:ResourceString Name=NavigationToolbarPaste/Label}"
+					LabelPosition="Collapsed"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutContextFlyoutPaste/Text}">
+					<AppBarButton.KeyboardAccelerators>
+						<KeyboardAccelerator
+							Key="V"
+							IsEnabled="False"
+							Modifiers="Control" />
+					</AppBarButton.KeyboardAccelerators>
+					<local:ColoredIcon BaseLayerGlyph="&#xF023;" OverlayLayerGlyph="&#xF024;" />
+				</AppBarButton>
+				<AppBarButton
+					x:Name="RenameButton"
+					Width="Auto"
+					MinWidth="40"
+					AccessKey="M"
+					Command="{x:Bind ViewModel.Rename, Mode=OneWay}"
+					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanRename, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
+					Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutRename/Text}"
+					LabelPosition="Collapsed"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutRename/Text}">
+					<AppBarButton.Content>
+						<local:ColoredIcon BaseLayerGlyph="&#xF027;" OverlayLayerGlyph="&#xF028;" />
+					</AppBarButton.Content>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="ShareButton"
+					Width="Auto"
+					MinWidth="40"
+					AccessKey="H"
+					Command="{x:Bind ViewModel.Share, Mode=OneWay}"
+					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanShare, ViewModel.InstanceViewModel.CanShareInPage), Mode=OneWay, FallbackValue=False}"
+					Label="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutShare/Text}"
+					LabelPosition="Collapsed"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=BaseLayoutItemContextFlyoutShare/Text}">
+					<AppBarButton.Content>
+						<local:ColoredIcon BaseLayerGlyph="&#xF025;" OverlayLayerGlyph="&#xF026;" />
+					</AppBarButton.Content>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="DeleteButton"
+					Width="Auto"
+					MinWidth="40"
+					Command="{x:Bind ViewModel.DeleteCommand, Mode=OneWay}"
+					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanCopy, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
+					Label="{helpers:ResourceString Name=Delete}"
+					LabelPosition="Collapsed"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=Delete}">
+					<AppBarButton.Content>
+						<local:ColoredIcon BaseLayerGlyph="&#xF035;" OverlayLayerGlyph="&#xF036;" />
+					</AppBarButton.Content>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="PropertiesButton"
+					Width="Auto"
+					MinWidth="40"
+					AccessKey="O"
+					AutomationProperties.Name="{helpers:ResourceString Name=PropertiesTitle}"
+					Command="{x:Bind ViewModel.PropertiesCommand, Mode=OneWay}"
+					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.CanViewProperties, ViewModel.InstanceViewModel.IsPageTypeNotHome), Mode=OneWay, FallbackValue=False}"
+					Label="{helpers:ResourceString Name=PropertiesTitle}"
+					LabelPosition="Collapsed"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=PropertiesTitle}">
+					<AppBarButton.Content>
+						<local:ColoredIcon BaseLayerGlyph="&#xF031;" OverlayLayerGlyph="&#xF032;" />
+					</AppBarButton.Content>
+				</AppBarButton>
+				<AppBarSeparator x:Name="AdditionalActionSeparator" x:Load="{x:Bind ViewModel.HasAdditionalAction, Mode=OneWay}" />
+				<AppBarButton
+					x:Name="EmptyRecycleBinButton"
+					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
+					AccessKey="B"
+					Command="{x:Bind ViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
+					IsEnabled="{x:Bind ViewModel.CanEmptyRecycleBin, Mode=OneWay}"
+					Label="{helpers:ResourceString Name=EmptyRecycleBin}"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=EmptyRecycleBin}">
+					<AppBarButton.Icon>
+						<FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="RestoreRecycleBinButton"
+					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
+					AccessKey="R"
+					Command="{x:Bind ViewModel.RestoreRecycleBinCommand, Mode=OneWay}"
+					IsEnabled="{x:Bind ViewModel.CanRestoreRecycleBin, Mode=OneWay}"
+					Label="{helpers:ResourceString Name=RestoreAllItems}"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=RestoreAllItems}"
+					Visibility="{x:Bind ViewModel.CanRestoreRecycleBin, Mode=OneWay}">
+					<AppBarButton.Icon>
+						<FontIcon Glyph="&#xE777;" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="RestoreSelectionRecycleBinButton"
+					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
+					AccessKey="R"
+					Command="{x:Bind ViewModel.RestoreSelectionRecycleBinCommand, Mode=OneWay}"
+					IsEnabled="{x:Bind ViewModel.CanRestoreSelectionRecycleBin, Mode=OneWay}"
+					Label="{helpers:ResourceString Name=RestoreSelection}"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=RestoreSelection}"
+					Visibility="{x:Bind ViewModel.CanRestoreSelectionRecycleBin, Mode=OneWay}">
+					<AppBarButton.Icon>
+						<FontIcon Glyph="&#xE777;" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="ExtractButton"
+					Width="Auto"
+					MinWidth="40"
+					x:Load="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
+					AccessKey="Z"
+					IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
+					Label="{helpers:ResourceString Name=Extract}"
+					LabelPosition="Default"
+					Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}">
+					<AppBarButton.Content>
+						<local:ColoredIcon BaseLayerGlyph="&#xF03F;" OverlayLayerGlyph="&#xF040;" />
+					</AppBarButton.Content>
+					<AppBarButton.Flyout>
+						<MenuFlyout helpers:MenuFlyoutHelper.IsVisible="{x:Bind ViewModel.CanExtract, Mode=OneWay}" Placement="Bottom">
+							<MenuFlyoutItem
+								x:Name="ExtractSingle"
+								x:Load="{x:Bind ViewModel.IsMultipleArchivesSelected, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+								Command="{x:Bind ViewModel.ExtractCommand, Mode=OneWay}"
+								IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
+								KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=ExtractKeyboardAcceleratorTextOverride}"
+								Text="{helpers:ResourceString Name=ExtractFiles}">
+								<MenuFlyoutItem.KeyboardAccelerators>
+									<KeyboardAccelerator
+										Key="E"
+										IsEnabled="False"
+										Modifiers="Control" />
+								</MenuFlyoutItem.KeyboardAccelerators>
+							</MenuFlyoutItem>
+							<MenuFlyoutItem
+								x:Name="ExtractHere"
+								x:Load="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+								Command="{x:Bind ViewModel.ExtractHereCommand, Mode=OneWay}"
+								IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
+								Text="{helpers:ResourceString Name=ExtractHere}" />
+							<MenuFlyoutItem
+								x:Name="ExtractTo"
+								x:Load="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+								Command="{x:Bind ViewModel.ExtractToCommand, Mode=OneWay}"
+								IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
+								Text="{x:Bind ViewModel.ExtractToText, Mode=OneWay}" />
+						</MenuFlyout>
+					</AppBarButton.Flyout>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="RunWithPowerShellButton"
+					Width="Auto"
+					MinWidth="40"
+					x:Load="{x:Bind ViewModel.IsPowerShellScript, Mode=OneWay, FallbackValue=False}"
+					AutomationProperties.Name="RunWithPowerShell"
+					Command="{x:Bind ViewModel.RunWithPowerShellCommand, Mode=OneWay}"
+					Label="{helpers:ResourceString Name=RunScript}"
+					LabelPosition="Default"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=RunWithPowerShell}">
+					<AppBarButton.Icon>
+						<FontIcon Glyph="&#xE756;" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="SetAsBackgroundButton"
+					Width="Auto"
+					MinWidth="40"
+					x:Load="{x:Bind converters:MultiBooleanConverter.AndNotConvert(ViewModel.IsImage, ViewModel.IsMultipleImageSelected), Mode=OneWay}"
+					Label="{helpers:ResourceString Name=SetAsBackgroundFlyout}"
+					LabelPosition="Default"
+					Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsBackgroundFlyout}">
+					<AppBarButton.Icon>
+						<FontIcon Glyph="&#xE91B;" />
+					</AppBarButton.Icon>
+					<AppBarButton.Flyout>
+						<MenuFlyout Placement="Bottom">
+							<MenuFlyoutItem
+								x:Name="SetAsBackgroundFlyoutItem"
+								Command="{x:Bind ViewModel.SetAsBackgroundCommand, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=Desktop}">
+								<MenuFlyoutItem.Icon>
+									<FontIcon Glyph="&#xE91B;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+							<MenuFlyoutItem
+								x:Name="SetAsLockscreenFlyoutItem"
+								Command="{x:Bind ViewModel.SetAsLockscreenBackgroundCommand, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=Lockscreen}">
+								<MenuFlyoutItem.Icon>
+									<FontIcon Glyph="&#xEE3F;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+						</MenuFlyout>
+					</AppBarButton.Flyout>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="SetAsSlideshowButton"
+					Width="Auto"
+					MinWidth="40"
+					x:Load="{x:Bind ViewModel.IsMultipleImageSelected, Mode=OneWay, FallbackValue=False}"
+					Command="{x:Bind ViewModel.SetAsSlideshowCommand, Mode=OneWay}"
+					Label="{helpers:ResourceString Name=SetAsSlideshow}"
+					LabelPosition="Default"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsSlideshow}">
+					<AppBarButton.Icon>
+						<FontIcon Glyph="&#xE91B;" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="InstallInfButton"
+					x:Load="{x:Bind ViewModel.IsInfFile, Mode=OneWay, FallbackValue=False}"
+					AutomationProperties.Name="InstallInf"
+					Command="{x:Bind ViewModel.InstallInfCommand, Mode=OneWay}"
+					Label="{helpers:ResourceString Name=Install}"
+					LabelPosition="Default"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
+					<AppBarButton.Icon>
+						<FontIcon Glyph="&#xE9F5;" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="RotateImageLeftButton"
+					x:Load="{x:Bind ViewModel.IsImage, Mode=OneWay, FallbackValue=False}"
+					Command="{x:Bind ViewModel.RotateImageLeftCommand, Mode=OneWay}"
+					Label="{helpers:ResourceString Name=RotateLeft}"
+					LabelPosition="Default"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=RotateLeft}">
+					<AppBarButton.Content>
+						<local:ColoredIcon BaseLayerGlyph="&#xF043;" OverlayLayerGlyph="&#xF044;" />
+					</AppBarButton.Content>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="RotateImageRightButton"
+					x:Load="{x:Bind ViewModel.IsImage, Mode=OneWay, FallbackValue=False}"
+					Command="{x:Bind ViewModel.RotateImageRightCommand, Mode=OneWay}"
+					Label="{helpers:ResourceString Name=RotateRight}"
+					LabelPosition="Default"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=RotateRight}">
+					<AppBarButton.Content>
+						<local:ColoredIcon BaseLayerGlyph="&#xF045;" OverlayLayerGlyph="&#xF046;" />
+					</AppBarButton.Content>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="InstallFontButton"
+					x:Load="{x:Bind ViewModel.IsFont, Mode=OneWay, FallbackValue=False}"
+					Command="{x:Bind ViewModel.InstallFontCommand, Mode=OneWay}"
+					Label="{helpers:ResourceString Name=Install}"
+					LabelPosition="Default"
+					ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
+					<AppBarButton.Content>
+						<local:ColoredIcon BaseLayerGlyph="&#xF041;" OverlayLayerGlyph="&#xF042;" />
+					</AppBarButton.Content>
+				</AppBarButton>
+			</CommandBar.PrimaryCommands>
+		</CommandBar>
+		<CommandBar
+			x:Name="BaseCommandBar"
+			Grid.Column="1"
+			HorizontalAlignment="Stretch"
+			VerticalAlignment="Center"
+			DefaultLabelPosition="Right">
+			<CommandBar.Resources>
+				<ResourceDictionary>
+					<SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
+					<SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
+				</ResourceDictionary>
+			</CommandBar.Resources>
+			<AppBarButton
+				x:Name="SelectionOptions"
+				Width="Auto"
+				MinWidth="40"
+				x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+				AccessKey="S"
+				AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSelectionOptions/AutomationProperties/Name}"
+				Label="{helpers:ResourceString Name=NavToolbarSelectionOptions/Label}"
+				LabelPosition="Collapsed"
+				Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
+				ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSelectionOptions/ToolTipService/ToolTip}">
+				<AppBarButton.Flyout>
+					<MenuFlyout Placement="Bottom">
+						<ToggleMenuFlyoutItem
+							x:Name="MultiselectMFI"
+							IsChecked="{x:Bind AppModel.MultiselectEnabled, Mode=TwoWay}"
+							Text="{helpers:ResourceString Name=NavToolbarMultiselect/Text}">
+							<MenuFlyoutItem.Icon>
+								<FontIcon Glyph="&#xE762;" />
+							</MenuFlyoutItem.Icon>
+						</ToggleMenuFlyoutItem>
+						<MenuFlyoutItem
+							x:Name="SelectAllMFI"
+							Command="{x:Bind ViewModel.SelectAllContentPageItemsCommand, Mode=OneWay}"
+							Text="{helpers:ResourceString Name=NavToolbarSelectAll/Text}">
+							<MenuFlyoutItem.Icon>
+								<FontIcon Glyph="&#xE8B3;" />
+							</MenuFlyoutItem.Icon>
+							<MenuFlyoutItem.KeyboardAccelerators>
+								<KeyboardAccelerator
+									Key="A"
+									IsEnabled="False"
+									Modifiers="Control" />
+							</MenuFlyoutItem.KeyboardAccelerators>
+						</MenuFlyoutItem>
+						<MenuFlyoutItem
+							x:Name="InvertSelectionMFI"
+							Command="{x:Bind ViewModel.InvertContentPageSelctionCommand, Mode=OneWay}"
+							Text="{helpers:ResourceString Name=NavToolbarInvertSelection/Text}">
+							<MenuFlyoutItem.Icon>
+								<FontIcon Glyph="&#xE746;" />
+							</MenuFlyoutItem.Icon>
+						</MenuFlyoutItem>
+						<MenuFlyoutItem
+							x:Name="ClearSelectionMFI"
+							Command="{x:Bind ViewModel.ClearContentPageSelectionCommand, Mode=OneWay}"
+							Text="{helpers:ResourceString Name=NavToolbarClearSelection/Text}">
+							<MenuFlyoutItem.Icon>
+								<FontIcon Glyph="&#xE8E6;" />
+							</MenuFlyoutItem.Icon>
+						</MenuFlyoutItem>
+					</MenuFlyout>
+				</AppBarButton.Flyout>
 
-                <local:ColoredIcon BaseLayerGlyph="&#xF02B;" OverlayLayerGlyph="&#xF02C;" />
-            </AppBarButton>
-            <AppBarButton
-                x:Name="ArrangementOptions"
-                Width="Auto"
-                MinWidth="40"
-                x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-                AccessKey="A"
-                AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSortOptionsButton/AutomationProperties/Name}"
-                Label="{helpers:ResourceString Name=NavToolbarSortOptionsButton/Label}"
-                LabelPosition="Collapsed"
-                Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
-                ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSortOptionsButton/ToolTipService/ToolTip}">
-                <AppBarButton.Content>
-                    <local:ColoredIcon BaseLayerGlyph="&#xF029;" OverlayLayerGlyph="&#xF02A;" />
-                </AppBarButton.Content>
-                <AppBarButton.Flyout>
-                    <MenuFlyout contract8Present:ShouldConstrainToRootBounds="False" Placement="Bottom">
-                        <MenuFlyoutSubItem Text="{helpers:ResourceString Name=NavToolbarSortByRadioButtons/Text}">
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByName, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionName/Text}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByDateModified, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateModifiedLowerCase}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByDateCreated, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateCreated}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedBySize, Mode=TwoWay}" Text="{helpers:ResourceString Name=Size}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByType, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionType/Text}" />
-                            <ToggleMenuFlyoutItem
-                                IsChecked="{x:Bind ViewModel.IsSortedBySyncStatus, Mode=TwoWay}"
-                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeCloudDrive, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=SyncStatus}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByFileTag, Mode=TwoWay}" Text="{helpers:ResourceString Name=FileTags}" />
-                            <ToggleMenuFlyoutItem
-                                IsChecked="{x:Bind ViewModel.IsSortedByOriginalFolder, Mode=TwoWay}"
-                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=NavToolbarArrangementOptionOriginalFolder/Text}" />
-                            <ToggleMenuFlyoutItem
-                                IsChecked="{x:Bind ViewModel.IsSortedByDateDeleted, Mode=TwoWay}"
-                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=DateDeleted}" />
-                        </MenuFlyoutSubItem>
-                        <MenuFlyoutSubItem Text="{helpers:ResourceString Name=NavToolbarGroupByRadioButtons/Text}">
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByNone, Mode=TwoWay}" Text="{helpers:ResourceString Name=None}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByName, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionName/Text}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByDateModified, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateModifiedLowerCase}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByDateCreated, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateCreated}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedBySize, Mode=TwoWay}" Text="{helpers:ResourceString Name=Size}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByType, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionType/Text}" />
-                            <ToggleMenuFlyoutItem
-                                IsChecked="{x:Bind ViewModel.IsGroupedBySyncStatus, Mode=TwoWay}"
-                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeCloudDrive, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=SyncStatus}" />
-                            <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByFileTag, Mode=TwoWay}" Text="{helpers:ResourceString Name=FileTags}" />
-                            <ToggleMenuFlyoutItem
-                                IsChecked="{x:Bind ViewModel.IsGroupedByOriginalFolder, Mode=TwoWay}"
-                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=NavToolbarArrangementOptionOriginalFolder/Text}" />
-                            <ToggleMenuFlyoutItem
-                                IsChecked="{x:Bind ViewModel.IsGroupedByDateDeleted, Mode=TwoWay}"
-                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=DateDeleted}" />
-                            <ToggleMenuFlyoutItem
-                                IsChecked="{x:Bind ViewModel.IsGroupedByFolderPath, Mode=TwoWay}"
-                                IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeLibrary, Mode=OneWay}"
-                                Text="{helpers:ResourceString Name=NavToolbarArrangementOptionFolderPath/Text}" />
-                        </MenuFlyoutSubItem>
-                        <MenuFlyoutSeparator />
-                        <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedAscending, Mode=TwoWay}" Text="{helpers:ResourceString Name=Ascending}" />
-                        <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedDescending, Mode=TwoWay}" Text="{helpers:ResourceString Name=Descending}" />
-                        <MenuFlyoutSeparator />
-                        <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.AreDirectoriesSortedAlongsideFiles, Mode=TwoWay}" Text="{helpers:ResourceString Name=SettingsListAndSortDirectoriesAlongsideFiles}" />
-                    </MenuFlyout>
-                </AppBarButton.Flyout>
-            </AppBarButton>
-            <AppBarButton
-                x:Name="LayoutOptionsButton"
-                Width="Auto"
-                MinWidth="40"
-                x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-                AccessKey="L"
-                AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/AutomationProperties/Name}"
-                Label="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/Label}"
-                LabelPosition="Collapsed"
-                Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
-                ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/ToolTipService/ToolTip}">
-                <AppBarButton.Icon>
-                    <FontIcon FontSize="10" Glyph="&#xE152;" />
-                </AppBarButton.Icon>
-                <AppBarButton.Flyout>
-                    <Flyout contract8Present:ShouldConstrainToRootBounds="False" Placement="Bottom">
-                        <StackPanel Spacing="12">
-                            <TextBlock FontWeight="Medium" Text="{helpers:ResourceString Name=NavToolbarLayout/Text}" />
+				<local:ColoredIcon BaseLayerGlyph="&#xF02B;" OverlayLayerGlyph="&#xF02C;" />
+			</AppBarButton>
+			<AppBarButton
+				x:Name="ArrangementOptions"
+				Width="Auto"
+				MinWidth="40"
+				x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+				AccessKey="A"
+				AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSortOptionsButton/AutomationProperties/Name}"
+				Label="{helpers:ResourceString Name=NavToolbarSortOptionsButton/Label}"
+				LabelPosition="Collapsed"
+				Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
+				ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSortOptionsButton/ToolTipService/ToolTip}">
+				<AppBarButton.Content>
+					<local:ColoredIcon BaseLayerGlyph="&#xF029;" OverlayLayerGlyph="&#xF02A;" />
+				</AppBarButton.Content>
+				<AppBarButton.Flyout>
+					<MenuFlyout contract8Present:ShouldConstrainToRootBounds="False" Placement="Bottom">
+						<MenuFlyoutSubItem Text="{helpers:ResourceString Name=NavToolbarSortByRadioButtons/Text}">
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByName, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionName/Text}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByDateModified, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateModifiedLowerCase}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByDateCreated, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateCreated}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedBySize, Mode=TwoWay}" Text="{helpers:ResourceString Name=Size}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByType, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionType/Text}" />
+							<ToggleMenuFlyoutItem
+								IsChecked="{x:Bind ViewModel.IsSortedBySyncStatus, Mode=TwoWay}"
+								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeCloudDrive, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=SyncStatus}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedByFileTag, Mode=TwoWay}" Text="{helpers:ResourceString Name=FileTags}" />
+							<ToggleMenuFlyoutItem
+								IsChecked="{x:Bind ViewModel.IsSortedByOriginalFolder, Mode=TwoWay}"
+								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=NavToolbarArrangementOptionOriginalFolder/Text}" />
+							<ToggleMenuFlyoutItem
+								IsChecked="{x:Bind ViewModel.IsSortedByDateDeleted, Mode=TwoWay}"
+								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=DateDeleted}" />
+						</MenuFlyoutSubItem>
+						<MenuFlyoutSubItem Text="{helpers:ResourceString Name=NavToolbarGroupByRadioButtons/Text}">
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByNone, Mode=TwoWay}" Text="{helpers:ResourceString Name=None}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByName, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionName/Text}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByDateModified, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateModifiedLowerCase}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByDateCreated, Mode=TwoWay}" Text="{helpers:ResourceString Name=DateCreated}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedBySize, Mode=TwoWay}" Text="{helpers:ResourceString Name=Size}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByType, Mode=TwoWay}" Text="{helpers:ResourceString Name=NavToolbarArrangementOptionType/Text}" />
+							<ToggleMenuFlyoutItem
+								IsChecked="{x:Bind ViewModel.IsGroupedBySyncStatus, Mode=TwoWay}"
+								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeCloudDrive, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=SyncStatus}" />
+							<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsGroupedByFileTag, Mode=TwoWay}" Text="{helpers:ResourceString Name=FileTags}" />
+							<ToggleMenuFlyoutItem
+								IsChecked="{x:Bind ViewModel.IsGroupedByOriginalFolder, Mode=TwoWay}"
+								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=NavToolbarArrangementOptionOriginalFolder/Text}" />
+							<ToggleMenuFlyoutItem
+								IsChecked="{x:Bind ViewModel.IsGroupedByDateDeleted, Mode=TwoWay}"
+								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=DateDeleted}" />
+							<ToggleMenuFlyoutItem
+								IsChecked="{x:Bind ViewModel.IsGroupedByFolderPath, Mode=TwoWay}"
+								IsEnabled="{x:Bind ViewModel.InstanceViewModel.IsPageTypeLibrary, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=NavToolbarArrangementOptionFolderPath/Text}" />
+						</MenuFlyoutSubItem>
+						<MenuFlyoutSeparator />
+						<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedAscending, Mode=TwoWay}" Text="{helpers:ResourceString Name=Ascending}" />
+						<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsSortedDescending, Mode=TwoWay}" Text="{helpers:ResourceString Name=Descending}" />
+						<MenuFlyoutSeparator />
+						<ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.AreDirectoriesSortedAlongsideFiles, Mode=TwoWay}" Text="{helpers:ResourceString Name=SettingsListAndSortDirectoriesAlongsideFiles}" />
+					</MenuFlyout>
+				</AppBarButton.Flyout>
+			</AppBarButton>
+			<AppBarButton
+				x:Name="LayoutOptionsButton"
+				Width="Auto"
+				MinWidth="40"
+				x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+				AccessKey="L"
+				AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/AutomationProperties/Name}"
+				Label="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/Label}"
+				LabelPosition="Collapsed"
+				Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
+				ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarLayoutOptionsButton/ToolTipService/ToolTip}">
+				<AppBarButton.Icon>
+					<FontIcon FontSize="10" Glyph="&#xE152;" />
+				</AppBarButton.Icon>
+				<AppBarButton.Flyout>
+					<Flyout contract8Present:ShouldConstrainToRootBounds="False" Placement="Bottom">
+						<StackPanel Spacing="12">
+							<TextBlock FontWeight="Medium" Text="{helpers:ResourceString Name=NavToolbarLayout/Text}" />
 
-                            <Grid ColumnSpacing="8" RowSpacing="8">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition MinHeight="30" />
-                                    <RowDefinition MinHeight="30" />
-                                    <RowDefinition MinHeight="30" />
-                                    <RowDefinition MinHeight="30" />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="40" />
-                                    <ColumnDefinition MaxWidth="100" />
-                                    <ColumnDefinition Width="40" />
-                                    <ColumnDefinition Width="40" />
-                                    <ColumnDefinition MaxWidth="100" />
-                                </Grid.ColumnDefinitions>
+							<Grid ColumnSpacing="8" RowSpacing="8">
+								<Grid.RowDefinitions>
+									<RowDefinition MinHeight="30" />
+									<RowDefinition MinHeight="30" />
+									<RowDefinition MinHeight="30" />
+									<RowDefinition MinHeight="30" />
+								</Grid.RowDefinitions>
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="40" />
+									<ColumnDefinition MaxWidth="100" />
+									<ColumnDefinition Width="40" />
+									<ColumnDefinition Width="40" />
+									<ColumnDefinition MaxWidth="100" />
+								</Grid.ColumnDefinitions>
 
-                                <RadioButton
-                                    Grid.Row="0"
-                                    Grid.Column="0"
-                                    Width="36"
-                                    Height="32"
-                                    MinWidth="0"
-                                    Padding="0"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    AutomationProperties.Name="{helpers:ResourceString Name=Details}"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsViewCommand, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    CornerRadius="{StaticResource ControlCornerRadius}"
-                                    IsChecked="{x:Bind ViewModel.IsLayoutDetailsView, Mode=OneWay}"
-                                    Style="{StaticResource DefaultToggleButtonStyle}"
-                                    ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarDetails/ToolTipService/ToolTip}">
-                                    <FontIcon FontSize="16" Glyph="&#xE179;" />
-                                </RadioButton>
+								<RadioButton
+									Grid.Row="0"
+									Grid.Column="0"
+									Width="36"
+									Height="32"
+									MinWidth="0"
+									Padding="0"
+									HorizontalContentAlignment="Center"
+									VerticalContentAlignment="Center"
+									AutomationProperties.Name="{helpers:ResourceString Name=Details}"
+									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsViewCommand, Mode=OneWay}"
+									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+									CornerRadius="{StaticResource ControlCornerRadius}"
+									IsChecked="{x:Bind ViewModel.IsLayoutDetailsView, Mode=OneWay}"
+									Style="{StaticResource DefaultToggleButtonStyle}"
+									ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarDetails/ToolTipService/ToolTip}">
+									<FontIcon FontSize="16" Glyph="&#xE179;" />
+								</RadioButton>
 
-                                <TextBlock
-                                    x:Name="NavToolbarDetailsHeader"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    VerticalAlignment="Center"
-                                    Tapped="NavToolbarDetailsHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=Details}" />
+								<TextBlock
+									x:Name="NavToolbarDetailsHeader"
+									Grid.Row="0"
+									Grid.Column="1"
+									VerticalAlignment="Center"
+									Tapped="NavToolbarDetailsHeader_Tapped"
+									Text="{helpers:ResourceString Name=Details}" />
 
-                                <RadioButton
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    Width="36"
-                                    Height="32"
-                                    MinWidth="0"
-                                    Padding="0"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    AutomationProperties.Name="{helpers:ResourceString Name=Tiles}"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTilesCommand, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    CornerRadius="{StaticResource ControlCornerRadius}"
-                                    IsChecked="{x:Bind ViewModel.IsLayoutTilesView, Mode=OneWay}"
-                                    Style="{StaticResource DefaultToggleButtonStyle}"
-                                    ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarTiles/ToolTipService/ToolTip}">
-                                    <FontIcon FontSize="16" Glyph="&#xE15C;" />
-                                </RadioButton>
+								<RadioButton
+									Grid.Row="1"
+									Grid.Column="0"
+									Width="36"
+									Height="32"
+									MinWidth="0"
+									Padding="0"
+									HorizontalContentAlignment="Center"
+									VerticalContentAlignment="Center"
+									AutomationProperties.Name="{helpers:ResourceString Name=Tiles}"
+									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTilesCommand, Mode=OneWay}"
+									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+									CornerRadius="{StaticResource ControlCornerRadius}"
+									IsChecked="{x:Bind ViewModel.IsLayoutTilesView, Mode=OneWay}"
+									Style="{StaticResource DefaultToggleButtonStyle}"
+									ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarTiles/ToolTipService/ToolTip}">
+									<FontIcon FontSize="16" Glyph="&#xE15C;" />
+								</RadioButton>
 
-                                <TextBlock
-                                    x:Name="NavToolbarTilesHeader"
-                                    Grid.Row="1"
-                                    Grid.Column="1"
-                                    VerticalAlignment="Center"
-                                    Tapped="NavToolbarTilesHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=Tiles}" />
+								<TextBlock
+									x:Name="NavToolbarTilesHeader"
+									Grid.Row="1"
+									Grid.Column="1"
+									VerticalAlignment="Center"
+									Tapped="NavToolbarTilesHeader_Tapped"
+									Text="{helpers:ResourceString Name=Tiles}" />
 
-                                <RadioButton
-                                    Grid.Row="2"
-                                    Grid.Column="0"
-                                    Width="36"
-                                    Height="32"
-                                    MinWidth="0"
-                                    Padding="0"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSmallIcons/AutomationProperties/Name}"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmallCommand, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    CornerRadius="{StaticResource ControlCornerRadius}"
-                                    IsChecked="{x:Bind ViewModel.IsLayoutGridViewSmall, Mode=OneWay}"
-                                    Style="{StaticResource DefaultToggleButtonStyle}"
-                                    ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSmallIcons/ToolTipService/ToolTip}">
-                                    <FontIcon FontSize="16" Glyph="&#xE80A;" />
-                                </RadioButton>
+								<RadioButton
+									Grid.Row="2"
+									Grid.Column="0"
+									Width="36"
+									Height="32"
+									MinWidth="0"
+									Padding="0"
+									HorizontalContentAlignment="Center"
+									VerticalContentAlignment="Center"
+									AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarSmallIcons/AutomationProperties/Name}"
+									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmallCommand, Mode=OneWay}"
+									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+									CornerRadius="{StaticResource ControlCornerRadius}"
+									IsChecked="{x:Bind ViewModel.IsLayoutGridViewSmall, Mode=OneWay}"
+									Style="{StaticResource DefaultToggleButtonStyle}"
+									ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarSmallIcons/ToolTipService/ToolTip}">
+									<FontIcon FontSize="16" Glyph="&#xE80A;" />
+								</RadioButton>
 
-                                <TextBlock
-                                    x:Name="NavToolbarSmallIconsHeader"
-                                    Grid.Row="2"
-                                    Grid.Column="1"
-                                    VerticalAlignment="Center"
-                                    Tapped="NavToolbarSmallIconsHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=SmallIcons}" />
+								<TextBlock
+									x:Name="NavToolbarSmallIconsHeader"
+									Grid.Row="2"
+									Grid.Column="1"
+									VerticalAlignment="Center"
+									Tapped="NavToolbarSmallIconsHeader_Tapped"
+									Text="{helpers:ResourceString Name=SmallIcons}" />
 
-                                <RadioButton
-                                    Grid.Row="3"
-                                    Grid.Column="0"
-                                    Width="36"
-                                    Height="32"
-                                    MinWidth="0"
-                                    Padding="0"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarMediumIcons/AutomationProperties/Name}"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMediumCommand, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    CornerRadius="{StaticResource ControlCornerRadius}"
-                                    IsChecked="{x:Bind ViewModel.IsLayoutGridViewMedium, Mode=OneWay}"
-                                    Style="{StaticResource DefaultToggleButtonStyle}"
-                                    ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarMediumIcons/ToolTipService/ToolTip}">
-                                    <FontIcon FontSize="16" Glyph="&#xF0E2;" />
-                                </RadioButton>
+								<RadioButton
+									Grid.Row="3"
+									Grid.Column="0"
+									Width="36"
+									Height="32"
+									MinWidth="0"
+									Padding="0"
+									HorizontalContentAlignment="Center"
+									VerticalContentAlignment="Center"
+									AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarMediumIcons/AutomationProperties/Name}"
+									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMediumCommand, Mode=OneWay}"
+									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+									CornerRadius="{StaticResource ControlCornerRadius}"
+									IsChecked="{x:Bind ViewModel.IsLayoutGridViewMedium, Mode=OneWay}"
+									Style="{StaticResource DefaultToggleButtonStyle}"
+									ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarMediumIcons/ToolTipService/ToolTip}">
+									<FontIcon FontSize="16" Glyph="&#xF0E2;" />
+								</RadioButton>
 
-                                <TextBlock
-                                    x:Name="NavToolbarMediumIconsHeader"
-                                    Grid.Row="3"
-                                    Grid.Column="1"
-                                    VerticalAlignment="Center"
-                                    Tapped="NavToolbarMediumIconsHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=MediumIcons}" />
+								<TextBlock
+									x:Name="NavToolbarMediumIconsHeader"
+									Grid.Row="3"
+									Grid.Column="1"
+									VerticalAlignment="Center"
+									Tapped="NavToolbarMediumIconsHeader_Tapped"
+									Text="{helpers:ResourceString Name=MediumIcons}" />
 
-                                <Border
-                                    Grid.RowSpan="4"
-                                    Grid.Column="2"
-                                    Height="120"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    BorderBrush="{ThemeResource ControlStrokeColorDefault}"
-                                    BorderThickness="1" />
+								<Border
+									Grid.RowSpan="4"
+									Grid.Column="2"
+									Height="120"
+									HorizontalAlignment="Center"
+									VerticalAlignment="Center"
+									BorderBrush="{ThemeResource ControlStrokeColorDefault}"
+									BorderThickness="1" />
 
-                                <RadioButton
-                                    Grid.Row="0"
-                                    Grid.Column="3"
-                                    Width="36"
-                                    Height="32"
-                                    MinWidth="0"
-                                    Padding="0"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarLargeIcons/AutomationProperties/Name}"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLargeCommand, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    CornerRadius="{StaticResource ControlCornerRadius}"
-                                    IsChecked="{x:Bind ViewModel.IsLayoutGridViewLarge, Mode=OneWay}"
-                                    Style="{StaticResource DefaultToggleButtonStyle}"
-                                    ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarLargeIcons/ToolTipService/ToolTip}">
-                                    <FontIcon FontSize="16" Glyph="&#xE739;" />
-                                </RadioButton>
+								<RadioButton
+									Grid.Row="0"
+									Grid.Column="3"
+									Width="36"
+									Height="32"
+									MinWidth="0"
+									Padding="0"
+									HorizontalContentAlignment="Center"
+									VerticalContentAlignment="Center"
+									AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarLargeIcons/AutomationProperties/Name}"
+									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLargeCommand, Mode=OneWay}"
+									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+									CornerRadius="{StaticResource ControlCornerRadius}"
+									IsChecked="{x:Bind ViewModel.IsLayoutGridViewLarge, Mode=OneWay}"
+									Style="{StaticResource DefaultToggleButtonStyle}"
+									ToolTipService.ToolTip="{helpers:ResourceString Name=NavToolbarLargeIcons/ToolTipService/ToolTip}">
+									<FontIcon FontSize="16" Glyph="&#xE739;" />
+								</RadioButton>
 
-                                <TextBlock
-                                    x:Name="NavToolbarLargeIconsHeader"
-                                    Grid.Row="0"
-                                    Grid.Column="4"
-                                    VerticalAlignment="Center"
-                                    Tapped="NavToolbarLargeIconsHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=LargeIcons}" />
+								<TextBlock
+									x:Name="NavToolbarLargeIconsHeader"
+									Grid.Row="0"
+									Grid.Column="4"
+									VerticalAlignment="Center"
+									Tapped="NavToolbarLargeIconsHeader_Tapped"
+									Text="{helpers:ResourceString Name=LargeIcons}" />
 
-                                <RadioButton
-                                    Grid.Row="1"
-                                    Grid.Column="3"
-                                    Width="36"
-                                    Height="32"
-                                    MinWidth="0"
-                                    Padding="0"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    AutomationProperties.Name="{helpers:ResourceString Name=Columns}"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnViewCommand, Mode=OneWay}"
-                                    CommandParameter="{xh:SystemTypeToXaml Bool=True}"
-                                    CornerRadius="{StaticResource ControlCornerRadius}"
-                                    IsChecked="{x:Bind ViewModel.IsLayoutColumnsView, Mode=OneWay}"
-                                    Style="{StaticResource DefaultToggleButtonStyle}"
-                                    ToolTipService.ToolTip="{helpers:ResourceString Name=ColumnsShortcutTooltip}">
-                                    <FontIcon
-                                        FontFamily="{StaticResource CustomGlyph}"
-                                        FontSize="16"
-                                        Glyph="&#xF115;" />
-                                </RadioButton>
+								<RadioButton
+									Grid.Row="1"
+									Grid.Column="3"
+									Width="36"
+									Height="32"
+									MinWidth="0"
+									Padding="0"
+									HorizontalContentAlignment="Center"
+									VerticalContentAlignment="Center"
+									AutomationProperties.Name="{helpers:ResourceString Name=Columns}"
+									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnViewCommand, Mode=OneWay}"
+									CommandParameter="{xh:SystemTypeToXaml Bool=True}"
+									CornerRadius="{StaticResource ControlCornerRadius}"
+									IsChecked="{x:Bind ViewModel.IsLayoutColumnsView, Mode=OneWay}"
+									Style="{StaticResource DefaultToggleButtonStyle}"
+									ToolTipService.ToolTip="{helpers:ResourceString Name=ColumnsShortcutTooltip}">
+									<FontIcon
+										FontFamily="{StaticResource CustomGlyph}"
+										FontSize="16"
+										Glyph="&#xF115;" />
+								</RadioButton>
 
-                                <TextBlock
-                                    x:Name="NavToolbarColumnsHeader"
-                                    Grid.Row="1"
-                                    Grid.Column="4"
-                                    VerticalAlignment="Center"
-                                    Tapped="NavToolbarColumnsHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=Columns}" />
+								<TextBlock
+									x:Name="NavToolbarColumnsHeader"
+									Grid.Row="1"
+									Grid.Column="4"
+									VerticalAlignment="Center"
+									Tapped="NavToolbarColumnsHeader_Tapped"
+									Text="{helpers:ResourceString Name=Columns}" />
 
-                                <RadioButton
-                                    Grid.Row="2"
-                                    Grid.Column="3"
-                                    Width="36"
-                                    Height="32"
-                                    MinWidth="0"
-                                    Padding="0"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    AutomationProperties.Name="{helpers:ResourceString Name=Adaptive}"
-                                    Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeAdaptiveCommand, Mode=OneWay}"
-                                    CornerRadius="{StaticResource ControlCornerRadius}"
-                                    IsChecked="{x:Bind ViewModel.IsLayoutAdaptive, Mode=OneWay}"
-                                    IsEnabled="{x:Bind ViewModel.IsAdaptiveLayoutEnabled, Mode=OneWay}"
-                                    Style="{StaticResource DefaultToggleButtonStyle}"
-                                    ToolTipService.ToolTip="{helpers:ResourceString Name=AdaptiveShortcutTooltip}">
-                                    <FontIcon FontSize="16" Glyph="&#xF576;" />
-                                </RadioButton>
+								<RadioButton
+									Grid.Row="2"
+									Grid.Column="3"
+									Width="36"
+									Height="32"
+									MinWidth="0"
+									Padding="0"
+									HorizontalContentAlignment="Center"
+									VerticalContentAlignment="Center"
+									AutomationProperties.Name="{helpers:ResourceString Name=Adaptive}"
+									Command="{x:Bind ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeAdaptiveCommand, Mode=OneWay}"
+									CornerRadius="{StaticResource ControlCornerRadius}"
+									IsChecked="{x:Bind ViewModel.IsLayoutAdaptive, Mode=OneWay}"
+									IsEnabled="{x:Bind ViewModel.IsAdaptiveLayoutEnabled, Mode=OneWay}"
+									Style="{StaticResource DefaultToggleButtonStyle}"
+									ToolTipService.ToolTip="{helpers:ResourceString Name=AdaptiveShortcutTooltip}">
+									<FontIcon FontSize="16" Glyph="&#xF576;" />
+								</RadioButton>
 
-                                <TextBlock
-                                    x:Name="NavToolbarAdaptiveHeader"
-                                    Grid.Row="2"
-                                    Grid.Column="4"
-                                    VerticalAlignment="Center"
-                                    Tapped="NavToolbarAdaptiveHeader_Tapped"
-                                    Text="{helpers:ResourceString Name=Adaptive}" />
-                            </Grid>
+								<TextBlock
+									x:Name="NavToolbarAdaptiveHeader"
+									Grid.Row="2"
+									Grid.Column="4"
+									VerticalAlignment="Center"
+									Tapped="NavToolbarAdaptiveHeader_Tapped"
+									Text="{helpers:ResourceString Name=Adaptive}" />
+							</Grid>
 
-                            <Border
-                                Margin="-20,0"
-                                HorizontalAlignment="Stretch"
-                                BorderBrush="{ThemeResource ControlStrokeColorDefault}"
-                                BorderThickness="1" />
+							<Border
+								Margin="-20,0"
+								HorizontalAlignment="Stretch"
+								BorderBrush="{ThemeResource ControlStrokeColorDefault}"
+								BorderThickness="1" />
 
-                            <Grid RowSpacing="4">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition MinHeight="30" />
-                                    <RowDefinition MinHeight="30" />
-                                </Grid.RowDefinitions>
-                                <TextBlock
-                                    Grid.Row="0"
-                                    Grid.Column="0"
-                                    VerticalAlignment="Center"
-                                    Text="{helpers:ResourceString Name=NavToolbarShowHiddenItemsHeader/Text}" />
-                                <ToggleSwitch
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    HorizontalAlignment="Right"
-                                    AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarShowHiddenItems/AutomationProperties/Name}"
-                                    IsOn="{x:Bind UserSettingsService.FoldersSettingsService.ShowHiddenItems, Mode=TwoWay}"
-                                    Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+							<Grid RowSpacing="4">
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="*" />
+									<ColumnDefinition Width="Auto" />
+								</Grid.ColumnDefinitions>
+								<Grid.RowDefinitions>
+									<RowDefinition MinHeight="30" />
+									<RowDefinition MinHeight="30" />
+								</Grid.RowDefinitions>
+								<TextBlock
+									Grid.Row="0"
+									Grid.Column="0"
+									VerticalAlignment="Center"
+									Text="{helpers:ResourceString Name=NavToolbarShowHiddenItemsHeader/Text}" />
+								<ToggleSwitch
+									Grid.Row="0"
+									Grid.Column="1"
+									HorizontalAlignment="Right"
+									AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarShowHiddenItems/AutomationProperties/Name}"
+									IsOn="{x:Bind UserSettingsService.FoldersSettingsService.ShowHiddenItems, Mode=TwoWay}"
+									Style="{StaticResource RightAlignedToggleSwitchStyle}" />
 
-                                <TextBlock
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    VerticalAlignment="Center"
-                                    Text="{helpers:ResourceString Name=NavToolbarShowFileExtensionsHeader/Text}" />
-                                <ToggleSwitch
-                                    Grid.Row="1"
-                                    Grid.Column="1"
-                                    HorizontalAlignment="Right"
-                                    AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarShowFileExtensions/AutomationProperties/Name}"
-                                    IsOn="{x:Bind UserSettingsService.PreferencesSettingsService.ShowFileExtensions, Mode=TwoWay}"
-                                    Rotation="1"
-                                    Style="{StaticResource RightAlignedToggleSwitchStyle}" />
-                            </Grid>
-                        </StackPanel>
-                    </Flyout>
-                </AppBarButton.Flyout>
-            </AppBarButton>
-            <AppBarToggleButton
-                x:Name="PreviewPane"
-                Width="Auto"
-                MinWidth="40"
-                AccessKey="P"
-                AutomationProperties.Name="{helpers:ResourceString Name=PreviewPaneToggle/AutomationProperties/Name}"
-                IsChecked="{x:Bind AppModel.PaneViewModel.IsPreviewSelected, Mode=TwoWay}"
-                IsEnabled="{x:Bind ShowPreviewPaneButton, Mode=OneWay}"
-                Label="{helpers:ResourceString Name=PreviewPaneToggle/Label}"
-                LabelPosition="Collapsed"
-                ToolTipService.ToolTip="{helpers:ResourceString Name=PreviewPaneToggle/ToolTipService/ToolTip}"
-                Visibility="{x:Bind ShowPreviewPaneButton, Mode=OneWay}">
-                <AppBarToggleButton.Content>
-                    <local:ColoredIcon BaseLayerGlyph="&#xF03b;" OverlayLayerGlyph="&#xF03c;" />
-                </AppBarToggleButton.Content>
-            </AppBarToggleButton>
-            <CommandBar.SecondaryCommands>
-                <AppBarButton
-                    x:Name="NavToolbarNewPane"
-                    x:Load="{x:Bind converters:MultiBooleanConverter.AndNotConvert(ShowMultiPaneControls, IsMultiPaneActive), Mode=OneWay}"
-                    Command="{x:Bind ViewModel.OpenNewPaneCommand, Mode=OneWay}"
-                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarNewPane/KeyboardAcceleratorTextOverride}"
-                    Label="{helpers:ResourceString Name=NavigationToolbarNewPane/Label}">
-                    <AppBarButton.Icon>
-                        <FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF117;" />
-                    </AppBarButton.Icon>
-                    <AppBarButton.KeyboardAccelerators>
-                        <KeyboardAccelerator
-                            Key="Add"
-                            IsEnabled="False"
-                            Modifiers="Menu,Shift" />
-                    </AppBarButton.KeyboardAccelerators>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="NavToolbarClosePane"
-                    x:Load="{x:Bind IsMultiPaneActive, Mode=OneWay}"
-                    Command="{x:Bind ViewModel.ClosePaneCommand, Mode=OneWay}"
-                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarClosePane/KeyboardAcceleratorTextOverride}"
-                    Label="{helpers:ResourceString Name=NavigationToolbarClosePane/Label}">
-                    <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE89F;" />
-                    </AppBarButton.Icon>
-                    <AppBarButton.KeyboardAccelerators>
-                        <KeyboardAccelerator
-                            Key="W"
-                            IsEnabled="False"
-                            Modifiers="Control,Shift" />
-                    </AppBarButton.KeyboardAccelerators>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="NavToolbarNewWindow"
-                    Command="{x:Bind ViewModel.OpenNewWindowCommand, Mode=OneWay}"
-                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarNewWindow/KeyboardAcceleratorTextOverride}"
-                    Label="{helpers:ResourceString Name=NavigationToolbarNewWindow/Label}">
-                    <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE737;" />
-                    </AppBarButton.Icon>
-                    <AppBarButton.KeyboardAccelerators>
-                        <KeyboardAccelerator
-                            Key="N"
-                            IsEnabled="False"
-                            Modifiers="Control" />
-                    </AppBarButton.KeyboardAccelerators>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="NavToolbarEnterCompactOverlay"
-                    Command="{x:Bind SetCompactOverlayCommand}"
-                    CommandParameter="{StaticResource True}"
-                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarEnterCompactOverlay/KeyboardAcceleratorTextOverride}"
-                    Label="{helpers:ResourceString Name=NavigationToolbarEnterCompactOverlay/Label}"
-                    Visibility="{x:Bind IsCompactOverlay, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
-                    <AppBarButton.KeyboardAccelerators>
-                        <KeyboardAccelerator
-                            Key="Up"
-                            IsEnabled="False"
-                            Modifiers="Menu,Control" />
-                    </AppBarButton.KeyboardAccelerators>
-                    <AppBarButton.Icon>
-                        <PathIcon
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Data="{StaticResource EnterCompactOverlay}" />
-                    </AppBarButton.Icon>
-                </AppBarButton>
-                <AppBarButton
-                    x:Name="NavToolbarExitCompactOverlay"
-                    Command="{x:Bind SetCompactOverlayCommand}"
-                    CommandParameter="{StaticResource False}"
-                    KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarExitCompactOverlay/KeyboardAcceleratorTextOverride}"
-                    Label="{helpers:ResourceString Name=NavigationToolbarExitCompactOverlay/Label}"
-                    Visibility="{x:Bind IsCompactOverlay, Mode=OneWay}">
-                    <AppBarButton.Icon>
-                        <PathIcon
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Data="{StaticResource ExitCompactOverlay}" />
-                    </AppBarButton.Icon>
-                    <AppBarButton.KeyboardAccelerators>
-                        <KeyboardAccelerator
-                            Key="Down"
-                            IsEnabled="False"
-                            Modifiers="Menu,Control" />
-                    </AppBarButton.KeyboardAccelerators>
-                </AppBarButton>
-                <AppBarSeparator x:Name="SeparatorBar" x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}" />
-                <AppBarButton
-                    x:Name="OpenInTerminalButton"
-                    x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-                    Command="{x:Bind ViewModel.OpenDirectoryInDefaultTerminalCommand, Mode=OneWay}"
-                    IsEnabled="{x:Bind ViewModel.InstanceViewModel.CanOpenTerminalInPage, Mode=OneWay}"
-                    Label="{x:Bind ViewModel.OpenInTerminal, Mode=OneWay}">
-                    <AppBarButton.Icon>
-                        <FontIcon Glyph="&#xE756;" />
-                    </AppBarButton.Icon>
-                </AppBarButton>
-            </CommandBar.SecondaryCommands>
-        </CommandBar>
-    </Grid>
+								<TextBlock
+									Grid.Row="1"
+									Grid.Column="0"
+									VerticalAlignment="Center"
+									Text="{helpers:ResourceString Name=NavToolbarShowFileExtensionsHeader/Text}" />
+								<ToggleSwitch
+									Grid.Row="1"
+									Grid.Column="1"
+									HorizontalAlignment="Right"
+									AutomationProperties.Name="{helpers:ResourceString Name=NavToolbarShowFileExtensions/AutomationProperties/Name}"
+									IsOn="{x:Bind UserSettingsService.PreferencesSettingsService.ShowFileExtensions, Mode=TwoWay}"
+									Rotation="1"
+									Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+							</Grid>
+						</StackPanel>
+					</Flyout>
+				</AppBarButton.Flyout>
+			</AppBarButton>
+			<AppBarToggleButton
+				x:Name="PreviewPane"
+				Width="Auto"
+				MinWidth="40"
+				AccessKey="P"
+				AutomationProperties.Name="{helpers:ResourceString Name=PreviewPaneToggle/AutomationProperties/Name}"
+				IsChecked="{x:Bind AppModel.PaneViewModel.IsPreviewSelected, Mode=TwoWay}"
+				IsEnabled="{x:Bind ShowPreviewPaneButton, Mode=OneWay}"
+				Label="{helpers:ResourceString Name=PreviewPaneToggle/Label}"
+				LabelPosition="Collapsed"
+				ToolTipService.ToolTip="{helpers:ResourceString Name=PreviewPaneToggle/ToolTipService/ToolTip}"
+				Visibility="{x:Bind ShowPreviewPaneButton, Mode=OneWay}">
+				<AppBarToggleButton.Content>
+					<local:ColoredIcon BaseLayerGlyph="&#xF03b;" OverlayLayerGlyph="&#xF03c;" />
+				</AppBarToggleButton.Content>
+			</AppBarToggleButton>
+			<CommandBar.SecondaryCommands>
+				<AppBarButton
+					x:Name="NavToolbarNewPane"
+					x:Load="{x:Bind converters:MultiBooleanConverter.AndNotConvert(ShowMultiPaneControls, IsMultiPaneActive), Mode=OneWay}"
+					Command="{x:Bind ViewModel.OpenNewPaneCommand, Mode=OneWay}"
+					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarNewPane/KeyboardAcceleratorTextOverride}"
+					Label="{helpers:ResourceString Name=NavigationToolbarNewPane/Label}">
+					<AppBarButton.Icon>
+						<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF117;" />
+					</AppBarButton.Icon>
+					<AppBarButton.KeyboardAccelerators>
+						<KeyboardAccelerator
+							Key="Add"
+							IsEnabled="False"
+							Modifiers="Menu,Shift" />
+					</AppBarButton.KeyboardAccelerators>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="NavToolbarClosePane"
+					x:Load="{x:Bind IsMultiPaneActive, Mode=OneWay}"
+					Command="{x:Bind ViewModel.ClosePaneCommand, Mode=OneWay}"
+					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarClosePane/KeyboardAcceleratorTextOverride}"
+					Label="{helpers:ResourceString Name=NavigationToolbarClosePane/Label}">
+					<AppBarButton.Icon>
+						<FontIcon Glyph="&#xE89F;" />
+					</AppBarButton.Icon>
+					<AppBarButton.KeyboardAccelerators>
+						<KeyboardAccelerator
+							Key="W"
+							IsEnabled="False"
+							Modifiers="Control,Shift" />
+					</AppBarButton.KeyboardAccelerators>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="NavToolbarNewWindow"
+					Command="{x:Bind ViewModel.OpenNewWindowCommand, Mode=OneWay}"
+					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarNewWindow/KeyboardAcceleratorTextOverride}"
+					Label="{helpers:ResourceString Name=NavigationToolbarNewWindow/Label}">
+					<AppBarButton.Icon>
+						<FontIcon Glyph="&#xE737;" />
+					</AppBarButton.Icon>
+					<AppBarButton.KeyboardAccelerators>
+						<KeyboardAccelerator
+							Key="N"
+							IsEnabled="False"
+							Modifiers="Control" />
+					</AppBarButton.KeyboardAccelerators>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="NavToolbarEnterCompactOverlay"
+					Command="{x:Bind SetCompactOverlayCommand}"
+					CommandParameter="{StaticResource True}"
+					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarEnterCompactOverlay/KeyboardAcceleratorTextOverride}"
+					Label="{helpers:ResourceString Name=NavigationToolbarEnterCompactOverlay/Label}"
+					Visibility="{x:Bind IsCompactOverlay, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
+					<AppBarButton.KeyboardAccelerators>
+						<KeyboardAccelerator
+							Key="Up"
+							IsEnabled="False"
+							Modifiers="Menu,Control" />
+					</AppBarButton.KeyboardAccelerators>
+					<AppBarButton.Icon>
+						<PathIcon
+							HorizontalAlignment="Center"
+							VerticalAlignment="Center"
+							Data="{StaticResource EnterCompactOverlay}" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+				<AppBarButton
+					x:Name="NavToolbarExitCompactOverlay"
+					Command="{x:Bind SetCompactOverlayCommand}"
+					CommandParameter="{StaticResource False}"
+					KeyboardAcceleratorTextOverride="{helpers:ResourceString Name=NavigationToolbarExitCompactOverlay/KeyboardAcceleratorTextOverride}"
+					Label="{helpers:ResourceString Name=NavigationToolbarExitCompactOverlay/Label}"
+					Visibility="{x:Bind IsCompactOverlay, Mode=OneWay}">
+					<AppBarButton.Icon>
+						<PathIcon
+							HorizontalAlignment="Center"
+							VerticalAlignment="Center"
+							Data="{StaticResource ExitCompactOverlay}" />
+					</AppBarButton.Icon>
+					<AppBarButton.KeyboardAccelerators>
+						<KeyboardAccelerator
+							Key="Down"
+							IsEnabled="False"
+							Modifiers="Menu,Control" />
+					</AppBarButton.KeyboardAccelerators>
+				</AppBarButton>
+				<AppBarSeparator x:Name="SeparatorBar" x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}" />
+				<AppBarButton
+					x:Name="OpenInTerminalButton"
+					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
+					Command="{x:Bind ViewModel.OpenDirectoryInDefaultTerminalCommand, Mode=OneWay}"
+					IsEnabled="{x:Bind ViewModel.InstanceViewModel.CanOpenTerminalInPage, Mode=OneWay}"
+					Label="{x:Bind ViewModel.OpenInTerminal, Mode=OneWay}">
+					<AppBarButton.Icon>
+						<FontIcon Glyph="&#xE756;" />
+					</AppBarButton.Icon>
+				</AppBarButton>
+			</CommandBar.SecondaryCommands>
+		</CommandBar>
+	</Grid>
 </UserControl>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
None

**Changes made**
This PR removes the icons from the archive extraction flyout, since they take up space and add clutter while adding little information.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility
