### PR TITLE
Fix: Changed the location of the "close" tooltip

### DIFF
--- a/src/Files.App/Dialogs/SettingsDialog.xaml
+++ b/src/Files.App/Dialogs/SettingsDialog.xaml
@@ -50,6 +50,7 @@
 				Background="Transparent"
 				BorderBrush="Transparent"
 				Click="CloseSettingsDialogButton_Click"
+				ToolTipService.Placement="Bottom"
 				ToolTipService.ToolTip="{helpers:ResourceString Name=Close}">
 				<FontIcon FontSize="12" Glyph="&#xE8BB;" />
 			</Button>

--- a/src/Files.App/UserControls/AddressToolbar.xaml
+++ b/src/Files.App/UserControls/AddressToolbar.xaml
@@ -294,6 +294,7 @@
 					AutomationProperties.Name="{x:Bind ViewModel.Commands.OpenSettings.Label, Mode=OneWay}"
 					Command="{x:Bind ViewModel.Commands.OpenSettings, Mode=OneWay}"
 					Style="{StaticResource AddressToolbarButtonStyle}"
+					ToolTipService.Placement="Bottom"
 					ToolTipService.ToolTip="{x:Bind ViewModel.Commands.OpenSettings.LabelWithHotKey, Mode=OneWay}"
 					Visibility="{x:Bind ShowSettingsButton, Mode=OneWay}">
 					<AnimatedIcon x:Name="SettingAnimatedIcon" Height="16">


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11982 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Hover `Settings` button