### PR TITLE
Fix: Fixed showing a negative elapsed time in case of a future timestamp

### DIFF
--- a/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
+++ b/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
@@ -25,7 +25,10 @@ namespace Files.App.ServicesImplementation.DateTimeFormatter
 				{ TotalHours: >= 1 } => string.Format("HourAgo".GetLocalizedResource(), elapsed.Hours),
 				{ TotalMinutes: >= 2 } => string.Format("MinutesAgo".GetLocalizedResource(), elapsed.Minutes),
 				{ TotalMinutes: >= 1 } => string.Format("MinuteAgo".GetLocalizedResource(), elapsed.Minutes),
-				_ => string.Format("SecondsAgo".GetLocalizedResource(), elapsed.Seconds),
+				{ TotalSeconds: >= 2 } => string.Format("SecondsAgo".GetLocalizedResource(), elapsed.Seconds),
+				{ TotalSeconds: >= 1 } => string.Format("SecondAgo".GetLocalizedResource(), elapsed.Seconds),
+				{ TotalSeconds: >= 0 } => "Now".GetLocalizedResource(),
+				_ => ToString(offset, "D"),
 			};
 		}
 

--- a/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
+++ b/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
@@ -26,7 +26,7 @@ namespace Files.App.ServicesImplementation.DateTimeFormatter
 				{ TotalMinutes: >= 2 } => string.Format("MinutesAgo".GetLocalizedResource(), elapsed.Minutes),
 				{ TotalMinutes: >= 1 } => string.Format("MinuteAgo".GetLocalizedResource(), elapsed.Minutes),
 				{ TotalSeconds: >= 2 } => string.Format("SecondsAgo".GetLocalizedResource(), elapsed.Seconds),
-				{ TotalSeconds: >= 1 } => string.Format("SecondAgo".GetLocalizedResource(), elapsed.Seconds),
+				{ TotalSeconds: >= 1 } => "OneSecondAgo".GetLocalizedResource(),
 				{ TotalSeconds: >= 0 } => "Now".GetLocalizedResource(),
 				_ => ToString(offset, "D"),
 			};

--- a/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
+++ b/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
@@ -41,7 +41,7 @@ namespace Files.App.ServicesImplementation.DateTimeFormatter
 				return " ";
 			}
 			var localTime = offset.ToLocalTime();
-			if (elapsed.TotalDays < 7)
+			if (elapsed.TotalDays < 7 && elapsed.TotalSeconds >= 0)
 			{
 				return $"{localTime:D} {localTime:t} ({ToShortLabel(offset)})";
 			}

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -495,8 +495,8 @@
   <data name="SecondsAgo" xml:space="preserve">
     <value>{0} seconds ago</value>
   </data>
-  <data name="SecondAgo" xml:space="preserve">
-    <value>{0} second ago</value>
+  <data name="OneSecondAgo" xml:space="preserve">
+    <value>1 second ago</value>
   </data>
   <data name="Now" xml:space="preserve">
     <value>Now</value>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -495,6 +495,12 @@
   <data name="SecondsAgo" xml:space="preserve">
     <value>{0} seconds ago</value>
   </data>
+  <data name="SecondAgo" xml:space="preserve">
+    <value>{0} second ago</value>
+  </data>
+  <data name="Now" xml:space="preserve">
+    <value>Now</value>
+  </data>
   <data name="SettingsOnStartupOpenASpecificPagePath.PlaceholderText" xml:space="preserve">
     <value>New Tab</value>
   </data>

--- a/src/Files.App/ViewModels/SettingsViewModels/PreferencesViewModel.cs
+++ b/src/Files.App/ViewModels/SettingsViewModels/PreferencesViewModel.cs
@@ -128,7 +128,7 @@ namespace Files.App.ViewModels.SettingsViewModels
 
 		private void AddDateTimeOptions()
 		{
-			DateTimeOffset sampleDate1 = DateTime.Now;
+			DateTimeOffset sampleDate1 = DateTime.Now.AddSeconds(-5);
 			DateTimeOffset sampleDate2 = new DateTime(sampleDate1.Year - 5, 12, 31, 14, 30, 0);
 			var styles = new DateTimeFormats[] { DateTimeFormats.Application, DateTimeFormats.System, DateTimeFormats.Universal };
 			DateFormats = styles.Select(style => new DateTimeFormatItem(style, sampleDate1, sampleDate2)).ToList();


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #9755 

**Details**
If the timestamp is in the future due to time synchronization or other reasons, the timestamp itself is displayed instead of the elapsed time.
Additionally, '1 seconds ago' replaces '1 second ago' and '0 seconds ago' replaces 'Now'.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility

**Screenshots**
<img width="836" alt="screenshot" src="https://user-images.githubusercontent.com/66369541/215982999-7c0830a0-4de7-402a-98b3-c7a5df4202f0.png">
