### PR TITLE
Fix: Open archives in existing tab if files is set as default app

### DIFF
--- a/src/Files.App/Filesystem/StorageItems/ZipStorageFolder.cs
+++ b/src/Files.App/Filesystem/StorageItems/ZipStorageFolder.cs
@@ -100,7 +100,7 @@ namespace Files.App.Filesystem.StorageItems
 				var assoc = await NativeWinApiHelper.GetFileAssociationAsync(filePath);
 				if (assoc is not null)
 				{
-					return assoc == Package.Current.Id.FamilyName
+					return assoc.EndsWith("Files.App\\Files.exe", StringComparison.OrdinalIgnoreCase)
 						|| assoc.Equals(IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "explorer.exe"), StringComparison.OrdinalIgnoreCase);
 				}
 				return true;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10529

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.


**Explanation**

Zip files were not recognized as browsable zip because this method returned false if Files is set as default app.

`assoc` contains the full path to the associated app, for example “C:\\Program Files\\WindowsApps\\FilesPreview_2.3.61.0_x64__wvne1zexy08sa\\Files.App\\Files.exe”

The package `FamilyName` is in debug mode for example “FilesDev_ykqwq8d6ps0ag”

I also thought about comparing it with the current executing assembly path or to check if the associated path contains the Package Name, but that would not work in debug mode or if multiple files apps are installed (Store, Sideload, …)
