### PR TITLE
Bug: Add windows defender to context menu

### DIFF
--- a/src/Files.App/Helpers/ShellContextMenuHelper.cs
+++ b/src/Files.App/Helpers/ShellContextMenuHelper.cs
@@ -189,6 +189,11 @@ namespace Files.App.Helpers
 				var menuId = menuItem.ID;
 				var isFont = FileExtensionHelpers.IsFontFile(contextMenu.ItemsPath[0]);
 				var verb = menuItem.CommandString;
+				if (menuItem.Label.Equals("Scan With Windows Defender"))
+				{
+					System.Diagnostics.Process.Start("CMD", "/K (\"%ProgramFiles%\\Windows Defender\\MpCmdRun.exe\" -Scan -ScanType 3 -File \"" + contextMenu.ItemsPath[0] + "\")");
+					return;
+				}
 				switch (verb)
 				{
 					case "install" when isFont:

--- a/src/Files.App/Shell/ContextMenu.cs
+++ b/src/Files.App/Shell/ContextMenu.cs
@@ -7,6 +7,10 @@ using System.Runtime.InteropServices;
 using Vanara.InteropServices;
 using Vanara.PInvoke;
 using Vanara.Windows.Shell;
+using static Vanara.PInvoke.ComCtl32;
+using static Vanara.PInvoke.Ole32;
+using static Vanara.PInvoke.Shell32;
+using static Vanara.PInvoke.ShlwApi;
 
 namespace Files.App.Shell
 {
@@ -161,6 +165,17 @@ namespace Files.App.Shell
 				Shell32.IContextMenu menu = sf.GetChildrenUIObjects<Shell32.IContextMenu>(default, shellItems);
 				var hMenu = User32.CreatePopupMenu();
 				menu.QueryContextMenu(hMenu, 0, 1, 0x7FFF, flags);
+				
+				int menuItemCount = User32.GetMenuItemCount(hMenu);
+				// Create a new MENUITEMINFO structure for Windows Defender
+				User32.MENUITEMINFO menuItemInfo = new User32.MENUITEMINFO();
+				menuItemInfo.cbSize = (uint)(Marshal.SizeOf(menuItemInfo));
+				menuItemInfo.fMask = User32.MenuItemInfoMask.MIIM_ID | User32.MenuItemInfoMask.MIIM_TYPE;
+				menuItemInfo.wID = 4323; // Assign a unique command ID
+				menuItemInfo.fType = (User32.MenuItemType)MenuItemType.MFT_STRING;
+				menuItemInfo.dwTypeData = Marshal.StringToHGlobalAuto("Scan With Windows Defender");
+				User32.InsertMenuItem(hMenu, (uint)0, true, ref menuItemInfo);
+
 				var contextMenu = new ContextMenu(menu, hMenu, shellItems.Select(x => x.ParsingName), owningThread, itemFilter);
 				contextMenu.EnumMenuItems(hMenu, contextMenu.Items);
 


### PR DESCRIPTION
This pr fixes missing windows defender (it runs cli after clicking  context menu item.)

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #[issue](https://github.com/files-community/Files/issues/11004)...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Screenshots (optional)**
Add screenshots here.
![Screenshot (4)](https://github.com/files-community/Files/assets/39624400/36ed3f0a-7cbb-4fda-b89c-bb761b4677b0)
