### PR TITLE
Fix: Fixed issue where 7z archives were not extracted correctly

### DIFF
--- a/src/Files.App/Helpers/ZipHelpers.cs
+++ b/src/Files.App/Helpers/ZipHelpers.cs
@@ -74,8 +74,8 @@ namespace Files.App.Helpers
 			if (zipFile is null)
 				return;
 			//zipFile.IsStreamOwner = true;
-			List<ArchiveFileInfo> directoryEntries = new List<ArchiveFileInfo>();
-			List<ArchiveFileInfo> fileEntries = new List<ArchiveFileInfo>();
+			var directoryEntries = new List<ArchiveFileInfo>();
+			var fileEntries = new List<ArchiveFileInfo>();
 			foreach (ArchiveFileInfo entry in zipFile.ArchiveFileData)
 			{
 				if (!entry.IsDirectory)
@@ -112,6 +112,8 @@ namespace Files.App.Helpers
 						NativeFileOperationsHelper.CreateDirectoryFromApp(dirName, IntPtr.Zero);
 					}
 				}
+
+				fileEntries.RemoveAll(file => file.FileName == dir);
 
 				if (cancellationToken.IsCancellationRequested) // Check if canceled
 					return;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10414

**Description**
- 7zip library doesn't distinct files and firectories. Because of this, they are all added to `fileEntries`
- I fixed this by removing the directories from the list after they are created

**Validation**
How did you test these changes?
- [x] Built and ran the app
