### PR TITLE
Feature: Set drag zone with debug toolbar area excluded

### DIFF
--- a/src/Files.App/Helpers/DragZoneHelper.cs
+++ b/src/Files.App/Helpers/DragZoneHelper.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Windows.Graphics;
+using Microsoft.UI;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using WinRT.Interop;
+
+namespace Files.App.Helpers
+{
+	public static class DragZoneHelper
+	{
+		/// <summary>
+		/// Get Scale Adjustment
+		/// </summary>
+		/// <returns>scale factor percent</returns>
+		/// <param name="window"></param>
+		public static double GetScaleAdjustment(Window window) => window.Content.XamlRoot.RasterizationScale;
+
+		/// <summary>
+		/// Calculate dragging-zones of title bar<br/>
+		/// <strong>You MUST transform the rectangles with <see cref="GetScaleAdjustment"/> before calling <see cref="AppWindowTitleBar.SetDragRectangles"/></strong>
+		/// </summary>
+		/// <param name="viewportWidth"></param>
+		/// <param name="dragZoneHeight"></param>
+		/// <param name="dragZoneLeftIndent"></param>
+		/// <param name="nonDraggingZones"></param>
+		/// <returns></returns>
+		public static IEnumerable<RectInt32> GetDragZones(int viewportWidth, int dragZoneHeight, int dragZoneLeftIndent, IEnumerable<RectInt32> nonDraggingZones)
+		{
+			var draggingZonesX = new List<Range> { new(dragZoneLeftIndent, viewportWidth) };
+			var draggingZonesY = new List<IEnumerable<Range>> { new[] { new Range(0, dragZoneHeight) } };
+
+			foreach (var nonDraggingZone in nonDraggingZones)
+			{
+				for (var i = 0; i < draggingZonesX.Count; ++i)
+				{
+					var x = draggingZonesX[i];
+					var y = draggingZonesY[i].ToArray();
+					var xSubtrahend = new Range(nonDraggingZone.X, nonDraggingZone.X + nonDraggingZone.Width);
+					var ySubtrahend = new Range(nonDraggingZone.Y, nonDraggingZone.Y + nonDraggingZone.Height);
+					var xResult = (x - xSubtrahend).ToArray();
+					if (xResult.Length is 1 && xResult[0] == x)
+						continue;
+					var yResult = (y - ySubtrahend).ToArray();
+					switch (xResult.Length)
+					{
+						case 0:
+							draggingZonesY[i] = yResult;
+							break;
+						case 1:
+							draggingZonesX.RemoveAt(i);
+							draggingZonesY.RemoveAt(i);
+							if (xResult[0].Lower == x.Lower)
+							{
+								draggingZonesY.InsertRange(i, new[] { y, yResult });
+								draggingZonesX.InsertRange(i, new[]
+								{
+								x with { Upper = xResult[0].Upper },
+								x with { Lower = xSubtrahend.Lower }
+							});
+							}
+							else // xResult[0].Upper == x.Upper
+							{
+								draggingZonesY.InsertRange(i, new[] { yResult, y });
+								draggingZonesX.InsertRange(i, new[]
+								{
+								x with { Upper = xSubtrahend.Upper },
+								x with { Lower = xResult[0].Lower }
+							});
+							}
+
+							++i;
+							break;
+						case 2:
+							draggingZonesX.RemoveAt(i);
+							draggingZonesY.RemoveAt(i);
+							draggingZonesY.InsertRange(i, new[] { y, yResult, y });
+							draggingZonesX.InsertRange(i, new[]
+							{
+							x with { Upper = xResult[0].Upper } ,
+							xSubtrahend,
+							x with { Lower = xResult[1].Lower }
+						});
+							++i;
+							++i;
+							break;
+					}
+				}
+			}
+
+			var rects = draggingZonesX
+				.SelectMany((rangeX, i) => draggingZonesY[i]
+					.Select(rangeY => new RectInt32(rangeX.Lower, rangeY.Lower, rangeX.Distance, rangeY.Distance)))
+				.OrderBy(t => t.Y)
+				.ThenBy(t => t.X).ToList();
+			for (var i = 0; i < rects.Count - 1; ++i)
+			{
+				var now = rects[i];
+				var next = rects[i + 1];
+				if (now.Height == next.Height && now.X + now.Width == next.X)
+				{
+					rects.RemoveRange(i, 2);
+					rects.Insert(i, now with { Width = now.Width + next.Width });
+				}
+			}
+
+			return rects;
+		}
+
+		/// <summary>
+		/// Set dragging-zones of title bar
+		/// </summary>
+		/// <param name="window"></param>
+		/// <param name="dragZoneHeight"></param>
+		/// <param name="dragZoneLeftIndent"></param>
+		/// <param name="nonDraggingZones"></param>
+		public static void SetDragZones(Window window, int dragZoneHeight = 40, int dragZoneLeftIndent = 0, IEnumerable<RectInt32>? nonDraggingZones = null)
+		{
+			var hWnd = WindowNative.GetWindowHandle(window);
+			var windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
+			var appWindow = AppWindow.GetFromWindowId(windowId);
+			var scaleAdjustment = GetScaleAdjustment(window);
+			var windowWidth = (int)(appWindow.Size.Width / scaleAdjustment);
+			nonDraggingZones ??= Array.Empty<RectInt32>();
+#if DEBUG
+			nonDraggingZones = nonDraggingZones.Concat(new RectInt32[] { new((windowWidth - DebugToolbarWidth) / 2, 0, DebugToolbarWidth, DebugToolbarHeight) });
+#endif
+			appWindow.TitleBar.SetDragRectangles(
+				GetDragZones(windowWidth, dragZoneHeight, dragZoneLeftIndent, nonDraggingZones)
+					.Select(rect => new RectInt32(
+						(int)(rect.X * scaleAdjustment),
+						(int)(rect.Y * scaleAdjustment),
+						(int)(rect.Width * scaleAdjustment),
+						(int)(rect.Height * scaleAdjustment)))
+					.ToArray());
+		}
+
+		private const int DebugToolbarWidth = 217;
+		private const int DebugToolbarHeight = 25;
+	}
+
+	file record Range(int Lower, int Upper)
+	{
+		public int Distance => Upper - Lower;
+
+		private bool Intersects(Range other) => other.Lower <= Upper && other.Upper >= Lower;
+
+		public static IEnumerable<Range> operator -(Range minuend, Range subtrahend)
+		{
+			if (!minuend.Intersects(subtrahend))
+			{
+				yield return minuend;
+				yield break;
+			}
+			if (minuend.Lower < subtrahend.Lower)
+				yield return minuend with { Upper = subtrahend.Lower };
+			if (minuend.Upper > subtrahend.Upper)
+				yield return minuend with { Lower = subtrahend.Upper };
+		}
+
+		public static IEnumerable<Range> operator -(IEnumerable<Range> minuends, Range subtrahend)
+			=> minuends.SelectMany(minuend => minuend - subtrahend);
+	}
+}

--- a/src/Files.App/Helpers/DragZoneHelper.cs
+++ b/src/Files.App/Helpers/DragZoneHelper.cs
@@ -124,7 +124,7 @@ namespace Files.App.Helpers
 			var windowWidth = (int)(appWindow.Size.Width / scaleAdjustment);
 			nonDraggingZones ??= Array.Empty<RectInt32>();
 #if DEBUG
-			// subtract the toolbar area (center-top in window), only in DEBUG mode.
+			// Subtract the toolbar area (center-top in window), only in DEBUG mode.
 			nonDraggingZones = nonDraggingZones.Concat(new RectInt32[] { new((windowWidth - DebugToolbarWidth) / 2, 0, DebugToolbarWidth, DebugToolbarHeight) });
 #endif
 			appWindow.TitleBar.SetDragRectangles(

--- a/src/Files.App/Helpers/DragZoneHelper.cs
+++ b/src/Files.App/Helpers/DragZoneHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Windows.Graphics;
 using Microsoft.UI;
@@ -124,7 +123,8 @@ namespace Files.App.Helpers
 			var scaleAdjustment = GetScaleAdjustment(window);
 			var windowWidth = (int)(appWindow.Size.Width / scaleAdjustment);
 			nonDraggingZones ??= Array.Empty<RectInt32>();
-#if DEBUG   // subtract the toolbar area (center-top in window), only in DEBUG mode.
+#if DEBUG
+			// subtract the toolbar area (center-top in window), only in DEBUG mode.
 			nonDraggingZones = nonDraggingZones.Concat(new RectInt32[] { new((windowWidth - DebugToolbarWidth) / 2, 0, DebugToolbarWidth, DebugToolbarHeight) });
 #endif
 			appWindow.TitleBar.SetDragRectangles(

--- a/src/Files.App/Helpers/DragZoneHelper.cs
+++ b/src/Files.App/Helpers/DragZoneHelper.cs
@@ -15,8 +15,8 @@ namespace Files.App.Helpers
 		/// <summary>
 		/// Get Scale Adjustment
 		/// </summary>
-		/// <returns>scale factor percent</returns>
 		/// <param name="window"></param>
+		/// <returns>scale factor percent</returns>
 		public static double GetScaleAdjustment(Window window) => window.Content.XamlRoot.RasterizationScale;
 
 		/// <summary>
@@ -58,20 +58,19 @@ namespace Files.App.Helpers
 								draggingZonesY.InsertRange(i, new[] { y, yResult });
 								draggingZonesX.InsertRange(i, new[]
 								{
-								x with { Upper = xResult[0].Upper },
-								x with { Lower = xSubtrahend.Lower }
-							});
+									x with { Upper = xResult[0].Upper },
+									x with { Lower = xSubtrahend.Lower }
+								});
 							}
 							else // xResult[0].Upper == x.Upper
 							{
 								draggingZonesY.InsertRange(i, new[] { yResult, y });
 								draggingZonesX.InsertRange(i, new[]
 								{
-								x with { Upper = xSubtrahend.Upper },
-								x with { Lower = xResult[0].Lower }
-							});
+									x with { Upper = xSubtrahend.Upper },
+									x with { Lower = xResult[0].Lower }
+								});
 							}
-
 							++i;
 							break;
 						case 2:
@@ -80,10 +79,10 @@ namespace Files.App.Helpers
 							draggingZonesY.InsertRange(i, new[] { y, yResult, y });
 							draggingZonesX.InsertRange(i, new[]
 							{
-							x with { Upper = xResult[0].Upper } ,
-							xSubtrahend,
-							x with { Lower = xResult[1].Lower }
-						});
+								x with { Upper = xResult[0].Upper },
+								xSubtrahend,
+								x with { Lower = xResult[1].Lower }
+							});
 							++i;
 							++i;
 							break;
@@ -125,7 +124,7 @@ namespace Files.App.Helpers
 			var scaleAdjustment = GetScaleAdjustment(window);
 			var windowWidth = (int)(appWindow.Size.Width / scaleAdjustment);
 			nonDraggingZones ??= Array.Empty<RectInt32>();
-#if DEBUG
+#if DEBUG   // subtract the toolbar area (center-top in window), only in DEBUG mode.
 			nonDraggingZones = nonDraggingZones.Concat(new RectInt32[] { new((windowWidth - DebugToolbarWidth) / 2, 0, DebugToolbarWidth, DebugToolbarHeight) });
 #endif
 			appWindow.TitleBar.SetDragRectangles(

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -136,16 +136,8 @@ namespace Files.App.Views
 
 		private void SetRectDragRegion()
 		{
-			var scaleAdjustment = XamlRoot.RasterizationScale;
-			var dragArea = TabControl.DragArea;
-
-			var x = (int)((TabControl.ActualWidth - dragArea.ActualWidth) * scaleAdjustment);
-			var y = 0;
-			var width = (int)(dragArea.ActualWidth * scaleAdjustment);
-			var height = (int)(TabControl.TitlebarArea.ActualHeight * scaleAdjustment);
-
-			var dragRect = new RectInt32(x, y, width, height);
-			App.Window.AppWindow.TitleBar.SetDragRectangles(new[] { dragRect });
+			DragZoneHelper.SetDragZones(App.Window,
+				dragZoneLeftIndent: (int)(TabControl.ActualWidth - TabControl.DragArea.ActualWidth));
 		}
 
 		public void TabItemContent_ContentChanged(object? sender, TabItemArguments e)
@@ -263,28 +255,28 @@ namespace Files.App.Views
 			switch ((invokedItemContainer.DataContext as INavigationControlItem)?.ItemType)
 			{
 				case NavigationControlItemType.Location:
+				{
+					var ItemPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
+
+					if (string.IsNullOrEmpty(ItemPath)) // Section item
 					{
-						var ItemPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
-
-						if (string.IsNullOrEmpty(ItemPath)) // Section item
-						{
-							navigationPath = invokedItemContainer.Tag?.ToString();
-						}
-						else if (ItemPath.Equals("Home", StringComparison.OrdinalIgnoreCase)) // Home item
-						{
-							if (ItemPath.Equals(SidebarAdaptiveViewModel.SidebarSelectedItem?.Path, StringComparison.OrdinalIgnoreCase))
-								return; // return if already selected
-
-							navigationPath = "Home";
-							sourcePageType = typeof(WidgetsPage);
-						}
-						else // Any other item
-						{
-							navigationPath = invokedItemContainer.Tag?.ToString();
-						}
-
-						break;
+						navigationPath = invokedItemContainer.Tag?.ToString();
 					}
+					else if (ItemPath.Equals("Home", StringComparison.OrdinalIgnoreCase)) // Home item
+					{
+						if (ItemPath.Equals(SidebarAdaptiveViewModel.SidebarSelectedItem?.Path, StringComparison.OrdinalIgnoreCase))
+							return; // return if already selected
+
+						navigationPath = "Home";
+						sourcePageType = typeof(WidgetsPage);
+					}
+					else // Any other item
+					{
+						navigationPath = invokedItemContainer.Tag?.ToString();
+					}
+
+					break;
+				}
 
 				case NavigationControlItemType.FileTag:
 					var tagPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
@@ -302,10 +294,10 @@ namespace Files.App.Views
 					return;
 
 				default:
-					{
-						navigationPath = invokedItemContainer.Tag?.ToString();
-						break;
-					}
+				{
+					navigationPath = invokedItemContainer.Tag?.ToString();
+					break;
+				}
 			}
 
 			if (SidebarAdaptiveViewModel.PaneHolder?.ActivePane is IShellPage shellPage)

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -294,10 +294,10 @@ namespace Files.App.Views
 					return;
 
 				default:
-				{
-					navigationPath = invokedItemContainer.Tag?.ToString();
-					break;
-				}
+					{
+						navigationPath = invokedItemContainer.Tag?.ToString();
+						break;
+					}
 			}
 
 			if (SidebarAdaptiveViewModel.PaneHolder?.ActivePane is IShellPage shellPage)

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -255,28 +255,28 @@ namespace Files.App.Views
 			switch ((invokedItemContainer.DataContext as INavigationControlItem)?.ItemType)
 			{
 				case NavigationControlItemType.Location:
-				{
-					var ItemPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
-
-					if (string.IsNullOrEmpty(ItemPath)) // Section item
 					{
-						navigationPath = invokedItemContainer.Tag?.ToString();
-					}
-					else if (ItemPath.Equals("Home", StringComparison.OrdinalIgnoreCase)) // Home item
-					{
-						if (ItemPath.Equals(SidebarAdaptiveViewModel.SidebarSelectedItem?.Path, StringComparison.OrdinalIgnoreCase))
-							return; // return if already selected
+						var ItemPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item
 
-						navigationPath = "Home";
-						sourcePageType = typeof(WidgetsPage);
-					}
-					else // Any other item
-					{
-						navigationPath = invokedItemContainer.Tag?.ToString();
-					}
+						if (string.IsNullOrEmpty(ItemPath)) // Section item
+						{
+							navigationPath = invokedItemContainer.Tag?.ToString();
+						}
+						else if (ItemPath.Equals("Home", StringComparison.OrdinalIgnoreCase)) // Home item
+						{
+							if (ItemPath.Equals(SidebarAdaptiveViewModel.SidebarSelectedItem?.Path, StringComparison.OrdinalIgnoreCase))
+								return; // return if already selected
 
-					break;
-				}
+							navigationPath = "Home";
+							sourcePageType = typeof(WidgetsPage);
+						}
+						else // Any other item
+						{
+							navigationPath = invokedItemContainer.Tag?.ToString();
+						}
+
+						break;
+					}
 
 				case NavigationControlItemType.FileTag:
 					var tagPath = (invokedItemContainer.DataContext as INavigationControlItem)?.Path; // Get the path of the invoked item

--- a/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
+++ b/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
@@ -86,6 +86,7 @@ namespace Files.App.Views.Properties
 			{
 				// WinUI3: Set rectangle for the Titlebar
 				TitlebarArea.SizeChanged += (_, _) => DragZoneHelper.SetDragZones(Window, (int)TitlebarArea.ActualHeight);
+				DragZoneHelper.SetDragZones(Window, (int)TitlebarArea.ActualHeight);
 				AppWindow.Destroying += AppWindow_Destroying;
 
 				await App.Window.DispatcherQueue.EnqueueAsync(() => AppSettings.UpdateThemeElements.Execute(null));

--- a/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
+++ b/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
@@ -84,8 +84,8 @@ namespace Files.App.Views.Properties
 
 			if (_usingWinUI)
 			{
-				// WINUI3: Set rectangle for the Titlebar
-				TitlebarArea.SizeChanged += TitlebarArea_SizeChanged;
+				// WinUI3: Set rectangle for the Titlebar
+				TitlebarArea.SizeChanged += (_, _) => DragZoneHelper.SetDragZones(Window, (int)TitlebarArea.ActualHeight);
 				AppWindow.Destroying += AppWindow_Destroying;
 
 				await App.Window.DispatcherQueue.EnqueueAsync(() => AppSettings.UpdateThemeElements.Execute(null));
@@ -95,11 +95,6 @@ namespace Files.App.Views.Properties
 				_propertiesDialog = DependencyObjectHelpers.FindParent<ContentDialog>(this);
 				_propertiesDialog.Closed += PropertiesDialog_Closed;
 			}
-		}
-
-		private void TitlebarArea_SizeChanged(object? sender, SizeChangedEventArgs? e)
-		{
-			DragZoneHelper.SetDragZones(Window, (int)TitlebarArea.ActualHeight);
 		}
 
 		private async void AppSettings_ThemeModeChanged(object? sender, EventArgs e)
@@ -241,7 +236,7 @@ namespace Files.App.Views.Properties
 				NavViewItems.Remove(detailsItem);
 				NavViewItems.Remove(securityItem);
 				NavViewItems.Remove(customizationItem);
-			} 
+			}
 			else if (item is ListedItem listedItem)
 			{
 				var isShortcut = listedItem.IsShortcut;

--- a/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
+++ b/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
@@ -99,12 +99,7 @@ namespace Files.App.Views.Properties
 
 		private void TitlebarArea_SizeChanged(object? sender, SizeChangedEventArgs? e)
 		{
-			var scaleAdjustment = XamlRoot.RasterizationScale;
-			var width = (int)(TitlebarArea.ActualWidth * scaleAdjustment);
-			var height = (int)(TitlebarArea.ActualHeight * scaleAdjustment);
-
-			// Sets properties window drag region.
-			AppWindow.TitleBar.SetDragRectangles(new RectInt32[] { new RectInt32(0, 0, width, height) });
+			DragZoneHelper.SetDragZones(Window, (int)TitlebarArea.ActualHeight);
 		}
 
 		private async void AppSettings_ThemeModeChanged(object? sender, EventArgs e)

--- a/src/Files.App/Views/Properties/SecurityPage.xaml.cs
+++ b/src/Files.App/Views/Properties/SecurityPage.xaml.cs
@@ -82,6 +82,8 @@ namespace Files.App.Views.Properties
 						Backdrop = new WinUIEx.MicaSystemBackdrop(),
 					};
 
+					frame.SizeChanged += (_, _) => DragZoneHelper.SetDragZones(newWindow);
+
 					var appWindow = newWindow.AppWindow;
 
 					// Set icon


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Closes  #11592 

**Details**

Toolbar is useful when debugging. So I subtract the toolbar area before calling `AppWindowTitleBar.SetDragRectangles()` , only when the app is running in DEBUG mode. Now the area of toolbar won't be blocked any longer.

Method `GetDragZone()` is an algorithm for rectangle subtraction, and it is well suited to expand other use. For example, excluding a new area for new avatar control.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility
