### PR TITLE
Fix: Assigned Enter as a hotkey to open item.

### DIFF
--- a/src/Files.App/Actions/FileSystem/OpenItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/OpenItemAction.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.Storage;
+using Windows.System;
 
 namespace Files.App.Actions
 {
@@ -23,9 +24,12 @@ namespace Files.App.Actions
 
 		public RichGlyph Glyph => new(opacityStyle: "ColorIconOpenFile");
 
+		public HotKey HotKey => new(VirtualKey.Enter);
+
 		private const int MaxOpenCount = 10;
 
-		public bool IsExecutable => context.HasSelection && context.SelectedItems.Count <= MaxOpenCount;
+		public bool IsExecutable => context.HasSelection && context.SelectedItems.Count <= MaxOpenCount &&
+			!(context.ShellPage is ColumnShellPage && context.SelectedItem?.PrimaryItemAttribute == StorageItemTypes.Folder);
 
 		public OpenItemAction()
 		{

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -278,8 +278,6 @@ namespace Files.App.Views.LayoutModes
 
 				if (IsItemSelected && SelectedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
 					ItemInvoked?.Invoke(new ColumnParam { NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
-				else
-					await NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
 			}
 			else if (e.Key == VirtualKey.Enter && e.KeyStatus.IsMenuKeyDown)
 			{

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -350,11 +350,6 @@ namespace Files.App.Views.LayoutModes
 				{
 					NavigationHelpers.OpenInSecondaryPane(ParentShellPageInstance, SelectedItems.FirstOrDefault(item => item.PrimaryItemAttribute == StorageItemTypes.Folder));
 				}
-				else
-				{
-					await NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
-					FileList.SelectedIndex = 0;
-				}
 			}
 			else if (e.Key == VirtualKey.Enter && e.KeyStatus.IsMenuKeyDown)
 			{

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -287,10 +287,6 @@ namespace Files.App.Views.LayoutModes
 				{
 					NavigationHelpers.OpenInSecondaryPane(ParentShellPageInstance, SelectedItems.FirstOrDefault(item => item.PrimaryItemAttribute == StorageItemTypes.Folder));
 				}
-				else
-				{
-					await NavigationHelpers.OpenSelectedItems(ParentShellPageInstance, false);
-				}
 			}
 			else if (e.Key == VirtualKey.Enter && e.KeyStatus.IsMenuKeyDown)
 			{


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11870 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [X] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

**Notes**
This will fix same issue as #11871, but this one uses RichCommand to open item with Enter key.