### PR TITLE
Fix: Focus first item in folder when opening it with keyboard in DetailsLayout

### DIFF
--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -782,7 +782,7 @@ namespace Files.App
 							dragOverTimer.Stop();
 							ItemManipulationModel.SetSelectedItem(dragOverItem);
 							dragOverItem = null;
-							NavigationHelpers.OpenSelectedItems(ParentShellPageInstance!, false);
+							_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance!, false);
 						}
 					}, TimeSpan.FromMilliseconds(1000), false);
 				}

--- a/src/Files.App/Helpers/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/NavigationHelpers.cs
@@ -42,7 +42,7 @@ namespace Files.App.Helpers
 			await Launcher.LaunchUriAsync(filesUWPUri);
 		}
 
-		public static async void OpenSelectedItems(IShellPage associatedInstance, bool openViaApplicationPicker = false)
+		public static async Task OpenSelectedItems(IShellPage associatedInstance, bool openViaApplicationPicker = false)
 		{
 			// Don't open files and folders inside recycle bin
 			if (associatedInstance.FilesystemViewModel.WorkingDirectory.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
@@ -60,7 +60,6 @@ namespace Files.App.Helpers
 				selectedItems.Count > 1 &&
 				selectedItems.All(x => x.PrimaryItemAttribute == StorageItemTypes.File && !x.IsExecutable && !x.IsShortcut))
 			{
-
 				opened = await Win32Helpers.InvokeWin32ComponentAsync(string.Join('|', selectedItems.Select(x => x.ItemPath)), associatedInstance);
 			}
 

--- a/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -129,7 +129,7 @@ namespace Files.App.Interacts
 
 		public virtual void OpenItem(RoutedEventArgs e)
 		{
-			NavigationHelpers.OpenSelectedItems(associatedInstance, false);
+			_ = NavigationHelpers.OpenSelectedItems(associatedInstance, false);
 		}
 
 		public virtual void UnpinDirectoryFromFavorites(RoutedEventArgs e)
@@ -238,7 +238,7 @@ namespace Files.App.Interacts
 
 		public virtual void OpenItemWithApplicationPicker(RoutedEventArgs e)
 		{
-			NavigationHelpers.OpenSelectedItems(associatedInstance, true);
+            _ = NavigationHelpers.OpenSelectedItems(associatedInstance, true);
 		}
 
 		public virtual async void OpenDirectoryInNewTab(RoutedEventArgs e)

--- a/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -238,7 +238,7 @@ namespace Files.App.Interacts
 
 		public virtual void OpenItemWithApplicationPicker(RoutedEventArgs e)
 		{
-            _ = NavigationHelpers.OpenSelectedItems(associatedInstance, true);
+			_ = NavigationHelpers.OpenSelectedItems(associatedInstance, true);
 		}
 
 		public virtual async void OpenDirectoryInNewTab(RoutedEventArgs e)

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -361,7 +361,7 @@ namespace Files.App.Views.LayoutModes
 				if (IsItemSelected && SelectedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
 					ItemInvoked?.Invoke(new ColumnParam { NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
 				else
-                    _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+					_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 
 				e.Handled = true;
 			}
@@ -450,15 +450,11 @@ namespace Files.App.Views.LayoutModes
 				{
 					case StorageItemTypes.File:
 						if (!UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
-						{
-                            _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
-						}
+							_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 						break;
 					case StorageItemTypes.Folder:
 						if (!UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick)
-						{
 							ItemInvoked?.Invoke(new ColumnParam { NavPathParam = (item is ShortcutItem sht ? sht.TargetPath : item.ItemPath), ListView = FileList }, EventArgs.Empty);
-						}
 						break;
 					default:
 						ParentShellPageInstance.Up_Click();
@@ -511,7 +507,7 @@ namespace Files.App.Views.LayoutModes
 				&& (UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick && item.PrimaryItemAttribute == StorageItemTypes.File))
 			{
 				ResetRenameDoubleClick();
-                _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+					_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -507,7 +507,7 @@ namespace Files.App.Views.LayoutModes
 				&& (UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick && item.PrimaryItemAttribute == StorageItemTypes.File))
 			{
 				ResetRenameDoubleClick();
-					_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+				_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -361,7 +361,7 @@ namespace Files.App.Views.LayoutModes
 				if (IsItemSelected && SelectedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
 					ItemInvoked?.Invoke(new ColumnParam { NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
 				else
-					NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                    _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 
 				e.Handled = true;
 			}
@@ -451,7 +451,7 @@ namespace Files.App.Views.LayoutModes
 					case StorageItemTypes.File:
 						if (!UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
 						{
-							NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                            _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 						}
 						break;
 					case StorageItemTypes.Folder:
@@ -511,7 +511,7 @@ namespace Files.App.Views.LayoutModes
 				&& (UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick && item.PrimaryItemAttribute == StorageItemTypes.File))
 			{
 				ResetRenameDoubleClick();
-				NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -446,7 +446,7 @@ namespace Files.App.Views.LayoutModes
 				}
 				else
 				{
-					NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+					await NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 				}
 				e.Handled = true;
 			}
@@ -554,7 +554,7 @@ namespace Files.App.Views.LayoutModes
 				&& UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
 			{
 				ResetRenameDoubleClick();
-				NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{
@@ -581,7 +581,7 @@ namespace Files.App.Views.LayoutModes
 			if ((e.OriginalSource as FrameworkElement)?.DataContext is ListedItem item
 				 && !UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
 			{
-				NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -447,6 +447,7 @@ namespace Files.App.Views.LayoutModes
 				else
 				{
 					await NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+					FileList.SelectedIndex = 0;
 				}
 				e.Handled = true;
 			}

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -554,7 +554,7 @@ namespace Files.App.Views.LayoutModes
 				&& UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
 			{
 				ResetRenameDoubleClick();
-                _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+				_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{
@@ -581,7 +581,7 @@ namespace Files.App.Views.LayoutModes
 			if ((e.OriginalSource as FrameworkElement)?.DataContext is ListedItem item
 				 && !UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
 			{
-                _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+				_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -392,7 +392,7 @@ namespace Files.App.Views.LayoutModes
 				}
 				else
 				{
-                    _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+					_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 				}
 				e.Handled = true;
 			}
@@ -517,7 +517,7 @@ namespace Files.App.Views.LayoutModes
 				&& UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
 			{
 				ResetRenameDoubleClick();
-                _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+				_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{
@@ -552,7 +552,7 @@ namespace Files.App.Views.LayoutModes
 			if ((e.OriginalSource as FrameworkElement)?.DataContext is ListedItem item
 				 && !UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
 			{
-                _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+				_ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -392,7 +392,7 @@ namespace Files.App.Views.LayoutModes
 				}
 				else
 				{
-					NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                    _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 				}
 				e.Handled = true;
 			}
@@ -517,7 +517,7 @@ namespace Files.App.Views.LayoutModes
 				&& UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
 			{
 				ResetRenameDoubleClick();
-				NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{
@@ -552,7 +552,7 @@ namespace Files.App.Views.LayoutModes
 			if ((e.OriginalSource as FrameworkElement)?.DataContext is ListedItem item
 				 && !UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
 			{
-				NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
+                _ = NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else
 			{


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9042 
- Related to #10438 (Example of bug that can be fixed if fixing `async void` method use)

**What has been done**
- Now selecting the first item of a newly opened folder using Enter in DetailsLayout.
- Changed `OpenSelectedItems` from `async void` to `async Task`
- Minor refactoring.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility

**Screenshots**

![9042](https://user-images.githubusercontent.com/110472580/200807457-b7180bde-3f16-43a5-8426-00afcad4f538.gif)
