### PR TITLE
Fix: Fix Issue with unselecting row immediately hiding checkbox

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -787,7 +787,7 @@
 
 									<VisualStateManager.VisualStateGroups>
 										<VisualStateGroup x:Name="CheckboxVisibilityStates">
-											<VisualState x:Name="Normal" />
+											<VisualState x:Name="HideCheckbox" />
 											<VisualState x:Name="ShowCheckbox">
 												<VisualState.Setters>
 													<Setter Target="SelectionCheckbox.Visibility" Value="Visible" />

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -30,6 +30,14 @@ namespace Files.App.Views.LayoutModes
 {
 	public sealed partial class DetailsLayoutBrowser : StandardViewBase
 	{
+		public bool IsPointerOver
+		{
+			get { return (bool)GetValue(IsPointerOverProperty); }
+			set { SetValue(IsPointerOverProperty, value); }
+		}
+		public static readonly DependencyProperty IsPointerOverProperty =
+			DependencyProperty.Register("IsPointerOver", typeof(bool), typeof(DetailsLayoutBrowser), new PropertyMetadata(false));
+
 		private const int TAG_TEXT_BLOCK = 1;
 
 		private uint currentIconSize;
@@ -760,7 +768,7 @@ namespace Files.App.Views.LayoutModes
 					checkbox.Checked += ItemSelected_Checked;
 					checkbox.Unchecked += ItemSelected_Unchecked;
 				}
-				UpdateCheckboxVisibility(container, false);
+				UpdateCheckboxVisibility(container);
 			}
 		}
 
@@ -815,14 +823,18 @@ namespace Files.App.Views.LayoutModes
 			UpdateCheckboxVisibility(sender, false);
 		}
 
-		private void UpdateCheckboxVisibility(object sender, bool isPointerOver)
+		private void UpdateCheckboxVisibility(object sender, bool? isPointerOver = null)
 		{
 			if (sender is ListViewItem control && control.FindDescendant<UserControl>() is UserControl userControl)
 			{
-				if (control.IsSelected)
+				// Save pointer over state accordingly
+				if(isPointerOver.HasValue)
+					control.SetValue(IsPointerOverProperty, isPointerOver);
+				// Handle visual states
+				if (control.IsSelected || control.GetValue(IsPointerOverProperty) is not false)
 					VisualStateManager.GoToState(userControl, "ShowCheckbox", true);
 				else
-					VisualStateManager.GoToState(userControl, isPointerOver ? "ShowCheckbox" : "Normal", true);
+					VisualStateManager.GoToState(userControl, "HideCheckbox", true);
 			}
 		}
 	}

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
@@ -215,7 +215,7 @@
 
 					<VisualStateManager.VisualStateGroups>
 						<VisualStateGroup x:Name="CheckboxVisibilityStates">
-							<VisualState x:Name="Normal" />
+							<VisualState x:Name="HideCheckbox" />
 							<VisualState x:Name="ShowCheckbox">
 								<VisualState.Setters>
 									<Setter Target="SelectionCheckbox.Visibility" Value="Visible" />

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -36,6 +36,14 @@ namespace Files.App.Views.LayoutModes
 		/// </summary>
 		public int GridViewItemMinWidth => FolderSettings.LayoutMode == FolderLayoutModes.TilesView ? Constants.Browser.GridViewBrowser.TilesView : FolderSettings.GridViewSize;
 
+		public bool IsPointerOver
+		{
+			get { return (bool)GetValue(IsPointerOverProperty); }
+			set { SetValue(IsPointerOverProperty, value); }
+		}
+		public static readonly DependencyProperty IsPointerOverProperty =
+			DependencyProperty.Register("IsPointerOver", typeof(bool), typeof(GridViewBrowser), new PropertyMetadata(false));
+
 		public GridViewBrowser()
 			: base()
 		{
@@ -459,7 +467,7 @@ namespace Files.App.Views.LayoutModes
 					checkbox.Checked += ItemSelected_Checked;
 					checkbox.Unchecked += ItemSelected_Unchecked;
 				}
-				UpdateCheckboxVisibility(container, false);
+				UpdateCheckboxVisibility(container);
 			}
 		}
 
@@ -489,14 +497,18 @@ namespace Files.App.Views.LayoutModes
 			UpdateCheckboxVisibility(sender, false);
 		}
 
-		private void UpdateCheckboxVisibility(object sender, bool isPointerOver)
+		private void UpdateCheckboxVisibility(object sender, bool? isPointerOver = null)
 		{
 			if (sender is GridViewItem control && control.FindDescendant<UserControl>() is UserControl userControl)
 			{
-				if (control.IsSelected)
+				// Save pointer over state accordingly
+				if (isPointerOver.HasValue)
+					control.SetValue(IsPointerOverProperty, isPointerOver);
+				// Handle visual states
+				if (control.IsSelected || control.GetValue(IsPointerOverProperty) is not false)
 					VisualStateManager.GoToState(userControl, "ShowCheckbox", true);
 				else
-					VisualStateManager.GoToState(userControl, isPointerOver ? "ShowCheckbox" : "Normal", true);
+					VisualStateManager.GoToState(userControl, "HideCheckbox", true);
 			}
 		}
 	}


### PR DESCRIPTION
**Resolved / Related Issues**
- Issue where unselecting a row hides checkbox instead of showing it unselected, supersedes #11715 @cinqmilleans FYI

Current issue is that the row is no longer highlighted when unselecting but I dont know a good workaround for this right now.
**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Screenshots (optional)**
Add screenshots here.
