### PR TITLE
Fix: Fixed a crash with ftp connections

### DIFF
--- a/src/Files.App/ViewModels/ItemViewModel.cs
+++ b/src/Files.App/ViewModels/ItemViewModel.cs
@@ -143,7 +143,7 @@ namespace Files.App.ViewModels
 			var pathRoot = FtpHelpers.IsFtpPath(WorkingDirectory) 
 				? WorkingDirectory.Substring(0, FtpHelpers.GetRootIndex(WorkingDirectory)) 
 				: Path.GetPathRoot(WorkingDirectory);
-			GitDirectory = GitHelpers.GetGitRepositoryPath(WorkingDirectory, pathRoot);
+			GitDirectory = pathRoot is null ? null : GitHelpers.GetGitRepositoryPath(WorkingDirectory, pathRoot);
 			OnPropertyChanged(nameof(WorkingDirectory));
 		}
 

--- a/src/Files.App/ViewModels/ItemViewModel.cs
+++ b/src/Files.App/ViewModels/ItemViewModel.cs
@@ -139,7 +139,11 @@ namespace Files.App.ViewModels
 				_ = Task.Run(() => jumpListService.AddFolderAsync(value));
 
 			WorkingDirectory = value;
-			GitDirectory = GitHelpers.GetGitRepositoryPath(WorkingDirectory, Path.GetPathRoot(WorkingDirectory));
+
+			var pathRoot = FtpHelpers.IsFtpPath(WorkingDirectory) 
+				? WorkingDirectory.Substring(0, FtpHelpers.GetRootIndex(WorkingDirectory)) 
+				: Path.GetPathRoot(WorkingDirectory);
+			GitDirectory = GitHelpers.GetGitRepositoryPath(WorkingDirectory, pathRoot);
 			OnPropertyChanged(nameof(WorkingDirectory));
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.

**Motivation**
When trying to access `ftp paths`, Files crashed because of a `stack overflow exception`. This PR prevents that 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Type and `ftp path` in the address bar
