### PR TITLE
RichCommands: Find

### DIFF
--- a/src/Files.App/Actions/Global/FindAction.cs
+++ b/src/Files.App/Actions/Global/FindAction.cs
@@ -1,0 +1,73 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using Files.App.Commands;
+using Files.App.Contexts;
+using Files.App.Extensions;
+using Files.App.Views;
+using Files.App.Views.LayoutModes;
+using System.CodeDom;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Windows.System;
+
+namespace Files.App.Actions
+{
+	internal class FindAction : ObservableObject, IAction
+	{
+		private readonly IContentPageContext context = Ioc.Default.GetRequiredService<IContentPageContext>();
+
+		public string Label => "Share".GetLocalizedResource();
+
+		public string Description => "TODO: Need to be described.";
+
+		public HotKey HotKey { get; } = new(VirtualKey.F, VirtualKeyModifiers.Control);
+
+		public HotKey SecondHotKey { get; } = new(VirtualKey.F3);
+
+		public RichGlyph Glyph { get; } = new();
+
+		public bool IsExecutable =>
+			context.ShellPage is not null &&
+			IsPageTypeValid();
+
+		public FindAction()
+		{
+			context.PropertyChanged += Context_PropertyChanged;
+		}
+
+		public Task ExecuteAsync()
+		{
+			context.ShellPage!.ToolbarViewModel.SwitchSearchBoxVisibility();
+			return Task.CompletedTask;
+		}
+
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			switch (e.PropertyName)
+			{
+				case nameof(IContentPageContext.ShellPage):
+				case nameof(IContentPageContext.PageLayoutType):
+					OnPropertyChanged(nameof(IsExecutable));
+					break;
+			}
+		}
+
+		private bool IsPageTypeValid()
+		{
+			return
+			(context.ShellPage is ModernShellPage &&
+			(
+				context.PageLayoutType == typeof(DetailsLayoutBrowser) ||
+				context.PageLayoutType == typeof(GridViewBrowser) ||
+				context.PageLayoutType == typeof(WidgetsPage)
+			)) ||
+			(context.ShellPage is ColumnShellPage &&
+			(
+				context.PageLayoutType == typeof(DetailsLayoutBrowser) ||
+				context.PageLayoutType == typeof(GridViewBrowser) ||
+				context.PageLayoutType == typeof(ColumnViewBase) ||
+				context.PageLayoutType == typeof(ColumnViewBrowser
+			)));
+		}
+	}
+}

--- a/src/Files.App/Commands/CommandCodes.cs
+++ b/src/Files.App/Commands/CommandCodes.cs
@@ -10,6 +10,7 @@ namespace Files.App.Commands
 		EnterCompactOverlay,
 		ExitCompactOverlay,
 		ToggleCompactOverlay,
+		Find,
 
 		// Show
 		ToggleShowHiddenItems,

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -28,6 +28,7 @@ namespace Files.App.Commands
 		public IRichCommand EnterCompactOverlay => commands[CommandCodes.EnterCompactOverlay];
 		public IRichCommand ExitCompactOverlay => commands[CommandCodes.ExitCompactOverlay];
 		public IRichCommand ToggleCompactOverlay => commands[CommandCodes.ToggleCompactOverlay];
+		public IRichCommand Find => commands[CommandCodes.Find];
 		public IRichCommand ToggleShowHiddenItems => commands[CommandCodes.ToggleShowHiddenItems];
 		public IRichCommand ToggleShowFileExtensions => commands[CommandCodes.ToggleShowFileExtensions];
 		public IRichCommand TogglePreviewPane => commands[CommandCodes.TogglePreviewPane];
@@ -150,6 +151,7 @@ namespace Files.App.Commands
 			[CommandCodes.EnterCompactOverlay] = new EnterCompactOverlayAction(),
 			[CommandCodes.ExitCompactOverlay] = new ExitCompactOverlayAction(),
 			[CommandCodes.ToggleCompactOverlay] = new ToggleCompactOverlayAction(),
+			[CommandCodes.Find] = new FindAction(),
 			[CommandCodes.ToggleShowHiddenItems] = new ToggleShowHiddenItemsAction(),
 			[CommandCodes.ToggleShowFileExtensions] = new ToggleShowFileExtensionsAction(),
 			[CommandCodes.TogglePreviewPane] = new TogglePreviewPaneAction(),

--- a/src/Files.App/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Commands/Manager/ICommandManager.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Files.App.Commands
@@ -15,6 +14,7 @@ namespace Files.App.Commands
 		IRichCommand EnterCompactOverlay { get; }
 		IRichCommand ExitCompactOverlay { get; }
 		IRichCommand ToggleCompactOverlay { get; }
+		IRichCommand Find { get; }
 
 		IRichCommand ToggleShowHiddenItems { get; }
 		IRichCommand ToggleShowFileExtensions { get; }

--- a/src/Files.App/Contexts/ContentPage/ContentPageContext.cs
+++ b/src/Files.App/Contexts/ContentPage/ContentPageContext.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.DependencyInjection;
 using Files.App.Filesystem;
 using Files.App.UserControls.MultitaskingControl;
 using Files.App.ViewModels;
+using Files.App.Views.LayoutModes;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -20,6 +21,8 @@ namespace Files.App.Contexts
 		private ItemViewModel? filesystemViewModel;
 
 		public IShellPage? ShellPage => context?.PaneOrColumn;
+
+		public Type PageLayoutType => ShellPage?.CurrentPageType ?? typeof(DetailsLayoutBrowser);
 
 		private ContentPageTypes pageType = ContentPageTypes.None;
 		public ContentPageTypes PageType => pageType;
@@ -45,6 +48,7 @@ namespace Files.App.Contexts
 		{
 			if (ShellPage is IShellPage page)
 			{
+				page.PropertyChanged -= Page_PropertyChanged;
 				page.ContentChanged -= Page_ContentChanged;
 				page.InstanceViewModel.PropertyChanged -= InstanceViewModel_PropertyChanged;
 				page.ToolbarViewModel.PropertyChanged -= ToolbarViewModel_PropertyChanged;
@@ -60,6 +64,7 @@ namespace Files.App.Contexts
 		{
 			if (ShellPage is IShellPage page)
 			{
+				page.PropertyChanged += Page_PropertyChanged;
 				page.ContentChanged += Page_ContentChanged;
 				page.InstanceViewModel.PropertyChanged += InstanceViewModel_PropertyChanged;
 				page.ToolbarViewModel.PropertyChanged += ToolbarViewModel_PropertyChanged;
@@ -71,6 +76,16 @@ namespace Files.App.Contexts
 
 			Update();
 			OnPropertyChanged(nameof(ShellPage));
+		}
+
+		private void Page_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			switch (e.PropertyName)
+			{
+				case nameof(ShellPage.CurrentPageType):
+					OnPropertyChanged(nameof(PageLayoutType));
+					break;
+			}
 		}
 
 		private void Page_ContentChanged(object? sender, TabItemArguments e) => Update();

--- a/src/Files.App/Contexts/ContentPage/IContentPageContext.cs
+++ b/src/Files.App/Contexts/ContentPage/IContentPageContext.cs
@@ -1,4 +1,5 @@
 ﻿using Files.App.Filesystem;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -9,6 +10,8 @@ namespace Files.App.Contexts
 		IShellPage? ShellPage { get; }
 
 		ContentPageTypes PageType { get; }
+
+		Type PageLayoutType { get; }
 
 		ListedItem? Folder { get; }
 

--- a/src/Files.App/IShellPage.cs
+++ b/src/Files.App/IShellPage.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 
 namespace Files.App
 {
-	public interface IShellPage : ITabItemContent, IMultiPaneInfo, IDisposable
+	public interface IShellPage : ITabItemContent, IMultiPaneInfo, IDisposable, INotifyPropertyChanged
 	{
 		ItemViewModel FilesystemViewModel { get; }
 

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -327,9 +327,6 @@
   <data name="NavRefreshButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Refresh (F5)</value>
   </data>
-  <data name="NavSearchButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Search (Ctrl+F)</value>
-  </data>
   <data name="ItemAlreadyExistsDialogContent" xml:space="preserve">
     <value>An item with this name already exists in this directory.</value>
   </data>

--- a/src/Files.App/UserControls/AddressToolbar.xaml
+++ b/src/Files.App/UserControls/AddressToolbar.xaml
@@ -201,18 +201,13 @@
 				<Button
 					x:Name="SearchButton"
 					AccessKey="I"
-					AutomationProperties.Name="{helpers:ResourceString Name=Search}"
-					Click="SearchButton_Click"
+					AutomationProperties.Name="{x:Bind ViewModel.Commands.Find.Label}"
+					Command="{x:Bind ViewModel.Commands.Find, Mode=OneWay}"
+					IsEnabled="{x:Bind ViewModel.Commands.Find.IsExecutable}"
 					Style="{StaticResource AddressToolbarButtonStyle}"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=NavSearchButton/ToolTipService/ToolTip}"
+					ToolTipService.ToolTip="{x:Bind ViewModel.Commands.Find.HotKeyText}"
 					Visibility="Collapsed">
 					<FontIcon FontSize="14" Glyph="{x:Bind ViewModel.SearchButtonGlyph, Mode=OneWay}" />
-					<Button.KeyboardAccelerators>
-						<KeyboardAccelerator
-							Key="F"
-							IsEnabled="False"
-							Modifiers="Control" />
-					</Button.KeyboardAccelerators>
 				</Button>
 
 				<Button

--- a/src/Files.App/UserControls/AddressToolbar.xaml.cs
+++ b/src/Files.App/UserControls/AddressToolbar.xaml.cs
@@ -115,7 +115,6 @@ namespace Files.App.UserControls
 				VisiblePath.Focus(FocusState.Programmatic);
 		}
 
-		private void SearchButton_Click(object _, RoutedEventArgs e) => ViewModel.SwitchSearchBoxVisibility();
 		private void SearchRegion_OnGotFocus(object sender, RoutedEventArgs e) => ViewModel.SearchRegion_GotFocus(sender, e);
 		private void SearchRegion_LostFocus(object sender, RoutedEventArgs e) => ViewModel.SearchRegion_LostFocus(sender, e);
 		private void SearchRegion_AccessKeyInvoked(UIElement sender, AccessKeyInvokedEventArgs args) => sender.Focus(FocusState.Keyboard);

--- a/src/Files.App/ViewModels/ToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/ToolbarViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.UI;
 using Files.App.Commands;
+using Files.App.Contexts;
 using Files.App.Extensions;
 using Files.App.Filesystem;
 using Files.App.Filesystem.StorageItems;
@@ -44,7 +45,7 @@ namespace Files.App.ViewModels
 
 		public IUpdateService UpdateService { get; } = Ioc.Default.GetService<IUpdateService>()!;
 
-		private static readonly ICommandManager commands = Ioc.Default.GetRequiredService<ICommandManager>();
+		public ICommandManager Commands { get; } = Ioc.Default.GetRequiredService<ICommandManager>();
 
 		public delegate void ToolbarPathItemInvokedEventHandler(object sender, PathNavigationEventArgs e);
 
@@ -517,8 +518,7 @@ namespace Files.App.ViewModels
 		{
 			if (IsSearchBoxVisible)
 			{
-				SearchBox.Query = string.Empty;
-				IsSearchBoxVisible = false;
+				CloseSearchBox();
 			}
 			else
 			{
@@ -549,6 +549,12 @@ namespace Files.App.ViewModels
 			{
 				SearchBox.Query = string.Empty;
 				IsSearchBoxVisible = false;
+
+				var page = Ioc.Default.GetRequiredService<IContentPageContext>().ShellPage?.SlimContentPage;
+				if (page is not null)
+					page.ItemManipulationModel.FocusFileList();
+				else
+					AddressToolbar.Focus(FocusState.Programmatic);
 			}
 		}
 

--- a/src/Files.App/Views/ColumnShellPage.xaml
+++ b/src/Files.App/Views/ColumnShellPage.xaml
@@ -80,15 +80,6 @@
 			Invoked="KeyboardAccelerator_Invoked"
 			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
 			Modifiers="None" />
-		<KeyboardAccelerator
-			Key="F"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-			Modifiers="Control" />
-		<KeyboardAccelerator
-			Key="F3"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}" />
 	</local:BaseShellPage.KeyboardAccelerators>
 	<Grid
 		x:Name="RootGrid"

--- a/src/Files.App/Views/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/ColumnShellPage.xaml.cs
@@ -144,11 +144,6 @@ namespace Files.App.Views
 						await storageHistoryHelpers.TryRedo();
 					break;
 
-				case (false, false, false, true, VirtualKey.F3): //f3
-				case (true, false, false, true, VirtualKey.F): // ctrl + f
-					ToolbarViewModel.SwitchSearchBoxVisibility();
-					break;
-
 				case (true, true, false, true, VirtualKey.N): // ctrl + shift + n, new item
 					if (InstanceViewModel.CanCreateFileInPage)
 					{

--- a/src/Files.App/Views/ModernShellPage.xaml
+++ b/src/Files.App/Views/ModernShellPage.xaml
@@ -79,15 +79,6 @@
 			Invoked="KeyboardAccelerator_Invoked"
 			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
 			Modifiers="None" />
-		<KeyboardAccelerator
-			Key="F"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-			Modifiers="Control" />
-		<KeyboardAccelerator
-			Key="F3"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}" />
 	</local:BaseShellPage.KeyboardAccelerators>
 
 	<Frame

--- a/src/Files.App/Views/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/ModernShellPage.xaml.cs
@@ -202,13 +202,6 @@ namespace Files.App.Views
 
 					break;
 
-				case (false, false, false, _, VirtualKey.F3): //f3
-				case (true, false, false, _, VirtualKey.F): // ctrl + f
-					if (tabInstance || CurrentPageType == typeof(WidgetsPage))
-						ToolbarViewModel.SwitchSearchBoxVisibility();
-
-					break;
-
 				case (true, true, false, true, VirtualKey.N): // ctrl + shift + n, new item
 					if (InstanceViewModel.CanCreateFileInPage)
 					{


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11481 
   Fixes an issue where `esc` was not closing the search box

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [x] Did you remove any strings from the en-us resource file?
   - [x] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app 
   2. Click `F3` or `Ctrl + F` and see that SearchBox gets focused
