### PR TITLE
Code Quality: Simplify ColorPicker control with `ColorPickerButton`

### DIFF
--- a/src/Files.App/Views/Settings/AppearancePage.xaml
+++ b/src/Files.App/Views/Settings/AppearancePage.xaml
@@ -126,28 +126,7 @@
 				<local:SettingsBlockControl.Icon>
 					<FontIcon Glyph="&#xE771;" />
 				</local:SettingsBlockControl.Icon>
-				<Button Padding="0" AutomationProperties.Name="{helpers:ResourceString Name=Background}">
-					<StackPanel Orientation="Horizontal">
-						<Border
-							Width="24"
-							Height="24"
-							Margin="4"
-							Background="{ThemeResource App.Theme.BackgroundBrush}"
-							CornerRadius="4" />
-						<FontIcon
-							Margin="8,4,10,4"
-							FontSize="12"
-							Glyph="&#xE019;" />
-					</StackPanel>
-					<Button.Flyout>
-						<Flyout>
-							<toolkit:ColorPicker
-								IsAlphaEnabled="True"
-								IsColorSpectrumVisible="False"
-								Color="{x:Bind ViewModel.AppThemeBackgroundColor, Mode=TwoWay}" />
-						</Flyout>
-					</Button.Flyout>
-				</Button>
+				<toolkit:ColorPickerButton AutomationProperties.Name="{helpers:ResourceString Name=Background}" SelectedColor="{x:Bind ViewModel.AppThemeBackgroundColor, Mode=TwoWay}" />
 				<local:SettingsBlockControl.ExpandableContent>
 					<GridView
 						Padding="8"

--- a/src/Files.App/Views/Settings/TagsPage.xaml
+++ b/src/Files.App/Views/Settings/TagsPage.xaml
@@ -182,28 +182,10 @@
 												</TextBox.Resources>
 											</TextBox>
 
-											<Button
+											<controls:ColorPickerButton
 												Margin="8,0"
-												Padding="0"
-												AutomationProperties.Name="{helpers:ResourceString Name=TagColor}">
-												<StackPanel Orientation="Horizontal">
-													<Border
-														Width="20"
-														Height="20"
-														Margin="4"
-														Background="{x:Bind NewColor, Mode=OneWay}"
-														CornerRadius="4" />
-													<FontIcon
-														Margin="8,4,10,4"
-														FontSize="12"
-														Glyph="&#xE019;" />
-												</StackPanel>
-												<Button.Flyout>
-													<Flyout>
-														<controls:ColorPicker Color="{x:Bind NewColor, Mode=TwoWay}" />
-													</Flyout>
-												</Button.Flyout>
-											</Button>
+												AutomationProperties.Name="{helpers:ResourceString Name=TagColor}"
+												SelectedColor="{x:Bind NewColor, Mode=TwoWay}" />
 										</StackPanel>
 
 										<StackPanel


### PR DESCRIPTION
**Details**
We can use new `ColorPickerButton` control to simplify code. It has better appearance and easy to maintain the code.

But both `ColorPicker` and `ColorPickerButton` under namespace `CommunityToolkit.WinUI.UI.Controls` have a XAML binding failure problem. I cannot help it and have to wait for _CommunityToolkit_ to fix.

**Validation**
How did you test these changes?
- [x] Built and ran the app
- [ ] Tested the changes for accessibility

**Screenshots**
Old control:
<img width="519" alt="image" src="https://user-images.githubusercontent.com/62325494/225182701-36e86bad-915e-4fba-b49f-91434a5be322.png">

New one:
<img width="498" alt="image" src="https://user-images.githubusercontent.com/62325494/225182449-4f635181-75f7-4173-b6ff-e35cdffcb9da.png">

XAML Binding failure (Unable to fix now):
Error: Converter failed to convert value of type 'null' to type 'Color'; BindingExpression: Path='Color' DataItem='CommunityToolkit.WinUI.UI.Controls.ColorPicker'; target element is 'Microsoft.UI.Xaml.Controls.GridView' (Name='null'); target property is 'SelectedValue' (type 'Object'). 

