### PR TITLE
Fix: Fixed null error in RotateLeft/Right

### DIFF
--- a/src/Files.App/Actions/Content/ImageEdition/RotateLeftAction.cs
+++ b/src/Files.App/Actions/Content/ImageEdition/RotateLeftAction.cs
@@ -4,7 +4,6 @@ using Files.App.Commands;
 using Files.App.Contexts;
 using Files.App.Extensions;
 using Files.App.Helpers;
-using Files.App.ViewModels;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -20,7 +19,7 @@ namespace Files.App.Actions.Content.ImageEdition
 
 		public RichGlyph Glyph { get; } = new RichGlyph(opacityStyle: "ColorIconRotateLeft");
 
-		public bool IsExecutable => context.ShellPage.SlimContentPage.SelectedItemsPropertiesViewModel.IsSelectedItemImage;
+		public bool IsExecutable => context.ShellPage?.SlimContentPage?.SelectedItemsPropertiesViewModel?.IsSelectedItemImage ?? false;
 
 		public RotateLeftAction()
 		{
@@ -32,15 +31,22 @@ namespace Files.App.Actions.Content.ImageEdition
 			foreach (var image in context.SelectedItems)
 				await BitmapHelper.Rotate(PathNormalization.NormalizePath(image.ItemPath), BitmapRotation.Clockwise270Degrees);
 
-			context.ShellPage.SlimContentPage.ItemManipulationModel.RefreshItemsThumbnail();
+			context.ShellPage?.SlimContentPage?.ItemManipulationModel?.RefreshItemsThumbnail();
 			App.PreviewPaneViewModel.UpdateSelectedItemPreview();
 		}
 
-		public void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName is nameof(IContentPageContext.HasSelection))
 			{
-				context.ShellPage.SlimContentPage.SelectedItemsPropertiesViewModel.CheckAllFileExtensions(context.SelectedItems.Select(selectedItem => selectedItem?.FileExtension).ToList<string>());
+				if (context.ShellPage is not null)
+				{
+					var viewModel = context.ShellPage.SlimContentPage.SelectedItemsPropertiesViewModel;
+					var extensions = context.SelectedItems.Select(selectedItem => selectedItem.FileExtension).Distinct().ToList();
+
+					viewModel.CheckAllFileExtensions(extensions);
+				}
+
 				OnPropertyChanged(nameof(IsExecutable));
 			}
 		}

--- a/src/Files.App/Actions/Content/ImageEdition/RotateRightAction.cs
+++ b/src/Files.App/Actions/Content/ImageEdition/RotateRightAction.cs
@@ -19,7 +19,7 @@ namespace Files.App.Actions.Content.ImageEdition
 
 		public RichGlyph Glyph { get; } = new RichGlyph(opacityStyle: "ColorIconRotateRight");
 
-		public bool IsExecutable => context.ShellPage.SlimContentPage.SelectedItemsPropertiesViewModel.IsSelectedItemImage;
+		public bool IsExecutable => context.ShellPage?.SlimContentPage?.SelectedItemsPropertiesViewModel?.IsSelectedItemImage ?? false;
 
 		public RotateRightAction()
 		{
@@ -31,15 +31,22 @@ namespace Files.App.Actions.Content.ImageEdition
 			foreach (var image in context.SelectedItems)
 				await BitmapHelper.Rotate(PathNormalization.NormalizePath(image.ItemPath), BitmapRotation.Clockwise90Degrees);
 
-			context.ShellPage.SlimContentPage.ItemManipulationModel.RefreshItemsThumbnail();
+			context.ShellPage?.SlimContentPage?.ItemManipulationModel?.RefreshItemsThumbnail();
 			App.PreviewPaneViewModel.UpdateSelectedItemPreview();
 		}
 
-		public void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName is nameof(IContentPageContext.HasSelection))
 			{
-				context.ShellPage.SlimContentPage.SelectedItemsPropertiesViewModel.CheckAllFileExtensions(context.SelectedItems.Select(selectedItem => selectedItem?.FileExtension).ToList<string>());
+				if (context.ShellPage is not null)
+				{
+					var viewModel = context.ShellPage.SlimContentPage.SelectedItemsPropertiesViewModel;
+					var extensions = context.SelectedItems.Select(selectedItem => selectedItem.FileExtension).Distinct().ToList();
+
+					viewModel.CheckAllFileExtensions(extensions);
+				}
+
 				OnPropertyChanged(nameof(IsExecutable));
 			}
 		}


### PR DESCRIPTION
**Resolved / Related Issues**
I had exceptions in these classes to use ShellPage when it is null. Here is a fix.
I improved readability and used distinct to avoid dealing with the same extension multiple times.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility