### PR TITLE
Feature: Improved checkbox behavior

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -719,20 +719,23 @@ namespace Files.App.Views.LayoutModes
 
 		private new void FileList_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
 		{
-			args.ItemContainer.FindDescendant("IconBox")!.PointerEntered -= IconBox_PointerEntered;
-			args.ItemContainer.FindDescendant("IconBox")!.PointerExited -= IconBox_PointerExited;
-			args.ItemContainer.FindDescendant("IconBox")!.PointerCanceled -= IconBox_PointerCanceled;
-			args.ItemContainer.FindDescendant("SelectionCheckbox")!.PointerExited -= SelectionCheckbox_PointerExited;
-			args.ItemContainer.FindDescendant("SelectionCheckbox")!.PointerCanceled -= SelectionCheckbox_PointerCanceled;
+			var iconBox = args.ItemContainer.FindDescendant("IconBox")!;
+			var selectionCheckbox = args.ItemContainer.FindDescendant("SelectionCheckbox")!;
+
+			iconBox.PointerEntered -= IconBox_PointerEntered;
+			iconBox.PointerExited -= IconBox_PointerExited;
+			iconBox.PointerCanceled -= IconBox_PointerCanceled;
+			selectionCheckbox.PointerExited -= SelectionCheckbox_PointerExited;
+			selectionCheckbox.PointerCanceled -= SelectionCheckbox_PointerCanceled;
 
 			base.FileList_ContainerContentChanging(sender, args);
 			SetCheckboxSelectionState(args.Item, args.ItemContainer as ListViewItem);
 
-			args.ItemContainer.FindDescendant("IconBox")!.PointerEntered += IconBox_PointerEntered;
-			args.ItemContainer.FindDescendant("IconBox")!.PointerExited += IconBox_PointerExited;
-			args.ItemContainer.FindDescendant("IconBox")!.PointerCanceled += IconBox_PointerCanceled;
-			args.ItemContainer.FindDescendant("SelectionCheckbox")!.PointerExited += SelectionCheckbox_PointerExited;
-			args.ItemContainer.FindDescendant("SelectionCheckbox")!.PointerCanceled += SelectionCheckbox_PointerCanceled;
+			iconBox.PointerEntered += IconBox_PointerEntered;
+			iconBox.PointerExited += IconBox_PointerExited;
+			iconBox.PointerCanceled += IconBox_PointerCanceled;
+			selectionCheckbox.PointerExited += SelectionCheckbox_PointerExited;
+			selectionCheckbox.PointerCanceled += SelectionCheckbox_PointerCanceled;
 		}
 
 		private void SetCheckboxSelectionState(object item, ListViewItem? lviContainer = null)

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -30,14 +30,6 @@ namespace Files.App.Views.LayoutModes
 {
 	public sealed partial class DetailsLayoutBrowser : StandardViewBase
 	{
-		public bool IsPointerOver
-		{
-			get { return (bool)GetValue(IsPointerOverProperty); }
-			set { SetValue(IsPointerOverProperty, value); }
-		}
-		public static readonly DependencyProperty IsPointerOverProperty =
-			DependencyProperty.Register("IsPointerOver", typeof(bool), typeof(DetailsLayoutBrowser), new PropertyMetadata(false));
-
 		private const int TAG_TEXT_BLOCK = 1;
 
 		private uint currentIconSize;
@@ -727,16 +719,20 @@ namespace Files.App.Views.LayoutModes
 
 		private new void FileList_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
 		{
-			args.ItemContainer.PointerEntered -= ItemRow_PointerEntered;
-			args.ItemContainer.PointerExited -= ItemRow_PointerExited;
-			args.ItemContainer.PointerCanceled -= ItemRow_PointerCanceled;
+			args.ItemContainer.FindDescendant("IconBox")!.PointerEntered -= IconBox_PointerEntered;
+			args.ItemContainer.FindDescendant("IconBox")!.PointerExited -= IconBox_PointerExited;
+			args.ItemContainer.FindDescendant("IconBox")!.PointerCanceled -= IconBox_PointerCanceled;
+			args.ItemContainer.FindDescendant("SelectionCheckbox")!.PointerExited -= SelectionCheckbox_PointerExited;
+			args.ItemContainer.FindDescendant("SelectionCheckbox")!.PointerCanceled -= SelectionCheckbox_PointerCanceled;
 
 			base.FileList_ContainerContentChanging(sender, args);
 			SetCheckboxSelectionState(args.Item, args.ItemContainer as ListViewItem);
 
-			args.ItemContainer.PointerEntered += ItemRow_PointerEntered;
-			args.ItemContainer.PointerExited += ItemRow_PointerExited;
-			args.ItemContainer.PointerCanceled += ItemRow_PointerCanceled;
+			args.ItemContainer.FindDescendant("IconBox")!.PointerEntered += IconBox_PointerEntered;
+			args.ItemContainer.FindDescendant("IconBox")!.PointerExited += IconBox_PointerExited;
+			args.ItemContainer.FindDescendant("IconBox")!.PointerCanceled += IconBox_PointerCanceled;
+			args.ItemContainer.FindDescendant("SelectionCheckbox")!.PointerExited += SelectionCheckbox_PointerExited;
+			args.ItemContainer.FindDescendant("SelectionCheckbox")!.PointerCanceled += SelectionCheckbox_PointerCanceled;
 		}
 
 		private void SetCheckboxSelectionState(object item, ListViewItem? lviContainer = null)
@@ -756,7 +752,7 @@ namespace Files.App.Views.LayoutModes
 					checkbox.Checked += ItemSelected_Checked;
 					checkbox.Unchecked += ItemSelected_Unchecked;
 				}
-				UpdateCheckboxVisibility(container);
+				UpdateCheckboxVisibility(container, false);
 			}
 		}
 
@@ -796,30 +792,37 @@ namespace Files.App.Views.LayoutModes
 			e.Handled = true;
 		}
 
-		private void ItemRow_PointerEntered(object sender, PointerRoutedEventArgs e)
+		private void IconBox_PointerEntered(object sender, PointerRoutedEventArgs e)
 		{
-			UpdateCheckboxVisibility(sender, true);
+			UpdateCheckboxVisibility((sender as FrameworkElement)!.FindAscendant<ListViewItem>()!, true);
 		}
 
-		private void ItemRow_PointerExited(object sender, PointerRoutedEventArgs e)
+		private void IconBox_PointerExited(object sender, PointerRoutedEventArgs e)
 		{
-			UpdateCheckboxVisibility(sender, false);
+			e.Handled = true;
 		}
 
-		private void ItemRow_PointerCanceled(object sender, PointerRoutedEventArgs e)
+		private void IconBox_PointerCanceled(object sender, PointerRoutedEventArgs e)
 		{
-			UpdateCheckboxVisibility(sender, false);
+			e.Handled = true;
 		}
 
-		private void UpdateCheckboxVisibility(object sender, bool? isPointerOver = null)
+		private void SelectionCheckbox_PointerExited(object sender, PointerRoutedEventArgs e)
+		{
+			UpdateCheckboxVisibility((sender as FrameworkElement)!.FindAscendant<ListViewItem>()!, false);
+		}
+
+		private void SelectionCheckbox_PointerCanceled(object sender, PointerRoutedEventArgs e)
+		{
+			UpdateCheckboxVisibility((sender as FrameworkElement)!.FindAscendant<ListViewItem>()!, false);
+		}
+
+		private void UpdateCheckboxVisibility(object sender, bool isPointerOver)
 		{
 			if (sender is ListViewItem control && control.FindDescendant<UserControl>() is UserControl userControl)
 			{
-				// Save pointer over state accordingly
-				if (isPointerOver.HasValue)
-					control.SetValue(IsPointerOverProperty, isPointerOver);
 				// Handle visual states
-				if (control.IsSelected || control.GetValue(IsPointerOverProperty) is not false && SelectedItems?.Count >= 1)
+				if (control.IsSelected || isPointerOver || (control.FindDescendant("SelectionCheckbox") as CheckBox)!.IsPointerOver)
 					VisualStateManager.GoToState(userControl, "ShowCheckbox", true);
 				else
 					VisualStateManager.GoToState(userControl, "HideCheckbox", true);

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -510,7 +510,7 @@ namespace Files.App.Views.LayoutModes
 				if (isPointerOver.HasValue)
 					control.SetValue(IsPointerOverProperty, isPointerOver);
 				// Handle visual states
-				if (control.IsSelected || control.GetValue(IsPointerOverProperty) is not false && SelectedItems?.Count >= 1)
+				if (control.IsSelected || control.GetValue(IsPointerOverProperty) is not false)
 					VisualStateManager.GoToState(userControl, "ShowCheckbox", true);
 				else
 					VisualStateManager.GoToState(userControl, "HideCheckbox", true);


### PR DESCRIPTION
This is slightly different from what we discussed in #11975, but I believe this is the best solution.
* In details view, unchecked checkboxes now appear only when the icon is hovered.
* In grid view, checkboxes appear when the item is hovered even if no item is selected (same as 2.4.60).

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11975 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

**Movie**

https://user-images.githubusercontent.com/66369541/230263831-da6436c1-bd37-48ef-a26d-c42aa3bc5c5c.mp4
