### PR TITLE
Fix: Fixed issue where search unindexed items wasn't clickable

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -182,21 +182,6 @@
 			Canvas.ZIndex="0"
 			EmptyTextType="{x:Bind ParentShellPageInstance.FilesystemViewModel.EmptyTextType, Mode=OneWay}" />
 
-		<!--  Search Unindexed Items  -->
-		<StackPanel
-			x:Name="SearchUnindexedItemsPanel"
-			HorizontalAlignment="Center"
-			VerticalAlignment="Bottom"
-			x:Load="{x:Bind InstanceViewModel.ShowSearchUnindexedItemsMessage, Mode=OneWay}"
-			Orientation="Vertical">
-			<TextBlock Text="{helpers:ResourceString Name=SearchUnindexedItemsLabel/Text}" />
-			<HyperlinkButton
-				x:Name="SearchUnindexedItemsButton"
-				HorizontalAlignment="Center"
-				Command="{x:Bind CommandsViewModel.SearchUnindexedItems}"
-				Content="{helpers:ResourceString Name=SearchUnindexedItemsButton/Content}" />
-		</StackPanel>
-
 		<!--  Invalid Item Name Tip  -->
 		<TeachingTip
 			x:Name="FileNameTeachingTip"
@@ -1043,6 +1028,21 @@
 			</SemanticZoom.ZoomedOutView>
 
 		</SemanticZoom>
+
+		<!--  Search Unindexed Items  -->
+		<StackPanel
+			x:Name="SearchUnindexedItemsPanel"
+			HorizontalAlignment="Center"
+			VerticalAlignment="Bottom"
+			x:Load="{x:Bind InstanceViewModel.ShowSearchUnindexedItemsMessage, Mode=OneWay}"
+			Orientation="Vertical">
+			<TextBlock Text="{helpers:ResourceString Name=SearchUnindexedItemsLabel/Text}" />
+			<HyperlinkButton
+				x:Name="SearchUnindexedItemsButton"
+				HorizontalAlignment="Center"
+				Command="{x:Bind CommandsViewModel.SearchUnindexedItems}"
+				Content="{helpers:ResourceString Name=SearchUnindexedItemsButton/Content}" />
+		</StackPanel>
 
 		<!--  Selector  -->
 		<Canvas HorizontalAlignment="Stretch" VerticalAlignment="Stretch">


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12085

**Description**
Moved the hyperlink button after the SemanticZoom control to allow tap event to invoke the command. This also helps keep the control center in the window.

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Confirm the hyperlink button in DetailsLayoutBrowser is clickable and the binding command is invoked
   2. Confirm the search unindexed items hyperkink works as expected in GridViewBrowser

**Screenshots (optional)**
Add screenshots here.
