### PR TITLE
Fix: Fixed issue where the drive letter was included in the name

### DIFF
--- a/src/Files.App/Views/Pages/PropertiesGeneral.xaml
+++ b/src/Files.App/Views/Pages/PropertiesGeneral.xaml
@@ -78,6 +78,8 @@
 				<TextBox
 					x:Name="ItemFileName"
 					x:Load="{x:Bind ViewModel.ItemNameVisibility, Mode=OneWay}"
+					GettingFocus="ItemFileName_GettingFocus"
+					LosingFocus="ItemFileName_LosingFocus"
 					PlaceholderText="{helpers:ResourceString Name=PropertiesItemFileName/PlaceholderText}"
 					Text="{x:Bind ViewModel.ItemName, Mode=TwoWay}" />
 				<TextBlock
@@ -308,9 +310,9 @@
 				Height="60"
 				HorizontalAlignment="Left"
 				x:Load="{x:Bind ViewModel.DriveCapacityVisibility, Mode=OneWay}"
+				Background="{ThemeResource ProgressRingBackgroundThemeBrush}"
 				IsIndeterminate="False"
-				Value="{x:Bind ViewModel.DrivePercentageValue, Mode=OneWay}"
-				Background="{ThemeResource ProgressRingBackgroundThemeBrush}">
+				Value="{x:Bind ViewModel.DrivePercentageValue, Mode=OneWay}">
 
 				<ProgressRing.Template>
 					<ControlTemplate TargetType="ProgressRing">

--- a/src/Files.App/Views/Pages/PropertiesGeneral.xaml.cs
+++ b/src/Files.App/Views/Pages/PropertiesGeneral.xaml.cs
@@ -112,14 +112,15 @@ namespace Files.App.Views
 		}
 		private void ItemFileName_LosingFocus(UIElement _, LosingFocusEventArgs e)
 		{
-			if (string.IsNullOrWhiteSpace(ItemFileName.Text))
-				ItemFileName.Text = ViewModel.ItemName;
-			else
+			if (string.IsNullOrWhiteSpace(ItemFileName.Text)) 
 			{
-				var match = letterRegex.Match(ViewModel.OriginalItemName);
-				if (match.Success)
-					ItemFileName.Text += match.Value;
+				ItemFileName.Text = ViewModel.ItemName;
+				return;
 			}
+
+			var match = letterRegex.Match(ViewModel.OriginalItemName);
+			if (match.Success)
+				ItemFileName.Text += match.Value;
 		}
 
 		private void DiskCleanupButton_Click(object sender, RoutedEventArgs e)

--- a/src/Files.App/Views/Pages/PropertiesGeneral.xaml.cs
+++ b/src/Files.App/Views/Pages/PropertiesGeneral.xaml.cs
@@ -1,113 +1,131 @@
-using Files.Shared;
+using CommunityToolkit.WinUI;
 using Files.App.Filesystem;
 using Files.App.Helpers;
-using Files.Shared.Enums;
-using Files.App.ViewModels.Properties;
-using CommunityToolkit.WinUI;
-using System.IO;
-using System.Threading.Tasks;
-using Windows.Foundation.Collections;
 using Files.App.Shell;
+using Files.App.ViewModels.Properties;
+using Files.Shared;
+using Files.Shared.Enums;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Windows.Storage;
 
 namespace Files.App.Views
 {
-    public sealed partial class PropertiesGeneral : PropertiesTab
-    {
-        public PropertiesGeneral()
-        {
-            this.InitializeComponent();
-        }
+	public sealed partial class PropertiesGeneral : PropertiesTab
+	{
+		private readonly Regex letterRegex = new(@"\s*\(\w:\)$");
 
-        public override async Task<bool> SaveChangesAsync(ListedItem item)
-        {
-            if (BaseProperties is DriveProperties driveProps)
-            {
-                var drive = driveProps.Drive;
-                ViewModel.ItemName = ItemFileName.Text; // Make sure Name is updated
-                if (!string.IsNullOrWhiteSpace(ViewModel.ItemName) && ViewModel.OriginalItemName != ViewModel.ItemName)
-                {
-                    var remDrive = new System.Text.RegularExpressions.Regex(@"\s*\(\w:\)$");
-                    ViewModel.ItemName = remDrive.Replace(ViewModel.ItemName, ""); // Remove "(C:)" from the new label
-                    if (AppInstance.FilesystemViewModel != null)
-                    {
-                        Win32API.SetVolumeLabel(drive.Path, ViewModel.ItemName);
-                        _ = App.Window.DispatcherQueue.EnqueueAsync(async () =>
-                        {
-                            await drive.UpdateLabelAsync();
-                            await AppInstance.FilesystemViewModel?.SetWorkingDirectoryAsync(drive.Path);
-                        });
-                        return true;
-                    }
-                }
-            }
-            else if (BaseProperties is LibraryProperties libProps)
-            {
-                var library = libProps.Library;
-                ViewModel.ItemName = ItemFileName.Text; // Make sure Name is updated
-                var newName = ViewModel.ItemName;
-                if (!string.IsNullOrWhiteSpace(newName) && ViewModel.OriginalItemName != newName)
-                {
-                    if (AppInstance.FilesystemViewModel != null && App.LibraryManager.CanCreateLibrary(newName).result)
-                    {
-                        var libraryPath = library.ItemPath;
-                        var renamed = await AppInstance.FilesystemHelpers.RenameAsync(new StorageFileWithPath(null, libraryPath), $"{newName}{ShellLibraryItem.EXTENSION}", Windows.Storage.NameCollisionOption.FailIfExists, false);
-                        if (renamed == ReturnResult.Success)
-                        {
-                            var newPath = Path.Combine(Path.GetDirectoryName(libraryPath), $"{newName}{ShellLibraryItem.EXTENSION}");
-                            _ = App.Window.DispatcherQueue.EnqueueAsync(async () =>
-                            {
-                                await AppInstance.FilesystemViewModel?.SetWorkingDirectoryAsync(newPath);
-                            });
-                            return true;
-                        }
-                    }
-                }
-            }
-            else if (BaseProperties is CombinedProperties combinedProps)
-            {
-                // Handle the visibility attribute for multiple files
-                if (AppInstance?.SlimContentPage?.ItemManipulationModel != null) // null on homepage
-                {
-                    foreach (var fileOrFolder in combinedProps.List)
-                    {
-                        await App.Window.DispatcherQueue.EnqueueAsync(() => UIFilesystemHelpers.SetHiddenAttributeItem(fileOrFolder, ViewModel.IsHidden, AppInstance.SlimContentPage.ItemManipulationModel));
-                    }
-                }
-                return true;
-            }
-            else
-            {
-                // Handle the visibility attribute for a single file
-                if (AppInstance?.SlimContentPage?.ItemManipulationModel != null) // null on homepage
-                {
-                    await App.Window.DispatcherQueue.EnqueueAsync(() => UIFilesystemHelpers.SetHiddenAttributeItem(item, ViewModel.IsHidden, AppInstance.SlimContentPage.ItemManipulationModel));
-                }
+		public PropertiesGeneral() => InitializeComponent();
 
-                ViewModel.ItemName = ItemFileName.Text; // Make sure Name is updated
-                if (!string.IsNullOrWhiteSpace(ViewModel.ItemName) && ViewModel.OriginalItemName != ViewModel.ItemName)
-                {
-                    return await App.Window.DispatcherQueue.EnqueueAsync(() => UIFilesystemHelpers.RenameFileItemAsync(item,
-                          ViewModel.ItemName,
-                          AppInstance));
-                }
-                return true;
-            }
+		public override async Task<bool> SaveChangesAsync(ListedItem item)
+		{
+			ViewModel.ItemName = ItemFileName.Text; // Make sure Name is updated
 
-            return false;
-        }
+			string newName = ViewModel.ItemName;
+			string oldName = ViewModel.OriginalItemName;
+			bool hasNewName = !string.IsNullOrWhiteSpace(newName) && newName != oldName;
 
-        public override void Dispose()
-        {
-        }
+			var fsVM = AppInstance.FilesystemViewModel;
+			var itemMM = AppInstance?.SlimContentPage?.ItemManipulationModel;
 
-        private void DiskCleanupButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
-        {
-            if (BaseProperties is DriveProperties driveProps)
-            {
-                var drive = driveProps.Drive;
+			if (BaseProperties is DriveProperties driveProps)
+			{
+				if (!hasNewName || fsVM is null)
+					return false;
 
-                StorageSenseHelper.OpenStorageSense(drive.Path);
-            }
-        }
-    }
+				var drive = driveProps.Drive;
+				newName = letterRegex.Replace(newName, string.Empty); // Remove "(C:)" from the new label
+
+				Win32API.SetVolumeLabel(drive.Path, newName);
+				_ = App.Window.DispatcherQueue.EnqueueAsync(async () =>
+				{
+					await drive.UpdateLabelAsync();
+					await fsVM.SetWorkingDirectoryAsync(drive.Path);
+				});
+				return true;
+			}
+
+			if (BaseProperties is LibraryProperties libProps)
+			{
+				if (!hasNewName || fsVM is null || !App.LibraryManager.CanCreateLibrary(newName).result)
+					return false;
+
+				string libraryPath = libProps.Library.ItemPath;
+				newName = $"{newName}{ShellLibraryItem.EXTENSION}";
+
+				var file = new StorageFileWithPath(null, libraryPath);
+				var renamed = await AppInstance!.FilesystemHelpers.RenameAsync(file, newName, NameCollisionOption.FailIfExists, false);
+				if (renamed is ReturnResult.Success)
+				{
+					var newPath = Path.Combine(Path.GetDirectoryName(libraryPath)!, newName);
+					_ = App.Window.DispatcherQueue.EnqueueAsync(async () =>
+					{
+						await fsVM.SetWorkingDirectoryAsync(newPath);
+					});
+					return true;
+				}
+
+				return false;
+			}
+
+			if (BaseProperties is CombinedProperties combinedProps)
+			{
+				// Handle the visibility attribute for multiple files
+				if (itemMM is not null) // null on homepage
+				{
+					foreach (var fileOrFolder in combinedProps.List)
+					{
+						await App.Window.DispatcherQueue.EnqueueAsync(() =>
+							UIFilesystemHelpers.SetHiddenAttributeItem(fileOrFolder, ViewModel.IsHidden, itemMM)
+						);
+					}
+				}
+				return true;
+			}
+
+			// Handle the visibility attribute for a single file
+			if (itemMM is not null) // null on homepage
+			{
+				await App.Window.DispatcherQueue.EnqueueAsync(() =>
+					UIFilesystemHelpers.SetHiddenAttributeItem(item, ViewModel.IsHidden, itemMM)
+				);
+			}
+
+			if (!hasNewName)
+				return true;
+
+			return await App.Window.DispatcherQueue.EnqueueAsync(() =>
+				UIFilesystemHelpers.RenameFileItemAsync(item, ViewModel.ItemName, AppInstance)
+			);
+		}
+
+		public override void Dispose()
+		{
+		}
+
+		private void ItemFileName_GettingFocus(UIElement _, GettingFocusEventArgs e)
+		{
+			ItemFileName.Text = letterRegex.Replace(ItemFileName.Text, string.Empty);
+		}
+		private void ItemFileName_LosingFocus(UIElement _, LosingFocusEventArgs e)
+		{
+			if (string.IsNullOrWhiteSpace(ItemFileName.Text))
+				ItemFileName.Text = ViewModel.ItemName;
+			else
+			{
+				var match = letterRegex.Match(ViewModel.OriginalItemName);
+				if (match.Success)
+					ItemFileName.Text += match.Value;
+			}
+		}
+
+		private void DiskCleanupButton_Click(object sender, RoutedEventArgs e)
+		{
+			if (BaseProperties is DriveProperties driveProps)
+				StorageSenseHelper.OpenStorageSense(driveProps.Drive.Path);
+		}
+	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
Improves PropertiesGeneral control:
- The code is more readable. Some warnings are fixed.
- When leaving the name field with an empty name, the previous name is returned.
- For drives, the letter of the name is removed during editing. #10263.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**

https://user-images.githubusercontent.com/46631671/198020958-e7927c35-3a52-45ce-a73c-1c6c67da5216.mp4

