### PR TITLE
Fix: Log only when pressed space

### DIFF
--- a/src/Files.App/Helpers/QuickLookHelpers.cs
+++ b/src/Files.App/Helpers/QuickLookHelpers.cs
@@ -17,9 +17,11 @@ public static class QuickLookHelpers
 	{
 		bool isQuickLookAvailable = await DetectQuickLookAvailability();
 
-		if (isQuickLookAvailable == false)
+		if (!isQuickLookAvailable)
 		{
-			App.Logger.Info($"QuickLook not detected!");
+			if (!switchPreview)
+				App.Logger.Info($"QuickLook not detected!");
+			
 			return;
 		}
 


### PR DESCRIPTION
_Targeted to the servicing branch_
`DetectQuickLookAvailability()` is called each time an item is selected, so this PR changes the log output timing to only when pressed space to try to launch QuickLook.

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
