### PR TITLE
Fix: Additional fix to show a confirmation dialog when undoing

### DIFF
--- a/src/Files.App/Filesystem/FilesystemOperations/Helpers/IFilesystemHelpers.cs
+++ b/src/Files.App/Filesystem/FilesystemOperations/Helpers/IFilesystemHelpers.cs
@@ -28,7 +28,7 @@ namespace Files.App.Filesystem
 		/// <param name="permanently">Determines whether <paramref name="source"/> is be deleted permanently</param>
 		/// <param name="registerHistory">Determines whether <see cref="IStorageHistory"/> is saved</param>
 		/// <returns><see cref="ReturnResult"/> of performed operation</returns>
-		Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItem> source, bool showDialog, bool permanently, bool registerHistory);
+		Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItem> source, ShowDeleteDialog showDialog, bool permanently, bool registerHistory);
 
 		/// <summary>
 		/// Deletes provided <paramref name="source"/>
@@ -38,7 +38,7 @@ namespace Files.App.Filesystem
 		/// <param name="permanently">Determines whether <paramref name="source"/> is be deleted permanently</param>
 		/// <param name="registerHistory">Determines whether <see cref="IStorageHistory"/> is saved</param>
 		/// <returns><see cref="ReturnResult"/> of performed operation</returns>
-		Task<ReturnResult> DeleteItemAsync(IStorageItem source, bool showDialog, bool permanently, bool registerHistory);
+		Task<ReturnResult> DeleteItemAsync(IStorageItem source, ShowDeleteDialog showDialog, bool permanently, bool registerHistory);
 
 		/// <summary>
 		/// Deletes provided <paramref name="source"/>
@@ -48,7 +48,7 @@ namespace Files.App.Filesystem
 		/// <param name="permanently">Determines whether <paramref name="source"/> is be deleted permanently</param>
 		/// <param name="registerHistory">Determines whether <see cref="IStorageHistory"/> is saved</param>
 		/// <returns><see cref="ReturnResult"/> of performed operation</returns>
-		Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItemWithPath> source, bool showDialog, bool permanently, bool registerHistory);
+		Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItemWithPath> source, ShowDeleteDialog showDialog, bool permanently, bool registerHistory);
 
 		/// <summary>
 		/// Deletes provided <paramref name="source"/>
@@ -58,7 +58,7 @@ namespace Files.App.Filesystem
 		/// <param name="permanently">Determines whether <paramref name="source"/> is be deleted permanently</param>
 		/// <param name="registerHistory">Determines whether <see cref="IStorageHistory"/> is saved</param>
 		/// <returns><see cref="ReturnResult"/> of performed operation</returns>
-		Task<ReturnResult> DeleteItemAsync(IStorageItemWithPath source, bool showDialog, bool permanently, bool registerHistory);
+		Task<ReturnResult> DeleteItemAsync(IStorageItemWithPath source, ShowDeleteDialog showDialog, bool permanently, bool registerHistory);
 
 		#endregion Delete
 
@@ -175,7 +175,7 @@ namespace Files.App.Filesystem
 		/// <returns><see cref="ReturnResult"/> of performed operation</returns>
 		Task<ReturnResult> CopyItemsFromClipboard(DataPackageView packageView, string destination, bool showDialog, bool registerHistory);
 
-		Task<ReturnResult> RecycleItemsFromClipboard(DataPackageView packageView, string destination, bool showDialog, bool registerHistory);
+		Task<ReturnResult> RecycleItemsFromClipboard(DataPackageView packageView, string destination, ShowDeleteDialog showDialog, bool registerHistory);
 
 		Task<ReturnResult> CreateShortcutFromClipboard(DataPackageView packageView, string destination, bool showDialog, bool registerHistory);
 

--- a/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
+++ b/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
@@ -38,13 +38,13 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.CreateNew: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Source))
 					{
-						return await helpers.DeleteItemsAsync(history.Source, true, true, false); // Show a dialog to prevent unexpected deletion
+						return await helpers.DeleteItemsAsync(history.Source, ShowDeleteDialog.Always, true, false); // Show a dialog to prevent unexpected deletion
 					}
 					break;
 				case FileOperationType.CreateLink: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, true, true, false); // Show a dialog to prevent unexpected deletion
+						return await helpers.DeleteItemsAsync(history.Destination, ShowDeleteDialog.Always, true, false); // Show a dialog to prevent unexpected deletion
 					}
 					break;
 				case FileOperationType.Rename: // Opposite: Restore original item names
@@ -61,7 +61,7 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.Copy: // Opposite: Delete copied items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, true, true, false); // Show a dialog to prevent unexpected deletion
+						return await helpers.DeleteItemsAsync(history.Destination, ShowDeleteDialog.Always, true, false); // Show a dialog to prevent unexpected deletion
 					}
 					break;
 				case FileOperationType.Move: // Opposite: Move the items to original directory

--- a/src/Files.App/Helpers/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/NavigationHelpers.cs
@@ -179,7 +179,7 @@ namespace Files.App.Helpers
 
 						// Delete shortcut
 						var shortcutItem = StorageHelpers.FromPathAndType(path, FilesystemItemType.File);
-						await associatedInstance.FilesystemHelpers.DeleteItemAsync(shortcutItem, false, false, true);
+						await associatedInstance.FilesystemHelpers.DeleteItemAsync(shortcutItem, ShowDeleteDialog.Never, false, true);
 					}
 				}
 				else if (isReparsePoint)

--- a/src/Files.App/Helpers/RecycleBinHelpers.cs
+++ b/src/Files.App/Helpers/RecycleBinHelpers.cs
@@ -169,7 +169,7 @@ namespace Files.App.Helpers
 			var items = associatedInstance.SlimContentPage.SelectedItems.ToList().Select((item) => StorageHelpers.FromPathAndType(
 				item.ItemPath,
 				item.PrimaryItemAttribute == StorageItemTypes.File ? FilesystemItemType.File : FilesystemItemType.Directory));
-			await associatedInstance.FilesystemHelpers.DeleteItemsAsync(items, true, false, true);
+			await associatedInstance.FilesystemHelpers.DeleteItemsAsync(items, ShowDeleteDialog.DependsOnSettings, false, true);
 		}
 	}
 }

--- a/src/Files.App/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/ColumnShellPage.xaml.cs
@@ -714,7 +714,7 @@ namespace Files.App.Views
 						var items = SlimContentPage.SelectedItems.ToList().Select((item) => StorageHelpers.FromPathAndType(
 							item.ItemPath,
 							item.PrimaryItemAttribute == StorageItemTypes.File ? FilesystemItemType.File : FilesystemItemType.Directory));
-						await FilesystemHelpers.DeleteItemsAsync(items, true, true, true);
+						await FilesystemHelpers.DeleteItemsAsync(items, ShowDeleteDialog.DependsOnSettings, true, true);
 					}
 
 					break;
@@ -758,7 +758,7 @@ namespace Files.App.Views
 						var items = SlimContentPage.SelectedItems.ToList().Select((item) => StorageHelpers.FromPathAndType(
 							item.ItemPath,
 							item.PrimaryItemAttribute == StorageItemTypes.File ? FilesystemItemType.File : FilesystemItemType.Directory));
-						await FilesystemHelpers.DeleteItemsAsync(items, true, false, true);
+						await FilesystemHelpers.DeleteItemsAsync(items, ShowDeleteDialog.DependsOnSettings, false, true);
 					}
 
 					break;

--- a/src/Files.App/Views/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/ModernShellPage.xaml.cs
@@ -725,7 +725,7 @@ namespace Files.App.Views
 						var items = SlimContentPage.SelectedItems.ToList().Select((item) => StorageHelpers.FromPathAndType(
 							item.ItemPath,
 							item.PrimaryItemAttribute == StorageItemTypes.File ? FilesystemItemType.File : FilesystemItemType.Directory));
-						await FilesystemHelpers.DeleteItemsAsync(items, true, true, true);
+						await FilesystemHelpers.DeleteItemsAsync(items, ShowDeleteDialog.DependsOnSettings, true, true);
 					}
 
 					break;
@@ -761,7 +761,7 @@ namespace Files.App.Views
 						var items = SlimContentPage.SelectedItems.ToList().Select((item) => StorageHelpers.FromPathAndType(
 							item.ItemPath,
 							item.PrimaryItemAttribute == StorageItemTypes.File ? FilesystemItemType.File : FilesystemItemType.Directory));
-						await FilesystemHelpers.DeleteItemsAsync(items, true, false, true);
+						await FilesystemHelpers.DeleteItemsAsync(items, ShowDeleteDialog.DependsOnSettings, false, true);
 					}
 
 					break;

--- a/src/Files.Shared/Enums/ShowDeleteDialog.cs
+++ b/src/Files.Shared/Enums/ShowDeleteDialog.cs
@@ -1,0 +1,9 @@
+﻿namespace Files.Shared.Enums
+{
+	public enum ShowDeleteDialog : byte
+	{
+		Never,
+		DependsOnSettings,
+		Always,
+	}
+}


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- This is an additional fix for #11185 

**Details**
Unfortunately, #11185 did not show a confirmation dialog on undo when the setting to show the dialog is off because DeleteItemAsync method always confirms the setting internally.
In this PR, the method parameter is changed to be able to show the dialog ignoring the setting.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility
