### PR TITLE
Commands Cut/Copy/Paste, Yes again.

### DIFF
--- a/src/Files.App/Actions/FileSystem/CopyItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/CopyItemAction.cs
@@ -20,10 +20,13 @@ namespace Files.App.Actions
 
 		public HotKey HotKey { get; } = new(VirtualKey.C, VirtualKeyModifiers.Control);
 
-		public bool IsExecutable => context.HasSelection;
+		private bool isExecutable;
+		public bool IsExecutable => isExecutable;
 
 		public CopyItemAction()
 		{
+			isExecutable = GetIsExecutable();
+
 			context.PropertyChanged += Context_PropertyChanged;
 		}
 
@@ -33,10 +36,17 @@ namespace Files.App.Actions
 				await UIFilesystemHelpers.CopyItem(context.ShellPage);
 		}
 
-		public void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		private bool GetIsExecutable() => context.PageType is not ContentPageTypes.RecycleBin && context.HasSelection;
+
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName is nameof(IContentPageContext.HasSelection))
-				OnPropertyChanged(nameof(IsExecutable));
+			switch (e.PropertyName)
+			{
+				case nameof(IContentPageContext.PageType):
+				case nameof(IContentPageContext.HasSelection):
+					SetProperty(ref isExecutable, GetIsExecutable(), nameof(IsExecutable));
+					break;
+			}
 		}
 	}
 }

--- a/src/Files.App/Actions/FileSystem/CopyItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/CopyItemAction.cs
@@ -20,13 +20,10 @@ namespace Files.App.Actions
 
 		public HotKey HotKey { get; } = new(VirtualKey.C, VirtualKeyModifiers.Control);
 
-		private bool isExecutable;
-		public bool IsExecutable => isExecutable;
+		public bool IsExecutable => context.HasSelection;
 
 		public CopyItemAction()
 		{
-			isExecutable = GetIsExecutable();
-
 			context.PropertyChanged += Context_PropertyChanged;
 		}
 
@@ -36,17 +33,10 @@ namespace Files.App.Actions
 				await UIFilesystemHelpers.CopyItem(context.ShellPage);
 		}
 
-		private bool GetIsExecutable() => context.PageType is not ContentPageTypes.RecycleBin && context.HasSelection;
-
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			switch (e.PropertyName)
-			{
-				case nameof(IContentPageContext.PageType):
-				case nameof(IContentPageContext.HasSelection):
-					SetProperty(ref isExecutable, GetIsExecutable(), nameof(IsExecutable));
-					break;
-			}
+			if (e.PropertyName is nameof(IContentPageContext.HasSelection))
+				OnPropertyChanged(nameof(IsExecutable));
 		}
 	}
 }

--- a/src/Files.App/Actions/FileSystem/CreateFolderAction.cs
+++ b/src/Files.App/Actions/FileSystem/CreateFolderAction.cs
@@ -32,7 +32,7 @@ namespace Files.App.Actions
 			return Task.CompletedTask;
 		}
 
-		public void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName is nameof(IContentPageContext.HasSelection))
 				OnPropertyChanged(nameof(IsExecutable));

--- a/src/Files.App/Actions/FileSystem/CreateShortcutAction.cs
+++ b/src/Files.App/Actions/FileSystem/CreateShortcutAction.cs
@@ -45,7 +45,7 @@ namespace Files.App.Actions
 			}
 		}
 
-		public void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName is nameof(IContentPageContext.HasSelection))
 				OnPropertyChanged(nameof(IsExecutable));

--- a/src/Files.App/Actions/FileSystem/CreateShortcutFromDialogAction.cs
+++ b/src/Files.App/Actions/FileSystem/CreateShortcutFromDialogAction.cs
@@ -30,7 +30,7 @@ namespace Files.App.Actions
 				await UIFilesystemHelpers.CreateShortcutFromDialogAsync(context.ShellPage);
 		}
 
-		public void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName is nameof(IContentPageContext.HasSelection))
 				OnPropertyChanged(nameof(IsExecutable));

--- a/src/Files.App/Actions/FileSystem/CutItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/CutItemAction.cs
@@ -14,16 +14,19 @@ namespace Files.App.Actions
 	{
 		private readonly IContentPageContext context = Ioc.Default.GetRequiredService<IContentPageContext>();
 
-		public string Label { get; } = "BaseLayoutItemContextFlyoutCut/Text".GetLocalizedResource();
+		public string Label { get; } = "Cut".GetLocalizedResource();
 
 		public RichGlyph Glyph { get; } = new RichGlyph(opacityStyle: "ColorIconCut");
 
 		public HotKey HotKey { get; } = new(VirtualKey.X, VirtualKeyModifiers.Control);
 
-		public bool IsExecutable => context.HasSelection;
+		private bool isExecutable;
+		public bool IsExecutable => isExecutable;
 
 		public CutItemAction()
 		{
+			isExecutable = GetIsExecutable();
+
 			context.PropertyChanged += Context_PropertyChanged;
 		}
 
@@ -34,10 +37,17 @@ namespace Files.App.Actions
 			return Task.CompletedTask;
 		}
 
-		public void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		private bool GetIsExecutable() => context.PageType is not ContentPageTypes.RecycleBin && context.HasSelection;
+
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName is nameof(IContentPageContext.HasSelection))
-				OnPropertyChanged(nameof(IsExecutable));
+			switch (e.PropertyName)
+			{
+				case nameof(IContentPageContext.PageType):
+				case nameof(IContentPageContext.HasSelection):
+					SetProperty(ref isExecutable, GetIsExecutable(), nameof(IsExecutable));
+					break;
+			}
 		}
 	}
 }

--- a/src/Files.App/Actions/FileSystem/CutItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/CutItemAction.cs
@@ -20,13 +20,10 @@ namespace Files.App.Actions
 
 		public HotKey HotKey { get; } = new(VirtualKey.X, VirtualKeyModifiers.Control);
 
-		private bool isExecutable;
-		public bool IsExecutable => isExecutable;
+		public bool IsExecutable => context.HasSelection;
 
 		public CutItemAction()
 		{
-			isExecutable = GetIsExecutable();
-
 			context.PropertyChanged += Context_PropertyChanged;
 		}
 
@@ -37,17 +34,10 @@ namespace Files.App.Actions
 			return Task.CompletedTask;
 		}
 
-		private bool GetIsExecutable() => context.PageType is not ContentPageTypes.RecycleBin && context.HasSelection;
-
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			switch (e.PropertyName)
-			{
-				case nameof(IContentPageContext.PageType):
-				case nameof(IContentPageContext.HasSelection):
-					SetProperty(ref isExecutable, GetIsExecutable(), nameof(IsExecutable));
-					break;
-			}
+			if (e.PropertyName is nameof(IContentPageContext.HasSelection))
+				OnPropertyChanged(nameof(IsExecutable));
 		}
 	}
 }

--- a/src/Files.App/Actions/FileSystem/DeleteItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/DeleteItemAction.cs
@@ -44,7 +44,7 @@ namespace Files.App.Actions
 			await context.ShellPage.FilesystemViewModel.ApplyFilesAndFoldersChangesAsync();
 		}
 
-		public void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName is nameof(IContentPageContext.HasSelection))
 				OnPropertyChanged(nameof(IsExecutable));

--- a/src/Files.App/Actions/FileSystem/PasteItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/PasteItemAction.cs
@@ -1,0 +1,77 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.App.Commands;
+using Files.App.Contexts;
+using Files.App.DataModels;
+using Files.App.Extensions;
+using Files.App.Helpers;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.System;
+
+namespace Files.App.Actions
+{
+	internal class PasteItemAction : ObservableObject, IAction
+	{
+		private readonly IContentPageContext context = Ioc.Default.GetRequiredService<IContentPageContext>();
+
+		public string Label { get; } = "Paste".GetLocalizedResource();
+
+		public RichGlyph Glyph { get; } = new RichGlyph(opacityStyle: "ColorIconPaste");
+
+		public HotKey HotKey { get; } = new(VirtualKey.V, VirtualKeyModifiers.Control);
+
+		private bool isExecutable;
+		public bool IsExecutable => isExecutable;
+
+		public PasteItemAction()
+		{
+			isExecutable = GetIsExecutable();
+
+			context.PropertyChanged += Context_PropertyChanged;
+			App.AppModel.PropertyChanged += AppModel_PropertyChanged;
+		}
+
+		public async Task ExecuteAsync()
+		{
+			if (context.ShellPage is null)
+				return;
+
+			string path = context.SelectedItem is not null
+				? context.SelectedItem.ItemPath
+				: context.ShellPage.FilesystemViewModel.WorkingDirectory;
+
+			await UIFilesystemHelpers.PasteItemAsync(path, context.ShellPage);
+		}
+
+		public bool GetIsExecutable()
+		{
+			if (!App.AppModel.IsPasteEnabled)
+				return false;
+			if (context.PageType is ContentPageTypes.Home or ContentPageTypes.RecycleBin or ContentPageTypes.SearchResults)
+				return false;
+			if (context.SelectedItems.Count > 1)
+				return false;
+			if (context.SelectedItem is not null && context.SelectedItem.PrimaryItemAttribute is not StorageItemTypes.Folder)
+				return false;
+			return true;
+		}
+
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			switch (e.PropertyName)
+			{
+				case nameof(IContentPageContext.PageType):
+				case nameof(IContentPageContext.SelectedItems):
+					SetProperty(ref isExecutable, GetIsExecutable(), nameof(IsExecutable));
+					break;
+			}
+		}
+		private void AppModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName is nameof(AppModel.IsPasteEnabled))
+				SetProperty(ref isExecutable, GetIsExecutable(), nameof(IsExecutable));
+		}
+	}
+}

--- a/src/Files.App/Commands/CommandCodes.cs
+++ b/src/Files.App/Commands/CommandCodes.cs
@@ -16,6 +16,7 @@
 		// File System
 		CopyItem,
 		CutItem,
+		PasteItem,
 		DeleteItem,
 		CreateFolder,
 		CreateShortcut,

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -56,6 +56,7 @@ namespace Files.App.Commands
 		public IRichCommand SetAsLockscreenBackground => commands[CommandCodes.SetAsLockscreenBackground];
 		public IRichCommand CopyItem => commands[CommandCodes.CopyItem];
 		public IRichCommand CutItem => commands[CommandCodes.CutItem];
+		public IRichCommand PasteItem => commands[CommandCodes.PasteItem];
 		public IRichCommand DeleteItem => commands[CommandCodes.DeleteItem];
 		public IRichCommand RunAsAdmin => commands[CommandCodes.RunAsAdmin];
 		public IRichCommand RunAsAnotherUser => commands[CommandCodes.RunAsAnotherUser];
@@ -107,6 +108,7 @@ namespace Files.App.Commands
 			[CommandCodes.SetAsLockscreenBackground] = new SetAsLockscreenBackgroundAction(),
 			[CommandCodes.CopyItem] = new CopyItemAction(),
 			[CommandCodes.CutItem] = new CutItemAction(),
+			[CommandCodes.PasteItem] = new PasteItemAction(),
 			[CommandCodes.DeleteItem] = new DeleteItemAction(),
 			[CommandCodes.RunAsAdmin] = new RunAsAdminAction(),
 			[CommandCodes.RunAsAnotherUser] = new RunAsAnotherUserAction(),

--- a/src/Files.App/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Commands/Manager/ICommandManager.cs
@@ -21,6 +21,7 @@ namespace Files.App.Commands
 
 		IRichCommand CopyItem { get; }
 		IRichCommand CutItem { get; }
+		IRichCommand PasteItem { get; }
 		IRichCommand DeleteItem { get; }
 		IRichCommand MultiSelect { get; }
 		IRichCommand SelectAll { get; }

--- a/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
@@ -721,7 +721,7 @@ namespace Files.App.Helpers
 				new ContextMenuFlyoutItemViewModelBuilder(commands.PasteItem)
 				{
 					IsPrimary = true,
-					IsVisible = !currentInstanceViewModel.IsPageTypeRecycleBin,
+					IsVisible = true,
 				}.Build(),
 				new ContextMenuFlyoutItemViewModel()
 				{

--- a/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
@@ -712,13 +712,16 @@ namespace Files.App.Helpers
 				},
 				new ContextMenuFlyoutItemViewModelBuilder(commands.CutItem)
 				{
-					IsVisible = itemsSelected,
 					IsPrimary = true,
 				}.Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(commands.CopyItem)
 				{
-					IsVisible = itemsSelected,
 					IsPrimary = true,
+				}.Build(),
+				new ContextMenuFlyoutItemViewModelBuilder(commands.PasteItem)
+				{
+					IsPrimary = true,
+					IsVisible = !currentInstanceViewModel.IsPageTypeRecycleBin,
 				}.Build(),
 				new ContextMenuFlyoutItemViewModel()
 				{
@@ -733,28 +736,6 @@ namespace Files.App.Helpers
 					ShowInFtpPage = true,
 					ShowInZipPage = true,
 					ShowItem = itemsSelected
-				},
-				new ContextMenuFlyoutItemViewModel()
-				{
-					Text = "Paste".GetLocalizedResource(),
-					IsPrimary = true,
-					OpacityIcon = new OpacityIconModel()
-					{
-						OpacityIconStyle = "ColorIconPaste",
-					},
-					Command = commandsViewModel.PasteItemsFromClipboardCommand,
-					ShowItem = areAllItemsFolders || !itemsSelected,
-					SingleItemOnly = true,
-					ShowInSearchPage = true,
-					ShowInFtpPage = true,
-					ShowInZipPage = true,
-					IsEnabled = App.AppModel.IsPasteEnabled,
-					KeyboardAccelerator = new KeyboardAccelerator
-					{
-						Key = VirtualKey.V,
-						Modifiers = VirtualKeyModifiers.Control,
-						IsEnabled = false,
-					},
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{

--- a/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -188,14 +188,6 @@ namespace Files.App.Interacts
 			UIFilesystemHelpers.CreateFileFromDialogResultType(AddItemDialogItemType.File, f, associatedInstance);
 		}
 
-		public virtual async void PasteItemsFromClipboard(RoutedEventArgs e)
-		{
-			if (SlimContentPage.SelectedItems.Count == 1 && SlimContentPage.SelectedItems.Single().PrimaryItemAttribute == StorageItemTypes.Folder)
-				await UIFilesystemHelpers.PasteItemAsync(SlimContentPage.SelectedItems.Single().ItemPath, associatedInstance);
-			else
-				await UIFilesystemHelpers.PasteItemAsync(associatedInstance.FilesystemViewModel.WorkingDirectory, associatedInstance);
-		}
-
 		public virtual void CopyPathOfSelectedItem(RoutedEventArgs e)
 		{
 			try

--- a/src/Files.App/Interacts/BaseLayoutCommandsViewModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandsViewModel.cs
@@ -37,7 +37,6 @@ namespace Files.App.Interacts
 			OpenDirectoryInNewPaneCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.OpenDirectoryInNewPane);
 			OpenInNewWindowItemCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.OpenInNewWindowItem);
 			CreateNewFileCommand = new RelayCommand<ShellNewEntry>(CommandsModel.CreateNewFile);
-			PasteItemsFromClipboardCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.PasteItemsFromClipboard);
 			CopyPathOfSelectedItemCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.CopyPathOfSelectedItem);
 			ShareItemCommand = new RelayCommand<RoutedEventArgs>(CommandsModel.ShareItem);
 			ItemPointerPressedCommand = new RelayCommand<PointerRoutedEventArgs>(CommandsModel.ItemPointerPressed);
@@ -81,8 +80,6 @@ namespace Files.App.Interacts
 		public ICommand OpenInNewWindowItemCommand { get; private set; }
 
 		public ICommand CreateNewFileCommand { get; private set; }
-
-		public ICommand PasteItemsFromClipboardCommand { get; private set; }
 
 		public ICommand CopyPathOfSelectedItemCommand { get; private set; }
 

--- a/src/Files.App/Interacts/IBaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/IBaseLayoutCommandImplementationModel.cs
@@ -29,8 +29,6 @@ namespace Files.App.Interacts
 
 		void CreateNewFile(ShellNewEntry e);
 
-		void PasteItemsFromClipboard(RoutedEventArgs e);
-
 		void CopyPathOfSelectedItem(RoutedEventArgs e);
 
 		void ShareItem(RoutedEventArgs e);

--- a/src/Files.App/UserControls/AddressToolbar.xaml.cs
+++ b/src/Files.App/UserControls/AddressToolbar.xaml.cs
@@ -52,14 +52,6 @@ namespace Files.App.UserControls
 			set => SetValue(SettingsButtonCommandProperty, value);
 		}
 
-		public static readonly DependencyProperty CanPasteInPageProperty =
-			DependencyProperty.Register("CanPasteInPage", typeof(bool), typeof(AddressToolbar), new PropertyMetadata(null));
-		public bool CanPasteInPage
-		{
-			get => (bool)GetValue(dp: CanPasteInPageProperty);
-			set => SetValue(CanPasteInPageProperty, value);
-		}
-
 		// Using a DependencyProperty as the backing store for ViewModel.  This enables animation, styling, binding, etc...
 		public static readonly DependencyProperty ViewModelProperty =
 			DependencyProperty.Register(nameof(ViewModel), typeof(ToolbarViewModel), typeof(AddressToolbar), new PropertyMetadata(null));

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -127,21 +127,13 @@
 					x:Name="PasteButton"
 					Width="Auto"
 					MinWidth="40"
-					AccessKey="P"
-					AutomationProperties.AutomationId="InnerNavigationToolbarPasteButton"
-					Command="{x:Bind ViewModel.PasteItemsFromClipboardCommand, Mode=OneWay}"
-					IsEnabled="{x:Bind converters:MultiBooleanConverter.AndConvert(ViewModel.InstanceViewModel.CanPasteInPage, local1:App.AppModel.IsPasteEnabled), Mode=OneWay, FallbackValue=False}"
-					Label="{helpers:ResourceString Name=Paste}"
+					AccessKey="V"
+					AutomationProperties.AutomationId="{x:Bind Commands.PasteItem.AutomationName}"
+					Command="{x:Bind Commands.PasteItem}"
+					Label="{x:Bind Commands.PasteItem.Label}"
 					LabelPosition="Collapsed"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=Paste}">
-					<AppBarButton.KeyboardAccelerators>
-						<KeyboardAccelerator
-							Key="V"
-							IsEnabled="False"
-							Modifiers="Control" />
-					</AppBarButton.KeyboardAccelerators>
-
-					<local:OpacityIcon Style="{StaticResource ColorIconPaste}" />
+					ToolTipService.ToolTip="{x:Bind Commands.PasteItem.LabelWithHotKey, Mode=OneWay}">
+					<local:OpacityIcon Style="{x:Bind Commands.PasteItem.OpacityStyle}" />
 				</AppBarButton>
 				<AppBarButton
 					x:Name="RenameButton"

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -105,7 +105,7 @@
 					Width="Auto"
 					MinWidth="40"
 					AccessKey="X"
-					AutomationProperties.AutomationId="InnerNavigationToolbarCutButton"
+					AutomationProperties.AutomationId="{x:Bind Commands.CutItem.AutomationName}"
 					Command="{x:Bind Commands.CutItem}"
 					Label="{x:Bind Commands.CutItem.Label}"
 					LabelPosition="Collapsed"
@@ -116,9 +116,9 @@
 					Width="Auto"
 					MinWidth="40"
 					AccessKey="C"
-					AutomationProperties.AutomationId="InnerNavigationToolbarCopyButton"
-					Command="{x:Bind Commands.CopyItem, Mode=OneWay}"
-					Label="{x:Bind Commands.CopyItem}"
+					AutomationProperties.AutomationId="{x:Bind Commands.CopyItem.AutomationName}"
+					Command="{x:Bind Commands.CopyItem}"
+					Label="{x:Bind Commands.CopyItem.Label}"
 					LabelPosition="Collapsed"
 					ToolTipService.ToolTip="{x:Bind Commands.CopyItem.LabelWithHotKey, Mode=OneWay}">
 					<local:OpacityIcon Style="{x:Bind Commands.CopyItem.OpacityStyle}" />

--- a/src/Files.App/ViewModels/CurrentInstanceViewModel.cs
+++ b/src/Files.App/ViewModels/CurrentInstanceViewModel.cs
@@ -31,7 +31,6 @@ namespace Files.App.ViewModels
 				SetProperty(ref isPageTypeSearchResults, value);
 				OnPropertyChanged(nameof(IsCreateButtonEnabledInPage));
 				OnPropertyChanged(nameof(CanCreateFileInPage));
-				OnPropertyChanged(nameof(CanPasteInPage));
 				OnPropertyChanged(nameof(CanCopyPathInPage));
 				OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
 				OnPropertyChanged(nameof(CanShareInPage));
@@ -73,7 +72,6 @@ namespace Files.App.ViewModels
 				SetProperty(ref isPageTypeNotHome, value);
 				OnPropertyChanged(nameof(IsCreateButtonEnabledInPage));
 				OnPropertyChanged(nameof(CanCreateFileInPage));
-				OnPropertyChanged(nameof(CanPasteInPage));
 				OnPropertyChanged(nameof(CanCopyPathInPage));
 				OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
 				OnPropertyChanged(nameof(CanShareInPage));
@@ -90,7 +88,6 @@ namespace Files.App.ViewModels
 				SetProperty(ref isPageTypeMtpDevice, value);
 				OnPropertyChanged(nameof(IsCreateButtonEnabledInPage));
 				OnPropertyChanged(nameof(CanCreateFileInPage));
-				OnPropertyChanged(nameof(CanPasteInPage));
 				OnPropertyChanged(nameof(CanCopyPathInPage));
 				OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
 				OnPropertyChanged(nameof(CanShareInPage));
@@ -107,7 +104,6 @@ namespace Files.App.ViewModels
 				SetProperty(ref isPageTypeRecycleBin, value);
 				OnPropertyChanged(nameof(IsCreateButtonEnabledInPage));
 				OnPropertyChanged(nameof(CanCreateFileInPage));
-				OnPropertyChanged(nameof(CanPasteInPage));
 				OnPropertyChanged(nameof(CanCopyPathInPage));
 				OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
 				OnPropertyChanged(nameof(CanShareInPage));
@@ -124,7 +120,6 @@ namespace Files.App.ViewModels
 				SetProperty(ref isPageTypeFtp, value);
 				OnPropertyChanged(nameof(IsCreateButtonEnabledInPage));
 				OnPropertyChanged(nameof(CanCreateFileInPage));
-				OnPropertyChanged(nameof(CanPasteInPage));
 				OnPropertyChanged(nameof(CanCopyPathInPage));
 				OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
 				OnPropertyChanged(nameof(CanShareInPage));
@@ -141,7 +136,6 @@ namespace Files.App.ViewModels
 				SetProperty(ref isPageTypeCloudDrive, value);
 				OnPropertyChanged(nameof(IsCreateButtonEnabledInPage));
 				OnPropertyChanged(nameof(CanCreateFileInPage));
-				OnPropertyChanged(nameof(CanPasteInPage));
 				OnPropertyChanged(nameof(CanCopyPathInPage));
 				OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
 				OnPropertyChanged(nameof(CanShareInPage));
@@ -158,7 +152,6 @@ namespace Files.App.ViewModels
 				SetProperty(ref isPageTypeZipFolder, value);
 				OnPropertyChanged(nameof(IsCreateButtonEnabledInPage));
 				OnPropertyChanged(nameof(CanCreateFileInPage));
-				OnPropertyChanged(nameof(CanPasteInPage));
 				OnPropertyChanged(nameof(CanCopyPathInPage));
 				OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
 				OnPropertyChanged(nameof(CanShareInPage));
@@ -175,7 +168,6 @@ namespace Files.App.ViewModels
 				SetProperty(ref isPageTypeLibrary, value);
 				OnPropertyChanged(nameof(IsCreateButtonEnabledInPage));
 				OnPropertyChanged(nameof(CanCreateFileInPage));
-				OnPropertyChanged(nameof(CanPasteInPage));
 				OnPropertyChanged(nameof(CanCopyPathInPage));
 				OnPropertyChanged(nameof(ShowSearchUnindexedItemsMessage));
 				OnPropertyChanged(nameof(CanShareInPage));
@@ -196,11 +188,6 @@ namespace Files.App.ViewModels
 		public bool CanCreateFileInPage
 		{
 			get => !isPageTypeMtpDevice && !isPageTypeRecycleBin && isPageTypeNotHome && !isPageTypeSearchResults && !isPageTypeFtp && !isPageTypeZipFolder;
-		}
-
-		public bool CanPasteInPage
-		{
-			get => !isPageTypeRecycleBin && isPageTypeNotHome && !isPageTypeSearchResults;
 		}
 
 		public bool CanShareInPage


### PR DESCRIPTION
**Resolved / Related Issues**
* New rich command PasteItem.
* Fix visibility of private methods.
* The Paste command is inconsistent. In the context menu, the selection must be empty or a single folder of type element. In the toolbar, if there are several elements selected, we copy to the parent folder. Now Paste is always disabled if the selection is more than one item or the item is not a folder.
* The Paste AccessKey is now V instead P. This corresponds to Cut(X) and Copy(C). This adds the accessKey P to the PreviewPane if need.
* Use commands Cut/Copy/Paste in the context menu.
* Paste is always visible in the context menu, It's more intuitive. It was visible in search results (useless) but not in RecycleBin. It was visible in search results (useless) but not in trash. Now Cut/Copy/Paste go together with less chance of getting it wrong.
* Fix the new text Cut.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility