### PR TITLE
Fix: Fixed crash when renaming in GridView

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -411,7 +411,6 @@ namespace Files.App.Views.LayoutModes
 				TextBlock? textBlock = listViewItem.FindDescendant("ItemName") as TextBlock;
 				textBox.Visibility = Visibility.Collapsed;
 				textBlock!.Visibility = Visibility.Visible;
-
 			}
 
 			textBox!.LostFocus -= RenameTextBox_LostFocus;

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -350,8 +350,8 @@ namespace Files.App.Views.LayoutModes
 			}
 			else if (FolderSettings.LayoutMode == FolderLayoutModes.GridView)
 			{
-				Popup popup = gridViewItem.FindDescendant("EditPopup") as Popup;
-				popup.IsOpen = false;
+				Popup? popup = gridViewItem.FindDescendant("EditPopup") as Popup;
+				popup!.IsOpen = false;
 			}
 			else if (FolderSettings.LayoutMode == FolderLayoutModes.TilesView)
 			{

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -342,22 +342,22 @@ namespace Files.App.Views.LayoutModes
 
 		private void EndRename(TextBox textBox)
 		{
-			if (textBox is null || textBox.Parent is null)
+			GridViewItem? gridViewItem = FileList.ContainerFromItem(RenamingItem) as GridViewItem;
+
+			if (textBox is null || gridViewItem is null)
 			{
 				// Navigating away, do nothing
 			}
 			else if (FolderSettings.LayoutMode == FolderLayoutModes.GridView)
 			{
-				Popup popup = (Popup)textBox.Parent;
-				TextBlock textBlock = (TextBlock)((Grid)popup.Parent).Children[1];
+				Popup popup = gridViewItem.FindDescendant("EditPopup") as Popup;
 				popup.IsOpen = false;
 			}
 			else if (FolderSettings.LayoutMode == FolderLayoutModes.TilesView)
 			{
-				Grid grid = (Grid)textBox.Parent;
-				TextBlock textBlock = (TextBlock)grid.Children[0];
+				TextBlock? textBlock = gridViewItem.FindDescendant("ItemName") as TextBlock;
 				textBox.Visibility = Visibility.Collapsed;
-				textBlock.Visibility = Visibility.Visible;
+				textBlock!.Visibility = Visibility.Visible;
 			}
 
 			textBox!.LostFocus -= RenameTextBox_LostFocus;
@@ -366,7 +366,6 @@ namespace Files.App.Views.LayoutModes
 			IsRenamingItem = false;
 
 			// Re-focus selected list item
-			GridViewItem? gridViewItem = FileList.ContainerFromItem(RenamingItem) as GridViewItem;
 			gridViewItem?.Focus(FocusState.Programmatic);
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10387

Find UI element by name instead of parent/child. Copied logic from Details layout.

**Validation**
How did you test these changes?
- [x] Built and ran the app
