### PR TITLE
Fix: Refactored ContextMenu

### DIFF
--- a/src/Files.App/Shell/ContextMenu.cs
+++ b/src/Files.App/Shell/ContextMenu.cs
@@ -165,15 +165,7 @@ namespace Files.App.Shell
 
 		public static async Task WarmUpQueryContextMenuAsync()
 		{
-			var thread = new ThreadWithMessageQueue();
-			await thread.PostMethod(() =>
-			{
-				// Create a dummy context menu for warming up
-				var shellItem = ShellFolderExtensions.GetShellItemFromPathOrPidl("C:\\");
-				Shell32.IContextMenu menu = shellItem.Parent.GetChildrenUIObjects<Shell32.IContextMenu>(default, shellItem);
-				menu.QueryContextMenu(User32.CreatePopupMenu(), 0, 1, 0x7FFF, Shell32.CMF.CMF_NORMAL);
-			});
-			thread.Dispose();
+			using var cMenu = await GetContextMenuForFiles(new string[] { "C:\\" }, Shell32.CMF.CMF_NORMAL);
 		}
 
 		#endregion FactoryMethods
@@ -262,18 +254,18 @@ namespace Files.App.Shell
 
 						if (loadSubenus)
 						{
-							LoadSubMenu(hSubMenu);
+							LoadSubMenu();
 						}
 						else
 						{
-							loadSubMenuActions.Add(subItems, () => LoadSubMenu(hSubMenu));
+							loadSubMenuActions.Add(subItems, LoadSubMenu);
 						}
 
 						menuItem.SubItems = subItems;
 
 						Debug.WriteLine("Item {0}: done submenu", ii);
 
-						void LoadSubMenu(HMENU hSubMenu)
+						void LoadSubMenu()
 						{
 							try
 							{
@@ -300,24 +292,25 @@ namespace Files.App.Shell
 
 		public async Task<bool> LoadSubMenu(List<Win32ContextMenuItem> subItems)
 		{
-			return await owningThread.PostMethod<bool>(() =>
+			if (loadSubMenuActions.Remove(subItems, out var loadSubMenuAction))
 			{
-				var result = loadSubMenuActions.Remove(subItems, out var loadSubMenuAction);
-
-				if (result)
+				return await owningThread.PostMethod<bool>(() =>
 				{
 					try
 					{
 						loadSubMenuAction!();
+						return true;
 					}
 					catch (COMException)
 					{
-						result = false;
+						return false;
 					}
-				}
-
-				return result;
-			});
+				});
+			}
+			else
+			{
+				return false;
+			}
 		}
 
 		private static string? GetCommandString(Shell32.IContextMenu cMenu, uint offset, Shell32.GCS flags = Shell32.GCS.GCS_VERBW)


### PR DESCRIPTION
I don't think this will solve all problems, but I believe it is important to prevent further problems.
* Fixed problem with COM objects not being properly discarded on context menu warm-up
* Fixed problem where ThreadWithMesssageQueue was being used unnecessarily for shell extensions with no submenu. This will improve performance

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?