### PR TITLE
Fix: Fixed SelectAll HotKey

### DIFF
--- a/src/Files.App/Views/ColumnShellPage.xaml
+++ b/src/Files.App/Views/ColumnShellPage.xaml
@@ -66,11 +66,6 @@
 			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
 			Modifiers="Control" />
 		<KeyboardAccelerator
-			Key="A"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-			Modifiers="Control" />
-		<KeyboardAccelerator
 			Key="D"
 			Invoked="KeyboardAccelerator_Invoked"
 			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"

--- a/src/Files.App/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/ColumnShellPage.xaml.cs
@@ -199,11 +199,6 @@ namespace Files.App.Views
 						UIFilesystemHelpers.CutItem(this);
 					break;
 
-				case (true, false, false, true, VirtualKey.A): // ctrl + a, select all
-					if (!ToolbarViewModel.IsEditModeEnabled && !ContentPage.IsRenamingItem)
-						SlimContentPage.ItemManipulationModel.SelectAllItems();
-					break;
-
 				case (true, false, false, true, VirtualKey.D): // ctrl + d, delete item
 				case (false, false, false, true, VirtualKey.Delete): // delete, delete item
 					if (ContentPage.IsItemSelected && !ContentPage.IsRenamingItem && !InstanceViewModel.IsPageTypeSearchResults)

--- a/src/Files.App/Views/ModernShellPage.xaml
+++ b/src/Files.App/Views/ModernShellPage.xaml
@@ -65,11 +65,6 @@
 			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
 			Modifiers="Control" />
 		<KeyboardAccelerator
-			Key="A"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-			Modifiers="Control" />
-		<KeyboardAccelerator
 			Key="D"
 			Invoked="KeyboardAccelerator_Invoked"
 			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"

--- a/src/Files.App/Views/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/ModernShellPage.xaml.cs
@@ -263,12 +263,6 @@ namespace Files.App.Views
 
 					break;
 
-				case (true, false, false, true, VirtualKey.A): // ctrl + a, select all
-					if (!ToolbarViewModel.IsEditModeEnabled && !ContentPage.IsRenamingItem)
-						SlimContentPage.ItemManipulationModel.SelectAllItems();
-
-					break;
-
 				case (true, false, false, true, VirtualKey.D): // ctrl + d, delete item
 				case (false, false, false, true, VirtualKey.Delete): // delete, delete item
 					if (ContentPage.IsItemSelected && !ContentPage.IsRenamingItem && !InstanceViewModel.IsPageTypeSearchResults)


### PR DESCRIPTION
**Resolved / Related Issues**
Views still have code to perform SelectAll with the shortcut Ctrl+A. This pr removes this code because the SelectAll action triggers this hotkey. This avoids a bug if we change the hotkey of the action or the action of the hotkey.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility