### PR TITLE
Fix: Fixed OpacityIcon visibility

### DIFF
--- a/src/Files.App/Commands/IRichCommand.cs
+++ b/src/Files.App/Commands/IRichCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Files.App.UserControls;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using System.ComponentModel;
@@ -18,7 +19,7 @@ namespace Files.App.Commands
 		RichGlyph Glyph { get; }
 		object? Icon { get; }
 		FontIcon? FontIcon { get; }
-		OpacityIcon? OpacityIcon { get; }
+		Style? OpacityStyle { get; }
 
 		HotKey DefaultHotKey { get; }
 		HotKey CustomHotKey { get; set; }

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -5,6 +5,7 @@ using Files.App.Actions.Content.Archives;
 using Files.App.Actions.Content.Background;
 using Files.App.Actions.Favorites;
 using Files.App.UserControls;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using System;
@@ -127,7 +128,7 @@ namespace Files.App.Commands
 			public RichGlyph Glyph => RichGlyph.None;
 			public object? Icon => null;
 			public FontIcon? FontIcon => null;
-			public OpacityIcon? OpacityIcon => null;
+			public Style? OpacityStyle => null;
 
 			public string? HotKeyText => null;
 			public HotKey DefaultHotKey => HotKey.None;
@@ -165,11 +166,9 @@ namespace Files.App.Commands
 			public string AutomationName => Label;
 
 			public RichGlyph Glyph => action.Glyph;
-			public FontIcon? FontIcon => Icon as FontIcon;
-			public OpacityIcon? OpacityIcon => Icon as OpacityIcon;
-
-			private readonly Lazy<object?> icon;
-			public object? Icon => icon.Value;
+			public object? Icon { get; }
+			public FontIcon? FontIcon { get; }
+			public Style? OpacityStyle { get; }
 
 			public string? HotKeyText => !customHotKey.IsNone ? CustomHotKey.ToString() : null;
 			public HotKey DefaultHotKey => action.HotKey;
@@ -224,7 +223,9 @@ namespace Files.App.Commands
 				this.manager = manager;
 				Code = code;
 				this.action = action;
-				icon = new(action.Glyph.ToIcon);
+				Icon = action.Glyph.ToIcon();
+				FontIcon = action.Glyph.ToFontIcon();
+				OpacityStyle = action.Glyph.ToOpacityStyle();
 				customHotKey = action.HotKey;
 				command = new AsyncRelayCommand(ExecuteAsync, () => action.IsExecutable);
 

--- a/src/Files.App/Commands/RichGlyph.cs
+++ b/src/Files.App/Commands/RichGlyph.cs
@@ -32,27 +32,40 @@ namespace Files.App.Commands
 			opacityStyle = OpacityStyle;
 		}
 
-		public object? ToIcon()
+		public object? ToIcon() => (object?)ToOpacityIcon() ?? ToFontIcon();
+
+		public FontIcon? ToFontIcon()
 		{
 			if (IsNone)
 				return null;
 
-			if (!string.IsNullOrEmpty(OpacityStyle))
-			{
-				return new OpacityIcon
-				{
-					Style = (Style)Current.Resources[OpacityStyle]
-				};
-			}
-
 			var fontIcon = new FontIcon
 			{
-				Glyph = BaseGlyph,
+				Glyph = BaseGlyph
 			};
+
 			if (!string.IsNullOrEmpty(FontFamily))
 				fontIcon.FontFamily = (FontFamily)Current.Resources[FontFamily];
 
 			return fontIcon;
+		}
+
+		public OpacityIcon? ToOpacityIcon()
+		{
+			if (string.IsNullOrEmpty(OpacityStyle))
+				return null;
+
+			return new()
+			{
+				Style = (Style)Current.Resources[OpacityStyle]
+			};
+		}
+
+		public Style? ToOpacityStyle()
+		{
+			if (string.IsNullOrEmpty(OpacityStyle))
+				return null;
+			return (Style)Current.Resources[OpacityStyle];
 		}
 	}
 }

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -107,22 +107,22 @@
 					AccessKey="X"
 					AutomationProperties.AutomationId="InnerNavigationToolbarCutButton"
 					Command="{x:Bind Commands.CutItem, Mode=OneWay}"
-					Content="{x:Bind Commands.CutItem.Icon}"
-					IsEnabled="{x:Bind Commands.CutItem.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.CutItem.Label}"
 					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{x:Bind Commands.CutItem.Label}" />
+					ToolTipService.ToolTip="{x:Bind Commands.CutItem.Label}">
+					<local:OpacityIcon Style="{x:Bind Commands.CutItem.OpacityStyle}" />
+				</AppBarButton>
 				<AppBarButton
 					Width="Auto"
 					MinWidth="40"
 					AccessKey="C"
 					AutomationProperties.AutomationId="InnerNavigationToolbarCopyButton"
 					Command="{x:Bind Commands.CopyItem, Mode=OneWay}"
-					Content="{x:Bind Commands.CopyItem.Icon}"
-					IsEnabled="{x:Bind Commands.CopyItem.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.CopyItem}"
 					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{x:Bind Commands.CopyItem}" />
+					ToolTipService.ToolTip="{x:Bind Commands.CopyItem}">
+					<local:OpacityIcon Style="{x:Bind Commands.CopyItem.OpacityStyle}" />
+				</AppBarButton>
 				<AppBarButton
 					x:Name="PasteButton"
 					Width="Auto"
@@ -176,11 +176,11 @@
 					MinWidth="40"
 					AutomationProperties.AutomationId="Delete"
 					Command="{x:Bind Commands.DeleteItem}"
-					Content="{x:Bind Commands.DeleteItem.Icon}"
-					IsEnabled="{x:Bind Commands.DeleteItem.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.DeleteItem.Label}"
 					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{x:Bind Commands.DeleteItem.Label}" />
+					ToolTipService.ToolTip="{x:Bind Commands.DeleteItem.Label}">
+					<local:OpacityIcon Style="{x:Bind Commands.DeleteItem.OpacityStyle}" />
+				</AppBarButton>
 				<AppBarButton
 					x:Name="PropertiesButton"
 					Width="Auto"
@@ -201,28 +201,30 @@
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
 					AccessKey="B"
 					Command="{x:Bind Commands.EmptyRecycleBin}"
-					Content="{x:Bind Commands.EmptyRecycleBin.Icon}"
-					IsEnabled="{x:Bind Commands.EmptyRecycleBin.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.EmptyRecycleBin.Label}"
-					ToolTipService.ToolTip="{x:Bind Commands.EmptyRecycleBin.Label}" />
+					ToolTipService.ToolTip="{x:Bind Commands.EmptyRecycleBin.Label}">
+					<local:OpacityIcon Style="{x:Bind Commands.EmptyRecycleBin.OpacityStyle}" />
+				</AppBarButton>
 				<AppBarButton
 					x:Name="RestoreAllRecycleBinButton"
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
 					AccessKey="R"
 					Command="{x:Bind Commands.RestoreAllRecycleBin}"
-					Content="{x:Bind Commands.RestoreAllRecycleBin.Icon}"
 					Label="{x:Bind Commands.RestoreAllRecycleBin.Label}"
 					ToolTipService.ToolTip="{x:Bind Commands.RestoreAllRecycleBin.Label}"
-					Visibility="{x:Bind Commands.RestoreRecycleBin.IsExecutable, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
+					Visibility="{x:Bind Commands.RestoreRecycleBin.IsExecutable, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}">
+					<local:OpacityIcon Style="{x:Bind Commands.RestoreAllRecycleBin.OpacityStyle}" />
+				</AppBarButton>
 				<AppBarButton
 					x:Name="RestoreRecycleBinButton"
 					x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeRecycleBin, Mode=OneWay, FallbackValue=False}"
 					AccessKey="R"
 					Command="{x:Bind Commands.RestoreRecycleBin}"
-					Content="{x:Bind Commands.RestoreRecycleBin.Icon}"
 					Label="{x:Bind Commands.RestoreRecycleBin.Label}"
 					ToolTipService.ToolTip="{x:Bind Commands.RestoreRecycleBin.Label}"
-					Visibility="{x:Bind Commands.RestoreRecycleBin.IsExecutable, Mode=OneWay}" />
+					Visibility="{x:Bind Commands.RestoreRecycleBin.IsExecutable, Mode=OneWay}">
+					<local:OpacityIcon Style="{x:Bind Commands.RestoreRecycleBin.OpacityStyle}" />
+				</AppBarButton>
 				<AppBarButton
 					x:Name="ExtractButton"
 					Width="Auto"
@@ -793,12 +795,13 @@
 				Width="Auto"
 				MinWidth="40"
 				AutomationProperties.Name="{x:Bind Commands.TogglePreviewPane.AutomationName}"
-				Content="{x:Bind Commands.TogglePreviewPane.Icon}"
 				IsChecked="{x:Bind Commands.TogglePreviewPane.IsOn, Mode=TwoWay}"
 				Label="{x:Bind Commands.TogglePreviewPane.Label}"
 				LabelPosition="Collapsed"
 				ToolTipService.ToolTip="{x:Bind Commands.TogglePreviewPane.LabelWithHotKey, Mode=OneWay}"
-				Visibility="{x:Bind ShowPreviewPaneButton, Mode=OneWay}" />
+				Visibility="{x:Bind ShowPreviewPaneButton, Mode=OneWay}">
+				<local:OpacityIcon Style="{x:Bind Commands.TogglePreviewPane.OpacityStyle}" />
+			</AppBarToggleButton>
 			<CommandBar.SecondaryCommands>
 				<AppBarButton
 					x:Name="NavToolbarNewPane"


### PR DESCRIPTION
**Resolved / Related Issues**
Fixes #11540.
XAML treats bindings of a Content attribute badly. We have to pass the content as a tag. This pr adds IRichCommand.OpacityStyle. This allows to display the icon without knowing the style used. The downside is that you have to know if it's a fonticon or opacityicon. The advantage is to be able to change the size (this will be used for the layout icons). This solution is acceptable because the icon will rarely change, and never by the user. Additionally, FontIcon may be phased out in favor of the more generic OpacityStyle.

I also removed IsEnabled properties to IsExecutable. By default, the command already notifies its state using IsExecutable, and XAML reacts to it.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility