### PR TITLE
Remove workaround for drag area on Windows 10

### DIFF
--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -133,18 +133,7 @@ namespace Files.App.Views
 
 		private void HorizontalMultitaskingControl_Loaded(object sender, RoutedEventArgs e)
 		{
-			// WINUI3: bad workaround to be removed asap!
-			// SetDragRectangles() does not work on windows 10 with winappsdk "1.2.220902.1-preview1"
-			if (Environment.OSVersion.Version.Build >= 22000)
-			{
-				horizontalMultitaskingControl.DragArea.SizeChanged += (_, _) => SetRectDragRegion();
-			}
-			else
-			{
-				App.Window.AppWindow.TitleBar.ExtendsContentIntoTitleBar = false;
-				App.Window.ExtendsContentIntoTitleBar = true;
-				App.Window.SetTitleBar(horizontalMultitaskingControl.DragArea);
-			}
+			horizontalMultitaskingControl.DragArea.SizeChanged += (_, _) => SetRectDragRegion();
 
 			if (ViewModel.MultitaskingControl is not HorizontalMultitaskingControl)
 			{
@@ -156,14 +145,6 @@ namespace Files.App.Views
 
 		private void SetRectDragRegion()
 		{
-			const uint MDT_Effective_DPI = 0;
-
-			var displayArea = DisplayArea.GetFromWindowId(App.Window.AppWindow.Id, DisplayAreaFallback.Primary);
-			var hMonitor = Win32Interop.GetMonitorFromDisplayId(displayArea.DisplayId);
-			var hr = NativeWinApiHelper.GetDpiForMonitor(hMonitor, MDT_Effective_DPI, out var dpiX, out _);
-			if (hr != 0)
-				return;
-
 			var scaleAdjustment = XamlRoot.RasterizationScale;
 			var dragArea = horizontalMultitaskingControl.DragArea;
 

--- a/src/Files.App/Views/Pages/Properties.xaml
+++ b/src/Files.App/Views/Pages/Properties.xaml
@@ -28,113 +28,110 @@
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 
-		<Grid
-			x:Name="TitleBarDragArea"
-			Grid.Row="0"
-			Height="32"
+		<Border
+			x:Name="TitlebarArea"
 			HorizontalAlignment="Stretch"
-			VerticalAlignment="Top"
-			Background="Transparent" />
-
-		<NavigationView
-			x:Name="NavigationView"
 			Grid.Row="0"
-			Margin="8,8,120,8"
-			HorizontalAlignment="Left"
-			AllowDrop="False"
-			Canvas.ZIndex="100"
-			IsBackButtonVisible="Collapsed"
-			IsPaneOpen="False"
-			IsPaneToggleButtonVisible="False"
-			IsSettingsVisible="False"
-			IsTitleBarAutoPaddingEnabled="False"
-			PaneDisplayMode="Top"
-			SelectedItem="{x:Bind TabGeneral}"
-			SelectionChanged="NavigationView_SelectionChanged"
-			SelectionFollowsFocus="Disabled">
-			<NavigationView.Resources>
-				<Style TargetType="NavigationViewItem">
-					<Setter Target="SelectionIndicator" Property="Margin" Value="0,-8,0,0" />
-				</Style>
-			</NavigationView.Resources>
-			<!--  SelectionFollowsFocus disabled to fix #5387  -->
+			Background="Transparent">
+			<NavigationView
+				x:Name="NavigationView"
+				Margin="8,8,120,8"
+				HorizontalAlignment="Left"
+				AllowDrop="False"
+				Canvas.ZIndex="100"
+				IsBackButtonVisible="Collapsed"
+				IsPaneOpen="False"
+				IsPaneToggleButtonVisible="False"
+				IsSettingsVisible="False"
+				IsTitleBarAutoPaddingEnabled="False"
+				PaneDisplayMode="Top"
+				SelectedItem="{x:Bind TabGeneral}"
+				SelectionChanged="NavigationView_SelectionChanged"
+				SelectionFollowsFocus="Disabled">
+				<NavigationView.Resources>
+					<Style TargetType="NavigationViewItem">
+						<Setter Target="SelectionIndicator" Property="Margin" Value="0,-8,0,0" />
+					</Style>
+				</NavigationView.Resources>
+				<!--  SelectionFollowsFocus disabled to fix #5387  -->
 
-			<!--  Tabs  -->
-			<NavigationView.MenuItems>
-				<NavigationViewItem
+				<!--  Tabs  -->
+				<NavigationView.MenuItems>
+					<NavigationViewItem
 					x:Name="TabGeneral"
 					AccessKey="G"
 					Content="{helpers:ResourceString Name=General}"
 					CornerRadius="0"
 					Tag="General">
-					<NavigationViewItem.Icon>
-						<FontIcon Glyph="&#xE7C3;" />
-					</NavigationViewItem.Icon>
-				</NavigationViewItem>
-				<NavigationViewItem
+						<NavigationViewItem.Icon>
+							<FontIcon Glyph="&#xE7C3;" />
+						</NavigationViewItem.Icon>
+					</NavigationViewItem>
+					<NavigationViewItem
 					x:Name="TabSecurity"
 					Content="{helpers:ResourceString Name=Security}"
 					CornerRadius="0"
 					Tag="Security">
-					<NavigationViewItem.Icon>
-						<FontIcon Glyph="&#xE730;" />
-					</NavigationViewItem.Icon>
-				</NavigationViewItem>
-				<NavigationViewItem
+						<NavigationViewItem.Icon>
+							<FontIcon Glyph="&#xE730;" />
+						</NavigationViewItem.Icon>
+					</NavigationViewItem>
+					<NavigationViewItem
 					x:Name="TabShorcut"
 					AccessKey="S"
 					Content="{helpers:ResourceString Name=Shortcut}"
 					CornerRadius="0"
 					Tag="Shortcut"
 					Visibility="Collapsed">
-					<NavigationViewItem.Icon>
-						<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF10A;" />
-					</NavigationViewItem.Icon>
-				</NavigationViewItem>
-				<NavigationViewItem
+						<NavigationViewItem.Icon>
+							<FontIcon FontFamily="{StaticResource CustomGlyph}" Glyph="&#xF10A;" />
+						</NavigationViewItem.Icon>
+					</NavigationViewItem>
+					<NavigationViewItem
 					x:Name="TabLibrary"
 					AccessKey="L"
 					Content="{helpers:ResourceString Name=Library}"
 					CornerRadius="0"
 					Tag="Library"
 					Visibility="Collapsed">
-					<NavigationViewItem.Icon>
-						<FontIcon Glyph="&#xE1D3;" />
-					</NavigationViewItem.Icon>
-				</NavigationViewItem>
-				<NavigationViewItem
+						<NavigationViewItem.Icon>
+							<FontIcon Glyph="&#xE1D3;" />
+						</NavigationViewItem.Icon>
+					</NavigationViewItem>
+					<NavigationViewItem
 					x:Name="TabDetails"
 					AccessKey="D"
 					Content="{helpers:ResourceString Name=Details}"
 					CornerRadius="0"
 					Tag="Details"
 					Visibility="Collapsed">
-					<NavigationViewItem.Icon>
-						<FontIcon Glyph="&#xE946;" />
-					</NavigationViewItem.Icon>
-				</NavigationViewItem>
-				<NavigationViewItem
+						<NavigationViewItem.Icon>
+							<FontIcon Glyph="&#xE946;" />
+						</NavigationViewItem.Icon>
+					</NavigationViewItem>
+					<NavigationViewItem
 					x:Name="TabCustomization"
 					Content="{helpers:ResourceString Name=Customization}"
 					CornerRadius="0"
 					Tag="Customization"
 					Visibility="Collapsed">
-					<NavigationViewItem.Icon>
-						<FontIcon Glyph="&#xE771;" />
-					</NavigationViewItem.Icon>
-				</NavigationViewItem>
-				<NavigationViewItem
+						<NavigationViewItem.Icon>
+							<FontIcon Glyph="&#xE771;" />
+						</NavigationViewItem.Icon>
+					</NavigationViewItem>
+					<NavigationViewItem
 					x:Name="TabCompatibility"
 					Content="{helpers:ResourceString Name=Compatibility}"
 					CornerRadius="0"
 					Tag="Compatibility"
 					Visibility="Collapsed">
-					<NavigationViewItem.Icon>
-						<FontIcon Glyph="&#xECAA;" />
-					</NavigationViewItem.Icon>
-				</NavigationViewItem>
-			</NavigationView.MenuItems>
-		</NavigationView>
+						<NavigationViewItem.Icon>
+							<FontIcon Glyph="&#xECAA;" />
+						</NavigationViewItem.Icon>
+					</NavigationViewItem>
+				</NavigationView.MenuItems>
+			</NavigationView>
+		</Border>
 
 		<ScrollViewer Grid.Row="1">
 			<Frame x:Name="contentFrame" IsNavigationStackEnabled="False" />

--- a/src/Files.App/Views/Pages/Properties.xaml.cs
+++ b/src/Files.App/Views/Pages/Properties.xaml.cs
@@ -78,7 +78,7 @@ namespace Files.App.Views
 			AppSettings.ThemeModeChanged += AppSettings_ThemeModeChanged;
 			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
 			{
-				NavigationView.SizeChanged += NavigationView_SizeChanged;
+				TitlebarArea.SizeChanged += TitlebarArea_SizeChanged;
 				appWindow.Destroying += AppWindow_Destroying;
 				await App.Window.DispatcherQueue.EnqueueAsync(() => AppSettings.UpdateThemeElements.Execute(null));
 			}
@@ -89,7 +89,7 @@ namespace Files.App.Views
 			}
 		}
 
-		private void NavigationView_SizeChanged(object? sender, SizeChangedEventArgs? e)
+		private void TitlebarArea_SizeChanged(object? sender, SizeChangedEventArgs? e)
 		{
 			/*
 			 We have to calculate the width of NavigationView as 'ActualWidth' is bigger than the real size occupied by the control.
@@ -128,7 +128,7 @@ namespace Files.App.Views
 		private void PropertiesMenu_Loaded(object sender, RoutedEventArgs e)
 		{
 			// Drag region is calculated each time the active tab is changed
-			NavigationView_SizeChanged(null, null);
+			TitlebarArea_SizeChanged(null, null);
 		}
 
 		private void AppWindow_Destroying(AppWindow sender, object args)

--- a/src/Files.App/Views/Pages/Properties.xaml.cs
+++ b/src/Files.App/Views/Pages/Properties.xaml.cs
@@ -13,6 +13,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Navigation;
 using System;
+using System.Linq;
 using System.Threading;
 using Windows.Foundation.Metadata;
 using Windows.Graphics;
@@ -95,31 +96,23 @@ namespace Files.App.Views
 			 This code calculates the sum of all the visible tabs' widths.
 			 If a tab is visible and its width is 0, it is shown in the overflow menu. In this case we add the overflow's size to the total.
 			 */
-			int navigationViewWidth = 0;
-			bool overflowAdded = false;
-			foreach (NavigationViewItem item in NavigationView.MenuItems)
-			{
-				if (item.Visibility == Visibility.Visible)
-				{
-					if (item.ActualWidth != 0)
-					{
-						navigationViewWidth += (int)item.ActualWidth;
-					}
-					else if (!overflowAdded)
-					{
-						navigationViewWidth += (int)item.CompactPaneLength;
-						overflowAdded = true;
-					}
-				}
-			}
+			int navigationViewWidth = (int)NavigationView.MenuItems.Cast<NavigationViewItem>()
+				.Where(item => item.Visibility == Visibility.Visible)
+				.GroupBy(item => item.ActualWidth != 0)
+				.Select(group => group.Key ? group.Select(item => item.ActualWidth).Sum() : group.First().CompactPaneLength)
+				.Sum();
+
+			var scaleAdjustment = XamlRoot.RasterizationScale;
+			int x = (int)(navigationViewWidth * scaleAdjustment);
+			var y = 0;
+			var width = (int)((TitlebarArea.ActualWidth - navigationViewWidth) * scaleAdjustment);
+			var height = (int)(TitlebarArea.ActualHeight * scaleAdjustment);
 
 			// Sets properties window drag region.
 			appWindow.TitleBar.SetDragRectangles(new RectInt32[]
 			{
-				// This area is over the top margin of NavigationView.
-				new RectInt32(0, 0, navigationViewWidth, (int)NavigationView.ActualOffset.Y),
 				// This area is on the right of NavigationView and stretches for all the remaining space.
-				new RectInt32(navigationViewWidth, 0, (int)(TitleBarDragArea.ActualSize.X - navigationViewWidth), (int)TitleBarDragArea.ActualSize.Y)
+				new RectInt32(x, y, width, height)
 			});
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.

Latest WinAppSdk appears to fix the titlebar issue on windows 10. This PR removes the workaround we had.
Also tries to solve #9919 aligning the code to what we do in MainPage (not sure if it works)

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots (optional)**
Add screenshots here.
