### PR TITLE
Feature: Expand the background colors section by default

### DIFF
--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2665,8 +2665,8 @@
   <data name="SettingsShowFileTagsSectionSwitch.AutomationProperties.Name" xml:space="preserve">
     <value>Show Tags section</value>
   </data>
-  <data name="UseCompactStyles" xml:space="preserve">
-    <value>Use compact styles in the details layout</value>
+  <data name="UseCompactSpacing" xml:space="preserve">
+    <value>Use compact spacing in the details layout</value>
   </data>
   <data name="Universal" xml:space="preserve">
     <value>Universal</value>

--- a/src/Files.App/Views/SettingsPages/Appearance.xaml
+++ b/src/Files.App/Views/SettingsPages/Appearance.xaml
@@ -167,12 +167,12 @@
 				</local:SettingsBlockControl.ExpandableContent>
 			</local:SettingsBlockControl>
 
-			<local:SettingsBlockControl Title="{helpers:ResourceString Name=UseCompactStyles}" HorizontalAlignment="Stretch">
+			<local:SettingsBlockControl Title="{helpers:ResourceString Name=UseCompactSpacing}" HorizontalAlignment="Stretch">
 				<local:SettingsBlockControl.Icon>
 					<FontIcon Glyph="&#xE14C;" />
 				</local:SettingsBlockControl.Icon>
 				<ToggleSwitch
-					AutomationProperties.Name="{helpers:ResourceString Name=UseCompactStyles}"
+					AutomationProperties.Name="{helpers:ResourceString Name=UseCompactSpacing}"
 					IsOn="{x:Bind ViewModel.UseCompactStyles, Mode=TwoWay}"
 					Style="{StaticResource RightAlignedToggleSwitchStyle}" />
 			</local:SettingsBlockControl>

--- a/src/Files.App/Views/SettingsPages/Appearance.xaml
+++ b/src/Files.App/Views/SettingsPages/Appearance.xaml
@@ -70,7 +70,10 @@
 					SelectedIndex="{x:Bind ViewModel.SelectedThemeIndex, Mode=TwoWay}" />
 			</local:SettingsBlockControl>
 
-			<local:SettingsBlockControl Title="{helpers:ResourceString Name=Background}" HorizontalAlignment="Stretch">
+			<local:SettingsBlockControl
+				Title="{helpers:ResourceString Name=Background}"
+				HorizontalAlignment="Stretch"
+				IsExpanded="True">
 				<local:SettingsBlockControl.Icon>
 					<FontIcon Glyph="&#xE771;" />
 				</local:SettingsBlockControl.Icon>

--- a/src/Files.App/Views/SettingsPages/Appearance/AppThemeResourcesFactory.cs
+++ b/src/Files.App/Views/SettingsPages/Appearance/AppThemeResourcesFactory.cs
@@ -33,24 +33,24 @@ namespace Files.App.Views.SettingsPages.Appearance
 				PreviewColor = new SolidColorBrush(Color.FromArgb(255, 247, 99, 12)), /* #F7630C */
 				Name = "Orange Bright"
 			},
-			new AppThemeResource
-			{
-				BackgroundColor = Color.FromArgb(50, 202, 80, 16), /* #CA5010 */
-				PreviewColor = new SolidColorBrush(Color.FromArgb(255, 202, 80, 16)), /* #CA5010 */
-				Name = "Orange Dark"
-			},
+			//new AppThemeResource
+			//{
+			//	BackgroundColor = Color.FromArgb(50, 202, 80, 16), /* #CA5010 */
+			//	PreviewColor = new SolidColorBrush(Color.FromArgb(255, 202, 80, 16)), /* #CA5010 */
+			//	Name = "Orange Dark"
+			//},
 			new AppThemeResource
 			{
 				BackgroundColor = Color.FromArgb(50, 218, 59, 1), /* #DA3B01 */
 				PreviewColor = new SolidColorBrush(Color.FromArgb(255, 218, 59, 1)), /* #DA3B01 */
 				Name = "Rust",
 			},
-			new AppThemeResource
-			{
-				BackgroundColor = Color.FromArgb(50, 239, 105, 80), /* #EF6950 */
-				PreviewColor = new SolidColorBrush(Color.FromArgb(255, 239, 105, 80)), /* #EF6950 */
-				Name = "Pale Rust"
-			},
+			//new AppThemeResource
+			//{
+			//	BackgroundColor = Color.FromArgb(50, 239, 105, 80), /* #EF6950 */
+			//	PreviewColor = new SolidColorBrush(Color.FromArgb(255, 239, 105, 80)), /* #EF6950 */
+			//	Name = "Pale Rust"
+			//},
 			new AppThemeResource
 			{
 				BackgroundColor = Color.FromArgb(50, 209, 52, 56), /* #D13438 */
@@ -81,36 +81,36 @@ namespace Files.App.Views.SettingsPages.Appearance
 				PreviewColor = new SolidColorBrush(Color.FromArgb(255, 234, 0, 94)), /* #EA005E */
 				Name = "Rose Bright"
 			},
-			new AppThemeResource
-			{
-				BackgroundColor = Color.FromArgb(50, 195, 0, 82), /* #C30052 */
-				PreviewColor = new SolidColorBrush(Color.FromArgb(255, 195, 0, 82)), /* #C30052 */
-				Name = "Rose"
-			},
+			//new AppThemeResource
+			//{
+			//	BackgroundColor = Color.FromArgb(50, 195, 0, 82), /* #C30052 */
+			//	PreviewColor = new SolidColorBrush(Color.FromArgb(255, 195, 0, 82)), /* #C30052 */
+			//	Name = "Rose"
+			//},
 			new AppThemeResource
 			{
 				BackgroundColor = Color.FromArgb(50, 227, 0, 140), /* #E3008C */
 				PreviewColor = new SolidColorBrush(Color.FromArgb(100, 227, 0, 140)), /* #E3008C */
 				Name = "Plum Light"
 			},
-			new AppThemeResource
-			{
-				BackgroundColor = Color.FromArgb(50, 191, 0, 119), /* #BF0077 */
-				PreviewColor = new SolidColorBrush(Color.FromArgb(100, 191, 0, 119)), /* #BF0077 */
-				Name = "Plum"
-			},
-			new AppThemeResource
-			{
-				BackgroundColor = Color.FromArgb(50, 194, 57, 179), /* #C239B3 */
-				PreviewColor = new SolidColorBrush(Color.FromArgb(255, 194, 57, 179)), /* #C239B3 */
-				Name = "Orchid Light"
-			},
-			new AppThemeResource
-			{
-				BackgroundColor = Color.FromArgb(50, 154, 0, 137), /* #9A0089 */
-				PreviewColor = new SolidColorBrush(Color.FromArgb(255, 154, 0, 137)), /* #9A0089 */
-				Name = "Orchid"
-			},
+			//new AppThemeResource
+			//{
+			//	BackgroundColor = Color.FromArgb(50, 191, 0, 119), /* #BF0077 */
+			//	PreviewColor = new SolidColorBrush(Color.FromArgb(100, 191, 0, 119)), /* #BF0077 */
+			//	Name = "Plum"
+			//},
+			//new AppThemeResource
+			//{
+			//	BackgroundColor = Color.FromArgb(50, 194, 57, 179), /* #C239B3 */
+			//	PreviewColor = new SolidColorBrush(Color.FromArgb(255, 194, 57, 179)), /* #C239B3 */
+			//	Name = "Orchid Light"
+			//},
+			//new AppThemeResource
+			//{
+			//	BackgroundColor = Color.FromArgb(50, 154, 0, 137), /* #9A0089 */
+			//	PreviewColor = new SolidColorBrush(Color.FromArgb(255, 154, 0, 137)), /* #9A0089 */
+			//	Name = "Orchid"
+			//},
 			new AppThemeResource
 			{
 				BackgroundColor = Color.FromArgb(50, 0, 120, 215), /* #0078D7 */


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Expand the background colors section by default
- Removed some of the unused color presets
- Renamed "Compact Styles" to "Compact Spacing"

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
