### PR TITLE
Fix: Fixed issue where item names in the Tags widget didn't have ellipsis

### DIFF
--- a/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml
+++ b/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml
@@ -97,6 +97,7 @@
 						IsItemClickEnabled="True"
 						ItemClick="FileTagItem_ItemClick"
 						ItemsSource="{x:Bind Tags}"
+						RightTapped="AdaptiveGridView_RightTapped"
 						SelectionMode="None"
 						StretchContentForSingleRow="False">
 						<controls:AdaptiveGridView.ItemContainerStyle>
@@ -108,13 +109,18 @@
 
 						<controls:AdaptiveGridView.ItemTemplate>
 							<DataTemplate x:DataType="vm:FileTagsItemViewModel">
-								<StackPanel
+								<Grid
+									ColumnSpacing="8"
 									DataContext="{x:Bind}"
-									Orientation="Horizontal"
-									RightTapped="Item_RightTapped"
-									Spacing="8">
+									ToolTipService.ToolTip="{x:Bind Path}">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="*" />
+									</Grid.ColumnDefinitions>
+
 									<!--  Icon  -->
 									<Image
+										Grid.Column="0"
 										Width="20"
 										Height="20"
 										VerticalAlignment="Center"
@@ -122,10 +128,11 @@
 
 									<!--  Name  -->
 									<TextBlock
+										Grid.Column="1"
 										VerticalAlignment="Center"
 										Text="{x:Bind Name, Mode=OneWay}"
 										TextTrimming="CharacterEllipsis" />
-								</StackPanel>
+								</Grid>
 							</DataTemplate>
 						</controls:AdaptiveGridView.ItemTemplate>
 					</controls:AdaptiveGridView>

--- a/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml.cs
@@ -1,26 +1,13 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using CommunityToolkit.Mvvm.DependencyInjection;
-using CommunityToolkit.Mvvm.Input;
-using Files.App.Extensions;
-using Files.App.Filesystem;
-using Files.App.Helpers;
 using Files.App.Helpers.ContextFlyouts;
-using Files.App.ViewModels;
 using Files.App.ViewModels.Widgets;
-using Files.Backend.Services.Settings;
-using Files.Shared.Extensions;
-using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Input;
 using Windows.Storage;
 
@@ -109,15 +96,13 @@ namespace Files.App.UserControls.Widgets
 				await itemViewModel.ClickCommand.ExecuteAsync(null);
 		}
 
-		private async void Item_RightTapped(object sender, RightTappedRoutedEventArgs e)
+		private async void AdaptiveGridView_RightTapped(object sender, RightTappedRoutedEventArgs e)
 		{
-			App.Logger.LogWarning("rightTapped");
 			var itemContextMenuFlyout = new CommandBarFlyout { Placement = FlyoutPlacementMode.Full };
 			itemContextMenuFlyout.Opening += (sender, e) => App.LastOpenedFlyout = sender as CommandBarFlyout;
-			if (sender is not StackPanel tagsItemsStackPanel || tagsItemsStackPanel.DataContext is not FileTagsItemViewModel item)
+			if (e.OriginalSource is not FrameworkElement element || element.DataContext is not FileTagsItemViewModel item)
 				return;
 
-			App.Logger.LogWarning("Item path: " + item.Path + " widgetcarditem.path = " + (item as WidgetCardItem)?.Path);
 			var menuItems = GetItemMenuItems(item, QuickAccessService.IsItemPinned(item.Path), item.IsFolder);
 			var (_, secondaryElements) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(menuItems);
 
@@ -127,7 +112,7 @@ namespace Files.App.UserControls.Widgets
 
 			secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
 			ItemContextMenuFlyout = itemContextMenuFlyout;
-			itemContextMenuFlyout.ShowAt(tagsItemsStackPanel, new FlyoutShowOptions { Position = e.GetPosition(tagsItemsStackPanel) });
+			itemContextMenuFlyout.ShowAt(element, new FlyoutShowOptions { Position = e.GetPosition(element) });
 
 			await ShellContextmenuHelper.LoadShellMenuItems(item.Path, itemContextMenuFlyout, showOpenWithMenu: true, showSendToMenu: true);
 			e.Handled = true;


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12650 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Item names now should have ellipsis if trimmed
   2. A tooltip with the path now should be displayed
   3. Right-clickable area of the item is now corrected