### PR TITLE
Fix: Fixed crash when previewing large html or svg files

### DIFF
--- a/src/Files.App/UserControls/FilePreviews/HtmlPreview.xaml.cs
+++ b/src/Files.App/UserControls/FilePreviews/HtmlPreview.xaml.cs
@@ -1,6 +1,6 @@
 using Files.App.ViewModels.Previews;
 using Microsoft.UI.Xaml.Controls;
-using System;
+using System.IO;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
@@ -19,7 +19,11 @@ namespace Files.App.UserControls.FilePreviews
 		private async void WebViewControl_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
 		{
 			await WebViewControl.EnsureCoreWebView2Async();
-			WebViewControl.NavigateToString(ViewModel.TextValue);
+			WebViewControl.CoreWebView2.SetVirtualHostNameToFolderMapping(
+				"preview.files",
+				Path.GetDirectoryName(ViewModel.Item.ItemPath),
+				Microsoft.Web.WebView2.Core.CoreWebView2HostResourceAccessKind.DenyCors);
+			WebViewControl.Source = new Uri("http://preview.files/" + ViewModel.Item.Name);
 		}
 	}
 }

--- a/src/Files.App/ViewModels/Previews/HtmlPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/Previews/HtmlPreviewViewModel.cs
@@ -7,13 +7,6 @@ namespace Files.App.ViewModels.Previews
 {
 	public class HtmlPreviewViewModel : BasePreviewModel
 	{
-		private string textValue = string.Empty;
-		public string TextValue
-		{
-			get => textValue;
-			private set => SetProperty(ref textValue, value);
-		}
-
 		public HtmlPreviewViewModel(ListedItem item)
 			: base(item)
 		{
@@ -23,10 +16,6 @@ namespace Files.App.ViewModels.Previews
 			=> extension is ".htm" or ".html" or ".svg";
 
 		public async override Task<List<FileProperty>> LoadPreviewAndDetailsAsync()
-		{
-			TextValue = await ReadFileAsTextAsync(Item.ItemFile);
-
-			return new List<FileProperty>();
-		}
+			=> new List<FileProperty>();
 	}
 }


### PR DESCRIPTION
References https://github.com/MicrosoftEdge/WebView2Feedback/issues/2281

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12151

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?