### PR TITLE
Code Quality: Use TaskCompletionSource for splash screen loading

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -211,6 +211,9 @@ namespace Files.App
 				// Initialize and activate MainWindow
 				EnsureSuperEarlyWindow();
 
+				// Wait for the Window to initialize
+				await Task.Delay(10);
+
 				IsSplashScreenLoading = new TaskCompletionSource();
 				MainWindow.Instance.ShowSplashScreen();
 

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -47,7 +47,7 @@ namespace Files.App
 		private static bool ShowErrorNotification = false;
 		public static string OutputPath { get; set; }
 		public static CommandBarFlyout? LastOpenedFlyout { get; set; }
-		public static TaskCompletionSource IsSplashScreenLoading { get; set; }
+		public static TaskCompletionSource? SplashScreenLoadingTCS { get; set; }
 
 		public static StorageHistoryWrapper HistoryWrapper { get; } = new();
 		public static AppModel AppModel { get; private set; }
@@ -214,7 +214,7 @@ namespace Files.App
 				// Wait for the Window to initialize
 				await Task.Delay(10);
 
-				IsSplashScreenLoading = new TaskCompletionSource();
+				SplashScreenLoadingTCS = new TaskCompletionSource();
 				MainWindow.Instance.ShowSplashScreen();
 
 				// Get AppActivationArguments
@@ -235,7 +235,7 @@ namespace Files.App
 				Logger.LogInformation($"App launched. Launch args type: {appActivationArguments.Data.GetType().Name}");
 
 				// Wait for the UI to update
-				await IsSplashScreenLoading.Task.WithTimeoutAsync(TimeSpan.FromMilliseconds(500));
+				await SplashScreenLoadingTCS.Task.WithTimeoutAsync(TimeSpan.FromMilliseconds(500));
 
 				_ = InitializeAppComponentsAsync().ContinueWith(t => Logger.LogWarning(t.Exception, "Error during InitializeAppComponentsAsync()"), TaskContinuationOptions.OnlyOnFaulted);
 

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -235,7 +235,7 @@ namespace Files.App
 				Logger.LogInformation($"App launched. Launch args type: {appActivationArguments.Data.GetType().Name}");
 
 				// Wait for the UI to update
-				await SplashScreenLoadingTCS.Task.WithTimeoutAsync(TimeSpan.FromMilliseconds(500));
+				await SplashScreenLoadingTCS!.Task.WithTimeoutAsync(TimeSpan.FromMilliseconds(500));
 
 				_ = InitializeAppComponentsAsync().ContinueWith(t => Logger.LogWarning(t.Exception, "Error during InitializeAppComponentsAsync()"), TaskContinuationOptions.OnlyOnFaulted);
 

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -236,6 +236,7 @@ namespace Files.App
 
 				// Wait for the UI to update
 				await SplashScreenLoadingTCS!.Task.WithTimeoutAsync(TimeSpan.FromMilliseconds(500));
+				SplashScreenLoadingTCS = null;
 
 				_ = InitializeAppComponentsAsync().ContinueWith(t => Logger.LogWarning(t.Exception, "Error during InitializeAppComponentsAsync()"), TaskContinuationOptions.OnlyOnFaulted);
 

--- a/src/Files.App/Views/SplashScreenPage.xaml.cs
+++ b/src/Files.App/Views/SplashScreenPage.xaml.cs
@@ -18,12 +18,12 @@ namespace Files.App.Views
 
 		private void Image_ImageOpened(object sender, RoutedEventArgs e)
 		{
-			App.IsSplashScreenLoading = false;
+			App.IsSplashScreenLoading.TrySetResult();
 		}
 
 		private void Image_ImageFailed(object sender, RoutedEventArgs e)
 		{
-			App.IsSplashScreenLoading = false;
+			App.IsSplashScreenLoading.TrySetResult();
 		}
 	}
 }

--- a/src/Files.App/Views/SplashScreenPage.xaml.cs
+++ b/src/Files.App/Views/SplashScreenPage.xaml.cs
@@ -18,12 +18,12 @@ namespace Files.App.Views
 
 		private void Image_ImageOpened(object sender, RoutedEventArgs e)
 		{
-			App.IsSplashScreenLoading.TrySetResult();
+			App.SplashScreenLoadingTCS?.TrySetResult();
 		}
 
 		private void Image_ImageFailed(object sender, RoutedEventArgs e)
 		{
-			App.IsSplashScreenLoading.TrySetResult();
+			App.SplashScreenLoadingTCS?.TrySetResult();
 		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

This PR modifies the splash screen loading wait to use TaskCompletionSource instead of looping. @hishitetsu what do you think?

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
