### PR TITLE
Feature: Translucent hidden or cut item name

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml
@@ -271,6 +271,7 @@
 									Margin="5,0,5,0"
 									HorizontalAlignment="Left"
 									VerticalAlignment="Center"
+									Opacity="{x:Bind Opacity, Mode=OneWay}"
 									Text="{x:Bind Name, Mode=OneWay}"
 									TextTrimming="CharacterEllipsis"
 									TextWrapping="NoWrap" />

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -640,6 +640,7 @@
 										<TextBlock
 											x:Name="ItemName"
 											VerticalAlignment="Center"
+											Opacity="{x:Bind Opacity, Mode=OneWay}"
 											Text="{x:Bind Name, Mode=OneWay}"
 											TextTrimming="CharacterEllipsis" />
 										<TextBox

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
@@ -213,10 +213,7 @@
 						Unchecked="ItemSelected_Unchecked"
 						Visibility="Collapsed" />
 
-					<Popup
-						x:Name="EditPopup"
-						Grid.Row="1"
-						x:Load="False">
+					<Popup x:Name="EditPopup" Grid.Row="1" x:Load="False">
 						<TextBox
 							x:Name="GridViewTextBoxItemName"
 							Width="{Binding ElementName=GridViewBrowserListedItem, Path=(tui:FrameworkElementExtensions.ActualWidth)}"

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
@@ -188,6 +188,7 @@
 							Grid.Column="2"
 							HorizontalAlignment="Stretch"
 							VerticalAlignment="Stretch"
+							Visibility="{Binding IsOpen, ElementName=EditPopup, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
 							Opacity="{x:Bind Opacity, Mode=OneWay}"
 							Text="{x:Bind Name, Mode=OneWay}"
 							TextAlignment="Center"
@@ -212,7 +213,10 @@
 						Unchecked="ItemSelected_Unchecked"
 						Visibility="Collapsed" />
 
-					<Popup x:Name="EditPopup" Grid.Row="1">
+					<Popup
+						x:Name="EditPopup"
+						Grid.Row="1"
+						x:Load="False">
 						<TextBox
 							x:Name="GridViewTextBoxItemName"
 							Width="{Binding ElementName=GridViewBrowserListedItem, Path=(tui:FrameworkElementExtensions.ActualWidth)}"

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
@@ -188,7 +188,7 @@
 							Grid.Column="2"
 							HorizontalAlignment="Stretch"
 							VerticalAlignment="Stretch"
-							Opacity="{Binding IsOpen, ElementName=EditPopup, Converter={StaticResource NegatedBoolToOpacityConverter}}"
+							Opacity="{x:Bind Opacity, Mode=OneWay}"
 							Text="{x:Bind Name, Mode=OneWay}"
 							TextAlignment="Center"
 							TextTrimming="CharacterEllipsis"
@@ -214,8 +214,7 @@
 
 					<Popup
 						x:Name="EditPopup"
-						Grid.Row="1"
-						x:Load="False">
+						Grid.Row="1">
 						<TextBox
 							x:Name="GridViewTextBoxItemName"
 							Width="{Binding ElementName=GridViewBrowserListedItem, Path=(tui:FrameworkElementExtensions.ActualWidth)}"
@@ -389,6 +388,7 @@
 							Grid.Row="0"
 							HorizontalAlignment="Left"
 							MaxLines="2"
+							Opacity="{x:Bind Opacity, Mode=OneWay}"
 							Text="{x:Bind Name, Mode=OneWay}"
 							TextTrimming="CharacterEllipsis"
 							TextWrapping="Wrap" />

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
@@ -188,12 +188,12 @@
 							Grid.Column="2"
 							HorizontalAlignment="Stretch"
 							VerticalAlignment="Stretch"
-							Visibility="{Binding IsOpen, ElementName=EditPopup, Converter={StaticResource NegatedBoolToVisibilityConverter}}"
 							Opacity="{x:Bind Opacity, Mode=OneWay}"
 							Text="{x:Bind Name, Mode=OneWay}"
 							TextAlignment="Center"
 							TextTrimming="CharacterEllipsis"
-							TextWrapping="Wrap" />
+							TextWrapping="Wrap"
+							Visibility="{Binding IsOpen, ElementName=EditPopup, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
 
 					</Grid>
 
@@ -213,7 +213,10 @@
 						Unchecked="ItemSelected_Unchecked"
 						Visibility="Collapsed" />
 
-					<Popup x:Name="EditPopup" Grid.Row="1" x:Load="False">
+					<Popup
+						x:Name="EditPopup"
+						Grid.Row="1"
+						x:Load="False">
 						<TextBox
 							x:Name="GridViewTextBoxItemName"
 							Width="{Binding ElementName=GridViewBrowserListedItem, Path=(tui:FrameworkElementExtensions.ActualWidth)}"

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
@@ -192,8 +192,7 @@
 							Text="{x:Bind Name, Mode=OneWay}"
 							TextAlignment="Center"
 							TextTrimming="CharacterEllipsis"
-							TextWrapping="Wrap"
-							Visibility="{Binding IsOpen, ElementName=EditPopup, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
+							TextWrapping="Wrap" />
 
 					</Grid>
 
@@ -213,10 +212,7 @@
 						Unchecked="ItemSelected_Unchecked"
 						Visibility="Collapsed" />
 
-					<Popup
-						x:Name="EditPopup"
-						Grid.Row="1"
-						x:Load="False">
+					<Popup x:Name="EditPopup" Grid.Row="1">
 						<TextBox
 							x:Name="GridViewTextBoxItemName"
 							Width="{Binding ElementName=GridViewBrowserListedItem, Path=(tui:FrameworkElementExtensions.ActualWidth)}"

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
@@ -212,9 +212,7 @@
 						Unchecked="ItemSelected_Unchecked"
 						Visibility="Collapsed" />
 
-					<Popup
-						x:Name="EditPopup"
-						Grid.Row="1">
+					<Popup x:Name="EditPopup" Grid.Row="1">
 						<TextBox
 							x:Name="GridViewTextBoxItemName"
 							Width="{Binding ElementName=GridViewBrowserListedItem, Path=(tui:FrameworkElementExtensions.ActualWidth)}"

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -185,6 +185,7 @@ namespace Files.App.Views.LayoutModes
 				TextBlock textBlock = gridViewItem.FindDescendant("ItemName") as TextBlock;
 				textBox = popup.Child as TextBox;
 				textBox.Text = textBlock.Text;
+				textBlock.Opacity = 0;
 				popup.IsOpen = true;
 				OldItemName = textBlock.Text;
 			}
@@ -233,7 +234,9 @@ namespace Files.App.Views.LayoutModes
 			else if (FolderSettings.LayoutMode == FolderLayoutModes.GridView)
 			{
 				Popup? popup = gridViewItem.FindDescendant("EditPopup") as Popup;
+				TextBlock? textBlock = gridViewItem.FindDescendant("ItemName") as TextBlock;
 				popup!.IsOpen = false;
+				textBlock!.Opacity = (textBlock.DataContext as ListedItem)!.Opacity;
 			}
 			else if (FolderSettings.LayoutMode == FolderLayoutModes.TilesView)
 			{


### PR DESCRIPTION
This is necessary to identify hidden or cut items when checkboxes are displayed instead of icons.

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [X] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

**Screenshots**
![image](https://user-images.githubusercontent.com/66369541/232197530-c961f820-97fc-46f9-a972-3c5e9f1a8067.png)
