### PR TITLE
Fix: Fixed a LayoutCycleException with the Tags widget

### DIFF
--- a/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml
+++ b/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml
@@ -26,7 +26,7 @@
 				ItemsStretch="Fill"
 				MaximumRowsOrColumns="6"
 				MinColumnSpacing="8"
-				MinItemHeight="260"
+				MinItemHeight="200"
 				MinItemWidth="220"
 				MinRowSpacing="8"
 				Orientation="Horizontal" />


### PR DESCRIPTION
It makes the Tags widget narrower but seems to avoid the crash.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12370 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [X] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

**Screenshots**
Before:
![image](https://github.com/files-community/Files/assets/66369541/bbedf711-fd46-4da1-b91f-e3e63d7c2468)

After:
![image](https://github.com/files-community/Files/assets/66369541/00d5a363-b86f-483f-bbc1-7758c401055a)
