### PR TITLE
Feature: Auto refresh after adding items if no directory watcher exists

### DIFF
--- a/src/Files.App/Actions/FileSystem/CreateShortcutAction.cs
+++ b/src/Files.App/Actions/FileSystem/CreateShortcutAction.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using System.IO;
-
 namespace Files.App.Actions
 {
 	internal class CreateShortcutAction : BaseUIAction, IAction
@@ -30,21 +28,9 @@ namespace Files.App.Actions
 			context.PropertyChanged += Context_PropertyChanged;
 		}
 
-		public async Task ExecuteAsync()
+		public Task ExecuteAsync()
 		{
-			var currentPath = context.ShellPage?.FilesystemViewModel.WorkingDirectory;
-
-			if (App.LibraryManager.TryGetLibrary(currentPath ?? string.Empty, out var library) && !library.IsEmpty)
-				currentPath = library.DefaultSaveFolder;
-
-			foreach (ListedItem selectedItem in context.SelectedItems)
-			{
-				var fileName = string.Format("ShortcutCreateNewSuffix".GetLocalizedResource(), selectedItem.Name) + ".lnk";
-				var filePath = Path.Combine(currentPath ?? string.Empty, fileName);
-
-				if (!await FileOperationsHelpers.CreateOrUpdateLinkAsync(filePath, selectedItem.ItemPath))
-					await UIFilesystemHelpers.HandleShortcutCannotBeCreated(fileName, selectedItem.ItemPath);
-			}
+			return UIFilesystemHelpers.CreateShortcutAsync(context.ShellPage, context.SelectedItems);
 		}
 
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Files.App/ViewModels/LayoutModes/BaseLayoutViewModel.cs
+++ b/src/Files.App/ViewModels/LayoutModes/BaseLayoutViewModel.cs
@@ -170,6 +170,8 @@ namespace Files.App.ViewModels.LayoutModes
 			{
 				await _associatedInstance.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, _associatedInstance.FilesystemViewModel.WorkingDirectory, false, true);
 				e.Handled = true;
+
+				await _associatedInstance.RefreshIfNoWatcherExists();
 			}
 
 			deferral.Complete();

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See the LICENSE.
 
 using Files.App.UserControls.MultitaskingControl;
-using Files.Core.Services;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -485,6 +484,12 @@ namespace Files.App.Views.Shells
 		public Task TabItemDrop(object sender, DragEventArgs e)
 		{
 			return SlimContentPage?.CommandsViewModel.Drop(e);
+		}
+
+		public async Task RefreshIfNoWatcherExists()
+		{
+			if (!FilesystemViewModel.IsWatcherEnabled)
+				await Refresh_Click();
 		}
 
 		public async Task Refresh_Click()

--- a/src/Files.App/Views/Shells/IShellPage.cs
+++ b/src/Files.App/Views/Shells/IShellPage.cs
@@ -25,6 +25,8 @@ namespace Files.App.Views.Shells
 
 		bool CanNavigateForward { get; }
 
+		Task RefreshIfNoWatcherExists();
+
 		Task Refresh_Click();
 
 		void Back_Click();


### PR DESCRIPTION
This doesn't solve the problem of occasional non-refresh on SMB servers, but solves the problem of always non-refresh on locations that don't support directory watchers, such as FTP servers.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related to #5869 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Open a location that doesn't support directory watchers, such as FTP servers.
   2. Add/Paste/Rename/Drop items.
   3. The page will automatically refresh to show the added/changed items.