### PR TITLE
Code Quality: Improved the code quality of the customization properties page

### DIFF
--- a/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
@@ -11,7 +11,6 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using Windows.Storage.Pickers;
 
 namespace Files.App.ViewModels.Properties

--- a/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
@@ -2,60 +2,109 @@
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI;
 using Files.App.Shell;
+using Files.App.Helpers;
+using Files.App.Views.Properties;
 using Files.Shared;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Windows.Storage.Pickers;
 
 namespace Files.App.ViewModels.Properties
 {
 	public class CustomizationViewModel : ObservableObject
 	{
-		public CustomizationViewModel(string selectedItemPath, string iconResourceItemPath, IShellPage appInstance, bool isShortcut)
+		public CustomizationViewModel(IShellPage appInstance, BaseProperties baseProperties)
 		{
-			SelectedItemPath = selectedItemPath;
-			IconResourceItemPath = iconResourceItemPath;
+			Filesystem.ListedItem item;
+
+			if (baseProperties is FileProperties fileProperties)
+				item = fileProperties.Item;
+			else if (baseProperties is FolderProperties folderProperties)
+				item = folderProperties.Item;
+			else
+				return;
+
 			AppInstance = appInstance;
-			IsShortcut = isShortcut;
+			IconResourceItemPath = Path.Combine(CommonPaths.SystemRootPath, "System32", "SHELL32.dll");
+			IsShortcut = item.IsShortcut;
+			SelectedItemPath = item.ItemPath;
 
 			_dllIcons = new();
 			DllIcons = new(_dllIcons);
 
-			RestoreButtonIsEnabled = true;
-
 			// Get default
 			LoadIconsForPath(IconResourceItemPath);
 
-			RestoreDefaultIconCommand = new AsyncRelayCommand(RestoreDefaultIcon);
+			RestoreDefaultIconCommand = new AsyncRelayCommand(ExecuteRestoreDefaultIconAsync);
+			PickDllFileCommand = new AsyncRelayCommand<XamlRoot>(ExecuteOpenFilePickerAsync);
 		}
 
 		private string? _selectedItemPath;
-		public string? SelectedItemPath { get => _selectedItemPath; set => SetProperty(ref _selectedItemPath, value); }
+		public string? SelectedItemPath
+		{
+			get => _selectedItemPath;
+			set => SetProperty(ref _selectedItemPath, value);
+		}
 
 		private string? _iconResourceItemPath;
-		public string? IconResourceItemPath { get => _iconResourceItemPath; set => SetProperty(ref _iconResourceItemPath, value); }
+		public string? IconResourceItemPath
+		{
+			get => _iconResourceItemPath;
+			set => SetProperty(ref _iconResourceItemPath, value);
+		}
 
 		private IShellPage? _appInstance;
-		private IShellPage? AppInstance { get => _appInstance; set => SetProperty(ref _appInstance, value); }
+		private IShellPage? AppInstance
+		{
+			get => _appInstance;
+			set => SetProperty(ref _appInstance, value);
+		}
 
 		private bool _isShortcut;
-		public bool IsShortcut { get => _isShortcut; private set => SetProperty(ref _isShortcut, value); }
+		public bool IsShortcut
+		{
+			get => _isShortcut;
+			private set => SetProperty(ref _isShortcut, value);
+		}
 
-		private bool _restoreButtonIsEnabled;
-		public bool RestoreButtonIsEnabled { get => _restoreButtonIsEnabled; private set => SetProperty(ref _restoreButtonIsEnabled, value); }
+		private bool _restoreButtonIsEnabled = true;
+		public bool RestoreButtonIsEnabled
+		{
+			get => _restoreButtonIsEnabled;
+			private set => SetProperty(ref _restoreButtonIsEnabled, value);
+		}
 
 		private readonly ObservableCollection<IconFileInfo> _dllIcons;
 		public ReadOnlyObservableCollection<IconFileInfo> DllIcons { get; }
 
-		public ICommand RestoreDefaultIconCommand { get; private set; }
+		private IconFileInfo _SelectedDllIcon;
+		public IconFileInfo SelectedDllIcon
+		{
+			get => _SelectedDllIcon;
+			set
+			{
+				if (value is not null && SetProperty(ref _SelectedDllIcon, value))
+				{
+					ChangeIcon(value);
+				}
+			}
+		}
 
-		private async Task RestoreDefaultIcon()
+		public IAsyncRelayCommand RestoreDefaultIconCommand { get; private set; }
+		public IAsyncRelayCommand<XamlRoot> PickDllFileCommand { get; private set; }
+
+		private async Task ExecuteRestoreDefaultIconAsync()
 		{
 			RestoreButtonIsEnabled = false;
 
 			var setIconResult = IsShortcut
-				? SetCustomFileIcon(SelectedItemPath, null)
-				: SetCustomFolderIcon(SelectedItemPath, null);
+				? Win32API.SetCustomFileIcon(SelectedItemPath, null)
+				: Win32API.SetCustomDirectoryIcon(SelectedItemPath, null);
 
 			if (setIconResult)
 			{
@@ -70,11 +119,40 @@ namespace Files.App.ViewModels.Properties
 			}
 		}
 
-		public async Task ChangeIcon(IconFileInfo selectedIconInfo)
+		private async Task ExecuteOpenFilePickerAsync(XamlRoot? xamlRoot)
+		{
+			if (xamlRoot is null)
+				return;
+
+			// Initialize picker
+			FileOpenPicker picker = new()
+			{
+				SuggestedStartLocation = PickerLocationId.ComputerFolder,
+				ViewMode = PickerViewMode.Thumbnail,
+			};
+
+			picker.FileTypeFilter.Add(".dll");
+			picker.FileTypeFilter.Add(".exe");
+			picker.FileTypeFilter.Add(".ico");
+
+			// WINUI3: Create and initialize new window
+			var parentWindowId = ((MainPropertiesPage)((Frame)xamlRoot.Content).Content).AppWindow.Id;
+			var handle = Microsoft.UI.Win32Interop.GetWindowFromWindowId(parentWindowId);
+			WinRT.Interop.InitializeWithWindow.Initialize(picker, handle);
+
+			// Open picker
+			var file = await picker.PickSingleFileAsync();
+			if (file is null)
+				return;
+
+			LoadIconsForPath(file.Path);
+		}
+
+		private async Task ChangeIcon(IconFileInfo selectedIconInfo)
 		{
 			var setIconResult = IsShortcut
-				? SetCustomFileIcon(SelectedItemPath, IconResourceItemPath, selectedIconInfo.Index)
-				: SetCustomFolderIcon(SelectedItemPath, IconResourceItemPath, selectedIconInfo.Index);
+				? Win32API.SetCustomFileIcon(SelectedItemPath, IconResourceItemPath, selectedIconInfo.Index)
+				: Win32API.SetCustomDirectoryIcon(SelectedItemPath, IconResourceItemPath, selectedIconInfo.Index);
 
 			if (setIconResult)
 			{
@@ -85,7 +163,7 @@ namespace Files.App.ViewModels.Properties
 			}
 		}
 
-		public void LoadIconsForPath(string path)
+		private void LoadIconsForPath(string path)
 		{
 			IconResourceItemPath = path;
 			_dllIcons.Clear();
@@ -97,11 +175,5 @@ namespace Files.App.ViewModels.Properties
 			foreach(var item in icons)
 				_dllIcons.Add(item);
 		}
-
-		private bool SetCustomFolderIcon(string? folderPath, string? iconFile, int iconIndex = 0)
-			=> Win32API.SetCustomDirectoryIcon(folderPath, iconFile, iconIndex);
-
-		private bool SetCustomFileIcon(string? filePath, string? iconFile, int iconIndex = 0)
-			=> Win32API.SetCustomFileIcon(filePath, iconFile, iconIndex);
 	}
 }

--- a/src/Files.App/Views/Properties/CustomizationPage.xaml
+++ b/src/Files.App/Views/Properties/CustomizationPage.xaml
@@ -14,7 +14,6 @@
 
 	<vm:BasePropertiesPage.Resources>
 		<ResourceDictionary>
-
 			<ResourceDictionary.MergedDictionaries>
 				<ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml" />
 			</ResourceDictionary.MergedDictionaries>
@@ -24,11 +23,10 @@
 		</ResourceDictionary>
 	</vm:BasePropertiesPage.Resources>
 
-	<Grid Padding="12">
+	<Grid x:Name="RootGrid">
 
 		<Grid
-			Grid.Row="0"
-			Padding="12"
+			Margin="12"
 			Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
 			BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
 			BorderThickness="1"
@@ -39,41 +37,40 @@
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
-				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
 			</Grid.RowDefinitions>
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="*" />
-				<ColumnDefinition Width="Auto" />
-			</Grid.ColumnDefinitions>
 
-			<TextBlock
-				Grid.Row="0"
-				Grid.Column="0"
-				Padding="4"
-				MaxLines="2"
-				Text="{helpers:ResourceString Name=ChooseCustomIcon}"
-				TextWrapping="WrapWholeWords" />
-			<Button
-				x:Name="RestoreDefaultButton"
-				Grid.Row="0"
-				Grid.Column="1"
-				HorizontalAlignment="Right"
-				x:Load="{x:Bind CustomizationViewModel.IsShortcut, Converter={StaticResource BoolNegationConverter}}"
-				Command="{x:Bind CustomizationViewModel.RestoreDefaultIconCommand}"
-				Content="{helpers:ResourceString Name=RestoreDefault}"
-				IsEnabled="{x:Bind CustomizationViewModel.RestoreButtonIsEnabled, Mode=OneWay}" />
+			<Grid Grid.Row="0" Margin="12,12,12,0">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="Auto" />
+				</Grid.ColumnDefinitions>
 
-			<MenuFlyoutSeparator
+				<TextBlock
+					Padding="4"
+					Text="{helpers:ResourceString Name=ChooseCustomIcon}"
+					TextTrimming="CharacterEllipsis"
+					TextWrapping="NoWrap" />
+
+				<Button
+					x:Name="RestoreDefaultButton"
+					Grid.Column="1"
+					x:Load="{x:Bind CustomizationViewModel.IsShortcut, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
+					Command="{x:Bind CustomizationViewModel.RestoreDefaultIconCommand, Mode=OneWay}"
+					Content="{helpers:ResourceString Name=RestoreDefault}"
+					IsEnabled="{x:Bind CustomizationViewModel.RestoreButtonIsEnabled, Mode=OneWay}" />
+
+			</Grid>
+
+			<Border
 				Grid.Row="1"
-				Grid.Column="0"
-				Grid.ColumnSpan="2"
+				Height="1"
 				Margin="-12,0"
-				Background="{ThemeResource CardStrokeColorDefaultBrush}" />
+				Background="{ThemeResource DividerStrokeColorDefaultBrush}" />
 
 			<Grid
 				Grid.Row="2"
-				Grid.Column="0"
-				Grid.ColumnSpan="2"
+				Margin="12,0"
 				ColumnSpacing="8">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="*" />
@@ -81,47 +78,37 @@
 				</Grid.ColumnDefinitions>
 
 				<TextBox
-					x:Name="ItemDisplayedPath"
-					Grid.Column="0"
+					x:Name="PickedDllFilePathTextBox"
 					IsReadOnly="True"
 					Text="{x:Bind CustomizationViewModel.IconResourceItemPath, Mode=OneWay}" />
 
 				<Button
-					x:Name="PickDllButton"
+					x:Name="PickDllFileButton"
 					Grid.Column="1"
-					HorizontalAlignment="Right"
-					Click="PickDllButton_Click"
+					Command="{x:Bind CustomizationViewModel.PickDllFileCommand, Mode=OneWay}"
+					CommandParameter="{x:Bind XamlRoot, Mode=OneWay}"
 					Content="{helpers:ResourceString Name=Browse}" />
+
 			</Grid>
 
 			<GridView
 				x:Name="IconSelectionGrid"
 				Grid.Row="3"
-				Grid.Column="0"
-				Grid.ColumnSpan="3"
-				MaxHeight="252"
-				HorizontalAlignment="Stretch"
-				VerticalAlignment="Stretch"
+				Padding="12"
 				ItemsSource="{x:Bind CustomizationViewModel.DllIcons, Mode=OneWay}"
-				ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-				ScrollViewer.HorizontalScrollMode="Disabled"
-				ScrollViewer.VerticalScrollBarVisibility="Auto"
-				ScrollViewer.VerticalScrollMode="Auto"
-				SelectionChanged="IconSelectionGrid_SelectionChanged"
-				SelectionMode="Single">
-				<GridView.ItemsPanel>
-					<ItemsPanelTemplate>
-						<ItemsWrapGrid Orientation="Horizontal" />
-					</ItemsPanelTemplate>
-				</GridView.ItemsPanel>
+				SelectedItem="{x:Bind CustomizationViewModel.SelectedDllIcon, Mode=TwoWay}">
 				<GridView.ItemTemplate>
 					<DataTemplate x:DataType="shared:IconFileInfo">
-						<Grid Width="32" Height="32">
-							<Image uc:ImageFromBytes.SourceBytes="{x:Bind IconData}" />
-						</Grid>
+
+						<Image
+							Width="32"
+							Height="32"
+							uc:ImageFromBytes.SourceBytes="{x:Bind IconData}" />
+
 					</DataTemplate>
 				</GridView.ItemTemplate>
 			</GridView>
+
 		</Grid>
 
 	</Grid>

--- a/src/Files.App/Views/Properties/CustomizationPage.xaml.cs
+++ b/src/Files.App/Views/Properties/CustomizationPage.xaml.cs
@@ -1,11 +1,5 @@
-using Files.App.Helpers;
 using Files.App.ViewModels.Properties;
-using Files.Shared;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using System;
-using System.IO;
 using System.Threading.Tasks;
 
 namespace Files.App.Views.Properties
@@ -22,54 +16,11 @@ namespace Files.App.Views.Properties
 		protected override void OnNavigatedTo(NavigationEventArgs e)
 		{
 			base.OnNavigatedTo(e);
-
-			string initialPath = Path.Combine(CommonPaths.SystemRootPath, "System32", "SHELL32.dll");
-			var item = (BaseProperties as FileProperties)?.Item ?? (BaseProperties as FolderProperties)?.Item;
-
-			CustomizationViewModel = new(item.ItemPath, initialPath, AppInstance, item.IsShortcut);
-		}
-
-
-		private async void PickDllButton_Click(object sender, RoutedEventArgs e)
-		{
-			// Initialize picker
-			Windows.Storage.Pickers.FileOpenPicker picker = new()
-			{
-				SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.ComputerFolder,
-				ViewMode = Windows.Storage.Pickers.PickerViewMode.Thumbnail,
-			};
-
-			picker.FileTypeFilter.Add(".dll");
-			picker.FileTypeFilter.Add(".exe");
-			picker.FileTypeFilter.Add(".ico");
-
-			// WINUI3: Create and initialize new window
-			var parentWindowId = ((Views.Properties.MainPropertiesPage)((Frame)XamlRoot.Content).Content).AppWindow.Id;
-			var handle = Microsoft.UI.Win32Interop.GetWindowFromWindowId(parentWindowId);
-			WinRT.Interop.InitializeWithWindow.Initialize(picker, handle);
-
-			// Open picker
-			var file = await picker.PickSingleFileAsync();
-			if (file is null)
-				return;
-
-			// TODO: View-ViewModel
-			CustomizationViewModel.LoadIconsForPath(file.Path);
-		}
-
-		private async void IconSelectionGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
-		{
-			if (((GridView)sender).SelectedItem is not IconFileInfo selectedIconInfo)
-				return;
-
-			// TODO: View-ViewModel
-			await CustomizationViewModel.ChangeIcon(selectedIconInfo);
+			CustomizationViewModel = new(AppInstance, BaseProperties);
 		}
 
 		public override Task<bool> SaveChangesAsync()
-		{
-			return Task.FromResult(true);
-		}
+			=> Task.FromResult(true);
 
 		public override void Dispose()
 		{


### PR DESCRIPTION
### Description

I've done this before in https://github.com/files-community/Files/pull/11421 and I reverted to avoid adding off-topic changes(although it was accepted change). But here you are again.

### Motivation and Context

- Fix UI that was created for out-dated window style
- Improve readability and maintainability of those codes

### Details of change

- Update UI to maximize GridView.
- Update divider to use Border instead of MenuFlyoutSeparator
- Update divider to use DividerStrokeDefaultBrush, which is expected, instead.
- Add Commands to the ViewModel.
- Remove events in the View.
- Remove event handling codes in View's code-behind.

### Self-check list

- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?

### Screenshots

Light
![image](https://user-images.githubusercontent.com/62196528/227781804-1314f920-009c-4d12-95d3-1537d0d0d6f3.png)

Dark
![image](https://user-images.githubusercontent.com/62196528/227781899-5449eb0f-c75a-4f18-b310-8b34bb4b3275.png)
