### PR TITLE
Feature: Disabled keyboard shortcuts when renaming items

### DIFF
--- a/src/Files.App/Data/Commands/HotKey/HotKeyHelpers.cs
+++ b/src/Files.App/Data/Commands/HotKey/HotKeyHelpers.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See the LICENSE.
 
 using Microsoft.UI.Input;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using Windows.System;
 using Windows.UI.Core;
 
@@ -11,56 +9,6 @@ namespace Files.App.Data.Commands
 {
 	internal static class HotKeyHelpers
 	{
-		private static readonly ImmutableArray<Keys> globalKeys = new List<Keys>
-		{
-			Keys.GoHome,
-			Keys.GoBack,
-			Keys.GoForward,
-			Keys.Application,
-			Keys.Favorites,
-			Keys.Search,
-			Keys.Refresh,
-			Keys.Pause,
-			Keys.Sleep,
-			Keys.Print,
-			Keys.F1,
-			Keys.F2,
-			Keys.F3,
-			Keys.F4,
-			Keys.F5,
-			Keys.F6,
-			Keys.F7,
-			Keys.F8,
-			Keys.F9,
-			Keys.F10,
-			Keys.F11,
-			Keys.F12,
-			Keys.F13,
-			Keys.F14,
-			Keys.F15,
-			Keys.F16,
-			Keys.F17,
-			Keys.F18,
-			Keys.F19,
-			Keys.F20,
-			Keys.F21,
-			Keys.F22,
-			Keys.F23,
-			Keys.F24,
-		}.ToImmutableArray();
-
-		private static readonly ImmutableArray<HotKey> textBoxHotKeys = new List<HotKey>
-		{
-			new HotKey(Keys.X, KeyModifiers.Ctrl), // Cut
-			new HotKey(Keys.C, KeyModifiers.Ctrl), // Copy
-			new HotKey(Keys.V, KeyModifiers.Ctrl), // Paste
-			new HotKey(Keys.A, KeyModifiers.Ctrl), // Select all
-			new HotKey(Keys.Z, KeyModifiers.Ctrl), // Cancel
-		}.ToImmutableArray();
-
-		public static bool IsGlobalKey(this Keys key) => globalKeys.Contains(key);
-		public static bool IsTextBoxHotKey(this HotKey hotKey) => textBoxHotKeys.Contains(hotKey);
-
 		public static KeyModifiers GetCurrentKeyModifiers()
 		{
 			var modifiers = VirtualKeyModifiers.None;

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -4,18 +4,13 @@
 using CommunityToolkit.WinUI.Helpers;
 using CommunityToolkit.WinUI.UI;
 using CommunityToolkit.WinUI.UI.Controls;
-using Files.App.Data.Items;
-using Files.App.Data.Models;
-using Files.App.UserControls;
 using Files.App.UserControls.MultitaskingControl;
-using Files.Core.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
-using Microsoft.Windows.ApplicationModel.Resources;
 using System.Runtime.CompilerServices;
 using Windows.ApplicationModel;
 using Windows.Services.Store;
@@ -220,14 +215,8 @@ namespace Files.App.Views
 					HotKey hotKey = new((Keys)e.Key, currentModifiers);
 
 					// A textbox takes precedence over certain hotkeys.
-					bool isTextBox = e.OriginalSource is DependencyObject source && source.FindAscendantOrSelf<TextBox>() is not null;
-					if (isTextBox)
-					{
-						if (hotKey.IsTextBoxHotKey())
-							break;
-						if (currentModifiers is KeyModifiers.None && !hotKey.Key.IsGlobalKey())
-							break;
-					}
+					if (e.OriginalSource is DependencyObject source && source.FindAscendantOrSelf<TextBox>() is not null)
+						break;
 
 					// Execute command for hotkey
 					var command = Commands[hotKey];
@@ -273,7 +262,7 @@ namespace Files.App.Views
 			e.SignalEvent?.Set();
 		}
 
-		private async void SidebarControl_SidebarItemPropertiesInvoked(object sender, SidebarItemPropertiesInvokedEventArgs e)
+		private void SidebarControl_SidebarItemPropertiesInvoked(object sender, SidebarItemPropertiesInvokedEventArgs e)
 		{
 			if (e.InvokedItemDataContext is DriveItem)
 				FilePropertiesHelpers.OpenPropertiesWindow(e.InvokedItemDataContext, SidebarAdaptiveViewModel.PaneHolder.ActivePane);


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12053

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Start renaming an item
   2. Try to use any shortcut (you should consider changing some shortcuts to `Shift + Letter` to test deeper)
