### PR TITLE
Preview: v2.4.81

### DIFF
--- a/src/Files.App (Package)/Package.appxmanifest
+++ b/src/Files.App (Package)/Package.appxmanifest
@@ -11,7 +11,7 @@
          xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"
          xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
          IgnorableNamespaces="uap uap5 mp rescap desktop6 desktop4 desktop">
-    <Identity Name="FilesDev" Publisher="CN=Files" Version="2.4.70.0" />
+    <Identity Name="FilesDev" Publisher="CN=Files" Version="2.4.81.0" />
     <Properties>
         <DisplayName>Files - Dev</DisplayName>
         <PublisherDisplayName>Yair A</PublisherDisplayName>


### PR DESCRIPTION
**Changes in v2.4.81**

- Fixed issue where it didn't work to drag multiple files from the tags area.
- Fixed NullReferenceException in folder.GetThumbnailAsync.
- Fixed crash with Win32Exception.
- Fixed wrong total editing time format in the details pane.
- Fixed issue with file preview in column layout.
- Fixed crash when creating bitmap images.
- Fixed an issue where it wasn't possible to edit some file permissions.
- Fixed crash that would occur in git directories on WSL drives.