### PR TITLE
Fix PageContext

### DIFF
--- a/src/Files.App/Contexts/Page/PageContext.cs
+++ b/src/Files.App/Contexts/Page/PageContext.cs
@@ -25,9 +25,14 @@ namespace Files.App.Contexts
 
 		private void Page_CurrentInstanceChanged(object? sender, PaneHolderPage? modifiedPage)
 		{
-			bool isCurrent = modifiedPage?.IsCurrentInstance ?? false;
-			var newPage = isCurrent ? modifiedPage : null;
-			UpdatePage(newPage);
+			if (page is not null && !page.IsCurrentInstance)
+			{
+				UpdatePage(null);
+			}
+			else if (modifiedPage is not null && modifiedPage.IsCurrentInstance)
+			{
+				UpdatePage(modifiedPage);
+			}
 		}
 
 		private void Page_ContentChanged(object? sender, TabItemArguments e)
@@ -37,12 +42,9 @@ namespace Files.App.Contexts
 
 		private void Page_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			switch (e.PropertyName)
+			if (e.PropertyName is nameof(IPaneHolder.ActivePaneOrColumn))
 			{
-				case nameof(IPaneHolder.ActivePane):
-				case nameof(IPaneHolder.ActivePaneOrColumn):
-					UpdateContent();
-					break;
+				UpdateContent();
 			}
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
When you activate a tab to the left of the current tab, the left tab becomes IsCurrentInstance = true before the right tab becomes IsCurrentInstance = false. As a result, there are 2 "current" instances at the same time. This case was mishandled by PageContext. This pr modifies PageContext so that this case is no longer an issue.

The consequence was that when switching tabs to the left, the actions no longer used the correct IShellPage and therefore everything was wrong.

I also removed the reaction to changing ActivePane, as it always involves changing ActivePaneOrColumn. This avoids triggering the change event twice.

- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11701

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
1. Open a second tab.
2. Reactive the first tab.
3. The icons in the toolbar react to selection.
