### PR TITLE
Fix: Fixed possible NullReferenceException in widgets

### DIFF
--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -61,7 +61,7 @@ namespace Files.App.UserControls.Widgets
 
 			// Thumbnail data is valid, set the item icon
 			if (thumbnailData is not null && thumbnailData.Length > 0)
-				Thumbnail = await App.Window.DispatcherQueue.EnqueueAsync(() => thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize));
+				Thumbnail = await thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize);
 		}
 
 		public int CompareTo(DriveCardItem? other) => Item.Path.CompareTo(other?.Item?.Path);

--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -97,7 +97,7 @@ namespace Files.App.UserControls.Widgets
 			}
 			if (thumbnailData is not null && thumbnailData.Length > 0)
 			{
-				Thumbnail = await App.Window.DispatcherQueue.EnqueueAsync(() => thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize));
+				Thumbnail = await thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize);
 			}
 		}
 	}


### PR DESCRIPTION
In widgets, `thumbnailData.ToBitmapAsync()` is called on the same thread as `LoadCardThumbnailAsync()`, so `DispatcherQueue.EnqueueAsync()` is redundant.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
