### PR TITLE
RichCommands: CreateFolderWithSelection

### DIFF
--- a/src/Files.App/Actions/FileSystem/AddItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/AddItemAction.cs
@@ -1,14 +1,10 @@
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.DependencyInjection;
+// Copyright (c) 2023 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
 using Files.App.Commands;
 using Files.App.Contexts;
-using Files.App.Extensions;
-using Files.App.Helpers;
-using Files.Backend.Enums;
 using Files.Backend.Services;
 using Files.Backend.ViewModels.Dialogs.AddItemDialog;
-using System.ComponentModel;
-using System.Threading.Tasks;
 
 namespace Files.App.Actions
 {

--- a/src/Files.App/Actions/FileSystem/CreateFolderWithSelectionAction.cs
+++ b/src/Files.App/Actions/FileSystem/CreateFolderWithSelectionAction.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) 2023 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
+using Files.App.Commands;
+using Files.App.Contexts;
+
+namespace Files.App.Actions
+{
+	internal class CreateFolderWithSelectionAction : ObservableObject, IAction
+	{
+		private readonly IContentPageContext context = Ioc.Default.GetRequiredService<IContentPageContext>();
+
+		public string Label { get; } = "CreateFolderWithSelection".GetLocalizedResource();
+
+		public string Description { get; } = "CreateFolderWithSelectionDescription".GetLocalizedResource();
+
+		public RichGlyph Glyph { get; } = new(opacityStyle: "ColorIconNewFolder");
+
+		public bool IsExecutable => context.ShellPage is not null;
+
+		public CreateFolderWithSelectionAction()
+		{
+			context.PropertyChanged += Context_PropertyChanged;
+		}
+
+		public Task ExecuteAsync()
+		{
+			return UIFilesystemHelpers.CreateFolderWithSelectionAsync(context.ShellPage!);
+		}
+
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName is nameof(IContentPageContext.ShellPage))
+				OnPropertyChanged(nameof(IsExecutable));
+		}
+	}
+}

--- a/src/Files.App/Actions/FileSystem/CreateFolderWithSelectionAction.cs
+++ b/src/Files.App/Actions/FileSystem/CreateFolderWithSelectionAction.cs
@@ -16,7 +16,7 @@ namespace Files.App.Actions
 
 		public RichGlyph Glyph { get; } = new(opacityStyle: "ColorIconNewFolder");
 
-		public bool IsExecutable => context.ShellPage is not null;
+		public bool IsExecutable => context.ShellPage is not null && context.HasSelection;
 
 		public CreateFolderWithSelectionAction()
 		{
@@ -30,8 +30,13 @@ namespace Files.App.Actions
 
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName is nameof(IContentPageContext.ShellPage))
-				OnPropertyChanged(nameof(IsExecutable));
+			switch (e.PropertyName)
+			{
+				case nameof(IContentPageContext.ShellPage):
+				case nameof(IContentPageContext.HasSelection):
+					OnPropertyChanged(nameof(IsExecutable));
+					break;
+			}
 		}
 	}
 }

--- a/src/Files.App/Actions/Global/EditPathAction.cs
+++ b/src/Files.App/Actions/Global/EditPathAction.cs
@@ -1,8 +1,8 @@
-﻿using CommunityToolkit.Mvvm.DependencyInjection;
+﻿// Copyright (c) 2023 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
 using Files.App.Commands;
 using Files.App.Contexts;
-using Files.App.Extensions;
-using System.Threading.Tasks;
 
 namespace Files.App.Actions
 {

--- a/src/Files.App/Actions/Global/SearchUnindexedItemsAction.cs
+++ b/src/Files.App/Actions/Global/SearchUnindexedItemsAction.cs
@@ -1,8 +1,7 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.DependencyInjection;
+﻿// Copyright (c) 2023 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
 using Files.App.Contexts;
-using Files.App.Extensions;
-using System.Threading.Tasks;
 
 namespace Files.App.Actions
 {

--- a/src/Files.App/Commands/CommandCodes.cs
+++ b/src/Files.App/Commands/CommandCodes.cs
@@ -34,6 +34,7 @@ namespace Files.App.Commands
 		DeleteItem,
 		DeleteItemPermanently,
 		CreateFolder,
+		CreateFolderWithSelection,
 		AddItem,
 		CreateShortcut,
 		CreateShortcutFromDialog,

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -51,6 +51,7 @@ namespace Files.App.Commands
 		public IRichCommand CreateShortcut => commands[CommandCodes.CreateShortcut];
 		public IRichCommand CreateShortcutFromDialog => commands[CommandCodes.CreateShortcutFromDialog];
 		public IRichCommand CreateFolder => commands[CommandCodes.CreateFolder];
+		public IRichCommand CreateFolderWithSelection => commands[CommandCodes.CreateFolderWithSelection];
 		public IRichCommand AddItem => commands[CommandCodes.AddItem];
 		public IRichCommand PinToStart => commands[CommandCodes.PinToStart];
 		public IRichCommand UnpinFromStart => commands[CommandCodes.UnpinFromStart];
@@ -197,6 +198,7 @@ namespace Files.App.Commands
 			[CommandCodes.CreateShortcut] = new CreateShortcutAction(),
 			[CommandCodes.CreateShortcutFromDialog] = new CreateShortcutFromDialogAction(),
 			[CommandCodes.CreateFolder] = new CreateFolderAction(),
+			[CommandCodes.CreateFolderWithSelection] = new CreateFolderWithSelectionAction(),
 			[CommandCodes.AddItem] = new AddItemAction(),
 			[CommandCodes.PinToStart] = new PinToStartAction(),
 			[CommandCodes.UnpinFromStart] = new UnpinFromStartAction(),

--- a/src/Files.App/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Commands/Manager/ICommandManager.cs
@@ -39,6 +39,7 @@ namespace Files.App.Commands
 		IRichCommand ToggleSelect { get; }
 		IRichCommand ShareItem { get; }
 		IRichCommand CreateFolder { get; }
+		IRichCommand CreateFolderWithSelection { get; }
 		IRichCommand AddItem { get; }
 		IRichCommand CreateShortcut { get; }
 		IRichCommand CreateShortcutFromDialog { get; }

--- a/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/ContextFlyoutItemHelper.cs
@@ -460,16 +460,10 @@ namespace Files.App.Helpers
 				{
 					IsVisible = itemsSelected && selectedItems.Count == 1 && !currentInstanceViewModel.IsPageTypeRecycleBin,
 				}.Build(),
-				new ContextMenuFlyoutItemViewModel()
+				new ContextMenuFlyoutItemViewModelBuilder(commands.CreateFolderWithSelection)
 				{
-					Text = "BaseLayoutItemContextFlyoutCreateFolderWithSelection/Text".GetLocalizedResource(),
-					OpacityIcon = new OpacityIconModel()
-					{
-						OpacityIconStyle = "ColorIconNewFolder",
-					},
-					Command = commandsViewModel.CreateFolderWithSelection,
-					ShowItem = itemsSelected,
-				},
+					IsVisible = itemsSelected
+				}.Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(commands.CreateShortcut)
 				{
 					IsVisible = itemsSelected && (!selectedItems.FirstOrDefault()?.IsShortcut ?? false)

--- a/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandImplementationModel.cs
@@ -40,10 +40,6 @@ namespace Files.App.Interacts
 
 		private IBaseLayout SlimContentPage => associatedInstance?.SlimContentPage;
 
-		private IFilesystemHelpers FilesystemHelpers => associatedInstance?.FilesystemHelpers;
-
-		private static IQuickAccessService QuickAccessService => Ioc.Default.GetRequiredService<IQuickAccessService>();
-
 		#endregion Singleton
 
 		#region Private Members
@@ -257,11 +253,6 @@ namespace Files.App.Interacts
 			}
 
 			deferral.Complete();
-		}
-
-		public Task CreateFolderWithSelection(RoutedEventArgs e)
-		{
-			return UIFilesystemHelpers.CreateFolderWithSelectionAsync(associatedInstance);
 		}
 
 		#endregion Command Implementation

--- a/src/Files.App/Interacts/BaseLayoutCommandsViewModel.cs
+++ b/src/Files.App/Interacts/BaseLayoutCommandsViewModel.cs
@@ -38,7 +38,6 @@ namespace Files.App.Interacts
 			PointerWheelChangedCommand = new RelayCommand<PointerRoutedEventArgs>(CommandsModel.PointerWheelChanged);
 			DragOverCommand = new AsyncRelayCommand<DragEventArgs>(CommandsModel.DragOver);
 			DropCommand = new AsyncRelayCommand<DragEventArgs>(CommandsModel.Drop);
-			CreateFolderWithSelection = new AsyncRelayCommand<RoutedEventArgs>(CommandsModel.CreateFolderWithSelection);
 		}
 
 		#endregion Command Initialization
@@ -62,8 +61,6 @@ namespace Files.App.Interacts
 		public ICommand DragOverCommand { get; private set; }
 
 		public ICommand DropCommand { get; private set; }
-
-		public ICommand CreateFolderWithSelection { get; private set; }
 
 		#endregion Commands
 

--- a/src/Files.App/Interacts/IBaseLayoutCommandImplementationModel.cs
+++ b/src/Files.App/Interacts/IBaseLayoutCommandImplementationModel.cs
@@ -28,7 +28,5 @@ namespace Files.App.Interacts
 		Task DragOver(DragEventArgs e);
 
 		Task Drop(DragEventArgs e);
-
-		Task CreateFolderWithSelection(RoutedEventArgs e);
 	}
 }

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -1353,7 +1353,7 @@
   <data name="ConflictingItemsDialogSubtitleSingleConflictNoNonConflicts" xml:space="preserve">
     <value>There is one conflicting file name.</value>
   </data>
-  <data name="BaseLayoutItemContextFlyoutCreateFolderWithSelection.Text" xml:space="preserve">
+  <data name="CreateFolderWithSelection" xml:space="preserve">
     <value>Create folder with selection</value>
   </data>
   <data name="ToolTipDescriptionName" xml:space="preserve">
@@ -3285,5 +3285,8 @@
   </data>
   <data name="NewBranch" xml:space="preserve">
     <value>New branch</value>
+  </data>
+  <data name="CreateFolderWithSelectionDescription" xml:space="preserve">
+    <value>Create a folder with the currently selected item(s)</value>
   </data>
 </root>

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -269,14 +269,7 @@
 								Command="{x:Bind Commands.DecompressArchive, Mode=OneWay}"
 								IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
 								KeyboardAcceleratorTextOverride="{x:Bind Commands.DecompressArchive.HotKeyText, Mode=OneWay}"
-								Text="{x:Bind Commands.DecompressArchive.Label}">
-								<MenuFlyoutItem.KeyboardAccelerators>
-									<KeyboardAccelerator
-										Key="E"
-										IsEnabled="False"
-										Modifiers="Control" />
-								</MenuFlyoutItem.KeyboardAccelerators>
-							</MenuFlyoutItem>
+								Text="{x:Bind Commands.DecompressArchive.Label}" />
 							<MenuFlyoutItem
 								x:Name="ExtractHere"
 								x:Load="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"

--- a/src/Files.App/Views/Shells/ColumnShellPage.xaml
+++ b/src/Files.App/Views/Shells/ColumnShellPage.xaml
@@ -21,16 +21,6 @@
 
 	<local:BaseShellPage.KeyboardAccelerators>
 		<KeyboardAccelerator
-			Key="E"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-			Modifiers="Control" />
-		<KeyboardAccelerator
-			Key="C"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-			Modifiers="Control,Shift" />
-		<KeyboardAccelerator
 			Key="V"
 			Invoked="KeyboardAccelerator_Invoked"
 			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"

--- a/src/Files.App/Views/Shells/ModernShellPage.xaml
+++ b/src/Files.App/Views/Shells/ModernShellPage.xaml
@@ -22,16 +22,6 @@
 
 	<local:BaseShellPage.KeyboardAccelerators>
 		<KeyboardAccelerator
-			Key="E"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-			Modifiers="Control" />
-		<KeyboardAccelerator
-			Key="C"
-			Invoked="KeyboardAccelerator_Invoked"
-			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"
-			Modifiers="Control,Shift" />
-		<KeyboardAccelerator
 			Key="V"
 			Invoked="KeyboardAccelerator_Invoked"
 			IsEnabled="{x:Bind IsCurrentInstance, Mode=OneWay}"


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related #11481 

**Additional Notes**
- I added the `copyright section` to two files that were missing it
- I cleaned up some rich command leftovers from `ModernShellPage`, `ColumnShellPage` and `InnerNavigationToolbar`

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [x] Did you remove any strings from the en-us resource file?
   - [x] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app and navigate to a folder
   2. Right click to open the context menu
   3. See that `Create folder with selected items` is not visible
   4. Select some items
   5. Right click to open the context menu
   6. See that `Create folder with selected items` is visible
   7. Click on it
