### PR TITLE
Feature: Display keyboard shortcuts in the right click menu

### DIFF
--- a/src/Files.App/Data/Models/ContextMenuFlyoutItemViewModelBuilder.cs
+++ b/src/Files.App/Data/Models/ContextMenuFlyoutItemViewModelBuilder.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Files.App.Data.Commands;
+using Windows.System;
 
 namespace Files.App.Data.Models
 {
@@ -78,6 +78,15 @@ namespace Files.App.Data.Models
 			{
 				viewModel.Glyph = glyph.BaseGlyph;
 				viewModel.GlyphFontFamilyName = glyph.FontFamily;
+			}
+
+			if (command.HotKeys.Length > 0)
+			{
+				viewModel.KeyboardAccelerator = new Microsoft.UI.Xaml.Input.KeyboardAccelerator()
+				{
+					Key = (VirtualKey)command.HotKeys[0].Key,
+					Modifiers = (VirtualKeyModifiers)command.HotKeys[0].Modifier
+				};
 			}
 
 			if (command.HotKeyText is not null)

--- a/src/Files.App/Data/Models/ContextMenuFlyoutItemViewModelBuilder.cs
+++ b/src/Files.App/Data/Models/ContextMenuFlyoutItemViewModelBuilder.cs
@@ -80,17 +80,17 @@ namespace Files.App.Data.Models
 				viewModel.GlyphFontFamilyName = glyph.FontFamily;
 			}
 
-			if (command.HotKeys.Length > 0)
+			if (command.HotKeys.Length > 0 &&
+				!(command.HotKeys[0].Key is Keys.Enter &&
+				command.HotKeys[0].Modifier is KeyModifiers.None))
 			{
 				viewModel.KeyboardAccelerator = new Microsoft.UI.Xaml.Input.KeyboardAccelerator()
 				{
 					Key = (VirtualKey)command.HotKeys[0].Key,
 					Modifiers = (VirtualKeyModifiers)command.HotKeys[0].Modifier
 				};
+				viewModel.KeyboardAcceleratorTextOverride = command.HotKeys[0].Label;
 			}
-
-			if (command.HotKeyText is not null)
-				viewModel.KeyboardAcceleratorTextOverride = command.HotKeyText;
 
 			return viewModel;
 		}

--- a/src/Files.App/Helpers/MenuFlyout/ItemModelListToContextFlyoutHelper.cs
+++ b/src/Files.App/Helpers/MenuFlyout/ItemModelListToContextFlyoutHelper.cs
@@ -1,17 +1,9 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Files.App.UserControls;
-using Files.App.ViewModels;
-using Files.Shared.Extensions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-
 namespace Files.App.Helpers.ContextFlyouts
 {
 	/// <summary>
@@ -255,6 +247,12 @@ namespace Files.App.Helpers.ContextFlyouts
 
 					if (item.IsPrimary || item.CollapseLabel)
 						toggleButton.SetValue(ToolTipService.ToolTipProperty, item.Text);
+
+					if (item.KeyboardAccelerator is not null && item.KeyboardAcceleratorTextOverride is not null)
+					{
+						toggleButton.KeyboardAccelerators.Add(item.KeyboardAccelerator);
+						toggleButton.KeyboardAcceleratorTextOverride = item.KeyboardAcceleratorTextOverride;
+					}
 				}
 			}
 			else
@@ -279,6 +277,12 @@ namespace Files.App.Helpers.ContextFlyouts
 
 					if (item.IsPrimary || item.CollapseLabel)
 						button.SetValue(ToolTipService.ToolTipProperty, item.Text);
+
+					if (item.KeyboardAccelerator is not null && item.KeyboardAcceleratorTextOverride is not null)
+					{
+						button.KeyboardAccelerators.Add(item.KeyboardAccelerator);
+						button.KeyboardAcceleratorTextOverride = item.KeyboardAcceleratorTextOverride;
+					}
 				}
 			}
 


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13055 

When there's more than one shortcut, should the label display all of them?
There's a bug involving `Enter` and I'm working on it (if you hit `Enter`, which is the accelerator for `Open`, it will cut the item, since that's the first button in the menu)

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Right click on a file / empty space

**Screenshots (optional)**
![image](https://github.com/files-community/Files/assets/102259289/42cfe6dc-d25d-4b97-97f6-495eb437e31d)