### PR TITLE
Fix: Fixed selecting wrong items when creating or renaming an item

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -714,7 +714,16 @@ namespace Files.App.Views.LayoutModes
 			{
 				var checkbox = container.FindDescendant("SelectionCheckbox") as CheckBox;
 				if (checkbox is not null)
+				{
+					// Temporarily disable events to avoid selecting wrong items
+					checkbox.Checked -= ItemSelected_Checked;
+					checkbox.Unchecked -= ItemSelected_Unchecked;
+
 					checkbox.IsChecked = FileList.SelectedItems.Contains(item);
+
+					checkbox.Checked += ItemSelected_Checked;
+					checkbox.Unchecked += ItemSelected_Unchecked;
+				}
 			}
 		}
 

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -471,7 +471,16 @@ namespace Files.App.Views.LayoutModes
 			{
 				var checkbox = container.FindDescendant("SelectionCheckbox") as CheckBox;
 				if (checkbox is not null)
+				{
+					// Temporarily disable events to avoid selecting wrong items
+					checkbox.Checked -= ItemSelected_Checked;
+					checkbox.Unchecked -= ItemSelected_Unchecked;
+
 					checkbox.IsChecked = FileList.SelectedItems.Contains(item);
+
+					checkbox.Checked += ItemSelected_Checked;
+					checkbox.Unchecked += ItemSelected_Unchecked;
+				}
 			}
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11092

**Details**
`ItemContainer.Content` appears to refer to the old item before the item was created or renamed.
Because of this, checked and unchecked events select wrong items.
These events are for (un)selecting (un)checked items and are not needed in this logic, so I disabled these events temporarily.

Deleteing items also selects another item, but this appears to be the intended specification so it is left as is at this time.
(ItemViewModel.cs:1850)

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility