### PR TITLE
Feature: Changed the format of the banner at extracting archives

### DIFF
--- a/src/Files.App/Helpers/ArchiveHelpers.cs
+++ b/src/Files.App/Helpers/ArchiveHelpers.cs
@@ -130,8 +130,8 @@ namespace Files.App.Helpers
 			CancellationTokenSource extractCancellation = new();
 
 			PostedStatusBanner banner = OngoingTasksViewModel.PostOperationBanner(
-				archive.Name.Length >= 30 ? archive.Name + "\n" : archive.Name,
 				"ExtractingArchiveText".GetLocalizedResource(),
+				archive.Path,
 				0,
 				ReturnResult.InProgress,
 				FileOperationType.Extract,


### PR DESCRIPTION
This formats the banner at extracting in the same format as the banner at compressing.
#12362 occurs when the title and message are short enough to be displayed on one line.
This does not completely fix #12362 but reduce its occurrence.

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [X] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

**Screenshots**
Before:
![スクリーンショット 2023-05-21 110825](https://github.com/files-community/Files/assets/66369541/729189b1-abf7-4a54-b56f-5d674c6c7a3f)

After:
![スクリーンショット 2023-05-21 110515](https://github.com/files-community/Files/assets/66369541/422d27fb-a083-4e27-9923-18f0e7191ccc)

Banner at compression (for comparison):
![スクリーンショット 2023-05-21 110621](https://github.com/files-community/Files/assets/66369541/4d7139de-221c-4b29-a0be-2f92968f3d51)