### PR TITLE
Fix AddressBar LostFocus

### DIFF
--- a/src/Files.App/UserControls/AddressToolbar.xaml
+++ b/src/Files.App/UserControls/AddressToolbar.xaml
@@ -13,6 +13,7 @@
 	xmlns:triggers="using:CommunityToolkit.WinUI.UI.Triggers"
 	xmlns:uc="using:Files.App.UserControls"
 	x:Name="NavToolbar"
+	Loading="NavToolbar_Loading"
 	Height="50"
 	d:DesignHeight="50"
 	d:DesignWidth="800"

--- a/src/Files.App/ViewModels/ToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/ToolbarViewModel.cs
@@ -763,8 +763,8 @@ namespace Files.App.ViewModels
 
 		public void SearchRegion_LostFocus(object sender, RoutedEventArgs e)
 		{
-			var focusedElement = FocusManager.GetFocusedElement();
-			if ((focusedElement is Button bttn && bttn.Name == "SearchButton") || focusedElement is FlyoutBase || focusedElement is AppBarButton)
+			var element = FocusManager.GetFocusedElement();
+			if (element is FlyoutBase or AppBarButton)
 				return;
 
 			SearchHasFocus = false;


### PR DESCRIPTION
**Resolved / Related Issues**
This pr fixes 2 bugs and refactors AddressToolbar.
1) AddressToolbar's edit mode never closes and keeps the address when changing pages.
2) In compact mode, the button to close the search bar does not work.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Bug 1

https://user-images.githubusercontent.com/46631671/202229181-f9a249a7-ac3a-44f3-8580-2f187fd2065a.mp4

Bug 2

https://user-images.githubusercontent.com/46631671/202229185-9e3818b7-12ac-4c1d-8e6d-1f3dc321cf2c.mp4
