### PR TITLE
Feature: Automatically hide the preview pane when the window is too small

### DIFF
--- a/src/Files.App/ResourceDictionaries/PathIcons.xaml
+++ b/src/Files.App/ResourceDictionaries/PathIcons.xaml
@@ -988,8 +988,8 @@
 										<VisualState x:Name="Normal" />
 										<VisualState x:Name="Selected">
 											<VisualState.Setters>
-												<Setter Target="Path1.Fill" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
-												<Setter Target="Path2.Fill" Value="Transparent" />
+												<Setter Target="Path1.Fill" Value="Transparent" />
+												<Setter Target="Path2.Fill" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
 												<Setter Target="Path3.Fill" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
 											</VisualState.Setters>
 										</VisualState>

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -489,7 +489,7 @@ namespace Files.App.Views
 			{
 				var isHomePage = !(SidebarAdaptiveViewModel.PaneHolder?.ActivePane?.InstanceViewModel?.IsPageTypeNotHome ?? false);
 				var isMultiPane = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
-				var isBigEnough = App.Window.Bounds.Width > 450 && App.Window.Bounds.Height > 400;
+				var isBigEnough = App.Window.Bounds.Width > 450 && App.Window.Bounds.Height > 450 || RootGrid.ActualWidth > 700 && App.Window.Bounds.Height > 360;
 				var isEnabled = (!isHomePage || isMultiPane) && isBigEnough;
 
 				return isEnabled;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #9902...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open the preview pane
   2. Make window as narrow as possible
   3. Start reducing the window height until there is only enough space for around three items in the details layout
   4. Confirm that the preview pane automatically hides
   5. Make the window wider until the preview pane is visible on the right
   6. Reduce the window height until there is just enough space to view the item details in the preview pane
   7. Confirm that the preview pane hides if you continue to reduce the window height

**Screenshots (optional)**
Add screenshots here.
