### PR TITLE
Fix: Fixed app crash when copying file from 7-zip

### DIFF
--- a/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -787,7 +787,7 @@ namespace Files.App.Filesystem
 								if (charsCopied > 0)
 								{
 									string path = buffer[..(int)charsCopied];
-									itemPaths.Add(path);
+									itemPaths.Add(Path.GetFullPath(path));
 								}
 							}
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11096 

**Details**
7-zip returns a partially short path, so convert it to a full path so that duplicate path entry can be eliminated without fail.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility