### PR TITLE
CommandManager - Remove unused field

### DIFF
--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -66,7 +66,7 @@ namespace Files.App.Commands
 		public CommandManager()
 		{
 			commands = CreateActions()
-				.Select(action => new ActionCommand(this, action.Key, action.Value))
+				.Select(action => new ActionCommand(action.Key, action.Value))
 				.Cast<IRichCommand>()
 				.Append(new NoneCommand())
 				.ToImmutableDictionary(command => command.Code);
@@ -163,8 +163,6 @@ namespace Files.App.Commands
 		[DebuggerDisplay("Command {Code}")]
 		private class ActionCommand : ObservableObject, IRichCommand
 		{
-			private readonly CommandManager manager;
-
 			public event EventHandler? CanExecuteChanged;
 
 			private readonly IAction action;
@@ -201,9 +199,8 @@ namespace Files.App.Commands
 
 			public bool IsExecutable => action.IsExecutable;
 
-			public ActionCommand(CommandManager manager, CommandCodes code, IAction action)
+			public ActionCommand(CommandCodes code, IAction action)
 			{
-				this.manager = manager;
 				Code = code;
 				this.action = action;
 				Icon = action.Glyph.ToIcon();


### PR DESCRIPTION
**Resolved / Related Issues**
Remove the unused field manager of each RichCommand. This is a code cleanup.

- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
No modification of the application, only a cleaning of the code.