### PR TITLE
Rich command: Selection

### DIFF
--- a/src/Files.App/Actions/Content/Selection/ClearSelectionAction.cs
+++ b/src/Files.App/Actions/Content/Selection/ClearSelectionAction.cs
@@ -1,0 +1,44 @@
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.App.Commands;
+using Files.App.Contexts;
+using Files.App.Extensions;
+using System.Threading.Tasks;
+
+namespace Files.App.Actions
+{
+	internal class ClearSelectionAction : IAction
+	{
+		private readonly IContentPageContext context = Ioc.Default.GetRequiredService<IContentPageContext>();
+
+		public string Label { get; } = "ClearSelection".GetLocalizedResource();
+
+		public RichGlyph Glyph { get; } = new("\uE8E6");
+
+		public bool IsExecutable
+		{
+			get
+			{
+				if (context.PageType is ContentPageTypes.Home)
+					return false;
+
+				if (!context.HasSelection)
+					return false;
+
+				var page = context.ShellPage;
+				if (page is null)
+					return false;
+
+				bool isEditing = page.ToolbarViewModel.IsEditModeEnabled;
+				bool isRenaming = page.SlimContentPage.IsRenamingItem;
+
+				return !isEditing && !isRenaming;
+			}
+		}
+
+		public Task ExecuteAsync()
+		{
+			context.ShellPage?.SlimContentPage?.ItemManipulationModel?.ClearSelection();
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/src/Files.App/Actions/Content/Selection/InvertSelectionAction.cs
+++ b/src/Files.App/Actions/Content/Selection/InvertSelectionAction.cs
@@ -1,0 +1,44 @@
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.App.Commands;
+using Files.App.Contexts;
+using Files.App.Extensions;
+using System.Threading.Tasks;
+
+namespace Files.App.Actions
+{
+	internal class InvertSelectionAction : IAction
+	{
+		private readonly IContentPageContext context = Ioc.Default.GetRequiredService<IContentPageContext>();
+
+		public string Label { get; } = "InvertSelection".GetLocalizedResource();
+
+		public RichGlyph Glyph { get; } = new("\uE746");
+
+		public bool IsExecutable
+		{
+			get
+			{
+				if (context.PageType is ContentPageTypes.Home)
+					return false;
+
+				if (!context.HasItem)
+					return false;
+
+				var page = context.ShellPage;
+				if (page is null)
+					return false;
+
+				bool isEditing = page.ToolbarViewModel.IsEditModeEnabled;
+				bool isRenaming = page.SlimContentPage.IsRenamingItem;
+
+				return !isEditing && !isRenaming;
+			}
+		}
+
+		public Task ExecuteAsync()
+		{
+			context?.ShellPage?.SlimContentPage?.ItemManipulationModel?.InvertSelection();
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/src/Files.App/Actions/Content/Selection/MultiSelectAction.cs
+++ b/src/Files.App/Actions/Content/Selection/MultiSelectAction.cs
@@ -1,0 +1,34 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Files.App.Commands;
+using Files.App.DataModels;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace Files.App.Actions
+{
+	internal class MultiSelectAction : ObservableObject, IToggleAction
+	{
+		public string Label { get; } = "MultiSelect";
+
+		public RichGlyph Glyph { get; } = new("\uE762");
+
+		public bool IsOn => App.AppModel.ShowSelectionCheckboxes;
+
+		public MultiSelectAction()
+		{
+			App.AppModel.PropertyChanged += Model_PropertyChanged;
+		}
+
+		public Task ExecuteAsync()
+		{
+			App.AppModel.ShowSelectionCheckboxes = !App.AppModel.ShowSelectionCheckboxes;
+			return Task.CompletedTask;
+		}
+
+		private void Model_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName is nameof(AppModel.ShowSelectionCheckboxes))
+				OnPropertyChanged(nameof(IsOn));
+		}
+	}
+}

--- a/src/Files.App/Actions/Content/Selection/SelectAllAction.cs
+++ b/src/Files.App/Actions/Content/Selection/SelectAllAction.cs
@@ -1,0 +1,48 @@
+﻿using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.App.Commands;
+using Files.App.Contexts;
+using Files.App.Extensions;
+using System.Threading.Tasks;
+using Windows.System;
+
+namespace Files.App.Actions
+{
+	internal class SelectAllAction : IAction
+	{
+		private readonly IContentPageContext context = Ioc.Default.GetRequiredService<IContentPageContext>();
+
+		public string Label { get; } = "SelectAll".GetLocalizedResource();
+
+		public RichGlyph Glyph { get; } = new("\uE8B3");
+		public HotKey HotKey { get; } = new(VirtualKey.A, VirtualKeyModifiers.Control);
+
+		public bool IsExecutable
+		{
+			get
+			{
+				if (context.PageType is ContentPageTypes.Home)
+					return false;
+
+				var page = context.ShellPage;
+				if (page is null)
+					return false;
+
+				int itemCount = page.FilesystemViewModel.FilesAndFolders.Count;
+				int selectedItemCount = context.SelectedItems.Count;
+				if (itemCount == selectedItemCount)
+					return false;
+
+				bool isEditing = page.ToolbarViewModel.IsEditModeEnabled;
+				bool isRenaming = page.SlimContentPage.IsRenamingItem;
+
+				return !isEditing && !isRenaming;
+			}
+		}
+
+		public Task ExecuteAsync()
+		{
+			context.ShellPage?.SlimContentPage?.ItemManipulationModel?.SelectAllItems();
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/src/Files.App/Commands/CommandCodes.cs
+++ b/src/Files.App/Commands/CommandCodes.cs
@@ -20,11 +20,17 @@
 		RestoreRecycleBin,
 		RestoreAllRecycleBin,
 
-    // Start
+		// selection
+		MultiSelect,
+		SelectAll,
+		InvertSelection,
+		ClearSelection,
+
+		// start
 		PinToStart,
 		UnpinFromStart,
 
-		// Favorites
+		// favorites
 		PinItemToFavorites,
 		UnpinItemFromFavorites,
 	}

--- a/src/Files.App/Commands/IRichCommand.cs
+++ b/src/Files.App/Commands/IRichCommand.cs
@@ -21,6 +21,7 @@ namespace Files.App.Commands
 
 		HotKey DefaultHotKey { get; }
 		HotKey CustomHotKey { get; set; }
+		string? HotKeyText { get; }
 
 		bool IsToggle { get; }
 		bool IsOn { get; set; }

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -32,6 +32,10 @@ namespace Files.App.Commands
 		public IRichCommand ToggleFullScreen => commands[CommandCodes.ToggleFullScreen];
 		public IRichCommand ToggleShowHiddenItems => commands[CommandCodes.ToggleShowHiddenItems];
 		public IRichCommand ToggleShowFileExtensions => commands[CommandCodes.ToggleShowFileExtensions];
+		public IRichCommand MultiSelect => commands[CommandCodes.MultiSelect];
+		public IRichCommand SelectAll => commands[CommandCodes.SelectAll];
+		public IRichCommand InvertSelection => commands[CommandCodes.InvertSelection];
+		public IRichCommand ClearSelection => commands[CommandCodes.ClearSelection];
 		public IRichCommand EmptyRecycleBin => commands[CommandCodes.EmptyRecycleBin];
 		public IRichCommand RestoreRecycleBin => commands[CommandCodes.RestoreRecycleBin];
 		public IRichCommand RestoreAllRecycleBin => commands[CommandCodes.RestoreAllRecycleBin];
@@ -42,7 +46,7 @@ namespace Files.App.Commands
 		public IRichCommand UnpinFromStart => commands[CommandCodes.UnpinFromStart];
 		public IRichCommand PinItemToFavorites => commands[CommandCodes.PinItemToFavorites];
 		public IRichCommand UnpinItemFromFavorites => commands[CommandCodes.UnpinItemFromFavorites];
-    
+
 		public CommandManager()
 		{
 			commands = CreateActions()
@@ -65,6 +69,10 @@ namespace Files.App.Commands
 			[CommandCodes.ToggleFullScreen] = new ToggleFullScreenAction(),
 			[CommandCodes.ToggleShowHiddenItems] = new ToggleShowHiddenItemsAction(),
 			[CommandCodes.ToggleShowFileExtensions] = new ToggleShowFileExtensionsAction(),
+			[CommandCodes.MultiSelect] = new MultiSelectAction(),
+			[CommandCodes.SelectAll] = new SelectAllAction(),
+			[CommandCodes.InvertSelection] = new InvertSelectionAction(),
+			[CommandCodes.ClearSelection] = new ClearSelectionAction(),
 			[CommandCodes.EmptyRecycleBin] = new EmptyRecycleBinAction(),
 			[CommandCodes.RestoreRecycleBin] = new RestoreRecycleBinAction(),
 			[CommandCodes.RestoreAllRecycleBin] = new RestoreAllRecycleBinAction(),
@@ -94,6 +102,7 @@ namespace Files.App.Commands
 			public FontIcon? FontIcon => null;
 			public OpacityIcon? OpacityIcon => null;
 
+			public string? HotKeyText => null;
 			public HotKey DefaultHotKey => HotKey.None;
 
 			public HotKey CustomHotKey
@@ -136,6 +145,7 @@ namespace Files.App.Commands
 			private readonly Lazy<OpacityIcon?> opacityIcon;
 			public OpacityIcon? OpacityIcon => opacityIcon.Value;
 
+			public string? HotKeyText => !customHotKey.IsNone ? CustomHotKey.ToString() : null;
 			public HotKey DefaultHotKey => action.HotKey;
 
 			private HotKey customHotKey;
@@ -164,6 +174,7 @@ namespace Files.App.Commands
 					};
 
 					SetProperty(ref customHotKey, value);
+					OnPropertyChanged(nameof(HotKeyText));
 					manager.HotKeyChanged?.Invoke(manager, args);
 				}
 			}

--- a/src/Files.App/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Commands/Manager/ICommandManager.cs
@@ -18,6 +18,11 @@ namespace Files.App.Commands
 		IRichCommand ToggleShowHiddenItems { get; }
 		IRichCommand ToggleShowFileExtensions { get; }
 
+		IRichCommand MultiSelect { get; }
+		IRichCommand SelectAll { get; }
+		IRichCommand InvertSelection { get; }
+		IRichCommand ClearSelection { get; }
+
 		IRichCommand CreateFolder { get; }
 		IRichCommand CreateShortcut { get; }
 		IRichCommand CreateShortcutFromDialog { get; }

--- a/src/Files.App/Contexts/ContentPage/ContentPageContext.cs
+++ b/src/Files.App/Contexts/ContentPage/ContentPageContext.cs
@@ -25,6 +25,9 @@ namespace Files.App.Contexts
 
 		public bool HasItem => shellPage?.ToolbarViewModel?.HasItem ?? false;
 
+		public bool HasSelection => SelectedItems.Count is not 0;
+		public ListedItem? SelectedItem => SelectedItems.Count is 1 ? SelectedItems[0] : null;
+
 		private IReadOnlyList<ListedItem> selectedItems = EmptyListedItemList;
 		public IReadOnlyList<ListedItem> SelectedItems => selectedItems;
 
@@ -94,8 +97,17 @@ namespace Files.App.Contexts
 
 		private void UpdateSelectedItems()
 		{
+			bool oldHasSelection = HasSelection;
+			ListedItem? oldSelectedItem = SelectedItem;
+
 			IReadOnlyList<ListedItem> items = shellPage?.ToolbarViewModel?.SelectedItems?.AsReadOnly() ?? EmptyListedItemList;
-			SetProperty(ref selectedItems, items, nameof(SelectedItems));
+			if (SetProperty(ref selectedItems, items, nameof(SelectedItems)))
+			{
+				if (HasSelection != oldHasSelection)
+					OnPropertyChanged(nameof(HasSelection));
+				if (SelectedItem != oldSelectedItem)
+					OnPropertyChanged(nameof(SelectedItem));
+			}
 		}
 
 		private void BaseShellPage_CurrentInstanceChanged(object? sender, BaseShellPage newShellPage)

--- a/src/Files.App/Contexts/ContentPage/IContentPageContext.cs
+++ b/src/Files.App/Contexts/ContentPage/IContentPageContext.cs
@@ -13,6 +13,8 @@ namespace Files.App.Contexts
 		ListedItem? Folder { get; }
 
 		bool HasItem { get; }
+		bool HasSelection { get; }
+		ListedItem? SelectedItem { get; }
 		IReadOnlyList<ListedItem> SelectedItems { get; }
 	}
 }

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -153,13 +153,13 @@
   <data name="Skip" xml:space="preserve">
     <value>Skip</value>
   </data>
-  <data name="NavToolbarSelectAll.Text" xml:space="preserve">
+  <data name="SelectAll" xml:space="preserve">
     <value>Select All</value>
   </data>
-  <data name="NavToolbarInvertSelection.Text" xml:space="preserve">
+  <data name="InvertSelection" xml:space="preserve">
     <value>Invert Selection</value>
   </data>
-  <data name="NavToolbarClearSelection.Text" xml:space="preserve">
+  <data name="ClearSelection" xml:space="preserve">
     <value>Clear Selection</value>
   </data>
   <data name="PropertiesModified.Text" xml:space="preserve">
@@ -2603,5 +2603,8 @@
   </data>
   <data name="Save" xml:space="preserve">
     <value>Save</value>
+  </data>
+  <data name="MultiSelect" xml:space="preserve">
+    <value>Multiselect</value>
   </data>
 </root>

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -414,34 +414,22 @@
 					<MenuFlyout Placement="Bottom">
 						<MenuFlyoutItem
 							x:Name="SelectAllMFI"
-							Command="{x:Bind ViewModel.SelectAllContentPageItemsCommand, Mode=OneWay}"
-							Text="{helpers:ResourceString Name=NavToolbarSelectAll/Text}">
-							<MenuFlyoutItem.Icon>
-								<FontIcon Glyph="&#xE8B3;" />
-							</MenuFlyoutItem.Icon>
-							<MenuFlyoutItem.KeyboardAccelerators>
-								<KeyboardAccelerator
-									Key="A"
-									IsEnabled="False"
-									Modifiers="Control" />
-							</MenuFlyoutItem.KeyboardAccelerators>
-						</MenuFlyoutItem>
+							Command="{x:Bind Commands.SelectAll}"
+							Icon="{x:Bind Commands.SelectAll.FontIcon}"
+							KeyboardAcceleratorTextOverride="{x:Bind Commands.SelectAll.HotKeyText}"
+							Text="{x:Bind Commands.SelectAll.Label}" />
 						<MenuFlyoutItem
 							x:Name="InvertSelectionMFI"
-							Command="{x:Bind ViewModel.InvertContentPageSelctionCommand, Mode=OneWay}"
-							Text="{helpers:ResourceString Name=NavToolbarInvertSelection/Text}">
-							<MenuFlyoutItem.Icon>
-								<FontIcon Glyph="&#xE746;" />
-							</MenuFlyoutItem.Icon>
-						</MenuFlyoutItem>
+							Command="{x:Bind Commands.InvertSelection}"
+							Icon="{x:Bind Commands.InvertSelection.FontIcon}"
+							KeyboardAcceleratorTextOverride="{x:Bind Commands.InvertSelection.HotKeyText}"
+							Text="{x:Bind Commands.InvertSelection.Label}" />
 						<MenuFlyoutItem
 							x:Name="ClearSelectionMFI"
-							Command="{x:Bind ViewModel.ClearContentPageSelectionCommand, Mode=OneWay}"
-							Text="{helpers:ResourceString Name=NavToolbarClearSelection/Text}">
-							<MenuFlyoutItem.Icon>
-								<FontIcon Glyph="&#xE8E6;" />
-							</MenuFlyoutItem.Icon>
-						</MenuFlyoutItem>
+							Command="{x:Bind Commands.ClearSelection}"
+							Icon="{x:Bind Commands.ClearSelection.FontIcon}"
+							KeyboardAcceleratorTextOverride="{x:Bind Commands.ClearSelection.HotKeyText}"
+							Text="{x:Bind Commands.ClearSelection.Label}" />
 					</MenuFlyout>
 				</AppBarButton.Flyout>
 

--- a/src/Files.App/ViewModels/ContextMenuFlyoutItemViewModelBuilder.cs
+++ b/src/Files.App/ViewModels/ContextMenuFlyoutItemViewModelBuilder.cs
@@ -65,7 +65,7 @@ namespace Files.App.ViewModels
 			}
 
 			if (!command.CustomHotKey.IsNone)
-				viewModel.KeyboardAcceleratorTextOverride = command.CustomHotKey.ToString();
+				viewModel.KeyboardAcceleratorTextOverride = command.HotKeyText!;
 
 			return viewModel;
 		}

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -1,4 +1,6 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI.UI;
+using Files.App.Commands;
 using Files.App.EventArguments;
 using Files.App.Filesystem;
 using Files.App.Helpers;
@@ -251,6 +253,18 @@ namespace Files.App.Views.LayoutModes
 			var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
 			var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
 
+			if (ctrlPressed && e.Key is VirtualKey.A)
+			{
+				e.Handled = true;
+
+				var commands = Ioc.Default.GetRequiredService<ICommandManager>();
+				var hotKey = new HotKey(VirtualKey.A, VirtualKeyModifiers.Control);
+
+				await commands[hotKey].ExecuteAsync();
+
+				return;
+			}
+
 			if (e.Key == VirtualKey.Enter && !e.KeyStatus.IsMenuKeyDown)
 			{
 				if (IsRenamingItem)
@@ -408,11 +422,11 @@ namespace Files.App.Views.LayoutModes
 				if (isItemFolder && UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick)
 				{
 					ItemInvoked?.Invoke(
-						new ColumnParam 
-						{ 
-							NavPathParam = (item is ShortcutItem sht ? sht.TargetPath : item!.ItemPath), 
-							ListView = FileList 
-						}, 
+						new ColumnParam
+						{
+							NavPathParam = (item is ShortcutItem sht ? sht.TargetPath : item!.ItemPath),
+							ListView = FileList
+						},
 						EventArgs.Empty);
 				}
 				else if (!IsRenamingItem && (isItemFile || isItemFolder))

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI.UI;
+using Files.App.Commands;
 using Files.App.EventArguments;
 using Files.App.Filesystem;
 using Files.App.Helpers;
@@ -8,7 +9,6 @@ using Files.App.Helpers.XamlHelpers;
 using Files.App.UserControls;
 using Files.App.UserControls.Selection;
 using Files.App.ViewModels;
-using Files.Backend.Services.Settings;
 using Files.Shared.Enums;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
@@ -326,6 +326,18 @@ namespace Files.App.Views.LayoutModes
 			var focusedElement = (FrameworkElement)FocusManager.GetFocusedElement(XamlRoot);
 			var isHeaderFocused = DependencyObjectHelpers.FindParent<DataGridHeader>(focusedElement) is not null;
 			var isFooterFocused = focusedElement is HyperlinkButton;
+
+			if (ctrlPressed && e.Key is VirtualKey.A)
+			{
+				e.Handled = true;
+
+				var commands = Ioc.Default.GetRequiredService<ICommandManager>();
+				var hotKey = new HotKey(VirtualKey.A, VirtualKeyModifiers.Control);
+
+				await commands[hotKey].ExecuteAsync();
+
+				return;
+			}
 
 			if (e.Key == VirtualKey.Enter && !e.KeyStatus.IsMenuKeyDown)
 			{

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -1,4 +1,6 @@
+using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI.UI;
+using Files.App.Commands;
 using Files.App.EventArguments;
 using Files.App.Filesystem;
 using Files.App.Helpers;
@@ -269,6 +271,18 @@ namespace Files.App.Views.LayoutModes
 			var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
 			var focusedElement = FocusManager.GetFocusedElement(XamlRoot) as FrameworkElement;
 			var isFooterFocused = focusedElement is HyperlinkButton;
+
+			if (ctrlPressed && e.Key is VirtualKey.A)
+			{
+				e.Handled = true;
+
+				var commands = Ioc.Default.GetRequiredService<ICommandManager>();
+				var hotKey = new HotKey(VirtualKey.A, VirtualKeyModifiers.Control);
+
+				await commands[hotKey].ExecuteAsync();
+
+				return;
+			}
 
 			if (e.Key == VirtualKey.Enter && !isFooterFocused && !e.KeyStatus.IsMenuKeyDown)
 			{


### PR DESCRIPTION
**Resolved / Related Issues**
*Adds commands SelectAll and ClearSelection and InvertSelection and MultiSelect. The menu is disabled if the command has no effect.
* Adds properties HasSelection and SelectedItem to IContentPageContext for to make it easier. SelectedItem is null when the selection does not contain one and only one element.
* The Ctrl+A hotkey is handled in the file lists and the appropriate command is reissued, to be able to reassign this hotkey.
* Rich commands use a new HotKeyText property, which is null when the hotkey is empty. Otherwise, the menus display None instead of displaying nothing.

**Validation**
How did you test these changes?
- [ ] Built and ran the app
- [ ] Tested the changes for accessibility