### PR TITLE
Fix: Fixed loading icons in Properties Customize page

### DIFF
--- a/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
@@ -88,6 +88,7 @@ namespace Files.App.ViewModels.Properties
 		public void LoadIconsForPath(string path)
 		{
 			IconResourceItemPath = path;
+			_dllIcons.Clear();
 
 			var icons = Win32API.ExtractIconsFromDLL(path);
 			if (icons?.Count is null or 0)

--- a/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
@@ -90,7 +90,7 @@ namespace Files.App.ViewModels.Properties
 			IconResourceItemPath = path;
 
 			var icons = Win32API.ExtractIconsFromDLL(path);
-			if (icons.Count == 0)
+			if (icons?.Count is null or 0)
 				return;
 
 			foreach(var item in icons)


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11542

**Details**
* When selecting a file, only icons of that file appears in the list like Explorer, rather than adding icons to the icon list.
* Avoid crash when the selected file has no icons.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility

