### PR TITLE
Fix: Fixed issue where middle clicking selected folders would cause crash

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -269,7 +269,7 @@ namespace Files.App.Views.LayoutModes
 				return;
 
 			var textBox = listViewItem.FindDescendant("ItemNameTextBox") as TextBox;
-			if (textBox is null)
+			if (textBox is null || textBox.FindParent<Grid>() is null)
 				return;
 
 			Grid.SetColumnSpan(textBox.FindParent<Grid>(), 8);

--- a/src/Files.App/Views/LayoutModes/StandardLayoutMode.cs
+++ b/src/Files.App/Views/LayoutModes/StandardLayoutMode.cs
@@ -188,6 +188,13 @@ namespace Files.App.Views.LayoutModes
 			OldItemName = textBlock.Text;
 			textBlock.Visibility = Visibility.Collapsed;
 			textBox.Visibility = Visibility.Visible;
+
+			if (textBox.FindParent<Grid>() is null)
+			{
+				textBlock.Visibility = Visibility.Collapsed;
+				return;
+			}
+
 			Grid.SetColumnSpan(textBox.FindParent<Grid>(), 8);
 
 			textBox.Focus(FocusState.Pointer);

--- a/src/Files.App/Views/LayoutModes/StandardLayoutMode.cs
+++ b/src/Files.App/Views/LayoutModes/StandardLayoutMode.cs
@@ -191,7 +191,8 @@ namespace Files.App.Views.LayoutModes
 
 			if (textBox.FindParent<Grid>() is null)
 			{
-				textBlock.Visibility = Visibility.Collapsed;
+				textBlock.Visibility = Visibility.Visible;
+				textBox.Visibility = Visibility.Collapsed;
 				return;
 			}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12613...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Select folder
   2. Middle click selected folder to open it in new tab
   3. Confirm it doesn't cause a crash
   4. Test in all the layouts

**Screenshots (optional)**
Add screenshots here.
