### PR TITLE
Fix: Fixed issue where delete confirmation dialog sometimes did not appear immediately

### DIFF
--- a/src/Files.App/Helpers/FileOperationsHelpers.cs
+++ b/src/Files.App/Helpers/FileOperationsHelpers.cs
@@ -122,7 +122,7 @@ namespace Files.App.Helpers
 					if (!SafetyExtensions.IgnoreExceptions(() =>
 					{
 						using var shi = new ShellItem(fileToDeletePath[i]);
-						var file = SafetyExtensions.IgnoreExceptions(() => GetFirstFile(shi)) ?? shi;
+						using var file = SafetyExtensions.IgnoreExceptions(() => GetFirstFile(shi)) ?? shi;
 						if (file.Properties.GetProperty<uint>(PKEY_FilePlaceholderStatus) == PS_CLOUDFILE_PLACEHOLDER)
 						{
 							// Online only files cannot be tried for deletion, so they are treated as to be permanently deleted.


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11501

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Try to delete a folder that contains one MP4 movie file only.
   2. The confirmation dialog will show immediately. Without this fix, it will show after doing some operations.