### PR TITLE
Fix: Fixed opening a tag from sidebar in a new tab

### DIFF
--- a/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
@@ -538,7 +538,7 @@ namespace Files.App.Helpers
 					Text = "BaseLayoutItemContextFlyoutPinToFavorites/Text".GetLocalizedResource(),
 					Glyph = "\uE840",
 					Command = commandsViewModel.PinDirectoryToFavoritesCommand,
-					ShowItem = !itemViewModel.CurrentFolder.IsPinned & userSettingsService.AppearanceSettingsService.ShowFavoritesSection,
+					ShowItem = itemViewModel.CurrentFolder is not null && !itemViewModel.CurrentFolder.IsPinned & userSettingsService.AppearanceSettingsService.ShowFavoritesSection,
 					ShowInFtpPage = true,
 					ShowInRecycleBin = true,
 				},
@@ -547,7 +547,7 @@ namespace Files.App.Helpers
 					Text = "BaseLayoutContextFlyoutUnpinFromFavorites/Text".GetLocalizedResource(),
 					Glyph = "\uE77A",
 					Command = commandsViewModel.UnpinDirectoryFromFavoritesCommand,
-					ShowItem = itemViewModel.CurrentFolder.IsPinned & userSettingsService.AppearanceSettingsService.ShowFavoritesSection,
+					ShowItem = itemViewModel.CurrentFolder is not null && itemViewModel.CurrentFolder.IsPinned & userSettingsService.AppearanceSettingsService.ShowFavoritesSection,
 					ShowInFtpPage = true,
 					ShowInRecycleBin = true,
 				},
@@ -558,7 +558,7 @@ namespace Files.App.Helpers
 					Command = commandsViewModel.PinItemToStartCommand,
 					ShowInFtpPage = true,
 					ShowOnShift = true,
-					ShowItem = !itemViewModel.CurrentFolder.IsItemPinnedToStart,
+					ShowItem = itemViewModel.CurrentFolder is not null && !itemViewModel.CurrentFolder.IsItemPinnedToStart,
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
@@ -567,7 +567,7 @@ namespace Files.App.Helpers
 					Command = commandsViewModel.UnpinItemFromStartCommand,
 					ShowInFtpPage = true,
 					ShowOnShift = true,
-					ShowItem = itemViewModel.CurrentFolder.IsItemPinnedToStart,
+					ShowItem = itemViewModel.CurrentFolder is not null && itemViewModel.CurrentFolder.IsItemPinnedToStart,
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{

--- a/src/Files.App/Views/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/ModernShellPage.xaml.cs
@@ -77,10 +77,10 @@ namespace Files.App.Views
 
 		public bool IsColumnView => SlimContentPage is ColumnViewBrowser;
 
-		public ItemViewModel FilesystemViewModel { get; private set; } = null;
+		public ItemViewModel FilesystemViewModel { get; private set; }
 		public CurrentInstanceViewModel InstanceViewModel { get; }
-		private BaseLayout contentPage = null;
 
+		private BaseLayout contentPage;
 		public BaseLayout ContentPage
 		{
 			get => contentPage;
@@ -96,7 +96,6 @@ namespace Files.App.Views
 		}
 
 		private bool isPageMainPane;
-
 		public bool IsPageMainPane
 		{
 			get => isPageMainPane;
@@ -142,6 +141,13 @@ namespace Files.App.Views
 			cancellationTokenSource = new CancellationTokenSource();
 			FilesystemHelpers = new FilesystemHelpers(this, cancellationTokenSource.Token);
 			storageHistoryHelpers = new StorageHistoryHelpers(new StorageHistoryOperations(this, cancellationTokenSource.Token));
+
+			FilesystemViewModel = new ItemViewModel(InstanceViewModel.FolderSettings);
+			FilesystemViewModel.WorkingDirectoryModified += ViewModel_WorkingDirectoryModified;
+			FilesystemViewModel.ItemLoadStatusChanged += FilesystemViewModel_ItemLoadStatusChanged;
+			FilesystemViewModel.DirectoryInfoUpdated += FilesystemViewModel_DirectoryInfoUpdated;
+			FilesystemViewModel.PageTypeUpdated += FilesystemViewModel_PageTypeUpdated;
+			FilesystemViewModel.OnSelectionRequestedEvent += FilesystemViewModel_OnSelectionRequestedEvent;
 
 			ToolbarViewModel.SearchBox.TextChanged += ModernShellPage_TextChanged;
 			ToolbarViewModel.SearchBox.QuerySubmitted += ModernShellPage_QuerySubmitted;
@@ -514,20 +520,29 @@ namespace Files.App.Views
 		private void OnNavigationParamsChanged()
 		{
 			if (string.IsNullOrEmpty(NavParams?.NavPath) || NavParams.NavPath == "Home".GetLocalizedResource())
+			{
 				ItemDisplayFrame.Navigate(typeof(WidgetsPage),
 					new NavigationArguments()
 					{
 						NavPathParam = NavParams?.NavPath,
 						AssociatedTabInstance = this
 					}, new EntranceNavigationTransitionInfo());
+			}
 			else
+			{
+				var isTagSearch = NavParams.NavPath.StartsWith("tag:");
+
 				ItemDisplayFrame.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(NavParams.NavPath),
 					new NavigationArguments()
 					{
 						NavPathParam = NavParams.NavPath,
 						SelectItems = !string.IsNullOrWhiteSpace(NavParams?.SelectItem) ? new[] { NavParams.SelectItem } : null,
+						IsSearchResultPage = isTagSearch,
+						SearchPathParam = isTagSearch ? "Home".GetLocalizedResource() : null,
+						SearchQuery = isTagSearch ? navParams.NavPath : null,
 						AssociatedTabInstance = this
 					});
+			}
 		}
 
 		public static readonly DependencyProperty NavParamsProperty =
@@ -574,12 +589,6 @@ namespace Files.App.Views
 
 		private void Page_Loaded(object sender, RoutedEventArgs e)
 		{
-			FilesystemViewModel = new ItemViewModel(InstanceViewModel?.FolderSettings);
-			FilesystemViewModel.WorkingDirectoryModified += ViewModel_WorkingDirectoryModified;
-			FilesystemViewModel.ItemLoadStatusChanged += FilesystemViewModel_ItemLoadStatusChanged;
-			FilesystemViewModel.DirectoryInfoUpdated += FilesystemViewModel_DirectoryInfoUpdated;
-			FilesystemViewModel.PageTypeUpdated += FilesystemViewModel_PageTypeUpdated;
-			FilesystemViewModel.OnSelectionRequestedEvent += FilesystemViewModel_OnSelectionRequestedEvent;
 			OnNavigationParamsChanged();
 			this.Loaded -= Page_Loaded;
 		}

--- a/src/Files.App/Views/PaneHolderPage.xaml.cs
+++ b/src/Files.App/Views/PaneHolderPage.xaml.cs
@@ -271,7 +271,7 @@ namespace Files.App.Views
 				InitialPageType = typeof(PaneHolderPage),
 				NavigationArg = new PaneNavigationArguments()
 				{
-					LeftPaneNavPathParam = e?.NavigationArg as string ?? PaneLeft.TabItemArguments?.NavigationArg as string,
+					LeftPaneNavPathParam = PaneLeft.TabItemArguments?.NavigationArg as string ?? e?.NavigationArg as string,
 					RightPaneNavPathParam = IsRightPaneVisible ? PaneRight?.TabItemArguments?.NavigationArg as string : null
 				}
 			};


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10663
- Fixes an issue causing "drive unplugged" dialog to appear when opening a tag from the sidebar in a new tab
- Fixes an issue causing context menu not to appear for tags in the sidebar
- Fixes an issue where "continue where you left off" would open the same folder in both panes

**Validation**
How did you test these changes?
- [x] Built and ran the app
