### PR TITLE
Feature Request: Showing Of Printers on Network Locations/Drives

### DIFF
--- a/src/Files.App (Package)/Package.appxmanifest
+++ b/src/Files.App (Package)/Package.appxmanifest
@@ -51,6 +51,7 @@
         <Resource Language="pl-PL"/>
         <Resource Language="pt-BR"/>
         <Resource Language="pt-PT"/>
+        <Resource Language="ro-RO"/>
         <Resource Language="ru-RU"/>
         <Resource Language="sk-SK"/>
         <Resource Language="sv-SE"/>

--- a/src/Files.App (Package)/Package.appxmanifest
+++ b/src/Files.App (Package)/Package.appxmanifest
@@ -9,7 +9,7 @@
          xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"
          xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
          IgnorableNamespaces="uap uap5 mp rescap desktop4 desktop">
-    <Identity Name="FilesDev" Publisher="CN=Files" Version="2.3.55.0" />
+    <Identity Name="FilesDev" Publisher="CN=Files" Version="2.3.61.0" />
     <Properties>
         <DisplayName>Files - Dev</DisplayName>
         <PublisherDisplayName>Yair A</PublisherDisplayName>


### PR DESCRIPTION
Hi I would like to request a feature for the application,
I feel it would be a worthy additon to add Printers into the Files app for network locations and drives at the moment i have to keep switching to the inbuilt windows explorer to add Printers. I feel people using this app would apriceate the abilty to see printers.
/#<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #issue...

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.#/
