### PR TITLE
Fix: Fixed issue where folder sizes weren't shown in Recycle Bin

### DIFF
--- a/src/Files.App/Filesystem/Search/FolderSearch.cs
+++ b/src/Files.App/Filesystem/Search/FolderSearch.cs
@@ -432,6 +432,8 @@ namespace Files.App.Filesystem.Search
 						ItemDateCreatedReal = folder.DateCreated,
 						NeedsPlaceholderGlyph = false,
 						Opacity = 1,
+						FileSize = props.Size.ToSizeString(),
+						FileSizeBytes = (long)props.Size,
 						ItemDateDeletedReal = binFolder.DateDeleted,
 						ItemOriginalPath = binFolder.OriginalPath
 					};

--- a/src/Files.App/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
+++ b/src/Files.App/Filesystem/StorageEnumerators/UniversalStorageEnumerator.cs
@@ -202,8 +202,8 @@ namespace Files.App.Filesystem.StorageEnumerators
 						FileImage = null,
 						LoadFileIcon = false,
 						ItemPath = string.IsNullOrEmpty(folder.Path) ? PathNormalization.Combine(currentStorageFolder.Path, folder.Name) : folder.Path,
-						FileSize = null,
-						FileSizeBytes = 0,
+						FileSize = basicProperties.Size.ToSizeString(),
+						FileSizeBytes = (long)basicProperties.Size,
 						ItemDateDeletedReal = binFolder.DateDeleted,
 						ItemOriginalPath = binFolder.OriginalPath,
 					};


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11043

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

Comment:

This pull request fixed the folder size appears blank in the recycle bin.

1. Tested recycle bin shows folders with their sizes
2. Tested folders with their sizes are correctly displayed when searching within the recycle bin.
3. Tested status bar at the bottom able to displays the total size of the recycle bin, whether all files and folders are selected or not.

**Screenshots (optional)**

Before

![image](https://github.com/files-community/Files/assets/26683979/8118ae9c-b385-464b-98bf-c4b262822683)

After

![image](https://github.com/files-community/Files/assets/26683979/922eb552-048a-4791-b582-cb3eb676e007)
