### PR TITLE
Fix: Fixed issue where grouping by tags wouldn't show all items

### DIFF
--- a/src/Files.App/Helpers/ItemListDisplayHelpers/BulkConcurrentObservableCollection.cs
+++ b/src/Files.App/Helpers/ItemListDisplayHelpers/BulkConcurrentObservableCollection.cs
@@ -168,7 +168,7 @@ namespace Files.App.Helpers
 
 				var key = GetGroupKeyForItem(item);
 				if (key is null)
-					return;
+					continue;
 
 				var groups = GroupedCollection?.Where(x => x.Model.Key == key);
 				if (item is IGroupableItem groupable)

--- a/src/Files.App/Helpers/ItemListDisplayHelpers/GroupingHelper.cs
+++ b/src/Files.App/Helpers/ItemListDisplayHelpers/GroupingHelper.cs
@@ -23,7 +23,7 @@ namespace Files.App.Helpers
 				GroupOption.DateModified => x => dateTimeFormatter.ToTimeSpanLabel(x.ItemDateModifiedReal).Text,
 				GroupOption.FileType => x => x.PrimaryItemAttribute == StorageItemTypes.Folder && !x.IsShortcut ? x.ItemType : x.FileExtension?.ToLowerInvariant() ?? " ",
 				GroupOption.SyncStatus => x => x.SyncStatusString,
-				GroupOption.FileTag => x => x.FileTags?.FirstOrDefault(),
+				GroupOption.FileTag => x => x.FileTags?.FirstOrDefault() ?? "Untagged",
 				GroupOption.OriginalFolder => x => (x as RecycleBinItem)?.ItemOriginalFolder,
 				GroupOption.DateDeleted => x => dateTimeFormatter.ToTimeSpanLabel((x as RecycleBinItem)?.ItemDateDeletedReal ?? DateTimeOffset.Now).Text,
 				GroupOption.FolderPath => x => PathNormalization.GetParentDir(x.ItemPath.TrimPath()),
@@ -94,9 +94,9 @@ namespace Files.App.Helpers
 
 				GroupOption.FileTag => (x =>
 				{
-					ListedItem first = x.First();
+					ListedItem first = x.FirstOrDefault();
 					x.Model.ShowCountTextBelow = true;
-					x.Model.Text = first.FileTagsUI?.FirstOrDefault()?.Name ?? "None".GetLocalizedResource();
+					x.Model.Text = first.FileTagsUI?.FirstOrDefault()?.Name ?? "Untagged".GetLocalizedResource();
 					//x.Model.Icon = first.FileTagsUI?.FirstOrDefault()?.Color;
 				}, null),
 

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2854,4 +2854,7 @@
   <data name="ShowFileExtensionWarning" xml:space="preserve">
     <value>Show warning when changing file extensions</value>
   </data>
+  <data name="Untagged" xml:space="preserve">
+    <value>Untagged</value>
+  </data>
 </root>


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related #11759 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ x Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open a folder which contains both tagged and untagged items
   2. Select `Group by Tag`
   3. See that all items are grouped
   4. Refresh the page
   5. See that all items are under the `Untagged` group

**Screenshots (optional)**
![1](https://user-images.githubusercontent.com/102259289/228872495-6c1c7aee-7263-45c0-a325-1195a8c0d7ab.png)
![2](https://user-images.githubusercontent.com/102259289/228872485-97adc5f1-e493-4990-97c6-e9c4233bd81f.png)
![3](https://user-images.githubusercontent.com/102259289/228872499-66874401-be3b-46c3-a60d-b5f3d6d65b5b.png)

