### PR TITLE
Add AccessKeys to InnerToolBar.

### DIFF
--- a/src/Files.App/UserControls/AddressToolbar.xaml
+++ b/src/Files.App/UserControls/AddressToolbar.xaml
@@ -188,6 +188,8 @@
 				Height="34"
 				HorizontalAlignment="Stretch"
 				VerticalAlignment="Center"
+				AccessKey="K"
+				AccessKeyInvoked="SearchRegion_AccessKeyInvoked"
 				Canvas.ZIndex="100"
 				CornerRadius="{StaticResource ControlCornerRadius}"
 				GotFocus="SearchRegion_OnGotFocus"

--- a/src/Files.App/UserControls/AddressToolbar.xaml.cs
+++ b/src/Files.App/UserControls/AddressToolbar.xaml.cs
@@ -118,6 +118,7 @@ namespace Files.App.UserControls
 		private void SearchButton_Click(object _, RoutedEventArgs e) => ViewModel.SwitchSearchBoxVisibility();
 		private void SearchRegion_OnGotFocus(object sender, RoutedEventArgs e) => ViewModel.SearchRegion_GotFocus(sender, e);
 		private void SearchRegion_LostFocus(object sender, RoutedEventArgs e) => ViewModel.SearchRegion_LostFocus(sender, e);
+		private void SearchRegion_AccessKeyInvoked(UIElement sender, AccessKeyInvokedEventArgs args) => sender.Focus(FocusState.Keyboard);
 
 		private void VisiblePath_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
 			=> ViewModel.VisiblePath_QuerySubmitted(sender, args);

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -1,16 +1,15 @@
 ﻿<UserControl
 	x:Class="Files.App.UserControls.InnerNavigationToolbar"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
-	xmlns:converters="using:Files.App.Converters"
-	xmlns:converters1="using:CommunityToolkit.WinUI.UI.Converters"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:helpers="using:Files.App.Helpers"
-	xmlns:local="using:Files.App.UserControls"
-	xmlns:local1="using:Files.App"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	d:DesignHeight="40"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,8)"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converters1="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:Files.App.Converters"
+    xmlns:helpers="using:Files.App.Helpers"
+    xmlns:local="using:Files.App.UserControls"
+    d:DesignHeight="40"
 	d:DesignWidth="400"
 	mc:Ignorable="d">
 	<UserControl.Resources>
@@ -65,6 +64,7 @@
 						<MenuFlyout x:Name="NewEmptySpace" Opening="NewEmptySpace_Opening">
 							<MenuFlyoutItem
 								x:Name="ToolbarNewFolderItem"
+								AccessKey="D"
 								AutomationProperties.AutomationId="InnerNavigationToolbarNewFolderButton"
 								Command="{x:Bind Commands.CreateFolder, Mode=OneWay}"
 								Text="{x:Bind Commands.CreateFolder.Label}">
@@ -74,6 +74,7 @@
 							</MenuFlyoutItem>
 							<MenuFlyoutItem
 								x:Name="NewFile"
+								AccessKey="F"
 								AutomationProperties.AutomationId="File"
 								Command="{x:Bind ViewModel.CreateNewFileCommand, Mode=OneWay}"
 								CommandParameter="{x:Null}"
@@ -85,6 +86,7 @@
 							</MenuFlyoutItem>
 							<MenuFlyoutItem
 								x:Name="NewShortcut"
+								AccessKey="S"
 								AutomationProperties.AutomationId="InnerNavigationToolbarNewShortcutButton"
 								Command="{x:Bind Commands.CreateShortcutFromDialog, Mode=OneWay}"
 								Text="{x:Bind Commands.CreateShortcutFromDialog.Label}">
@@ -400,18 +402,21 @@
 					<MenuFlyout Placement="Bottom">
 						<MenuFlyoutItem
 							x:Name="SelectAllMFI"
+							AccessKey="A"
 							Command="{x:Bind Commands.SelectAll}"
 							Icon="{x:Bind Commands.SelectAll.FontIcon}"
 							KeyboardAcceleratorTextOverride="{x:Bind Commands.SelectAll.HotKeyText}"
 							Text="{x:Bind Commands.SelectAll.Label}" />
 						<MenuFlyoutItem
 							x:Name="InvertSelectionMFI"
+							AccessKey="I"
 							Command="{x:Bind Commands.InvertSelection}"
 							Icon="{x:Bind Commands.InvertSelection.FontIcon}"
 							KeyboardAcceleratorTextOverride="{x:Bind Commands.InvertSelection.HotKeyText}"
 							Text="{x:Bind Commands.InvertSelection.Label}" />
 						<MenuFlyoutItem
 							x:Name="ClearSelectionMFI"
+							AccessKey="C"
 							Command="{x:Bind Commands.ClearSelection}"
 							Icon="{x:Bind Commands.ClearSelection.FontIcon}"
 							KeyboardAcceleratorTextOverride="{x:Bind Commands.ClearSelection.HotKeyText}"
@@ -436,7 +441,10 @@
 				<local:OpacityIcon Style="{StaticResource ColorIconSort}" />
 				<AppBarButton.Flyout>
 					<MenuFlyout contract8Present:ShouldConstrainToRootBounds="False" Placement="Bottom">
-						<MenuFlyoutSubItem Text="{helpers:ResourceString Name=NavToolbarSortByRadioButtons/Text}">
+						<MenuFlyoutSubItem
+							AccessKey="S"
+							AccessKeyInvoked="SortGroup_AccessKeyInvoked"
+							Text="{helpers:ResourceString Name=NavToolbarSortByRadioButtons/Text}">
 							<ToggleMenuFlyoutItem IsChecked="{x:Bind Commands.SortByName.IsOn, Mode=TwoWay}" Text="{x:Bind Commands.SortByName.Label}" />
 							<ToggleMenuFlyoutItem IsChecked="{x:Bind Commands.SortByDateModified.IsOn, Mode=TwoWay}" Text="{x:Bind Commands.SortByDateModified.Label}" />
 							<ToggleMenuFlyoutItem IsChecked="{x:Bind Commands.SortByDateCreated.IsOn, Mode=TwoWay}" Text="{x:Bind Commands.SortByDateCreated.Label}" />
@@ -456,10 +464,19 @@
 								IsEnabled="{x:Bind Commands.SortByDateDeleted.IsExecutable, Mode=OneWay}"
 								Text="{x:Bind Commands.SortByDateDeleted.Label}" />
 							<MenuFlyoutSeparator />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind Commands.SortAscending.IsOn, Mode=TwoWay}" Text="{x:Bind Commands.SortAscending.Label}" />
-							<ToggleMenuFlyoutItem IsChecked="{x:Bind Commands.SortDescending.IsOn, Mode=TwoWay}" Text="{x:Bind Commands.SortDescending.Label}" />
+							<ToggleMenuFlyoutItem
+								AccessKey="A"
+								IsChecked="{x:Bind Commands.SortAscending.IsOn, Mode=TwoWay}"
+								Text="{x:Bind Commands.SortAscending.Label}" />
+							<ToggleMenuFlyoutItem
+								AccessKey="D"
+								IsChecked="{x:Bind Commands.SortDescending.IsOn, Mode=TwoWay}"
+								Text="{x:Bind Commands.SortDescending.Label}" />
 						</MenuFlyoutSubItem>
-						<MenuFlyoutSubItem Text="{helpers:ResourceString Name=NavToolbarGroupByRadioButtons/Text}">
+						<MenuFlyoutSubItem
+							AccessKey="G"
+							AccessKeyInvoked="SortGroup_AccessKeyInvoked"
+							Text="{helpers:ResourceString Name=NavToolbarGroupByRadioButtons/Text}">
 							<ToggleMenuFlyoutItem IsChecked="{x:Bind Commands.GroupByNone.IsOn, Mode=TwoWay}" Text="{x:Bind Commands.GroupByNone.Label}" />
 							<ToggleMenuFlyoutItem IsChecked="{x:Bind Commands.GroupByName.IsOn, Mode=TwoWay}" Text="{x:Bind Commands.GroupByName.Label}" />
 							<ToggleMenuFlyoutItem IsChecked="{x:Bind Commands.GroupByDateModified.IsOn, Mode=TwoWay}" Text="{x:Bind Commands.GroupByDateModified.Label}" />
@@ -485,16 +502,21 @@
 								Text="{x:Bind Commands.GroupByFolderPath.Label}" />
 							<MenuFlyoutSeparator />
 							<ToggleMenuFlyoutItem
+								AccessKey="A"
 								IsChecked="{x:Bind Commands.GroupAscending.IsOn, Mode=TwoWay}"
 								IsEnabled="{x:Bind Commands.GroupAscending.IsExecutable, Mode=OneWay}"
 								Text="{x:Bind Commands.GroupAscending.Label}" />
 							<ToggleMenuFlyoutItem
+								AccessKey="D"
 								IsChecked="{x:Bind Commands.GroupDescending.IsOn, Mode=TwoWay}"
 								IsEnabled="{x:Bind Commands.GroupDescending.IsExecutable, Mode=OneWay}"
 								Text="{x:Bind Commands.GroupDescending.Label}" />
 						</MenuFlyoutSubItem>
 						<MenuFlyoutSeparator />
-						<ToggleMenuFlyoutItem IsChecked="{x:Bind Commands.ToggleSortDirectoriesAlongsideFiles.IsOn, Mode=TwoWay}" Text="{x:Bind Commands.ToggleSortDirectoriesAlongsideFiles.Label}" />
+						<ToggleMenuFlyoutItem
+							AccessKey="A"
+							IsChecked="{x:Bind Commands.ToggleSortDirectoriesAlongsideFiles.IsOn, Mode=TwoWay}"
+							Text="{x:Bind Commands.ToggleSortDirectoriesAlongsideFiles.Label}" />
 					</MenuFlyout>
 				</AppBarButton.Flyout>
 			</AppBarButton>
@@ -749,6 +771,7 @@
 								<ToggleSwitch
 									Grid.Row="0"
 									Grid.Column="1"
+									AccessKey="H"
 									HorizontalAlignment="Right"
 									AutomationProperties.Name="{x:Bind Commands.ToggleShowHiddenItems.AutomationName}"
 									IsOn="{x:Bind Commands.ToggleShowHiddenItems.IsOn, Mode=TwoWay}"
@@ -763,6 +786,7 @@
 								<ToggleSwitch
 									Grid.Row="1"
 									Grid.Column="1"
+									AccessKey="E"
 									HorizontalAlignment="Right"
 									AutomationProperties.Name="{x:Bind Commands.ToggleShowFileExtensions.AutomationName}"
 									IsOn="{x:Bind Commands.ToggleShowFileExtensions.IsOn, Mode=TwoWay}"
@@ -776,6 +800,7 @@
 			</AppBarButton>
 			<AppBarToggleButton
 				x:Name="PreviewPane"
+				AccessKey="P"
 				Width="Auto"
 				MinWidth="40"
 				AutomationProperties.Name="{x:Bind Commands.TogglePreviewPane.AutomationName}"

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml.cs
@@ -107,6 +107,10 @@ namespace Files.App.UserControls
 			if (!NewEmptySpace.Items.Any(x => (x.Tag as string) == "CreateNewFile"))
 			{
 				var separatorIndex = NewEmptySpace.Items.IndexOf(NewEmptySpace.Items.Single(x => x.Name == "NewMenuFileFolderSeparator"));
+
+				ushort key = 0;
+				string keyFormat = $"D{cachedNewContextMenuEntries.Count.ToString().Length}";
+
 				foreach (var newEntry in Enumerable.Reverse(cachedNewContextMenuEntries))
 				{
 					MenuFlyoutItem menuLayoutItem;
@@ -128,13 +132,14 @@ namespace Files.App.UserControls
 						menuLayoutItem = new MenuFlyoutItem()
 						{
 							Text = newEntry.Name,
-							Icon = new FontIcon()
+							Icon = new FontIcon
 							{
 								Glyph = "\xE7C3"
 							},
 							Tag = "CreateNewFile"
 						};
 					}
+					menuLayoutItem.AccessKey = (cachedNewContextMenuEntries.Count + 1 - (++key)).ToString(keyFormat);
 					menuLayoutItem.Command = ViewModel.CreateNewFileCommand;
 					menuLayoutItem.CommandParameter = newEntry;
 					NewEmptySpace.Items.Insert(separatorIndex + 1, menuLayoutItem);
@@ -142,19 +147,23 @@ namespace Files.App.UserControls
 			}
 		}
 
-		private void NavToolbarDetailsHeader_Tapped(object sender, TappedRoutedEventArgs e)
-			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeDetailsView(true);
-		private void NavToolbarTilesHeader_Tapped(object sender, TappedRoutedEventArgs e)
-			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeTiles(true);
-		private void NavToolbarSmallIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
-			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewSmall(true);
-		private void NavToolbarMediumIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
-			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewMedium(true);
-		private void NavToolbarLargeIconsHeader_Tapped(object sender, TappedRoutedEventArgs e)
-			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeGridViewLarge(true);
-		private void NavToolbarColumnsHeader_Tapped(object sender, TappedRoutedEventArgs e)
-			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeColumnView(true);
-		private void NavToolbarAdaptiveHeader_Tapped(object sender, TappedRoutedEventArgs e)
-			=> ViewModel.InstanceViewModel.FolderSettings.ToggleLayoutModeAdaptive();
+		private void SortGroup_AccessKeyInvoked(UIElement sender, AccessKeyInvokedEventArgs args)
+		{
+			if (sender is MenuFlyoutSubItem menu)
+			{
+				var items = menu.Items
+					.TakeWhile(item => item is not MenuFlyoutSeparator)
+					.Where(item => item.IsEnabled)
+					.ToList();
+
+				string format = $"D{items.Count.ToString().Length}";
+
+				for (ushort index = 0; index < items.Count; ++index)
+				{
+					items[index].AccessKey = (index+1).ToString(format);
+				}
+			}
+
+		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
Adds new AccessKeys to the toolbar.
* Some menus use automatically generated numbers. If necessary, these numbers have several digits.
* Added in New, Selection, Sort and Layout menus.
* The Layout menu is partial because the accesskeys on the button layouts do not always appear (to be investigated). They will be added later.
* Added for PreviewPane and SearchBox.

- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
Test the accesskeys.

**Screenshots (optional)**

https://user-images.githubusercontent.com/46631671/226976170-a6678074-ddad-4e7e-8109-5c70b21fbb08.mp4
