### PR TITLE
Fix: Fixed issue where open in VS Code didn't work if there were spaces in the path

### DIFF
--- a/src/Files.App/Actions/Open/OpenInVSAction.cs
+++ b/src/Files.App/Actions/Open/OpenInVSAction.cs
@@ -37,7 +37,7 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync()
 		{
-			Win32API.RunPowershellCommand($"start {_context.SolutionFilePath}", false);
+			Win32API.RunPowershellCommand($"start \'{_context.SolutionFilePath}\'", false);
 
 			return Task.CompletedTask;
 		}

--- a/src/Files.App/Actions/Open/OpenInVSCodeAction.cs
+++ b/src/Files.App/Actions/Open/OpenInVSCodeAction.cs
@@ -31,7 +31,7 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync()
 		{
-			Win32API.RunPowershellCommand($"code {_context.ShellPage?.FilesystemViewModel.WorkingDirectory}", false);
+			Win32API.RunPowershellCommand($"code \'{_context.ShellPage?.FilesystemViewModel.WorkingDirectory}\'", false);
 
 			return Task.CompletedTask;
 		}


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related #12645 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Navigate to a git repository that has a " " in the path
   2. Use "Open in VS" or "Open in VS Code" button
