### PR TITLE
Code Quality: Removed unnecessary IsPageTypeNotHome changes

### DIFF
--- a/src/Files.App/Views/HomePage.xaml.cs
+++ b/src/Files.App/Views/HomePage.xaml.cs
@@ -166,9 +166,6 @@ namespace Files.App.Views
 			{
 				NavPathParam = e.Path
 			});
-
-			// Show controls that were hidden on the home page
-			AppInstance.InstanceViewModel.IsPageTypeNotHome = true;
 		}
 
 		private void WidgetCardNewPaneInvoked(object sender, QuickAccessCardInvokedEventArgs e)
@@ -200,9 +197,6 @@ namespace Files.App.Views
 			{
 				NavPathParam = e.Path
 			});
-
-			// Show controls that were hidden on the home page
-			AppInstance.InstanceViewModel.IsPageTypeNotHome = true;
 		}
 
 		protected override async void OnNavigatedTo(NavigationEventArgs eventArgs)


### PR DESCRIPTION
![image](https://github.com/files-community/Files/assets/66369541/049a9c93-4eee-415a-80eb-6e0323244916)
This is one of the crashes that has become more frequent since 2.5. I don't know why this happens, but there is code that is needlessly changing the property that is causing this crash, and I would like to remove it and see if that solves the problem.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?