### PR TITLE
Fix: Fixed issue where properties were sometimes not displayed in the details pane

### DIFF
--- a/src/Files.App/ViewModels/UserControls/PreviewPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/PreviewPaneViewModel.cs
@@ -14,8 +14,6 @@ namespace Files.App.ViewModels.UserControls
 {
 	public class PreviewPaneViewModel : ObservableObject, IDisposable
 	{
-		private readonly IUserSettingsService userSettingsService;
-
 		private readonly IPreviewPaneSettingsService previewSettingsService;
 
 		private readonly IContentPageContext contentPageContextService;
@@ -69,16 +67,14 @@ namespace Files.App.ViewModels.UserControls
 			set => SetProperty(ref previewPaneContent, value);
 		}
 
-		public PreviewPaneViewModel(IUserSettingsService userSettings, IPreviewPaneSettingsService previewSettings, IContentPageContext contentPageContextService = null)
+		public PreviewPaneViewModel(IPreviewPaneSettingsService previewSettings, IContentPageContext contentPageContextService = null)
 		{
-			userSettingsService = userSettings;
 			previewSettingsService = previewSettings;
 
 			ShowPreviewOnlyInvoked = new RelayCommand(async () => await UpdateSelectedItemPreview());
 
 			IsEnabled = previewSettingsService.IsEnabled;
 
-			userSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
 			previewSettingsService.PropertyChanged += PreviewSettingsService_OnPropertyChangedEvent;
 
 			this.contentPageContextService = contentPageContextService ?? Ioc.Default.GetRequiredService<IContentPageContext>();
@@ -313,18 +309,14 @@ namespace Files.App.ViewModels.UserControls
 
 		public ICommand ShowPreviewOnlyInvoked { get; }
 
-		private async void UserSettingsService_OnSettingChangedEvent(object sender, SettingChangedEventArgs e)
+		private async void PreviewSettingsService_OnPropertyChangedEvent(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.SettingName is nameof(IPreviewPaneSettingsService.ShowPreviewOnly))
+			if (e.PropertyName is nameof(IPreviewPaneSettingsService.ShowPreviewOnly))
 			{
 				// The preview will need refreshing as the file details won't be accurate
 				await UpdateSelectedItemPreview();
 			}
-		}
-
-		private void PreviewSettingsService_OnPropertyChangedEvent(object sender, PropertyChangedEventArgs e)
-		{
-			if (e.PropertyName is nameof(IPreviewPaneSettingsService.IsEnabled))
+			else if (e.PropertyName is nameof(IPreviewPaneSettingsService.IsEnabled))
 			{
 				var newEnablingStatus = previewSettingsService.IsEnabled;
 				if (isEnabled != newEnablingStatus)
@@ -353,7 +345,6 @@ namespace Files.App.ViewModels.UserControls
 
 		public void Dispose()
 		{
-			userSettingsService.OnSettingChangedEvent -= UserSettingsService_OnSettingChangedEvent;
 			previewSettingsService.PropertyChanged -= PreviewSettingsService_OnPropertyChangedEvent;
 		}
 	}


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12878 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Show the details pane.
   2. Switch the pane to Preview mode.
   3. Select a file.
   4. Switch the pane to Details mode.
   5. Properties should load and display.