### PR TITLE
Fix: Fixed Tags Widget Context Menu Uses Wrong Strings

### DIFF
--- a/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml.cs
@@ -158,7 +158,7 @@ namespace Files.App.UserControls.Widgets
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "SideBarOpenInNewTab/Text".GetLocalizedResource(),
+					Text = "OpenInNewTab".GetLocalizedResource(),
 					OpacityIcon = new OpacityIconModel()
 					{
 						OpacityIconStyle = "ColorIconOpenInNewTab",
@@ -169,7 +169,7 @@ namespace Files.App.UserControls.Widgets
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "SideBarOpenInNewWindow/Text".GetLocalizedResource(),
+					Text = "OpenInNewWindow".GetLocalizedResource(),
 					OpacityIcon = new OpacityIconModel()
 					{
 						OpacityIconStyle = "ColorIconOpenInNewWindow",
@@ -206,7 +206,7 @@ namespace Files.App.UserControls.Widgets
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "SideBarUnpinFromFavorites/Text".GetLocalizedResource(),
+					Text = "UnpinFromFavorites".GetLocalizedResource(),
 					OpacityIcon = new OpacityIconModel()
 					{
 						OpacityIconStyle = "ColorIconUnpinFromFavorites",
@@ -217,7 +217,7 @@ namespace Files.App.UserControls.Widgets
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "BaseLayoutContextFlyoutPropertiesFolder/Text".GetLocalizedResource(),
+					Text = "Properties".GetLocalizedResource(),
 					Glyph = "\uE946",
 					Command = OpenPropertiesCommand,
 					CommandParameter = item,


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes #11599 

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility