### PR TITLE
Fix: Fixed crash that would occur when previewing .svg files

### DIFF
--- a/src/Files.App/UserControls/FilePreviews/HtmlPreview.xaml.cs
+++ b/src/Files.App/UserControls/FilePreviews/HtmlPreview.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Files.App.ViewModels.Previews;
 using Microsoft.UI.Xaml.Controls;
 
@@ -7,8 +8,6 @@ namespace Files.App.UserControls.FilePreviews
 {
 	public sealed partial class HtmlPreview : UserControl
 	{
-		// TODO: Move to WebView2 on WinUI 3.0 release
-
 		public HtmlPreview(HtmlPreviewViewModel model)
 		{
 			ViewModel = model;
@@ -17,8 +16,9 @@ namespace Files.App.UserControls.FilePreviews
 
 		public HtmlPreviewViewModel ViewModel { get; set; }
 
-		private void WebViewControl_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+		private async void WebViewControl_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
 		{
+			await WebViewControl.EnsureCoreWebView2Async();
 			WebViewControl.NavigateToString(ViewModel.TextValue);
 		}
 	}


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10525

WebView2 must be initialized before use.

**Validation**
How did you test these changes?
- [x] Built and ran the app

**Screenshots (optional)**
Add screenshots here.