### PR TITLE
Fix: Application no longer crashes when going from Tags to Drivers

### DIFF
--- a/src/Files.App/Views/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/ModernShellPage.xaml.cs
@@ -1089,6 +1089,9 @@ namespace Files.App.Views
 					return;
 				}
 
+				if (string.IsNullOrEmpty(navigationPath))
+					return;
+
 				NavigationTransitionInfo transition = new SuppressNavigationTransitionInfo();
 
 				if (sourcePageType == typeof(WidgetsPage)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10662 

**What has been done**
- Clicking on the sidebar to an element with no navigation path no longer uses this null path.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots**

![10662_fix](https://user-images.githubusercontent.com/110472580/207425649-a0fe62b8-0bbc-4808-a989-de09c00143a9.gif)
