### PR TITLE
Fix: Fixed issue where opening folder from external source didn't honor dual pane settings

### DIFF
--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -207,10 +207,12 @@ namespace Files.App
 						payload = folder.Path; // Convert short name to long name (#6190)
 				}
 
+				var generalSettingsService = Ioc.Default.GetService<IGeneralSettingsService>();
 				var paneNavigationArgs = new PaneNavigationArguments
 				{
 					LeftPaneNavPathParam = payload,
 					LeftPaneSelectItemParam = selectItem,
+					RightPaneNavPathParam = Bounds.Width > PaneHolderPage.DualPaneWidthThreshold && (generalSettingsService?.AlwaysOpenDualPaneInNewTab ?? false) ? "Home" : null,
 				};
 
 				if (rootFrame.Content is not null)

--- a/src/Files.App/Views/PaneHolderPage.xaml.cs
+++ b/src/Files.App/Views/PaneHolderPage.xaml.cs
@@ -14,6 +14,8 @@ namespace Files.App.Views
 {
 	public sealed partial class PaneHolderPage : Page, IPaneHolder, ITabItemContent
 	{
+		public static readonly int DualPaneWidthThreshold = 750;
+
 		public static event EventHandler<PaneHolderPage>? CurrentInstanceChanged;
 
 		private IUserSettingsService UserSettingsService { get; }
@@ -46,7 +48,7 @@ namespace Files.App.Views
 			}
 		}
 
-		private bool _WindowIsCompact = MainWindow.Instance.Bounds.Width <= 750;
+		private bool _WindowIsCompact = MainWindow.Instance.Bounds.Width <= DualPaneWidthThreshold;
 		public bool WindowIsCompact
 		{
 			get => _WindowIsCompact;
@@ -78,7 +80,7 @@ namespace Files.App.Views
 			=> IsRightPaneVisible;
 
 		public bool IsMultiPaneEnabled
-			=> !(MainWindow.Instance.Bounds.Width <= 750);
+			=> MainWindow.Instance.Bounds.Width > DualPaneWidthThreshold;
 
 		private NavigationParams _NavParamsLeft;
 		public NavigationParams NavParamsLeft
@@ -208,7 +210,7 @@ namespace Files.App.Views
 
 		private void Current_SizeChanged(object sender, WindowSizeChangedEventArgs e)
 		{
-			WindowIsCompact = MainWindow.Instance.Bounds.Width <= 750;
+			WindowIsCompact = MainWindow.Instance.Bounds.Width <= DualPaneWidthThreshold;
 		}
 
 		protected override void OnNavigatedTo(NavigationEventArgs eventArgs)


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #7748 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?