### PR TITLE
Fix: Fixed issue where right clicking an item wouldn't show the context menu 

### DIFF
--- a/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
@@ -563,7 +563,7 @@ namespace Files.App.Helpers
 					Text = "FormatDriveText".GetLocalizedResource(),
 					Command = commandsViewModel.FormatDriveCommand,
 					CommandParameter = itemViewModel?.CurrentFolder,
-					ShowItem = itemViewModel.CurrentFolder is not null && (App.DrivesManager.Drives.Where(x => string.Equals(x.Path, itemViewModel?.CurrentFolder.ItemPath)).FirstOrDefault()?.MenuOptions.ShowFormatDrive ?? false),
+					ShowItem = itemViewModel?.CurrentFolder is not null && (App.DrivesManager.Drives.FirstOrDefault(x => string.Equals(x.Path, itemViewModel?.CurrentFolder.ItemPath))?.MenuOptions.ShowFormatDrive ?? false),
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{


### PR DESCRIPTION
**Description**
Context menu was not shot showing up on main branch because of a NullReferenceException
Only occured when clicking on an item (file or directory). Empty space or sidebar item is working as expected

Caused by #11364

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- None

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots (optional)**
The exception
![image](https://user-images.githubusercontent.com/56681014/220460057-94b88dfd-1826-485f-b483-06d5f759cc48.png)
