### PR TITLE
Fix: Fixed possible NullReferenceException with `DispatcherQueue.EnqueueAsync()`

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -270,7 +270,7 @@ namespace Files.App
 			var data = activatedEventArgs.Data;
 
 			// InitializeApplication accesses UI, needs to be called on UI thread
-			_ = Window.DispatcherQueue.EnqueueAsync(() => Window.InitializeApplication(data));
+			_ = Window.DispatcherQueue.EnqueueOrInvokeAsync(() => Window.InitializeApplication(data));
 		}
 
 		/// <summary>
@@ -475,7 +475,7 @@ namespace Files.App
 				userSettingsService.AppSettingsService.RestoreTabsOnStartup = true;
 				userSettingsService.GeneralSettingsService.LastCrashedTabList = lastSessionTabList;
 
-				Window.DispatcherQueue.EnqueueAsync(async () =>
+				Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
 					await Launcher.LaunchUriAsync(new Uri("files-uwp:"));
 				}).Wait(1000);

--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -257,7 +257,7 @@ namespace Files.App
 						if (selectedItems.Count == 1)
 						{
 							SelectedItemsPropertiesViewModel.SelectedItemsCountString = $"{selectedItems.Count} {"ItemSelected/Text".GetLocalizedResource()}";
-							DispatcherQueue.EnqueueAsync(async () =>
+							DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 							{
 								// Tapped event must be executed first
 								await Task.Delay(50);
@@ -1355,7 +1355,7 @@ namespace Files.App
 			{
 				args.Cancel = true;
 
-				await DispatcherQueue.EnqueueAsync(() =>
+				await DispatcherQueue.EnqueueOrInvokeAsync(() =>
 				{
 					var oldSelection = textBox.SelectionStart + textBox.SelectionLength;
 					var oldText = textBox.Text;

--- a/src/Files.App/DataModels/NavigationControlItems/DriveItem.cs
+++ b/src/Files.App/DataModels/NavigationControlItems/DriveItem.cs
@@ -184,7 +184,7 @@ namespace Files.App.DataModels.NavigationControlItems
 			item.DeviceID = deviceId;
 			item.Root = root;
 
-			_ = App.Window.DispatcherQueue.EnqueueAsync(() => item.UpdatePropertiesAsync());
+			_ = App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => item.UpdatePropertiesAsync());
 
 			return item;
 		}

--- a/src/Files.App/DataModels/NavigationControlItems/LocationItem.cs
+++ b/src/Files.App/DataModels/NavigationControlItems/LocationItem.cs
@@ -95,7 +95,7 @@ namespace Files.App.DataModels.NavigationControlItems
 			{
 				SetProperty(ref spaceUsed, value);
 
-				App.Window.DispatcherQueue.EnqueueAsync(() => OnPropertyChanged(nameof(ToolTipText)));
+				App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => OnPropertyChanged(nameof(ToolTipText)));
 			}
 		}
 

--- a/src/Files.App/DataModels/SidebarPinnedModel.cs
+++ b/src/Files.App/DataModels/SidebarPinnedModel.cs
@@ -115,7 +115,7 @@ namespace Files.App.DataModels
 				{
 					var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(res.Result, 96u, ThumbnailMode.ListView);
 					locationItem.IconData = iconData;
-					locationItem.Icon = await App.Window.DispatcherQueue.EnqueueAsync(() => locationItem.IconData.ToBitmapAsync());
+					locationItem.Icon = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => locationItem.IconData.ToBitmapAsync());
 				}
 
 				if (locationItem.IconData is null)
@@ -123,12 +123,12 @@ namespace Files.App.DataModels
 					locationItem.IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(path, 96u);
 
 					if (locationItem.IconData is not null)
-						locationItem.Icon = await App.Window.DispatcherQueue.EnqueueAsync(() => locationItem.IconData.ToBitmapAsync());
+						locationItem.Icon = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => locationItem.IconData.ToBitmapAsync());
 				}
 			}
 			else
 			{
-				locationItem.Icon = await App.Window.DispatcherQueue.EnqueueAsync(() => UIHelpers.GetSidebarIconResource(Constants.ImageRes.Folder));
+				locationItem.Icon = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => UIHelpers.GetSidebarIconResource(Constants.ImageRes.Folder));
 				locationItem.IsInvalid = true;
 				Debug.WriteLine($"Pinned item was invalid {res.ErrorCode}, item: {path}");
 			}

--- a/src/Files.App/Extensions/DispatcherQueueExtensions.cs
+++ b/src/Files.App/Extensions/DispatcherQueueExtensions.cs
@@ -1,0 +1,48 @@
+﻿using CommunityToolkit.WinUI;
+using Microsoft.UI.Dispatching;
+using System;
+using System.Threading.Tasks;
+
+namespace Files.App.Extensions
+{
+	// Window.DispatcherQueue seems to be null sometimes.
+	// We don't know why, but as a workaround, we invoke the function directly if DispatcherQueue is null.
+	public static class DispatcherQueueExtensions
+	{
+		public static Task EnqueueOrInvokeAsync(this DispatcherQueue dispatcher, Func<Task> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+		{
+			if (dispatcher is not null)
+				return dispatcher.EnqueueAsync(function, priority);
+			else
+				return function();
+		}
+
+		public static Task<T> EnqueueOrInvokeAsync<T>(this DispatcherQueue dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+		{
+			if (dispatcher is not null)
+				return dispatcher.EnqueueAsync(function, priority);
+			else
+				return function();
+		}
+
+		public static Task EnqueueOrInvokeAsync(this DispatcherQueue dispatcher, Action function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+		{
+			if (dispatcher is not null)
+				return dispatcher.EnqueueAsync(function, priority);
+			else
+			{
+				function();
+				return Task.CompletedTask;
+			}
+		}
+
+		public static Task<T> EnqueueOrInvokeAsync<T>(this DispatcherQueue dispatcher, Func<T> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+		{
+			if (dispatcher is not null)
+				return dispatcher.EnqueueAsync(function, priority);
+			else
+				return Task.FromResult(function());
+		}
+
+	}
+}

--- a/src/Files.App/Extensions/DispatcherQueueExtensions.cs
+++ b/src/Files.App/Extensions/DispatcherQueueExtensions.cs
@@ -9,7 +9,7 @@ namespace Files.App.Extensions
 	// We don't know why, but as a workaround, we invoke the function directly if DispatcherQueue is null.
 	public static class DispatcherQueueExtensions
 	{
-		public static Task EnqueueOrInvokeAsync(this DispatcherQueue dispatcher, Func<Task> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+		public static Task EnqueueOrInvokeAsync(this DispatcherQueue? dispatcher, Func<Task> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
 		{
 			if (dispatcher is not null)
 				return dispatcher.EnqueueAsync(function, priority);
@@ -17,7 +17,7 @@ namespace Files.App.Extensions
 				return function();
 		}
 
-		public static Task<T> EnqueueOrInvokeAsync<T>(this DispatcherQueue dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+		public static Task<T> EnqueueOrInvokeAsync<T>(this DispatcherQueue? dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
 		{
 			if (dispatcher is not null)
 				return dispatcher.EnqueueAsync(function, priority);
@@ -25,7 +25,7 @@ namespace Files.App.Extensions
 				return function();
 		}
 
-		public static Task EnqueueOrInvokeAsync(this DispatcherQueue dispatcher, Action function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+		public static Task EnqueueOrInvokeAsync(this DispatcherQueue? dispatcher, Action function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
 		{
 			if (dispatcher is not null)
 				return dispatcher.EnqueueAsync(function, priority);
@@ -36,7 +36,7 @@ namespace Files.App.Extensions
 			}
 		}
 
-		public static Task<T> EnqueueOrInvokeAsync<T>(this DispatcherQueue dispatcher, Func<T> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+		public static Task<T> EnqueueOrInvokeAsync<T>(this DispatcherQueue? dispatcher, Func<T> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
 		{
 			if (dispatcher is not null)
 				return dispatcher.EnqueueAsync(function, priority);

--- a/src/Files.App/Filesystem/Cloud/CloudDrivesManager.cs
+++ b/src/Files.App/Filesystem/Cloud/CloudDrivesManager.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
 using Files.App.DataModels.NavigationControlItems;
+using Files.App.Extensions;
 using Files.App.Helpers;
 using Files.Shared;
 using Files.Shared.Cloud;
@@ -53,7 +54,7 @@ namespace Files.App.Filesystem.Cloud
 				try
 				{
 					cloudProviderItem.Root = await StorageFolder.GetFolderFromPathAsync(cloudProviderItem.Path);
-					_ = App.Window.DispatcherQueue.EnqueueAsync(() => cloudProviderItem.UpdatePropertiesAsync());
+					_ = App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => cloudProviderItem.UpdatePropertiesAsync());
 				}
 				catch (Exception ex)
 				{
@@ -72,7 +73,7 @@ namespace Files.App.Filesystem.Cloud
 				{
 					cloudProviderItem.IconData = iconData;
 					await App.Window.DispatcherQueue
-						.EnqueueAsync(async () => cloudProviderItem.Icon = await iconData.ToBitmapAsync());
+						.EnqueueOrInvokeAsync(async () => cloudProviderItem.Icon = await iconData.ToBitmapAsync());
 				}
 
 				lock (drives)

--- a/src/Files.App/Filesystem/Search/FolderSearch.cs
+++ b/src/Files.App/Filesystem/Search/FolderSearch.cs
@@ -393,7 +393,7 @@ namespace Files.App.Filesystem.Search
 					{
 						if (t.IsCompletedSuccessfully && t.Result is not null)
 						{
-							_ = FilesystemTasks.Wrap(() => App.Window.DispatcherQueue.EnqueueAsync(async () =>
+							_ = FilesystemTasks.Wrap(() => App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 							{
 								listedItem.FileImage = await t.Result.ToBitmapAsync();
 							}, Microsoft.UI.Dispatching.DispatcherQueuePriority.Low));

--- a/src/Files.App/Helpers/DynamicDialogFactory.cs
+++ b/src/Files.App/Helpers/DynamicDialogFactory.cs
@@ -98,7 +98,7 @@ namespace Files.App.Helpers
 			inputText.Loaded += (s, e) =>
 			{
 				// dispatching to the ui thread fixes an issue where the primary dialog button would steal focus
-				_ = inputText.DispatcherQueue.EnqueueAsync(() => inputText.Focus(FocusState.Programmatic));
+				_ = inputText.DispatcherQueue.EnqueueOrInvokeAsync(() => inputText.Focus(FocusState.Programmatic));
 				((RenameDialogViewModel)warning.DataContext).IsNameInvalid = true;
 			};
 

--- a/src/Files.App/Helpers/MenuFlyoutHelper.cs
+++ b/src/Files.App/Helpers/MenuFlyoutHelper.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.WinUI;
+using Files.App.Extensions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
@@ -101,7 +102,7 @@ namespace Files.App.Helpers
 				return;
 			}
 
-			await menu.DispatcherQueue.EnqueueAsync(() =>
+			await menu.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 			{
 				menu.Items.Clear();
 				AddItems(menu.Items, itemSource);

--- a/src/Files.App/Helpers/ThemeHelper.cs
+++ b/src/Files.App/Helpers/ThemeHelper.cs
@@ -75,7 +75,7 @@ namespace Files.App.Helpers
 				titleBar = App.GetAppWindow(currentApplicationWindow)?.TitleBar;
 
 			// Dispatch on UI thread so that we have a current appbar to access and change
-			await currentApplicationWindow.DispatcherQueue.EnqueueAsync(ApplyTheme);
+			await currentApplicationWindow.DispatcherQueue.EnqueueOrInvokeAsync(ApplyTheme);
 		}
 
 		private static void ApplyTheme()

--- a/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -100,7 +100,7 @@ namespace Files.App.Interacts
 		{
 			foreach (ListedItem listedItem in SlimContentPage.SelectedItems)
 			{
-				await App.Window.DispatcherQueue.EnqueueAsync(async () =>
+				await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
 					await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), (listedItem as ShortcutItem)?.TargetPath ?? listedItem.ItemPath);
 				},

--- a/src/Files.App/ServicesImplementation/RemovableDrivesService.cs
+++ b/src/Files.App/ServicesImplementation/RemovableDrivesService.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.WinUI;
 using Files.App.DataModels.NavigationControlItems;
+using Files.App.Extensions;
 using Files.App.Filesystem;
 using Files.App.Helpers;
 using Files.App.Storage.WindowsStorage;
@@ -66,7 +67,7 @@ namespace Files.App.ServicesImplementation
 			var rootModified = await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(drive.Path).AsTask());
 			if (rootModified && drive is DriveItem matchingDriveEjected)
 			{
-				_ = App.Window.DispatcherQueue.EnqueueAsync(() =>
+				_ = App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 				{
 					matchingDriveEjected.Root = rootModified.Result;
 					matchingDriveEjected.Text = rootModified.Result.DisplayName;

--- a/src/Files.App/ServicesImplementation/ThreadingService.cs
+++ b/src/Files.App/ServicesImplementation/ThreadingService.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.WinUI;
+using Files.App.Extensions;
 using Files.Backend.Services;
 using Microsoft.UI.Dispatching;
 using System;
@@ -17,12 +18,12 @@ namespace Files.App.ServicesImplementation
 
 		public Task ExecuteOnUiThreadAsync(Action action)
 		{
-			return _dispatcherQueue.EnqueueAsync(action);
+			return _dispatcherQueue.EnqueueOrInvokeAsync(action);
 		}
 
 		public Task<TResult?> ExecuteOnUiThreadAsync<TResult>(Func<TResult?> func)
 		{
-			return _dispatcherQueue.EnqueueAsync<TResult?>(func);
+			return _dispatcherQueue.EnqueueOrInvokeAsync<TResult?>(func);
 		}
 	}
 }

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -61,7 +61,7 @@ namespace Files.App.UserControls.Widgets
 
 			// Thumbnail data is valid, set the item icon
 			if (thumbnailData is not null && thumbnailData.Length > 0)
-				Thumbnail = await thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize);
+				Thumbnail = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize));
 		}
 
 		public int CompareTo(DriveCardItem? other) => Item.Path.CompareTo(other?.Item?.Path);
@@ -146,7 +146,7 @@ namespace Files.App.UserControls.Widgets
 
 		private async void Drives_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
 		{
-			await DispatcherQueue.EnqueueAsync(async () =>
+			await DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 			{
 				foreach (DriveItem drive in drivesViewModel.Drives.ToList())
 				{

--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -97,7 +97,7 @@ namespace Files.App.UserControls.Widgets
 			}
 			if (thumbnailData is not null && thumbnailData.Length > 0)
 			{
-				Thumbnail = await thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize);
+				Thumbnail = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize));
 			}
 		}
 	}
@@ -247,7 +247,7 @@ namespace Files.App.UserControls.Widgets
 			if (e is null)
 				return;
 
-			await DispatcherQueue.EnqueueAsync(async () =>
+			await DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 			{
 				if (e.Reset)
 				{

--- a/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -210,7 +210,7 @@ namespace Files.App.UserControls.Widgets
 
 		private async void Manager_RecentFilesChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			await DispatcherQueue.EnqueueAsync(async () =>
+			await DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 			{
 				// e.Action can only be Reset right now; naively refresh everything for simplicity
 				await UpdateRecentsList(e);

--- a/src/Files.App/ViewModels/ItemViewModel.cs
+++ b/src/Files.App/ViewModels/ItemViewModel.cs
@@ -399,7 +399,7 @@ namespace Files.App.ViewModels
 			if (!CommonPaths.RecycleBinPath.Equals(CurrentFolder?.ItemPath, StringComparison.OrdinalIgnoreCase))
 				return;
 
-			await dispatcherQueue.EnqueueAsync(() =>
+			await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 			{
 				RefreshItems(null);
 			});
@@ -460,7 +460,7 @@ namespace Files.App.ViewModels
 				var matchingItem = filesAndFolders.FirstOrDefault(x => x.ItemPath == e.Path);
 				if (matchingItem is not null)
 				{
-					await dispatcherQueue.EnqueueAsync(() =>
+					await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 					{
 						if (e.ValueState is SizeChangedValueState.None)
 						{
@@ -486,7 +486,7 @@ namespace Files.App.ViewModels
 
 		private async void FileTagsSettingsService_OnSettingUpdated(object? sender, EventArgs e)
 		{
-			await dispatcherQueue.EnqueueAsync(() =>
+			await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 			{
 				if (WorkingDirectory != "Home")
 					RefreshItems(null);
@@ -506,7 +506,7 @@ namespace Files.App.ViewModels
 				case nameof(UserSettingsService.FoldersSettingsService.CalculateFolderSizes):
 				case nameof(UserSettingsService.FoldersSettingsService.SelectFilesOnHover):
 				case nameof(UserSettingsService.FoldersSettingsService.ShowCheckboxesWhenSelectingItems):
-					await dispatcherQueue.EnqueueAsync(() =>
+					await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 					{
 						if (WorkingDirectory != "Home")
 							RefreshItems(null);
@@ -516,7 +516,7 @@ namespace Files.App.ViewModels
 				case nameof(UserSettingsService.FoldersSettingsService.DefaultGroupOption):
 				case nameof(UserSettingsService.FoldersSettingsService.DefaultSortDirectoriesAlongsideFiles):
 				case nameof(UserSettingsService.FoldersSettingsService.SyncFolderPreferencesAcrossDirectories):
-					await dispatcherQueue.EnqueueAsync(() =>
+					await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 					{
 						folderSettings.OnDefaultPreferencesChanged(WorkingDirectory, e.SettingName);
 						UpdateSortAndGroupOptions();
@@ -553,7 +553,7 @@ namespace Files.App.ViewModels
 		public async Task ApplySingleFileChangeAsync(ListedItem item)
 		{
 			var newIndex = filesAndFolders.IndexOf(item);
-			await dispatcherQueue.EnqueueAsync(() =>
+			await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 			{
 				FilesAndFolders.Remove(item);
 				if (newIndex != -1)
@@ -595,7 +595,7 @@ namespace Files.App.ViewModels
 					if (NativeWinApiHelper.IsHasThreadAccessPropertyPresent && dispatcherQueue.HasThreadAccess)
 						ClearDisplay();
 					else
-						await dispatcherQueue.EnqueueAsync(ClearDisplay);
+						await dispatcherQueue.EnqueueOrInvokeAsync(ClearDisplay);
 
 					return;
 				}
@@ -681,7 +681,7 @@ namespace Files.App.ViewModels
 				else
 				{
 					ApplyChanges();
-					await dispatcherQueue.EnqueueAsync(UpdateUI);
+					await dispatcherQueue.EnqueueOrInvokeAsync(UpdateUI);
 				}
 			}
 			catch (Exception ex)
@@ -696,7 +696,7 @@ namespace Files.App.ViewModels
 			if (itemsToSelect is null || itemsToSelect.IsEmpty())
 				return Task.CompletedTask;
 
-			return dispatcherQueue.EnqueueAsync(() =>
+			return dispatcherQueue.EnqueueOrInvokeAsync(() =>
 			{
 				OnSelectionRequestedEvent?.Invoke(this, itemsToSelect);
 			});
@@ -800,7 +800,7 @@ namespace Files.App.ViewModels
 				if (token.IsCancellationRequested)
 					return;
 
-				await dispatcherQueue.EnqueueAsync(
+				await dispatcherQueue.EnqueueOrInvokeAsync(
 					FilesAndFolders.EndBulkOperation);
 			}
 			catch (Exception ex)
@@ -824,7 +824,7 @@ namespace Files.App.ViewModels
 				foreach (var gp in FilesAndFolders.GroupedCollection.ToList())
 				{
 					var img = await GetItemTypeGroupIcon(gp.FirstOrDefault());
-					await dispatcherQueue.EnqueueAsync(() =>
+					await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 					{
 						gp.Model.ImageSource = img;
 					}, Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
@@ -898,7 +898,7 @@ namespace Files.App.ViewModels
 
 						if (!(Thumbnail is null || Thumbnail.Size == 0 || Thumbnail.OriginalHeight == 0 || Thumbnail.OriginalWidth == 0))
 						{
-							await dispatcherQueue.EnqueueAsync(async () =>
+							await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 							{
 								item.FileImage ??= new BitmapImage();
 								item.FileImage.DecodePixelType = DecodePixelType.Logical;
@@ -917,7 +917,7 @@ namespace Files.App.ViewModels
 						var overlayInfo = await FileThumbnailHelper.LoadOverlayAsync(item.ItemPath, thumbnailSize);
 						if (overlayInfo is not null)
 						{
-							await dispatcherQueue.EnqueueAsync(async () =>
+							await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 							{
 								item.IconOverlay = await overlayInfo.ToBitmapAsync();
 								item.ShieldIcon = await GetShieldIcon();
@@ -931,7 +931,7 @@ namespace Files.App.ViewModels
 					var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize, false);
 					if (iconInfo.IconData is not null)
 					{
-						await dispatcherQueue.EnqueueAsync(async () =>
+						await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 						{
 							item.FileImage = await iconInfo.IconData.ToBitmapAsync();
 							if (!string.IsNullOrEmpty(item.FileExtension) &&
@@ -945,7 +945,7 @@ namespace Files.App.ViewModels
 
 					if (iconInfo.OverlayData is not null)
 					{
-						await dispatcherQueue.EnqueueAsync(async () =>
+						await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 						{
 							item.IconOverlay = await iconInfo.OverlayData.ToBitmapAsync();
 							item.ShieldIcon = await GetShieldIcon();
@@ -968,7 +968,7 @@ namespace Files.App.ViewModels
 						using StorageItemThumbnail Thumbnail = await FilesystemTasks.Wrap(() => matchingStorageFolder.GetThumbnailAsync(thumbnailMode, thumbnailSize, ThumbnailOptions.ReturnOnlyIfCached).AsTask());
 						if (!(Thumbnail is null || Thumbnail.Size == 0 || Thumbnail.OriginalHeight == 0 || Thumbnail.OriginalWidth == 0))
 						{
-							await dispatcherQueue.EnqueueAsync(async () =>
+							await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 							{
 								item.FileImage ??= new BitmapImage();
 								item.FileImage.DecodePixelType = DecodePixelType.Logical;
@@ -981,7 +981,7 @@ namespace Files.App.ViewModels
 						var overlayInfo = await FileThumbnailHelper.LoadOverlayAsync(item.ItemPath, thumbnailSize);
 						if (overlayInfo is not null)
 						{
-							await dispatcherQueue.EnqueueAsync(async () =>
+							await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 							{
 								item.IconOverlay = await overlayInfo.ToBitmapAsync();
 								item.ShieldIcon = await GetShieldIcon();
@@ -995,7 +995,7 @@ namespace Files.App.ViewModels
 					var iconInfo = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize, true);
 					if (iconInfo.IconData is not null)
 					{
-						await dispatcherQueue.EnqueueAsync(async () =>
+						await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 						{
 							item.FileImage = await iconInfo.IconData.ToBitmapAsync();
 						}, Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
@@ -1003,7 +1003,7 @@ namespace Files.App.ViewModels
 
 					if (iconInfo.OverlayData is not null)
 					{
-						await dispatcherQueue.EnqueueAsync(async () =>
+						await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 						{
 							item.IconOverlay = await iconInfo.OverlayData.ToBitmapAsync();
 							item.ShieldIcon = await GetShieldIcon();
@@ -1069,7 +1069,7 @@ namespace Files.App.ViewModels
 									var itemType = (item.ItemType == "Folder".GetLocalizedResource()) ? item.ItemType : matchingStorageFile.DisplayType;
 									cts.Token.ThrowIfCancellationRequested();
 
-									await dispatcherQueue.EnqueueAsync(() =>
+									await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 									{
 										item.FolderRelativeId = matchingStorageFile.FolderRelativeId;
 										item.ItemType = itemType;
@@ -1100,7 +1100,7 @@ namespace Files.App.ViewModels
 									if (matchingStorageFolder.DisplayName != item.Name && !matchingStorageFolder.DisplayName.StartsWith("$R", StringComparison.Ordinal))
 									{
 										cts.Token.ThrowIfCancellationRequested();
-										await dispatcherQueue.EnqueueAsync(() =>
+										await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 										{
 											item.ItemNameRaw = matchingStorageFolder.DisplayName;
 										});
@@ -1119,7 +1119,7 @@ namespace Files.App.ViewModels
 									var itemType = (item.ItemType == "Folder".GetLocalizedResource()) ? item.ItemType : matchingStorageFolder.DisplayType;
 									cts.Token.ThrowIfCancellationRequested();
 
-									await dispatcherQueue.EnqueueAsync(() =>
+									await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 									{
 										item.FolderRelativeId = matchingStorageFolder.FolderRelativeId;
 										item.ItemType = itemType;
@@ -1158,7 +1158,7 @@ namespace Files.App.ViewModels
 							{
 								var fileTag = FileTagsHelper.ReadFileTag(item.ItemPath);
 
-								await dispatcherQueue.EnqueueAsync(() =>
+								await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 								{
 									// Reset cloud sync status icon
 									item.SyncStatusUI = new CloudDriveSyncStatusUI();
@@ -1175,7 +1175,7 @@ namespace Files.App.ViewModels
 						{
 							cts.Token.ThrowIfCancellationRequested();
 							await SafetyExtensions.IgnoreExceptions(() =>
-								dispatcherQueue.EnqueueAsync(() =>
+								dispatcherQueue.EnqueueOrInvokeAsync(() =>
 								{
 									gp.Model.ImageSource = groupImage;
 									gp.InitializeExtendedGroupHeaderInfoAsync();
@@ -1202,7 +1202,7 @@ namespace Files.App.ViewModels
 				var headerIconInfo = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(item.ItemPath, 64u, false);
 
 				if (headerIconInfo is not null && !item.IsShortcut)
-					groupImage = await dispatcherQueue.EnqueueAsync(() => headerIconInfo.ToBitmapAsync(), Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
+					groupImage = await dispatcherQueue.EnqueueOrInvokeAsync(() => headerIconInfo.ToBitmapAsync(), Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
 
 				// The groupImage is null if loading icon from fulltrust process failed
 				if (!item.IsShortcut && !item.IsHiddenItem && !FtpHelpers.IsFtpPath(item.ItemPath) && groupImage is null)
@@ -1214,7 +1214,7 @@ namespace Files.App.ViewModels
 						using StorageItemThumbnail headerThumbnail = await FilesystemTasks.Wrap(() => matchingStorageItem.GetThumbnailAsync(ThumbnailMode.DocumentsView, 36, ThumbnailOptions.UseCurrentScale).AsTask());
 						if (headerThumbnail is not null)
 						{
-							await dispatcherQueue.EnqueueAsync(async () =>
+							await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 							{
 								var bmp = new BitmapImage();
 								await bmp.SetSourceAsync(headerThumbnail);
@@ -1228,7 +1228,7 @@ namespace Files.App.ViewModels
 			// This prevents both the shortcut glyph and folder icon being shown
 			else if (!item.IsShortcut)
 			{
-				await dispatcherQueue.EnqueueAsync(() => groupImage = new SvgImageSource(new Uri("ms-appx:///Assets/FolderIcon2.svg"))
+				await dispatcherQueue.EnqueueOrInvokeAsync(() => groupImage = new SvgImageSource(new Uri("ms-appx:///Assets/FolderIcon2.svg"))
 				{
 					RasterizePixelHeight = 128,
 					RasterizePixelWidth = 128,
@@ -1449,7 +1449,7 @@ namespace Files.App.ViewModels
 				{
 					if (!client.IsConnected && await WrappedAutoConnectFtpAsync(client) is null)
 					{
-						await dispatcherQueue.EnqueueAsync(async () =>
+						await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 						{
 							var credentialDialogViewModel = new CredentialDialogViewModel();
 
@@ -1812,7 +1812,7 @@ namespace Files.App.ViewModels
 		{
 			Debug.WriteLine($"Directory watcher event: {e.ChangeType}, {e.FullPath}");
 
-			await dispatcherQueue.EnqueueAsync(() =>
+			await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 			{
 				RefreshItems(null);
 			});
@@ -1832,7 +1832,7 @@ namespace Files.App.ViewModels
 
 			sender.ApplyNewQueryOptions(options);
 
-			await dispatcherQueue.EnqueueAsync(() =>
+			await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 			{
 				RefreshItems(null);
 			});
@@ -2188,7 +2188,7 @@ namespace Files.App.ViewModels
 				var matchingItems = filesAndFolders.Where(x => paths.Any(p => p.Equals(x.ItemPath, StringComparison.OrdinalIgnoreCase)));
 				var results = await Task.WhenAll(matchingItems.Select(x => GetFileOrFolderUpdateInfoAsync(x, hasSyncStatus)));
 
-				await dispatcherQueue.EnqueueAsync(() =>
+				await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 				{
 					foreach (var result in results)
 					{

--- a/src/Files.App/ViewModels/Previews/BasePreviewModel.cs
+++ b/src/Files.App/ViewModels/Previews/BasePreviewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.WinUI;
+using Files.App.Extensions;
 using Files.App.Filesystem;
 using Files.App.Filesystem.StorageItems;
 using Files.App.Helpers;
@@ -98,11 +99,11 @@ namespace Files.App.ViewModels.Previews
 			iconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 256);
 			if (iconData is not null)
 			{
-				await App.Window.DispatcherQueue.EnqueueAsync(async () => FileImage = await iconData.ToBitmapAsync());
+				await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () => FileImage = await iconData.ToBitmapAsync());
 			}
 			else
 			{
-				FileImage ??= await App.Window.DispatcherQueue.EnqueueAsync(() => new BitmapImage());
+				FileImage ??= await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => new BitmapImage());
 			}
 
 			return new List<FileProperty>();

--- a/src/Files.App/ViewModels/Previews/ImagePreviewViewModel.cs
+++ b/src/Files.App/ViewModels/Previews/ImagePreviewViewModel.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.WinUI;
+using Files.App.Extensions;
 using Files.App.Filesystem;
 using Files.App.ViewModels.Properties;
 using Microsoft.UI.Xaml.Media;
@@ -33,7 +34,7 @@ namespace Files.App.ViewModels.Previews
 		{
 			using IRandomAccessStream stream = await Item.ItemFile.OpenAsync(FileAccessMode.Read);
 
-			await App.Window.DispatcherQueue.EnqueueAsync(async () =>
+			await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 			{
 				BitmapImage bitmap = new();
 				await bitmap.SetSourceAsync(stream);

--- a/src/Files.App/ViewModels/Previews/PDFPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/Previews/PDFPreviewViewModel.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.WinUI;
+using Files.App.Extensions;
 using Files.App.Filesystem;
 using Files.App.ViewModels.Properties;
 using Microsoft.UI.Xaml;
@@ -91,7 +92,7 @@ namespace Files.App.ViewModels.Previews
 				BitmapDecoder decoder = await BitmapDecoder.CreateAsync(stream);
 				using SoftwareBitmap sw = await decoder.GetSoftwareBitmapAsync();
 
-				await App.Window.DispatcherQueue.EnqueueAsync(async () =>
+				await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
 					BitmapImage src = new();
 					PageViewModel pageData = new()

--- a/src/Files.App/ViewModels/Properties/BaseProperties.cs
+++ b/src/Files.App/ViewModels/Properties/BaseProperties.cs
@@ -92,7 +92,7 @@ namespace Files.App.ViewModels.Properties
 
 					if (size > ViewModel.ItemSizeBytes)
 					{
-						await Dispatcher.EnqueueAsync(() =>
+						await Dispatcher.EnqueueOrInvokeAsync(() =>
 						{
 							ViewModel.ItemSizeBytes = size;
 							ViewModel.ItemSize = size.ToSizeString();

--- a/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
@@ -12,6 +12,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading.Tasks;
 using Windows.Storage.Pickers;
+using Files.App.Extensions;
 
 namespace Files.App.ViewModels.Properties
 {
@@ -107,11 +108,11 @@ namespace Files.App.ViewModels.Properties
 
 			if (setIconResult)
 			{
-				await App.Window.DispatcherQueue.EnqueueAsync(() =>
+				await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 				{
 					AppInstance?.FilesystemViewModel?.RefreshItems(null, async () =>
 					{
-						await App.Window.DispatcherQueue.EnqueueAsync(() => RestoreButtonIsEnabled = true);
+						await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => RestoreButtonIsEnabled = true);
 						
 					});
 				});
@@ -155,7 +156,7 @@ namespace Files.App.ViewModels.Properties
 
 			if (setIconResult)
 			{
-				await App.Window.DispatcherQueue.EnqueueAsync(() =>
+				await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 				{
 					AppInstance?.FilesystemViewModel?.RefreshItems(null);
 				});

--- a/src/Files.App/ViewModels/Properties/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/FileProperties.cs
@@ -90,7 +90,7 @@ namespace Files.App.ViewModels.Properties
 				}
 				else
 				{
-					await App.Window.DispatcherQueue.EnqueueAsync(
+					await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(
 						() => NavigationHelpers.OpenPathInNewTab(Path.GetDirectoryName(ViewModel.ShortcutItemPath)));
 				}
 			},

--- a/src/Files.App/ViewModels/Properties/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/FolderProperties.cs
@@ -65,7 +65,7 @@ namespace Files.App.ViewModels.Properties
 					ViewModel.ShortcutItemArgumentsVisibility = false;
 					ViewModel.ShortcutItemOpenLinkCommand = new RelayCommand(async () =>
 					{
-						await App.Window.DispatcherQueue.EnqueueAsync(
+						await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(
 							() => NavigationHelpers.OpenPathInNewTab(Path.GetDirectoryName(Environment.ExpandEnvironmentVariables(ViewModel.ShortcutItemPath))));
 					},
 					() =>

--- a/src/Files.App/ViewModels/Properties/HashesViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/HashesViewModel.cs
@@ -83,7 +83,7 @@ namespace Files.App.ViewModels.Properties
 			{
 				hashInfoItem.HashValue = "Calculating".GetLocalizedResource();
 
-				App.Window.DispatcherQueue.EnqueueAsync(async () =>
+				App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
 					try
 					{

--- a/src/Files.App/ViewModels/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/SidebarViewModel.cs
@@ -245,7 +245,7 @@ namespace Files.App.ViewModels
 
 		private async void Manager_DataChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			await dispatcherQueue.EnqueueAsync(async () =>
+			await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
 			{
 				var sectionType = (sender is SectionType s) ? s : SectionType.Drives;
 				var section = await GetOrCreateSection(sectionType);

--- a/src/Files.App/ViewModels/ToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/ToolbarViewModel.cs
@@ -488,7 +488,7 @@ namespace Files.App.ViewModels
 
 			if (pointerRoutedEventArgs is not null)
 			{
-				await App.Window.DispatcherQueue.EnqueueAsync(async () =>
+				await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
 					await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), itemTappedPath);
 				}, DispatcherQueuePriority.Low);

--- a/src/Files.App/Views/BaseShellPage.cs
+++ b/src/Files.App/Views/BaseShellPage.cs
@@ -628,7 +628,7 @@ namespace Files.App.Views
 			if (drivesViewModel?.ShowUserConsentOnInit ?? false)
 			{
 				drivesViewModel.ShowUserConsentOnInit = false;
-				await DispatcherQueue.EnqueueAsync(async () =>
+				await DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
 					var dialog = DynamicDialogFactory.GetFor_ConsentDialog();
 					await SetContentDialogRoot(dialog).ShowAsync(ContentDialogPlacement.Popup);

--- a/src/Files.App/Views/Properties/GeneralPage.xaml.cs
+++ b/src/Files.App/Views/Properties/GeneralPage.xaml.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.WinUI;
 using Files.App.DataModels.NavigationControlItems;
+using Files.App.Extensions;
 using Files.App.Filesystem;
 using Files.App.Helpers;
 using Files.App.Shell;
@@ -55,7 +56,7 @@ namespace Files.App.Views.Properties
 				newName = letterRegex.Replace(newName, string.Empty); // Remove "(C:)" from the new label
 
 				Win32API.SetVolumeLabel(drive.Path, newName);
-				_ = App.Window.DispatcherQueue.EnqueueAsync(async () =>
+				_ = App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
 					await drive.UpdateLabelAsync();
 					await fsVM.SetWorkingDirectoryAsync(drive.Path);
@@ -76,7 +77,7 @@ namespace Files.App.Views.Properties
 				if (renamed is ReturnResult.Success)
 				{
 					var newPath = Path.Combine(Path.GetDirectoryName(library.ItemPath)!, newName);
-					_ = App.Window.DispatcherQueue.EnqueueAsync(async () =>
+					_ = App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 					{
 						await fsVM.SetWorkingDirectoryAsync(newPath);
 					});
@@ -94,7 +95,7 @@ namespace Files.App.Views.Properties
 				{
 					foreach (var fileOrFolder in fileOrFolders)
 					{
-						await App.Window.DispatcherQueue.EnqueueAsync(() =>
+						await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 							UIFilesystemHelpers.SetHiddenAttributeItem(fileOrFolder, ViewModel.IsHidden, itemMM)
 						);
 					}
@@ -108,7 +109,7 @@ namespace Files.App.Views.Properties
 				var itemMM = AppInstance?.SlimContentPage?.ItemManipulationModel;
 				if (itemMM is not null) // null on homepage
 				{
-					await App.Window.DispatcherQueue.EnqueueAsync(() =>
+					await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 						UIFilesystemHelpers.SetHiddenAttributeItem(item, ViewModel.IsHidden, itemMM)
 					);
 				}
@@ -116,7 +117,7 @@ namespace Files.App.Views.Properties
 				if (!GetNewName(out var newName))
 					return true;
 
-				return await App.Window.DispatcherQueue.EnqueueAsync(() =>
+				return await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 					UIFilesystemHelpers.RenameFileItemAsync(item, ViewModel.ItemName, AppInstance, false)
 				);
 			}

--- a/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
+++ b/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
@@ -89,7 +89,7 @@ namespace Files.App.Views.Properties
 				DragZoneHelper.SetDragZones(Window, (int)TitlebarArea.ActualHeight);
 				AppWindow.Destroying += AppWindow_Destroying;
 
-				await App.Window.DispatcherQueue.EnqueueAsync(() => AppSettings.UpdateThemeElements.Execute(null));
+				await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => AppSettings.UpdateThemeElements.Execute(null));
 			}
 			else
 			{
@@ -116,7 +116,7 @@ namespace Files.App.Views.Properties
 
 		private async void AppSettings_ThemeModeChanged(object? sender, EventArgs e)
 		{
-			await DispatcherQueue.EnqueueAsync(() =>
+			await DispatcherQueue.EnqueueOrInvokeAsync(() =>
 			{
 				((Frame)Parent).RequestedTheme = ThemeHelper.RootTheme;
 

--- a/src/Files.App/Views/Properties/SecurityAdvancedPage.xaml.cs
+++ b/src/Files.App/Views/Properties/SecurityAdvancedPage.xaml.cs
@@ -67,7 +67,7 @@ namespace Files.App.Views.Properties
 				appWindow.Destroying += AppWindow_Destroying;
 
 				// Update theme
-				await App.Window.DispatcherQueue.EnqueueAsync(() => AppSettings.UpdateThemeElements.Execute(null));
+				await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => AppSettings.UpdateThemeElements.Execute(null));
 			}
 		}
 
@@ -81,7 +81,7 @@ namespace Files.App.Views.Properties
 		{
 			var selectedTheme = ThemeHelper.RootTheme;
 
-			await DispatcherQueue.EnqueueAsync(() =>
+			await DispatcherQueue.EnqueueOrInvokeAsync(() =>
 			{
 				((Frame)Parent).RequestedTheme = selectedTheme;
 

--- a/src/Files.App/Views/Properties/SecurityPage.xaml.cs
+++ b/src/Files.App/Views/Properties/SecurityPage.xaml.cs
@@ -127,7 +127,7 @@ namespace Files.App.Views.Properties
 			if (SecurityViewModel is not null)
 			{
 				// Reload permissions when closing
-				await DispatcherQueue.EnqueueAsync(() => SecurityViewModel.GetAccessControlList());
+				await DispatcherQueue.EnqueueOrInvokeAsync(() => SecurityViewModel.GetAccessControlList());
 			}
 		}
 

--- a/src/Files.App/Views/Properties/ShortcutPage.xaml.cs
+++ b/src/Files.App/Views/Properties/ShortcutPage.xaml.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.WinUI;
+using Files.App.Extensions;
 using Files.App.Filesystem;
 using Files.App.Helpers;
 using Files.App.ViewModels.Properties;
@@ -25,7 +26,7 @@ namespace Files.App.Views.Properties
 			if (shortcutItem is null)
 				return true;
 
-			await App.Window.DispatcherQueue.EnqueueAsync(() =>
+			await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 				UIFilesystemHelpers.UpdateShortcutItemProperties(shortcutItem,
 				ViewModel.ShortcutItemPath,
 				ViewModel.ShortcutItemArguments,


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
