### PR TITLE
Fix: Add forgotten null ref checks for image rotations on flyout menu

### DIFF
--- a/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
@@ -694,11 +694,11 @@ namespace Files.App.Helpers
 				},
 				new ContextMenuFlyoutItemViewModelBuilder(commands.RotateLeft)
 				{
-					IsVisible = selectedItemsPropertiesViewModel.IsSelectedItemImage
+					IsVisible = selectedItemsPropertiesViewModel?.IsSelectedItemImage ?? false
 				}.Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(commands.RotateRight)
 				{
-					IsVisible = selectedItemsPropertiesViewModel.IsSelectedItemImage
+					IsVisible = selectedItemsPropertiesViewModel?.IsSelectedItemImage ?? false
 				}.Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(commands.RunAsAdmin).Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(commands.RunAsAnotherUser).Build(),


### PR DESCRIPTION
**Resolved / Related Issues**
- Forgotten null refs checks would prevent the flyout menu to be correctly generated.

**Validation**
How did you test these changes?
- [x] Built and ran the app

