### PR TITLE
Fix: Fixed issue where progress bar was overlapping text in ongoing operations

### DIFF
--- a/src/Files.App/Data/Items/StatusBanner.cs
+++ b/src/Files.App/Data/Items/StatusBanner.cs
@@ -45,6 +45,7 @@ namespace Files.App.Data.Items
 
 		private string message;
 		public string Message {
+			// A workaround to avoid overlapping the progress bar (#12362)
 			get => isProgressing ? message + "\n" : message;
 			private set => SetProperty(ref message, value);
 		}

--- a/src/Files.App/Data/Items/StatusBanner.cs
+++ b/src/Files.App/Data/Items/StatusBanner.cs
@@ -22,11 +22,14 @@ namespace Files.App.Data.Items
 		}
 
 		private bool isProgressing = false;
-
 		public bool IsProgressing
 		{
 			get => isProgressing;
-			set => SetProperty(ref isProgressing, value);
+			set
+			{
+				if (SetProperty(ref isProgressing, value))
+					OnPropertyChanged(nameof(Message));
+			}
 		}
 
 		public string Title { get; private set; }
@@ -40,7 +43,11 @@ namespace Files.App.Data.Items
 
 		public FileOperationType Operation { get; private set; }
 
-		public string Message { get; private set; }
+		private string message;
+		public string Message {
+			get => isProgressing ? message + "\n" : message;
+			private set => SetProperty(ref message, value);
+		}
 
 		public InfoBarSeverity InfoBarSeverity { get; private set; } = InfoBarSeverity.Informational;
 

--- a/src/Files.App/UserControls/OngoingTasksFlyout.xaml
+++ b/src/Files.App/UserControls/OngoingTasksFlyout.xaml
@@ -67,7 +67,7 @@
 
 							<ProgressBar
 								x:Name="ProgressBar"
-								Margin="0,0,12,12"
+								Margin="0,-24,12,12"
 								IsIndeterminate="{x:Bind IsCancelled, Mode=OneWay}"
 								Visibility="{x:Bind IsProgressing, Mode=OneWay}"
 								Value="{x:Bind Progress, Mode=OneWay}" />


### PR DESCRIPTION
This will fix #12362 completely.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12362 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

**Screenshots**
Before:
![image](https://github.com/files-community/Files/assets/66369541/5e16c38d-d593-4049-8a70-b95127b37540)

After:
![image](https://github.com/files-community/Files/assets/66369541/5f0c0bb3-01a8-4edc-abff-53aaf654ca0d)
