### PR TITLE
Fix: Fixed issue with some date formats not reflecting language settings

### DIFF
--- a/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
+++ b/src/Files.App/ServicesImplementation/DateTimeFormatter/ApplicationDateTimeFormatter.cs
@@ -43,12 +43,10 @@ namespace Files.App.ServicesImplementation.DateTimeFormatter
 			if (offset.Year is <= 1601 or >= 9999)
 				return " ";
 
-			var localTime = offset.ToLocalTime();
-
 			if (elapsed.TotalDays < 7 && elapsed.TotalSeconds >= 0)
-				return $"{localTime:D} {localTime:t} ({ToShortLabel(offset)})";
+				return $"{ToString(offset, "D")} {ToString(offset, "t")} ({ToShortLabel(offset)})";
 
-			return $"{localTime:D} {localTime:t}";
+			return $"{ToString(offset, "D")} {ToString(offset, "t")}";
 		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Change language settings to a language other than the system language.
   2. Open properties and select Details.
   3. You will see the date is displayed in the set language. Without this fix, the date is displayed in the system language regardless of the setting.