### PR TITLE
Fix: Fixed icon loading delayed for quick access widget

### DIFF
--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -16,6 +16,7 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
@@ -123,6 +124,8 @@ namespace Files.App.UserControls.Widgets
 			OpenPropertiesCommand = new RelayCommand<FolderCardItem>(OpenProperties);
 			PinToFavoritesCommand = new RelayCommand<FolderCardItem>(PinToFavorites);
 			UnpinFromFavoritesCommand = new RelayCommand<FolderCardItem>(UnpinFromFavorites);
+
+			ItemsAdded.CollectionChanged += ItemsAdded_CollectionChanged;
 		}
 
 		public delegate void QuickAccessCardInvokedEventHandler(object sender, QuickAccessCardInvokedEventArgs e);
@@ -270,8 +273,6 @@ namespace Files.App.UserControls.Widgets
 							SelectCommand = QuickAccessCardCommand
 						});
 					}
-					var cardLoadTasks = ItemsAdded.Select(cardItem => cardItem.LoadCardThumbnailAsync());
-					await Task.WhenAll(cardLoadTasks);
 
 					return;
 				}
@@ -287,9 +288,6 @@ namespace Files.App.UserControls.Widgets
 							SelectCommand = QuickAccessCardCommand
 						});
 					}
-
-					var cardLoadTasks = ItemsAdded.Select(cardItem => cardItem.LoadCardThumbnailAsync());
-					await Task.WhenAll(cardLoadTasks);
 				}
 				else
 					foreach (var itemToRemove in ItemsAdded.Where(x => e.Paths.Contains(x.Path)).ToList())
@@ -314,15 +312,21 @@ namespace Files.App.UserControls.Widgets
 			}
 
 			App.QuickAccessManager.UpdateQuickAccessWidget += ModifyItem;
-
-			var cardLoadTasks = ItemsAdded.Select(cardItem => cardItem.LoadCardThumbnailAsync());
-			await Task.WhenAll(cardLoadTasks);
 		}
 
 		private void QuickAccessWidget_Unloaded(object sender, RoutedEventArgs e)
 		{
 			Unloaded -= QuickAccessWidget_Unloaded;
 			App.QuickAccessManager.UpdateQuickAccessWidget -= ModifyItem;
+		}
+
+		private async void ItemsAdded_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (e.Action is NotifyCollectionChangedAction.Add)
+			{
+				foreach (FolderCardItem cardItem in e.NewItems!)
+					await cardItem.LoadCardThumbnailAsync();
+			}
 		}
 
 		private void MenuFlyout_Opening(object sender)
@@ -416,8 +420,8 @@ namespace Files.App.UserControls.Widgets
 		}
 
 		public void Dispose() 
-		{ 
-		
+		{
+			ItemsAdded.CollectionChanged -= ItemsAdded_CollectionChanged;
 		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11794 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [X] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   This pr changes the timing of icon loading. You will see icons are displayed during page loading, not after loaded.