### PR TITLE
Fix: Fixed issue where properties window was always on top

### DIFF
--- a/src/Files.App/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Helpers/FilePropertiesHelpers.cs
@@ -66,7 +66,6 @@ namespace Files.App.Helpers
 
 				var propertiesWindow = new WinUIEx.WindowEx
 				{
-					IsAlwaysOnTop = true,
 					IsMinimizable = false,
 					IsMaximizable = false,
 					MinWidth = 460,

--- a/src/Files.App/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Helpers/FilePropertiesHelpers.cs
@@ -70,6 +70,8 @@ namespace Files.App.Helpers
 					IsMaximizable = false,
 					MinWidth = 460,
 					MinHeight = 550,
+					Width = 550,
+					Height = 550,
 					Content = frame,
 					Backdrop = new WinUIEx.MicaSystemBackdrop(),
 				};
@@ -80,7 +82,6 @@ namespace Files.App.Helpers
 				appWindow.TitleBar.ButtonBackgroundColor = Colors.Transparent;
 				appWindow.TitleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
 
-				appWindow.Resize(new SizeInt32(460, 550));
 				appWindow.SetIcon(LogoPath);
 
 				if (frame.Content is Properties properties)

--- a/src/Files.App/Views/Pages/PropertiesSecurityAdvanced.xaml
+++ b/src/Files.App/Views/Pages/PropertiesSecurityAdvanced.xaml
@@ -48,7 +48,7 @@
 			Text="{x:Bind DialogTitle}" />
 
 		<ScrollViewer Grid.Row="1">
-			<StackPanel Padding="12,0,12,12" Spacing="8">
+			<StackPanel Padding="12,0,12,12" Spacing="4">
 				<Grid
 					Padding="8"
 					Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixed issue where properties window was always on top

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
