### PR TITLE
Feature: Added option to confirm permanent deletion only

### DIFF
--- a/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -125,7 +125,8 @@ namespace Files.App.Filesystem
 			var deleteFromRecycleBin = source.Select(item => item.Path).Any(path => RecycleBinHelpers.IsPathUnderRecycleBin(path));
 			var canBeSentToBin = !deleteFromRecycleBin && await RecycleBinHelpers.HasRecycleBin(source.FirstOrDefault()?.Path);
 
-			if (showDialog is DeleteConfirmationPolicies.Always || showDialog is DeleteConfirmationPolicies.PermanentOnly && (permanently || !canBeSentToBin))
+			if (showDialog is DeleteConfirmationPolicies.Always
+				|| showDialog is DeleteConfirmationPolicies.PermanentOnly && (permanently || !canBeSentToBin))
 			{
 				var incomingItems = new List<BaseFileSystemDialogItemViewModel>();
 				List<ShellFileItem>? binItems = null;

--- a/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -126,7 +126,8 @@ namespace Files.App.Filesystem
 			var canBeSentToBin = !deleteFromRecycleBin && await RecycleBinHelpers.HasRecycleBin(source.FirstOrDefault()?.Path);
 
 			if (showDialog is DeleteConfirmationPolicies.Always
-				|| showDialog is DeleteConfirmationPolicies.PermanentOnly && (permanently || !canBeSentToBin))
+				|| showDialog is DeleteConfirmationPolicies.PermanentOnly &&
+				(permanently || !canBeSentToBin))
 			{
 				var incomingItems = new List<BaseFileSystemDialogItemViewModel>();
 				List<ShellFileItem>? binItems = null;

--- a/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -126,8 +126,7 @@ namespace Files.App.Filesystem
 			var canBeSentToBin = !deleteFromRecycleBin && await RecycleBinHelpers.HasRecycleBin(source.FirstOrDefault()?.Path);
 
 			if (showDialog is DeleteConfirmationPolicies.Always
-				|| showDialog is DeleteConfirmationPolicies.PermanentOnly &&
-				(permanently || !canBeSentToBin))
+				|| showDialog is DeleteConfirmationPolicies.PermanentOnly && (permanently || !canBeSentToBin))
 			{
 				var incomingItems = new List<BaseFileSystemDialogItemViewModel>();
 				List<ShellFileItem>? binItems = null;

--- a/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -116,7 +116,7 @@ namespace Files.App.Filesystem
 
 		#region Delete
 
-		public async Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItemWithPath> source, bool showDialog, bool permanently, bool registerHistory)
+		public async Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItemWithPath> source, DeleteConfirmationPolicies showDialog, bool permanently, bool registerHistory)
 		{
 			source = await source.ToListAsync();
 
@@ -125,7 +125,7 @@ namespace Files.App.Filesystem
 			var deleteFromRecycleBin = source.Select(item => item.Path).Any(path => RecycleBinHelpers.IsPathUnderRecycleBin(path));
 			var canBeSentToBin = !deleteFromRecycleBin && await RecycleBinHelpers.HasRecycleBin(source.FirstOrDefault()?.Path);
 
-			if (showDialog)
+			if (showDialog is DeleteConfirmationPolicies.Always || showDialog is DeleteConfirmationPolicies.PermanentOnly && (permanently || !canBeSentToBin))
 			{
 				var incomingItems = new List<BaseFileSystemDialogItemViewModel>();
 				List<ShellFileItem>? binItems = null;
@@ -193,13 +193,13 @@ namespace Files.App.Filesystem
 			return returnStatus;
 		}
 
-		public Task<ReturnResult> DeleteItemAsync(IStorageItemWithPath source, bool showDialog, bool permanently, bool registerHistory)
+		public Task<ReturnResult> DeleteItemAsync(IStorageItemWithPath source, DeleteConfirmationPolicies showDialog, bool permanently, bool registerHistory)
 			=> DeleteItemsAsync(source.CreateEnumerable(), showDialog, permanently, registerHistory);
 
-		public Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItem> source, bool showDialog, bool permanently, bool registerHistory)
+		public Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItem> source, DeleteConfirmationPolicies showDialog, bool permanently, bool registerHistory)
 			=> DeleteItemsAsync(source.Select((item) => item.FromStorageItem()), showDialog, permanently, registerHistory);
 
-		public Task<ReturnResult> DeleteItemAsync(IStorageItem source, bool showDialog, bool permanently, bool registerHistory)
+		public Task<ReturnResult> DeleteItemAsync(IStorageItem source, DeleteConfirmationPolicies showDialog, bool permanently, bool registerHistory)
 			=> DeleteItemAsync(source.FromStorageItem(), showDialog, permanently, registerHistory);
 
 		#endregion Delete
@@ -258,7 +258,7 @@ namespace Files.App.Filesystem
 				}
 				if (destination.StartsWith(CommonPaths.RecycleBinPath, StringComparison.Ordinal))
 				{
-					return await RecycleItemsFromClipboard(packageView, destination, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, registerHistory);
+					return await RecycleItemsFromClipboard(packageView, destination, UserSettingsService.FoldersSettingsService.DeleteConfirmationPolicy, registerHistory);
 				}
 				else if (operation.HasFlag(DataPackageOperation.Copy))
 				{
@@ -625,7 +625,7 @@ namespace Files.App.Filesystem
 			return returnStatus;
 		}
 
-		public async Task<ReturnResult> RecycleItemsFromClipboard(DataPackageView packageView, string destination, bool showDialog, bool registerHistory)
+		public async Task<ReturnResult> RecycleItemsFromClipboard(DataPackageView packageView, string destination, DeleteConfirmationPolicies showDialog, bool registerHistory)
 		{
 			if (!HasDraggedStorageItems(packageView))
 			{

--- a/src/Files.App/Filesystem/FilesystemOperations/Helpers/IFilesystemHelpers.cs
+++ b/src/Files.App/Filesystem/FilesystemOperations/Helpers/IFilesystemHelpers.cs
@@ -28,7 +28,7 @@ namespace Files.App.Filesystem
 		/// <param name="permanently">Determines whether <paramref name="source"/> is be deleted permanently</param>
 		/// <param name="registerHistory">Determines whether <see cref="IStorageHistory"/> is saved</param>
 		/// <returns><see cref="ReturnResult"/> of performed operation</returns>
-		Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItem> source, bool showDialog, bool permanently, bool registerHistory);
+		Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItem> source, DeleteConfirmationPolicies showDialog, bool permanently, bool registerHistory);
 
 		/// <summary>
 		/// Deletes provided <paramref name="source"/>
@@ -38,7 +38,7 @@ namespace Files.App.Filesystem
 		/// <param name="permanently">Determines whether <paramref name="source"/> is be deleted permanently</param>
 		/// <param name="registerHistory">Determines whether <see cref="IStorageHistory"/> is saved</param>
 		/// <returns><see cref="ReturnResult"/> of performed operation</returns>
-		Task<ReturnResult> DeleteItemAsync(IStorageItem source, bool showDialog, bool permanently, bool registerHistory);
+		Task<ReturnResult> DeleteItemAsync(IStorageItem source, DeleteConfirmationPolicies showDialog, bool permanently, bool registerHistory);
 
 		/// <summary>
 		/// Deletes provided <paramref name="source"/>
@@ -48,7 +48,7 @@ namespace Files.App.Filesystem
 		/// <param name="permanently">Determines whether <paramref name="source"/> is be deleted permanently</param>
 		/// <param name="registerHistory">Determines whether <see cref="IStorageHistory"/> is saved</param>
 		/// <returns><see cref="ReturnResult"/> of performed operation</returns>
-		Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItemWithPath> source, bool showDialog, bool permanently, bool registerHistory);
+		Task<ReturnResult> DeleteItemsAsync(IEnumerable<IStorageItemWithPath> source, DeleteConfirmationPolicies showDialog, bool permanently, bool registerHistory);
 
 		/// <summary>
 		/// Deletes provided <paramref name="source"/>
@@ -58,7 +58,7 @@ namespace Files.App.Filesystem
 		/// <param name="permanently">Determines whether <paramref name="source"/> is be deleted permanently</param>
 		/// <param name="registerHistory">Determines whether <see cref="IStorageHistory"/> is saved</param>
 		/// <returns><see cref="ReturnResult"/> of performed operation</returns>
-		Task<ReturnResult> DeleteItemAsync(IStorageItemWithPath source, bool showDialog, bool permanently, bool registerHistory);
+		Task<ReturnResult> DeleteItemAsync(IStorageItemWithPath source, DeleteConfirmationPolicies showDialog, bool permanently, bool registerHistory);
 
 		#endregion Delete
 
@@ -175,7 +175,7 @@ namespace Files.App.Filesystem
 		/// <returns><see cref="ReturnResult"/> of performed operation</returns>
 		Task<ReturnResult> CopyItemsFromClipboard(DataPackageView packageView, string destination, bool showDialog, bool registerHistory);
 
-		Task<ReturnResult> RecycleItemsFromClipboard(DataPackageView packageView, string destination, bool showDialog, bool registerHistory);
+		Task<ReturnResult> RecycleItemsFromClipboard(DataPackageView packageView, string destination, DeleteConfirmationPolicies showDialog, bool registerHistory);
 
 		Task<ReturnResult> CreateShortcutFromClipboard(DataPackageView packageView, string destination, bool showDialog, bool registerHistory);
 

--- a/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
+++ b/src/Files.App/Filesystem/StorageHistory/StorageHistoryOperations.cs
@@ -38,13 +38,15 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.CreateNew: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Source))
 					{
-						return await helpers.DeleteItemsAsync(history.Source, true, true, false); // Show a dialog to prevent unexpected deletion
+						// Show a dialog regardless of the setting to prevent unexpected deletion
+						return await helpers.DeleteItemsAsync(history.Source, DeleteConfirmationPolicies.Always, true, false);
 					}
 					break;
 				case FileOperationType.CreateLink: // Opposite: Delete created items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, true, true, false); // Show a dialog to prevent unexpected deletion
+						// Show a dialog regardless of the setting to prevent unexpected deletion
+						return await helpers.DeleteItemsAsync(history.Destination, DeleteConfirmationPolicies.Always, true, false);
 					}
 					break;
 				case FileOperationType.Rename: // Opposite: Restore original item names
@@ -61,7 +63,8 @@ namespace Files.App.Filesystem.FilesystemHistory
 				case FileOperationType.Copy: // Opposite: Delete copied items
 					if (!IsHistoryNull(history.Destination))
 					{
-						return await helpers.DeleteItemsAsync(history.Destination, true, true, false); // Show a dialog to prevent unexpected deletion
+						// Show a dialog regardless of the setting to prevent unexpected deletion
+						return await helpers.DeleteItemsAsync(history.Destination, DeleteConfirmationPolicies.Always, true, false);
 					}
 					break;
 				case FileOperationType.Move: // Opposite: Move the items to original directory

--- a/src/Files.App/Helpers/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/NavigationHelpers.cs
@@ -179,7 +179,7 @@ namespace Files.App.Helpers
 
 						// Delete shortcut
 						var shortcutItem = StorageHelpers.FromPathAndType(path, FilesystemItemType.File);
-						await associatedInstance.FilesystemHelpers.DeleteItemAsync(shortcutItem, false, false, true);
+						await associatedInstance.FilesystemHelpers.DeleteItemAsync(shortcutItem, DeleteConfirmationPolicies.Never, false, true);
 					}
 				}
 				else if (isReparsePoint)

--- a/src/Files.App/Helpers/RecycleBinHelpers.cs
+++ b/src/Files.App/Helpers/RecycleBinHelpers.cs
@@ -63,9 +63,9 @@ namespace Files.App.Helpers
 				SecondaryButtonText = "Cancel".GetLocalizedResource(),
 				DefaultButton = ContentDialogButton.Primary
 			};
-			ContentDialogResult result = await SetContentDialogRoot(ConfirmEmptyBinDialog).ShowAsync();
 
-			if (result == ContentDialogResult.Primary)
+			if (userSettingsService.FoldersSettingsService.DeleteConfirmationPolicy is DeleteConfirmationPolicies.Never
+				|| await SetContentDialogRoot(ConfirmEmptyBinDialog).ShowAsync() == ContentDialogResult.Primary)
 			{
 				string bannerTitle = "EmptyRecycleBin".GetLocalizedResource();
 				var banner = App.OngoingTasksViewModel.PostBanner(
@@ -173,7 +173,7 @@ namespace Files.App.Helpers
 			var items = associatedInstance.SlimContentPage.SelectedItems.ToList().Select((item) => StorageHelpers.FromPathAndType(
 				item.ItemPath,
 				item.PrimaryItemAttribute == StorageItemTypes.File ? FilesystemItemType.File : FilesystemItemType.Directory));
-			await associatedInstance.FilesystemHelpers.DeleteItemsAsync(items, userSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, false, true);
+			await associatedInstance.FilesystemHelpers.DeleteItemsAsync(items, userSettingsService.FoldersSettingsService.DeleteConfirmationPolicy, false, true);
 		}
 	}
 }

--- a/src/Files.App/ServicesImplementation/Settings/FoldersSettingsService.cs
+++ b/src/Files.App/ServicesImplementation/Settings/FoldersSettingsService.cs
@@ -238,10 +238,10 @@ namespace Files.App.ServicesImplementation.Settings
 			set => Set(value);
 		}
 
-		public bool ShowConfirmDeleteDialog
+		public DeleteConfirmationPolicies DeleteConfirmationPolicy
 		{
-			get => Get(true);
-			set => Set(value);
+			get => (DeleteConfirmationPolicies)Get((long)DeleteConfirmationPolicies.Always);
+			set => Set((long)value);
 		}
 
 		public bool SelectFilesOnHover
@@ -283,7 +283,7 @@ namespace Files.App.ServicesImplementation.Settings
 				case nameof(CalculateFolderSizes):
 				case nameof(ShowFileExtensions):
 				case nameof(ShowThumbnails):
-				case nameof(ShowConfirmDeleteDialog):
+				case nameof(DeleteConfirmationPolicy):
 				case nameof(SelectFilesOnHover):
 				case nameof(ShowSelectionCheckboxes):
 				case nameof(DoubleClickToGoUp):

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2913,4 +2913,13 @@
   <data name="WindowsVersion" xml:space="preserve">
     <value>Windows version</value>
   </data>
+  <data name="Always" xml:space="preserve">
+    <value>Always</value>
+  </data>
+  <data name="PermanentDeletionOnly" xml:space="preserve">
+    <value>Permanent deletion only</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Never</value>
+  </data>
 </root>

--- a/src/Files.App/ViewModels/SettingsViewModels/FoldersViewModel.cs
+++ b/src/Files.App/ViewModels/SettingsViewModels/FoldersViewModel.cs
@@ -21,6 +21,7 @@ namespace Files.App.ViewModels.SettingsViewModels
 			SelectedDefaultLayoutModeIndex = (int)DefaultLayoutMode;
 			SelectedDefaultSortingIndex = UserSettingsService.FoldersSettingsService.DefaultSortOption == SortOption.FileTag ? FileTagSortingIndex : (int)UserSettingsService.FoldersSettingsService.DefaultSortOption;
 			SelectedDefaultGroupingIndex = UserSettingsService.FoldersSettingsService.DefaultGroupOption == GroupOption.FileTag ? FileTagGroupingIndex : (int)UserSettingsService.FoldersSettingsService.DefaultGroupOption;
+			SelectedDeleteConfirmationPolicyIndex = (int)DeleteConfirmationPolicy;
 		}
 
 		// Properties
@@ -35,6 +36,20 @@ namespace Files.App.ViewModels.SettingsViewModels
 				{
 					OnPropertyChanged(nameof(SelectedDefaultLayoutModeIndex));
 					DefaultLayoutMode = (FolderLayoutModes)value;
+				}
+			}
+		}
+
+		private int selectedDeleteConfirmationPolicyIndex;
+		public int SelectedDeleteConfirmationPolicyIndex
+		{
+			get => selectedDeleteConfirmationPolicyIndex;
+			set
+			{
+				if (SetProperty(ref selectedDeleteConfirmationPolicyIndex, value))
+				{
+					OnPropertyChanged(nameof(SelectedDeleteConfirmationPolicyIndex));
+					DeleteConfirmationPolicy = (DeleteConfirmationPolicies)value;
 				}
 			}
 		}
@@ -315,14 +330,14 @@ namespace Files.App.ViewModels.SettingsViewModels
 			}
 		}
 
-		public bool ShowConfirmDeleteDialog
+		public DeleteConfirmationPolicies DeleteConfirmationPolicy
 		{
-			get => UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog;
+			get => UserSettingsService.FoldersSettingsService.DeleteConfirmationPolicy;
 			set
 			{
-				if (value != UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog)
+				if (value != UserSettingsService.FoldersSettingsService.DeleteConfirmationPolicy)
 				{
-					UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog = value;
+					UserSettingsService.FoldersSettingsService.DeleteConfirmationPolicy = value;
 					OnPropertyChanged();
 				}
 			}

--- a/src/Files.App/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/ColumnShellPage.xaml.cs
@@ -714,7 +714,7 @@ namespace Files.App.Views
 						var items = SlimContentPage.SelectedItems.ToList().Select((item) => StorageHelpers.FromPathAndType(
 							item.ItemPath,
 							item.PrimaryItemAttribute == StorageItemTypes.File ? FilesystemItemType.File : FilesystemItemType.Directory));
-						await FilesystemHelpers.DeleteItemsAsync(items, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, true);
+						await FilesystemHelpers.DeleteItemsAsync(items, UserSettingsService.FoldersSettingsService.DeleteConfirmationPolicy, true, true);
 					}
 
 					break;
@@ -758,7 +758,7 @@ namespace Files.App.Views
 						var items = SlimContentPage.SelectedItems.ToList().Select((item) => StorageHelpers.FromPathAndType(
 							item.ItemPath,
 							item.PrimaryItemAttribute == StorageItemTypes.File ? FilesystemItemType.File : FilesystemItemType.Directory));
-						await FilesystemHelpers.DeleteItemsAsync(items, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, false, true);
+						await FilesystemHelpers.DeleteItemsAsync(items, UserSettingsService.FoldersSettingsService.DeleteConfirmationPolicy, false, true);
 					}
 
 					break;

--- a/src/Files.App/Views/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/ModernShellPage.xaml.cs
@@ -725,7 +725,7 @@ namespace Files.App.Views
 						var items = SlimContentPage.SelectedItems.ToList().Select((item) => StorageHelpers.FromPathAndType(
 							item.ItemPath,
 							item.PrimaryItemAttribute == StorageItemTypes.File ? FilesystemItemType.File : FilesystemItemType.Directory));
-						await FilesystemHelpers.DeleteItemsAsync(items, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, true, true);
+						await FilesystemHelpers.DeleteItemsAsync(items, UserSettingsService.FoldersSettingsService.DeleteConfirmationPolicy, true, true);
 					}
 
 					break;
@@ -761,7 +761,7 @@ namespace Files.App.Views
 						var items = SlimContentPage.SelectedItems.ToList().Select((item) => StorageHelpers.FromPathAndType(
 							item.ItemPath,
 							item.PrimaryItemAttribute == StorageItemTypes.File ? FilesystemItemType.File : FilesystemItemType.Directory));
-						await FilesystemHelpers.DeleteItemsAsync(items, UserSettingsService.FoldersSettingsService.ShowConfirmDeleteDialog, false, true);
+						await FilesystemHelpers.DeleteItemsAsync(items, UserSettingsService.FoldersSettingsService.DeleteConfirmationPolicy, false, true);
 					}
 
 					break;

--- a/src/Files.App/Views/SettingsPages/Folders.xaml
+++ b/src/Files.App/Views/SettingsPages/Folders.xaml
@@ -283,11 +283,11 @@
 					<FontIcon Glyph="&#xE107;" />
 				</local:SettingsBlockControl.Icon>
 
-				<ToggleSwitch
-					x:Name="ShowConfirmDeleteDialogSwitch"
-					AutomationProperties.Name="{helpers:ResourceString Name=ShowConfirmationWhenDeletingItems}"
-					IsOn="{x:Bind ViewModel.ShowConfirmDeleteDialog, Mode=TwoWay}"
-					Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+				<ComboBox AutomationProperties.Name="{helpers:ResourceString Name=ShowConfirmationWhenDeletingItems}" SelectedIndex="{x:Bind ViewModel.SelectedDeleteConfirmationPolicyIndex, Mode=TwoWay}">
+					<ComboBoxItem Content="{helpers:ResourceString Name=Always}" />
+					<ComboBoxItem Content="{helpers:ResourceString Name=PermanentDeletionOnly}" />
+					<ComboBoxItem Content="{helpers:ResourceString Name=Never}" />
+				</ComboBox>
 			</local:SettingsBlockControl>
 
 			<!--  Select On Hover  -->

--- a/src/Files.Backend/Services/Settings/IFoldersSettingsService.cs
+++ b/src/Files.Backend/Services/Settings/IFoldersSettingsService.cs
@@ -169,7 +169,7 @@ namespace Files.Backend.Services.Settings
 		/// <summary>
 		/// Gets or sets a value indicating whether or not to show the delete confirmation dialog when deleting items.
 		/// </summary>
-		bool ShowConfirmDeleteDialog { get; set; }
+		DeleteConfirmationPolicies DeleteConfirmationPolicy { get; set; }
 
 		/// <summary>
 		/// Gets or sets a value indicating whether or not to select files and folders when hovering them.

--- a/src/Files.Shared/Enums/DeleteConfirmationPolicy.cs
+++ b/src/Files.Shared/Enums/DeleteConfirmationPolicy.cs
@@ -1,0 +1,9 @@
+﻿namespace Files.Shared.Enums
+{
+	public enum DeleteConfirmationPolicies : byte
+	{
+		Always,
+		PermanentOnly,
+		Never,
+	}
+}


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11126 

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility

**Details**
* The setting to show a delete confirmation dialog now has three choices: Always, Permanent deletion only, Never.
* When "Never" is selected, the dialog to confirm emptying the recycle bin will also not appear.
* To avoid errors when updating, the setting will be "Always" after updating regardless of the previous setting.

**Screenshots**
![image](https://user-images.githubusercontent.com/66369541/217553310-cbbdfba9-768c-4393-9bc3-126a4e0b873a.png)
