### PR TITLE
Fix: Fixed issue where the columns were misaligned in Recycle Bin

### DIFF
--- a/src/Files.App/Filesystem/StorageItems/ShellStorageFile.cs
+++ b/src/Files.App/Filesystem/StorageItems/ShellStorageFile.cs
@@ -72,11 +72,11 @@ namespace Files.App.Filesystem.StorageItems
 
 		public static ShellStorageFile FromShellItem(ShellFileItem item)
 		{
-			if (item is ShellLinkItem linkItem)
-				return new ShortcutStorageFile(linkItem);
-
 			if (item.RecyclePath.Contains("$Recycle.Bin", StringComparison.OrdinalIgnoreCase))
 				return new BinStorageFile(item);
+
+			if (item is ShellLinkItem linkItem)
+				return new ShortcutStorageFile(linkItem);
 
 			return new ShellStorageFile(item);
 		}


### PR DESCRIPTION
Note: Date deleted of the shortcut is always displayed as Now because it can't be retrieved from system properties correctly.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12756 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

**Screenshots**
![image](https://github.com/files-community/Files/assets/66369541/155bf9d6-3b70-4dbd-a172-b2b4556ea455)
