### PR TITLE
Fix: Fixed issue that caused NullReferenceException to be raised unnecessarily

### DIFF
--- a/src/Files.App/Shell/Win32Shell.cs
+++ b/src/Files.App/Shell/Win32Shell.cs
@@ -45,9 +45,9 @@ namespace Files.App.Shell
 						controlPanelCategoryView.PIDL.IsParentOf(shellFolder.PIDL, false)) &&
 						!shellFolder.Any())
 					{
-							// Return null to force open unsupported items in explorer
-							// only if inside control panel and folder appears empty
-							return (null, flc);
+						// Return null to force open unsupported items in explorer
+						// only if inside control panel and folder appears empty
+						return (null, flc);
 					}
 
 					folder = ShellFolderExtensions.GetShellFileItem(shellFolder);

--- a/src/Files.App/Shell/Win32Shell.cs
+++ b/src/Files.App/Shell/Win32Shell.cs
@@ -39,16 +39,18 @@ namespace Files.App.Shell
 				try
 				{
 					using var shellFolder = ShellFolderExtensions.GetShellItemFromPathOrPidl(path) as ShellFolder;
-					folder = ShellFolderExtensions.GetShellFileItem(shellFolder);
 
-					if ((controlPanel.PIDL.IsParentOf(shellFolder.PIDL, false) ||
+					if (shellFolder is null ||
+						(controlPanel.PIDL.IsParentOf(shellFolder.PIDL, false) ||
 						controlPanelCategoryView.PIDL.IsParentOf(shellFolder.PIDL, false)) &&
-						(shellFolder is null || !shellFolder.Any()))
+						!shellFolder.Any())
 					{
-						// Return null to force open unsupported items in explorer
-						// only if inside control panel and folder appears empty
-						return (null, flc);
+							// Return null to force open unsupported items in explorer
+							// only if inside control panel and folder appears empty
+							return (null, flc);
 					}
+
+					folder = ShellFolderExtensions.GetShellFileItem(shellFolder);
 
 					if (action == "Enumerate")
 					{


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [X] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   - If you run it in debug mode, you will see that NullReferenceException is no longer raised.
