### PR TITLE
Code Quality: Use thread-safe collections in ItemViewModel

### DIFF
--- a/src/Files.App/Helpers/StorageItemCollection/BulkConcurrentObservableCollection.cs
+++ b/src/Files.App/Helpers/StorageItemCollection/BulkConcurrentObservableCollection.cs
@@ -403,8 +403,8 @@ namespace Files.App.Helpers
 			{
 				oldItems = collection.Skip(index).Take(count).ToList();
 				newItems = items.ToList();
+				collection.RemoveRange(index, count);
 				collection.InsertRange(index, newItems);
-				collection.RemoveRange(index + count, count);
 			}
 
 			OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newItems, oldItems, index), false);
@@ -467,15 +467,30 @@ namespace Files.App.Helpers
 			return index;
 		}
 
-		bool IList.Contains(object? value) => Contains((T?)value);
+		bool IList.Contains(object? value)
+		{
+			return Contains((T?)value);
+		}
 
-		int IList.IndexOf(object? value) => IndexOf((T?)value);
+		int IList.IndexOf(object? value)
+		{
+			return IndexOf((T?)value);
+		}
 
-		void IList.Insert(int index, object? value) => Insert(index, (T?)value);
+		void IList.Insert(int index, object? value)
+		{
+			Insert(index, (T?)value);
+		}
 
-		void IList.Remove(object? value) => Remove((T?)value);
+		void IList.Remove(object? value)
+		{
+			Remove((T?)value);
+		}
 
-		void ICollection.CopyTo(Array array, int index) => CopyTo((T[])array, index);
+		void ICollection.CopyTo(Array array, int index)
+		{
+			CopyTo((T[])array, index);
+		}
 
 		private static class EventArgsCache
 		{

--- a/src/Files.App/Helpers/StorageItemCollection/ConcurrentCollection.cs
+++ b/src/Files.App/Helpers/StorageItemCollection/ConcurrentCollection.cs
@@ -1,0 +1,294 @@
+// Copyright (c) 2023 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
+namespace Files.App.Helpers
+{
+	[DebuggerTypeProxy(typeof(CollectionDebugView<>))]
+	[DebuggerDisplay("Count = {Count}")]
+	public class ConcurrentCollection<T> : ICollection<T>, IList<T>, ICollection, IList
+	{
+		private readonly object syncRoot = new object();
+		private readonly List<T> collection = new List<T>();
+
+		public int Count
+		{
+			get
+			{
+				lock (syncRoot)
+				{
+					return collection.Count;
+				}
+			}
+		}
+
+		public bool IsReadOnly => false;
+
+		public bool IsFixedSize => false;
+
+		public bool IsSynchronized => true;
+
+		public object SyncRoot => syncRoot;
+
+		object? IList.this[int index]
+		{
+			get
+			{
+				return this[index];
+			}
+			set
+			{
+				if (value is not null)
+					this[index] = (T)value;
+			}
+		}
+
+		public T this[int index]
+		{
+			get
+			{
+				lock (syncRoot)
+				{
+					return collection[index];
+				}
+			}
+			set
+			{
+				T item;
+				lock (syncRoot)
+				{
+					item = collection[index];
+					collection[index] = value;
+				}
+			}
+		}
+
+		public ConcurrentCollection() { }
+
+		public ConcurrentCollection(IEnumerable<T> items)
+		{
+			AddRange(items);
+		}
+
+		public void Add(T? item)
+		{
+			if (item is null)
+				return;
+
+			lock (syncRoot)
+			{
+				collection.Add(item);
+			}
+		}
+
+		public void Clear()
+		{
+			lock (syncRoot)
+			{
+				collection.Clear();
+			}
+		}
+
+		public bool Contains(T? item)
+		{
+			if (item is null)
+				return false;
+
+			lock (syncRoot)
+			{
+				return collection.Contains(item);
+			}
+		}
+
+		public void CopyTo(T[] array, int arrayIndex)
+		{
+			lock (syncRoot)
+			{
+				collection.CopyTo(array, arrayIndex);
+			}
+		}
+
+		public bool Remove(T? item)
+		{
+			if (item is null)
+				return false;
+
+			int index;
+
+			lock (syncRoot)
+			{
+				index = collection.IndexOf(item);
+
+				if (index == -1)
+					return false;
+
+				collection.RemoveAt(index);
+			}
+
+			return true;
+		}
+
+		public IEnumerator<T> GetEnumerator()
+		{
+			return new BlockingListEnumerator<T>(collection, syncRoot);
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		public int IndexOf(T? item)
+		{
+			if (item is null)
+				return -1;
+
+			lock (syncRoot)
+			{
+				return collection.IndexOf(item);
+			}
+		}
+
+		public void Insert(int index, T? item)
+		{
+			if (item is null)
+				return;
+
+			lock (syncRoot)
+			{
+				collection.Insert(index, item);
+			}
+		}
+
+		public void RemoveAt(int index)
+		{
+			T item;
+
+			lock (syncRoot)
+			{
+				item = collection[index];
+				collection.RemoveAt(index);
+			}
+		}
+
+		public void AddRange(IEnumerable<T> items)
+		{
+			if (!items.Any())
+				return;
+
+			lock (syncRoot)
+			{
+				collection.AddRange(items);
+			}
+		}
+
+		public void InsertRange(int index, IEnumerable<T> items)
+		{
+			if (!items.Any())
+				return;
+
+			lock (syncRoot)
+			{
+				collection.InsertRange(index, items);
+			}
+		}
+
+		public void RemoveRange(int index, int count)
+		{
+			if (count <= 0)
+				return;
+
+			List<T> items;
+
+			lock (syncRoot)
+			{
+				items = collection.Skip(index).Take(count).ToList();
+				collection.RemoveRange(index, count);
+			}
+		}
+
+		public void ReplaceRange(int index, IEnumerable<T> items)
+		{
+			var count = items.Count();
+
+			if (count == 0)
+				return;
+
+			List<T> oldItems;
+			List<T> newItems;
+
+			lock (syncRoot)
+			{
+				oldItems = collection.Skip(index).Take(count).ToList();
+				newItems = items.ToList();
+				collection.InsertRange(index, newItems);
+				collection.RemoveRange(index + count, count);
+			}
+		}
+
+		public void Sort()
+		{
+			lock (syncRoot)
+			{
+				collection.Sort();
+			}
+		}
+
+		public void Sort(Comparison<T> comparison)
+		{
+			lock (syncRoot)
+			{
+				collection.Sort(comparison);
+			}
+		}
+
+		public void Order(Func<List<T>, IEnumerable<T>> func)
+		{
+			IEnumerable<T> result;
+			lock (syncRoot)
+			{
+				result = func.Invoke(collection);
+			}
+
+			ReplaceRange(0, result);
+		}
+
+		public void OrderOne(Func<List<T>, IEnumerable<T>> func, T item)
+		{
+			IList<T> result;
+			lock (syncRoot)
+			{
+				result = func.Invoke(collection).ToList();
+			}
+
+			Remove(item);
+			var index = result.IndexOf(item);
+			if (index != -1)
+				Insert(index, item);
+		}
+
+		int IList.Add(object? value)
+		{
+			if (value is null)
+				return -1;
+
+			int index;
+
+			lock (syncRoot)
+			{
+				index = ((IList)collection).Add((T)value);
+			}
+
+			return index;
+		}
+
+		bool IList.Contains(object? value) => Contains((T?)value);
+
+		int IList.IndexOf(object? value) => IndexOf((T?)value);
+
+		void IList.Insert(int index, object? value) => Insert(index, (T?)value);
+
+		void IList.Remove(object? value) => Remove((T?)value);
+
+		void ICollection.CopyTo(Array array, int index) => CopyTo((T[])array, index);
+	}
+}

--- a/src/Files.App/Helpers/StorageItemCollection/ConcurrentCollection.cs
+++ b/src/Files.App/Helpers/StorageItemCollection/ConcurrentCollection.cs
@@ -112,11 +112,9 @@ namespace Files.App.Helpers
 			if (item is null)
 				return false;
 
-			int index;
-
 			lock (syncRoot)
 			{
-				index = collection.IndexOf(item);
+				var index = collection.IndexOf(item);
 
 				if (index == -1)
 					return false;
@@ -161,11 +159,8 @@ namespace Files.App.Helpers
 
 		public void RemoveAt(int index)
 		{
-			T item;
-
 			lock (syncRoot)
 			{
-				item = collection[index];
 				collection.RemoveAt(index);
 			}
 		}
@@ -197,11 +192,8 @@ namespace Files.App.Helpers
 			if (count <= 0)
 				return;
 
-			List<T> items;
-
 			lock (syncRoot)
 			{
-				items = collection.Skip(index).Take(count).ToList();
 				collection.RemoveRange(index, count);
 			}
 		}
@@ -213,15 +205,10 @@ namespace Files.App.Helpers
 			if (count == 0)
 				return;
 
-			List<T> oldItems;
-			List<T> newItems;
-
 			lock (syncRoot)
 			{
-				oldItems = collection.Skip(index).Take(count).ToList();
-				newItems = items.ToList();
-				collection.InsertRange(index, newItems);
-				collection.RemoveRange(index + count, count);
+				collection.RemoveRange(index, count);
+				collection.InsertRange(index, items.ToList());
 			}
 		}
 
@@ -281,14 +268,28 @@ namespace Files.App.Helpers
 			return index;
 		}
 
-		bool IList.Contains(object? value) => Contains((T?)value);
+		bool IList.Contains(object? value)
+		{
+			return Contains((T?)value);
+		}
 
-		int IList.IndexOf(object? value) => IndexOf((T?)value);
+		int IList.IndexOf(object? value) {
+			return IndexOf((T?)value);
+		}
 
-		void IList.Insert(int index, object? value) => Insert(index, (T?)value);
+		void IList.Insert(int index, object? value)
+		{
+			Insert(index, (T?)value);
+		}
 
-		void IList.Remove(object? value) => Remove((T?)value);
+		void IList.Remove(object? value)
+		{ 
+			Remove((T?)value);
+		}
 
-		void ICollection.CopyTo(Array array, int index) => CopyTo((T[])array, index);
+		void ICollection.CopyTo(Array array, int index)
+		{
+			CopyTo((T[])array, index);
+		}
 	}
 }

--- a/src/Files.App/Helpers/StorageItemCollection/ConcurrentCollection.cs
+++ b/src/Files.App/Helpers/StorageItemCollection/ConcurrentCollection.cs
@@ -273,7 +273,8 @@ namespace Files.App.Helpers
 			return Contains((T?)value);
 		}
 
-		int IList.IndexOf(object? value) {
+		int IList.IndexOf(object? value)
+		{
 			return IndexOf((T?)value);
 		}
 
@@ -283,7 +284,7 @@ namespace Files.App.Helpers
 		}
 
 		void IList.Remove(object? value)
-		{ 
+		{
 			Remove((T?)value);
 		}
 

--- a/src/Files.App/Helpers/StorageItemCollection/SortingHelper.cs
+++ b/src/Files.App/Helpers/StorageItemCollection/SortingHelper.cs
@@ -31,7 +31,7 @@ namespace Files.App.Helpers
 			};
 		}
 
-		public static IEnumerable<ListedItem> OrderFileList(List<ListedItem> filesAndFolders, SortOption directorySortOption, SortDirection directorySortDirection, bool sortDirectoriesAlongsideFiles)
+		public static IEnumerable<ListedItem> OrderFileList(IList<ListedItem> filesAndFolders, SortOption directorySortOption, SortDirection directorySortDirection, bool sortDirectoriesAlongsideFiles)
 		{
 			var orderFunc = GetSortFunc(directorySortOption);
 			var naturalStringComparer = NaturalStringComparer.GetForProcessor();


### PR DESCRIPTION
I believe this may avoid crashes like #12924.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related to #12617 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?