### PR TITLE
Implement Oem plus key for Alt+Shift++ (New pane) shortcut

### DIFF
--- a/src/Files.App/Views/PaneHolderPage.xaml
+++ b/src/Files.App/Views/PaneHolderPage.xaml
@@ -181,5 +181,9 @@
 			Key="Add"
 			Invoked="KeyboardAccelerator_Invoked"
 			Modifiers="Menu,Shift" />
-	</Page.KeyboardAccelerators>
+        <KeyboardAccelerator
+			Key="{x:Bind PlusKey}"
+			Invoked="KeyboardAccelerator_Invoked"
+			Modifiers="Menu,Shift" />
+    </Page.KeyboardAccelerators>
 </Page>

--- a/src/Files.App/Views/PaneHolderPage.xaml.cs
+++ b/src/Files.App/Views/PaneHolderPage.xaml.cs
@@ -194,7 +194,9 @@ namespace Files.App.Views
 			}
 		}
 
-		public PaneHolderPage()
+        public readonly VirtualKey PlusKey = (VirtualKey)187;
+
+        public PaneHolderPage()
 		{
 			this.InitializeComponent();
 			App.Window.SizeChanged += Current_SizeChanged;
@@ -322,6 +324,7 @@ namespace Files.App.Views
 					break;
 
 				case (false, true, true, VirtualKey.Add): // alt + shift + "+" open pane
+				case (false, true, true, (VirtualKey)187):
 					if (UserSettingsService.MultitaskingSettingsService.IsDualPaneEnabled)
 					{
 						if (string.IsNullOrEmpty(NavParamsRight?.NavPath))


### PR DESCRIPTION
The New Pane keyboard shortcut (Alt+Shift++) is now also executed with the "oem" plus key, in addition to the numpad plus key.

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9508 

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility
