### PR TITLE
Feature: Added support for renaming network drives

### DIFF
--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -166,7 +166,6 @@ namespace Files.App.Data.Items
 
 			item.Text = type switch
 			{
-				DriveType.Network => $"{root.DisplayName} ({deviceId})",
 				DriveType.CDRom when !string.IsNullOrEmpty(label) => root.DisplayName.Replace(label.Left(32), label),
 				_ => root.DisplayName
 			};

--- a/src/Files.App/Utils/Shell/Win32API.cs
+++ b/src/Files.App/Utils/Shell/Win32API.cs
@@ -511,10 +511,15 @@ namespace Files.App.Utils.Shell
 			RunPowershellCommand($"-command \"$Signature = '[DllImport(\\\"shell32.dll\\\", SetLastError = false)]public static extern uint SHFormatDrive(IntPtr hwnd, uint drive, uint fmtID, uint options);'; $SHFormatDrive = Add-Type -MemberDefinition $Signature -Name \"Win32SHFormatDrive\" -Namespace Win32Functions -PassThru; $SHFormatDrive::SHFormatDrive(0, {driveIndex}, 0xFFFF, 0x0001)\"", true);
 		}
 
-		public static void SetVolumeLabel(string driveName, string newLabel)
+		public static void SetVolumeLabel(string drivePath, string newLabel)
 		{
 			// Rename requires elevation
-			RunPowershellCommand($"-command \"$Signature = '[DllImport(\\\"kernel32.dll\\\", SetLastError = false)]public static extern bool SetVolumeLabel(string lpRootPathName, string lpVolumeName);'; $SetVolumeLabel = Add-Type -MemberDefinition $Signature -Name \"Win32SetVolumeLabel\" -Namespace Win32Functions -PassThru; $SetVolumeLabel::SetVolumeLabel('{driveName}', '{newLabel}')\"", true);
+			RunPowershellCommand($"-command \"$Signature = '[DllImport(\\\"kernel32.dll\\\", SetLastError = false)]public static extern bool SetVolumeLabel(string lpRootPathName, string lpVolumeName);'; $SetVolumeLabel = Add-Type -MemberDefinition $Signature -Name \"Win32SetVolumeLabel\" -Namespace Win32Functions -PassThru; $SetVolumeLabel::SetVolumeLabel('{drivePath}', '{newLabel}')\"", true);
+		}
+
+		public static void SetNetworkDriveLabel(string driveName, string newLabel)
+		{
+			RunPowershellCommand($"-command \"(New-Object -ComObject Shell.Application).NameSpace('{driveName}').Self.Name='{newLabel}'\"", false);
 		}
 
 		public static bool MountVhdDisk(string vhdPath)

--- a/src/Files.App/Views/Properties/GeneralPage.xaml.cs
+++ b/src/Files.App/Views/Properties/GeneralPage.xaml.cs
@@ -84,7 +84,11 @@ namespace Files.App.Views.Properties
 
 				newName = letterRegex.Replace(newName, string.Empty); // Remove "(C:)" from the new label
 
-				Win32API.SetVolumeLabel(drive.Path, newName);
+				if (drive.Type == Data.Items.DriveType.Network)
+					Win32API.SetNetworkDriveLabel(drive.DeviceID, newName);
+				else
+					Win32API.SetVolumeLabel(drive.Path, newName);
+
 				_ = MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
 					await drive.UpdateLabelAsync();


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #6154 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Network drive letters no longer appear in duplicate.
   2. Both regular and network drives can be renamed.