### PR TITLE
Fix: Removed extra AppBarSeparator from Edit Tags menu

### DIFF
--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -701,7 +701,6 @@ namespace Files.App
 			if (!UserSettingsService.PreferencesSettingsService.ShowEditTagsMenu)
 				return;
 
-			contextMenu.SecondaryCommands.Insert(index, new AppBarSeparator());
 			contextMenu.SecondaryCommands.Insert(index + 1, new AppBarButton()
 			{
 				Label = "SettingsEditFileTagsExpander/Title".GetLocalizedResource(),


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Removed extra AppBarSeparator from Edit Tags menu

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
