### PR TITLE
Fix: Fixed DataGrid resize cursor

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -570,6 +570,8 @@ namespace Files.App.Views.LayoutModes
 		{
 			var columnToResize = Grid.GetColumn(sender as CommunityToolkit.WinUI.UI.Controls.GridSplitter) / 2 + 1;
 			ResizeColumnToFit(columnToResize);
+
+			this.ChangeCursor(arrowCursor);
 			e.Handled = true;
 		}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
Items resolved / related issues by this PR.
- Fixed DataGrid resize cursor when double clicking Grid Splitter

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [x] Tested the changes for accessibility

**Screenshots (optional)**
Add screenshots here.
