### PR TITLE
Fix: Fixed crash from #10467

### DIFF
--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -448,7 +448,7 @@ namespace Files.App.UserControls
 				return;
 			}
 
-			var navigationPath = args.InvokedItemContainer.Tag.ToString();
+			var navigationPath = args.InvokedItemContainer.Tag?.ToString();
 
 			if (await CheckEmptyDrive(navigationPath))
 				return;


### PR DESCRIPTION
**Resolved / Related Issues**
- Related #10467 - A crash would occurs for some users when expanding/collapsing the sidebar since the refactoring, because of an access on a null object.

**What has been done**
- Added back the null check that seemingly prevents the crash to occur for the concerned users.