### PR TITLE
RichCommand: Added support for multiple hot keys

### DIFF
--- a/src/Files.App/Actions/IAction.cs
+++ b/src/Files.App/Actions/IAction.cs
@@ -10,6 +10,8 @@ namespace Files.App.Actions
 		RichGlyph Glyph => RichGlyph.None;
 
 		HotKey HotKey => HotKey.None;
+		HotKey SecondHotKey => HotKey.None;
+		HotKey MediaHotKey => HotKey.None;
 
 		bool IsExecutable => true;
 

--- a/src/Files.App/Actions/IAction.cs
+++ b/src/Files.App/Actions/IAction.cs
@@ -11,6 +11,7 @@ namespace Files.App.Actions
 
 		HotKey HotKey => HotKey.None;
 		HotKey SecondHotKey => HotKey.None;
+		HotKey ThirdHotKey => HotKey.None;
 		HotKey MediaHotKey => HotKey.None;
 
 		bool IsExecutable => true;

--- a/src/Files.App/Commands/IRichCommand.cs
+++ b/src/Files.App/Commands/IRichCommand.cs
@@ -1,5 +1,4 @@
-﻿using Files.App.UserControls;
-using Microsoft.UI.Xaml;
+﻿using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using System.ComponentModel;
@@ -21,9 +20,10 @@ namespace Files.App.Commands
 		FontIcon? FontIcon { get; }
 		Style? OpacityStyle { get; }
 
-		HotKey DefaultHotKey { get; }
-		HotKey CustomHotKey { get; set; }
 		string? HotKeyText { get; }
+		HotKey HotKey { get; }
+		HotKey SecondHotKey { get; }
+		HotKey MediaHotKey { get; }
 
 		bool IsToggle { get; }
 		bool IsOn { get; set; }

--- a/src/Files.App/Commands/IRichCommand.cs
+++ b/src/Files.App/Commands/IRichCommand.cs
@@ -23,6 +23,7 @@ namespace Files.App.Commands
 		string? HotKeyText { get; }
 		HotKey HotKey { get; }
 		HotKey SecondHotKey { get; }
+		HotKey ThirdHotKey { get; }
 		HotKey MediaHotKey { get; }
 
 		bool IsToggle { get; }

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -77,6 +77,8 @@ namespace Files.App.Commands
 					hotKeys.Add(command.HotKey, command);
 				if (!command.SecondHotKey.IsNone)
 					hotKeys.Add(command.SecondHotKey, command);
+				if (!command.ThirdHotKey.IsNone)
+					hotKeys.Add(command.ThirdHotKey, command);
 				if (!command.MediaHotKey.IsNone)
 					hotKeys.Add(command.MediaHotKey, command);
 			}
@@ -143,6 +145,7 @@ namespace Files.App.Commands
 			public string? HotKeyText => null;
 			public HotKey HotKey => HotKey.None;
 			public HotKey SecondHotKey => HotKey.None;
+			public HotKey ThirdHotKey => HotKey.None;
 			public HotKey MediaHotKey => HotKey.None;
 
 			public bool IsToggle => false;
@@ -179,6 +182,7 @@ namespace Files.App.Commands
 			public string? HotKeyText { get; }
 			public HotKey HotKey => action.HotKey;
 			public HotKey SecondHotKey => action.SecondHotKey;
+			public HotKey ThirdHotKey => action.ThirdHotKey;
 			public HotKey MediaHotKey => action.MediaHotKey;
 
 			public bool IsToggle => action is IToggleAction;
@@ -262,13 +266,12 @@ namespace Files.App.Commands
 
 			private string? GetHotKeyText()
 			{
-				if (action.HotKey.IsNone && action.SecondHotKey.IsNone)
-					return null;
-				if (action.SecondHotKey.IsNone)
-					return action.HotKey.ToString();
-				if (action.HotKey.IsNone)
-					return action.SecondHotKey.ToString();
-				return $"{action.HotKey},{action.SecondHotKey}";
+				string text = string.Join(',',
+					new List<HotKey> { HotKey, SecondHotKey, ThirdHotKey }
+					.Where(hotKey => !hotKey.IsNone)
+					.Select(HotKey => HotKey.ToString())
+				);
+				return text.Length > 0 ? text : null;
 			}
 		}
 	}

--- a/src/Files.App/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Commands/Manager/ICommandManager.cs
@@ -5,8 +5,6 @@ namespace Files.App.Commands
 {
 	public interface ICommandManager : IEnumerable<IRichCommand>
 	{
-		event EventHandler<HotKeyChangedEventArgs>? HotKeyChanged;
-
 		IRichCommand this[CommandCodes code] { get; }
 		IRichCommand this[HotKey customHotKey] { get; }
 

--- a/src/Files.App/ViewModels/ContextMenuFlyoutItemViewModelBuilder.cs
+++ b/src/Files.App/ViewModels/ContextMenuFlyoutItemViewModelBuilder.cs
@@ -67,8 +67,8 @@ namespace Files.App.ViewModels
 				viewModel.GlyphFontFamilyName = glyph.FontFamily;
 			}
 
-			if (!command.CustomHotKey.IsNone)
-				viewModel.KeyboardAcceleratorTextOverride = command.HotKeyText!;
+			if (command.HotKeyText is not null)
+				viewModel.KeyboardAcceleratorTextOverride = command.HotKeyText;
 
 			return viewModel;
 		}


### PR DESCRIPTION
**Resolved / Related Issues**
This pr allows to use several hotkeys for the same action. Added SecondHotKey and MediaHotKey in addition to HotKey. They are optional.
If SecondHotKey is set, it also displays in menus (eg: Ctrl+T,Ctrl-Shit+B.
If MediaHotkey is set, it does not display. This allows to assign the optional media keys of some keyboards (GoBack, GoHome, ...).

The code to modify the HotKeys, which was not yet used, has been removed. It had been designed for a single hotkey per command. A multikey version will come later.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility