### PR TITLE
Fix: Fixed "NotAFolder" error when changing the language

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -341,7 +341,7 @@ namespace Files.App
 				}
 				else
 				{
-					var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home".GetLocalizedResource() };
+					var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home" };
 					return defaultArg.Serialize();
 				}
 			}).ToList();

--- a/src/Files.App/DataModels/NavigationControlItems/LocationItem.cs
+++ b/src/Files.App/DataModels/NavigationControlItems/LocationItem.cs
@@ -35,7 +35,7 @@ namespace Files.App.DataModels.NavigationControlItems
 			set
 			{
 				path = value;
-				ToolTipText = string.IsNullOrEmpty(Path) || Path.Contains('?', StringComparison.Ordinal) || Path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase) || Path.EndsWith(ShellLibraryItem.EXTENSION, StringComparison.OrdinalIgnoreCase) || Path == "Home".GetLocalizedResource() ? Text : Path;
+				ToolTipText = string.IsNullOrEmpty(Path) || Path.Contains('?', StringComparison.Ordinal) || Path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase) || Path.EndsWith(ShellLibraryItem.EXTENSION, StringComparison.OrdinalIgnoreCase) || Path == "Home" ? Text : Path;
 			}
 		}
 

--- a/src/Files.App/Filesystem/Search/FolderSearch.cs
+++ b/src/Files.App/Filesystem/Search/FolderSearch.cs
@@ -84,7 +84,7 @@ namespace Files.App.Filesystem.Search
 				{
 					return AddItemsAsyncForLibrary(library, results, token);
 				}
-				else if (Folder == "Home".GetLocalizedResource())
+				else if (Folder == "Home")
 				{
 					return AddItemsAsyncForHome(results, token);
 				}
@@ -119,7 +119,7 @@ namespace Files.App.Filesystem.Search
 				{
 					await AddItemsAsyncForLibrary(library, results, token);
 				}
-				else if (Folder == "Home".GetLocalizedResource())
+				else if (Folder == "Home")
 				{
 					await AddItemsAsyncForHome(results, token);
 				}

--- a/src/Files.App/Helpers/CommonPaths.cs
+++ b/src/Files.App/Helpers/CommonPaths.cs
@@ -31,12 +31,12 @@ namespace Files.App.Helpers
 
 		public static Dictionary<string, string> ShellPlaces = new Dictionary<string, string>() {
 			{ "::{645FF040-5081-101B-9F08-00AA002F954E}", RecycleBinPath },
-			{ "::{5E5F29CE-E0A8-49D3-AF32-7A7BDC173478}", "Home".GetLocalizedResource() /*MyComputerPath*/ },
-			{ "::{20D04FE0-3AEA-1069-A2D8-08002B30309D}", "Home".GetLocalizedResource() /*MyComputerPath*/ },
+			{ "::{5E5F29CE-E0A8-49D3-AF32-7A7BDC173478}", "Home" /*MyComputerPath*/ },
+			{ "::{20D04FE0-3AEA-1069-A2D8-08002B30309D}", "Home" /*MyComputerPath*/ },
 			{ "::{F02C1A0D-BE21-4350-88B0-7367FC96EF3C}", NetworkFolderPath },
 			{ "::{208D2C60-3AEA-1069-A2D7-08002B30309D}", NetworkFolderPath },
 			{ RecycleBinPath.ToUpperInvariant(), RecycleBinPath },
-			{ MyComputerPath.ToUpperInvariant(), "Home".GetLocalizedResource() /*MyComputerPath*/ },
+			{ MyComputerPath.ToUpperInvariant(), "Home" /*MyComputerPath*/ },
 			{ NetworkFolderPath.ToUpperInvariant(), NetworkFolderPath },
 		};
 	}

--- a/src/Files.App/Helpers/MultitaskingTabsHelpers.cs
+++ b/src/Files.App/Helpers/MultitaskingTabsHelpers.cs
@@ -50,7 +50,7 @@ namespace Files.App.Helpers
 
 			return tabItemArguments is not null
 				? NavigationHelpers.OpenTabInNewWindowAsync(tabItemArguments.Serialize())
-				: NavigationHelpers.OpenPathInNewWindowAsync("Home".GetLocalizedResource());
+				: NavigationHelpers.OpenPathInNewWindowAsync("Home");
 		}
 
 		public static async Task AddNewTab(Type type, object tabViewItemArgs, int atIndex = -1)

--- a/src/Files.App/Helpers/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/NavigationHelpers.cs
@@ -144,7 +144,7 @@ namespace Files.App.Helpers
 					associatedInstance.NavigateToPath(path, new NavigationArguments()
 					{
 						IsSearchResultPage = true,
-						SearchPathParam = "Home".GetLocalizedResource(),
+						SearchPathParam = "Home",
 						SearchQuery = path,
 						AssociatedTabInstance = associatedInstance,
 						NavPathParam = path

--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -539,7 +539,7 @@ namespace Files.App.UserControls
 				}
 				else if (isPathNull ||
 					(hasStorageItems && storageItems.AreItemsAlreadyInFolder(locationItem.Path)) ||
-					locationItem.Path.StartsWith("Home".GetLocalizedResource(), StringComparison.OrdinalIgnoreCase))
+					locationItem.Path.StartsWith("Home", StringComparison.OrdinalIgnoreCase))
 				{
 					e.AcceptedOperation = DataPackageOperation.None;
 				}

--- a/src/Files.App/ViewModels/ItemViewModel.cs
+++ b/src/Files.App/ViewModels/ItemViewModel.cs
@@ -126,7 +126,7 @@ namespace Files.App.ViewModels
 			else if (!Path.IsPathRooted(WorkingDirectory) || Path.GetPathRoot(WorkingDirectory) != Path.GetPathRoot(value))
 				workingRoot = await FilesystemTasks.Wrap(() => DrivesManager.GetRootFromPathAsync(value));
 
-			if (value == "Home".GetLocalizedResource())
+			if (value == "Home")
 				currentStorageFolder = null;
 			else
 				App.JumpList.AddFolderToJumpList(value);
@@ -458,7 +458,7 @@ namespace Files.App.ViewModels
 		{
 			await dispatcherQueue.EnqueueAsync(() =>
 			{
-				if (WorkingDirectory != "Home".GetLocalizedResource())
+				if (WorkingDirectory != "Home")
 					RefreshItems(null);
 			});
 		}
@@ -477,7 +477,7 @@ namespace Files.App.ViewModels
 				case nameof(UserSettingsService.FoldersSettingsService.SelectFilesOnHover):
 					await dispatcherQueue.EnqueueAsync(() =>
 					{
-						if (WorkingDirectory != "Home".GetLocalizedResource())
+						if (WorkingDirectory != "Home")
 							RefreshItems(null);
 					});
 					break;

--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -176,7 +176,7 @@ namespace Files.App.ViewModels
 		public static async Task AddNewTabByPathAsync(Type type, string? path, int atIndex = -1)
 		{
 			if (string.IsNullOrEmpty(path))
-				path = "Home".GetLocalizedResource();
+				path = "Home";
 			else if (path.EndsWith("\\?")) // Support drives launched through jump list by stripping away the question mark at the end.
 				path = path.Remove(path.Length - 1);
 
@@ -254,7 +254,7 @@ namespace Files.App.ViewModels
 			var iconSource = new Microsoft.UI.Xaml.Controls.ImageIconSource();
 			string toolTipText = currentPath;
 
-			if (string.IsNullOrEmpty(currentPath) || currentPath == "Home".GetLocalizedResource())
+			if (string.IsNullOrEmpty(currentPath) || currentPath == "Home")
 			{
 				tabLocationHeader = "Home".GetLocalizedResource();
 				iconSource.ImageSource = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(Constants.FluentIconsPaths.HomeIcon));
@@ -372,7 +372,7 @@ namespace Files.App.ViewModels
 							var tabArgs = TabItemArguments.Deserialize(tabArgsString);
 							await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
 						}
-						var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home".GetLocalizedResource() };
+						var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home" };
 						userSettingsService.PreferencesSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
 					}
 					else
@@ -402,7 +402,7 @@ namespace Files.App.ViewModels
 
 		public static Task AddNewTabAsync()
 		{
-			return AddNewTabByPathAsync(typeof(PaneHolderPage), "Home".GetLocalizedResource());
+			return AddNewTabByPathAsync(typeof(PaneHolderPage), "Home");
 		}
 
 		public void AddNewTab()
@@ -427,7 +427,7 @@ namespace Files.App.ViewModels
 			}
 			else
 			{
-				await AddNewTabByPathAsync(typeof(PaneHolderPage), "Home".GetLocalizedResource());
+				await AddNewTabByPathAsync(typeof(PaneHolderPage), "Home");
 			}
 		}
 

--- a/src/Files.App/ViewModels/SettingsViewModels/PreferencesViewModel.cs
+++ b/src/Files.App/ViewModels/SettingsViewModels/PreferencesViewModel.cs
@@ -155,7 +155,7 @@ namespace Files.App.ViewModels.SettingsViewModels
 			recentsItem.Items.Add(new MenuFlyoutItemViewModel("Home".GetLocalizedResource())
 			{
 				Command = AddPageCommand,
-				CommandParameter = "Home".GetLocalizedResource(),
+				CommandParameter = "Home",
 				Tooltip = "Home".GetLocalizedResource()
 			});
 			await PopulateRecentItems(recentsItem);
@@ -631,7 +631,7 @@ namespace Files.App.ViewModels.SettingsViewModels
 		{
 			get
 			{
-				if (Path == "Home".GetLocalizedResource())
+				if (Path == "Home")
 					return "Home".GetLocalizedResource();
 				return (Path == CommonPaths.RecycleBinPath)
 					   ? ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin")

--- a/src/Files.App/ViewModels/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/SidebarViewModel.cs
@@ -93,7 +93,7 @@ namespace Files.App.ViewModels
 
 			if (string.IsNullOrEmpty(value))
 			{
-				//SidebarSelectedItem = sidebarItems.FirstOrDefault(x => x.Path.Equals("Home".GetLocalizedResource()));
+				//SidebarSelectedItem = sidebarItems.FirstOrDefault(x => x.Path.Equals("Home"));
 				return;
 			}
 
@@ -101,8 +101,8 @@ namespace Files.App.ViewModels
 			item ??= sidebarItems.FirstOrDefault(x => x.Path.Equals(value + "\\", StringComparison.OrdinalIgnoreCase));
 			item ??= sidebarItems.FirstOrDefault(x => value.StartsWith(x.Path, StringComparison.OrdinalIgnoreCase));
 			item ??= sidebarItems.FirstOrDefault(x => x.Path.Equals(Path.GetPathRoot(value), StringComparison.OrdinalIgnoreCase));
-			if (item is null && value == "Home".GetLocalizedResource())
-				item = sidebarItems.FirstOrDefault(x => x.Path.Equals("Home".GetLocalizedResource()));
+			if (item is null && value == "Home")
+				item = sidebarItems.FirstOrDefault(x => x.Path.Equals("Home"));
 
 			if (SidebarSelectedItem != item)
 				SidebarSelectedItem = item;
@@ -382,7 +382,7 @@ namespace Files.App.ViewModels
 				case SectionType.Home:
 					{
 						section = BuildSection("Home".GetLocalizedResource(), sectionType, new ContextMenuOptions { IsLocationItem = true }, true);
-						section.Path = "Home".GetLocalizedResource();
+						section.Path = "Home";
 						section.Font = App.AppModel.SymbolFontFamily;
 						section.Icon = new BitmapImage(new Uri(Constants.FluentIconsPaths.HomeIcon));
 						break;

--- a/src/Files.App/ViewModels/ToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/ToolbarViewModel.cs
@@ -560,7 +560,7 @@ namespace Files.App.ViewModels
 		public void PathBoxItem_DragLeave(object sender, DragEventArgs e)
 		{
 			if (((StackPanel)sender).DataContext is not PathBoxItem pathBoxItem ||
-				pathBoxItem.Path == "Home".GetLocalizedResource())
+				pathBoxItem.Path == "Home")
 			{
 				return;
 			}
@@ -582,7 +582,7 @@ namespace Files.App.ViewModels
 			dragOverPath = null; // Reset dragged over pathbox item
 
 			if (((StackPanel)sender).DataContext is not PathBoxItem pathBoxItem ||
-				pathBoxItem.Path == "Home".GetLocalizedResource())
+				pathBoxItem.Path == "Home")
 			{
 				return;
 			}
@@ -608,7 +608,7 @@ namespace Files.App.ViewModels
 		{
 			if (IsSingleItemOverride ||
 				((StackPanel)sender).DataContext is not PathBoxItem pathBoxItem ||
-				pathBoxItem.Path == "Home".GetLocalizedResource())
+				pathBoxItem.Path == "Home")
 			{
 				return;
 			}
@@ -988,7 +988,7 @@ namespace Files.App.ViewModels
 
 			if (currentInput != shellPage.FilesystemViewModel.WorkingDirectory || shellPage.CurrentPageType == typeof(WidgetsPage))
 			{
-				if (currentInput.Equals("Home".GetLocalizedResource(), StringComparison.OrdinalIgnoreCase))
+				if (currentInput.Equals("Home", StringComparison.OrdinalIgnoreCase) || currentInput.Equals("Home".GetLocalizedResource(), StringComparison.OrdinalIgnoreCase))
 				{
 					shellPage.NavigateHome();
 				}

--- a/src/Files.App/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/ColumnShellPage.xaml.cs
@@ -160,7 +160,7 @@ namespace Files.App.Views
 				FlowDirection = FlowDirection.RightToLeft;
 			}
 
-			//NavigationToolbar.PathControlDisplayText = "Home".GetLocalizedResource();
+			//NavigationToolbar.PathControlDisplayText = "Home";
 			//NavigationToolbar.CanGoBack = false;
 			//NavigationToolbar.CanGoForward = false;
 			//NavigationToolbar.SearchBox.QueryChanged += ColumnShellPage_QueryChanged;
@@ -279,7 +279,7 @@ namespace Files.App.Views
 			ToolbarViewModel.ClearContentPageSelectionCommand = new RelayCommand(() => SlimContentPage?.ItemManipulationModel.ClearSelection());
 			ToolbarViewModel.PasteItemsFromClipboardCommand = new RelayCommand(async () => await UIFilesystemHelpers.PasteItemAsync(FilesystemViewModel.WorkingDirectory, this));
 			ToolbarViewModel.OpenNewWindowCommand = new AsyncRelayCommand(NavigationHelpers.LaunchNewWindowAsync);
-			ToolbarViewModel.OpenNewPaneCommand = new RelayCommand(() => PaneHolder?.OpenPathInNewPane("Home".GetLocalizedResource()));
+			ToolbarViewModel.OpenNewPaneCommand = new RelayCommand(() => PaneHolder?.OpenPathInNewPane("Home"));
 			ToolbarViewModel.ClosePaneCommand = new RelayCommand(() => PaneHolder?.CloseActivePane());
 			ToolbarViewModel.CreateNewFileCommand = new RelayCommand<ShellNewEntry>(x => UIFilesystemHelpers.CreateFileFromDialogResultType(AddItemDialogItemType.File, x, this));
 			ToolbarViewModel.CreateNewFolderCommand = new RelayCommand(() => UIFilesystemHelpers.CreateFileFromDialogResultType(AddItemDialogItemType.Folder, null, this));
@@ -891,7 +891,7 @@ namespace Files.App.Views
 		{
 			if (incomingSourcePageType == typeof(WidgetsPage) && incomingSourcePageType is not null)
 			{
-				ToolbarViewModel.PathControlDisplayText = "Home".GetLocalizedResource();
+				ToolbarViewModel.PathControlDisplayText = "Home";
 			}
 		}
 

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -262,12 +262,12 @@ namespace Files.App.Views
 						{
 							navigationPath = invokedItemContainer.Tag?.ToString();
 						}
-						else if (ItemPath.Equals("Home".GetLocalizedResource(), StringComparison.OrdinalIgnoreCase)) // Home item
+						else if (ItemPath.Equals("Home", StringComparison.OrdinalIgnoreCase)) // Home item
 						{
 							if (ItemPath.Equals(SidebarAdaptiveViewModel.SidebarSelectedItem?.Path, StringComparison.OrdinalIgnoreCase))
 								return; // return if already selected
 
-							navigationPath = "Home".GetLocalizedResource();
+							navigationPath = "Home";
 							sourcePageType = typeof(WidgetsPage);
 						}
 						else // Any other item
@@ -285,7 +285,7 @@ namespace Files.App.Views
 						shp.NavigateToPath(tagPath, new NavigationArguments()
 						{
 							IsSearchResultPage = true,
-							SearchPathParam = "Home".GetLocalizedResource(),
+							SearchPathParam = "Home",
 							SearchQuery = tagPath,
 							AssociatedTabInstance = shp,
 							NavPathParam = tagPath

--- a/src/Files.App/Views/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/ModernShellPage.xaml.cs
@@ -167,7 +167,7 @@ namespace Files.App.Views
 			if (flowDirectionSetting == "RTL")
 				FlowDirection = FlowDirection.RightToLeft;
 
-			ToolbarViewModel.PathControlDisplayText = "Home".GetLocalizedResource();
+			ToolbarViewModel.PathControlDisplayText = "Home";
 
 			ToolbarViewModel.ToolbarPathItemInvoked += ModernShellPage_NavigationRequested;
 			ToolbarViewModel.ToolbarFlyoutOpened += ModernShellPage_ToolbarFlyoutOpened;
@@ -253,7 +253,7 @@ namespace Files.App.Views
 			ToolbarViewModel.ClearContentPageSelectionCommand = new RelayCommand(() => SlimContentPage?.ItemManipulationModel.ClearSelection());
 			ToolbarViewModel.PasteItemsFromClipboardCommand = new RelayCommand(async () => await UIFilesystemHelpers.PasteItemAsync(FilesystemViewModel.WorkingDirectory, this));
 			ToolbarViewModel.OpenNewWindowCommand = new AsyncRelayCommand(NavigationHelpers.LaunchNewWindowAsync);
-			ToolbarViewModel.OpenNewPaneCommand = new RelayCommand(() => PaneHolder?.OpenPathInNewPane("Home".GetLocalizedResource()));
+			ToolbarViewModel.OpenNewPaneCommand = new RelayCommand(() => PaneHolder?.OpenPathInNewPane("Home"));
 			ToolbarViewModel.ClosePaneCommand = new RelayCommand(() => PaneHolder?.CloseActivePane());
 			ToolbarViewModel.CreateNewFileCommand = new RelayCommand<ShellNewEntry>(x => UIFilesystemHelpers.CreateFileFromDialogResultType(AddItemDialogItemType.File, x, this));
 			ToolbarViewModel.CreateNewFolderCommand = new RelayCommand(() => UIFilesystemHelpers.CreateFileFromDialogResultType(AddItemDialogItemType.Folder, null, this));
@@ -527,7 +527,7 @@ namespace Files.App.Views
 
 		private void OnNavigationParamsChanged()
 		{
-			if (string.IsNullOrEmpty(NavParams?.NavPath) || NavParams.NavPath == "Home".GetLocalizedResource())
+			if (string.IsNullOrEmpty(NavParams?.NavPath) || NavParams.NavPath == "Home")
 			{
 				ItemDisplayFrame.Navigate(typeof(WidgetsPage),
 					new NavigationArguments()
@@ -546,7 +546,7 @@ namespace Files.App.Views
 						NavPathParam = NavParams.NavPath,
 						SelectItems = !string.IsNullOrWhiteSpace(NavParams?.SelectItem) ? new[] { NavParams.SelectItem } : null,
 						IsSearchResultPage = isTagSearch,
-						SearchPathParam = isTagSearch ? "Home".GetLocalizedResource() : null,
+						SearchPathParam = isTagSearch ? "Home" : null,
 						SearchQuery = isTagSearch ? navParams.NavPath : null,
 						AssociatedTabInstance = this
 					});
@@ -905,7 +905,7 @@ namespace Files.App.Views
 				ItemDisplayFrame.Navigate(typeof(WidgetsPage),
 					new NavigationArguments()
 					{
-						NavPathParam = "Home".GetLocalizedResource(),
+						NavPathParam = "Home",
 						AssociatedTabInstance = this
 					}, new SuppressNavigationTransitionInfo());
 			}
@@ -934,7 +934,7 @@ namespace Files.App.Views
 		private void SelectSidebarItemFromPath(Type incomingSourcePageType = null)
 		{
 			if (incomingSourcePageType == typeof(WidgetsPage) && incomingSourcePageType is not null)
-				ToolbarViewModel.PathControlDisplayText = "Home".GetLocalizedResource();
+				ToolbarViewModel.PathControlDisplayText = "Home";
 		}
 
 		public void Dispose()
@@ -1050,7 +1050,7 @@ namespace Files.App.Views
 			ItemDisplayFrame.Navigate(typeof(WidgetsPage),
 				new NavigationArguments()
 				{
-					NavPathParam = "Home".GetLocalizedResource(),
+					NavPathParam = "Home",
 					AssociatedTabInstance = this
 				}, new SuppressNavigationTransitionInfo());
 		}

--- a/src/Files.App/Views/PaneHolderPage.xaml.cs
+++ b/src/Files.App/Views/PaneHolderPage.xaml.cs
@@ -226,7 +226,7 @@ namespace Files.App.Views
 			if (eventArgs.Parameter is string navPath)
 			{
 				NavParamsLeft = new NavigationParams { NavPath = navPath };
-				NavParamsRight = new NavigationParams { NavPath = "Home".GetLocalizedResource() };
+				NavParamsRight = new NavigationParams { NavPath = "Home" };
 			}
 			else if (eventArgs.Parameter is PaneNavigationArguments paneArgs)
 			{
@@ -309,7 +309,7 @@ namespace Files.App.Views
 					{
 						if (string.IsNullOrEmpty(NavParamsRight?.NavPath))
 						{
-							NavParamsRight = new NavigationParams { NavPath = "Home".GetLocalizedResource() };
+							NavParamsRight = new NavigationParams { NavPath = "Home" };
 						}
 						IsRightPaneVisible = true;
 						ActivePane = PaneRight;
@@ -326,7 +326,7 @@ namespace Files.App.Views
 					{
 						if (string.IsNullOrEmpty(NavParamsRight?.NavPath))
 						{
-							NavParamsRight = new NavigationParams { NavPath = "Home".GetLocalizedResource() };
+							NavParamsRight = new NavigationParams { NavPath = "Home" };
 						}
 						IsRightPaneVisible = true;
 					}

--- a/src/Files.App/Views/WidgetsPage.xaml.cs
+++ b/src/Files.App/Views/WidgetsPage.xaml.cs
@@ -238,11 +238,11 @@ namespace Files.App.Views
 			AppInstance.ToolbarViewModel.RefreshRequested += ToolbarViewModel_RefreshRequested;
 
 			// Set path of working directory empty
-			await AppInstance.FilesystemViewModel.SetWorkingDirectoryAsync("Home".GetLocalizedResource());
+			await AppInstance.FilesystemViewModel.SetWorkingDirectoryAsync("Home");
 
 			// Clear the path UI and replace with Favorites
 			AppInstance.ToolbarViewModel.PathComponents.Clear();
-			string componentLabel = parameters.NavPathParam;
+			string componentLabel = parameters.NavPathParam == "Home" ? "Home".GetLocalizedResource() : parameters.NavPathParam;
 			string tag = parameters.NavPathParam;
 			PathBoxItem item = new PathBoxItem()
 			{


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11203 

**Details**
The path to the home screen is now "Home" regardless of the language though the display name is still localized.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility