### PR TITLE
Use KeyDown instead of KeyboardAccelerator for command's hotkeys.

### DIFF
--- a/src/Files.App/Commands/HotKey.cs
+++ b/src/Files.App/Commands/HotKey.cs
@@ -32,6 +32,7 @@ namespace Files.App.Commands
 			[VirtualKey.NumberPad8] = "Pad8",
 			[VirtualKey.NumberPad9] = "Pad9",
 			[VirtualKey.Delete] = "Del",
+			[(VirtualKey)192] = "`",
 		}.ToImmutableDictionary();
 
 		public static HotKey None { get; } = new(VirtualKey.None, VirtualKeyModifiers.None);

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI.Helpers;
+using CommunityToolkit.WinUI.UI;
 using CommunityToolkit.WinUI.UI.Controls;
 using Files.App.Commands;
 using Files.App.DataModels;
@@ -22,7 +23,6 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -31,6 +31,7 @@ using Windows.ApplicationModel;
 using Windows.Graphics;
 using Windows.Services.Store;
 using Windows.Storage;
+using Windows.System;
 
 namespace Files.App.Views
 {
@@ -39,6 +40,8 @@ namespace Files.App.Views
 	/// </summary>
 	public sealed partial class MainPage : Page, INotifyPropertyChanged
 	{
+		private VirtualKeyModifiers currentModifiers = VirtualKeyModifiers.None;
+
 		public IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
 		public ICommandManager Commands { get; } = Ioc.Default.GetRequiredService<ICommandManager>();
 
@@ -218,6 +221,62 @@ namespace Files.App.Views
 			SidebarControl.SidebarItemNewPaneInvoked += SidebarControl_SidebarItemNewPaneInvoked;
 		}
 
+		protected override async void OnPreviewKeyDown(KeyRoutedEventArgs e)
+		{
+			base.OnPreviewKeyDown(e);
+
+			switch (e.Key)
+			{
+				case VirtualKey.Menu:
+					currentModifiers |= VirtualKeyModifiers.Menu;
+					break;
+				case VirtualKey.Control:
+					currentModifiers |= VirtualKeyModifiers.Control;
+					break;
+				case VirtualKey.Shift:
+					currentModifiers |= VirtualKeyModifiers.Shift;
+					break;
+				default:
+					// break for natives hotkeys in textbox (cut/copy/paste/selectAll/cancel)
+					bool isTextBox = e.OriginalSource is DependencyObject source && source.FindAscendantOrSelf<TextBox>() is not null;
+					if (isTextBox)
+					{
+						if (currentModifiers is VirtualKeyModifiers.Control &&
+							e.Key is VirtualKey.X or VirtualKey.C or VirtualKey.V or VirtualKey.A or VirtualKey.Z)
+						{
+							break;
+						}
+					}
+
+					// execute command for hotkey
+					var hotKey = new HotKey(e.Key, currentModifiers);
+					var command = Commands[hotKey];
+					if (command.Code is not CommandCodes.None)
+					{
+						e.Handled = true;
+						await command.ExecuteAsync();
+					}
+					break;
+			}
+		}
+		protected override void OnPreviewKeyUp(KeyRoutedEventArgs e)
+		{
+			base.OnPreviewKeyDown(e);
+
+			switch (e.Key)
+			{
+				case VirtualKey.Menu:
+					currentModifiers &= ~VirtualKeyModifiers.Menu;
+					break;
+				case VirtualKey.Control:
+					currentModifiers &= ~VirtualKeyModifiers.Control;
+					break;
+				case VirtualKey.Shift:
+					currentModifiers &= ~VirtualKeyModifiers.Shift;
+					break;
+			}
+		}
+
 		private async void SidebarControl_SidebarItemDropped(object sender, SidebarItemDroppedEventArgs e)
 		{
 			await SidebarAdaptiveViewModel.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.Package, e.ItemPath, false, true);
@@ -319,11 +378,6 @@ namespace Files.App.Views
 			FindName(nameof(InnerNavigationToolbar));
 			FindName(nameof(TabControl));
 			FindName(nameof(NavToolbar));
-
-			var commands = Commands.Where(command => !command.CustomHotKey.IsNone);
-			foreach (var command in commands)
-				KeyboardAccelerators.Add(new CommandAccelerator(command));
-			Commands.HotKeyChanged += Commands_HotKeyChanged;
 
 			if (Package.Current.Id.Name != "49306atecsolution.FilesUWP" || UserSettingsService.ApplicationSettingsService.ClickedToReviewApp)
 				return;
@@ -513,51 +567,5 @@ namespace Files.App.Views
 		}
 
 		private void NavToolbar_Loaded(object sender, RoutedEventArgs e) => UpdateNavToolbarProperties();
-
-		private void Commands_HotKeyChanged(object? sender, HotKeyChangedEventArgs e)
-		{
-			if (!e.OldHotKey.IsNone)
-			{
-				var oldAccelerator = KeyboardAccelerators.FirstOrDefault(IsOldHotKey);
-				if (oldAccelerator is CommandAccelerator commandAccelerator)
-				{
-					commandAccelerator.Dispose();
-					KeyboardAccelerators.Remove(commandAccelerator);
-				}
-			}
-
-			if (!e.NewHotKey.IsNone)
-			{
-				var newAccelerator = new CommandAccelerator(e.Command);
-				KeyboardAccelerators.Add(newAccelerator);
-			}
-
-			bool IsOldHotKey(KeyboardAccelerator accelerator)
-				=> accelerator is CommandAccelerator commandAccelerator
-				&& accelerator.Key == e.OldHotKey.Key
-				&& accelerator.Modifiers == e.OldHotKey.Modifiers;
-		}
-
-		private class CommandAccelerator : KeyboardAccelerator, IDisposable
-		{
-			public IRichCommand Command { get; }
-
-			public CommandAccelerator(IRichCommand command)
-			{
-				Command = command;
-
-				Key = Command.CustomHotKey.Key;
-				Modifiers = Command.CustomHotKey.Modifiers;
-				Invoked += CommandAccelerator_Invoked;
-			}
-
-			public void Dispose() => Invoked -= CommandAccelerator_Invoked;
-
-			private async void CommandAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs e)
-			{
-				e.Handled = true;
-				await Command.ExecuteAsync();
-			}
-		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
This method allows more keys to be used for keyboard shortcuts. Native textbox hotkeys are ignored.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility