### PR TITLE
Code Quality: Reduce splash screen display time for faster startup

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -47,6 +47,7 @@ namespace Files.App
 		private static bool ShowErrorNotification = false;
 		public static string OutputPath { get; set; }
 		public static CommandBarFlyout? LastOpenedFlyout { get; set; }
+		public static bool IsSplashScreenLoading { get; set; }
 
 		public static StorageHistoryWrapper HistoryWrapper { get; } = new();
 		public static AppModel AppModel { get; private set; }
@@ -213,10 +214,8 @@ namespace Files.App
 				// Wait for the Window to initialize
 				await Task.Delay(10);
 
+				IsSplashScreenLoading = true;
 				MainWindow.Instance.ShowSplashScreen();
-
-				// Wait for the UI to update
-				await Task.Delay(500);
 
 				// Get AppActivationArguments
 				var appActivationArguments = Microsoft.Windows.AppLifecycle.AppInstance.GetCurrent().GetActivatedEventArgs();
@@ -234,6 +233,15 @@ namespace Files.App
 				// TODO: Remove App.Logger instance and replace with DI
 				Logger = Ioc.Default.GetRequiredService<ILogger<App>>();
 				Logger.LogInformation($"App launched. Launch args type: {appActivationArguments.Data.GetType().Name}");
+
+				// Wait for the UI to update
+				for (var i = 0; i < 50; i++)
+				{
+					if (IsSplashScreenLoading)
+						await Task.Delay(10);
+					else
+						break;
+				}
 
 				_ = InitializeAppComponentsAsync().ContinueWith(t => Logger.LogWarning(t.Exception, "Error during InitializeAppComponentsAsync()"), TaskContinuationOptions.OnlyOnFaulted);
 

--- a/src/Files.App/Views/SplashScreenPage.xaml
+++ b/src/Files.App/Views/SplashScreenPage.xaml
@@ -12,6 +12,8 @@
 		<Image
 			x:Name="MainSplashScreenImage"
 			Width="420"
+			ImageFailed="Image_ImageFailed"
+			ImageOpened="Image_ImageOpened"
 			Source="\Assets\AppTiles\Dev\SplashScreen.png" />
 
 		<ProgressRing

--- a/src/Files.App/Views/SplashScreenPage.xaml.cs
+++ b/src/Files.App/Views/SplashScreenPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Files.App.Views
@@ -13,6 +14,16 @@ namespace Files.App.Views
 		public SplashScreenPage()
 		{
 			InitializeComponent();
+		}
+
+		private void Image_ImageOpened(object sender, RoutedEventArgs e)
+		{
+			App.IsSplashScreenLoading = false;
+		}
+
+		private void Image_ImageFailed(object sender, RoutedEventArgs e)
+		{
+			App.IsSplashScreenLoading = false;
 		}
 	}
 }


### PR DESCRIPTION
This PR modifies the splash screen loading wait to end as soon as the image loading is complete, rather than fixed at 500 ms.

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?