### PR TITLE
Fix: Fixed issue where toolbar icons were mistakenly enabled on startup

### DIFF
--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -107,6 +107,7 @@
 					AccessKey="X"
 					AutomationProperties.AutomationId="InnerNavigationToolbarCutButton"
 					Command="{x:Bind Commands.CutItem, Mode=OneWay}"
+					IsEnabled="{x:Bind Commands.CutItem.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.CutItem.Label}"
 					LabelPosition="Collapsed"
 					ToolTipService.ToolTip="{x:Bind Commands.CutItem.Label}">
@@ -118,6 +119,7 @@
 					AccessKey="C"
 					AutomationProperties.AutomationId="InnerNavigationToolbarCopyButton"
 					Command="{x:Bind Commands.CopyItem, Mode=OneWay}"
+					IsEnabled="{x:Bind Commands.CopyItem.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.CopyItem}"
 					LabelPosition="Collapsed"
 					ToolTipService.ToolTip="{x:Bind Commands.CopyItem}">
@@ -176,6 +178,7 @@
 					MinWidth="40"
 					AutomationProperties.AutomationId="Delete"
 					Command="{x:Bind Commands.DeleteItem}"
+					IsEnabled="{x:Bind Commands.DeleteItem.IsExecutable, Mode=OneWay}"
 					Label="{x:Bind Commands.DeleteItem.Label}"
 					LabelPosition="Collapsed"
 					ToolTipService.ToolTip="{x:Bind Commands.DeleteItem.Label}">


### PR DESCRIPTION
**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Related to #11588 

**Details**
In #11588, `IsEnabled` properties were removed in favor of `IsExecutable`. However, without `IsEnabled`, `IsExecutable` is not evaluated on initialization and icons are shown as 'Enabled', so Cut, Copy and Delete still need `IsEnabled` property.
I missed this behavior when I tested #11588. Sorry.

**Validation**
How did you test these changes?
- [X] Built and ran the app
- [X] Tested the changes for accessibility
