### PR TITLE
Feature: More improved (but hacky) context menu loading

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -13,6 +13,7 @@ using Files.App.Helpers;
 using Files.App.ServicesImplementation;
 using Files.App.ServicesImplementation.DateTimeFormatter;
 using Files.App.ServicesImplementation.Settings;
+using Files.App.Shell;
 using Files.App.Storage.NativeStorage;
 using Files.App.UserControls.MultitaskingControl;
 using Files.App.ViewModels;
@@ -139,7 +140,8 @@ namespace Files.App
 
 				await Task.WhenAll(
 					JumpListHelper.InitializeUpdatesAsync(),
-					addItemService.GetNewEntriesAsync()
+					addItemService.GetNewEntriesAsync(),
+					ContextMenu.WarmUpQueryContextMenuAsync()
 				);
 
 				FileTagsHelper.UpdateTagsDb();

--- a/src/Files.App/Shell/ContextMenu.cs
+++ b/src/Files.App/Shell/ContextMenu.cs
@@ -163,6 +163,17 @@ namespace Files.App.Shell
 			}
 		}
 
+		public static async Task WarmUpQueryContextMenuAsync()
+		{
+			await new ThreadWithMessageQueue().PostMethod(() =>
+			{
+				// Create a dummy context menu for warming up
+				var shellItem = ShellFolderExtensions.GetShellItemFromPathOrPidl("C:\\");
+				Shell32.IContextMenu menu = shellItem.Parent.GetChildrenUIObjects<Shell32.IContextMenu>(default, shellItem);
+				menu.QueryContextMenu(User32.CreatePopupMenu(), 0, 1, 0x7FFF, Shell32.CMF.CMF_NORMAL);
+			});
+		}
+
 		#endregion FactoryMethods
 
 		private void EnumMenuItems(


### PR DESCRIPTION
In this PR, a dummy context menu is generated when the application is launched.
I know this is hacky, but this certainly improves the performance of the first appearance of the context menu.

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?