### PR TITLE
Only save necessary info to folder preferences

### DIFF
--- a/src/Files.App/ViewModels/ColumnsViewModel.cs
+++ b/src/Files.App/ViewModels/ColumnsViewModel.cs
@@ -103,6 +103,7 @@ namespace Files.App.ViewModels
 			set => SetProperty(ref sizeColumn, value);
 		}
 
+		[LiteDB.BsonIgnore]
 		public double TotalWidth => IconColumn.Length.Value + TagColumn.Length.Value + NameColumn.Length.Value + DateModifiedColumn.Length.Value + OriginalPathColumn.Length.Value
 			+ ItemTypeColumn.Length.Value + DateDeletedColumn.Length.Value + DateCreatedColumn.Length.Value + SizeColumn.Length.Value + StatusColumn.Length.Value;
 
@@ -188,6 +189,7 @@ namespace Files.App.ViewModels
 
 		private double normalMaxLength = 800;
 
+		[LiteDB.BsonIgnore]
 		public double NormalMaxLength
 		{
 			get => normalMaxLength;
@@ -227,6 +229,7 @@ namespace Files.App.ViewModels
 			}
 		}
 
+		[LiteDB.BsonIgnore]
 		public GridLength Length
 		{
 			get => IsHidden || UserCollapsed ? new GridLength(0) : UserLength;
@@ -234,6 +237,7 @@ namespace Files.App.ViewModels
 
 		private const int gridSplitterWidth = 8;
 
+		[LiteDB.BsonIgnore]
 		public GridLength LengthIncludingGridSplitter
 		{
 			get => IsHidden || UserCollapsed ? new GridLength(0) : new GridLength(UserLength.Value + (IsResizeable ? gridSplitterWidth : 0));
@@ -244,6 +248,7 @@ namespace Files.App.ViewModels
 
 		private GridLength userLength = new GridLength(200, GridUnitType.Pixel);
 
+		[LiteDB.BsonIgnore]
 		public GridLength UserLength
 		{
 			get => userLength;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- None, small optimization

Currently we are serializing unnecessary/calculated fields of ColumnsViewModel to the preference DB. This PR adds [BsonIgnore] to those.

Before (each column per each folder):
```json
"NameColumn": 
{
  "LengthIncludingGridSplitter": 
  {
    "Value": 248.0,
    "GridUnitType": "Pixel",
    "IsAbsolute": true,
    "IsAuto": false,
    "IsStar": false
  },
  "Length": 
  {
    "Value": 240.0,
    "GridUnitType": "Pixel",
    "IsAbsolute": true,
    "IsAuto": false,
    "IsStar": false
  },
  "UserCollapsed": false,
  "UserLength": 
  {
    "Value": 240.0,
    "GridUnitType": "Pixel",
    "IsAbsolute": true,
    "IsAuto": false,
    "IsStar": false
  },
  "UserLengthPixels": 240.0
},
```

After:
```json
"NameColumn": 
{
  "UserCollapsed": false,
  "UserLengthPixels": 240.0
}
```

**Validation**
How did you test these changes?
- [x] Built and ran the app
