### PR TITLE
RichCommand: HotKey for ToggleShowHiddenItems

### DIFF
--- a/src/Files.App/Actions/Show/ToggleShowHiddenItemsAction.cs
+++ b/src/Files.App/Actions/Show/ToggleShowHiddenItemsAction.cs
@@ -1,9 +1,11 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.App.Commands;
 using Files.App.Extensions;
 using Files.Backend.Services.Settings;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using Windows.System;
 
 namespace Files.App.Actions
 {
@@ -12,6 +14,8 @@ namespace Files.App.Actions
 		private readonly IFoldersSettingsService settings = Ioc.Default.GetRequiredService<IFoldersSettingsService>();
 
 		public string Label { get; } = "ShowHiddenItems".GetLocalizedResource();
+
+		public HotKey HotKey { get; } = new(VirtualKey.H, VirtualKeyModifiers.Control);
 
 		public bool IsOn => settings.ShowHiddenItems;
 

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -763,20 +763,23 @@
 									Grid.Row="0"
 									Grid.Column="0"
 									VerticalAlignment="Center"
-									Text="{x:Bind Commands.ToggleShowHiddenItems.Label}" />
+									Text="{x:Bind Commands.ToggleShowHiddenItems.Label}"
+									ToolTipService.ToolTip="{x:Bind Commands.ToggleShowHiddenItems.LabelWithHotKey, Mode=OneWay}" />
 								<ToggleSwitch
 									Grid.Row="0"
 									Grid.Column="1"
 									HorizontalAlignment="Right"
 									AutomationProperties.Name="{x:Bind Commands.ToggleShowHiddenItems.AutomationName}"
 									IsOn="{x:Bind Commands.ToggleShowHiddenItems.IsOn, Mode=TwoWay}"
-									Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+									Style="{StaticResource RightAlignedToggleSwitchStyle}"
+									ToolTipService.ToolTip="{x:Bind Commands.ToggleShowHiddenItems.LabelWithHotKey, Mode=OneWay}" />
 
 								<TextBlock
 									Grid.Row="1"
 									Grid.Column="0"
 									VerticalAlignment="Center"
-									Text="{x:Bind Commands.ToggleShowFileExtensions.Label}" />
+									Text="{x:Bind Commands.ToggleShowFileExtensions.Label}"
+									ToolTipService.ToolTip="{x:Bind Commands.ToggleShowFileExtensions.LabelWithHotKey, Mode=OneWay}" />
 								<ToggleSwitch
 									Grid.Row="1"
 									Grid.Column="1"
@@ -784,7 +787,8 @@
 									AutomationProperties.Name="{x:Bind Commands.ToggleShowFileExtensions.AutomationName}"
 									IsOn="{x:Bind Commands.ToggleShowFileExtensions.IsOn, Mode=TwoWay}"
 									Rotation="1"
-									Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+									Style="{StaticResource RightAlignedToggleSwitchStyle}"
+									ToolTipService.ToolTip="{x:Bind Commands.ToggleShowFileExtensions.LabelWithHotKey, Mode=OneWay}" />
 							</Grid>
 						</StackPanel>
 					</Flyout>

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -763,8 +763,7 @@
 									Grid.Row="0"
 									Grid.Column="0"
 									VerticalAlignment="Center"
-									Text="{x:Bind Commands.ToggleShowHiddenItems.Label}"
-									ToolTipService.ToolTip="{x:Bind Commands.ToggleShowHiddenItems.LabelWithHotKey, Mode=OneWay}" />
+									Text="{x:Bind Commands.ToggleShowHiddenItems.Label}" />
 								<ToggleSwitch
 									Grid.Row="0"
 									Grid.Column="1"
@@ -772,14 +771,13 @@
 									AutomationProperties.Name="{x:Bind Commands.ToggleShowHiddenItems.AutomationName}"
 									IsOn="{x:Bind Commands.ToggleShowHiddenItems.IsOn, Mode=TwoWay}"
 									Style="{StaticResource RightAlignedToggleSwitchStyle}"
-									ToolTipService.ToolTip="{x:Bind Commands.ToggleShowHiddenItems.LabelWithHotKey, Mode=OneWay}" />
+									ToolTipService.ToolTip="{x:Bind Commands.ToggleShowHiddenItems.HotKeyText, Mode=OneWay}" />
 
 								<TextBlock
 									Grid.Row="1"
 									Grid.Column="0"
 									VerticalAlignment="Center"
-									Text="{x:Bind Commands.ToggleShowFileExtensions.Label}"
-									ToolTipService.ToolTip="{x:Bind Commands.ToggleShowFileExtensions.LabelWithHotKey, Mode=OneWay}" />
+									Text="{x:Bind Commands.ToggleShowFileExtensions.Label}" />
 								<ToggleSwitch
 									Grid.Row="1"
 									Grid.Column="1"
@@ -788,7 +786,7 @@
 									IsOn="{x:Bind Commands.ToggleShowFileExtensions.IsOn, Mode=TwoWay}"
 									Rotation="1"
 									Style="{StaticResource RightAlignedToggleSwitchStyle}"
-									ToolTipService.ToolTip="{x:Bind Commands.ToggleShowFileExtensions.LabelWithHotKey, Mode=OneWay}" />
+									ToolTipService.ToolTip="{x:Bind Commands.ToggleShowFileExtensions.HotKeyText, Mode=OneWay}" />
 							</Grid>
 						</StackPanel>
 					</Flyout>

--- a/src/Files.App/Views/ColumnShellPage.xaml
+++ b/src/Files.App/Views/ColumnShellPage.xaml
@@ -94,11 +94,6 @@
 			Invoked="KeyboardAccelerator_Invoked"
 			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
 			Modifiers="Control,Shift" />
-		<KeyboardAccelerator
-			Key="H"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-			Modifiers="Control" />
 	</local:BaseShellPage.KeyboardAccelerators>
 	<Grid
 		x:Name="RootGrid"

--- a/src/Files.App/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/ColumnShellPage.xaml.cs
@@ -211,10 +211,6 @@ namespace Files.App.Views
 				case (true, true, false, true, VirtualKey.K): // ctrl + shift + k, duplicate tab
 					await NavigationHelpers.OpenPathInNewTab(FilesystemViewModel.WorkingDirectory);
 					break;
-
-				case (true, false, false, true, VirtualKey.H): // ctrl + h, toggle hidden folder visibility
-					userSettingsService.FoldersSettingsService.ShowHiddenItems ^= true; // flip bool
-					break;
 			}
 		}
 

--- a/src/Files.App/Views/ModernShellPage.xaml
+++ b/src/Files.App/Views/ModernShellPage.xaml
@@ -128,11 +128,6 @@
 			Invoked="KeyboardAccelerator_Invoked"
 			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
 			Modifiers="Control,Shift" />
-		<KeyboardAccelerator
-			Key="H"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-			Modifiers="Control" />
 	</local:BaseShellPage.KeyboardAccelerators>
 
 	<Frame

--- a/src/Files.App/Views/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/ModernShellPage.xaml.cs
@@ -279,10 +279,6 @@ namespace Files.App.Views
 					await NavigationHelpers.OpenPathInNewTab(FilesystemViewModel.WorkingDirectory);
 					break;
 
-				case (true, false, false, true, VirtualKey.H): // ctrl + h, toggle hidden folder visibility
-					userSettingsService.FoldersSettingsService.ShowHiddenItems ^= true; // flip bool
-					break;
-
 				case (true, true, false, _, VirtualKey.Number1): // ctrl+shift+1, details view
 					InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView(true);
 					break;


### PR DESCRIPTION
**Resolved / Related Issues**
There was already a hotkey for ToggleShowHiddenItems, but not visible. This pr moves the hotkey into the existing command and adds the information to the button's tooltip.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility