### PR TITLE
Fix: Fixed issue with compressing files

### DIFF
--- a/src/Files.App/Helpers/ZipHelpers.cs
+++ b/src/Files.App/Helpers/ZipHelpers.cs
@@ -31,7 +31,12 @@ namespace Files.App.Helpers
 					if (i > 0)
 						compressor.CompressionMode = CompressionMode.Append;
 
-					await compressor.CompressDirectoryAsync(sourceFolders[i], archive);
+					var item = sourceFolders[i];
+					if (File.Exists(item))
+						await compressor.CompressFilesAsync(archive, item);
+					else if (Directory.Exists(item))
+						await compressor.CompressDirectoryAsync(item, archive);
+
 					float percentage = (i + 1.0f) / sourceFolders.Length * 100.0f;
 					progressDelegate?.Report(percentage);
 				}


### PR DESCRIPTION
**Resolved / Related Issues**
Compression fails when one of the selected items is a file (not a directory). This pr fixes this.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility