### PR TITLE
Exit renaming with F2

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -224,7 +224,7 @@ namespace Files.App.Views.LayoutModes
 
 		private void RenameTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
 		{
-			if (e.Key == VirtualKey.Escape)
+			if (e.Key is VirtualKey.Escape or VirtualKey.F2)
 			{
 				TextBox textBox = (TextBox)sender;
 				textBox.LostFocus -= RenameTextBox_LostFocus;
@@ -232,7 +232,7 @@ namespace Files.App.Views.LayoutModes
 				EndRename(textBox);
 				e.Handled = true;
 			}
-			else if (e.Key == VirtualKey.Enter)
+			else if (e.Key is VirtualKey.Enter)
 			{
 				TextBox textBox = (TextBox)sender;
 				textBox.LostFocus -= RenameTextBox_LostFocus;

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -352,7 +352,7 @@ namespace Files.App.Views.LayoutModes
 
 		private void RenameTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
 		{
-			if (e.Key == VirtualKey.Escape)
+			if (e.Key is VirtualKey.Escape or VirtualKey.F2)
 			{
 				TextBox? textBox = sender as TextBox;
 				textBox!.LostFocus -= RenameTextBox_LostFocus;
@@ -360,7 +360,7 @@ namespace Files.App.Views.LayoutModes
 				EndRename(textBox);
 				e.Handled = true;
 			}
-			else if (e.Key == VirtualKey.Enter)
+			else if (e.Key is VirtualKey.Enter)
 			{
 				TextBox? textBox = sender as TextBox;
 				if (textBox is null)

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -306,7 +306,7 @@ namespace Files.App.Views.LayoutModes
 
 		private void RenameTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
 		{
-			if (e.Key == VirtualKey.Escape)
+			if (e.Key is VirtualKey.Escape or VirtualKey.F2)
 			{
 				TextBox textBox = (TextBox)sender;
 				textBox.LostFocus -= RenameTextBox_LostFocus;
@@ -314,7 +314,7 @@ namespace Files.App.Views.LayoutModes
 				EndRename(textBox);
 				e.Handled = true;
 			}
-			else if (e.Key == VirtualKey.Enter)
+			else if (e.Key is VirtualKey.Enter)
 			{
 				TextBox textBox = (TextBox)sender;
 				textBox.LostFocus -= RenameTextBox_LostFocus;


### PR DESCRIPTION
**Resolved / Related Issues**
On the keyboard, it is possible to enter renaming mode with the F2 key, but you must use Escape to exit without validating (or Enter to exit and validate).
This pr allows you to exit without validating with F2, which is easier in the event of an error.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility