### PR TITLE
Fix: Fixed issue where hotkeys with dialog would not work

### DIFF
--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -251,6 +251,7 @@ namespace Files.App.Views
 					break;
 			}
 		}
+
 		protected override void OnPreviewKeyUp(KeyRoutedEventArgs e)
 		{
 			base.OnPreviewKeyUp(e);
@@ -268,7 +269,8 @@ namespace Files.App.Views
 					break;
 			}
 		}
-		
+
+		// A workaround for issue with OnPreviewKeyUp not being called when the hotkey displays a dialog
 		protected override void OnLostFocus(RoutedEventArgs e)
 		{
 			base.OnLostFocus(e);

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -268,6 +268,7 @@ namespace Files.App.Views
 					break;
 			}
 		}
+		
 		protected override void OnLostFocus(RoutedEventArgs e)
 		{
 			base.OnLostFocus(e);

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -253,7 +253,7 @@ namespace Files.App.Views
 		}
 		protected override void OnPreviewKeyUp(KeyRoutedEventArgs e)
 		{
-			base.OnPreviewKeyDown(e);
+			base.OnPreviewKeyUp(e);
 
 			switch (e.Key)
 			{
@@ -267,6 +267,12 @@ namespace Files.App.Views
 					keyReleased = true;
 					break;
 			}
+		}
+		protected override void OnLostFocus(RoutedEventArgs e)
+		{
+			base.OnLostFocus(e);
+
+			keyReleased = true;
 		}
 
 		private async void SidebarControl_SidebarItemDropped(object sender, SidebarItemDroppedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11800 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [X] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Select an item.
   2. Press Delete key.
   3. You will see a dialog. Press Cancel button.
   4. Press Delete key again.
   5. You will see a dialog again. In 2.4.57.0, no dialog appears.
