### PR TITLE
Fix: Fixed issue where the properties window opened from widgets was hidden behind

### DIFF
--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -134,7 +134,7 @@ namespace Files.App.UserControls.Widgets
 			OpenInNewTabCommand = new RelayCommand<WidgetCardItem>(OpenInNewTab);
 			OpenInNewWindowCommand = new RelayCommand<WidgetCardItem>(OpenInNewWindow);
 			OpenInNewPaneCommand = new AsyncRelayCommand<DriveCardItem>(OpenInNewPane);
-			OpenPropertiesCommand = new AsyncRelayCommand<DriveCardItem>(OpenProperties);
+			OpenPropertiesCommand = new RelayCommand<DriveCardItem>(OpenProperties);
 			PinToFavoritesCommand = new RelayCommand<WidgetCardItem>(PinToFavorites);
 			UnpinFromFavoritesCommand = new RelayCommand<WidgetCardItem>(UnpinFromFavorites);
 			MapNetworkDriveCommand = new AsyncRelayCommand(DoNetworkMapDrive); 
@@ -277,9 +277,15 @@ namespace Files.App.UserControls.Widgets
 			Win32API.OpenFormatDriveDialog(item?.Path ?? string.Empty);
 		}
 
-		private async Task OpenProperties(DriveCardItem item)
-		{ 
-			await FilePropertiesHelpers.OpenPropertiesWindowAsync(item.Item, associatedInstance); 
+		private void OpenProperties(DriveCardItem item)
+		{
+			EventHandler<object> flyoutClosed = null!;
+			flyoutClosed = async (s, e) =>
+			{
+				ItemContextMenuFlyout.Closed -= flyoutClosed;
+				await FilePropertiesHelpers.OpenPropertiesWindowAsync(item.Item, associatedInstance);
+			};
+			ItemContextMenuFlyout.Closed += flyoutClosed;
 		}
 
 		private async void Button_Click(object sender, RoutedEventArgs e)

--- a/src/Files.App/UserControls/Widgets/HomePageWidget.cs
+++ b/src/Files.App/UserControls/Widgets/HomePageWidget.cs
@@ -31,6 +31,8 @@ namespace Files.App.UserControls.Widgets
 		public ICommand PinToFavoritesCommand;
 		public ICommand UnpinFromFavoritesCommand;
 
+		protected CommandBarFlyout ItemContextMenuFlyout;
+
 		public abstract List<ContextMenuFlyoutItemViewModel> GetItemMenuItems(WidgetCardItem item, bool isPinned);
 
 		public void Button_RightTapped(object sender, RightTappedRoutedEventArgs e)
@@ -47,6 +49,7 @@ namespace Files.App.UserControls.Widgets
 							 .ForEach(i => i.MinWidth = Constants.UI.ContextMenuItemsMaxWidth);
 
 			secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
+			ItemContextMenuFlyout = itemContextMenuFlyout;
 			itemContextMenuFlyout.ShowAt(widgetCardItem, new FlyoutShowOptions { Position = e.GetPosition(widgetCardItem) });
 
 			_ = ShellContextmenuHelper.LoadShellMenuItems(item.Path, itemContextMenuFlyout);

--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -315,7 +315,13 @@ namespace Files.App.UserControls.Widgets
 
 		private void OpenProperties(FolderCardItem item)
 		{
-			CardPropertiesInvoked?.Invoke(this, new QuickAccessCardEventArgs { Item = item.Item });
+			EventHandler<object> flyoutClosed = null!;
+			flyoutClosed = (s, e) =>
+			{
+				ItemContextMenuFlyout.Closed -= flyoutClosed;
+				CardPropertiesInvoked?.Invoke(this, new QuickAccessCardEventArgs { Item = item.Item });
+			};
+			ItemContextMenuFlyout.Closed += flyoutClosed;
 		}
 
 		public override async void PinToFavorites(WidgetCardItem item)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11432 

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility