### PR TITLE
Fix: Fixed issue where compatibility settings weren't working

### DIFF
--- a/src/Files.App/ViewModels/Properties/CompatibilityProperties.cs
+++ b/src/Files.App/ViewModels/Properties/CompatibilityProperties.cs
@@ -31,7 +31,7 @@ namespace Files.App.ViewModels.Properties
 					RunAsAdministrator = value.RunAsAdministrator;
 					RegisterForRestart = value.RegisterForRestart;
 					OSCompatibility = OSCompatibilityList.SingleOrDefault(x => x.Value == value.OSCompatibility);
-					HighDpiOption = HighDpiOptionList.SingleOrDefault(x => x.Value == value.HighDpiOption) ;
+					HighDpiOption = HighDpiOptionList.SingleOrDefault(x => x.Value == value.HighDpiOption);
 					HighDpiOverride = HighDpiOverrideList.SingleOrDefault(x => x.Value == value.HighDpiOverride);
 					ReducedColorMode = ReducedColorModeList.SingleOrDefault(x => x.Value == value.ReducedColorMode);
 				}

--- a/src/Files.App/ViewModels/Properties/CompatibilityProperties.cs
+++ b/src/Files.App/ViewModels/Properties/CompatibilityProperties.cs
@@ -26,12 +26,12 @@ namespace Files.App.ViewModels.Properties
 			{
 				if (SetProperty(ref compatibilityOptions, value))
 				{
-					ExecuteAt640X480 = value?.ExecuteAt640X480 ?? false;
-					DisableMaximized = value?.DisableMaximized ?? false;
-					RunAsAdministrator = value?.RunAsAdministrator ?? false;
-					RegisterForRestart = value?.RegisterForRestart ?? false;
+					ExecuteAt640X480 = value.ExecuteAt640X480;
+					DisableMaximized = value.DisableMaximized;
+					RunAsAdministrator = value.RunAsAdministrator;
+					RegisterForRestart = value.RegisterForRestart;
 					OSCompatibility = OSCompatibilityList.SingleOrDefault(x => x.Value == value.OSCompatibility);
-					HighDpiOption = HighDpiOptionList.SingleOrDefault(x => x.Value == value.HighDpiOption);
+					HighDpiOption = HighDpiOptionList.SingleOrDefault(x => x.Value == value.HighDpiOption) ;
 					HighDpiOverride = HighDpiOverrideList.SingleOrDefault(x => x.Value == value.HighDpiOverride);
 					ReducedColorMode = ReducedColorModeList.SingleOrDefault(x => x.Value == value.ReducedColorMode);
 				}
@@ -164,7 +164,7 @@ namespace Files.App.ViewModels.Properties
 		}
 
 		public bool SetCompatibilityOptions()
-			=> FileOperationsHelpers.SetCompatOptions(ExePath, CompatibilityOptions?.ToString());
+			=> FileOperationsHelpers.SetCompatOptions(ExePath, CompatibilityOptions.ToString());
 
 		public Task RunTroubleshooter()
 			=> LaunchHelper.RunCompatibilityTroubleshooterAsync(ExePath);

--- a/src/Files.App/ViewModels/Properties/CompatibilityProperties.cs
+++ b/src/Files.App/ViewModels/Properties/CompatibilityProperties.cs
@@ -26,10 +26,10 @@ namespace Files.App.ViewModels.Properties
 			{
 				if (SetProperty(ref compatibilityOptions, value))
 				{
-					ExecuteAt640X480 = value.ExecuteAt640X480;
-					DisableMaximized = value.DisableMaximized;
-					RunAsAdministrator = value.RunAsAdministrator;
-					RegisterForRestart = value.RegisterForRestart;
+					ExecuteAt640X480 = value?.ExecuteAt640X480 ?? false;
+					DisableMaximized = value?.DisableMaximized ?? false;
+					RunAsAdministrator = value?.RunAsAdministrator ?? false;
+					RegisterForRestart = value?.RegisterForRestart ?? false;
 					OSCompatibility = OSCompatibilityList.SingleOrDefault(x => x.Value == value.OSCompatibility);
 					HighDpiOption = HighDpiOptionList.SingleOrDefault(x => x.Value == value.HighDpiOption);
 					HighDpiOverride = HighDpiOverrideList.SingleOrDefault(x => x.Value == value.HighDpiOverride);
@@ -160,8 +160,7 @@ namespace Files.App.ViewModels.Properties
 		{
 			var options = FileOperationsHelpers.ReadCompatOptions(ExePath);
 
-			if (options is not null)
-				CompatibilityOptions = CompatibilityOptions.FromString(options);
+			CompatibilityOptions = CompatibilityOptions.FromString(options);
 		}
 
 		public bool SetCompatibilityOptions()

--- a/src/Files.Shared/CompatibilityOptions.cs
+++ b/src/Files.Shared/CompatibilityOptions.cs
@@ -30,7 +30,7 @@ namespace Files.Shared
 			return System.Text.RegularExpressions.Regex.Replace(value.Trim(), @"\s+", " ");
 		}
 
-		public static CompatibilityOptions FromString(string rawValue)
+		public static CompatibilityOptions FromString(string? rawValue)
 		{
 			var compatOptions = new CompatibilityOptions();
 			if (!string.IsNullOrEmpty(rawValue))


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11317 

**Notes**
- `CompatibilityOptions.FromString(options)` will always return an object even when `options is null`
- Since `CompatibilityOptions` will always have a value, the user will be able to interact with the `Compatibility` tab
- Changes are saved correctly

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility