### PR TITLE
Fix: Fixed layout mode icon not reflecting current folder layout

### DIFF
--- a/src/Files.App/Actions/Display/LayoutAction.cs
+++ b/src/Files.App/Actions/Display/LayoutAction.cs
@@ -175,7 +175,7 @@ namespace Files.App.Actions
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName is nameof(IDisplayPageContext.LayoutType))
-				OnContextChanged(nameof(IsOn));
+				OnPropertyChanged(nameof(IsOn));
 
 			if (e.PropertyName is not null)
 				OnContextChanged(e.PropertyName);

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -459,14 +459,7 @@ namespace Files.App.Commands
 			}
 
 			public bool CanExecute(object? parameter) => Action.IsExecutable;
-			public async void Execute(object? parameter) => await ExecuteAsync(parameter);
-
-			public Task ExecuteAsync(object? parameter)
-			{
-				if (parameter is RoutedEventArgs ev && ev.OriginalSource is ToggleSwitch tg && tg.IsOn == IsOn)
-					return Task.CompletedTask;
-				return ExecuteAsync();
-			}
+			public async void Execute(object? parameter) => await ExecuteAsync();
 
 			public Task ExecuteAsync()
 			{

--- a/src/Files.App/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Commands/Manager/CommandManager.cs
@@ -459,17 +459,24 @@ namespace Files.App.Commands
 			}
 
 			public bool CanExecute(object? parameter) => Action.IsExecutable;
-			public async void Execute(object? parameter) => await ExecuteAsync();
+			public async void Execute(object? parameter) => await ExecuteAsync(parameter);
+
+			public Task ExecuteAsync(object? parameter)
+			{
+				if (parameter is RoutedEventArgs ev && ev.OriginalSource is ToggleSwitch tg && tg.IsOn == IsOn)
+					return Task.CompletedTask;
+				return ExecuteAsync();
+			}
 
 			public Task ExecuteAsync()
 			{
 				if (IsExecutable)
 				{
-                    Analytics.TrackEvent($"Triggered {Code} action");
-                    return Action.ExecuteAsync();
-                }
+					Analytics.TrackEvent($"Triggered {Code} action");
+					return Action.ExecuteAsync();
+				}
 
-                return Task.CompletedTask;
+				return Task.CompletedTask;
 			}
 
 			public async void ExecuteTapped(object sender, TappedRoutedEventArgs e) => await ExecuteAsync();

--- a/src/Files.App/Contexts/DisplayPage/DisplayPageContext.cs
+++ b/src/Files.App/Contexts/DisplayPage/DisplayPageContext.cs
@@ -160,6 +160,7 @@ namespace Files.App.Contexts
 			{
 				case nameof(FolderSettingsViewModel.LayoutMode):
 				case nameof(FolderSettingsViewModel.GridViewSize):
+				case nameof(FolderSettingsViewModel.IsAdaptiveLayoutEnabled):
 					SetProperty(ref _LayoutType, GetLayoutType(), nameof(LayoutType));
 					break;
 				case nameof(FolderSettingsViewModel.DirectorySortOption):

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -643,6 +643,7 @@
 									AutomationProperties.Name="{x:Bind Commands.LayoutDetails.AutomationName}"
 									Command="{x:Bind Commands.LayoutDetails}"
 									CornerRadius="{StaticResource ControlCornerRadius}"
+									GroupName="LayoutRadio"
 									IsChecked="{x:Bind Commands.LayoutDetails.IsOn, Mode=OneWay}"
 									Style="{StaticResource DefaultToggleButtonStyle}"
 									ToolTipService.ToolTip="{x:Bind Commands.LayoutDetails.LabelWithHotKey, Mode=OneWay}">
@@ -674,6 +675,7 @@
 									AutomationProperties.Name="{x:Bind Commands.LayoutTiles.AutomationName}"
 									Command="{x:Bind Commands.LayoutTiles}"
 									CornerRadius="{StaticResource ControlCornerRadius}"
+									GroupName="LayoutRadio"
 									IsChecked="{x:Bind Commands.LayoutTiles.IsOn, Mode=OneWay}"
 									Style="{StaticResource DefaultToggleButtonStyle}"
 									ToolTipService.ToolTip="{x:Bind Commands.LayoutTiles.LabelWithHotKey, Mode=OneWay}">
@@ -705,6 +707,7 @@
 									AutomationProperties.Name="{x:Bind Commands.LayoutGridSmall.AutomationName}"
 									Command="{x:Bind Commands.LayoutGridSmall}"
 									CornerRadius="{StaticResource ControlCornerRadius}"
+									GroupName="LayoutRadio"
 									IsChecked="{x:Bind Commands.LayoutGridSmall.IsOn, Mode=OneWay}"
 									Style="{StaticResource DefaultToggleButtonStyle}"
 									ToolTipService.ToolTip="{x:Bind Commands.LayoutGridSmall.LabelWithHotKey, Mode=OneWay}">
@@ -736,6 +739,7 @@
 									AutomationProperties.Name="{x:Bind Commands.LayoutGridMedium.AutomationName}"
 									Command="{x:Bind Commands.LayoutGridMedium}"
 									CornerRadius="{StaticResource ControlCornerRadius}"
+									GroupName="LayoutRadio"
 									IsChecked="{x:Bind Commands.LayoutGridMedium.IsOn, Mode=OneWay}"
 									Style="{StaticResource DefaultToggleButtonStyle}"
 									ToolTipService.ToolTip="{x:Bind Commands.LayoutGridMedium.LabelWithHotKey, Mode=OneWay}">
@@ -777,6 +781,7 @@
 									AutomationProperties.Name="{x:Bind Commands.LayoutGridLarge.AutomationName}"
 									Command="{x:Bind Commands.LayoutGridLarge}"
 									CornerRadius="{StaticResource ControlCornerRadius}"
+									GroupName="LayoutRadio"
 									IsChecked="{x:Bind Commands.LayoutGridLarge.IsOn, Mode=OneWay}"
 									Style="{StaticResource DefaultToggleButtonStyle}"
 									ToolTipService.ToolTip="{x:Bind Commands.LayoutGridLarge.LabelWithHotKey, Mode=OneWay}">
@@ -808,6 +813,7 @@
 									AutomationProperties.Name="{x:Bind Commands.LayoutColumns.AutomationName}"
 									Command="{x:Bind Commands.LayoutColumns}"
 									CornerRadius="{StaticResource ControlCornerRadius}"
+									GroupName="LayoutRadio"
 									IsChecked="{x:Bind Commands.LayoutColumns.IsOn, Mode=OneWay}"
 									Style="{StaticResource DefaultToggleButtonStyle}"
 									ToolTipService.ToolTip="{x:Bind Commands.LayoutColumns.LabelWithHotKey, Mode=OneWay}">
@@ -894,16 +900,10 @@
 									Grid.Column="1"
 									HorizontalAlignment="Right"
 									AutomationProperties.Name="{x:Bind Commands.LayoutAdaptive.AutomationName}"
-									IsOn="{x:Bind Commands.LayoutAdaptive.IsOn, Mode=OneWay}"
+									IsOn="{x:Bind Commands.LayoutAdaptive.IsOn, Mode=TwoWay}"
 									Rotation="1"
 									Style="{StaticResource RightAlignedToggleSwitchStyle}"
-									ToolTipService.ToolTip="{x:Bind Commands.LayoutAdaptive.LabelWithHotKey, Mode=OneWay}">
-									<i:Interaction.Behaviors>
-										<icore:EventTriggerBehavior EventName="Toggled">
-											<icore:InvokeCommandAction Command="{x:Bind Commands.LayoutAdaptive}" />
-										</icore:EventTriggerBehavior>
-									</i:Interaction.Behaviors>
-								</ToggleSwitch>
+									ToolTipService.ToolTip="{x:Bind Commands.LayoutAdaptive.LabelWithHotKey, Mode=OneWay}" />
 
 							</Grid>
 


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Go to folder with adaptive mode enabled -> check that adaptive toggle is on
   2. Go to folder with adaptive mode disabled -> check that correct layout is highlited

**Screenshots (optional)**
<img width="244" alt="image" src="https://github.com/files-community/Files/assets/9673091/213f88f2-8e68-4819-a9ae-fea7b49f6366">
