### PR TITLE
Feature: Added support for turning off file extension warning

### DIFF
--- a/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
+++ b/src/Files.App/Filesystem/FilesystemOperations/Helpers/FilesystemHelpers.cs
@@ -561,9 +561,14 @@ namespace Files.App.Filesystem
 					history = await filesystemOperations.RenameAsync(source, newName, collision, progress, cancellationToken);
 					break;
 
+				// Prompt user when extension has changed, not when file name has changed
 				case FilesystemItemType.File:
-					if (showExtensionDialog &&
-						Path.GetExtension(source.Path) != Path.GetExtension(newName)) // Only prompt user when extension has changed, not when file name has changed
+					if
+					(
+						showExtensionDialog &&
+						Path.GetExtension(source.Path) != Path.GetExtension(newName) &&
+						UserSettingsService.FoldersSettingsService.ShowFileExtensionWarning
+					)
 					{
 						var yesSelected = await DialogDisplayHelper.ShowDialogAsync("Rename".GetLocalizedResource(), "RenameFileDialog/Text".GetLocalizedResource(), "Yes".GetLocalizedResource(), "No".GetLocalizedResource());
 						if (yesSelected)

--- a/src/Files.App/ServicesImplementation/Settings/FoldersSettingsService.cs
+++ b/src/Files.App/ServicesImplementation/Settings/FoldersSettingsService.cs
@@ -268,6 +268,12 @@ namespace Files.App.ServicesImplementation.Settings
 			set => Set(value);
 		}
 
+		public bool ShowFileExtensionWarning
+		{
+			get => Get(true);
+			set => Set(value);
+		}
+
 		protected override void RaiseOnSettingChangedEvent(object sender, SettingChangedEventArgs e)
 		{
 			switch (e.SettingName)
@@ -298,6 +304,7 @@ namespace Files.App.ServicesImplementation.Settings
 				case nameof(DeleteConfirmationPolicy):
 				case nameof(SelectFilesOnHover):
 				case nameof(DoubleClickToGoUp):
+				case nameof(ShowFileExtensionWarning):
 					Analytics.TrackEvent($"Set {e.SettingName} to {e.NewValue}");
 					break;
 			}

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2667,4 +2667,7 @@
   <data name="ToggleSelect" xml:space="preserve">
     <value>Toggle Selection</value>
   </data>
+  <data name="ShowFileExtensionWarning" xml:space="preserve">
+    <value>Show warning when changing file extensions</value>
+  </data>
 </root>

--- a/src/Files.App/ViewModels/Settings/FoldersViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/FoldersViewModel.cs
@@ -407,6 +407,20 @@ namespace Files.App.ViewModels.Settings
 			}
 		}
 
+		public bool ShowFileExtensionWarning
+		{
+			get => UserSettingsService.FoldersSettingsService.ShowFileExtensionWarning;
+			set
+			{
+				if (value != UserSettingsService.FoldersSettingsService.ShowFileExtensionWarning)
+				{
+					UserSettingsService.FoldersSettingsService.ShowFileExtensionWarning = value;
+
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		public void ResetLayoutPreferences()
 		{
 			// Is this proper practice?

--- a/src/Files.App/Views/Settings/FoldersPage.xaml
+++ b/src/Files.App/Views/Settings/FoldersPage.xaml
@@ -289,6 +289,18 @@
 					<ComboBoxItem Content="{helpers:ResourceString Name=Never}" />
 				</ComboBox>
 			</local:SettingsBlockControl>
+			
+			<!--  File Extension Warning  -->
+			<local:SettingsBlockControl Title="{helpers:ResourceString Name=ShowFileExtensionWarning}" HorizontalAlignment="Stretch">
+				<local:SettingsBlockControl.Icon>
+					<FontIcon Glyph="&#xE8AC;" />
+				</local:SettingsBlockControl.Icon>
+
+				<ToggleSwitch
+					AutomationProperties.Name="{helpers:ResourceString Name=ShowFileExtensionWarning}"
+					IsOn="{x:Bind ViewModel.ShowFileExtensionWarning, Mode=TwoWay}"
+					Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+			</local:SettingsBlockControl>
 
 			<!--  Select On Hover  -->
 			<local:SettingsBlockControl Title="{helpers:ResourceString Name=SelectFilesAndFoldersOnHover}" HorizontalAlignment="Stretch">

--- a/src/Files.Backend/Services/Settings/IFoldersSettingsService.cs
+++ b/src/Files.Backend/Services/Settings/IFoldersSettingsService.cs
@@ -189,5 +189,10 @@ namespace Files.Backend.Services.Settings
 		/// Gets or sets a value indicating if double clicking a blank space should go up a directory.
 		/// </summary>
 		bool DoubleClickToGoUp { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating if a warning dialog show be shown when changing file extensions.
+		/// </summary>
+		bool ShowFileExtensionWarning { get; set; }
 	}
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #10221...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Rename a file extension
   3. Verify that the warning dialog is displayed 
   4. Open setting, navigate to the folder page and turn off the option for displaying the warning
   5. Rename a file extension and verify the warning isn't displayed

**Screenshots (optional)**
Add screenshots here.
