### PR TITLE
Fix: Reduced tooltip size when only the drive name is available

### DIFF
--- a/src/Files.App/UserControls/SidebarControl.xaml
+++ b/src/Files.App/UserControls/SidebarControl.xaml
@@ -100,168 +100,163 @@
 					Visibility="{x:Bind ItemVisibility}">
 					<ToolTipService.ToolTip>
 						<ToolTip>
-							<Grid
-								x:Name="DriveTooltip"
-								Padding="0"
-								HorizontalAlignment="Stretch"
-								ColumnSpacing="8"
-								CornerRadius="4"
-								RowSpacing="8">
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="72" />
-									<ColumnDefinition
-										Width="Auto"
-										MinWidth="100"
-										MaxWidth="140" />
-									<ColumnDefinition Width="*" />
-									<ColumnDefinition Width="Auto" />
-								</Grid.ColumnDefinitions>
-								<Grid.RowDefinitions>
-									<RowDefinition Height="Auto" />
-									<RowDefinition Height="Auto" />
-									<RowDefinition Height="Auto" />
-									<RowDefinition Height="Auto" />
-								</Grid.RowDefinitions>
-
+							<StackPanel>
 								<!--  Displays the drive name, this is hidden when the extended details are shown  -->
 								<TextBlock
 									x:Name="DriveNameTextBlock"
 									x:Load="{x:Bind ShowDriveDetails, Converter={StaticResource BoolNegationConverter}}"
 									Text="{x:Bind Text, Mode=OneWay}" />
 
-								<!--  Label  -->
-								<TextBlock
-									x:Name="DriveLabel"
-									Grid.ColumnSpan="3"
-									Padding="8,8,0,0"
-									VerticalAlignment="Center"
+								<Grid
+									x:Name="DriveTooltip"
+									Padding="0"
+									HorizontalAlignment="Stretch"
 									x:Load="{x:Bind ShowDriveDetails}"
-									FontSize="14"
-									FontWeight="Medium"
-									Text="{x:Bind Text, Mode=OneWay}" />
+									ColumnSpacing="8"
+									CornerRadius="4"
+									RowSpacing="8">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="72" />
+										<ColumnDefinition
+											Width="Auto"
+											MinWidth="100"
+											MaxWidth="140" />
+										<ColumnDefinition Width="*" />
+										<ColumnDefinition Width="Auto" />
+									</Grid.ColumnDefinitions>
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+									</Grid.RowDefinitions>
 
-								<!--  Space used progress  -->
-								<ProgressRing
-									x:Name="SpaceUserProgressRing"
-									Grid.Row="1"
-									Grid.RowSpan="3"
-									Grid.Column="0"
-									Width="60"
-									Height="60"
-									HorizontalAlignment="Left"
-									x:Load="{x:Bind ShowDriveDetails}"
-									Background="{ThemeResource ProgressRingBackgroundThemeBrush}"
-									IsIndeterminate="False"
-									Value="{x:Bind PercentageUsed, Mode=OneWay}">
-
-									<ProgressRing.Template>
-										<ControlTemplate TargetType="ProgressRing">
-											<Grid x:Name="LayoutRoot" Background="Transparent">
-												<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-													<TextBlock
-														Margin="0"
-														FontWeight="SemiBold"
-														Text="{Binding Value, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0}%', Mode=OneWay}"
-														TextAlignment="Center" />
-												</StackPanel>
-
-												<!--  AnimatedVisualPlayer for Lottie  -->
-												<AnimatedVisualPlayer
-													x:Name="LottiePlayer"
-													AutoPlay="false"
-													Opacity="1"
-													Stretch="fill" />
-
-												<VisualStateManager.VisualStateGroups>
-													<VisualStateGroup x:Name="CommonStates">
-														<VisualState x:Name="Inactive">
-															<VisualState.Setters>
-																<Setter Target="LayoutRoot.Opacity" Value="0" />
-															</VisualState.Setters>
-														</VisualState>
-														<VisualState x:Name="DeterminateActive" />
-														<VisualState x:Name="Active" />
-													</VisualStateGroup>
-												</VisualStateManager.VisualStateGroups>
-											</Grid>
-										</ControlTemplate>
-									</ProgressRing.Template>
-								</ProgressRing>
-
-								<!--  Disk used space  -->
-								<StackPanel
-									x:Name="UsedSpaceDrivePanel"
-									Grid.Row="1"
-									Grid.Column="1"
-									x:Load="{x:Bind ShowDriveDetails}"
-									Orientation="Horizontal">
-									<Rectangle
-										Width="16"
-										Height="16"
-										Margin="0,0,12,0"
-										Fill="{Binding Foreground, ElementName=SpaceUserProgressRing}"
-										RadiusX="2"
-										RadiusY="2"
-										Stroke="{ThemeResource TextControlElevationBorderBrush}" />
+									<!--  Label  -->
 									<TextBlock
+										x:Name="DriveLabel"
+										Grid.ColumnSpan="3"
+										Padding="8,8,0,0"
+										VerticalAlignment="Center"
+										FontSize="14"
+										FontWeight="Medium"
+										Text="{x:Bind Text, Mode=OneWay}" />
+
+									<!--  Space used progress  -->
+									<ProgressRing
+										x:Name="SpaceUserProgressRing"
+										Grid.Row="1"
+										Grid.RowSpan="3"
+										Grid.Column="0"
+										Width="60"
+										Height="60"
+										HorizontalAlignment="Left"
+										Background="{ThemeResource ProgressRingBackgroundThemeBrush}"
+										IsIndeterminate="False"
+										Value="{x:Bind PercentageUsed, Mode=OneWay}">
+
+										<ProgressRing.Template>
+											<ControlTemplate TargetType="ProgressRing">
+												<Grid x:Name="LayoutRoot" Background="Transparent">
+													<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+														<TextBlock
+															Margin="0"
+															FontWeight="SemiBold"
+															Text="{Binding Value, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:0}%', Mode=OneWay}"
+															TextAlignment="Center" />
+													</StackPanel>
+
+													<!--  AnimatedVisualPlayer for Lottie  -->
+													<AnimatedVisualPlayer
+														x:Name="LottiePlayer"
+														AutoPlay="false"
+														Opacity="1"
+														Stretch="fill" />
+
+													<VisualStateManager.VisualStateGroups>
+														<VisualStateGroup x:Name="CommonStates">
+															<VisualState x:Name="Inactive">
+																<VisualState.Setters>
+																	<Setter Target="LayoutRoot.Opacity" Value="0" />
+																</VisualState.Setters>
+															</VisualState>
+															<VisualState x:Name="DeterminateActive" />
+															<VisualState x:Name="Active" />
+														</VisualStateGroup>
+													</VisualStateManager.VisualStateGroups>
+												</Grid>
+											</ControlTemplate>
+										</ProgressRing.Template>
+									</ProgressRing>
+
+									<!--  Disk used space  -->
+									<StackPanel
+										x:Name="UsedSpaceDrivePanel"
+										Grid.Row="1"
+										Grid.Column="1"
+										Orientation="Horizontal">
+										<Rectangle
+											Width="16"
+											Height="16"
+											Margin="0,0,12,0"
+											Fill="{Binding Foreground, ElementName=SpaceUserProgressRing}"
+											RadiusX="2"
+											RadiusY="2"
+											Stroke="{ThemeResource TextControlElevationBorderBrush}" />
+										<TextBlock
+											VerticalAlignment="Center"
+											FontWeight="Bold"
+											Text="{helpers:ResourceString Name=PropertiesDriveUsedSpace/Text}" />
+									</StackPanel>
+									<TextBlock
+										x:Name="UsedSpaceDriveValue"
+										Grid.Row="1"
+										Grid.Column="2"
+										Style="{StaticResource PropertyValueTextBlock}"
+										Text="{x:Bind UsedSpaceText, Mode=OneWay}" />
+
+									<!--  Disk free space  -->
+									<StackPanel
+										x:Name="FreeSpaceDrivePanel"
+										Grid.Row="2"
+										Grid.Column="1"
+										Orientation="Horizontal">
+										<Rectangle
+											Width="16"
+											Height="16"
+											Margin="0,0,12,0"
+											Fill="{ThemeResource ProgressRingBackgroundThemeBrush}"
+											RadiusX="2"
+											RadiusY="2"
+											Stroke="{ThemeResource TextControlElevationBorderBrush}" />
+										<TextBlock
+											VerticalAlignment="Center"
+											FontWeight="Bold"
+											Text="{helpers:ResourceString Name=PropertiesDriveFreeSpace/Text}" />
+									</StackPanel>
+									<TextBlock
+										x:Name="FreeSpaceDriveValue"
+										Grid.Row="2"
+										Grid.Column="2"
+										Style="{StaticResource PropertyValueTextBlock}"
+										Text="{x:Bind FreeSpaceText, Mode=OneWay}" />
+
+									<!--  Drive capacity  -->
+									<TextBlock
+										x:Name="MaxSpaceDriveLabel"
+										Grid.Row="3"
+										Grid.Column="1"
+										Padding="28,0,0,0"
 										VerticalAlignment="Center"
 										FontWeight="Bold"
-										Text="{helpers:ResourceString Name=PropertiesDriveUsedSpace/Text}" />
-								</StackPanel>
-								<TextBlock
-									x:Name="UsedSpaceDriveValue"
-									Grid.Row="1"
-									Grid.Column="2"
-									x:Load="{x:Bind ShowDriveDetails}"
-									Style="{StaticResource PropertyValueTextBlock}"
-									Text="{x:Bind UsedSpaceText, Mode=OneWay}" />
-
-								<!--  Disk free space  -->
-								<StackPanel
-									x:Name="FreeSpaceDrivePanel"
-									Grid.Row="2"
-									Grid.Column="1"
-									x:Load="{x:Bind ShowDriveDetails}"
-									Orientation="Horizontal">
-									<Rectangle
-										Width="16"
-										Height="16"
-										Margin="0,0,12,0"
-										Fill="{ThemeResource ProgressRingBackgroundThemeBrush}"
-										RadiusX="2"
-										RadiusY="2"
-										Stroke="{ThemeResource TextControlElevationBorderBrush}" />
+										Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />
 									<TextBlock
-										VerticalAlignment="Center"
-										FontWeight="Bold"
-										Text="{helpers:ResourceString Name=PropertiesDriveFreeSpace/Text}" />
-								</StackPanel>
-								<TextBlock
-									x:Name="FreeSpaceDriveValue"
-									Grid.Row="2"
-									Grid.Column="2"
-									x:Load="{x:Bind ShowDriveDetails}"
-									Style="{StaticResource PropertyValueTextBlock}"
-									Text="{x:Bind FreeSpaceText, Mode=OneWay}" />
-
-								<!--  Drive capacity  -->
-								<TextBlock
-									x:Name="MaxSpaceDriveLabel"
-									Grid.Row="3"
-									Grid.Column="1"
-									Padding="28,0,0,0"
-									VerticalAlignment="Center"
-									x:Load="{x:Bind ShowDriveDetails}"
-									FontWeight="Bold"
-									Text="{helpers:ResourceString Name=PropertiesDriveCapacity/Text}" />
-								<TextBlock
-									x:Name="MaxSpaceDriveValue"
-									Grid.Row="3"
-									Grid.Column="2"
-									x:Load="{x:Bind ShowDriveDetails}"
-									Style="{StaticResource PropertyValueTextBlock}"
-									Text="{x:Bind MaxSpaceText, Mode=OneWay}" />
-							</Grid>
+										x:Name="MaxSpaceDriveValue"
+										Grid.Row="3"
+										Grid.Column="2"
+										Style="{StaticResource PropertyValueTextBlock}"
+										Text="{x:Bind MaxSpaceText, Mode=OneWay}" />
+								</Grid>
+							</StackPanel>
 						</ToolTip>
 					</ToolTipService.ToolTip>
 					<NavigationViewItem.Icon>


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes None

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app 
   2. Hover a drive such as `C:\`, see that the tooltip looks as before
   3. Hover `Network` folder or any other that has no detail

**Screenshots (optional)**
Before/After
![2](https://user-images.githubusercontent.com/102259289/235287146-10148b31-243e-4e77-9f94-59ab22220154.png) ![3](https://user-images.githubusercontent.com/102259289/235287144-6ce8816d-b3c6-4cbf-86ee-2f733184be07.png)

Before/After
![5](https://user-images.githubusercontent.com/102259289/235346412-52ccd7a4-87f7-4f01-8c9f-383a127dd1e0.png) ![4](https://user-images.githubusercontent.com/102259289/235346414-e257d8f8-1f5d-458c-b0d9-fb8dd479ab5c.png)
