### PR TITLE
Fix: Fixed issue where nav menu had extra margin in the properties window

### DIFF
--- a/src/Files.App/Views/Pages/Properties.xaml
+++ b/src/Files.App/Views/Pages/Properties.xaml
@@ -39,7 +39,7 @@
 		<NavigationView
 			x:Name="NavigationView"
 			Grid.Row="0"
-			Margin="8,8,120,8"
+			Margin="8"
 			HorizontalAlignment="Left"
 			AllowDrop="False"
 			Canvas.ZIndex="100"

--- a/src/Files.App/Views/Pages/Properties.xaml
+++ b/src/Files.App/Views/Pages/Properties.xaml
@@ -39,7 +39,7 @@
 		<NavigationView
 			x:Name="NavigationView"
 			Grid.Row="0"
-			Margin="8"
+			Margin="8,8,32,8"
 			HorizontalAlignment="Left"
 			AllowDrop="False"
 			Canvas.ZIndex="100"


### PR DESCRIPTION
**Resolved / Related Issues**
Properties tabs use an unnecessary right margin. Some tabs do not appear. This removes the margin.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Before
![PropertyBefore](https://user-images.githubusercontent.com/46631671/202033868-dd4d4d80-f1a3-4363-a7bd-4729d580d624.png)
After
![PropertyAfter](https://user-images.githubusercontent.com/46631671/202033866-205766b4-5778-41bb-bd54-7602dbeb68b9.png)