### PR TITLE
Fix: Display tags on network drives when selecting tag

### DIFF
--- a/src/Files.App/Filesystem/Search/FolderSearch.cs
+++ b/src/Files.App/Filesystem/Search/FolderSearch.cs
@@ -111,9 +111,16 @@ namespace Files.App.Filesystem.Search
 
 		private async Task AddItemsAsyncForHome(IList<ListedItem> results, CancellationToken token)
 		{
-			foreach (var drive in drivesViewModel.Drives.Cast<DriveItem>().Where(x => !x.IsNetwork))
+			if (AQSQuery.StartsWith("tag:", StringComparison.Ordinal))
 			{
-				await AddItemsAsync(drive.Path, results, token);
+				await SearchTagsAsync("", results, token); // Search tags everywhere, not only local drives
+			}
+			else
+			{
+				foreach (var drive in drivesViewModel.Drives.Cast<DriveItem>().Where(x => !x.IsNetwork))
+				{
+					await AddItemsAsync(drive.Path, results, token);
+				}
 			}
 		}
 

--- a/src/Files.Shared/FileTagsDb.cs
+++ b/src/Files.Shared/FileTagsDb.cs
@@ -160,6 +160,8 @@ namespace Common
 		public IEnumerable<TaggedFile> GetAllUnderPath(string folderPath)
 		{
 			var col = db.GetCollection<TaggedFile>(TaggedFiles);
+			if (string.IsNullOrEmpty(folderPath))
+				return col.FindAll();
 			return col.Find(x => x.FilePath.StartsWith(folderPath, StringComparison.OrdinalIgnoreCase));
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12331

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Assign tag on network drive ("\\\\localhost\\some_shared_folder" will work)
   2. Check that it appears when clicking the same tag on the sidebar

**Screenshots (optional)**
Add screenshots here.
