### PR TITLE
Fix: Fixed issue where Status Center didn't update when archives were finished being extracted

### DIFF
--- a/src/Files.App/Helpers/ArchiveHelpers.cs
+++ b/src/Files.App/Helpers/ArchiveHelpers.cs
@@ -1,25 +1,13 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using CommunityToolkit.Mvvm.DependencyInjection;
 using Files.App.Dialogs;
-using Files.App.Extensions;
-using Files.App.Filesystem;
 using Files.App.Filesystem.Archive;
 using Files.App.Filesystem.StorageItems;
-using Files.App.ViewModels;
 using Files.App.ViewModels.Dialogs;
-using Files.Backend.Helpers;
-using Files.Shared.Enums;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Windows.Storage;
 
 namespace Files.App.Helpers
@@ -138,23 +126,16 @@ namespace Files.App.Helpers
 				FileOperationType.Extract,
 				extractCancellation);
 
-			Stopwatch sw = new();
-			sw.Start();
-
 			await FilesystemTasks.Wrap(() => ZipHelpers.ExtractArchive(archive, destinationFolder, password, banner.ProgressEventSource, extractCancellation.Token));
 
-			sw.Stop();
 			banner.Remove();
-
-			if (sw.Elapsed.TotalSeconds >= 6)
-			{
-				OngoingTasksViewModel.PostBanner(
-					"ExtractingCompleteText".GetLocalizedResource(),
-					"ArchiveExtractionCompletedSuccessfullyText".GetLocalizedResource(),
-					0,
-					ReturnResult.Success,
-					FileOperationType.Extract);
-			}
+			
+			OngoingTasksViewModel.PostBanner(
+				"ExtractingCompleteText".GetLocalizedResource(),
+				"ArchiveExtractionCompletedSuccessfullyText".GetLocalizedResource(),
+				0,
+				ReturnResult.Success,
+				FileOperationType.Extract);
 		}
 
 		public static async Task DecompressArchive(IShellPage associatedInstance)


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12809 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Select a small archive (extraction should take less than 6 seconds)
   2. Extract it
   3. Check the status center
   4. Repeat using a big archive  (extraction time >= 6s)
