### PR TITLE
Fix: Fixed drag and drop

### DIFF
--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -26,10 +26,13 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.ComTypes;
 using System.Threading;
 using System.Threading.Tasks;
+using Vanara.PInvoke;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.ApplicationModel.DataTransfer.DragDrop;
 using Windows.Foundation;
@@ -37,6 +40,7 @@ using Windows.Foundation.Collections;
 using Windows.Storage;
 using Windows.System;
 using static Files.App.Helpers.PathNormalization;
+using VA = Vanara.Windows.Shell;
 using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
 using SortDirection = Files.Shared.Enums.SortDirection;
 
@@ -875,11 +879,27 @@ namespace Files.App
 		protected void FileList_DragItemsStarting(object sender, DragItemsStartingEventArgs e)
 		{
 			SelectedItems!.AddRange(e.Items.OfType<ListedItem>());
+
 			try
 			{
-				// Only support IStorageItem capable paths
-				var itemList = e.Items.OfType<ListedItem>().Where(x => !(x.IsHiddenItem && x.IsLinkItem && x.IsRecycleBinItem && x.IsShortcut)).Select(x => VirtualStorageItem.FromListedItem(x));
-				e.Data.SetStorageItems(itemList, false);
+				var shellItemList = e.Items.OfType<ListedItem>().Select(x => new VA.ShellItem(x.ItemPath)).ToArray();
+				if (shellItemList[0].FileSystemPath is not null)
+				{
+					var iddo = shellItemList[0].Parent.GetChildrenUIObjects<IDataObject>(HWND.NULL, shellItemList);
+					shellItemList.ForEach(x => x.Dispose());
+					var format = System.Windows.Forms.DataFormats.GetFormat("Shell IDList Array");
+					if (iddo.TryGetData<byte[]>((uint)format.Id, out var data))
+					{
+						var mem = new MemoryStream(data).AsRandomAccessStream();
+						e.Data.SetData(format.Name, mem);
+					}
+				}
+				else
+				{
+					// Only support IStorageItem capable paths
+					var storageItemList = e.Items.OfType<ListedItem>().Where(x => !(x.IsHiddenItem && x.IsLinkItem && x.IsRecycleBinItem && x.IsShortcut)).Select(x => VirtualStorageItem.FromListedItem(x));
+					e.Data.SetStorageItems(storageItemList, false);
+				}
 			}
 			catch (Exception)
 			{


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Partially closes #10171

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [X] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   I have verified that drag-and-drop works for the following applications.
   * Explorer
   * Edge (working in the latest preview but #10949 breaks it)
   * WordPad (working in the latest preview but #10949 breaks it)
   * Visual Studio (not working in the latest preview)
   * WhatsApp (not working in the latest preview)

**Details**
I was looking at #10949 and noticed that drag and drop works in many apps by setting the data to "Shell IDList Array" only.
This still does not allow drag and drop to Notepad or XShell, but there appears to be no regression. It may be necessary to create another data manually for these applications.
Also, #10949 only works for files that actually exist on the file system, so I made other files (such as files in archives) fall back to StorageItem.