### PR TITLE
Fix: Fixed crash that would occur when trying to display tags

### DIFF
--- a/src/Files.App/Filesystem/FileTagsHelper.cs
+++ b/src/Files.App/Filesystem/FileTagsHelper.cs
@@ -26,7 +26,7 @@ namespace Files.App.Filesystem
 		public static string[] ReadFileTag(string filePath)
 		{
 			var tagString = NativeFileOperationsHelper.ReadStringFromFile($"{filePath}:files");
-			return tagString?.Split(',');
+			return tagString?.Split(',', StringSplitOptions.RemoveEmptyEntries);
 		}
 
 		public static void WriteFileTag(string filePath, string[] tag)

--- a/src/Files.App/Services/Settings/FileTagsSettingsService.cs
+++ b/src/Files.App/Services/Settings/FileTagsSettingsService.cs
@@ -80,7 +80,7 @@ namespace Files.App.Services.Settings
 
 		public IList<TagViewModel> GetTagsByIds(string[] uids)
 		{
-			return uids?.Select(x => GetTagById(x)).ToList();
+			return uids?.Select(x => GetTagById(x)).Where(x => x is not null).ToList();
 		}
 
 		public IEnumerable<TagViewModel> GetTagsByName(string tagName)


### PR DESCRIPTION
![image](https://github.com/files-community/Files/assets/66369541/13570e62-6ee8-4d12-a465-03f98008388f)

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?