### PR TITLE
Fix: Fixed issue where the startup settings were ignored if a location is specified

### DIFF
--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -335,6 +335,30 @@ namespace Files.App.ViewModels
 			}
 			else
 			{
+				try
+				{
+					if (userSettingsService.PreferencesSettingsService.OpenSpecificPageOnStartup &&
+							userSettingsService.PreferencesSettingsService.TabsOnStartupList is not null)
+					{
+						foreach (string path in userSettingsService.PreferencesSettingsService.TabsOnStartupList)
+							await AddNewTabByPathAsync(typeof(PaneHolderPage), path);
+					}
+					else if (userSettingsService.PreferencesSettingsService.ContinueLastSessionOnStartUp &&
+						userSettingsService.PreferencesSettingsService.LastSessionTabList is not null)
+					{
+						foreach (string tabArgsString in userSettingsService.PreferencesSettingsService.LastSessionTabList)
+						{
+							var tabArgs = TabItemArguments.Deserialize(tabArgsString);
+							await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
+						}
+
+						var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home" };
+
+						userSettingsService.PreferencesSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
+					}
+				}
+				catch (Exception) { }
+
 				if (e.Parameter is string navArgs)
 					await AddNewTabByPathAsync(typeof(PaneHolderPage), navArgs);
 				else if (e.Parameter is PaneNavigationArguments paneArgs)


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11894 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Make Files the default file manager.
   2. Set the startup settings to other than "Open a new tab".
   3. Launch Files via "Open file location" in the Start menu.
   4. You see tabs are opened according to the startup settings in addition to the specified location.