### PR TITLE
Fix: Fixed cannot select Files in columns view

### DIFF
--- a/src/Files.App/Views/ColumnParam.cs
+++ b/src/Files.App/Views/ColumnParam.cs
@@ -1,3 +1,4 @@
+using Files.App.Views.LayoutModes;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Files.App.Views
@@ -7,5 +8,7 @@ namespace Files.App.Views
 		public int Column { get; set; }
 
 		public ListView ListView { get; set; }
+
+		public ColumnViewBase? Source { get; set; }
 	}
 }

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -234,7 +234,7 @@ namespace Files.App.Views.LayoutModes
 		{
 			// Open selected directory
 			if (IsItemSelected && SelectedItem?.PrimaryItemAttribute == StorageItemTypes.Folder)
-				ItemInvoked?.Invoke(new ColumnParam { NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
+				ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
 		}
 
 		protected override async void FileList_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
@@ -259,7 +259,7 @@ namespace Files.App.Views.LayoutModes
 				e.Handled = true;
 
 				if (IsItemSelected && SelectedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
-					ItemInvoked?.Invoke(new ColumnParam { NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
+					ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
 			}
 			else if (e.Key == VirtualKey.Enter && e.KeyStatus.IsMenuKeyDown)
 			{
@@ -328,7 +328,7 @@ namespace Files.App.Views.LayoutModes
 						break;
 					case StorageItemTypes.Folder:
 						if (!UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick)
-							ItemInvoked?.Invoke(new ColumnParam { NavPathParam = (item is ShortcutItem sht ? sht.TargetPath : item.ItemPath), ListView = FileList }, EventArgs.Empty);
+							ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (item is ShortcutItem sht ? sht.TargetPath : item.ItemPath), ListView = FileList }, EventArgs.Empty);
 						break;
 					default:
 						if (UserSettingsService.FoldersSettingsService.DoubleClickToGoUp)
@@ -405,6 +405,7 @@ namespace Files.App.Views.LayoutModes
 					ItemInvoked?.Invoke(
 						new ColumnParam
 						{
+							Source = this,
 							NavPathParam = (item is ShortcutItem sht ? sht.TargetPath : item!.ItemPath),
 							ListView = FileList
 						},
@@ -418,7 +419,7 @@ namespace Files.App.Views.LayoutModes
 						? item.ItemPath.Substring(0, item.ItemPath.Length - 1)
 						: item.ItemPath;
 
-					ItemTapped?.Invoke(new ColumnParam { NavPathParam = Path.GetDirectoryName(itemPath), ListView = FileList }, EventArgs.Empty);
+					ItemTapped?.Invoke(new ColumnParam { Source = this, NavPathParam = Path.GetDirectoryName(itemPath), ListView = FileList }, EventArgs.Empty);
 				}
 			}
 		}

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -19,7 +19,9 @@ using System.Linq;
 using Windows.Storage;
 using Windows.System;
 using Windows.UI.Core;
+using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
 using static Files.App.Constants;
+using Microsoft.UI.Dispatching;
 
 namespace Files.App.Views.LayoutModes
 {
@@ -30,6 +32,8 @@ namespace Files.App.Views.LayoutModes
 		protected override ListViewBase ListViewBase => FileList;
 
 		protected override SemanticZoom RootZoom => RootGridZoom;
+
+		private readonly DispatcherQueueTimer doubleClickTimer;
 
 		private ColumnViewBrowser? columnsOwner;
 
@@ -42,6 +46,8 @@ namespace Files.App.Views.LayoutModes
 			selectionRectangle.SelectionEnded += SelectionRectangle_SelectionEnded;
 			ItemInvoked += ColumnViewBase_ItemInvoked;
 			GotFocus += ColumnViewBase_GotFocus;
+
+			doubleClickTimer = DispatcherQueue.CreateTimer();
 		}
 
 		private void ColumnViewBase_GotFocus(object sender, RoutedEventArgs e)
@@ -316,6 +322,8 @@ namespace Files.App.Views.LayoutModes
 
 		private void FileList_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
 		{
+			doubleClickTimer.Stop();
+
 			var clickedItem = e.OriginalSource as FrameworkElement;
 
 			if (clickedItem?.DataContext is ListedItem item)
@@ -413,15 +421,26 @@ namespace Files.App.Views.LayoutModes
 				}
 				else if (!IsRenamingItem && (isItemFile || isItemFolder))
 				{
-					ClearOpenedFolderSelectionIndicator();
-
-					var itemPath = item!.ItemPath.EndsWith('\\')
-						? item.ItemPath.Substring(0, item.ItemPath.Length - 1)
-						: item.ItemPath;
-
-					ItemTapped?.Invoke(new ColumnParam { Source = this, NavPathParam = Path.GetDirectoryName(itemPath), ListView = FileList }, EventArgs.Empty);
+					CheckDoubleClick(item!);
 				}
 			}
+		}
+
+		private void CheckDoubleClick(ListedItem item)
+		{
+			doubleClickTimer.Debounce(() =>
+			{
+				ClearOpenedFolderSelectionIndicator();
+
+				var itemPath = item!.ItemPath.EndsWith('\\')
+					? item.ItemPath.Substring(0, item.ItemPath.Length - 1)
+					: item.ItemPath;
+
+				ItemTapped?.Invoke(new ColumnParam { Source = this, NavPathParam = Path.GetDirectoryName(itemPath), ListView = FileList }, EventArgs.Empty);
+
+				doubleClickTimer.Stop();
+			},
+			TimeSpan.FromMilliseconds(200));
 		}
 
 		private void Grid_Loaded(object sender, RoutedEventArgs e)

--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -441,6 +441,9 @@ namespace Files.App.Views.LayoutModes
 
 		private void CloseUnnecessaryColumns(ColumnParam column)
 		{
+			if (string.IsNullOrEmpty(column.NavPathParam))
+				return;
+
 			var relativeIndex = -1;
 
 			if (column.Source is not null)
@@ -455,7 +458,7 @@ namespace Files.App.Views.LayoutModes
 
 			if (relativeIndex is -1)
 				while (relativeIndex < ColumnHost.ActiveBlades.Count &&
-					(!column.NavPathParam?.Equals(GetWorkingDirOfColumnAt(++relativeIndex)) ?? false)) ;
+					!column.NavPathParam.Equals(GetWorkingDirOfColumnAt(++relativeIndex))) ;
 
 			if (relativeIndex >= 0 && relativeIndex < ColumnHost.ActiveBlades.Count)
 			{

--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -444,7 +444,7 @@ namespace Files.App.Views.LayoutModes
 			if (string.IsNullOrEmpty(column.NavPathParam))
 				return;
 
-			var relativeIndex = -1;
+			var relativeIndex = column.Column is not 0 ? column.Column : -1;
 
 			if (column.Source is not null)
 			{
@@ -457,6 +457,7 @@ namespace Files.App.Views.LayoutModes
 			}
 
 			if (relativeIndex is -1)
+				// Get the index of the blade with the same path as the requested
 				while (relativeIndex < ColumnHost.ActiveBlades.Count &&
 					!column.NavPathParam.Equals(GetWorkingDirOfColumnAt(++relativeIndex))) ;
 

--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -457,11 +457,16 @@ namespace Files.App.Views.LayoutModes
 			}
 
 			if (relativeIndex is -1)
+			{
 				// Get the index of the blade with the same path as the requested
-				while (relativeIndex < ColumnHost.ActiveBlades.Count &&
-					!column.NavPathParam.Equals(GetWorkingDirOfColumnAt(++relativeIndex))) ;
+				var blade = ColumnHost.ActiveBlades.FirstOrDefault(b => 
+					column.NavPathParam.Equals(((b.Content as Frame)?.Content as ColumnShellPage)?.FilesystemViewModel?.WorkingDirectory));
 
-			if (relativeIndex >= 0 && relativeIndex < ColumnHost.ActiveBlades.Count)
+				if (blade is not null)
+					relativeIndex = ColumnHost.ActiveBlades.IndexOf(blade);
+			}
+
+			if (relativeIndex >= 0)
 			{
 				ColumnHost.ActiveBlades[relativeIndex].FindDescendant<ColumnViewBase>()?.ClearOpenedFolderSelectionIndicator();
 				DismissOtherBlades(relativeIndex);
@@ -493,11 +498,6 @@ namespace Files.App.Views.LayoutModes
 
 			ColumnHost.Items.Add(newblade);
 			return (frame, newblade);
-		}
-
-		private string? GetWorkingDirOfColumnAt(int index)
-		{
-			return ((ColumnHost.ActiveBlades[index].Content as Frame)?.Content as ColumnShellPage)?.FilesystemViewModel?.WorkingDirectory;
 		}
 	}
 }

--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Windows.Storage;
+using Windows.System.Threading.Core;
 using static Files.App.Constants;
 using static Files.App.Helpers.PathNormalization;
 
@@ -442,8 +443,19 @@ namespace Files.App.Views.LayoutModes
 		{
 			var relativeIndex = -1;
 
-			while (relativeIndex < ColumnHost.ActiveBlades.Count && 
-				(!column.NavPathParam?.Equals(GetWorkingDirOfColumnAt(++relativeIndex)) ?? false));
+			if (column.Source is not null)
+			{
+				for (var i = 0; i < ColumnHost.ActiveBlades.Count && relativeIndex is -1; i++)
+				{
+					var bladeColumn = ColumnHost.ActiveBlades[i].FindDescendant<ColumnViewBase>();
+					if (bladeColumn is not null && bladeColumn == column.Source)
+						relativeIndex = i;
+				}
+			}
+
+			if (relativeIndex is -1)
+				while (relativeIndex < ColumnHost.ActiveBlades.Count &&
+					(!column.NavPathParam?.Equals(GetWorkingDirOfColumnAt(++relativeIndex)) ?? false)) ;
 
 			if (relativeIndex >= 0 && relativeIndex < ColumnHost.ActiveBlades.Count)
 			{


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12090 

**Description**
- I simplified the code to find the last column that should remain open (I don't know why I wrote that complex code in the first place). Now it looks for the blade with the same path as the requested one.
- As mentioned in #11898, there's a bug with double click to open

**Notes**
- Please, test these changes deeply since they may cause many regressions
- It may happen that the user creates a loop of columns (like: `C:\Users\username\Desktop\shortcut_to_Users\username\Desktop\something_else`). In this case, if the user clicks an item in `Desktop`, should we always close all columns after the first `Desktop`?

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
**Test 1**
   1. Open app and a folder using colums view
   2. Use `Open folders with single click in columns view`
   3. Open a shortcut to a folder (try with a shortcut to a sub-subfolder of the current directory, a shortcut to a parent folder of the current and with one to a random folder)
   4. Select a file
**Test 2**
   1. Repeat all the steps above using `double click to open`
   2. Navigate between folders using `Up/Down arrows` to ensure there's no regression from #11986   
**Test 3**
   1. Open a path such as C:\Windows\System32 in columns layout
   2. Click on Windows (Single click to open option) (Check that there's no regression from #11898)
