### PR TITLE
Feature: Added icon property to RichCommand

### DIFF
--- a/src/Files.App/Commands/IRichCommand.cs
+++ b/src/Files.App/Commands/IRichCommand.cs
@@ -16,6 +16,7 @@ namespace Files.App.Commands
 		string AutomationName { get; }
 
 		RichGlyph Glyph { get; }
+		object? Icon { get; }
 		FontIcon? FontIcon { get; }
 		OpacityIcon? OpacityIcon { get; }
 

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -105,6 +105,7 @@ namespace Files.App.Commands
 			public string AutomationName => string.Empty;
 
 			public RichGlyph Glyph => RichGlyph.None;
+			public object? Icon => null;
 			public FontIcon? FontIcon => null;
 			public OpacityIcon? OpacityIcon => null;
 
@@ -144,12 +145,11 @@ namespace Files.App.Commands
 			public string AutomationName => Label;
 
 			public RichGlyph Glyph => action.Glyph;
+			public FontIcon? FontIcon => Icon as FontIcon;
+			public OpacityIcon? OpacityIcon => Icon as OpacityIcon;
 
-			private readonly Lazy<FontIcon?> fontIcon;
-			public FontIcon? FontIcon => fontIcon.Value;
-
-			private readonly Lazy<OpacityIcon?> opacityIcon;
-			public OpacityIcon? OpacityIcon => opacityIcon.Value;
+			private readonly Lazy<object?> icon;
+			public object? Icon => icon.Value;
 
 			public string? HotKeyText => !customHotKey.IsNone ? CustomHotKey.ToString() : null;
 			public HotKey DefaultHotKey => action.HotKey;
@@ -204,8 +204,7 @@ namespace Files.App.Commands
 				this.manager = manager;
 				Code = code;
 				this.action = action;
-				fontIcon = new(action.Glyph.ToFontIcon);
-				opacityIcon = new(action.Glyph.ToOpacityIcon);
+				icon = new(action.Glyph.ToIcon);
 				customHotKey = action.HotKey;
 				command = new AsyncRelayCommand(ExecuteAsync, () => action.IsExecutable);
 

--- a/src/Files.App/Commands/RichGlyph.cs
+++ b/src/Files.App/Commands/RichGlyph.cs
@@ -32,39 +32,27 @@ namespace Files.App.Commands
 			opacityStyle = OpacityStyle;
 		}
 
-		public FontFamily ToFontFamily()
-		{
-			return string.IsNullOrEmpty(FontFamily)
-				? App.AppModel.SymbolFontFamily
-				: (FontFamily)Current.Resources[FontFamily];
-		}
-
-		public FontIcon? ToFontIcon()
+		public object? ToIcon()
 		{
 			if (IsNone)
 				return null;
 
-			var icon = new FontIcon
+			if (!string.IsNullOrEmpty(OpacityStyle))
+			{
+				return new OpacityIcon
+				{
+					Style = (Style)Current.Resources[OpacityStyle]
+				};
+			}
+
+			var fontIcon = new FontIcon
 			{
 				Glyph = BaseGlyph,
 			};
 			if (!string.IsNullOrEmpty(FontFamily))
-				icon.FontFamily = (FontFamily)Current.Resources[FontFamily];
+				fontIcon.FontFamily = (FontFamily)Current.Resources[FontFamily];
 
-			return icon;
-		}
-
-		public OpacityIcon? ToOpacityIcon()
-		{
-			if (IsNone)
-				return null;
-
-			var icon = new OpacityIcon
-			{
-				Style = (Style)Current.Resources[OpacityStyle]
-			};
-
-			return icon;
+			return fontIcon;
 		}
 	}
 }

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -207,7 +207,7 @@
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
 					AccessKey="B"
 					Command="{x:Bind Commands.EmptyRecycleBin}"
-					Content="{x:Bind Commands.EmptyRecycleBin.OpacityIcon}"
+					Content="{x:Bind Commands.EmptyRecycleBin.Icon}"
 					IsEnabled="{x:Bind Commands.EmptyRecycleBin.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.EmptyRecycleBin.Label}"
 					ToolTipService.ToolTip="{x:Bind Commands.EmptyRecycleBin.Label}" />
@@ -216,7 +216,7 @@
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
 					AccessKey="R"
 					Command="{x:Bind Commands.RestoreAllRecycleBin}"
-					Content="{x:Bind Commands.RestoreAllRecycleBin.OpacityIcon}"
+					Content="{x:Bind Commands.RestoreAllRecycleBin.Icon}"
 					Label="{x:Bind Commands.RestoreAllRecycleBin.Label}"
 					ToolTipService.ToolTip="{x:Bind Commands.RestoreAllRecycleBin.Label}"
 					Visibility="{x:Bind Commands.RestoreRecycleBin.IsExecutable, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
@@ -225,7 +225,7 @@
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
 					AccessKey="R"
 					Command="{x:Bind Commands.RestoreRecycleBin}"
-					Content="{x:Bind Commands.RestoreRecycleBin.OpacityIcon}"
+					Content="{x:Bind Commands.RestoreRecycleBin.Icon}"
 					Label="{x:Bind Commands.RestoreRecycleBin.Label}"
 					ToolTipService.ToolTip="{x:Bind Commands.RestoreRecycleBin.Label}"
 					Visibility="{x:Bind Commands.RestoreRecycleBin.IsExecutable, Mode=OneWay}" />


### PR DESCRIPTION
**Resolved / Related Issues**
Add Icon property to IRichCommand. The view no longer needs to know if it's a fontIcon or opacityIcon to display an icon as content.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility