### PR TITLE
Fix: Fixed checkbox visibility for multiselect

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -741,7 +741,15 @@ namespace Files.App.Views.LayoutModes
 		private void ItemSelected_Unchecked(object sender, RoutedEventArgs e)
 		{
 			if (sender is CheckBox checkBox && checkBox.DataContext is ListedItem item && FileList.SelectedItems.Contains(item))
+			{
+				FileList.SelectionChanged -= FileList_SelectionChanged;
+
 				FileList.SelectedItems.Remove(item);
+				if (SelectedItems is not null && SelectedItems.Contains(item))
+					SelectedItems.Remove(item);
+
+				FileList.SelectionChanged += FileList_SelectionChanged;
+			}
 		}
 
 		private new void FileList_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -425,7 +425,11 @@ namespace Files.App.Views.LayoutModes
 		private void ItemSelected_Unchecked(object sender, RoutedEventArgs e)
 		{
 			if (sender is CheckBox checkBox && checkBox.DataContext is ListedItem item && FileList.SelectedItems.Contains(item))
+			{
+				FileList.SelectionChanged -= FileList_SelectionChanged;
 				FileList.SelectedItems.Remove(item);
+				FileList.SelectionChanged += FileList_SelectionChanged;
+			}
 		}
 
 		private new void FileList_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)


### PR DESCRIPTION
**Resolved / Related Issues**
In detail view, the selection checkbox disappears when manuelly unchecked. This pr leaves it visible but unchecked.

In grid view, there is a slight blinking of the element when unchecking the selection checkbox (which disappears briefly then comes back). This pr leaves it visible to avoid this visual issue.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility