### PR TITLE
Fix: Fixed NullReferenceException with EnumerateItemsFromStandardFolderAsync

### DIFF
--- a/src/Files.App/Data/Models/SidebarPinnedModel.cs
+++ b/src/Files.App/Data/Models/SidebarPinnedModel.cs
@@ -107,9 +107,7 @@ namespace Files.App.Data.Models
 				{
 					var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(res.Result, 96u, ThumbnailMode.ListView);
 					locationItem.IconData = iconData;
-
-					if (locationItem.IconData is not null)
-						locationItem.Icon = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => locationItem.IconData.ToBitmapAsync());
+					locationItem.Icon = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => locationItem.IconData.ToBitmapAsync());
 				}
 
 				if (locationItem.IconData is null)

--- a/src/Files.App/Data/Models/SidebarPinnedModel.cs
+++ b/src/Files.App/Data/Models/SidebarPinnedModel.cs
@@ -107,7 +107,9 @@ namespace Files.App.Data.Models
 				{
 					var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(res.Result, 96u, ThumbnailMode.ListView);
 					locationItem.IconData = iconData;
-					locationItem.Icon = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => locationItem.IconData.ToBitmapAsync());
+
+					if (locationItem.IconData is not null)
+						locationItem.Icon = await App.Window.DispatcherQueue.EnqueueOrInvokeAsync(() => locationItem.IconData.ToBitmapAsync());
 				}
 
 				if (locationItem.IconData is null)

--- a/src/Files.App/ViewModels/ItemViewModel.cs
+++ b/src/Files.App/ViewModels/ItemViewModel.cs
@@ -98,7 +98,7 @@ namespace Files.App.ViewModels
 
 		public string? GitDirectory { get; private set; }
 
-		private StorageFolderWithPath currentStorageFolder;
+		private StorageFolderWithPath? currentStorageFolder;
 		private StorageFolderWithPath workingRoot;
 
 		public delegate void WorkingDirectoryModifiedEventHandler(object sender, WorkingDirectoryModifiedEventArgs e);
@@ -1412,7 +1412,7 @@ namespace Files.App.ViewModels
 		{
 			var isFtp = FtpHelpers.IsFtpPath(path);
 
-			CurrentFolder = new ListedItem(null)
+			CurrentFolder = new ListedItem(null!)
 			{
 				PrimaryItemAttribute = StorageItemTypes.Folder,
 				ItemPropertiesInitialized = true,
@@ -1581,22 +1581,22 @@ namespace Files.App.ViewModels
 			if (enumFromStorageFolder)
 			{
 				var basicProps = await rootFolder?.GetBasicPropertiesAsync();
-				var currentFolder = library ?? new ListedItem(rootFolder.FolderRelativeId)
+				var currentFolder = library ?? new ListedItem(rootFolder?.FolderRelativeId ?? string.Empty)
 				{
 					PrimaryItemAttribute = StorageItemTypes.Folder,
 					ItemPropertiesInitialized = true,
-					ItemNameRaw = rootFolder.DisplayName,
+					ItemNameRaw = rootFolder?.DisplayName ?? string.Empty,
 					ItemDateModifiedReal = basicProps.DateModified,
-					ItemType = rootFolder.DisplayType,
+					ItemType = rootFolder?.DisplayType ?? string.Empty,
 					FileImage = null,
 					LoadFileIcon = false,
-					ItemPath = string.IsNullOrEmpty(rootFolder.Path) ? currentStorageFolder.Path : rootFolder.Path,
+					ItemPath = string.IsNullOrEmpty(rootFolder?.Path) ? currentStorageFolder?.Path ?? string.Empty : rootFolder.Path,
 					FileSize = null,
 					FileSizeBytes = 0,
 				};
 
 				if (library is null)
-					currentFolder.ItemDateCreatedReal = rootFolder.DateCreated;
+					currentFolder.ItemDateCreatedReal = rootFolder?.DateCreated ?? DateTimeOffset.Now;
 
 				CurrentFolder = currentFolder;
 				await EnumFromStorageFolderAsync(path, rootFolder, currentStorageFolder, cancellationToken);


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
![image](https://github.com/files-community/Files/assets/55754091/e46ab655-251e-4597-9d5d-b128550539fd)

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Screenshots (optional)**
Add screenshots here.
