### PR TITLE
Perf: Small performance improvement for CalculateChecksumForPath

### DIFF
--- a/src/Files.Shared/Helpers/ChecksumHelpers.cs
+++ b/src/Files.Shared/Helpers/ChecksumHelpers.cs
@@ -9,9 +9,9 @@ namespace Files.Shared.Helpers
 		public static string CalculateChecksumForPath(string path)
 		{
 			var buffer = Encoding.UTF8.GetBytes(path);
-			var hash = MD5.HashData(buffer);
-
-			return BitConverter.ToString(hash).Replace("-", string.Empty);
+			Span<byte> hash = stackalloc byte[MD5.HashSizeInBytes];
+			MD5.HashData(buffer, hash);
+			return Convert.ToHexString(hash);
 		}
 	}
 }


### PR DESCRIPTION
This is a small performance improvement for `CalculateChecksumForPath`:

1. MD5 hashes are stack-buffer size friendly, so switch to the buffer-writing `MD5.HashData` and write to the stack.
2. Replace `BitConverter.ToString(..).Replace(..)` with `Convert.ToHexString`. This eliminates a 32 character string allocation.


Note that this method could be further optimized to make it near allocation-less at the cost of readability, adding complexity. and using unsafe code. But it isn't clear to me how "hot" this code path is. Right now the allocations scale with the length of the path. However, these changes are small and don't harm the readability of the method.

Benchmarks:

| Method | PathLength |       Mean |   Error |  StdDev |   Gen0 | Allocated |
|------- |----------- |-----------:|--------:|--------:|-------:|----------:|
|  After |        260 |   815.4 ns | 5.43 ns | 5.07 ns | 0.0591 |     376 B |
| Before |        260 | 1,054.6 ns | 2.77 ns | 2.59 ns | 0.0839 |     536 B |

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
Not really applicable.