### PR TITLE
Fix: Switch focus to the primary pane when closing dual pane mode

### DIFF
--- a/src/Files.App/Views/PaneHolderPage.xaml.cs
+++ b/src/Files.App/Views/PaneHolderPage.xaml.cs
@@ -28,7 +28,7 @@ namespace Files.App.Views
 
 		public event EventHandler<TabItemArguments> ContentChanged;
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged;
 
 		public IFilesystemHelpers FilesystemHelpers
 			=> ActivePane?.FilesystemHelpers;
@@ -308,6 +308,7 @@ namespace Files.App.Views
 		{
 			// NOTE: Can only close right pane at the moment
 			IsRightPaneVisible = false;
+			PaneLeft.Focus(FocusState.Programmatic);
 		}
 
 		private void Pane_Loaded(object sender, RoutedEventArgs e)
@@ -353,9 +354,9 @@ namespace Files.App.Views
 
 	public class PaneNavigationArguments
 	{
-		public string LeftPaneNavPathParam { get; set; } = null;
-		public string LeftPaneSelectItemParam { get; set; } = null;
-		public string RightPaneNavPathParam { get; set; } = null;
-		public string RightPaneSelectItemParam { get; set; } = null;
+		public string? LeftPaneNavPathParam { get; set; } = null;
+		public string? LeftPaneSelectItemParam { get; set; } = null;
+		public string? RightPaneNavPathParam { get; set; } = null;
+		public string? RightPaneSelectItemParam { get; set; } = null;
 	}
 }


### PR DESCRIPTION
…h shortcuts

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12202 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open two panes (`Home` and `Home`, if the primary pane was not on `Home` it worked even before)
   2. Click on the secondary pane
   3. Use `Ctrl + Shift + W` to close it
   4. Open a favorite from the sidebar (do not click on the primary pane)
