### PR TITLE
Fix: Fixed crash that would occur when enabling the tags widget

### DIFF
--- a/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml
+++ b/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml
@@ -89,7 +89,7 @@
 					</Grid>
 
 					<!--  Contents  -->
-					<!--  We hide the scrollbar because it may cause a crash inside the ScrollViewer (#12370)  -->
+					<!--  The vertical scroll bar must be hidden because it may cause a crash inside the ScrollViewer (#12370)  -->
 					<controls:AdaptiveGridView
 						Grid.Row="1"
 						Padding="4"

--- a/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml
+++ b/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml
@@ -98,6 +98,7 @@
 						ItemClick="FileTagItem_ItemClick"
 						ItemsSource="{x:Bind Tags}"
 						RightTapped="AdaptiveGridView_RightTapped"
+						ScrollViewer.VerticalScrollBarVisibility="Hidden"
 						SelectionMode="None"
 						StretchContentForSingleRow="False">
 						<controls:AdaptiveGridView.ItemContainerStyle>

--- a/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml
+++ b/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml
@@ -89,6 +89,7 @@
 					</Grid>
 
 					<!--  Contents  -->
+					<!--  We hide the scrollbar because it may cause a crash inside the ScrollViewer (#12370)  -->
 					<controls:AdaptiveGridView
 						Grid.Row="1"
 						Padding="4"


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12370 
   Closes #12751 
   Closes #12818 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Enable the tags widget.
   2. Open the home page.
   3. Adjust the window width so that the tags widgets are lined up vertically in a row.
   4. Repeat scrolling up and down.
   5. No more crash happens.