### PR TITLE
Fix: Clear highlight in the last blade

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -60,7 +60,7 @@ namespace Files.App.Views.LayoutModes
 			openedFolderPresenter = FileList.ContainerFromItem(FileList.SelectedItem) as ListViewItem;
 		}
 
-		private void ClearOpenedFolderSelectionIndicator()
+		internal void ClearOpenedFolderSelectionIndicator()
 		{
 			if (openedFolderPresenter is null)
 				return;

--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -429,7 +429,10 @@ namespace Files.App.Views.LayoutModes
 			var destComponents = StorageFileExtensions.GetDirectoryPathComponents(column.NavPathParam);
 			var (_, relativeIndex) = GetLastCommonAndRelativeIndex(destComponents, columnPath, columnFirstPath);
 			if (relativeIndex >= 0)
+			{
+				ColumnHost.ActiveBlades[relativeIndex].FindDescendant<ColumnViewBase>()?.ClearOpenedFolderSelectionIndicator();
 				DismissOtherBlades(relativeIndex);
+			}
 		}
 
 		private (int, int) GetLastCommonAndRelativeIndex(List<PathBoxItem> destComponents, string columnPath, string columnFirstPath)


### PR DESCRIPTION
This is a follow-up to #11898.
When a parent folder is selected in the column view, the item highlight in the last blade should be cleared.

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [X] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

**Screenshots**
Berfore:
![image](https://user-images.githubusercontent.com/66369541/228711008-d13a4c37-f377-474e-9a5b-a4045eb66c01.png)

After:
![image](https://user-images.githubusercontent.com/66369541/228710748-d1fee0ac-0ea4-48e1-9f10-21066f538d41.png)
