### PR TITLE
Fix: Fixed issue where credentials dialog wasn't shown when accessing FTP

### DIFF
--- a/src/Files.App/ViewModels/ItemViewModel.cs
+++ b/src/Files.App/ViewModels/ItemViewModel.cs
@@ -1442,15 +1442,15 @@ namespace Files.App.ViewModels
 			client.Port = FtpHelpers.GetFtpPort(path);
 			client.Credentials = FtpManager.Credentials.Get(client.Host, FtpManager.Anonymous);
 
-			static Task<FtpProfile?> WrappedAutoConnectFtpAsync(AsyncFtpClient client)
+			static async Task<FtpProfile?> WrappedAutoConnectFtpAsync(AsyncFtpClient client)
 			{
 				try
 				{
-					return client.AutoConnect();
+					return await client.AutoConnect();
 				}
 				catch (FtpAuthenticationException)
 				{
-					return Task.FromResult<FtpProfile?>(null);
+					return null;
 				}
 
 				throw new InvalidOperationException();


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related #12010 

**Notes**
Removing `async` from that method would prevent the exception from being caught by the local `catch`

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Try to access an ftp folder
   3. See that the `Credentials dialog` is shown
