### PR TITLE
Fix: Fixed issue where "Open in new window" followed the startup settings

### DIFF
--- a/src/Files.App/Data/EventArguments/MainPageNavigationArguments.cs
+++ b/src/Files.App/Data/EventArguments/MainPageNavigationArguments.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) 2023 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
+namespace Files.App.Data.EventArguments
+{
+	internal class MainPageNavigationArguments
+	{
+		public object? Parameter { get; set; }
+
+		public bool IgnoreStartupSettings { get; set; }
+	}
+}

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -1,13 +1,10 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Files.App.Services.Settings;
 using Files.App.UserControls.MultitaskingControl;
 using Microsoft.UI;
-using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Navigation;
 using System.IO;
@@ -104,11 +101,15 @@ namespace Files.App
 						switch (parsedArgs[0])
 						{
 							case "tab":
-								rootFrame.Navigate(typeof(MainPage), TabItemArguments.Deserialize(unescapedValue), new SuppressNavigationTransitionInfo());
+								rootFrame.Navigate(typeof(MainPage),
+									new MainPageNavigationArguments() { Parameter = TabItemArguments.Deserialize(unescapedValue), IgnoreStartupSettings = true },
+									new SuppressNavigationTransitionInfo());
 								break;
 
 							case "folder":
-								rootFrame.Navigate(typeof(MainPage), unescapedValue, new SuppressNavigationTransitionInfo());
+								rootFrame.Navigate(typeof(MainPage),
+									new MainPageNavigationArguments() { Parameter = unescapedValue, IgnoreStartupSettings = true },
+									new SuppressNavigationTransitionInfo());
 								break;
 
 							case "cmd":

--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -1,11 +1,8 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Files.App.Data.Items;
 using Files.App.Filesystem.StorageItems;
 using Files.App.UserControls.MultitaskingControl;
-using Files.App.Views;
-using Files.Core.Services;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
@@ -279,7 +276,15 @@ namespace Files.App.ViewModels
 			//to handle theme changes without restarting the app
 			ThemeHelper.Initialize();
 
-			if (e.Parameter is null || (e.Parameter is string eventStr && string.IsNullOrEmpty(eventStr)))
+			var parameter = e.Parameter;
+			var ignoreStartupSettings = false;
+			if (parameter is MainPageNavigationArguments mainPageNavigationArguments)
+			{
+				parameter = mainPageNavigationArguments.Parameter;
+				ignoreStartupSettings = mainPageNavigationArguments.IgnoreStartupSettings;
+			}
+
+			if (parameter is null || (parameter is string eventStr && string.IsNullOrEmpty(eventStr)))
 			{
 				try
 				{
@@ -332,42 +337,45 @@ namespace Files.App.ViewModels
 						await AddNewTabAsync();
 					}
 				}
-				catch (Exception)
+				catch
 				{
 					await AddNewTabAsync();
 				}
 			}
 			else
 			{
-				try
+				if (!ignoreStartupSettings)
 				{
-					if (userSettingsService.GeneralSettingsService.OpenSpecificPageOnStartup &&
-							userSettingsService.GeneralSettingsService.TabsOnStartupList is not null)
+					try
 					{
-						foreach (string path in userSettingsService.GeneralSettingsService.TabsOnStartupList)
-							await AddNewTabByPathAsync(typeof(PaneHolderPage), path);
-					}
-					else if (userSettingsService.GeneralSettingsService.ContinueLastSessionOnStartUp &&
-						userSettingsService.GeneralSettingsService.LastSessionTabList is not null)
-					{
-						foreach (string tabArgsString in userSettingsService.GeneralSettingsService.LastSessionTabList)
+						if (userSettingsService.GeneralSettingsService.OpenSpecificPageOnStartup &&
+								userSettingsService.GeneralSettingsService.TabsOnStartupList is not null)
 						{
-							var tabArgs = TabItemArguments.Deserialize(tabArgsString);
-							await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
+							foreach (string path in userSettingsService.GeneralSettingsService.TabsOnStartupList)
+								await AddNewTabByPathAsync(typeof(PaneHolderPage), path);
 						}
+						else if (userSettingsService.GeneralSettingsService.ContinueLastSessionOnStartUp &&
+							userSettingsService.GeneralSettingsService.LastSessionTabList is not null)
+						{
+							foreach (string tabArgsString in userSettingsService.GeneralSettingsService.LastSessionTabList)
+							{
+								var tabArgs = TabItemArguments.Deserialize(tabArgsString);
+								await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
+							}
 
-						var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home" };
+							var defaultArg = new TabItemArguments() { InitialPageType = typeof(PaneHolderPage), NavigationArg = "Home" };
 
-						userSettingsService.GeneralSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
+							userSettingsService.GeneralSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
+						}
 					}
+					catch { }
 				}
-				catch (Exception) { }
 
-				if (e.Parameter is string navArgs)
+				if (parameter is string navArgs)
 					await AddNewTabByPathAsync(typeof(PaneHolderPage), navArgs);
-				else if (e.Parameter is PaneNavigationArguments paneArgs)
+				else if (parameter is PaneNavigationArguments paneArgs)
 					await AddNewTabByParam(typeof(PaneHolderPage), paneArgs);
-				else if (e.Parameter is TabItemArguments tabArgs)
+				else if (parameter is TabItemArguments tabArgs)
 					await AddNewTabByParam(tabArgs.InitialPageType, tabArgs.NavigationArg);
 			}
 


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12812 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. If you perform "Open in new window", the new window will contain a tab of selected item only.
   2. If you launch the app from command line with a path to open, it will still follow the startup settings.