### PR TITLE
The RichCommand implementation no longer uses RelayCommand.

### DIFF
--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -1,5 +1,4 @@
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 using Files.App.Actions;
 using Files.App.Actions.Content.Archives;
 using Files.App.Actions.Content.Background;
@@ -16,7 +15,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows.Input;
 
 namespace Files.App.Commands
 {
@@ -252,7 +250,6 @@ namespace Files.App.Commands
 			public event EventHandler? CanExecuteChanged;
 
 			private readonly IAction action;
-			private readonly ICommand command;
 
 			public CommandCodes Code { get; }
 
@@ -279,7 +276,7 @@ namespace Files.App.Commands
 				set
 				{
 					if (action is IToggleAction toggleAction && toggleAction.IsOn != value)
-						command.Execute(null);
+						Execute(null);
 				}
 			}
 
@@ -294,7 +291,6 @@ namespace Files.App.Commands
 				OpacityStyle = action.Glyph.ToOpacityStyle();
 				HotKeyText = GetHotKeyText();
 				LabelWithHotKey = HotKeyText is null ? Label : $"{Label} ({HotKeyText})";
-				command = new AsyncRelayCommand(ExecuteAsync);
 
 				if (action is INotifyPropertyChanging notifyPropertyChanging)
 					notifyPropertyChanging.PropertyChanging += Action_PropertyChanging;
@@ -303,7 +299,7 @@ namespace Files.App.Commands
 			}
 
 			public bool CanExecute(object? parameter) => action.IsExecutable;
-			public void Execute(object? parameter) => command.Execute(parameter);
+			public async void Execute(object? parameter) => await ExecuteAsync();
 
 			public async Task ExecuteAsync()
 			{
@@ -311,7 +307,7 @@ namespace Files.App.Commands
 					await action.ExecuteAsync();
 			}
 
-			public async void ExecuteTapped(object sender, TappedRoutedEventArgs e) => await action.ExecuteAsync();
+			public async void ExecuteTapped(object sender, TappedRoutedEventArgs e) => await ExecuteAsync();
 
 			private void Action_PropertyChanging(object? sender, PropertyChangingEventArgs e)
 			{


### PR DESCRIPTION
**Resolved / Related Issues**
The RichCommand implementation encapsulates RelayCommand. It was easier when the concept was still a bit fuzzy. Today, this is no longer necessary. Removing it avoids unnecessary instantiations.

- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
The behavior of richcommands remains unchanged.