### PR TITLE
Fix: Fix crash when branch tip is null

### DIFF
--- a/src/Files.App/Helpers/GitHelpers.cs
+++ b/src/Files.App/Helpers/GitHelpers.cs
@@ -83,7 +83,7 @@ namespace Files.App.Helpers
 				.Where(b => !b.IsRemote || b.RemoteName == "origin")
 				.OrderByDescending(b => b.IsCurrentRepositoryHead)
 				.ThenBy(b => b.IsRemote)
-				.ThenByDescending(b => b.Tip.Committer.When)
+				.ThenByDescending(b => b.Tip?.Committer.When)
 				.Select(b => new BranchItem(b.FriendlyName, b.IsRemote, b.TrackingDetails.AheadBy, b.TrackingDetails.BehindBy))
 				.ToArray();
 		}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12618

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Comment**

I found that the crash is actually caused by the remote HEAD pointing to `origin/master`, which no longer exists, causing the `Tip` is `null`.

I not sure how the remote HEAD ended up in this state since I cloned the Windows-universal-samples repository a long time ago. It might be an edge case.

Here are the steps and git commands I tested that can lead to the HEAD pointing to a non-existent branch:

1. Create a new repository
2. Clone the repository
3. Make changes and commit them
4. `git push -u origin master`
5. `git checkout -b main`
6. `git push -u origin main`
7. Update the default branch to `main` on GitHub.
8. `git remote set-head origin master`
9. `git push origin -d master`
10. `git branch --delete master`

![image](https://github.com/files-community/Files/assets/26683979/d2068b61-bd2d-4027-a78f-936bdf4540bc)
![image](https://github.com/files-community/Files/assets/26683979/ad84a24f-9b6e-4d61-8344-a333cd1a0eb1)
