### PR TITLE
Fix: Use x:Load in conflicts dialog again

### DIFF
--- a/src/Files.App/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files.App/Dialogs/FilesystemOperationDialog.xaml
@@ -33,7 +33,6 @@
 		<vc2:ConflictResolveOptionToIndexConverter x:Key="ConflictResolveOptionToIndexConverter" />
 		<vc3:VisibilityInvertConverter x:Key="VisibilityInvertConverter" />
 		<tvc:BoolNegationConverter x:Key="BoolNegationConverter" />
-		<tvc:BoolToVisibilityConverter  x:Key="BoolToVisibilityConverter" />
 
 		<DataTemplate x:Key="ConflictItemDataTemplate" x:DataType="vm:FileSystemDialogConflictItemViewModel">
 			<Grid ColumnSpacing="12">
@@ -105,14 +104,14 @@
 				</Grid>
 
 				<!--  Options  -->
-				<!-- Use Visibility because x:Load does not reflect the SelectedIndex value in the combo box -->
 				<ComboBox
 					x:Name="ConflictOptions"
 					Grid.Column="2"
 					Width="200"
 					HorizontalAlignment="Right"
 					VerticalAlignment="Center"
-					Visibility="{x:Bind IsConflict, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+					x:Load="{x:Bind IsConflict, Mode=OneWay}"
+					Loaded="ConflictOptions_Loaded"
 					SelectedIndex="{x:Bind ConflictResolveOption, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay, Converter={StaticResource ConflictResolveOptionToIndexConverter}}">
 					<ComboBox.Items>
 						<ComboBoxItem Content="{helpers:ResourceString Name=GenerateNewName}" />

--- a/src/Files.App/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files.App/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -129,6 +129,19 @@ namespace Files.App.Dialogs
 			(sender as TextBox)?.Focus(FocusState.Programmatic);
 		}
 
+		private void ConflictOptions_Loaded(object sender, RoutedEventArgs e)
+		{
+			if (sender is ComboBox comboBox)
+				comboBox.SelectedIndex = ViewModel.LoadConflictResolveOption() switch
+				{
+					FileNameConflictResolveOptionType.None => -1,
+					FileNameConflictResolveOptionType.GenerateNewName => 0,
+					FileNameConflictResolveOptionType.ReplaceExisting => 1,
+					FileNameConflictResolveOptionType.Skip => 2,
+					_ => -1
+				};
+		}
+
 		private void FilesystemOperationDialog_Opened(ContentDialog sender, ContentDialogOpenedEventArgs args)
 		{
 			if (ViewModel.FileSystemDialogMode.IsInDeleteMode)
@@ -136,7 +149,6 @@ namespace Files.App.Dialogs
 				DescriptionText.Foreground = App.Current.Resources["TextControlForeground"] as SolidColorBrush;
 			}
 
-			ViewModel.LoadConflictResolveOption();
 			UpdateDialogLayout();
 		}
 	}

--- a/src/Files.Backend/ViewModels/Dialogs/FileSystemDialog/FileSystemDialogViewModel.cs
+++ b/src/Files.Backend/ViewModels/Dialogs/FileSystemDialog/FileSystemDialogViewModel.cs
@@ -114,10 +114,7 @@ namespace Files.Backend.ViewModels.Dialogs.FileSystemDialog
 			}
 		}
 
-		public void LoadConflictResolveOption()
-		{
-			AggregatedResolveOption = UserSettingsService.PreferencesSettingsService.ConflictsResolveOption;
-		}
+		public FileNameConflictResolveOptionType LoadConflictResolveOption() => UserSettingsService.PreferencesSettingsService.ConflictsResolveOption;
 
 		public void SaveConflictResolveOption()
 		{


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related to #11399 

**Details**
In #11399, I used `Visibility` instead of `x:Load` because the initial value of the combo box could not be set correctly.
But I found a way to set the initial value correctly for `x:Load`, so I changed `Visibility` back to `x:Load`.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility
