### PR TITLE
Fix: Fixed issues with recent context menu changes

### DIFF
--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -604,6 +604,8 @@ namespace Files.App
 					var shellMenuItems = await ContextFlyoutItemHelper.GetBaseContextShellCommandsAsync(workingDir: ParentShellPageInstance.FilesystemViewModel.WorkingDirectory, shiftPressed: shiftPressed, showOpenMenu: false, shellContextMenuItemCancellationToken.Token);
 					if (shellMenuItems.Any())
 						AddShellItemsToMenu(shellMenuItems, BaseContextMenuFlyout, shiftPressed);
+					else
+						RemoveOverflow(BaseContextMenuFlyout);
 				}
 			}
 			catch (Exception error)
@@ -661,6 +663,8 @@ namespace Files.App
 				var shellMenuItems = await ContextFlyoutItemHelper.GetItemContextShellCommandsAsync(workingDir: ParentShellPageInstance.FilesystemViewModel.WorkingDirectory, selectedItems: SelectedItems!, shiftPressed: shiftPressed, showOpenMenu: false, shellContextMenuItemCancellationToken.Token);
 				if (shellMenuItems.Any())
 					AddShellItemsToMenu(shellMenuItems, ItemContextMenuFlyout, shiftPressed);
+				else
+					RemoveOverflow(ItemContextMenuFlyout);
 			}
 		}
 
@@ -820,6 +824,17 @@ namespace Files.App
 					}
 				});
 			}
+		}
+
+		private void RemoveOverflow(CommandBarFlyout contextMenuFlyout)
+		{
+			var overflowItem = contextMenuFlyout.SecondaryCommands.FirstOrDefault(x => x is AppBarButton appBarButton && (appBarButton.Tag as string) == "ItemOverflow") as AppBarButton;
+			var overflowSeparator = contextMenuFlyout.SecondaryCommands.FirstOrDefault(x => x is AppBarSeparator appBarSeparator && (appBarSeparator.Tag as string) == "OverflowSeparator") as AppBarSeparator;
+
+			if (overflowItem is not null)
+				overflowItem.Visibility = Visibility.Collapsed;
+			if (overflowSeparator is not null)
+				overflowSeparator.Visibility = Visibility.Collapsed;
 		}
 
 		protected virtual void Page_CharacterReceived(UIElement sender, CharacterReceivedRoutedEventArgs args)

--- a/src/Files.App/Helpers/ItemModelListToContextFlyoutHelper.cs
+++ b/src/Files.App/Helpers/ItemModelListToContextFlyoutHelper.cs
@@ -1,5 +1,6 @@
 using Files.App.UserControls;
 using Files.App.ViewModels;
+using Files.Shared.Extensions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -30,7 +31,7 @@ namespace Files.App.Helpers.ContextFlyouts
 			var primaryModels = items.Where(i => i.IsPrimary).ToList();
 			var secondaryModels = items.Except(primaryModels).ToList();
 
-			if (secondaryModels.Last().ItemType is ItemType.Separator)
+			if (!secondaryModels.IsEmpty() && secondaryModels.Last().ItemType is ItemType.Separator)
 				secondaryModels.RemoveAt(secondaryModels.Count - 1);
 
 			var primary = new List<ICommandBarElement>();

--- a/src/Files.App/ServicesImplementation/QuickAccessService.cs
+++ b/src/Files.App/ServicesImplementation/QuickAccessService.cs
@@ -55,9 +55,9 @@ namespace Files.App.ServicesImplementation
 			App.QuickAccessManager.UpdateQuickAccessWidget?.Invoke(this, new ModifyQuickAccessEventArgs(folderPaths, false));
 		}
 
-		public bool IsItemPinned(ILocatableFolder folder)
+		public bool IsItemPinned(string folderPath)
 		{
-			return App.QuickAccessManager.Model.FavoriteItems.Contains(folder.Path);
+			return App.QuickAccessManager.Model.FavoriteItems.Contains(folderPath);
 		}
 	}
 }

--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -276,6 +276,12 @@ namespace Files.App.UserControls
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
+					ItemType = ItemType.Separator,
+					Tag = "OverflowSeparator",
+					IsHidden = !options.ShowShellItems,
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
 					Text = "LoadingMoreOptions".GetLocalizedResource(),
 					Glyph = "\xE712",
 					Items = new List<ContextMenuFlyoutItemViewModel>(),

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -206,6 +206,11 @@ namespace Files.App.UserControls.Widgets
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
+					ItemType = ItemType.Separator,
+					Tag = "OverflowSeparator",
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
 					Text = "LoadingMoreOptions".GetLocalizedResource(),
 					Glyph = "\xE712",
 					Items = new List<ContextMenuFlyoutItemViewModel>(),

--- a/src/Files.App/UserControls/Widgets/HomePageWidget.cs
+++ b/src/Files.App/UserControls/Widgets/HomePageWidget.cs
@@ -50,7 +50,7 @@ namespace Files.App.UserControls.Widgets
 			if (sender is not Button widgetCardItem || widgetCardItem.DataContext is not WidgetCardItem item)
 				return;
 
-			var menuItems = GetItemMenuItems(item, QuickAccessService.IsItemPinned(await StorageService.GetFolderFromPathAsync(item.Path)));
+			var menuItems = GetItemMenuItems(item, QuickAccessService.IsItemPinned(item.Path));
 			var (_, secondaryElements) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(menuItems);
 
 			if (!UserSettingsService.AppearanceSettingsService.MoveShellExtensionsToSubMenu)

--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -228,6 +228,11 @@ namespace Files.App.UserControls.Widgets
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
+					ItemType = ItemType.Separator,
+					Tag = "OverflowSeparator",
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
 					Text = "LoadingMoreOptions".GetLocalizedResource(),
 					Glyph = "\xE712",
 					Items = new List<ContextMenuFlyoutItemViewModel>(),

--- a/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -122,7 +122,7 @@ namespace Files.App.UserControls.Widgets
 			secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
 			itemContextMenuFlyout.ShowAt(recentItemsGrid, new FlyoutShowOptions { Position = e.GetPosition(recentItemsGrid) });
 
-			await ShellContextmenuHelper.LoadShellMenuItems(item.Path, itemContextMenuFlyout, showOpenWithMenu: true);
+			await ShellContextmenuHelper.LoadShellMenuItems(item.Path, itemContextMenuFlyout);
 
 			e.Handled = true;
 		}
@@ -150,6 +150,11 @@ namespace Files.App.UserControls.Widgets
 					Glyph = "\uED25",
 					Command = OpenFileLocationCommand,
 					CommandParameter = item
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
+					ItemType = ItemType.Separator,
+					Tag = "OverflowSeparator",
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{

--- a/src/Files.Backend/Services/IQuickAccessService.cs
+++ b/src/Files.Backend/Services/IQuickAccessService.cs
@@ -46,6 +46,6 @@ namespace Files.App.ServicesImplementation
 		/// </summary>
 		/// <param name="folderPath">The path of the folder</param>
 		/// <returns>true if the item is pinned</returns>
-		bool IsItemPinned(ILocatableFolder folder);
+		bool IsItemPinned(string folderPath);
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
This is a PR of some fixes for recent context menu changes. (#11243 etc.)

**Details**
* Fixed an issue that could cause a hang when right-clicking on a widget
* Fixed an issue in which "Loading more options" did not disappear in some cases
* Some tweaks to the overflow separator

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility