### PR TITLE
Feature: Increased maximum volume label length to 128 characters for UDF images

### DIFF
--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -167,7 +167,7 @@ namespace Files.App.Data.Items
 			item.Text = type switch
 			{
 				DriveType.Network => $"{root.DisplayName} ({deviceId})",
-				DriveType.CDRom => label,
+				DriveType.CDRom => root.DisplayName.Replace(label.Substring(0, Math.Min(32, label.Length)), label),
 				_ => root.DisplayName
 			};
 			item.Type = type;

--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -167,7 +167,7 @@ namespace Files.App.Data.Items
 			item.Text = type switch
 			{
 				DriveType.Network => $"{root.DisplayName} ({deviceId})",
-				DriveType.CDRom => root.DisplayName.Replace(label.Substring(0, Math.Min(32, label.Length)), label),
+				DriveType.CDRom when !string.IsNullOrEmpty(label) => root.DisplayName.Replace(label.Left(32), label),
 				_ => root.DisplayName
 			};
 			item.Type = type;

--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -157,14 +157,19 @@ namespace Files.App.Data.Items
 			ItemType = NavigationControlItemType.CloudDrive;
 		}
 
-		public static async Task<DriveItem> CreateFromPropertiesAsync(StorageFolder root, string deviceId, DriveType type, IRandomAccessStream imageStream = null)
+		public static async Task<DriveItem> CreateFromPropertiesAsync(StorageFolder root, string deviceId, string label, DriveType type, IRandomAccessStream imageStream = null)
 		{
 			var item = new DriveItem();
 
 			if (imageStream is not null)
 				item.IconData = await imageStream.ToByteArrayAsync();
 
-			item.Text = type is DriveType.Network ? $"{root.DisplayName} ({deviceId})" : root.DisplayName;
+			item.Text = type switch
+			{
+				DriveType.Network => $"{root.DisplayName} ({deviceId})",
+				DriveType.CDRom => label,
+				_ => root.DisplayName
+			};
 			item.Type = type;
 			item.MenuOptions = new ContextMenuOptions
 			{
@@ -248,7 +253,7 @@ namespace Files.App.Data.Items
 			{
 				if (!string.IsNullOrEmpty(DeviceID) && !string.Equals(DeviceID, "network-folder"))
 					IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(DeviceID, 24);
-				
+
 				if (Root is not null)
 				{
 					using var thumbnail = await DriveHelpers.GetThumbnailAsync(Root);

--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -71,6 +71,7 @@
     <ItemGroup>
         <PackageReference Include="ByteSize" Version="2.1.1" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+        <PackageReference Include="DiscUtils.Udf" Version="0.16.13" />
         <PackageReference Include="FluentFTP" Version="43.0.1" />
         <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
         <PackageReference Include="LibGit2Sharp" Version="0.27.2" />

--- a/src/Files.App/Helpers/Storage/DriveHelpers.cs
+++ b/src/Files.App/Helpers/Storage/DriveHelpers.cs
@@ -147,7 +147,7 @@ namespace Files.App.Helpers
 				if (string.IsNullOrEmpty(dosDevicePath))
 					return drive.VolumeLabel;
 				using var driveStream = new FileStream(dosDevicePath.Replace(@"\Device\", @"\\.\"), FileMode.Open, FileAccess.Read);
-				var udf = new UdfReader(driveStream);
+				using var udf = new UdfReader(driveStream);
 				return udf.VolumeLabel;
 			}) ?? drive.VolumeLabel;
 		}

--- a/src/Files.App/Helpers/Storage/DriveHelpers.cs
+++ b/src/Files.App/Helpers/Storage/DriveHelpers.cs
@@ -16,6 +16,7 @@ using Windows.Devices.Enumeration;
 using Windows.Devices.Portable;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
+using DiscUtils.Udf;
 
 namespace Files.App.Helpers
 {
@@ -134,6 +135,21 @@ namespace Files.App.Helpers
 				System.IO.DriveType.Removable => Data.Items.DriveType.Removable,
 				_ => Data.Items.DriveType.Unknown,
 			};
+		}
+
+		public static string GetExtendedDriveLabel(DriveInfo drive)
+		{
+			if (drive.DriveType is not System.IO.DriveType.CDRom || drive.DriveFormat is not "UDF")
+				return drive.VolumeLabel;
+			return SafetyExtensions.IgnoreExceptions(() =>
+			{
+				var dosDevicePath = Vanara.PInvoke.Kernel32.QueryDosDevice(drive.Name).FirstOrDefault();
+				if (string.IsNullOrEmpty(dosDevicePath))
+					return drive.VolumeLabel;
+				using var driveStream = new FileStream(dosDevicePath.Replace(@"\Device\", @"\\.\"), FileMode.Open, FileAccess.Read);
+				var udf = new UdfReader(driveStream);
+				return udf.VolumeLabel;
+			}) ?? drive.VolumeLabel;
 		}
 
 		public static async Task<StorageItemThumbnail> GetThumbnailAsync(StorageFolder folder)

--- a/src/Files.App/Services/RemovableDrivesService.cs
+++ b/src/Files.App/Services/RemovableDrivesService.cs
@@ -38,7 +38,8 @@ namespace Files.App.Services
 
 				using var thumbnail = await DriveHelpers.GetThumbnailAsync(res.Result);
 				var type = DriveHelpers.GetDriveType(drive);
-				var driveItem = await DriveItem.CreateFromPropertiesAsync(res.Result, drive.Name.TrimEnd('\\'), type, thumbnail);
+				var label = DriveHelpers.GetExtendedDriveLabel(drive);
+				var driveItem = await DriveItem.CreateFromPropertiesAsync(res.Result, drive.Name.TrimEnd('\\'), label, type, thumbnail);
 
 				App.Logger.LogInformation($"Drive added: {driveItem.Path}, {driveItem.Type}");
 

--- a/src/Files.App/Utils/WindowsStorageDeviceWatcher.cs
+++ b/src/Files.App/Utils/WindowsStorageDeviceWatcher.cs
@@ -64,7 +64,8 @@ namespace Files.App.Utils
 			}
 			
 			var type = DriveHelpers.GetDriveType(driveAdded);
-			DriveItem driveItem = await DriveItem.CreateFromPropertiesAsync(rootAdded, e.DeviceId, type);
+			var label = DriveHelpers.GetExtendedDriveLabel(driveAdded);
+			DriveItem driveItem = await DriveItem.CreateFromPropertiesAsync(rootAdded, e.DeviceId, label, type);
 
 			DeviceAdded?.Invoke(this, driveItem);
 		}
@@ -95,18 +96,21 @@ namespace Files.App.Utils
 			}
 
             Data.Items.DriveType type;
+			string label;
 			try
 			{
 				// Check if this drive is associated with a drive letter
 				var driveAdded = new DriveInfo(root.Path);
 				type = DriveHelpers.GetDriveType(driveAdded);
+				label = DriveHelpers.GetExtendedDriveLabel(driveAdded);
 			}
 			catch (ArgumentException)
 			{
 				type = Data.Items.DriveType.Removable;
+				label = root.DisplayName;
 			}
 
-			var driveItem = await DriveItem.CreateFromPropertiesAsync(root, deviceId, type);
+			var driveItem = await DriveItem.CreateFromPropertiesAsync(root, deviceId, label, type);
 
 			DeviceAdded?.Invoke(this, driveItem);
 		}

--- a/src/Files.App/Utils/WindowsStorageDeviceWatcher.cs
+++ b/src/Files.App/Utils/WindowsStorageDeviceWatcher.cs
@@ -107,7 +107,7 @@ namespace Files.App.Utils
 			catch (ArgumentException)
 			{
 				type = Data.Items.DriveType.Removable;
-				label = root.DisplayName;
+				label = string.Empty;
 			}
 
 			var driveItem = await DriveItem.CreateFromPropertiesAsync(root, deviceId, label, type);


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12901

NB: added a new nuget dependency (DiscUtils.Udf) as winapi GetVolumeInformation only returns up to 32 chars. I won't raise a fuss if PR is refused due to this :)

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Mount attached ISOs
   2. Check UDF formatted ISO label is > 32 characters

**Screenshots (optional)**
<img width="620" alt="Screenshot 2023-07-10 003322" src="https://github.com/files-community/Files/assets/9673091/e73f188f-4549-437b-8d49-d0e0b9f43fb4">

[udf_long_name.zip](https://github.com/files-community/Files/files/12021489/udf_long_name.zip)
