### PR TITLE
Fix: Fixed quick access widgets when there are few items

### DIFF
--- a/src/Files.App/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.App/DataModels/SidebarPinnedModel.cs
@@ -51,7 +51,9 @@ namespace Files.App.DataModels
 
 			try
 			{
-				FavoriteItems = await QuickAccessService.GetPinnedFoldersAsync();
+				FavoriteItems = (await QuickAccessService.GetPinnedFoldersAsync())
+					.Where(link => (bool?)link.Properties["System.Home.IsPinned"] ?? false)
+					.Select(link => link.FilePath).ToList();
 				RemoveStaleSidebarItems();
 				await AddAllItemsToSidebar();
 			}

--- a/src/Files.App/Filesystem/RecentItems.cs
+++ b/src/Files.App/Filesystem/RecentItems.cs
@@ -206,9 +206,7 @@ namespace Files.App.Filesystem
 				using var shellItem = ShellItem.Open(pidl);
 				using var cMenu = await ContextMenu.GetContextMenuForFiles(new[] { shellItem }, Shell32.CMF.CMF_NORMAL);
 				if (cMenu is not null)
-				{
 					return await cMenu.InvokeVerb("remove");
-				}
 				return false;
 			}));
 		}

--- a/src/Files.App/ServicesImplementation/QuickAccessService.cs
+++ b/src/Files.App/ServicesImplementation/QuickAccessService.cs
@@ -9,8 +9,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Permissions;
 using System.Threading.Tasks;
-using Vanara.PInvoke;
-using Vanara.Windows.Shell;
 
 namespace Files.App.ServicesImplementation
 {

--- a/src/Files.App/Shell/Win32Shell.cs
+++ b/src/Files.App/Shell/Win32Shell.cs
@@ -1,4 +1,5 @@
 ﻿using Files.Shared;
+using Files.Shared.Extensions;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -52,10 +53,10 @@ namespace Files.App.Shell
 									ShellFolderExtensions.GetShellLinkItem(link) :
 									ShellFolderExtensions.GetShellFileItem(folderItem);
 								foreach (var prop in properties)
-									shellFileItem.Properties[prop] = folderItem.Properties[prop];
+									shellFileItem.Properties[prop] = SafetyExtensions.IgnoreExceptions(() => folderItem.Properties[prop]);
 								flc.Add(shellFileItem);
 							}
-							catch (FileNotFoundException)
+							catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
 							{
 								// Happens if files are being deleted
 							}

--- a/src/Files.App/Shell/Win32Shell.cs
+++ b/src/Files.App/Shell/Win32Shell.cs
@@ -20,7 +20,7 @@ namespace Files.App.Shell
 			controlPanelCategoryView = new ShellFolder("::{26EE0668-A00A-44D7-9371-BEB064C98683}");
 		}
 
-		public static async Task<(ShellFileItem Folder, List<ShellFileItem> Enumerate)> GetShellFolderAsync(string path, string action, int from, int count)
+		public static async Task<(ShellFileItem Folder, List<ShellFileItem> Enumerate)> GetShellFolderAsync(string path, string action, int from, int count, params string[] properties)
 		{
 			if (path.StartsWith("::{", StringComparison.Ordinal))
 			{
@@ -51,6 +51,8 @@ namespace Files.App.Shell
 								var shellFileItem = folderItem is ShellLink link ?
 									ShellFolderExtensions.GetShellLinkItem(link) :
 									ShellFolderExtensions.GetShellFileItem(folderItem);
+								foreach (var prop in properties)
+									shellFileItem.Properties[prop] = folderItem.Properties[prop];
 								flc.Add(shellFileItem);
 							}
 							catch (FileNotFoundException)

--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -175,12 +175,9 @@ namespace Files.App.UserControls.Widgets
 			{
 				if (e.Add)
 				{
-					var locationItems = new List<LocationItem>();
-					foreach (var item in e.Paths)
-						locationItems.Add(await App.QuickAccessManager.Model.CreateLocationItemFromPathAsync(item));
-
-					foreach (var item in locationItems)
+					foreach (var itemToAdd in e.Paths)
 					{
+						var item = await App.QuickAccessManager.Model.CreateLocationItemFromPathAsync(itemToAdd);
 						var lastIndex = ItemsAdded.IndexOf(ItemsAdded.FirstOrDefault(x => !x.IsPinned));
 						ItemsAdded.Insert(e.Pin && lastIndex >= 0 ? lastIndex : ItemsAdded.Count, new FolderCardItem(item, Path.GetFileName(item.Text), e.Pin) // Add just after the Recent Folders
 						{

--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -182,8 +182,7 @@ namespace Files.App.UserControls.Widgets
 					foreach (var item in locationItems)
 					{
 						var lastIndex = ItemsAdded.IndexOf(ItemsAdded.FirstOrDefault(x => !x.IsPinned));
-						lastIndex = lastIndex < 0 ? ItemsAdded.Count : lastIndex;
-						ItemsAdded.Insert(e.Pin ? lastIndex : ItemsAdded.Count, new FolderCardItem(item, Path.GetFileName(item.Text), e.Pin) // Add just after the Recent Folders
+						ItemsAdded.Insert(e.Pin && lastIndex >= 0 ? lastIndex : ItemsAdded.Count, new FolderCardItem(item, Path.GetFileName(item.Text), e.Pin) // Add just after the Recent Folders
 						{
 							Path = item.Path,
 							SelectCommand = QuickAccessCardCommand

--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -68,27 +68,21 @@ namespace Files.App.UserControls.Widgets
 			get => thumbnail;
 			set => SetProperty(ref thumbnail, value);
 		}
-		public bool IsLibrary => Item is LibraryLocationItem;
-		public bool IsUserCreatedLibrary => IsLibrary && !LibraryManager.IsDefaultLibrary(Item.Path);
 		public LocationItem Item { get; private set; }
 		public string Path { get; set; }
 		public ICommand SelectCommand { get; set; }
 		public string Text { get; set; }
 		public bool IsPinned { get; set; }
 
-		public FolderCardItem(LocationItem item = null, string text = null, bool isPinned = true) : this(text, isPinned)
-		{
-			Item = item;
-		}
-
-		public FolderCardItem(string text, bool isPinned)
+		public FolderCardItem(LocationItem item, string text, bool isPinned)
 		{
 			if (!string.IsNullOrWhiteSpace(text))
 			{
 				Text = text;
 				AutomationProperties = Text;
-				IsPinned = isPinned;
 			}
+			IsPinned = isPinned;
+			Item = item;
 		}
 
 		public async Task LoadCardThumbnailAsync()
@@ -189,7 +183,7 @@ namespace Files.App.UserControls.Widgets
 					{
 						var lastIndex = ItemsAdded.IndexOf(ItemsAdded.FirstOrDefault(x => !x.IsPinned));
 						lastIndex = lastIndex < 0 ? ItemsAdded.Count : lastIndex;
-						ItemsAdded.Insert(e.Pin ? lastIndex : ItemsAdded.Count, new FolderCardItem(Path.GetFileName(item.Text), e.Pin) // Add just after the Recent Folders
+						ItemsAdded.Insert(e.Pin ? lastIndex : ItemsAdded.Count, new FolderCardItem(item, Path.GetFileName(item.Text), e.Pin) // Add just after the Recent Folders
 						{
 							Path = item.Path,
 							SelectCommand = QuickAccessCardCommand
@@ -325,11 +319,6 @@ namespace Files.App.UserControls.Widgets
 		{
 			if (string.IsNullOrEmpty(item.Path))
 			{
-				return Task.CompletedTask;
-			}
-			if (item.Item is LibraryLocationItem lli && lli.IsEmpty)
-			{
-				// TODO: show message?
 				return Task.CompletedTask;
 			}
 

--- a/src/Files.Backend/Services/IQuickAccessService.cs
+++ b/src/Files.Backend/Services/IQuickAccessService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Files.Shared;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Files.App.ServicesImplementation
@@ -9,7 +10,7 @@ namespace Files.App.ServicesImplementation
 		/// Gets the list of quick access items
 		/// </summary>
 		/// <returns></returns>
-		Task<List<string>> GetPinnedFoldersAsync(bool getRecentItems = false);
+		Task<IEnumerable<ShellFileItem>> GetPinnedFoldersAsync();
 
 		/// <summary>
 		/// Pins a folder to the quick access list

--- a/src/Files.Shared/ShellFileItem.cs
+++ b/src/Files.Shared/ShellFileItem.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Files.Shared
 {
@@ -15,14 +16,16 @@ namespace Files.Shared
 		public ulong FileSizeBytes { get; set; }
 		public string FileType { get; set; }
 		public byte[] PIDL { get; set; } // Low level shell item identifier
+		public Dictionary<string, object> Properties { get; set; }
 
 		public ShellFileItem()
 		{
+			Properties = new Dictionary<string, object>();
 		}
 
 		public ShellFileItem(
 			bool isFolder, string recyclePath, string fileName, string filePath,
-			DateTime recycleDate, DateTime modifiedDate, DateTime createdDate, string fileSize, ulong fileSizeBytes, string fileType, byte[] pidl)
+			DateTime recycleDate, DateTime modifiedDate, DateTime createdDate, string fileSize, ulong fileSizeBytes, string fileType, byte[] pidl) : this()
 		{
 			IsFolder = isFolder;
 			RecyclePath = recyclePath;

--- a/src/Files.Shared/ShellFileItem.cs
+++ b/src/Files.Shared/ShellFileItem.cs
@@ -16,11 +16,11 @@ namespace Files.Shared
 		public ulong FileSizeBytes { get; set; }
 		public string FileType { get; set; }
 		public byte[] PIDL { get; set; } // Low level shell item identifier
-		public Dictionary<string, object> Properties { get; set; }
+		public Dictionary<string, object?> Properties { get; set; }
 
 		public ShellFileItem()
 		{
-			Properties = new Dictionary<string, object>();
+			Properties = new Dictionary<string, object?>();
 		}
 
 		public ShellFileItem(


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.

Fixes an issue where the recent folders widgets misbehaves when there are few pinned folder.
Current code works assuming the non-pinned items are the last 4 which is not always the case.
This PR looks instead at the "System.Home.IsPinned" property.

**Validation**
How did you test these changes?
- [x] Built and ran the app
