### PR TITLE
Code Quality: Use constant documentation for help command

### DIFF
--- a/src/Files.App/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/ColumnShellPage.xaml.cs
@@ -788,7 +788,7 @@ namespace Files.App.Views
 					break;
 
 				case (false, false, false, _, VirtualKey.F1): // F1, open Files wiki
-					await Launcher.LaunchUriAsync(new Uri(@"https://files.community/docs"));
+					await Launcher.LaunchUriAsync(new Uri(Constants.GitHub.DocumentationUrl));
 					break;
 			}
 

--- a/src/Files.App/Views/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/ModernShellPage.xaml.cs
@@ -778,7 +778,7 @@ namespace Files.App.Views
 					break;
 
 				case (false, false, false, _, VirtualKey.F1): // F1, open Files wiki
-					await Launcher.LaunchUriAsync(new Uri(@"https://files.community/docs"));
+					await Launcher.LaunchUriAsync(new Uri(Constants.GitHub.DocumentationUrl));
 					break;
 
 				case (true, true, false, _, VirtualKey.Number1): // ctrl+shift+1, details view


### PR DESCRIPTION
**Resolved / Related Issues**
The help command (key F1) use the url instead of the constant. This pr uses the constant that already exists.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility