### PR TITLE
Fix: Fixed closing app when the item flyout is open to hang

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -2,7 +2,6 @@ using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Helpers;
 using CommunityToolkit.WinUI.Notifications;
-using Files.App.Controllers;
 using Files.App.DataModels;
 using Files.App.Extensions;
 using Files.App.Filesystem;
@@ -30,6 +29,7 @@ using Microsoft.AppCenter.Crashes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.Windows.AppLifecycle;
 using System;
 using System.Diagnostics;
@@ -54,6 +54,7 @@ namespace Files.App
 		private static bool ShowErrorNotification = false;
 
 		public static string OutputPath { get; set; }
+		public static CommandBarFlyout? LastOpenedFlyout { get; set; }
 		public static StorageHistoryWrapper HistoryWrapper = new StorageHistoryWrapper();
 		public static SettingsViewModel AppSettings { get; private set; }
 		public static AppModel AppModel { get; private set; }
@@ -286,6 +287,15 @@ namespace Files.App
 		private async void Window_Closed(object sender, WindowEventArgs args)
 		{
 			// Save application state and stop any background activity
+
+			// A Workaround for the crash (#10110)
+			if (LastOpenedFlyout?.IsOpen ?? false)
+			{
+				args.Handled = true;
+				LastOpenedFlyout.Closed += (sender, e) => App.Current.Exit();
+				LastOpenedFlyout.Hide();
+				return;
+			}
 
 			await Task.Yield(); // Method can take a long time, make sure the window is hidden
 

--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -556,6 +556,8 @@ namespace Files.App
 
 		public async void ItemContextFlyout_Opening(object? sender, object e)
 		{
+			App.LastOpenedFlyout = sender as CommandBarFlyout;
+
 			try
 			{
 				if (!IsItemSelected && ((sender as CommandBarFlyout)?.Target as ListViewItem)?.Content is ListedItem li) // Workaround for item sometimes not getting selected
@@ -574,6 +576,8 @@ namespace Files.App
 
 		public async void BaseContextFlyout_Opening(object? sender, object e)
 		{
+			App.LastOpenedFlyout = sender as CommandBarFlyout;
+
 			try
 			{
 				// Reset menu max height

--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -420,6 +420,7 @@ namespace Files.App.UserControls
 		private void NavigationViewItem_RightTapped(object sender, RightTappedRoutedEventArgs e)
 		{
 			var itemContextMenuFlyout = new CommandBarFlyout { Placement = FlyoutPlacementMode.Full };
+			itemContextMenuFlyout.Opening += (sender, e) => App.LastOpenedFlyout = sender as CommandBarFlyout;
 			if (sender is not NavigationViewItem sidebarItem ||
 				sidebarItem.DataContext is not INavigationControlItem item)
 				return;

--- a/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml.cs
@@ -65,6 +65,7 @@ namespace Files.App.UserControls.Widgets
 		private void Item_RightTapped(object sender, RightTappedRoutedEventArgs e)
 		{
 			var itemContextMenuFlyout = new CommandBarFlyout { Placement = FlyoutPlacementMode.Full };
+			itemContextMenuFlyout.Opening += (sender, e) => App.LastOpenedFlyout = sender as CommandBarFlyout;
 			if (sender is not StackPanel tagsItemsStackPanel || tagsItemsStackPanel.DataContext is not FileTagsItemViewModel item)
 				return;
 			itemContextMenuFlyout.ShowAt(tagsItemsStackPanel, new FlyoutShowOptions { Position = e.GetPosition(tagsItemsStackPanel) });

--- a/src/Files.App/UserControls/Widgets/HomePageWidget.cs
+++ b/src/Files.App/UserControls/Widgets/HomePageWidget.cs
@@ -47,6 +47,7 @@ namespace Files.App.UserControls.Widgets
 		public void Button_RightTapped(object sender, RightTappedRoutedEventArgs e)
 		{
 			var itemContextMenuFlyout = new CommandBarFlyout { Placement = FlyoutPlacementMode.Full };
+			itemContextMenuFlyout.Opening += (sender, e) => App.LastOpenedFlyout = sender as CommandBarFlyout;
 			if (sender is not Button widgetCardItem || widgetCardItem.DataContext is not WidgetCardItem item)
 				return;
 

--- a/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -109,6 +109,7 @@ namespace Files.App.UserControls.Widgets
 		private void Grid_RightTapped(object sender, RightTappedRoutedEventArgs e)
 		{
 			var itemContextMenuFlyout = new CommandBarFlyout { Placement = FlyoutPlacementMode.Full };
+			itemContextMenuFlyout.Opening += (sender, e) => App.LastOpenedFlyout = sender as CommandBarFlyout;
 			if (sender is not Grid recentItemsGrid || recentItemsGrid.DataContext is not RecentItem item)
 				return;
 


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #10110

**Details**
For some reason, the application does not close properly when a CommandBarFlyout is open, so the open flyout is forced to close before closing app, and then the application is closed as the event after closing the flyout.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility