### PR TITLE
Fix: Fixed crash in Dual Pane mode when switching away from Git folder

### DIFF
--- a/src/Files.App/UserControls/StatusBarControl.xaml
+++ b/src/Files.App/UserControls/StatusBarControl.xaml
@@ -232,10 +232,11 @@
 								Grid.Row="1"
 								Padding="4"
 								Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+								DataContext="{x:Bind DirectoryPropertiesViewModel, Mode=OneWay}"
 								IsItemClickEnabled="True"
 								ItemClick="BranchesList_ItemClick"
 								ItemsSource="{x:Bind DirectoryPropertiesViewModel.BranchesNames, Mode=OneWay}"
-								SelectedIndex="{x:Bind DirectoryPropertiesViewModel.SelectedBranchIndex, Mode=TwoWay}"
+								SelectedIndex="{Binding SelectedBranchIndex, Mode=TwoWay}"
 								SelectionMode="Single" />
 						</Grid>
 					</Flyout>

--- a/src/Files.App/UserControls/StatusBarControl.xaml
+++ b/src/Files.App/UserControls/StatusBarControl.xaml
@@ -208,7 +208,8 @@
 									Orientation="Horizontal">
 									<RadioButton
 										Content="{helpers:ResourceString Name=Locals}"
-										IsChecked="{x:Bind DirectoryPropertiesViewModel.ShowLocals, Mode=TwoWay}"
+										DataContext="{x:Bind DirectoryPropertiesViewModel, Mode=OneWay}"
+										IsChecked="{Binding ShowLocals, Mode=TwoWay}"
 										Style="{StaticResource Local.RadioButtonStyle}" />
 									<RadioButton Content="{helpers:ResourceString Name=Remotes}" Style="{StaticResource Local.RadioButtonStyle}" />
 								</StackPanel>


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12589

There seem to be an issue with x:Bind so that you can't use a TwoWay x:Bind on an element that is inside an element with x:Load:
```cs
<StackPanel x:Load="{x:Bind ...}">
    <RadioButton IsChecked="{x:Bind ..., Mode=TwoWay}" />
</StackPanel>
```
Workaround is to use Binding.

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open a non-git folder in left pane and set layout to Tiles
   2. Open a git folder in right pane and set layout to Details
   3. Switch focus between the two panes
   4. Verify that you can still switch between local and remote branches in the Git flyout
