### PR TITLE
Fix: Fixed issue were removing a tag after changing the layout would cause a crash

### DIFF
--- a/src/Files.App/Filesystem/ListedItem.cs
+++ b/src/Files.App/Filesystem/ListedItem.cs
@@ -133,7 +133,7 @@ namespace Files.App.Filesystem
 			}
 		}
 
-		public IList<TagViewModel> FileTagsUI
+		public IList<TagViewModel>? FileTagsUI
 		{
 			get => fileTagsSettingsService.GetTagsByIds(FileTags);
 		}

--- a/src/Files.App/Services/Settings/FileTagsSettingsService.cs
+++ b/src/Files.App/Services/Settings/FileTagsSettingsService.cs
@@ -78,9 +78,11 @@ namespace Files.App.Services.Settings
 			return tag;
 		}
 
-		public IList<TagViewModel> GetTagsByIds(string[] uids)
+		public IList<TagViewModel>? GetTagsByIds(string[] uids)
 		{
-			return uids?.Select(x => GetTagById(x)).Where(x => x is not null).ToList();
+			return uids is null || uids.Length == 0
+				? null
+				: uids.Select(x => GetTagById(x)).Where(x => x is not null).ToList();
 		}
 
 		public IEnumerable<TagViewModel> GetTagsByName(string tagName)

--- a/src/Files.Backend/Services/Settings/IFileTagsSettingsService.cs
+++ b/src/Files.Backend/Services/Settings/IFileTagsSettingsService.cs
@@ -17,7 +17,7 @@ namespace Files.Backend.Services.Settings
 
 		TagViewModel GetTagById(string uid);
 
-		IList<TagViewModel> GetTagsByIds(string[] uids);
+		IList<TagViewModel>? GetTagsByIds(string[] uids);
 
 		IEnumerable<TagViewModel> GetTagsByName(string tagName);
 


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12814

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Set "Home" tag and "Work" tag to a folder in the details layout.
   2. Change the layout to the grid layout.
   3. Change the layout back to the details layout.
   4. Delete "Home" tag.
   5. Delete "Work" tag.
   6. The app will crash.

**Screenshots (optional)**
A part of the issue is caused by `Select` throwing exception with empty arrays, the other is related to this piece of code
![Screenshot 2023-07-03 221547](https://github.com/files-community/Files/assets/102259289/6cc4a608-24e0-4197-bc61-30cb021f9cda)
Since `FileTagsUI` is empty `[0]` doesn't exist. I fixed setting it to null, but we could also create a `FirstTag` property