### PR TITLE
Feature: Stretch image previews

### DIFF
--- a/src/Files.App/UserControls/FilePreviews/BasicPreview.xaml
+++ b/src/Files.App/UserControls/FilePreviews/BasicPreview.xaml
@@ -17,7 +17,7 @@
 		<Viewbox
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch"
-			StretchDirection="DownOnly">
+			StretchDirection="Both">
 			<Image
 				HorizontalAlignment="Stretch"
 				VerticalAlignment="Stretch"

--- a/src/Files.App/UserControls/FilePreviews/FolderPreview.xaml
+++ b/src/Files.App/UserControls/FilePreviews/FolderPreview.xaml
@@ -14,7 +14,7 @@
 		HorizontalAlignment="Center"
 		VerticalAlignment="Center"
 		CornerRadius="{StaticResource ControlCornerRadius}">
-		<Viewbox StretchDirection="DownOnly">
+		<Viewbox StretchDirection="Both">
 			<Image Source="{x:Bind Model.Thumbnail}" />
 		</Viewbox>
 	</Border>

--- a/src/Files.App/UserControls/FilePreviews/ImagePreview.xaml
+++ b/src/Files.App/UserControls/FilePreviews/ImagePreview.xaml
@@ -13,7 +13,7 @@
 		HorizontalAlignment="Center"
 		VerticalAlignment="Center"
 		CornerRadius="{StaticResource ControlCornerRadius}">
-		<Viewbox StretchDirection="DownOnly">
+		<Viewbox StretchDirection="Both">
 			<Image Source="{x:Bind ViewModel.ImageSource, Mode=OneWay}" />
 		</Viewbox>
 	</Border>

--- a/src/Files.App/UserControls/FilePreviews/PDFPreview.xaml
+++ b/src/Files.App/UserControls/FilePreviews/PDFPreview.xaml
@@ -20,7 +20,7 @@
 				<Viewbox
 					HorizontalAlignment="Stretch"
 					VerticalAlignment="Stretch"
-					StretchDirection="DownOnly">
+					StretchDirection="Both">
 					<Image
 						HorizontalAlignment="Stretch"
 						VerticalAlignment="Stretch"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
Thumbnail previews now stretch properly when more space is available.

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open preview pane and resize it

**Screenshots (optional)**
Add screenshots here.
