### PR TITLE
RichCommand: Glyph + ContextMenu + EmptyRecycleBinAction

### DIFF
--- a/src/Files.App/Actions/FileSystem/EmptyRecycleBinAction.cs
+++ b/src/Files.App/Actions/FileSystem/EmptyRecycleBinAction.cs
@@ -1,0 +1,16 @@
+﻿using Files.App.Commands;
+using Files.App.Extensions;
+using Files.App.Helpers;
+using System.Threading.Tasks;
+
+namespace Files.App.Actions
+{
+	internal class EmptyRecycleBinAction : IAction
+	{
+		public string Label { get; } = "EmptyRecycleBin".GetLocalizedResource();
+
+		public RichGlyph Glyph { get; } = new RichGlyph("\uEF88", fontFamily: "RecycleBinIcons");
+
+		public async Task ExecuteAsync() => await RecycleBinHelpers.EmptyRecycleBin();
+	}
+}

--- a/src/Files.App/Actions/FileSystem/EmptyRecycleBinAction.cs
+++ b/src/Files.App/Actions/FileSystem/EmptyRecycleBinAction.cs
@@ -11,6 +11,9 @@ namespace Files.App.Actions
 
 		public RichGlyph Glyph { get; } = new RichGlyph("\uEF88", fontFamily: "RecycleBinIcons");
 
-		public async Task ExecuteAsync() => await RecycleBinHelpers.EmptyRecycleBin();
+		public async Task ExecuteAsync()
+		{
+			await RecycleBinHelpers.EmptyRecycleBin();
+		}
 	}
 }

--- a/src/Files.App/Actions/IAction.cs
+++ b/src/Files.App/Actions/IAction.cs
@@ -7,6 +7,8 @@ namespace Files.App.Actions
 	{
 		string Label { get; }
 
+		RichGlyph Glyph => RichGlyph.None;
+
 		HotKey HotKey => HotKey.None;
 
 		bool IsExecutable => true;

--- a/src/Files.App/Commands/CommandCodes.cs
+++ b/src/Files.App/Commands/CommandCodes.cs
@@ -11,5 +11,8 @@
 		// show
 		ToggleShowHiddenItems,
 		ToggleShowFileExtensions,
+
+		// file system
+		EmptyRecycleBin,
 	}
 }

--- a/src/Files.App/Commands/HotKey.cs
+++ b/src/Files.App/Commands/HotKey.cs
@@ -57,7 +57,7 @@ namespace Files.App.Commands
 					continue;
 				}
 
-				if (key is not VirtualKey.None)
+				if (key is VirtualKey.None)
 				{
 					var k = ToKey(part);
 					if (k is not VirtualKey.None)

--- a/src/Files.App/Commands/IRichCommand.cs
+++ b/src/Files.App/Commands/IRichCommand.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.UI.Xaml.Input;
+﻿using Files.App.UserControls;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -12,6 +14,10 @@ namespace Files.App.Commands
 		string Label { get; }
 		string LabelWithHotKey { get; }
 		string AutomationName { get; }
+
+		RichGlyph Glyph { get; }
+		FontIcon? FontIcon { get; }
+		ColoredIcon? ColoredIcon { get; }
 
 		HotKey DefaultHotKey { get; }
 		HotKey CustomHotKey { get; set; }

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -1,6 +1,8 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Files.App.Actions;
+using Files.App.UserControls;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using System;
 using System.Collections;
@@ -29,6 +31,7 @@ namespace Files.App.Commands
 		public IRichCommand ToggleFullScreen => commands[CommandCodes.ToggleFullScreen];
 		public IRichCommand ToggleShowHiddenItems => commands[CommandCodes.ToggleShowHiddenItems];
 		public IRichCommand ToggleShowFileExtensions => commands[CommandCodes.ToggleShowFileExtensions];
+		public IRichCommand EmptyRecycleBin => commands[CommandCodes.EmptyRecycleBin];
 
 		public CommandManager()
 		{
@@ -52,6 +55,7 @@ namespace Files.App.Commands
 			[CommandCodes.ToggleFullScreen] = new ToggleFullScreenAction(),
 			[CommandCodes.ToggleShowHiddenItems] = new ToggleShowHiddenItemsAction(),
 			[CommandCodes.ToggleShowFileExtensions] = new ToggleShowFileExtensionsAction(),
+			[CommandCodes.EmptyRecycleBin] = new EmptyRecycleBinAction(),
 		};
 
 		[DebuggerDisplay("Command None")]
@@ -66,6 +70,10 @@ namespace Files.App.Commands
 			public string Label => string.Empty;
 			public string LabelWithHotKey => string.Empty;
 			public string AutomationName => string.Empty;
+
+			public RichGlyph Glyph => RichGlyph.None;
+			public FontIcon? FontIcon => null;
+			public ColoredIcon? ColoredIcon => null;
 
 			public HotKey DefaultHotKey => HotKey.None;
 
@@ -100,6 +108,14 @@ namespace Files.App.Commands
 			public string Label => action.Label;
 			public string LabelWithHotKey => $"{Label} ({CustomHotKey})";
 			public string AutomationName => Label;
+
+			public RichGlyph Glyph => action.Glyph;
+
+			private readonly Lazy<FontIcon?> fontIcon;
+			public FontIcon? FontIcon => fontIcon.Value;
+
+			private readonly Lazy<ColoredIcon?> coloredIcon;
+			public ColoredIcon? ColoredIcon => coloredIcon.Value;
 
 			public HotKey DefaultHotKey => action.HotKey;
 
@@ -152,6 +168,8 @@ namespace Files.App.Commands
 				this.manager = manager;
 				Code = code;
 				this.action = action;
+				fontIcon = new(action.Glyph.ToFontIcon);
+				coloredIcon = new(action.Glyph.ToColoredIcon);
 				customHotKey = action.HotKey;
 				command = new AsyncRelayCommand(ExecuteAsync, () => action.IsExecutable);
 

--- a/src/Files.App/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Commands/Manager/ICommandManager.cs
@@ -17,5 +17,7 @@ namespace Files.App.Commands
 
 		IRichCommand ToggleShowHiddenItems { get; }
 		IRichCommand ToggleShowFileExtensions { get; }
+
+		IRichCommand EmptyRecycleBin { get; }
 	}
 }

--- a/src/Files.App/Commands/RichGlyph.cs
+++ b/src/Files.App/Commands/RichGlyph.cs
@@ -30,11 +30,14 @@ namespace Files.App.Commands
 			if (IsNone)
 				return null;
 
-			return new FontIcon
+			var icon = new FontIcon
 			{
 				Glyph = BaseGlyph,
-				FontFamily = ToFontFamily(),
 			};
+			if (!string.IsNullOrEmpty(FontFamily))
+				icon.FontFamily = (FontFamily)Current.Resources[FontFamily];
+
+			return icon;
 		}
 
 		public ColoredIcon? ToColoredIcon()
@@ -42,12 +45,15 @@ namespace Files.App.Commands
 			if (IsNone)
 				return null;
 
-			return new ColoredIcon
+			var icon = new ColoredIcon
 			{
 				BaseLayerGlyph = BaseGlyph,
 				OverlayLayerGlyph = OverlayGlyph,
-				FontFamily = ToFontFamily(),
 			};
+			if (!string.IsNullOrEmpty(FontFamily))
+				icon.FontFamily = (FontFamily)Current.Resources[FontFamily];
+
+			return icon;
 		}
 	}
 }

--- a/src/Files.App/Commands/RichGlyph.cs
+++ b/src/Files.App/Commands/RichGlyph.cs
@@ -1,0 +1,53 @@
+﻿using Files.App.UserControls;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using static Microsoft.UI.Xaml.Application;
+
+namespace Files.App.Commands
+{
+	public readonly struct RichGlyph
+	{
+		public static RichGlyph None { get; } = new(string.Empty);
+
+		public bool IsNone => string.IsNullOrEmpty(BaseGlyph);
+
+		public string BaseGlyph { get; }
+		public string OverlayGlyph { get; }
+		public string FontFamily { get; }
+
+		public RichGlyph(string baseGlyph, string overlayGlyph = "", string fontFamily = "")
+			=> (BaseGlyph, OverlayGlyph, FontFamily) = (baseGlyph, overlayGlyph, fontFamily);
+
+		public void Deconstruct(out string baseGlyph, out string overlayGlyph, out string fontFamily)
+			=> (baseGlyph, overlayGlyph, fontFamily) = (BaseGlyph, OverlayGlyph, FontFamily);
+
+		public FontFamily ToFontFamily() => string.IsNullOrEmpty(FontFamily)
+			? App.AppModel.SymbolFontFamily
+			: (FontFamily)Current.Resources[FontFamily];
+
+		public FontIcon? ToFontIcon()
+		{
+			if (IsNone)
+				return null;
+
+			return new FontIcon
+			{
+				Glyph = BaseGlyph,
+				FontFamily = ToFontFamily(),
+			};
+		}
+
+		public ColoredIcon? ToColoredIcon()
+		{
+			if (IsNone)
+				return null;
+
+			return new ColoredIcon
+			{
+				BaseLayerGlyph = BaseGlyph,
+				OverlayLayerGlyph = OverlayGlyph,
+				FontFamily = ToFontFamily(),
+			};
+		}
+	}
+}

--- a/src/Files.App/Commands/RichGlyph.cs
+++ b/src/Files.App/Commands/RichGlyph.cs
@@ -16,14 +16,25 @@ namespace Files.App.Commands
 		public string FontFamily { get; }
 
 		public RichGlyph(string baseGlyph, string overlayGlyph = "", string fontFamily = "")
-			=> (BaseGlyph, OverlayGlyph, FontFamily) = (baseGlyph, overlayGlyph, fontFamily);
+		{
+			BaseGlyph = baseGlyph;
+			OverlayGlyph = overlayGlyph;
+			FontFamily = fontFamily;
+		}
 
 		public void Deconstruct(out string baseGlyph, out string overlayGlyph, out string fontFamily)
-			=> (baseGlyph, overlayGlyph, fontFamily) = (BaseGlyph, OverlayGlyph, FontFamily);
+		{
+			baseGlyph = BaseGlyph;
+			overlayGlyph = OverlayGlyph;
+			fontFamily = FontFamily;
+		}
 
-		public FontFamily ToFontFamily() => string.IsNullOrEmpty(FontFamily)
-			? App.AppModel.SymbolFontFamily
-			: (FontFamily)Current.Resources[FontFamily];
+		public FontFamily ToFontFamily()
+		{
+			return string.IsNullOrEmpty(FontFamily)
+				? App.AppModel.SymbolFontFamily
+				: (FontFamily)Current.Resources[FontFamily];
+		}
 
 		public FontIcon? ToFontIcon()
 		{

--- a/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -156,11 +156,6 @@ namespace Files.App.Interacts
 			_ = QuickAccessService.UnpinFromSidebar(associatedInstance.FilesystemViewModel.WorkingDirectory);
 		}
 
-		public virtual async void EmptyRecycleBin(RoutedEventArgs e)
-		{
-			await RecycleBinHelpers.EmptyRecycleBin();
-		}
-
 		public virtual async void RestoreRecycleBin(RoutedEventArgs e)
 		{
 			await RecycleBinHelpers.RestoreRecycleBin(associatedInstance);

--- a/src/Files.App/Interacts/BaseLayoutCommandsViewModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandsViewModel.cs
@@ -39,7 +39,6 @@ namespace Files.App.Interacts
 			SidebarUnpinItemCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.SidebarUnpinItem);
 			UnpinDirectoryFromFavoritesCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.UnpinDirectoryFromFavorites);
 			OpenItemCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.OpenItem);
-			EmptyRecycleBinCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.EmptyRecycleBin);
 			RestoreRecycleBinCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.RestoreRecycleBin);
 			RestoreSelectionRecycleBinCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.RestoreSelectionRecycleBin);
 			QuickLookCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.QuickLook);
@@ -113,8 +112,6 @@ namespace Files.App.Interacts
 		public ICommand OpenItemCommand { get; private set; }
 
 		public ICommand UnpinDirectoryFromFavoritesCommand { get; private set; }
-
-		public ICommand EmptyRecycleBinCommand { get; private set; }
 
 		public ICommand RestoreRecycleBinCommand { get; private set; }
 

--- a/src/Files.App/Interacts/IBaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/IBaseLayoutCommandImplementationModel.cs
@@ -33,8 +33,6 @@ namespace Files.App.Interacts
 
 		void OpenItem(RoutedEventArgs e);
 
-		void EmptyRecycleBin(RoutedEventArgs e);
-
 		void RestoreRecycleBin(RoutedEventArgs e);
 
 		void RestoreSelectionRecycleBin(RoutedEventArgs e);

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -468,9 +468,6 @@
   <data name="PropertiesDialogHidden.Text" xml:space="preserve">
     <value>Hidden</value>
   </data>
-  <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
-    <value>Empty recycle bin</value>
-  </data>
   <data name="BaseLayoutItemContextFlyoutRestore.Text" xml:space="preserve">
     <value>Restore</value>
   </data>

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -210,14 +210,11 @@
 					x:Name="EmptyRecycleBinButton"
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
 					AccessKey="B"
-					Command="{x:Bind ViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
+					Command="{x:Bind Commands.EmptyRecycleBin}"
+					Icon="{x:Bind Commands.EmptyRecycleBin.FontIcon}"
 					IsEnabled="{x:Bind ViewModel.CanEmptyRecycleBin, Mode=OneWay}"
-					Label="{helpers:ResourceString Name=EmptyRecycleBin}"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=EmptyRecycleBin}">
-					<AppBarButton.Icon>
-						<FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />
-					</AppBarButton.Icon>
-				</AppBarButton>
+					Label="{x:Bind Commands.EmptyRecycleBin.Label}"
+					ToolTipService.ToolTip="{x:Bind Commands.EmptyRecycleBin.Label}" />
 				<AppBarButton
 					x:Name="RestoreRecycleBinButton"
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
@@ -798,26 +795,26 @@
 									Grid.Row="0"
 									Grid.Column="0"
 									VerticalAlignment="Center"
-									Text="{x:Bind CommandManager.ToggleShowHiddenItems.Label}" />
+									Text="{x:Bind Commands.ToggleShowHiddenItems.Label}" />
 								<ToggleSwitch
 									Grid.Row="0"
 									Grid.Column="1"
 									HorizontalAlignment="Right"
-									AutomationProperties.Name="{x:Bind CommandManager.ToggleShowHiddenItems.AutomationName}"
-									IsOn="{x:Bind CommandManager.ToggleShowHiddenItems.IsOn, Mode=TwoWay}"
+									AutomationProperties.Name="{x:Bind Commands.ToggleShowHiddenItems.AutomationName}"
+									IsOn="{x:Bind Commands.ToggleShowHiddenItems.IsOn, Mode=TwoWay}"
 									Style="{StaticResource RightAlignedToggleSwitchStyle}" />
 
 								<TextBlock
 									Grid.Row="1"
 									Grid.Column="0"
 									VerticalAlignment="Center"
-									Text="{x:Bind CommandManager.ToggleShowFileExtensions.Label}" />
+									Text="{x:Bind Commands.ToggleShowFileExtensions.Label}" />
 								<ToggleSwitch
 									Grid.Row="1"
 									Grid.Column="1"
 									HorizontalAlignment="Right"
-									AutomationProperties.Name="{x:Bind CommandManager.ToggleShowFileExtensions.AutomationName}"
-									IsOn="{x:Bind CommandManager.ToggleShowFileExtensions.IsOn, Mode=TwoWay}"
+									AutomationProperties.Name="{x:Bind Commands.ToggleShowFileExtensions.AutomationName}"
+									IsOn="{x:Bind Commands.ToggleShowFileExtensions.IsOn, Mode=TwoWay}"
 									Rotation="1"
 									Style="{StaticResource RightAlignedToggleSwitchStyle}" />
 							</Grid>

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml.cs
@@ -25,7 +25,7 @@ namespace Files.App.UserControls
 		}
 
 		public IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
-		public ICommandManager CommandManager { get; } = Ioc.Default.GetRequiredService<ICommandManager>();
+		public ICommandManager Commands { get; } = Ioc.Default.GetRequiredService<ICommandManager>();
 
 		private readonly IAddItemService addItemService = Ioc.Default.GetRequiredService<IAddItemService>();
 

--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI.UI;
+using Files.App.Commands;
 using Files.App.DataModels;
 using Files.App.DataModels.NavigationControlItems;
 using Files.App.Extensions;
@@ -37,7 +38,9 @@ namespace Files.App.UserControls
 {
 	public sealed partial class SidebarControl : NavigationView, INotifyPropertyChanged
 	{
-		public IUserSettingsService userSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
+		private readonly IUserSettingsService userSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
+		private readonly ICommandManager commands = Ioc.Default.GetRequiredService<ICommandManager>();
+
 		public IQuickAccessService QuickAccessService { get; } = Ioc.Default.GetRequiredService<IQuickAccessService>();
 
 		public delegate void SidebarItemInvokedEventHandler(object sender, SidebarItemInvokedEventArgs e);
@@ -73,8 +76,6 @@ namespace Files.App.UserControls
 
 		public SidebarPinnedModel SidebarPinnedModel => App.QuickAccessManager.Model;
 
-		public static readonly DependencyProperty EmptyRecycleBinCommandProperty = DependencyProperty.Register(nameof(EmptyRecycleBinCommand), typeof(ICommand), typeof(SidebarControl), new PropertyMetadata(null));
-
 		// Using a DependencyProperty as the backing store for ViewModel.  This enables animation, styling, binding, etc...
 		public static readonly DependencyProperty ViewModelProperty =
 			DependencyProperty.Register(nameof(ViewModel), typeof(SidebarViewModel), typeof(SidebarControl), new PropertyMetadata(null));
@@ -97,12 +98,6 @@ namespace Files.App.UserControls
 		{
 			get => (UIElement)GetValue(TabContentProperty);
 			set => SetValue(TabContentProperty, value);
-		}
-
-		public ICommand EmptyRecycleBinCommand
-		{
-			get => (ICommand)GetValue(EmptyRecycleBinCommandProperty);
-			set => SetValue(EmptyRecycleBinCommandProperty, value);
 		}
 
 		public readonly ICommand CreateLibraryCommand = new RelayCommand(LibraryManager.ShowCreateNewLibraryDialog);
@@ -208,16 +203,12 @@ namespace Files.App.UserControls
 					Command = RestoreLibrariesCommand,
 					ShowItem = options.IsLibrariesHeader
 				},
-				new ContextMenuFlyoutItemViewModel()
+				new ContextMenuFlyoutItemViewModel(commands.EmptyRecycleBin)
 				{
-					Text = "BaseLayoutContextFlyoutEmptyRecycleBin/Text".GetLocalizedResource(),
-					Glyph = "\uEF88",
-					GlyphFontFamilyName = "RecycleBinIcons",
-					Command = EmptyRecycleBinCommand,
-					ShowItem = options.ShowEmptyRecycleBin,
-					IsEnabled = false,
 					ID = "EmptyRecycleBin",
 					Tag = "EmptyRecycleBin",
+					IsEnabled = false,
+					ShowItem = options.ShowEmptyRecycleBin,
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{

--- a/src/Files.App/ViewModels/ContextMenuFlyoutItemViewModel.cs
+++ b/src/Files.App/ViewModels/ContextMenuFlyoutItemViewModel.cs
@@ -89,6 +89,7 @@ namespace Files.App.ViewModels
 		public ContextMenuFlyoutItemViewModel()
 		{
 		}
+
 		public ContextMenuFlyoutItemViewModel(IRichCommand command)
 		{
 			Text = command.Label;

--- a/src/Files.App/ViewModels/ContextMenuFlyoutItemViewModel.cs
+++ b/src/Files.App/ViewModels/ContextMenuFlyoutItemViewModel.cs
@@ -1,3 +1,4 @@
+using Files.App.Commands;
 using Files.App.UserControls;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
@@ -84,6 +85,36 @@ namespace Files.App.ViewModels
 		public bool ShowLoadingIndicator { get; set; }
 
 		public bool IsHidden { get; set; }
+
+		public ContextMenuFlyoutItemViewModel()
+		{
+		}
+		public ContextMenuFlyoutItemViewModel(IRichCommand command)
+		{
+			Text = command.Label;
+			Command = command;
+
+			var glyph = command.Glyph;
+			if (string.IsNullOrEmpty(glyph.OverlayGlyph))
+			{
+				Glyph = glyph.BaseGlyph;
+				GlyphFontFamilyName = glyph.FontFamily;
+			}
+			else
+			{
+				ColoredIcon = new ColoredIconModel
+				{
+					BaseLayerGlyph = glyph.BaseGlyph,
+					OverlayLayerGlyph = glyph.OverlayGlyph,
+				};
+			}
+
+			ShowItem = command.IsExecutable;
+			ShowInRecycleBin = ShowInSearchPage = ShowInFtpPage = ShowInZipPage = true;
+
+			if (!command.CustomHotKey.IsNone)
+				KeyboardAcceleratorTextOverride = command.CustomHotKey.ToString();
+		}
 	}
 
 	public enum ItemType
@@ -111,7 +142,7 @@ namespace Files.App.ViewModels
 
 		public bool IsValid => !string.IsNullOrEmpty(BaseLayerGlyph);
 	}
-	
+
 	public struct OpacityIconModel
 	{
 		public Style OpacityIconStyle { get; set; }

--- a/src/Files.App/ViewModels/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/SidebarViewModel.cs
@@ -28,8 +28,6 @@ namespace Files.App.ViewModels
 	{
 		private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
 
-		public ICommand EmptyRecycleBinCommand { get; private set; }
-
 		private IPaneHolder paneHolder;
 		public IPaneHolder PaneHolder
 		{
@@ -220,7 +218,6 @@ namespace Files.App.ViewModels
 			dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
 			SideBarItems = new BulkConcurrentObservableCollection<INavigationControlItem>();
-			EmptyRecycleBinCommand = new RelayCommand<RoutedEventArgs>(EmptyRecycleBin);
 			UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
 			CreateItemHome();
 
@@ -545,11 +542,6 @@ namespace Files.App.ViewModels
 			{
 				SideBarItems.Remove(SideBarItems.FirstOrDefault(x => x.Section == sectionType));
 			}
-		}
-
-		public async void EmptyRecycleBin(RoutedEventArgs e)
-		{
-			await RecycleBinHelpers.EmptyRecycleBin();
 		}
 
 		private void UserSettingsService_OnSettingChangedEvent(object sender, SettingChangedEventArgs e)

--- a/src/Files.App/ViewModels/ToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/ToolbarViewModel.cs
@@ -968,8 +968,6 @@ namespace Files.App.ViewModels
 
 		public ICommand? CutCommand { get; set; }
 
-		public ICommand? EmptyRecycleBinCommand { get; set; }
-
 		public ICommand RestoreRecycleBinCommand { get; set; }
 
 		public ICommand RestoreSelectionRecycleBinCommand { get; set; }

--- a/src/Files.App/Views/BaseShellPage.cs
+++ b/src/Files.App/Views/BaseShellPage.cs
@@ -630,7 +630,6 @@ namespace Files.App.Views
 			ToolbarViewModel.Share = new RelayCommand(() => SlimContentPage?.CommandsViewModel.ShareItemCommand.Execute(null));
 			ToolbarViewModel.DeleteCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.DeleteItemCommand.Execute(null));
 			ToolbarViewModel.CutCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.CutItemCommand.Execute(null));
-			ToolbarViewModel.EmptyRecycleBinCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.EmptyRecycleBinCommand.Execute(null));
 			ToolbarViewModel.RestoreRecycleBinCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.RestoreRecycleBinCommand.Execute(null));
 			ToolbarViewModel.RestoreSelectionRecycleBinCommand = new RelayCommand(() => SlimContentPage?.CommandsViewModel.RestoreSelectionRecycleBinCommand.Execute(null));
 			ToolbarViewModel.RunWithPowerShellCommand = new RelayCommand(async () => await Win32Helpers.InvokeWin32ComponentAsync("powershell", this, PathNormalization.NormalizePath(SlimContentPage?.SelectedItem.ItemPath)));

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -203,7 +203,6 @@
 			HorizontalContentAlignment="Stretch"
 			CanOpenInNewPane="{x:Bind SidebarAdaptiveViewModel.PaneHolder.IsMultiPaneEnabled, Mode=OneWay}"
 			DisplayModeChanged="{x:Bind SidebarAdaptiveViewModel.SidebarControl_DisplayModeChanged}"
-			EmptyRecycleBinCommand="{x:Bind SidebarAdaptiveViewModel.EmptyRecycleBinCommand, Mode=OneWay}"
 			IsPaneOpen="{x:Bind SidebarAdaptiveViewModel.IsSidebarOpen, Mode=TwoWay}"
 			IsPaneToggleButtonVisible="False"
 			Loaded="SidebarControl_Loaded"

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -320,7 +320,7 @@ namespace Files.App.Views
 			FindName(nameof(TabControl));
 			FindName(nameof(NavToolbar));
 
-			var commands = Commands.Where(command => !command.CustomHotKey.IsNone);
+			var commands = Commands.Where(command => !command.CustomHotKey.IsNone).ToList();
 			foreach (var command in commands)
 				KeyboardAccelerators.Add(new CommandAccelerator(command));
 			Commands.HotKeyChanged += Commands_HotKeyChanged;

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -320,7 +320,7 @@ namespace Files.App.Views
 			FindName(nameof(TabControl));
 			FindName(nameof(NavToolbar));
 
-			var commands = Commands.Where(command => !command.CustomHotKey.IsNone).ToList();
+			var commands = Commands.Where(command => !command.CustomHotKey.IsNone);
 			foreach (var command in commands)
 				KeyboardAccelerators.Add(new CommandAccelerator(command));
 			Commands.HotKeyChanged += Commands_HotKeyChanged;

--- a/tests/Files.InteractionTests/Tests/FolderTests.cs
+++ b/tests/Files.InteractionTests/Tests/FolderTests.cs
@@ -11,8 +11,6 @@ namespace Files.InteractionTests.Tests
 		[TestCleanup]
 		public void Cleanup()
 		{
-			DeleteFolderTest();
-
 			// Navigate back home
 			TestHelper.InvokeButtonById("Home");
 		}
@@ -27,6 +25,8 @@ namespace Files.InteractionTests.Tests
 			RenameFolderTest();
 
 			CopyPasteFolderTest();
+
+			DeleteFolderTest();
 		}
 
 		/// <summary>


### PR DESCRIPTION
**Resolved / Related Issues**
* Usage of glyphs in IAction. This simplifies the use of icons with the FontIcon and ColoredIcon properties of IRichCommand.
* Simplifies the creation of context menus. It is possible to pass a RichCommand to ContextMenuFlyoutItemViewModel to initialize it.
* Added RichCommand EmptyRecycleBin, which uses glyphs. This command is used everywhere, including the sidebar. Old commands are deleted. This new action does not yet use the IsExecutable property. This requires the context class and will be the subject of a future pr.
* A behavior has changed slightly. In the context menu of the RecycleBin page, the RecycleBin command is no longer active if the RecycleBin is empty. This seemed like a bug to me.
* A bug has been fixed in the parser of HotKey (not yet used).
* The next step is to add the context. This is the last part of the command base. Then, it will be necessary to convert the current commands (actions + use in the views).

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility