### PR TITLE
Fix: Fixed regressions caused by "Always apply most current layout"

### DIFF
--- a/src/Files.App/ViewModels/FolderSettingsViewModel.cs
+++ b/src/Files.App/ViewModels/FolderSettingsViewModel.cs
@@ -94,11 +94,14 @@ namespace Files.App.ViewModels
 			set => SetProperty(ref isLayoutModeChanging, value);
 		}
 
-		public Type GetLayoutType(string folderPath)
+		public Type GetLayoutType(string folderPath, bool changeLayoutMode = true)
 		{
 			var prefsForPath = GetLayoutPreferencesForPath(folderPath);
-			IsLayoutModeChanging = LayoutPreference.LayoutMode != prefsForPath.LayoutMode;
-			LayoutPreference = prefsForPath;
+			if (changeLayoutMode)
+			{
+				IsLayoutModeChanging = LayoutPreference.LayoutMode != prefsForPath.LayoutMode;
+				LayoutPreference = prefsForPath;
+			}
 
 			return (prefsForPath.LayoutMode) switch
 			{

--- a/src/Files.App/Views/BaseShellPage.cs
+++ b/src/Files.App/Views/BaseShellPage.cs
@@ -503,7 +503,8 @@ namespace Files.App.Views
 		{
 			foreach (PageStackEntry entry in ItemDisplay.BackStack.ToList())
 			{
-				if (entry.Parameter is NavigationArguments args && args.NavPathParam is not null and not "Home")
+				if (entry.Parameter is NavigationArguments args && 
+					args.NavPathParam is not null and not "Home")
 				{
 					var correctPageType = FolderSettings.GetLayoutType(args.NavPathParam, false);
 					if (!entry.SourcePageType.Equals(correctPageType))
@@ -518,7 +519,8 @@ namespace Files.App.Views
 
 			foreach (PageStackEntry entry in ItemDisplay.ForwardStack.ToList())
 			{
-				if (entry.Parameter is NavigationArguments args && args.NavPathParam is not null and not "Home")
+				if (entry.Parameter is NavigationArguments args &&
+					args.NavPathParam is not null and not "Home")
 				{
 					var correctPageType = FolderSettings.GetLayoutType(args.NavPathParam, false);
 					if (!entry.SourcePageType.Equals(correctPageType))

--- a/src/Files.App/Views/BaseShellPage.cs
+++ b/src/Files.App/Views/BaseShellPage.cs
@@ -503,9 +503,9 @@ namespace Files.App.Views
 		{
 			foreach (PageStackEntry entry in ItemDisplay.BackStack.ToList())
 			{
-				if (entry.Parameter is NavigationArguments args)
+				if (entry.Parameter is NavigationArguments args && args.NavPathParam != "Home")
 				{
-					var correctPageType = FolderSettings.GetLayoutType(args.NavPathParam);
+					var correctPageType = FolderSettings.GetLayoutType(args.NavPathParam, false);
 					if (!entry.SourcePageType.Equals(correctPageType))
 					{
 						int index = ItemDisplay.BackStack.IndexOf(entry);
@@ -518,9 +518,9 @@ namespace Files.App.Views
 
 			foreach (PageStackEntry entry in ItemDisplay.ForwardStack.ToList())
 			{
-				if (entry.Parameter is NavigationArguments args)
+				if (entry.Parameter is NavigationArguments args && args.NavPathParam != "Home")
 				{
-					var correctPageType = FolderSettings.GetLayoutType(args.NavPathParam);
+					var correctPageType = FolderSettings.GetLayoutType(args.NavPathParam, false);
 					if (!entry.SourcePageType.Equals(correctPageType))
 					{
 						int index = ItemDisplay.ForwardStack.IndexOf(entry);

--- a/src/Files.App/Views/BaseShellPage.cs
+++ b/src/Files.App/Views/BaseShellPage.cs
@@ -503,7 +503,7 @@ namespace Files.App.Views
 		{
 			foreach (PageStackEntry entry in ItemDisplay.BackStack.ToList())
 			{
-				if (entry.Parameter is NavigationArguments args && args.NavPathParam != "Home")
+				if (entry.Parameter is NavigationArguments args && args.NavPathParam is not null and not "Home")
 				{
 					var correctPageType = FolderSettings.GetLayoutType(args.NavPathParam, false);
 					if (!entry.SourcePageType.Equals(correctPageType))
@@ -518,7 +518,7 @@ namespace Files.App.Views
 
 			foreach (PageStackEntry entry in ItemDisplay.ForwardStack.ToList())
 			{
-				if (entry.Parameter is NavigationArguments args && args.NavPathParam != "Home")
+				if (entry.Parameter is NavigationArguments args && args.NavPathParam is not null and not "Home")
 				{
 					var correctPageType = FolderSettings.GetLayoutType(args.NavPathParam, false);
 					if (!entry.SourcePageType.Equals(correctPageType))


### PR DESCRIPTION
_Targeted to the servicing branch_

#11851 has caused some regressions. This PR will fix them.
* Fixed issue with layout changes sometimes not working properly
* Fixed "NotAFolder" error when returning to the home page with the back button after changing the layout

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Layout changes should always work correctly. In 2.4.60, layout changes sometimes causes blank screen or no change.
   2. "NotAFolder" error shouldn't occur when returning to the home page with the back button after changing the layout.
