### PR TITLE
Fix: Don't show DriveUnpluggedDialog error for recent files

### DIFF
--- a/src/Files.App/Views/WidgetsPage.xaml.cs
+++ b/src/Files.App/Views/WidgetsPage.xaml.cs
@@ -91,7 +91,7 @@ namespace Files.App.Views
 			if (shouldReloadFileTags && fileTagsWidget is not null)
 			{
 				Widgets.ViewModel.InsertWidget(new(fileTagsWidget, (value) => UserSettingsService.PreferencesSettingsService.FileTagsWidgetExpanded = value, () => UserSettingsService.PreferencesSettingsService.FileTagsWidgetExpanded), 2);
-				
+
 				fileTagsWidget.AppInstance = AppInstance;
 				fileTagsWidget.OpenAction = x => NavigationHelpers.OpenPath(x, AppInstance);
 				fileTagsWidget.FileTagsOpenLocationInvoked -= WidgetOpenLocationInvoked;
@@ -155,11 +155,11 @@ namespace Files.App.Views
 				DynamicDialog dialog = DynamicDialogFactory.GetFor_ConsentDialog();
 				await SetContentDialogRoot(dialog).ShowAsync();
 			}
-			catch (Exception ex) when (ex is COMException || ex is ArgumentException)
+			catch (COMException)
 			{
-				await DialogDisplayHelper.ShowDialogAsync(
-					"DriveUnpluggedDialog/Title".GetLocalizedResource(),
-					"DriveUnpluggedDialog/Text".GetLocalizedResource());
+			}
+			catch (ArgumentException)
+			{
 			}
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
Sometimes a recent file is no longer available because its disk is unplugged. The homepage show an error dialog. It's annoying because the user does not try to access it but receives this message every time.

This pr no longer shows the dialog for recent files.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility