### PR TITLE
Fix: Set the FontFamily for the TabViewItem

### DIFF
--- a/src/Files.App/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
+++ b/src/Files.App/UserControls/MultitaskingControl/HorizontalMultitaskingControl.xaml
@@ -126,6 +126,7 @@
 						<Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
 						<Setter Property="BorderThickness" Value="{ThemeResource TabViewItemBorderThickness}" />
 						<Setter Property="BorderBrush" Value="{ThemeResource TabViewItemBorderBrush}" />
+						<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
 						<Setter Property="Template">
 							<Setter.Value>
 								<ControlTemplate TargetType="TabViewItem">


### PR DESCRIPTION
Hi @yair100 , i just saw that the issue [11838](https://github.com/files-community/Files/issues/11838) was closed, but i think it could be solved by these changes.
Could you have a quick look at it again?

This is a screenshot of what it looks like with the changes:

![image](https://user-images.githubusercontent.com/56681014/227751267-346240ea-c621-4a31-9716-39db27f7c1df.png)
