### PR TITLE
Fix: Fixed issue where the wrong notification was displayed when opening an optical drive tray

### DIFF
--- a/src/Files.App/Helpers/UI/UIHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIHelpers.cs
@@ -41,11 +41,12 @@ namespace Files.App.Helpers
 		/// Displays a toast or dialog to indicate the result of
 		/// a device ejection operation.
 		/// </summary>
+		/// <param name="type">Type of drive to eject</param>
 		/// <param name="result">Only true implies a successful device ejection</param>
 		/// <returns></returns>
-		public static async Task ShowDeviceEjectResultAsync(bool result)
+		public static async Task ShowDeviceEjectResultAsync(Data.Items.DriveType type, bool result)
 		{
-			if (result)
+			if (type != Data.Items.DriveType.CDRom && result)
 			{
 				Debug.WriteLine("Device successfully ejected");
 
@@ -81,7 +82,7 @@ namespace Files.App.Helpers
 				// And send the notification
 				ToastNotificationManager.CreateToastNotifier().Show(toastNotif);
 			}
-			else
+			else if (!result)
 			{
 				Debug.WriteLine("Can't eject device");
 

--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -401,7 +401,7 @@ namespace Files.App.UserControls
 		private async Task EjectDevice()
 		{
 			var result = await DriveHelpers.EjectDeviceAsync(rightClickedItem.Path);
-			await UIHelpers.ShowDeviceEjectResultAsync(result);
+			await UIHelpers.ShowDeviceEjectResultAsync(rightClickedItem is DriveItem driveItem ? driveItem.Type : Data.Items.DriveType.Unknown, result);
 		}
 
 		private void FormatDrive()

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -272,7 +272,7 @@ namespace Files.App.UserControls.Widgets
 		private async Task EjectDevice(DriveCardItem item)
 		{
 			var result = await DriveHelpers.EjectDeviceAsync(item.Item.Path);
-			await UIHelpers.ShowDeviceEjectResultAsync(result);
+			await UIHelpers.ShowDeviceEjectResultAsync(item.Item.Type, result);
 		}
 
 		private void FormatDrive(DriveCardItem? item)

--- a/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
@@ -49,7 +49,7 @@ namespace Files.App.Utils.Storage
 			if (ejectButton)
 			{
 				var result = await EjectDeviceAsync(matchingDrive.Path);
-				await UIHelpers.ShowDeviceEjectResultAsync(result);
+				await UIHelpers.ShowDeviceEjectResultAsync(matchingDrive.Type, result);
 			}
 			return true;
 		}

--- a/src/Files.App/ViewModels/UserControls/ToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/ToolbarViewModel.cs
@@ -681,7 +681,7 @@ namespace Files.App.ViewModels.UserControls
 							if (ejectButton)
 							{
 								var result = await DriveHelpers.EjectDeviceAsync(matchingDrive.Path);
-								await UIHelpers.ShowDeviceEjectResultAsync(result);
+								await UIHelpers.ShowDeviceEjectResultAsync(matchingDrive.Type, result);
 							}
 							return;
 						}


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12987 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?