### PR TITLE
Allow Textbox to use keyboard despite hotkeys

### DIFF
--- a/src/Files.App/Commands/HotKeyHelpers.cs
+++ b/src/Files.App/Commands/HotKeyHelpers.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using Windows.System;
+
+namespace Files.App.Commands
+{
+	internal static class HotKeyHelpers
+	{
+		private static readonly ImmutableArray<VirtualKey> globalKeys = new List<VirtualKey>
+		{
+			VirtualKey.GoHome,
+			VirtualKey.GoBack,
+			VirtualKey.GoForward,
+			VirtualKey.Application,
+			VirtualKey.Favorites,
+			VirtualKey.Search,
+			VirtualKey.Refresh,
+			VirtualKey.Pause,
+			VirtualKey.Sleep,
+			VirtualKey.Print,
+			VirtualKey.F1,
+			VirtualKey.F2,
+			VirtualKey.F3,
+			VirtualKey.F4,
+			VirtualKey.F5,
+			VirtualKey.F6,
+			VirtualKey.F7,
+			VirtualKey.F8,
+			VirtualKey.F9,
+			VirtualKey.F10,
+			VirtualKey.F11,
+			VirtualKey.F12,
+			VirtualKey.F13,
+			VirtualKey.F14,
+			VirtualKey.F15,
+			VirtualKey.F16,
+			VirtualKey.F17,
+			VirtualKey.F18,
+			VirtualKey.F19,
+			VirtualKey.F20,
+			VirtualKey.F21,
+			VirtualKey.F22,
+			VirtualKey.F23,
+			VirtualKey.F24,
+		}.ToImmutableArray();
+
+		private static readonly ImmutableArray<HotKey> textBoxHotKeys = new List<HotKey>
+		{
+			new HotKey(VirtualKey.X, VirtualKeyModifiers.Control), // Cut
+			new HotKey(VirtualKey.C, VirtualKeyModifiers.Control), // Copy
+			new HotKey(VirtualKey.V, VirtualKeyModifiers.Control), // Paste
+			new HotKey(VirtualKey.A, VirtualKeyModifiers.Control), // Select all
+			new HotKey(VirtualKey.Z, VirtualKeyModifiers.Control), // Cancel
+		}.ToImmutableArray();
+
+		public static bool IsGlobalKey(this VirtualKey key) => globalKeys.Contains(key);
+		public static bool IsTextBoxHotKey(this HotKey hotKey) => textBoxHotKeys.Contains(hotKey);
+	}
+}

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -235,17 +235,23 @@ namespace Files.App.Views
 					currentModifiers |= VirtualKeyModifiers.Shift;
 					break;
 				default:
-					// break for natives hotkeys in textbox (cut/copy/paste/selectAll/cancel)
+					HotKey hotKey = new(e.Key, currentModifiers);
+
+					// A textbox takes precedence over certain hotkeys.
 					bool isTextBox = e.OriginalSource is DependencyObject source && source.FindAscendantOrSelf<TextBox>() is not null;
-					if (isTextBox &&
-						currentModifiers is VirtualKeyModifiers.Control &&
-						e.Key is VirtualKey.X or VirtualKey.C or VirtualKey.V or VirtualKey.A or VirtualKey.Z)
+					if (isTextBox)
 					{
-						break;
+						if (hotKey.IsTextBoxHotKey())
+						{
+							break;
+						}
+						if (currentModifiers is VirtualKeyModifiers.None && !e.Key.IsGlobalKey())
+						{
+							break;
+						}
 					}
 
-					// execute command for hotkey
-					var hotKey = new HotKey(e.Key, currentModifiers);
+					// Execute command for hotkey
 					var command = Commands[hotKey];
 					if (command.Code is not CommandCodes.None && keyReleased)
 					{


### PR DESCRIPTION
**Resolved / Related Issues**
Some hotkeys should be disabled in textboxes, especially if there are no modifiers. This pr filters the keys that can trigger hotkeys in a textbox.

- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
Test the hotkeys in the search field (ctrl+a, space, home, F11 ...)
