### PR TITLE
Fix: Fixed OpacityIcon state

### DIFF
--- a/src/Files.App/UserControls/OpacityIcon.xaml
+++ b/src/Files.App/UserControls/OpacityIcon.xaml
@@ -3,14 +3,12 @@
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:local="using:Files.App.UserControls"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:triggers="using:CommunityToolkit.WinUI.UI.Triggers"
 	d:DesignHeight="300"
 	d:DesignWidth="400"
+	Loaded="OpacityIcon_Loaded"
 	Loading="OpacityIcon_Loading"
 	mc:Ignorable="d">
-
 	<VisualStateManager.VisualStateGroups>
 		<VisualStateGroup>
 			<VisualState x:Name="Normal" />

--- a/src/Files.App/UserControls/OpacityIcon.xaml.cs
+++ b/src/Files.App/UserControls/OpacityIcon.xaml.cs
@@ -6,7 +6,10 @@ namespace Files.App.UserControls
 {
 	public sealed partial class OpacityIcon : Control
 	{
-		public OpacityIcon() => InitializeComponent();
+		public OpacityIcon()
+		{
+			InitializeComponent();
+		}
 
 		private void IsEnabledChange(DependencyObject sender, DependencyProperty dp)
 		{

--- a/src/Files.App/UserControls/OpacityIcon.xaml.cs
+++ b/src/Files.App/UserControls/OpacityIcon.xaml.cs
@@ -2,38 +2,30 @@ using CommunityToolkit.WinUI.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
-// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
-
 namespace Files.App.UserControls
 {
 	public sealed partial class OpacityIcon : Control
 	{
-		public OpacityIcon()
-		{
-			InitializeComponent();
-		}
+		public OpacityIcon() => InitializeComponent();
 
 		private void IsEnabledChange(DependencyObject sender, DependencyProperty dp)
 		{
-			var v = sender.GetValue(dp) as bool?;
-			if (v is not null && v == false)
-			{
-				VisualStateManager.GoToState(this, "Disabled", true);
-			}
-			else
-			{
-				VisualStateManager.GoToState(this, "Normal", true);
-			}
+			string state = sender.GetValue(dp) is false ? "Disabled" : "Normal";
+			VisualStateManager.GoToState(this, state, true);
 		}
 
-		private void OpacityIcon_Loading(FrameworkElement sender, object args)
+		private void OpacityIcon_Loading(FrameworkElement sender, object e)
 		{
 			// register a property change callback for the parent content presenter's foreground to allow reacting to button state changes, eg disabled
-			var p = this.FindAscendant<Control>();
-			if (p is not null)
-			{
-				p.RegisterPropertyChangedCallback(Control.IsEnabledProperty, IsEnabledChange);
-			}
+			var control = this.FindAscendant<Control>();
+			control?.RegisterPropertyChangedCallback(IsEnabledProperty, IsEnabledChange);
+		}
+
+		private void OpacityIcon_Loaded(object sender, RoutedEventArgs e)
+		{
+			var control = this.FindAscendant<Control>();
+			if (control is not null && !control.IsEnabled)
+				VisualStateManager.GoToState(this, "Disabled", true);
 		}
 	}
 }

--- a/src/Files.App/UserControls/OpacityIcon.xaml.cs
+++ b/src/Files.App/UserControls/OpacityIcon.xaml.cs
@@ -28,7 +28,7 @@ namespace Files.App.UserControls
 		{
 			var control = this.FindAscendant<Control>();
 			if (control is not null && !control.IsEnabled)
-				VisualStateManager.GoToState(this, "Disabled", true);
+				VisualStateManager.GoToState(this, "Disabled", false);
 		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
The state of OpacityIcon is updated whenever its parent control's IsEnabled changes. But it is not initialized. It can therefore be active when its control is not.

This is the case when starting the application on the homepage. The Cut, Copy and Delete toolbar icons are shown as active while the button is inactive.

This pr updates the state of OpacityIcon when loaded. Fixes #11605.
This pr is not the same as #11539, which fixes the button. This pr fixes the icon.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility