### PR TITLE
Fix: Fixed issue where it didn't work to open a path in Files using command line

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -240,7 +240,7 @@ namespace Files.App
 
 			_ = InitializeAppComponentsAsync().ContinueWith(t => Logger.Warn(t.Exception, "Error during InitializeAppComponentsAsync()"), TaskContinuationOptions.OnlyOnFaulted);
 
-			_ = Window.InitializeApplication(activatedEventArgs);
+			_ = Window.InitializeApplication(activatedEventArgs.Data);
 		}
 
 		private void EnsureWindowIsInitialized()
@@ -264,8 +264,9 @@ namespace Files.App
 		public void OnActivated(AppActivationArguments activatedEventArgs)
 		{
 			Logger.Info($"App activated. Activated args type: {activatedEventArgs.Data.GetType().Name}");
+			var data = activatedEventArgs.Data;
 			// InitializeApplication accesses UI, needs to be called on UI thread
-			_ = Window.DispatcherQueue.EnqueueAsync(() => Window.InitializeApplication(activatedEventArgs));
+			_ = Window.DispatcherQueue.EnqueueAsync(() => Window.InitializeApplication(data));
 		}
 
 		/// <summary>

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -62,16 +62,26 @@ namespace Files.App
 			base.MinWidth = 516;
 		}
 
-		public async Task InitializeApplication(AppActivationArguments activatedEventArgs)
+		public async Task InitializeApplication(object activatedEventArgs)
 		{
 			var rootFrame = EnsureWindowIsInitialized();
 			Activate();
 
 			// WINUI3: port activation args from App.xaml.cs.old: OnActivated, OnFileActivated
-			switch (activatedEventArgs.Data)
+			switch (activatedEventArgs)
 			{
 				case ILaunchActivatedEventArgs launchArgs:
-					if (rootFrame.Content is null)
+					if (launchArgs.Arguments is not null && launchArgs.Arguments.Contains($"{Package.Current.Id.FamilyName}\\files.exe", StringComparison.OrdinalIgnoreCase))
+					{
+						// WINUI3 bug: when launching from commandline the argument is not ICommandLineActivatedEventArgs (#10370)
+						var ppm = CommandLineParser.ParseUntrustedCommands(launchArgs.Arguments);
+						if (ppm.IsEmpty())
+						{
+							ppm = new ParsedCommands() { new ParsedCommand() { Type = ParsedCommandType.Unknown, Args = new() { "." } } };
+						}
+						await InitializeFromCmdLineArgs(rootFrame, ppm);
+					}
+					else if (rootFrame.Content is null)
 					{
 						// When the navigation stack isn't restored navigate to the first page,
 						// configuring the new page by passing required information as a navigation
@@ -265,9 +275,9 @@ namespace Files.App
 						}
 						else
 						{
-							var target = IO.Path.GetFullPath(IO.Path.Combine(activationPath, command.Payload));
 							if (!string.IsNullOrEmpty(command.Payload))
 							{
+								var target = IO.Path.GetFullPath(IO.Path.Combine(activationPath, command.Payload));
 								await PerformNavigation(target);
 							}
 							else


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10370

This looks like a WinUI bug. When launching Files from command line I'd expect the launch arg to be of type ICommandLineActivatedEventArgs, but it's of type ILaunchActivatedEventArgs instead.
This PR adds a workaround by checking if the argument contains the files.exe executable path and treating it like a cmdline arg in case.

**Validation**
How did you test these changes?
- [x] Built and ran the app
