### PR TITLE
Fix: Fixed spacing in the create archive dialog

### DIFF
--- a/src/Files.App/Dialogs/CreateArchiveDialog.xaml
+++ b/src/Files.App/Dialogs/CreateArchiveDialog.xaml
@@ -19,7 +19,7 @@
 	RequestedTheme="{x:Bind helpers:ThemeHelper.RootTheme}"
 	Style="{StaticResource DefaultContentDialogStyle}"
 	mc:Ignorable="d">
-	<StackPanel Width="440" Spacing="8">
+	<StackPanel Width="440" Spacing="4">
 
 		<!--  Archive Name  -->
 		<Grid
@@ -53,7 +53,7 @@
 			BorderThickness="1"
 			ColumnSpacing="8"
 			CornerRadius="4"
-			RowSpacing="8">
+			RowSpacing="12">
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="*" />
 				<ColumnDefinition Width="Auto" />

--- a/src/Files.App/Dialogs/CreateArchiveDialog.xaml
+++ b/src/Files.App/Dialogs/CreateArchiveDialog.xaml
@@ -53,7 +53,7 @@
 			BorderThickness="1"
 			ColumnSpacing="8"
 			CornerRadius="4"
-			RowSpacing="12">
+			RowSpacing="8">
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="*" />
 				<ColumnDefinition Width="Auto" />


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixed an issue where the spacing in the create archive dialog was inconsistent with the spacing in properties and settings.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
