### PR TITLE
Feature: Show a progress ring or bar while loading in the properties window

### DIFF
--- a/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
+++ b/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
@@ -613,5 +613,12 @@ namespace Files.App.Data.Models
 			get => runAsAdminEnabled;
 			set => SetProperty(ref runAsAdminEnabled, value);
 		}
+
+		private bool isPropertiesLoaded;
+		public bool IsPropertiesLoaded
+		{
+			get => isPropertiesLoaded;
+			set => SetProperty(ref isPropertiesLoaded, value);
+		}
 	}
 }

--- a/src/Files.App/ViewModels/Properties/HashesViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/HashesViewModel.cs
@@ -81,12 +81,12 @@ namespace Files.App.ViewModels.Properties
 
 			if (hashInfoItem.HashValue is null && hashInfoItem.IsEnabled)
 			{
-				hashInfoItem.HashValue = "Calculating".GetLocalizedResource();
-
 				App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
 					try
 					{
+						hashInfoItem.IsCalculating = true;
+
 						using (var stream = File.OpenRead(_item.ItemPath))
 						{
 							hashInfoItem.HashValue = hashInfoItem.Algorithm switch
@@ -110,6 +110,10 @@ namespace Files.App.ViewModels.Properties
 					catch (Exception)
 					{
 						hashInfoItem.HashValue = "CalculationError".GetLocalizedResource();
+					}
+					finally
+					{
+						hashInfoItem.IsCalculating = false;
 					}
 				});
 			}

--- a/src/Files.App/ViewModels/Properties/HashesViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/HashesViewModel.cs
@@ -81,12 +81,12 @@ namespace Files.App.ViewModels.Properties
 
 			if (hashInfoItem.HashValue is null && hashInfoItem.IsEnabled)
 			{
+				hashInfoItem.IsCalculating = true;
+
 				App.Window.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
 					try
 					{
-						hashInfoItem.IsCalculating = true;
-
 						using (var stream = File.OpenRead(_item.ItemPath))
 						{
 							hashInfoItem.HashValue = hashInfoItem.Algorithm switch

--- a/src/Files.App/Views/Properties/DetailsPage.xaml
+++ b/src/Files.App/Views/Properties/DetailsPage.xaml
@@ -6,6 +6,7 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:helpers="using:Files.App.Helpers"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:toolkitconverters="using:CommunityToolkit.WinUI.UI.Converters"
 	xmlns:vm="using:Files.App.ViewModels.Properties"
 	Loaded="Properties_Loaded"
 	Tag="Details"
@@ -16,16 +17,33 @@
 			<ResourceDictionary.MergedDictionaries>
 				<ResourceDictionary Source="ms-appx:///ResourceDictionaries/PropertiesStyles.xaml" />
 			</ResourceDictionary.MergedDictionaries>
+			<toolkitconverters:BoolNegationConverter x:Key="BoolNegationConverter" />
 		</ResourceDictionary>
 	</Page.Resources>
 
 	<ScrollViewer>
 		<Grid Padding="12">
 
+			<!--  Loading  -->
+			<StackPanel
+				x:Name="LoadingStatePanel"
+				HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				x:Load="{x:Bind ViewModel.IsPropertiesLoaded, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
+				Spacing="8">
+				<ProgressRing HorizontalAlignment="Center" IsIndeterminate="True" />
+				<TextBlock
+					x:Name="LoadingTextBlock"
+					HorizontalAlignment="Center"
+					Style="{StaticResource BodyStrongTextBlockStyle}"
+					Text="{helpers:ResourceString Name=Loading}" />
+			</StackPanel>
+
 			<!--  Details Expander List  -->
 			<ListView
 				x:Name="MainList"
 				HorizontalAlignment="Stretch"
+				x:Load="{x:Bind ViewModel.IsPropertiesLoaded, Mode=OneWay}"
 				ItemsSource="{x:Bind ViewModel.PropertySections, Mode=OneWay}"
 				SelectionMode="None">
 

--- a/src/Files.App/Views/Properties/DetailsPage.xaml.cs
+++ b/src/Files.App/Views/Properties/DetailsPage.xaml.cs
@@ -24,6 +24,8 @@ namespace Files.App.Views.Properties
 				await fileProps.GetSystemFilePropertiesAsync();
 				stopwatch.Stop();
 				Debug.WriteLine(string.Format("System file properties were obtained in {0} milliseconds", stopwatch.ElapsedMilliseconds));
+
+				ViewModel.IsPropertiesLoaded = true;
 			}
 		}
 

--- a/src/Files.App/Views/Properties/HashesPage.xaml
+++ b/src/Files.App/Views/Properties/HashesPage.xaml
@@ -145,10 +145,30 @@
 									Style="{StaticResource BodyTextBlockStyle}"
 									Text="{x:Bind Algorithm}" />
 
+								<!--  Calculating  -->
+								<StackPanel
+									x:Name="CalculatingPanel"
+									Grid.Column="2"
+									x:Load="{x:Bind IsCalculating, Mode=OneWay}"
+									Orientation="Horizontal">
+									<TextBlock
+										VerticalAlignment="Center"
+										Style="{StaticResource BodyTextBlockStyle}"
+										Text="{helpers:ResourceString Name=Calculating}" />
+
+									<ProgressBar
+										Width="100"
+										Margin="16,0,0,0"
+										HorizontalAlignment="Left"
+										IsIndeterminate="True" />
+								</StackPanel>
+
 								<!--  Hash Value  -->
 								<TextBlock
+									x:Name="HashValueText"
 									Grid.Column="2"
 									VerticalAlignment="Center"
+									x:Load="{x:Bind IsCalculating, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}"
 									Style="{StaticResource BodyTextBlockStyle}"
 									Text="{x:Bind HashValue, Mode=OneWay}"
 									TextTrimming="CharacterEllipsis"

--- a/src/Files.Backend/Models/HashInfoItem.cs
+++ b/src/Files.Backend/Models/HashInfoItem.cs
@@ -28,6 +28,13 @@ namespace Files.Backend.Models
 			set => SetProperty(ref _IsSelected, value);
 		}
 
+		private bool _IsCalculating;
+		public bool IsCalculating
+		{
+			get => _IsCalculating;
+			set => SetProperty(ref _IsCalculating, value);
+		}
+
 		private bool _IsCalculated;
 		public bool IsCalculated
 		{


### PR DESCRIPTION
In addition to during properties loading, a progress bar is now displayed during hash value calculation.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12532 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

**Screenshots**
Details tab:
![image](https://github.com/files-community/Files/assets/66369541/c94248cc-9414-4940-96b3-3f7161f8bb00)

Hashes tab:
![image](https://github.com/files-community/Files/assets/66369541/98d74070-6d58-4f09-80e2-5642daf703f4)
