### PR TITLE
Fix: Fixed crash with moving into an empty folder in column layout

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -326,7 +326,7 @@ namespace Files.App.Views.LayoutModes
 			if (activeBladeColumnViewBase is not null)
 			{
 				activeBladeColumnViewBase.FileList.SelectedIndex = 0;
-				var selectedItem = activeBladeColumnViewBase.FileList.Items.First() as ListedItem;
+				var selectedItem = activeBladeColumnViewBase.FileList.Items.FirstOrDefault() as ListedItem;
 				if (selectedItem is not null)
 					UpdatePreviewPaneSelection(new List<ListedItem>() { selectedItem });
 			}


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12724 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Select an empty folder in column layout
   2. Press right arrow key
   3. Files doesn't crash