### PR TITLE
Feature: Show confirmation dialog when the undo operation is to delete items.

### DIFF
--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -86,7 +86,7 @@
         <PackageReference Include="Vanara.Windows.Extensions" Version="3.4.12" />
         <PackageReference Include="WinUIEx" Version="2.1.0" />
         <PackageReference Include="Vanara.PInvoke.Mpr" Version="3.4.12" />
-        <PackageReference Include="Vanara.Windows.Shell" Version="3.4.12" />
+        <PackageReference Include="Vanara.Windows.Shell" Version="3.4.13" />
         <PackageReference Include="Microsoft.Management.Infrastructure" Version="2.0.0" />
         <PackageReference Include="Microsoft.Management.Infrastructure.Runtime.Win" Version="2.0.1" />
     </ItemGroup>

--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -83,7 +83,7 @@
         <PackageReference Include="CommunityToolkit.WinUI.UI.Behaviors" Version="7.1.2" />
         <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
         <PackageReference Include="Tulpep.ActiveDirectoryObjectPicker" Version="3.0.11" />
-        <PackageReference Include="Vanara.Windows.Extensions" Version="3.4.12" />
+        <PackageReference Include="Vanara.Windows.Extensions" Version="3.4.13" />
         <PackageReference Include="WinUIEx" Version="2.1.0" />
         <PackageReference Include="Vanara.PInvoke.Mpr" Version="3.4.12" />
         <PackageReference Include="Vanara.Windows.Shell" Version="3.4.13" />

--- a/src/Files.App/Filesystem/StorageHistory/Helpers/StorageHistoryHelpers.cs
+++ b/src/Files.App/Filesystem/StorageHistory/Helpers/StorageHistoryHelpers.cs
@@ -22,13 +22,17 @@ namespace Files.App.Filesystem.FilesystemHistory
 				{
 					return ReturnResult.InProgress;
 				}
+				bool keepHistory = false;
 				try
 				{
-					return await operations.Undo(App.HistoryWrapper.GetCurrentHistory());
+					ReturnResult result = await operations.Undo(App.HistoryWrapper.GetCurrentHistory());
+					keepHistory = result is ReturnResult.Cancelled;
+					return result;
 				}
 				finally
 				{
-					App.HistoryWrapper.DecreaseIndex();
+					if (!keepHistory)
+						App.HistoryWrapper.DecreaseIndex();
 					semaphore.Release();
 				}
 			}

--- a/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
+++ b/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
@@ -38,13 +38,13 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.CreateNew: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Source))
 					{
-						return await helpers.DeleteItemsAsync(history.Source, false, true, false);
+						return await helpers.DeleteItemsAsync(history.Source, true, true, false); // Show a dialog to prevent unexpected deletion
 					}
 					break;
 				case FileOperationType.CreateLink: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, false, true, false);
+						return await helpers.DeleteItemsAsync(history.Destination, true, true, false); // Show a dialog to prevent unexpected deletion
 					}
 					break;
 				case FileOperationType.Rename: // Opposite: Restore original item names
@@ -61,7 +61,7 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.Copy: // Opposite: Delete copied items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, false, true, false);
+						return await helpers.DeleteItemsAsync(history.Destination, true, true, false); // Show a dialog to prevent unexpected deletion
 					}
 					break;
 				case FileOperationType.Move: // Opposite: Move the items to original directory

--- a/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
+++ b/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
@@ -1,4 +1,6 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
 using Files.App.Helpers;
+using Files.Backend.Services.Settings;
 using Files.Shared.Enums;
 using Files.Shared.Extensions;
 using System;
@@ -19,6 +21,8 @@ namespace Files.App.Filesystem.FilesystemHistory
 
 		private readonly CancellationToken cancellationToken;
 
+		private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
+
 		public StorageHistoryOperations(IShellPage associatedInstance, CancellationToken cancellationToken)
 		{
 			this.cancellationToken = cancellationToken;
@@ -38,13 +42,13 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.CreateNew: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Source))
 					{
-						return await helpers.DeleteItemsAsync(history.Source, false, true, false);
+						return await helpers.DeleteItemsAsync(history.Source, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
 					}
 					break;
 				case FileOperationType.CreateLink: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, false, true, false);
+						return await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
 					}
 					break;
 				case FileOperationType.Rename: // Opposite: Restore original item names
@@ -61,7 +65,7 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.Copy: // Opposite: Delete copied items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, false, true, false);
+						return await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
 					}
 					break;
 				case FileOperationType.Move: // Opposite: Move the items to original directory

--- a/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
+++ b/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
@@ -42,19 +42,13 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.CreateNew: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Source))
 					{
-						ReturnResult result = await helpers.DeleteItemsAsync(history.Source, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
-						if (result is ReturnResult.Cancelled)
-							App.HistoryWrapper.AddHistory(history); // hack to keep the history
-						return result;
+						return await helpers.DeleteItemsAsync(history.Source, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
 					}
 					break;
 				case FileOperationType.CreateLink: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Destination))
 					{
-						ReturnResult result = await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
-						if (result is ReturnResult.Cancelled)
-							App.HistoryWrapper.AddHistory(history); // hack to keep the history
-						return result;
+						return await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
 					}
 					break;
 				case FileOperationType.Rename: // Opposite: Restore original item names
@@ -71,10 +65,7 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.Copy: // Opposite: Delete copied items
 					if (!IsHistoryNull(history.Destination))
 					{
-						ReturnResult result = await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
-						if (result is ReturnResult.Cancelled)
-							App.HistoryWrapper.AddHistory(history); // hack to keep the history
-						return result;
+						return await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
 					}
 					break;
 				case FileOperationType.Move: // Opposite: Move the items to original directory

--- a/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
+++ b/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
@@ -1,6 +1,4 @@
-using CommunityToolkit.Mvvm.DependencyInjection;
 using Files.App.Helpers;
-using Files.Backend.Services.Settings;
 using Files.Shared.Enums;
 using Files.Shared.Extensions;
 using System;
@@ -21,8 +19,6 @@ namespace Files.App.Filesystem.FilesystemHistory
 
 		private readonly CancellationToken cancellationToken;
 
-		private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
-
 		public StorageHistoryOperations(IShellPage associatedInstance, CancellationToken cancellationToken)
 		{
 			this.cancellationToken = cancellationToken;
@@ -42,13 +38,13 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.CreateNew: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Source))
 					{
-						return await helpers.DeleteItemsAsync(history.Source, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
+						return await helpers.DeleteItemsAsync(history.Source, false, true, false);
 					}
 					break;
 				case FileOperationType.CreateLink: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
+						return await helpers.DeleteItemsAsync(history.Destination, false, true, false);
 					}
 					break;
 				case FileOperationType.Rename: // Opposite: Restore original item names
@@ -65,7 +61,7 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.Copy: // Opposite: Delete copied items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
+						return await helpers.DeleteItemsAsync(history.Destination, false, true, false);
 					}
 					break;
 				case FileOperationType.Move: // Opposite: Move the items to original directory

--- a/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
+++ b/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
@@ -42,13 +42,19 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.CreateNew: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Source))
 					{
-						return await helpers.DeleteItemsAsync(history.Source, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
+						ReturnResult result = await helpers.DeleteItemsAsync(history.Source, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
+						if (result is ReturnResult.Cancelled)
+							App.HistoryWrapper.AddHistory(history); // hack to keep the history
+						return result;
 					}
 					break;
 				case FileOperationType.CreateLink: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
+						ReturnResult result = await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
+						if (result is ReturnResult.Cancelled)
+							App.HistoryWrapper.AddHistory(history); // hack to keep the history
+						return result;
 					}
 					break;
 				case FileOperationType.Rename: // Opposite: Restore original item names
@@ -65,7 +71,10 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.Copy: // Opposite: Delete copied items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
+						ReturnResult result = await helpers.DeleteItemsAsync(history.Destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, false);
+						if (result is ReturnResult.Cancelled)
+							App.HistoryWrapper.AddHistory(history); // hack to keep the history
+						return result;
 					}
 					break;
 				case FileOperationType.Move: // Opposite: Move the items to original directory


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11174

**Details**
A confirmation dialog will appear when the undo operation is to delete items to prevent unexpected deletion.

**TODO**
- [X] ~~The setting should be separate from "Show confirmation dialog when deleting items"~~. No new settings this time.
- [X] When cancelling the undo operation, ~~the history is erased even though it is not actually undone. Is that right?~~ keep the history.
- [X] On the confirmation dialog, we can choose to put it in the trash instead of deleting it. ~~Is that right?~~ It's ok.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [x] Tested the changes for accessibility
