### PR TITLE
Fix: Fixed issue where custom font wasn't applied to the details pane

### DIFF
--- a/src/Files.App/Constants.cs
+++ b/src/Files.App/Constants.cs
@@ -103,6 +103,11 @@ namespace Files.App
 			public const double ContextMenuItemsMaxWidth = 250;
 		}
 
+		public static class Appearance
+		{
+			public const string StandardFont = "Segoe UI Variable";
+		}
+
 		public static class Browser
 		{
 			public static class GridViewBrowser

--- a/src/Files.App/Helpers/AppThemeResourcesHelper.cs
+++ b/src/Files.App/Helpers/AppThemeResourcesHelper.cs
@@ -25,22 +25,22 @@ namespace Files.App.Helpers
 			service.SetCompactSpacing(useCompactStyles);
 			service.SetAppThemeBackgroundColor(appThemeBackgroundColor.FromWindowsColor());
 
-			if (!String.IsNullOrWhiteSpace(appThemeAddressBarBackgroundColor) && appThemeAddressBarBackgroundColor != "#00000000")
+			if (!string.IsNullOrWhiteSpace(appThemeAddressBarBackgroundColor) && appThemeAddressBarBackgroundColor != "#00000000")
 				service.SetAppThemeAddressBarBackgroundColor(ColorHelper.ToColor(appThemeAddressBarBackgroundColor).FromWindowsColor());
 			else
 				appearance.AppThemeAddressBarBackgroundColor = ""; //migrate to new default
 
-			if (!String.IsNullOrWhiteSpace(appThemeSidebarBackgroundColor) && appThemeAddressBarBackgroundColor != "#00000000")
+			if (!string.IsNullOrWhiteSpace(appThemeSidebarBackgroundColor) && appThemeAddressBarBackgroundColor != "#00000000")
 				service.SetAppThemeSidebarBackgroundColor(ColorHelper.ToColor(appThemeSidebarBackgroundColor).FromWindowsColor());
 			else
 				appearance.AppThemeSidebarBackgroundColor = ""; //migrate to new default
 
-			if (!String.IsNullOrWhiteSpace(appThemeFileAreaBackgroundColor) && appThemeAddressBarBackgroundColor != "#00000000")
+			if (!string.IsNullOrWhiteSpace(appThemeFileAreaBackgroundColor) && appThemeAddressBarBackgroundColor != "#00000000")
 				service.SetAppThemeFileAreaBackgroundColor(ColorHelper.ToColor(appThemeFileAreaBackgroundColor).FromWindowsColor());
 			else
 				appearance.AppThemeFileAreaBackgroundColor = ""; //migrate to new default
 
-			if (appThemeFontFamily != "Segoe UI Variable")
+			if (appThemeFontFamily != Constants.Appearance.StandardFont)
 				service.SetAppThemeFontFamily(appThemeFontFamily);
 
 			service.ApplyResources();

--- a/src/Files.App/UserControls/Pane/PreviewPane.xaml
+++ b/src/Files.App/UserControls/Pane/PreviewPane.xaml
@@ -185,7 +185,7 @@
 				HorizontalAlignment="Center"
 				VerticalAlignment="Center"
 				Text="{x:Bind GetLocalizedResource('NoItemSelected')}"
-				TextWrapping="WrapWholeWords"  />
+				TextWrapping="WrapWholeWords" />
 			<ContentPresenter
 				x:Name="PreviewControlPresenter"
 				HorizontalContentAlignment="Stretch"

--- a/src/Files.App/UserControls/Pane/PreviewPane.xaml
+++ b/src/Files.App/UserControls/Pane/PreviewPane.xaml
@@ -112,10 +112,6 @@
 							</Setter.Value>
 						</Setter>
 					</Style>
-					<Style x:Key="Local.FileDetailsRepeaterStyle" TargetType="TextBlock">
-						<Setter Property="FontWeight" Value="Normal" />
-						<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
-					</Style>
 
 				</ResourceDictionary>
 			</ResourceDictionary.MergedDictionaries>
@@ -236,8 +232,8 @@
 								<TextBlock
 									HorizontalAlignment="Stretch"
 									VerticalAlignment="Center"
+									FontFamily="{ThemeResource ContentControlThemeFontFamily}"
 									MaxLines="2"
-									Style="{StaticResource Local.FileDetailsRepeaterStyle}"
 									Text="{x:Bind Name, Mode=OneWay}" />
 
 								<!--  Value  -->

--- a/src/Files.App/UserControls/Pane/PreviewPane.xaml
+++ b/src/Files.App/UserControls/Pane/PreviewPane.xaml
@@ -112,6 +112,10 @@
 							</Setter.Value>
 						</Setter>
 					</Style>
+					<Style x:Key="Local.FileDetailsRepeaterStyle" TargetType="TextBlock">
+						<Setter Property="FontWeight" Value="Normal" />
+						<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+					</Style>
 
 				</ResourceDictionary>
 			</ResourceDictionary.MergedDictionaries>
@@ -232,8 +236,8 @@
 								<TextBlock
 									HorizontalAlignment="Stretch"
 									VerticalAlignment="Center"
-									FontFamily="{ThemeResource ContentControlThemeFontFamily}"
 									MaxLines="2"
+									Style="{StaticResource Local.FileDetailsRepeaterStyle}"
 									Text="{x:Bind Name, Mode=OneWay}" />
 
 								<!--  Value  -->

--- a/src/Files.App/UserControls/Pane/PreviewPane.xaml
+++ b/src/Files.App/UserControls/Pane/PreviewPane.xaml
@@ -112,6 +112,10 @@
 							</Setter.Value>
 						</Setter>
 					</Style>
+					<Style x:Key="Local.FileDetailsRepeaterStyle" TargetType="TextBlock">
+						<Setter Property="FontWeight" Value="Normal" />
+						<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+					</Style>
 
 				</ResourceDictionary>
 			</ResourceDictionary.MergedDictionaries>
@@ -181,7 +185,7 @@
 				HorizontalAlignment="Center"
 				VerticalAlignment="Center"
 				Text="{x:Bind GetLocalizedResource('NoItemSelected')}"
-				TextWrapping="WrapWholeWords" />
+				TextWrapping="WrapWholeWords"  />
 			<ContentPresenter
 				x:Name="PreviewControlPresenter"
 				HorizontalContentAlignment="Stretch"
@@ -207,12 +211,12 @@
 					HorizontalAlignment="Center"
 					FontSize="20"
 					FontWeight="Bold"
+					FontFamily="{ThemeResource ContentControlThemeFontFamily}"
 					IsTextSelectionEnabled="True"
 					Text="{x:Bind ViewModel.SelectedItem.Name, Mode=OneWay}"
 					TextAlignment="Center"
 					TextWrapping="Wrap"
 					Visibility="Collapsed" />
-
 				<ItemsControl
 					x:Name="FileDetailsRepeater"
 					Margin="12"
@@ -233,7 +237,7 @@
 									HorizontalAlignment="Stretch"
 									VerticalAlignment="Center"
 									MaxLines="2"
-									Style="{StaticResource BodyTextBlockStyle}"
+									Style="{StaticResource Local.FileDetailsRepeaterStyle}"
 									Text="{x:Bind Name, Mode=OneWay}" />
 
 								<!--  Value  -->

--- a/src/Files.App/UserControls/Pane/PreviewPane.xaml
+++ b/src/Files.App/UserControls/Pane/PreviewPane.xaml
@@ -209,9 +209,9 @@
 				<TextBlock
 					x:Name="DetailsListHeader"
 					HorizontalAlignment="Center"
+					FontFamily="{ThemeResource ContentControlThemeFontFamily}"
 					FontSize="20"
 					FontWeight="Bold"
-					FontFamily="{ThemeResource ContentControlThemeFontFamily}"
 					IsTextSelectionEnabled="True"
 					Text="{x:Bind ViewModel.SelectedItem.Name, Mode=OneWay}"
 					TextAlignment="Center"

--- a/src/Files.App/UserControls/Pane/PreviewPane.xaml
+++ b/src/Files.App/UserControls/Pane/PreviewPane.xaml
@@ -112,6 +112,7 @@
 							</Setter.Value>
 						</Setter>
 					</Style>
+
 					<Style x:Key="Local.FileDetailsTextBlockStyle" TargetType="TextBlock">
 						<Setter Property="FontWeight" Value="Normal" />
 						<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />

--- a/src/Files.App/UserControls/Pane/PreviewPane.xaml
+++ b/src/Files.App/UserControls/Pane/PreviewPane.xaml
@@ -112,7 +112,7 @@
 							</Setter.Value>
 						</Setter>
 					</Style>
-					<Style x:Key="Local.FileDetailsRepeaterStyle" TargetType="TextBlock">
+					<Style x:Key="Local.FileDetailsTextBlockStyle" TargetType="TextBlock">
 						<Setter Property="FontWeight" Value="Normal" />
 						<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
 					</Style>
@@ -237,7 +237,7 @@
 									HorizontalAlignment="Stretch"
 									VerticalAlignment="Center"
 									MaxLines="2"
-									Style="{StaticResource Local.FileDetailsRepeaterStyle}"
+									Style="{StaticResource Local.FileDetailsTextBlockStyle}"
 									Text="{x:Bind Name, Mode=OneWay}" />
 
 								<!--  Value  -->

--- a/src/Files.App/ViewModels/Previews/FolderPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/Previews/FolderPreviewViewModel.cs
@@ -47,10 +47,9 @@ namespace Files.App.ViewModels.Previews
 				GetFileProperty("PropertyDateModified", dateTimeFormatter.ToLongLabel(info.DateModified)),
 				GetFileProperty("PropertyDateCreated", dateTimeFormatter.ToLongLabel(info.ItemDate)),
 				GetFileProperty("PropertyItemPathDisplay", Folder.Path),
+				GetFileProperty("FileTags",
+				Item.FileTagsUI is not null ? string.Join(',', Item.FileTagsUI.Select(x => x.Name)) : null)
 			};
-
-			Item.FileDetails.Add(GetFileProperty("FileTags",
-				Item.FileTagsUI is not null ? string.Join(',', Item.FileTagsUI.Select(x => x.Name)) : null));
 		}
 
 		private static FileProperty GetFileProperty(string nameResource, object value)


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12027 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Screenshots**

![PreviewFonts](https://github.com/files-community/Files/assets/110472580/f56f7de2-fa30-48c4-afdb-21c34547d559)
