### PR TITLE
Fix: create button is always disabled in new shortcut dialog

### DIFF
--- a/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
@@ -64,7 +64,11 @@ namespace Files.App.ViewModels.Dialogs
 		public bool IsLocationValid
 		{
 			get => _isLocationValid;
-			set => SetProperty(ref _isLocationValid, value, nameof(ShowWarningTip));
+			set
+			{
+				if (SetProperty(ref _isLocationValid, value))
+					OnPropertyChanged(nameof(ShowWarningTip));
+			}
 		}
 
 		public bool ShowWarningTip => !string.IsNullOrEmpty(DestinationItemPath) && !_isLocationValid;


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related #12150 

The former code was blocking all the listeners subscribed to the change of `IsLocationValid`

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app 
   2. Right click on empty space
   3. Click new > new shortcut
   4. Enter an invalid path and then a valid one
