### PR TITLE
Use Special keys Browser Back/Forward

### DIFF
--- a/src/Files.App/Actions/Navigation/NavigateBackAction.cs
+++ b/src/Files.App/Actions/Navigation/NavigateBackAction.cs
@@ -20,6 +20,7 @@ namespace Files.App.Actions
 		public HotKey HotKey { get; } = new(VirtualKey.Left, VirtualKeyModifiers.Menu);
 		public HotKey SecondHotKey { get; } = new(VirtualKey.Back);
 		public HotKey ThirdHotKey { get; } = new(VirtualKey.XButton1);
+		public HotKey MediaHotKey { get; } = new((VirtualKey)166); // VK_BROWSER_BACK
 
 		public RichGlyph Glyph { get; } = new("\uE72B");
 

--- a/src/Files.App/Actions/Navigation/NavigateForwardAction.cs
+++ b/src/Files.App/Actions/Navigation/NavigateForwardAction.cs
@@ -19,6 +19,7 @@ namespace Files.App.Actions
 
 		public HotKey HotKey { get; } = new(VirtualKey.Right, VirtualKeyModifiers.Menu);
 		public HotKey SecondHotKey { get; } = new(VirtualKey.XButton2);
+		public HotKey MediaHotKey { get; } = new((VirtualKey)167); // VK_BROWSER_FORWARD
 
 		public RichGlyph Glyph { get; } = new("\uE72A");
 


### PR DESCRIPTION
**Resolved / Related Issues**
Some keyboards have direct keys for "BrowserBack" and BrowserForward. This pr adds these keys to the commands. These are media keys, so do not appear in HotKeys labels.

- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
Open multiple pages in the same tab to enable history.
Use BrowserBack and BrowserForward to navigate through history.