### PR TITLE
Fix: Fixed issue where unpin from start didn't work

### DIFF
--- a/src/Files.App/Actions/Start/UnpinFromStartAction.cs
+++ b/src/Files.App/Actions/Start/UnpinFromStartAction.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using CommunityToolkit.Mvvm.DependencyInjection;
 using Files.App.Commands;
 using Files.App.Contexts;
-using Files.App.Extensions;
-using Files.App.Filesystem;
-using System.Threading.Tasks;
 
 namespace Files.App.Actions
 {
@@ -25,11 +21,11 @@ namespace Files.App.Actions
 			if (context.SelectedItems.Count > 0)
 			{
 				foreach (ListedItem listedItem in context.ShellPage?.SlimContentPage.SelectedItems)
-					await App.SecondaryTileHelper.TryPinFolderAsync(listedItem.ItemPath, listedItem.Name);
+					await App.SecondaryTileHelper.UnpinFromStartAsync(listedItem.ItemPath);
 			}
 			else
 			{
-				await App.SecondaryTileHelper.TryPinFolderAsync(context.ShellPage?.FilesystemViewModel.CurrentFolder.ItemPath, context.ShellPage?.FilesystemViewModel.CurrentFolder.Name);
+				await App.SecondaryTileHelper.UnpinFromStartAsync(context.ShellPage?.FilesystemViewModel.CurrentFolder.ItemPath);
 			}
 		}
 	}


### PR DESCRIPTION
**Description**
The `UnpinFromStartAction` calls currently the `TryPinFolderAsync` instead of the `UnpinFromStartAsync` method.
The bug was introduced in #11493 where the code was migrated to a RichCommand.

With this change it is again possible to unpin items from the start menu.


**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Unpin a single file
   2. Unpin multiple files
   3. Unpin single directory
   4. Unpin multiple directories

**Screenshots (optional)**
Add screenshots here.
