### PR TITLE
Fix HorizontalMultitaskingControl RightPaddingColumn.Width

### DIFF
--- a/src/Files.App/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
+++ b/src/Files.App/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
@@ -125,7 +125,7 @@ namespace Files.App.UserControls.MultitaskingControl
 				return;
 			}
 
-			if (!e.DataView.Properties.TryGetValue(TabPathIdentifier, out object tabViewItemPathObj) || tabViewItemPathObj is not string tabViewItemString)
+			if (!e.DataView.Properties.TryGetValue(TabPathIdentifier, out object tabViewItemPathObj) || !(tabViewItemPathObj is string tabViewItemString))
 			{
 				return;
 			}

--- a/src/Files.App/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
+++ b/src/Files.App/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml.cs
@@ -27,7 +27,8 @@ namespace Files.App.UserControls.MultitaskingControl
 			var flowDirectionSetting = new Microsoft.Windows.ApplicationModel.Resources.ResourceManager().CreateResourceContext().QualifierValues["LayoutDirection"];
 
 			var appWindowTitleBar = App.GetAppWindow(App.Window).TitleBar;
-			RightPaddingColumn.Width = (flowDirectionSetting == "RTL") ? new GridLength(appWindowTitleBar.LeftInset) : new GridLength(appWindowTitleBar.RightInset);
+			double rightPaddingColumnWidth = flowDirectionSetting is "RTL" ? appWindowTitleBar.LeftInset : appWindowTitleBar.RightInset;
+			RightPaddingColumn.Width = new GridLength(rightPaddingColumnWidth >= 0 ? rightPaddingColumnWidth : 0);
 		}
 
 		private void HorizontalTabView_TabItemsChanged(TabView sender, Windows.Foundation.Collections.IVectorChangedEventArgs args)
@@ -124,7 +125,7 @@ namespace Files.App.UserControls.MultitaskingControl
 				return;
 			}
 
-			if (!e.DataView.Properties.TryGetValue(TabPathIdentifier, out object tabViewItemPathObj) || !(tabViewItemPathObj is string tabViewItemString))
+			if (!e.DataView.Properties.TryGetValue(TabPathIdentifier, out object tabViewItemPathObj) || tabViewItemPathObj is not string tabViewItemString)
 			{
 				return;
 			}


### PR DESCRIPTION
**Resolved / Related Issues**
It happened to me that the appWindowTitleBar.RightInset value was negative. This value is provided by the sdk, we do not calculate it. This may cause an exception because GridLength does not accept a negative value. This pr fixes that problem.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility