### PR TITLE
Feature: Prompt for credentials when connecting smb

### DIFF
--- a/src/Files.App/Helpers/DynamicDialogFactory.cs
+++ b/src/Files.App/Helpers/DynamicDialogFactory.cs
@@ -60,7 +60,6 @@ namespace Files.App.Helpers
 			DynamicDialog? dialog = null;
 			TextBox inputText = new()
 			{
-				Height = 35d,
 				PlaceholderText = "RenameDialogInputText/PlaceholderText".GetLocalizedResource()
 			};
 
@@ -132,6 +131,84 @@ namespace Files.App.Helpers
 				PrimaryButtonText = "OK",
 				DynamicButtons = DynamicDialogButtons.Primary
 			});
+			return dialog;
+		}
+
+		public static DynamicDialog GetFor_CredentialEntryDialog(string path)
+		{
+			string[] userAndPass = new string[3];
+			DynamicDialog? dialog = null;
+
+			TextBox inputUsername = new()
+			{
+				PlaceholderText = "CredentialDialogUserName/PlaceholderText".GetLocalizedResource()
+			};
+
+			PasswordBox inputPassword = new()
+			{
+				PlaceholderText = "CredentialDialogPassword/PlaceholderText".GetLocalizedResource()
+			};
+
+			CheckBox saveCreds = new()
+			{
+				Content = "NetworkAuthenticationSaveCheckbox".GetLocalizedResource()
+			};
+
+			inputUsername.TextChanged += (textBox, args) =>
+			{
+				userAndPass[0] = inputUsername.Text;
+				dialog.ViewModel.AdditionalData = userAndPass;
+			};
+
+			inputPassword.PasswordChanged += (textBox, args) =>
+			{
+				userAndPass[1] = inputPassword.Password;
+				dialog.ViewModel.AdditionalData = userAndPass;
+			};
+
+			saveCreds.Checked += (textBox, args) =>
+			{
+				userAndPass[2] = "y";
+				dialog.ViewModel.AdditionalData = userAndPass;
+			};
+
+			saveCreds.Unchecked += (textBox, args) =>
+			{
+				userAndPass[2] = "n";
+				dialog.ViewModel.AdditionalData = userAndPass;
+			};
+
+			dialog = new DynamicDialog(new DynamicDialogViewModel()
+			{
+				TitleText = "NetworkAuthenticationDialogTitle".GetLocalizedResource(),
+				PrimaryButtonText = "AskCredentialDialog/PrimaryButtonText".GetLocalizedResource(),
+				CloseButtonText = "Cancel".GetLocalizedResource(),
+				SubtitleText = string.Format("NetworkAuthenticationDialogMessage".GetLocalizedResource(), path.Substring(2)),
+				DisplayControl = new Grid()
+				{
+					MinWidth = 250d,
+					Children =
+					{
+						new StackPanel()
+						{
+							Spacing = 10d,
+							Children =
+							{
+								inputUsername,
+								inputPassword,
+								saveCreds
+							}
+						}
+					}
+				},
+				CloseButtonAction = (vm, e) =>
+				{
+					dialog.ViewModel.AdditionalData = null;
+					vm.HideDialog();
+				}
+
+			});
+
 			return dialog;
 		}
 	}

--- a/src/Files.App/Helpers/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/NavigationHelpers.cs
@@ -284,6 +284,7 @@ namespace Files.App.Helpers
 			var opened = (FilesystemResult)false;
 			bool isHiddenItem = NativeFileOperationsHelper.HasFileAttribute(path, System.IO.FileAttributes.Hidden);
 			bool isShortcut = FileExtensionHelpers.IsShortcutOrUrlFile(path);
+			bool isNetwork = path.StartsWith(@"\\", StringComparison.Ordinal);
 
 			if (isShortcut)
 			{
@@ -329,6 +330,27 @@ namespace Files.App.Helpers
 				}
 
 				opened = (FilesystemResult)true;
+			}
+			else if (isNetwork)
+			{
+				var auth = await NetworkDrivesAPI.AuthenticateNetworkShare(path);
+				if (auth)
+				{
+					if (forceOpenInNewTab || userSettingsService.FoldersSettingsService.OpenFoldersInNewTab)
+					{
+						await OpenPathInNewTab(path);
+					}
+					else
+					{
+						associatedInstance.ToolbarViewModel.PathControlDisplayText = path;
+						associatedInstance.NavigateWithArguments(associatedInstance.InstanceViewModel.FolderSettings.GetLayoutType(path), new NavigationArguments()
+						{
+							NavPathParam = path,
+							AssociatedTabInstance = associatedInstance
+						});
+					}
+					opened = (FilesystemResult)true;
+				}
 			}
 			else
 			{

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2901,4 +2901,16 @@
   <data name="DisplayEditTagsMenu" xml:space="preserve">
     <value>Display the edit tags flyout</value>
   </data>
+	<data name="NetworkAuthenticationDialogMessage" xml:space="preserve">
+    <value>Enter your credentials to connect to: {0}</value>
+  </data>
+	<data name="NetworkAuthenticationDialogTitle" xml:space="preserve">
+    <value>Enter Network Credentials</value>
+  </data>
+	<data name="NetworkAuthenticationSaveCheckbox" xml:space="preserve">
+    <value>Remember my credentials</value>
+  </data>
+	<data name="NetworkFolderErrorDialogTitle" xml:space="preserve">
+    <value>Network folder error</value>
+  </data>
 </root>

--- a/src/Files.App/ViewModels/ToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/ToolbarViewModel.cs
@@ -950,6 +950,13 @@ namespace Files.App.ViewModels
 			if (currentInput.StartsWith('\\') && !currentInput.StartsWith("\\\\", StringComparison.Ordinal))
 				currentInput = currentInput.Insert(0, "\\");
 
+			if (currentInput.StartsWith('\\'))
+			{
+				var auth = await NetworkDrivesAPI.AuthenticateNetworkShare(currentInput);
+				if (!auth)
+					return;
+			}
+
 			if (currentSelectedPath == currentInput || string.IsNullOrWhiteSpace(currentInput))
 				return;
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #258 
- Typing in the toolbar or navigating from the Network folder to a SMB share which does not have cached/saved credentials, will prompt the user for a username and password, and whether or not they want to save their credentials (Screenshot 1).
- Credentials are stored directly to Windows Credential Manager, not in the application (Screenshot 4). The application also does not need to read the saved credentials in order to access a network share.
- Win32Errors are outputted in a dialog in the event of an error (Screenshots 2,3).

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
1.
![credsDialog](https://user-images.githubusercontent.com/35540114/216651303-6f2db872-ba63-47bb-a400-2db642c294c7.png)
2.
![incorrect_pass](https://user-images.githubusercontent.com/35540114/216652398-35db512d-31ce-4e78-9646-bd79eaf6ff83.png)
3.
![net_err](https://user-images.githubusercontent.com/35540114/216652407-a8afa3d5-9331-4aa6-879d-715071389fb8.png)
4.
![credManager](https://user-images.githubusercontent.com/35540114/216652609-9b628817-9b5b-4449-b2d1-1938dde8c5e6.png)


