### PR TITLE
Fix: Fixed issue where a text box would remain visible in the tiles layout when returning from a new tab

### DIFF
--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -197,6 +197,13 @@ namespace Files.App.Views.LayoutModes
 				OldItemName = textBlock.Text;
 				textBlock.Visibility = Visibility.Collapsed;
 				textBox.Visibility = Visibility.Visible;
+
+				if (textBox.FindParent<Grid>() is null)
+				{
+					textBlock.Visibility = Visibility.Visible;
+					textBox.Visibility = Visibility.Collapsed;
+					return;
+				}
 			}
 
 			textBox.Focus(FocusState.Pointer);


### PR DESCRIPTION
References https://github.com/files-community/Files/pull/12683#pullrequestreview-1492479396

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related to #12683 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?