### PR TITLE
Feature: Allow resizing the status column

### DIFF
--- a/src/Files.App/ViewModels/ColumnsViewModel.cs
+++ b/src/Files.App/ViewModels/ColumnsViewModel.cs
@@ -188,7 +188,6 @@ namespace Files.App.ViewModels
 
 		private double normalMaxLength = 800;
 
-		[LiteDB.BsonIgnore]
 		public double NormalMaxLength
 		{
 			get => normalMaxLength;

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -339,7 +339,8 @@
 									x:Name="Column10"
 									Width="{x:Bind ColumnsViewModel.StatusColumn.Length, Mode=OneWay}"
 									MaxWidth="{x:Bind ColumnsViewModel.StatusColumn.MaxLength, Mode=OneWay}" />
-								<ColumnDefinition x:Name="Column11" Width="0" />
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="0" />
 							</Grid.ColumnDefinitions>
 
 							<Grid Grid.Column="0" />


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10432 

**Changes**
- I added a column with `width=0`, since I discovered that you can't resize the last column
- I removed `BsonIgnore` from `NormalMaxLength`, as this prevented length constraints from being applied to custom folders

**Validation**
How did you test these changes?
- [x] Built and ran the app
