### PR TITLE
Fix: Fixed issue where app would freeze when deleting a folder that had an open file

### DIFF
--- a/src/Files.App/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
+++ b/src/Files.App/Filesystem/FilesystemOperations/ShellFilesystemOperations.cs
@@ -723,7 +723,7 @@ namespace Files.App.Filesystem
 			return false;
 		}
 
-		private Task<DialogResult> GetFileInUseDialog(IEnumerable<string> source, List<Win32Process> lockingProcess = null)
+		private Task<DialogResult> GetFileInUseDialog(IEnumerable<string> source, IEnumerable<Win32Process> lockingProcess = null)
 		{
 			var titleText = "FileInUseDialog/Title".GetLocalizedResource();
 			var subtitleText = lockingProcess.IsEmpty() ? "FileInUseDialog/Text".GetLocalizedResource() :
@@ -760,8 +760,8 @@ namespace Files.App.Filesystem
 			return await dialogService.ShowDialogAsync(dialogViewModel);
 		}
 
-		private List<Win32Process> WhoIsLocking(IEnumerable<string> filesToCheck)
-			=> FileOperationsHelpers.CheckFileInUse(filesToCheck.ToArray()).ToList();
+		private IEnumerable<Win32Process> WhoIsLocking(IEnumerable<string> filesToCheck)
+			=> FileOperationsHelpers.CheckFileInUse(filesToCheck.ToArray());
 
 		#region IDisposable
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10530

When it could not find which process was locking a file, code was calling ToList() on a null object.

**Validation**
How did you test these changes?
- [x] Built and ran the app
