### PR TITLE
Feature: Improve Column View

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -107,14 +107,29 @@ namespace Files.App.Views.LayoutModes
 		{
 			if (eventArgs.Parameter is NavigationArguments navArgs)
 			{
-				navArgs.FocusOnNavigation = (navArgs.AssociatedTabInstance as ColumnShellPage)?.ColumnParams?.Column == 0; // Focus filelist only if first column
 				columnsOwner = (navArgs.AssociatedTabInstance as FrameworkElement)?.FindAscendant<ColumnViewBrowser>();
+				navArgs.FocusOnNavigation = (navArgs.AssociatedTabInstance as ColumnShellPage)?.ColumnParams?.Column == columnsOwner?.NumberOfColumns() - 1;
+				if (!navArgs.FocusOnNavigation)
+				{
+					FileList.ContainerContentChanging += HighlightPathDirectory;
+				}
 			}
 
 			base.OnNavigatedTo(eventArgs);
 
 			FolderSettings.GroupOptionPreferenceUpdated -= ZoomIn;
 			FolderSettings.GroupOptionPreferenceUpdated += ZoomIn;
+		}
+
+		private void HighlightPathDirectory(ListViewBase sender, ContainerContentChangingEventArgs args)
+		{
+			if (args.Item is ListedItem item && columnsOwner?.OwnerPath() is string ownerPath
+				&& (ownerPath == item.ItemPath || ownerPath.StartsWith(item.ItemPath) && ownerPath[item.ItemPath.Length] is '/' or '\\'))
+			{
+				var presenter = args.ItemContainer.FindDescendant<Grid>()!;
+				presenter!.Background = this.Resources["ListViewItemBackgroundSelected"] as SolidColorBrush;
+				FileList.ContainerContentChanging -= HighlightPathDirectory;
+			}
 		}
 
 		protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -124,7 +124,7 @@ namespace Files.App.Views.LayoutModes
 
 		private void HighlightPathDirectory(ListViewBase sender, ContainerContentChangingEventArgs args)
 		{
-			if (args.Item is ListedItem item && columnsOwner?.OwnerPath() is string ownerPath
+			if (args.Item is ListedItem item && columnsOwner?.OwnerPath is string ownerPath
 				&& (ownerPath == item.ItemPath || ownerPath.StartsWith(item.ItemPath) && ownerPath[item.ItemPath.Length] is '/' or '\\'))
 			{
 				var presenter = args.ItemContainer.FindDescendant<Grid>()!;

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -110,10 +110,9 @@ namespace Files.App.Views.LayoutModes
 				columnsOwner = (navArgs.AssociatedTabInstance as FrameworkElement)?.FindAscendant<ColumnViewBrowser>();
 				var index = (navArgs.AssociatedTabInstance as ColumnShellPage)?.ColumnParams?.Column;
 				navArgs.FocusOnNavigation = index == columnsOwner?.FocusIndex;
+
 				if (index < columnsOwner?.FocusIndex)
-				{
 					FileList.ContainerContentChanging += HighlightPathDirectory;
-				}
 			}
 
 			base.OnNavigatedTo(eventArgs);

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -108,8 +108,9 @@ namespace Files.App.Views.LayoutModes
 			if (eventArgs.Parameter is NavigationArguments navArgs)
 			{
 				columnsOwner = (navArgs.AssociatedTabInstance as FrameworkElement)?.FindAscendant<ColumnViewBrowser>();
-				navArgs.FocusOnNavigation = (navArgs.AssociatedTabInstance as ColumnShellPage)?.ColumnParams?.Column == columnsOwner?.NumberOfColumns() - 1;
-				if (!navArgs.FocusOnNavigation)
+				var index = (navArgs.AssociatedTabInstance as ColumnShellPage)?.ColumnParams?.Column;
+				navArgs.FocusOnNavigation = index == columnsOwner?.FocusIndex;
+				if (index < columnsOwner?.FocusIndex)
 				{
 					FileList.ContainerContentChanging += HighlightPathDirectory;
 				}

--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -21,7 +21,7 @@ namespace Files.App.Views.LayoutModes
 		protected override uint IconSize => Browser.ColumnViewBrowser.ColumnViewSizeSmall;
 		protected override ItemsControl ItemsControl => ColumnHost;
 
-		public string? OwnerPath() => navigationArguments.NavPathParam;
+		public string? OwnerPath { get; private set; }
 		public int FocusIndex { get; private set; }
 
 		public ColumnViewBrowser() : base()
@@ -109,6 +109,8 @@ namespace Files.App.Views.LayoutModes
 				SearchPathParam = navigationArguments.SearchPathParam,
 				NavPathParam = path
 			});
+			OwnerPath = navigationArguments.NavPathParam;
+			FocusIndex = pathStack.Count;
 			var index = 0;
 			while (pathStack.TryPop(out path))
 			{
@@ -120,7 +122,6 @@ namespace Files.App.Views.LayoutModes
 					NavPathParam = path
 				});
 			}
-			FocusIndex = index;
 		}
 
 		protected override void InitializeCommandsViewModel()

--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using static Files.App.Constants;
+using static Files.App.Helpers.PathNormalization;
 
 namespace Files.App.Views.LayoutModes
 {
@@ -19,6 +20,9 @@ namespace Files.App.Views.LayoutModes
 	{
 		protected override uint IconSize => Browser.ColumnViewBrowser.ColumnViewSizeSmall;
 		protected override ItemsControl ItemsControl => ColumnHost;
+
+		public string? OwnerPath() => navigationArguments.NavPathParam;
+		public int NumberOfColumns() => ColumnHost.ActiveBlades.Count;
 
 		public ColumnViewBrowser() : base()
 		{
@@ -66,6 +70,8 @@ namespace Files.App.Views.LayoutModes
 					Column = ColumnHost.ActiveBlades.IndexOf(newblade),
 					NavPathParam = column.NavPathParam
 				});
+				navigationArguments.NavPathParam = column.NavPathParam;
+				ParentShellPageInstance.TabItemArguments.NavigationArg = column.NavPathParam;
 			}
 		}
 
@@ -78,7 +84,21 @@ namespace Files.App.Views.LayoutModes
 		{
 			base.OnNavigatedTo(eventArgs);
 
-			var navigationArguments = (NavigationArguments)eventArgs.Parameter;
+			var path = navigationArguments.NavPathParam;
+			var pathStack = new Stack<string>();
+
+			if (path is not null)
+			{
+				var rootPathList = App.QuickAccessManager.Model.FavoriteItems.Select(x => NormalizePath(x)).ToList();
+				rootPathList.Add(NormalizePath(GetPathRoot(path)));
+
+				while (!rootPathList.Contains(NormalizePath(path)))
+				{
+					pathStack.Push(path);
+					path = GetParentDir(path);
+				}
+			}
+
 			MainPageFrame.Navigated += Frame_Navigated;
 			MainPageFrame.Navigate(typeof(ColumnShellPage), new ColumnParam
 			{
@@ -87,8 +107,19 @@ namespace Files.App.Views.LayoutModes
 				SearchQuery = navigationArguments.SearchQuery,
 				SearchUnindexedItems = navigationArguments.SearchUnindexedItems,
 				SearchPathParam = navigationArguments.SearchPathParam,
-				NavPathParam = navigationArguments.NavPathParam
+				NavPathParam = path
 			});
+			var index = 0;
+			while (pathStack.TryPop(out path))
+			{
+				var (frame, _) = CreateAndAddNewBlade();
+
+				frame.Navigate(typeof(ColumnShellPage), new ColumnParam
+				{
+					Column = ++index,
+					NavPathParam = path
+				});
+			}
 		}
 
 		protected override void InitializeCommandsViewModel()
@@ -162,6 +193,11 @@ namespace Files.App.Views.LayoutModes
 						(frame?.Content as ColumnShellPage).ContentChanged -= ColumnViewBrowser_ContentChanged;
 						ColumnHost.Items.RemoveAt(index + 1);
 						ColumnHost.ActiveBlades.RemoveAt(index + 1);
+					}
+					if ((ColumnHost.ActiveBlades[index].Content as Frame)?.Content is ColumnShellPage s)
+					{
+						navigationArguments.NavPathParam = s.FilesystemViewModel.WorkingDirectory;
+						ParentShellPageInstance.TabItemArguments.NavigationArg = s.FilesystemViewModel.WorkingDirectory;
 					}
 				});
 			}

--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -22,7 +22,7 @@ namespace Files.App.Views.LayoutModes
 		protected override ItemsControl ItemsControl => ColumnHost;
 
 		public string? OwnerPath() => navigationArguments.NavPathParam;
-		public int NumberOfColumns() => ColumnHost.ActiveBlades.Count;
+		public int FocusIndex { get; private set; }
 
 		public ColumnViewBrowser() : base()
 		{
@@ -120,6 +120,7 @@ namespace Files.App.Views.LayoutModes
 					NavPathParam = path
 				});
 			}
+			FocusIndex = index;
 		}
 
 		protected override void InitializeCommandsViewModel()
@@ -278,6 +279,7 @@ namespace Files.App.Views.LayoutModes
 
 			var activeBlade = ColumnHost.ActiveBlades[currentBladeIndex - 1];
 			activeBlade.Focus(FocusState.Programmatic);
+			FocusIndex = currentBladeIndex - 1;
 
 			var activeBladeColumnViewBase = RetrieveBladeColumnViewBase(activeBlade);
 			if (activeBladeColumnViewBase is null)
@@ -296,6 +298,7 @@ namespace Files.App.Views.LayoutModes
 
 			var activeBlade = ColumnHost.ActiveBlades[currentBladeIndex];
 			activeBlade.Focus(FocusState.Programmatic);
+			FocusIndex = currentBladeIndex;
 
 			var activeBladeColumnViewBase = RetrieveBladeColumnViewBase(activeBlade);
 			if (activeBladeColumnViewBase is not null)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #6902 
- Closes #7589
- Closes #11128

**Details**
* When a directory is opened in column view, any folder pinned to favorites starts from the directory and everything else from root.
* When the navigation button is clicked or the application relaunches to show column view, the last opened directory is displayed (not the last focused directory).

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility