### PR TITLE
Fix: Fixed network folder error with phones

### DIFF
--- a/src/Files.App/ViewModels/ItemViewModel.cs
+++ b/src/Files.App/ViewModels/ItemViewModel.cs
@@ -12,6 +12,7 @@ using Files.App.Helpers.FileListCache;
 using Files.App.Shell;
 using Files.App.UserControls;
 using Files.App.ViewModels.Previews;
+using Files.App.ViewModels.Properties;
 using Files.Backend.Services;
 using Files.Backend.Services.Settings;
 using Files.Backend.Services.SizeProvider;
@@ -1468,7 +1469,7 @@ namespace Files.App.ViewModels
 		{
 			// Flag to use FindFirstFileExFromApp or StorageFolder enumeration - Use storage folder for Box Drive (#4629)
 			var isBoxFolder = App.CloudDrivesManager.Drives.FirstOrDefault(x => x.Text == "Box")?.Path?.TrimEnd('\\') is string boxFolder && path.StartsWith(boxFolder);
-			bool isNetwork = path.StartsWith(@"\\", StringComparison.Ordinal);
+			bool isNetwork = path.StartsWith(@"\\", StringComparison.Ordinal) && !path.StartsWith(@"\\?\", StringComparison.Ordinal);
 			bool enumFromStorageFolder = isBoxFolder;
 
 			BaseStorageFolder? rootFolder = null;

--- a/src/Files.App/ViewModels/ItemViewModel.cs
+++ b/src/Files.App/ViewModels/ItemViewModel.cs
@@ -12,7 +12,6 @@ using Files.App.Helpers.FileListCache;
 using Files.App.Shell;
 using Files.App.UserControls;
 using Files.App.ViewModels.Previews;
-using Files.App.ViewModels.Properties;
 using Files.Backend.Services;
 using Files.Backend.Services.Settings;
 using Files.Backend.Services.SizeProvider;


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11413 

**Details**
- Problem was introduced with #11193. 
- Paths that start with `\\?\` are USB devices, not network folders

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility