### PR TITLE
Alphabetical sorting of template files in the New menu.

### DIFF
--- a/src/Files.App/Shell/ShellNewMenuHelper.cs
+++ b/src/Files.App/Shell/ShellNewMenuHelper.cs
@@ -36,7 +36,7 @@ namespace Files.App.Shell
 			if (!newMenuItems.Any(x => ".txt".Equals(x.Extension, StringComparison.OrdinalIgnoreCase)))
 				newMenuItems.Add(await CreateShellNewEntry(".txt", null, null, null));
 
-			return newMenuItems;
+			return newMenuItems.OrderBy(item => item.Name).ToList();
 		}
 
 		public static async Task<ShellNewEntry> GetNewContextMenuEntryForType(string extension)


### PR DESCRIPTION
**Resolved / Related Issues**
In the New menu (toolbar or context menu), les items are not sorted. For example, different Office documents do not appear together. This pr sorts them alphabetically.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility