### PR TITLE
Fix: Fixed Files crashes when opening properties from search page

### DIFF
--- a/src/Files.App/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Helpers/FilePropertiesHelpers.cs
@@ -61,6 +61,9 @@ namespace Files.App.Helpers
 			{
 				// Instance's current folder
 				var folder = associatedInstance.FilesystemViewModel.CurrentFolder;
+				if (folder is null)
+					return;
+
 				item = folder;
 
 				var drivesViewModel = Ioc.Default.GetRequiredService<DrivesViewModel>();


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related #12220

This PR will only prevent the crash. I posted a fix to disable the button in #12269 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open a new tab on `Home` (this won't happen if you navigate anywhere. The tab must open on `Home`)
   2. Click on a tag on the sidebar (or search for anything)
   3. See that the `Properties` button on the toolbar is enabled
   4. Click on it
   5. See that Files doesn't crash anymore
