### PR TITLE
Fixed issue where the Files window wasn't being activated on Win+Num

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -257,8 +257,6 @@ namespace Files.App
 			{
 				ShowErrorNotification = true;
 				ApplicationData.Current.LocalSettings.Values["INSTANCE_ACTIVE"] = -Process.GetCurrentProcess().Id;
-				if (AppModel is not null)
-					AppModel.Clipboard_ContentChanged(null, null);
 			}
 		}
 

--- a/src/Files.App/DataModels/AppModel.cs
+++ b/src/Files.App/DataModels/AppModel.cs
@@ -27,8 +27,6 @@ namespace Files.App.DataModels
 		{
 			try
 			{
-				// Clipboard.GetContent() will throw UnauthorizedAccessException
-				// if the app window is not in the foreground and active
 				DataPackageView packageView = Clipboard.GetContent();
 				if (packageView.Contains(StandardDataFormats.StorageItems) || packageView.Contains(StandardDataFormats.Bitmap))
 				{


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10379

Issue was checking the Clipboard in the window Activated event. Doing so is not necessary in Winui3 (window receives Clipboard events also when minimized).

**Validation**
How did you test these changes?
- [x] Built and ran the app
