### PR TITLE
Fix: Fixed issue where scrollbar wasn't visible when reordering pinned favorites

### DIFF
--- a/src/Files.App/Dialogs/ReorderSidebarItemsDialog.xaml
+++ b/src/Files.App/Dialogs/ReorderSidebarItemsDialog.xaml
@@ -17,22 +17,8 @@
 	Style="{StaticResource DefaultContentDialogStyle}"
 	mc:Ignorable="d">
 
-	<Grid
-		x:Name="DestinationPathGrid"
-		ColumnSpacing="8"
-		RowSpacing="8">
-		<Grid.ColumnDefinitions>
-			<ColumnDefinition />
-			<ColumnDefinition Width="Auto" />
-		</Grid.ColumnDefinitions>
-		<Grid.RowDefinitions>
-			<RowDefinition Height="Auto" />
-		</Grid.RowDefinitions>
-
-		<ListView
-			x:Name="SidebarNavView"
-			Grid.Row="1"
-			ItemsSource="{x:Bind ViewModel.SidebarFavoriteItems, Mode=OneWay}">
+	<Grid x:Name="DestinationPathGrid">
+		<ListView x:Name="SidebarNavView" ItemsSource="{x:Bind ViewModel.SidebarFavoriteItems, Mode=OneWay}">
 			<ListView.ItemTemplate>
 				<DataTemplate x:DataType="dataitems:LocationItem">
 					<Grid


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12596...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open reorder sidebar items dialog
   2. Resize window so that the dialog shrinks
   3. Confirm that scrollbar is visible

**Screenshots (optional)**
Add screenshots here.
