### PR TITLE
Fix: Use date from Windows culture instead of Files culture

### DIFF
--- a/src/Files.App/ServicesImplementation/DateTimeFormatter/AbstractDateTimeFormatter.cs
+++ b/src/Files.App/ServicesImplementation/DateTimeFormatter/AbstractDateTimeFormatter.cs
@@ -1,13 +1,14 @@
-using Files.Shared.Services.DateTimeFormatter;
 using Files.App.Extensions;
+using Files.Shared.Services.DateTimeFormatter;
 using System;
 using System.Globalization;
+using Windows.Globalization;
 
 namespace Files.App.ServicesImplementation.DateTimeFormatter
 {
-    internal abstract class AbstractDateTimeFormatter : IDateTimeFormatter
+	internal abstract class AbstractDateTimeFormatter : IDateTimeFormatter
     {
-        private readonly Calendar calendar = new CultureInfo(CultureInfo.CurrentUICulture.Name).Calendar;
+        private static readonly CultureInfo cultureInfo = new(ApplicationLanguages.PrimaryLanguageOverride);
 
         public abstract string Name { get; }
 
@@ -36,10 +37,12 @@ namespace Files.App.ServicesImplementation.DateTimeFormatter
             };
         }
 
-        private int GetWeekOfYear(DateTimeOffset t)
+        protected static string ToString(DateTimeOffset offset, string format) => offset.ToLocalTime().ToString(format, cultureInfo);
+
+        private static int GetWeekOfYear(DateTimeOffset t)
         {
             // Should we use the system setting for the first day of week in the future?
-            return calendar.GetWeekOfYear(t.DateTime, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            return cultureInfo.Calendar.GetWeekOfYear(t.DateTime, CalendarWeekRule.FirstDay, System.DayOfWeek.Sunday);
         }
 
         private class Label : ITimeSpanLabel

--- a/src/Files.App/ServicesImplementation/DateTimeFormatter/AbstractDateTimeFormatter.cs
+++ b/src/Files.App/ServicesImplementation/DateTimeFormatter/AbstractDateTimeFormatter.cs
@@ -6,7 +6,7 @@ using Windows.Globalization;
 
 namespace Files.App.ServicesImplementation.DateTimeFormatter
 {
-	internal abstract class AbstractDateTimeFormatter : IDateTimeFormatter
+    internal abstract class AbstractDateTimeFormatter : IDateTimeFormatter
     {
         private static readonly CultureInfo cultureInfo = new(ApplicationLanguages.PrimaryLanguageOverride);
 

--- a/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
+++ b/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Files.App.ServicesImplementation.DateTimeFormatter
 {
-    internal class ApplicationDateTimeFormatter : AbstractDateTimeFormatter
+	internal class ApplicationDateTimeFormatter : AbstractDateTimeFormatter
     {
         public override string Name => "Application".GetLocalizedResource();
 
@@ -18,7 +18,7 @@ namespace Files.App.ServicesImplementation.DateTimeFormatter
 
             return elapsed switch
             {
-                { TotalDays: >= 7 } => offset.ToLocalTime().ToString("D"),
+                { TotalDays: >= 7 } => ToString(offset, "D"),
                 { TotalDays: >= 2 } => string.Format("DaysAgo".GetLocalizedResource(), elapsed.Days),
                 { TotalDays: >= 1 } => string.Format("DayAgo".GetLocalizedResource(), elapsed.Days),
                 { TotalHours: >= 2 } => string.Format("HoursAgo".GetLocalizedResource(), elapsed.Hours),

--- a/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
+++ b/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Files.App.ServicesImplementation.DateTimeFormatter
 {
-	internal class ApplicationDateTimeFormatter : AbstractDateTimeFormatter
+    internal class ApplicationDateTimeFormatter : AbstractDateTimeFormatter
     {
         public override string Name => "Application".GetLocalizedResource();
 

--- a/src/Files.App/ServicesImplementation/DateTimeFormatter/SystemDateTimeFormatter.cs
+++ b/src/Files.App/ServicesImplementation/DateTimeFormatter/SystemDateTimeFormatter.cs
@@ -13,7 +13,7 @@ namespace Files.App.ServicesImplementation.DateTimeFormatter
             {
                 return " ";
             }
-            return offset.ToLocalTime().ToString("g");
+            return ToString(offset, "g");
         }
     }
 }

--- a/src/Files.App/ServicesImplementation/DateTimeFormatter/UniversalDateTimeFormatter.cs
+++ b/src/Files.App/ServicesImplementation/DateTimeFormatter/UniversalDateTimeFormatter.cs
@@ -13,7 +13,7 @@ namespace Files.App.ServicesImplementation.DateTimeFormatter
             {
                 return " ";
             }
-            return offset.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+            return ToString(offset, "yyyy-MM-dd HH:mm:ss");
         }
     }
 }


### PR DESCRIPTION
**Resolved / Related Issues**
Some dates may display in the Windows culture (language and format) instead of the Files culture. This is fixed. 

The issue mentions other location issues. These are special folders whose names are provided by Windows. We cannot modify these texts according to the language in a simple way. I think it is useless to replace these texts according to the language.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility