### PR TITLE
Fix: Fixed issue where the startup settings was ignored when launched from terminal

### DIFF
--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -75,10 +75,9 @@ namespace Files.App
 						// WINUI3 bug: when launching from commandline the argument is not ICommandLineActivatedEventArgs (#10370)
 						var ppm = CommandLineParser.ParseUntrustedCommands(launchArgs.Arguments);
 						if (ppm.IsEmpty())
-						{
-							ppm = new ParsedCommands() { new ParsedCommand() { Type = ParsedCommandType.Unknown, Args = new() { "." } } };
-						}
-						await InitializeFromCmdLineArgs(rootFrame, ppm);
+							rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+						else
+							await InitializeFromCmdLineArgs(rootFrame, ppm);
 					}
 					else if (rootFrame.Content is null)
 					{
@@ -123,10 +122,9 @@ namespace Files.App
 							case "cmd":
 								var ppm = CommandLineParser.ParseUntrustedCommands(unescapedValue);
 								if (ppm.IsEmpty())
-								{
-									ppm = new ParsedCommands() { new ParsedCommand() { Type = ParsedCommandType.Unknown, Args = new() { "." } } };
-								}
-								await InitializeFromCmdLineArgs(rootFrame, ppm);
+									rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+								else
+									await InitializeFromCmdLineArgs(rootFrame, ppm);
 								break;
 						}
 					}


### PR DESCRIPTION
It's not approved yet, but I believe it should be fixed.

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11858 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [X] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Open a terminal.
   2. Type "files.exe" and press enter.
   3. You will see that the startup settings are reflected.
