### PR TITLE
Command ToggleSelect

### DIFF
--- a/src/Files.App/Actions/Content/Selection/ToggleSelectAction.cs
+++ b/src/Files.App/Actions/Content/Selection/ToggleSelectAction.cs
@@ -1,0 +1,33 @@
+﻿using Files.App.Commands;
+using Files.App.Extensions;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
+using System.Threading.Tasks;
+using Windows.System;
+
+namespace Files.App.Actions
+{
+	internal class ToggleSelectAction : IAction
+	{
+		public string Label { get; } = "ToggleSelect".GetLocalizedResource();
+		public string Description => "TODO: Need to be described.";
+
+		public HotKey HotKey { get; } = new(VirtualKey.Space, VirtualKeyModifiers.Control);
+
+		public bool IsExecutable => GetFocusedElement() is not null;
+
+		public Task ExecuteAsync()
+		{
+			if (GetFocusedElement() is SelectorItem item)
+			{
+				item.IsSelected = !item.IsSelected;
+			}
+			return Task.CompletedTask;
+		}
+
+		private static SelectorItem? GetFocusedElement()
+		{
+			return FocusManager.GetFocusedElement(App.Window.Content.XamlRoot) as SelectorItem;
+		}
+	}
+}

--- a/src/Files.App/Commands/CommandCodes.cs
+++ b/src/Files.App/Commands/CommandCodes.cs
@@ -37,6 +37,7 @@ namespace Files.App.Commands
 		SelectAll,
 		InvertSelection,
 		ClearSelection,
+		ToggleSelect,
 
 		// Start
 		PinToStart,

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -34,6 +34,7 @@ namespace Files.App.Commands
 		public IRichCommand SelectAll => commands[CommandCodes.SelectAll];
 		public IRichCommand InvertSelection => commands[CommandCodes.InvertSelection];
 		public IRichCommand ClearSelection => commands[CommandCodes.ClearSelection];
+		public IRichCommand ToggleSelect => commands[CommandCodes.ToggleSelect];
 		public IRichCommand EmptyRecycleBin => commands[CommandCodes.EmptyRecycleBin];
 		public IRichCommand RestoreRecycleBin => commands[CommandCodes.RestoreRecycleBin];
 		public IRichCommand RestoreAllRecycleBin => commands[CommandCodes.RestoreAllRecycleBin];
@@ -156,6 +157,7 @@ namespace Files.App.Commands
 			[CommandCodes.SelectAll] = new SelectAllAction(),
 			[CommandCodes.InvertSelection] = new InvertSelectionAction(),
 			[CommandCodes.ClearSelection] = new ClearSelectionAction(),
+			[CommandCodes.ToggleSelect] = new ToggleSelectAction(),
 			[CommandCodes.EmptyRecycleBin] = new EmptyRecycleBinAction(),
 			[CommandCodes.RestoreRecycleBin] = new RestoreRecycleBinAction(),
 			[CommandCodes.RestoreAllRecycleBin] = new RestoreAllRecycleBinAction(),

--- a/src/Files.App/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Commands/Manager/ICommandManager.cs
@@ -29,6 +29,7 @@ namespace Files.App.Commands
 		IRichCommand SelectAll { get; }
 		IRichCommand InvertSelection { get; }
 		IRichCommand ClearSelection { get; }
+		IRichCommand ToggleSelect { get; }
 		IRichCommand CreateFolder { get; }
 		IRichCommand CreateShortcut { get; }
 		IRichCommand CreateShortcutFromDialog { get; }


### PR DESCRIPTION
**Resolved / Related Issues**
* Add Command ToggleSelect for (de)select distant items with the keyboard.
* Use hotkey Ctrl+Space.
* Works on all SelectorItem controls, including layout items.
* Works well with Ctrl+Up/Down/Left/Right to focus items with the keyboard without moving in the list/grid (native hotkeys).

- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
Use Ctrl+Up/Down/Left/Right for moving in list/grid. Use Ctrl+Space for (de)select distant items.

**Screenshots (optional)**

https://user-images.githubusercontent.com/46631671/227733686-0fed1665-2ade-48df-9b87-9137f7cf4eff.mp4
