### PR TITLE
Check zip assoc against FamilyName

### DIFF
--- a/src/Files.App/Filesystem/StorageItems/ZipStorageFolder.cs
+++ b/src/Files.App/Filesystem/StorageItems/ZipStorageFolder.cs
@@ -100,7 +100,8 @@ namespace Files.App.Filesystem.StorageItems
 				var assoc = await NativeWinApiHelper.GetFileAssociationAsync(filePath);
 				if (assoc is not null)
 				{
-					return assoc.EndsWith("Files.App\\Files.exe", StringComparison.OrdinalIgnoreCase)
+					return assoc == Package.Current.Id.FamilyName
+						|| assoc.EndsWith("Files.App\\Files.exe", StringComparison.OrdinalIgnoreCase)
 						|| assoc.Equals(IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "explorer.exe"), StringComparison.OrdinalIgnoreCase);
 				}
 				return true;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixes an issue with #10554

On my PC `assoc` contains exactly `FilesDev_ykqwq8d6ps0ag` (FamilyName). So the PR for me actually causes the issue it's supposed to solve.
Not sure where the difference is (OS version?) but leaving both checks (FamilyName + Files.exe path) should be good for everyone.

**Validation**
How did you test these changes?
- [x] Built and ran the app
