### PR TITLE
Fix: Fixed issue with file preview in column layout

### DIFF
--- a/src/Files.App/BaseLayout.cs
+++ b/src/Files.App/BaseLayout.cs
@@ -201,7 +201,7 @@ namespace Files.App
 				//if (!(value?.All(x => selectedItems?.Contains(x) ?? false) ?? value == selectedItems))
 				if (value != selectedItems)
 				{
-					if (value?.FirstOrDefault() != selectedItems?.FirstOrDefault())
+					if (value?.FirstOrDefault() != PreviewPaneViewModel.SelectedItem)
 					{
 						// Update preview pane properties
 						PreviewPaneViewModel.IsItemSelected = value?.Count > 0;

--- a/src/Files.App/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Helpers/DriveHelpers.cs
@@ -137,12 +137,7 @@ namespace Files.App.Helpers
 		}
 
 		public static async Task<StorageItemThumbnail?> GetThumbnailAsync(StorageFolder folder)
-		{
-			return folder is null
-				? null
-				: (StorageItemThumbnail)await FilesystemTasks.Wrap(()
+			=> (StorageItemThumbnail)await FilesystemTasks.Wrap(()
 					=> folder.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale).AsTask()
-			);
-		}
 	}
 }

--- a/src/Files.App/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Helpers/DriveHelpers.cs
@@ -138,7 +138,7 @@ namespace Files.App.Helpers
 
 		public static async Task<StorageItemThumbnail> GetThumbnailAsync(StorageFolder folder)
 			=> (StorageItemThumbnail)await FilesystemTasks.Wrap(()
-					=> folder.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale).AsTask()
+				=> folder.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale).AsTask()
 			);
 	}
 }

--- a/src/Files.App/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Helpers/DriveHelpers.cs
@@ -136,8 +136,9 @@ namespace Files.App.Helpers
 			};
 		}
 
-		public static async Task<StorageItemThumbnail?> GetThumbnailAsync(StorageFolder folder)
+		public static async Task<StorageItemThumbnail> GetThumbnailAsync(StorageFolder folder)
 			=> (StorageItemThumbnail)await FilesystemTasks.Wrap(()
-					=> folder.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale).AsTask());
+					=> folder.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale).AsTask()
+			);
 	}
 }

--- a/src/Files.App/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Helpers/DriveHelpers.cs
@@ -136,9 +136,13 @@ namespace Files.App.Helpers
 			};
 		}
 
-		public static async Task<StorageItemThumbnail> GetThumbnailAsync(StorageFolder folder)
-			=> (StorageItemThumbnail)await FilesystemTasks.Wrap(()
-				=> folder.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale).AsTask()
+		public static async Task<StorageItemThumbnail?> GetThumbnailAsync(StorageFolder folder)
+		{
+			return folder is null
+				? null
+				: (StorageItemThumbnail)await FilesystemTasks.Wrap(()
+					=> folder.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale).AsTask()
 			);
+		}
 	}
 }

--- a/src/Files.App/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Helpers/DriveHelpers.cs
@@ -138,6 +138,6 @@ namespace Files.App.Helpers
 
 		public static async Task<StorageItemThumbnail?> GetThumbnailAsync(StorageFolder folder)
 			=> (StorageItemThumbnail)await FilesystemTasks.Wrap(()
-					=> folder.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale).AsTask()
+					=> folder.GetThumbnailAsync(ThumbnailMode.SingleItem, 40, ThumbnailOptions.UseCurrentScale).AsTask());
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12227 

This PR also handles a null exception 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes? (I used @ZLAllen steps)
   1. Open "Files"
   2. Select "Documents"
   3. Change View Layout to "Columns"
   4. Enable Preview Panel
   5. Click any items in the first level, the detail shows up correctly in the preview.
   6. Select a folder and click on an item at the second level, the preview is not rendered. Select a different item or lose focus of the current selection and reselect the item will cause it to render correctly in the preview.
