### PR TITLE
Feature: Move shell extensions to sub menu by default

### DIFF
--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -635,7 +635,7 @@ namespace Files.App
 		private void AddShellItemsToMenu(List<ContextMenuFlyoutItemViewModel> shellMenuItems, CommandBarFlyout contextMenuFlyout, bool shiftPressed)
 		{
 			var openWithSubItems = ItemModelListToContextFlyoutHelper.GetMenuFlyoutItemsFromModel(ShellContextmenuHelper.GetOpenWithItems(shellMenuItems));
-			var mainShellMenuItems = shellMenuItems.RemoveFrom(!UserSettingsService.AppearanceSettingsService.MoveOverflowMenuItemsToSubMenu ? int.MaxValue : shiftPressed ? 6 : 4);
+			var mainShellMenuItems = shellMenuItems.RemoveFrom(!UserSettingsService.AppearanceSettingsService.MoveShellExtensionsToSubMenu ? int.MaxValue : shiftPressed ? 6 : 0);
 			var overflowShellMenuItems = shellMenuItems.Except(mainShellMenuItems).ToList();
 
 			var overflowItems = ItemModelListToContextFlyoutHelper.GetMenuFlyoutItemsFromModel(overflowShellMenuItems);

--- a/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
@@ -55,7 +55,7 @@ namespace Files.App.Helpers
 			var overflow = items.Where(x => x.ID == "ItemOverflow").FirstOrDefault();
 			if (overflow is not null)
 			{
-				if (!shiftPressed && userSettingsService.AppearanceSettingsService.MoveOverflowMenuItemsToSubMenu) // items with ShowOnShift to overflow menu
+				if (!shiftPressed && userSettingsService.AppearanceSettingsService.MoveShellExtensionsToSubMenu) // items with ShowOnShift to overflow menu
 				{
 					var overflowItems = items.Where(x => x.ShowOnShift).ToList();
 
@@ -609,7 +609,7 @@ namespace Files.App.Helpers
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "ContextMenuMoreItemsLabel".GetLocalizedResource(),
+					Text = "ShowMoreOptions".GetLocalizedResource(),
 					Glyph = "\xE712",
 					Items = new List<ContextMenuFlyoutItemViewModel>(),
 					ID = "ItemOverflow",
@@ -1074,7 +1074,7 @@ namespace Files.App.Helpers
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "ContextMenuMoreItemsLabel".GetLocalizedResource(),
+					Text = "ShowMoreOptions".GetLocalizedResource(),
 					Glyph = "\xE712",
 					Items = new List<ContextMenuFlyoutItemViewModel>(),
 					ID = "ItemOverflow",

--- a/src/Files.App/Helpers/ShellContextMenuHelper.cs
+++ b/src/Files.App/Helpers/ShellContextMenuHelper.cs
@@ -88,7 +88,7 @@ namespace Files.App.Helpers
 				{
 					var menuLayoutSubItem = new ContextMenuFlyoutItemViewModel()
 					{
-						Text = "ContextMenuMoreItemsLabel".GetLocalizedResource(),
+						Text = "ShowMoreOptions".GetLocalizedResource(),
 						Glyph = "\xE712",
 					};
 					LoadMenuFlyoutItem(menuLayoutSubItem.Items, contextMenu, overflowItems, cancellationToken, showIcons);

--- a/src/Files.App/ServicesImplementation/Settings/AppearanceSettingsService.cs
+++ b/src/Files.App/ServicesImplementation/Settings/AppearanceSettingsService.cs
@@ -26,7 +26,7 @@ namespace Files.App.ServicesImplementation.Settings
 			set => Set(value);
 		}
 
-		public bool MoveOverflowMenuItemsToSubMenu
+		public bool MoveShellExtensionsToSubMenu
 		{
 			get => Get(true);
 			set => Set(value);
@@ -77,7 +77,7 @@ namespace Files.App.ServicesImplementation.Settings
 		{
 			switch (e.SettingName)
 			{
-				case nameof(MoveOverflowMenuItemsToSubMenu):
+				case nameof(MoveShellExtensionsToSubMenu):
 				case nameof(UseCompactStyles):
 				case nameof(AppThemeBackgroundColor):
 				case nameof(AppThemeAddressBarBackgroundColor):

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -738,8 +738,8 @@
   <data name="RenameError.TooLong.Title" xml:space="preserve">
     <value>Item name was too long</value>
   </data>
-  <data name="ContextMenuMoreItemsLabel" xml:space="preserve">
-    <value>More</value>
+  <data name="ShowMoreOptions" xml:space="preserve">
+    <value>Show more options</value>
   </data>
   <data name="RestartNotificationText.Text" xml:space="preserve">
     <value>The application needs to be restarted in order to apply these settings, would you like to restart the app?</value>

--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -498,7 +498,7 @@ namespace Files.App.UserControls
 			var menuItems = GetLocationItemMenuItems(item, itemContextMenuFlyout);
 			var (_, secondaryElements) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(menuItems);
 
-			if (!UserSettingsService.AppearanceSettingsService.MoveOverflowMenuItemsToSubMenu)
+			if (!UserSettingsService.AppearanceSettingsService.MoveShellExtensionsToSubMenu)
 				secondaryElements.OfType<FrameworkElement>()
 								 .ForEach(i => i.MinWidth = Constants.UI.ContextMenuItemsMaxWidth); // Set menu min width if the overflow menu setting is disabled
 
@@ -1056,7 +1056,7 @@ namespace Files.App.UserControls
 				var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
 				var shellMenuItems = await ContextFlyoutItemHelper.GetItemContextShellCommandsAsync(currentInstanceViewModel: null, workingDir: null,
 					new List<ListedItem>() { new ListedItem(null) { ItemPath = rightClickedItem.Path } }, shiftPressed: shiftPressed, showOpenMenu: false, default);
-				if (!UserSettingsService.AppearanceSettingsService.MoveOverflowMenuItemsToSubMenu)
+				if (!UserSettingsService.AppearanceSettingsService.MoveShellExtensionsToSubMenu)
 				{
 					var (_, secondaryElements) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(shellMenuItems);
 					if (!secondaryElements.Any())

--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -316,7 +316,7 @@ namespace Files.App.UserControls
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "ContextMenuMoreItemsLabel".GetLocalizedResource(),
+					Text = "ShowMoreOptions".GetLocalizedResource(),
 					Glyph = "\xE712",
 					Items = new List<ContextMenuFlyoutItemViewModel>(),
 					ID = "ItemOverflow",

--- a/src/Files.App/ViewModels/SettingsViewModels/AppearanceViewModel.cs
+++ b/src/Files.App/ViewModels/SettingsViewModels/AppearanceViewModel.cs
@@ -95,14 +95,14 @@ namespace Files.App.ViewModels.SettingsViewModels
 			get => (ElementTheme)selectedThemeIndex;
 		}
 
-		public bool MoveOverflowMenuItemsToSubMenu
+		public bool MoveShellExtensionsToSubMenu
 		{
-			get => UserSettingsService.AppearanceSettingsService.MoveOverflowMenuItemsToSubMenu;
+			get => UserSettingsService.AppearanceSettingsService.MoveShellExtensionsToSubMenu;
 			set
 			{
-				if (value != UserSettingsService.AppearanceSettingsService.MoveOverflowMenuItemsToSubMenu)
+				if (value != UserSettingsService.AppearanceSettingsService.MoveShellExtensionsToSubMenu)
 				{
-					UserSettingsService.AppearanceSettingsService.MoveOverflowMenuItemsToSubMenu = value;
+					UserSettingsService.AppearanceSettingsService.MoveShellExtensionsToSubMenu = value;
 					OnPropertyChanged();
 				}
 			}

--- a/src/Files.App/Views/SettingsPages/Appearance.xaml
+++ b/src/Files.App/Views/SettingsPages/Appearance.xaml
@@ -182,7 +182,7 @@
 				</local:SettingsBlockControl.Icon>
 				<ToggleSwitch
 					AutomationProperties.Name="{helpers:ResourceString Name=SettingsContextMenuOverflow}"
-					IsOn="{x:Bind ViewModel.MoveOverflowMenuItemsToSubMenu, Mode=TwoWay}"
+					IsOn="{x:Bind ViewModel.MoveShellExtensionsToSubMenu, Mode=TwoWay}"
 					Style="{StaticResource RightAlignedToggleSwitchStyle}" />
 			</local:SettingsBlockControl>
 		</StackPanel>

--- a/src/Files.Backend/Services/Settings/IAppearanceSettingsService.cs
+++ b/src/Files.Backend/Services/Settings/IAppearanceSettingsService.cs
@@ -6,9 +6,9 @@ namespace Files.Backend.Services.Settings
 	public interface IAppearanceSettingsService : IBaseSettingsService, INotifyPropertyChanged
 	{
 		/// <summary>
-		/// Gets or sets a value indicating whether or not to move overflow menu items into a sub menu.
+		/// Gets or sets a value indicating whether or not to move shell extensions into a sub menu.
 		/// </summary>
-		bool MoveOverflowMenuItemsToSubMenu { get; set; }
+		bool MoveShellExtensionsToSubMenu { get; set; }
 
 		#region Internal Settings
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**About this change**
The goal of this change is to have a more predictable height for the context menu. Once we find a way to load extensions faster, we should look into reverting this change.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
