### PR TITLE
Fix: Don't clear multiselect on hover if the item is part of the selection

### DIFF
--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -1101,11 +1101,8 @@ namespace Files.App
 			if (!UserSettingsService.FoldersSettingsService.SelectFilesOnHover)
 				return;
 
-			var hovered = GetItemFromElement(sender);
-			if (hovered == hoveredItem)
-				return;
+			hoveredItem = GetItemFromElement(sender);
 
-			hoveredItem = hovered;
 			hoverTimer.Stop();
 			hoverTimer.Debounce(() =>
 			{
@@ -1142,8 +1139,6 @@ namespace Files.App
 				{
 					ItemManipulationModel.SetSelectedItem(hoveredItem);
 				}
-
-				hoveredItem = null;
 			},
 			TimeSpan.FromMilliseconds(600), false);
 		}


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11867

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Hovering over multiple selected items won't clear selection
   2. Hovering over not selected items will clear the multi selection & select the new item



**Screenshots (optional)**

https://user-images.githubusercontent.com/56681014/228270965-5a829742-9e86-456b-a124-9fecd457829c.mp4



**Notes**
The first commit inverts two conditions and uses `return` to save some indentation
The second commit is the actual fix
