### PR TITLE
Fix: Prevent Visual Studio from stopping when deleting an item

### DIFF
--- a/src/Files.App/Helpers/FileOperationsHelpers.cs
+++ b/src/Files.App/Helpers/FileOperationsHelpers.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -178,7 +179,7 @@ namespace Files.App.Helpers
 				}
 
 				var deleteTcs = new TaskCompletionSource<bool>();
-				op.PreDeleteItem += (s, e) =>
+				op.PreDeleteItem += [DebuggerHidden] (s, e) =>
 				{
 					if (!e.Flags.HasFlag(ShellFileOperations.TransferFlags.DeleteRecycleIfPossible))
 					{


### PR DESCRIPTION
**Resolved / Related Issues**
In debug, Visual sSudio stops at a Win32Exception necessary to know if the recycle bin can be used. This pr disables Visual Studio stops for this exception.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility