### PR TITLE
Fix: Fixed crash when trying to create bitmap from null IconData in `SidebarPinnedModel.cs`

### DIFF
--- a/src/Files.App/Data/Models/SidebarPinnedModel.cs
+++ b/src/Files.App/Data/Models/SidebarPinnedModel.cs
@@ -107,7 +107,9 @@ namespace Files.App.Data.Models
 				{
 					var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(res.Result, 96u, ThumbnailMode.ListView);
 					locationItem.IconData = iconData;
-					locationItem.Icon = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => locationItem.IconData.ToBitmapAsync());
+
+					if (locationItem.IconData is not null)
+						locationItem.Icon = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => locationItem.IconData.ToBitmapAsync());
 				}
 
 				if (locationItem.IconData is null)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

![2023-05-11 18_05_33-DispatcherQueueExtensions EnqueueAsync T  (DispatcherQueue dispatcher, Func`1 fu](https://github.com/files-community/Files/assets/55754091/b94631f0-069c-4b72-9003-2ae23142dc2b)

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Screenshots (optional)**
Add screenshots here.
