### PR TITLE
Fix: Fixed issue where Empty and Restore button disappeared

### DIFF
--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -107,22 +107,26 @@
 					AccessKey="X"
 					AutomationProperties.AutomationId="InnerNavigationToolbarCutButton"
 					Command="{x:Bind Commands.CutItem, Mode=OneWay}"
-					Content="{x:Bind Commands.CutItem.Icon}"
 					IsEnabled="{x:Bind Commands.CutItem.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.CutItem.Label}"
 					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{x:Bind Commands.CutItem.Label}" />
+					ToolTipService.ToolTip="{x:Bind Commands.CutItem.Label}">
+
+					<local:OpacityIcon Style="{x:Bind Commands.CutItem.OpacityIcon.Style}" />
+				</AppBarButton>
 				<AppBarButton
 					Width="Auto"
 					MinWidth="40"
 					AccessKey="C"
 					AutomationProperties.AutomationId="InnerNavigationToolbarCopyButton"
 					Command="{x:Bind Commands.CopyItem, Mode=OneWay}"
-					Content="{x:Bind Commands.CopyItem.Icon}"
 					IsEnabled="{x:Bind Commands.CopyItem.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.CopyItem}"
 					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{x:Bind Commands.CopyItem}" />
+					ToolTipService.ToolTip="{x:Bind Commands.CopyItem}">
+
+					<local:OpacityIcon Style="{x:Bind Commands.CopyItem.OpacityIcon.Style}" />
+				</AppBarButton>
 				<AppBarButton
 					x:Name="PasteButton"
 					Width="Auto"
@@ -176,11 +180,13 @@
 					MinWidth="40"
 					AutomationProperties.AutomationId="Delete"
 					Command="{x:Bind Commands.DeleteItem}"
-					Content="{x:Bind Commands.DeleteItem.Icon}"
 					IsEnabled="{x:Bind Commands.DeleteItem.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.DeleteItem.Label}"
 					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{x:Bind Commands.DeleteItem.Label}" />
+					ToolTipService.ToolTip="{x:Bind Commands.DeleteItem.Label}">
+
+					<local:OpacityIcon Style="{x:Bind Commands.DeleteItem.OpacityIcon.Style}" />
+				</AppBarButton>
 				<AppBarButton
 					x:Name="PropertiesButton"
 					Width="Auto"
@@ -201,28 +207,34 @@
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
 					AccessKey="B"
 					Command="{x:Bind Commands.EmptyRecycleBin}"
-					Content="{x:Bind Commands.EmptyRecycleBin.Icon}"
 					IsEnabled="{x:Bind Commands.EmptyRecycleBin.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.EmptyRecycleBin.Label}"
-					ToolTipService.ToolTip="{x:Bind Commands.EmptyRecycleBin.Label}" />
+					ToolTipService.ToolTip="{x:Bind Commands.EmptyRecycleBin.Label}">
+
+					<local:OpacityIcon Style="{x:Bind Commands.EmptyRecycleBin.OpacityIcon.Style}" />
+				</AppBarButton>
 				<AppBarButton
 					x:Name="RestoreAllRecycleBinButton"
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
 					AccessKey="R"
 					Command="{x:Bind Commands.RestoreAllRecycleBin}"
-					Content="{x:Bind Commands.RestoreAllRecycleBin.Icon}"
 					Label="{x:Bind Commands.RestoreAllRecycleBin.Label}"
 					ToolTipService.ToolTip="{x:Bind Commands.RestoreAllRecycleBin.Label}"
-					Visibility="{x:Bind Commands.RestoreRecycleBin.IsExecutable, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
+					Visibility="{x:Bind Commands.RestoreRecycleBin.IsExecutable, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
+
+					<local:OpacityIcon Style="{x:Bind Commands.RestoreAllRecycleBin.OpacityIcon.Style}" />
+				</AppBarButton>
 				<AppBarButton
 					x:Name="RestoreRecycleBinButton"
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
 					AccessKey="R"
 					Command="{x:Bind Commands.RestoreRecycleBin}"
-					Content="{x:Bind Commands.RestoreRecycleBin.Icon}"
 					Label="{x:Bind Commands.RestoreRecycleBin.Label}"
 					ToolTipService.ToolTip="{x:Bind Commands.RestoreRecycleBin.Label}"
-					Visibility="{x:Bind Commands.RestoreRecycleBin.IsExecutable, Mode=OneWay}" />
+					Visibility="{x:Bind Commands.RestoreRecycleBin.IsExecutable, Mode=OneWay}">
+
+					<local:OpacityIcon Style="{x:Bind Commands.RestoreRecycleBin.OpacityIcon.Style}" />
+				</AppBarButton>
 				<AppBarButton
 					x:Name="ExtractButton"
 					Width="Auto"


### PR DESCRIPTION
I don't know why, but it seems that when using x:Load, we have to refer to OpacityIcon in the local resource, not in Commands.

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11540 

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility
