### PR TITLE
Fix: Fixed focus flickering between columns or panes

### DIFF
--- a/src/Files.App/Views/PaneHolderPage.xaml.cs
+++ b/src/Files.App/Views/PaneHolderPage.xaml.cs
@@ -182,7 +182,12 @@ namespace Files.App.Views
 					PaneRight.IsCurrentInstance = false;
 
 				if (ActivePane is not null)
+				{
 					ActivePane.IsCurrentInstance = value;
+
+					if (value && ActivePane is BaseShellPage baseShellPage)
+						baseShellPage.ContentPage?.ItemManipulationModel.FocusFileList();
+				}
 
 				CurrentInstanceChanged?.Invoke(null, this);
 			}

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -128,9 +128,7 @@ namespace Files.App.Views.Shells
 				{
 					_IsCurrentInstance = value;
 
-					if (value)
-						ContentPage?.ItemManipulationModel.FocusFileList();
-					else if (SlimContentPage is not ColumnViewBrowser)
+					if (!value && SlimContentPage is not ColumnViewBrowser)
 						ToolbarViewModel.IsEditModeEnabled = false;
 
 					NotifyPropertyChanged(nameof(IsCurrentInstance));


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12280 
   Closes #12285  

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
#12285 is 100% reproducible with the following steps. This should be fixed once this PR is applied.
   1. Start dual pane mode.
   2. Open any folder that is not the home page in each pane.
   3. Start renaming an item.
   4. Click on the other pane while renaming.
   5. The focus will keep switching between panes.