### PR TITLE
Feature: Open selected folders in new tab using Ctrl+Enter

### DIFF
--- a/src/Files.App/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/ColumnShellPage.xaml.cs
@@ -179,12 +179,12 @@ namespace Files.App.Views
             ToolbarViewModel.PathBoxItemDropped += ColumnShellPage_PathBoxItemDropped;
 
             /*
-              
             TODO UA307 Default back button in the title bar does not exist in WinUI3 apps.
             The tool has generated a custom back button in the MainWindow.xaml.cs file.
             Feel free to edit its position, behavior and use the custom back button instead.
             Read: https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/case-study-1#restoring-back-button-functionality
-            */ToolbarViewModel.BackRequested += ColumnShellPage_BackNavRequested;
+            */
+            ToolbarViewModel.BackRequested += ColumnShellPage_BackNavRequested;
             ToolbarViewModel.UpRequested += ColumnShellPage_UpNavRequested;
             ToolbarViewModel.RefreshRequested += ColumnShellPage_RefreshRequested;
             ToolbarViewModel.ForwardRequested += ColumnShellPage_ForwardNavRequested;

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -8,6 +8,7 @@ using Files.App.Interacts;
 using Files.App.UserControls.Selection;
 using Files.Backend.Services.Settings;
 using Files.Shared.Enums;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -132,6 +133,7 @@ namespace Files.App.Views.LayoutModes
         {
             if (ItemManipulationModel == null)
                 return;
+
             ItemManipulationModel.FocusFileListInvoked -= ItemManipulationModel_FocusFileListInvoked;
             ItemManipulationModel.SelectAllItemsInvoked -= ItemManipulationModel_SelectAllItemsInvoked;
             ItemManipulationModel.ClearSelectionInvoked -= ItemManipulationModel_ClearSelectionInvoked;
@@ -350,8 +352,8 @@ namespace Files.App.Views.LayoutModes
 
         private async void FileList_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
         {
-            var ctrlPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            var shiftPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+            var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
 
             if (e.Key == VirtualKey.Enter && !e.KeyStatus.IsMenuKeyDown)
             {
@@ -497,8 +499,8 @@ namespace Files.App.Views.LayoutModes
 
         private void FileList_ItemTapped(object sender, TappedRoutedEventArgs e)
         {
-            var ctrlPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            var shiftPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+            var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
             var item = (e.OriginalSource as FrameworkElement)?.DataContext as ListedItem;
 
 			// Allow for Ctrl+Shift selection

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -357,14 +357,15 @@ namespace Files.App.Views.LayoutModes
 
             if (e.Key == VirtualKey.Enter && !e.KeyStatus.IsMenuKeyDown)
             {
-                if (!IsRenamingItem)
-                {
-                    if (IsItemSelected && SelectedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
-                        ItemInvoked?.Invoke(new ColumnParam { NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
-                    else
-                        NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
-                    e.Handled = true;
-                }
+                if (IsRenamingItem)
+                    return;
+
+                if (IsItemSelected && SelectedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
+                    ItemInvoked?.Invoke(new ColumnParam { NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
+                else
+                    NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+
+                e.Handled = true;
             }
             else if (e.Key == VirtualKey.Enter && e.KeyStatus.IsMenuKeyDown)
             {

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UWPToWinAppSDKUpgradeHelpers;
 using Windows.Foundation;
+using Windows.Storage;
 using Windows.System;
 using Windows.UI.Core;
 
@@ -434,11 +435,23 @@ namespace Files.App.Views.LayoutModes
 
             if (e.Key == VirtualKey.Enter && !e.KeyStatus.IsMenuKeyDown)
             {
-                if (!IsRenamingItem && !isHeaderFocused && !isFooterFocused)
+                if (IsRenamingItem)
+                    return;
+
+                if (ctrlPressed)
+                {
+                    var folders = ParentShellPageInstance?.SlimContentPage.SelectedItems?.Where(file => file.PrimaryItemAttribute == StorageItemTypes.Folder);
+                    foreach (ListedItem? folder in folders)
+                    {
+                        if (folder != null)
+                            await NavigationHelpers.OpenPathInNewTab(folder.ItemPath);
+                    }
+                }
+                else
                 {
                     NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
-                    e.Handled = true;
                 }
+                e.Handled = true;
             }
             else if (e.Key == VirtualKey.Enter && e.KeyStatus.IsMenuKeyDown)
             {

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -21,7 +21,6 @@ using System.Collections.Generic;
 using System.Linq;
 using UWPToWinAppSDKUpgradeHelpers;
 using Windows.Foundation;
-using Windows.Storage;
 using Windows.System;
 using Windows.UI.Core;
 
@@ -176,6 +175,7 @@ namespace Files.App.Views.LayoutModes
         {
             if (ItemManipulationModel == null)
                 return;
+
             ItemManipulationModel.FocusFileListInvoked -= ItemManipulationModel_FocusFileListInvoked;
             ItemManipulationModel.SelectAllItemsInvoked -= ItemManipulationModel_SelectAllItemsInvoked;
             ItemManipulationModel.ClearSelectionInvoked -= ItemManipulationModel_ClearSelectionInvoked;
@@ -426,8 +426,8 @@ namespace Files.App.Views.LayoutModes
 
         private async void FileList_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
         {
-            var ctrlPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            var shiftPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+            var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
             var focusedElement = (FrameworkElement)FocusManager.GetFocusedElement();
             var isHeaderFocused = DependencyObjectHelpers.FindParent<DataGridHeader>(focusedElement) != null;
             var isFooterFocused = focusedElement is HyperlinkButton;
@@ -530,8 +530,8 @@ namespace Files.App.Views.LayoutModes
 
         private void FileList_ItemTapped(object sender, TappedRoutedEventArgs e)
         {
-            var ctrlPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            var shiftPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+            var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
             var item = (e.OriginalSource as FrameworkElement)?.DataContext as ListedItem;
             if (item == null)
                 return;

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -16,6 +16,7 @@ using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Windows.Storage;
 using Windows.System;
 using Windows.UI.Core;
 
@@ -378,15 +379,27 @@ namespace Files.App.Views.LayoutModes
             var focusedElement = FocusManager.GetFocusedElement() as FrameworkElement;
             var isFooterFocused = focusedElement is HyperlinkButton;
 
-			if (e.Key == VirtualKey.Enter && !isFooterFocused && !e.KeyStatus.IsMenuKeyDown)
-			{
-				if (IsRenamingItem)
-					return;
+            if (e.Key == VirtualKey.Enter && !isFooterFocused && !e.KeyStatus.IsMenuKeyDown)
+            {
+                if (IsRenamingItem)
+                    return;
 
-				NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
-				e.Handled = true;
-			}
-			else if (e.Key == VirtualKey.Enter && e.KeyStatus.IsMenuKeyDown)
+                if (ctrlPressed)
+                {
+                    var folders = ParentShellPageInstance?.SlimContentPage.SelectedItems?.Where(file => file.PrimaryItemAttribute == StorageItemTypes.Folder);
+                    foreach (ListedItem? folder in folders)
+                    {
+                        if (folder != null)
+                            await NavigationHelpers.OpenPathInNewTab(folder.ItemPath);
+                    }
+                }
+                else
+                {
+                    NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                }
+                e.Handled = true;
+            }
+            else if (e.Key == VirtualKey.Enter && e.KeyStatus.IsMenuKeyDown)
 			{
 				FilePropertiesHelpers.ShowProperties(ParentShellPageInstance);
 				e.Handled = true;

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -6,6 +6,7 @@ using Files.App.Helpers.XamlHelpers;
 using Files.App.Interacts;
 using Files.App.UserControls.Selection;
 using Files.Shared.Enums;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -27,6 +28,7 @@ namespace Files.App.Views.LayoutModes
         private uint currentIconSize;
 
         protected override uint IconSize => currentIconSize;
+
         protected override ItemsControl ItemsControl => FileList;
 
         /// <summary>
@@ -178,8 +180,7 @@ namespace Files.App.Views.LayoutModes
             FolderSettings.LayoutModeChangeRequested -= FolderSettings_LayoutModeChangeRequested;
             FolderSettings.LayoutModeChangeRequested += FolderSettings_LayoutModeChangeRequested;
             SetItemTemplate(); // Set ItemTemplate
-            if (FileList.ItemsSource == null)
-                FileList.ItemsSource = ParentShellPageInstance.FilesystemViewModel.FilesAndFolders;
+            FileList.ItemsSource ??= ParentShellPageInstance.FilesystemViewModel.FilesAndFolders;
             var parameters = (NavigationArguments)eventArgs.Parameter;
             if (parameters.IsLayoutSwitch)
                 ReloadItemIcons();
@@ -254,11 +255,12 @@ namespace Files.App.Views.LayoutModes
 			int extensionLength = RenamingItem.FileExtension?.Length ?? 0;
 
 			GridViewItem gridViewItem = FileList.ContainerFromItem(RenamingItem) as GridViewItem;
-			TextBox textBox = null;
 			if (gridViewItem == null)
 			{
 				return;
 			}
+
+			TextBox textBox = null;
 
 			// Handle layout differences between tiles browser and photo album
 			if (FolderSettings.LayoutMode == FolderLayoutModes.GridView)
@@ -371,8 +373,8 @@ namespace Files.App.Views.LayoutModes
 
         private async void FileList_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
         {
-            var ctrlPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-            var shiftPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+            var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+            var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
             var focusedElement = FocusManager.GetFocusedElement() as FrameworkElement;
             var isFooterFocused = focusedElement is HyperlinkButton;
 
@@ -427,7 +429,7 @@ namespace Files.App.Views.LayoutModes
 			{
 				// Don't block the various uses of enter key (key 13)
 				var focusedElement = (FrameworkElement)FocusManager.GetFocusedElement();
-				if (Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Enter) == CoreVirtualKeyStates.Down
+				if (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Enter) == CoreVirtualKeyStates.Down
 					|| focusedElement is Button
 					|| focusedElement is TextBox
 					|| focusedElement is PasswordBox
@@ -489,8 +491,8 @@ namespace Files.App.Views.LayoutModes
 
 		private void FileList_ItemTapped(object sender, TappedRoutedEventArgs e)
 		{
-			var ctrlPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-			var shiftPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+			var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+			var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
 
 			var item = (e.OriginalSource as FrameworkElement)?.DataContext as ListedItem;
 			if (item == null)

--- a/src/Files.App/Views/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/ModernShellPage.xaml.cs
@@ -158,13 +158,13 @@ namespace Files.App.Views
 
             DisplayFilesystemConsentDialog();
 
-            var flowDirectionSetting = /*
-                TODO ResourceContext.GetForCurrentView and ResourceContext.GetForViewIndependentUse do not exist in Windows App SDK
-                Use your ResourceManager instance to create a ResourceContext as below. If you already have a ResourceManager instance,
-                replace the new instance created below with correct instance.
-                Read: https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/guides/mrtcore
-            */new Microsoft.Windows.ApplicationModel.Resources.ResourceManager().CreateResourceContext().QualifierValues["LayoutDirection"];
-
+            /*TODO ResourceContext.GetForCurrentView and ResourceContext.GetForViewIndependentUse do not exist in Windows App SDK
+              Use your ResourceManager instance to create a ResourceContext as below.If you already have a ResourceManager instance,
+              replace the new instance created below with correct instance.
+              Read: https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/guides/mrtcore
+            */
+            var flowDirectionSetting = new Microsoft.Windows.ApplicationModel.Resources.ResourceManager().CreateResourceContext().QualifierValues["LayoutDirection"];
+			
             if (flowDirectionSetting == "RTL")
                 FlowDirection = FlowDirection.RightToLeft;
 
@@ -192,7 +192,6 @@ namespace Files.App.Views
             this.PointerPressed += CoreWindow_PointerPressed;
 
             /*
-              
             TODO UA307 Default back button in the title bar does not exist in WinUI3 apps.
             The tool has generated a custom back button in the MainWindow.xaml.cs file.
             Feel free to edit its position, behavior and use the custom back button instead.
@@ -299,7 +298,6 @@ namespace Files.App.Views
          * whenever the path changes. We will get the individual directories from
          * the updated, most-current path and add them to the UI.
          */
-
         public void UpdatePathUIToWorkingDirectory(string newWorkingDir, string singleItemOverride = null)
         {
             if (string.IsNullOrWhiteSpace(singleItemOverride))


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9499 

**What has been done**
- Added a shortcut so Ctrl+Enter opens all selected folders into news tab in GridViewBrowser and DetailsLayoutBrower.
- Did some minor refactoring.

**Validation**
How did you test these changes?
- [X] Built and ran the app