### PR TITLE
Fixed crash that would occur when checking for updates

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -283,6 +283,8 @@ namespace Files.App
 		{
 			// Save application state and stop any background activity
 
+			await Task.Yield(); // Method can take a long time, make sure the window is hidden
+
 			SaveSessionTabs();
 
 			if (OutputPath is not null)

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -162,9 +162,6 @@ namespace Files.App
 			FileTagsManager ??= new FileTagsManager();
 			SidebarPinnedController ??= new SidebarPinnedController();
 			TerminalController ??= new TerminalController();
-
-			//FileTagsHelpers.UpdateTagsDb();
-			FileOperationsHelpers.WaitForCompletion();
 		}
 
 		private static async Task StartAppCenter()
@@ -209,6 +206,7 @@ namespace Files.App
 					JumpList.InitializeAsync(),
 					ContextFlyoutItemHelper.CachedNewContextMenuEntries
 				);
+				FileTagsHelper.UpdateTagsDb();
 			});
 
 			// Check for required updates
@@ -243,17 +241,8 @@ namespace Files.App
 			EnsureWindowIsInitialized();
 
 			EnsureSettingsAndConfigurationAreBootstrapped();
-			Task.Run(async () =>
-			{
-				try
-				{
-					await InitializeAppComponentsAsync();
-				}
-				catch (Exception ex)
-				{
-					Logger.Warn(ex, "Error during InitializeAppComponentsAsync()");
-				}
-			});
+
+			_ = InitializeAppComponentsAsync().ContinueWith(t => Logger.Warn(t.Exception, "Error during InitializeAppComponentsAsync()"), TaskContinuationOptions.OnlyOnFaulted);
 
 			_ = Window.InitializeApplication(activatedEventArgs);
 		}
@@ -324,6 +313,9 @@ namespace Files.App
 						Clipboard.Flush();
 				}
 			}, Logger);
+
+			// Wait for ongoing file operations
+			FileOperationsHelpers.WaitForCompletion();
 		}
 
 		public static void SaveSessionTabs() // Enumerates through all tabs and gets the Path property and saves it to AppSettings.LastSessionPages


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fix crash when checking for updates. IUpdateService methods are supposed to be called from the UI thread.
- Wait for file transfers to complete before terminating process
- Restored call to UpdateTagsDb()

**Validation**
How did you test these changes?
- [x] Built and ran the app
