### PR TITLE
Fix: Fixed crash that would occur in git directories on WSL drives

### DIFF
--- a/src/Files.App/Helpers/GitHelpers.cs
+++ b/src/Files.App/Helpers/GitHelpers.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See the LICENSE.
 
 using LibGit2Sharp;
-using System;
 using Files.App.Filesystem.StorageItems;
 
 namespace Files.App.Helpers
@@ -22,9 +21,16 @@ namespace Files.App.Helpers
 				)
 				return null;
 
-			return Repository.IsValid(path)
-				? path
-				: GetGitRepositoryPath(PathNormalization.GetParentDir(path), root);
+			try
+			{
+				return Repository.IsValid(path)
+					? path
+					: GetGitRepositoryPath(PathNormalization.GetParentDir(path), root);
+			}
+			catch (LibGit2SharpException)
+			{
+				return null;
+			}
 		}
 	}
 }

--- a/src/Files.App/ViewModels/CurrentInstanceViewModel.cs
+++ b/src/Files.App/ViewModels/CurrentInstanceViewModel.cs
@@ -181,8 +181,8 @@ namespace Files.App.ViewModels
 				if (IsGitRepository)
 				{
 					using var repository = new Repository(gitRepositoryPath);
-					return repository.Branches.First(branch =>
-						branch.IsCurrentRepositoryHead).FriendlyName;
+					return repository.Branches.FirstOrDefault(branch =>
+						branch.IsCurrentRepositoryHead)?.FriendlyName ?? string.Empty;
 				}
 
 				return string.Empty;


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12292 

**IMPORTANT**
At the moment this PR only prevents the crash (branch name is still not displayed). The exception is raised because the repository belongs to a different user. We can't show the branch name/interact with the repository unless the user set it as "safe".
I think we should show a modal to warn the user about this. We might also provide the command to resolve the issue (`git config --global --add safe.directory = path`) or show a button to execute that

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open a git repository in WSL
