### PR TITLE
Feature: Added support for opening shortcut files as another user

### DIFF
--- a/src/Files.App/Actions/Content/Run/RunAsAdminAction.cs
+++ b/src/Files.App/Actions/Content/Run/RunAsAdminAction.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Files.App.Utils.Shell;
-
 namespace Files.App.Actions
 {
 	internal class RunAsAdminAction : ObservableObject, IAction
@@ -20,7 +18,9 @@ namespace Files.App.Actions
 
 		public bool IsExecutable =>
 			context.SelectedItem is not null &&
-			FileExtensionHelpers.IsExecutableFile(context.SelectedItem.FileExtension);
+			(FileExtensionHelpers.IsExecutableFile(context.SelectedItem.FileExtension) ||
+			(context.SelectedItem is ShortcutItem shortcut &&
+			shortcut.IsExecutable));
 
 		public RunAsAdminAction()
 		{

--- a/src/Files.App/Actions/Content/Run/RunAsAnotherUserAction.cs
+++ b/src/Files.App/Actions/Content/Run/RunAsAnotherUserAction.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Files.App.Utils.Shell;
-
 namespace Files.App.Actions
 {
 	internal class RunAsAnotherUserAction : ObservableObject, IAction
@@ -11,7 +9,9 @@ namespace Files.App.Actions
 
 		public bool IsExecutable =>
 			context.SelectedItem is not null &&
-			FileExtensionHelpers.IsExecutableFile(context.SelectedItem.FileExtension);
+			(FileExtensionHelpers.IsExecutableFile(context.SelectedItem.FileExtension) ||
+			(context.SelectedItem is ShortcutItem shortcut &&
+			shortcut.IsExecutable));
 
 		public string Label
 			=> "BaseLayoutContextFlyoutRunAsAnotherUser/Text".GetLocalizedResource();


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12457 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Right click a shortcut to an executable
   3. Try `Run as administrator` and `Run as a different user`
   4. Right click a shortcut to file/folder
   5. Check that `Run as administrator` and `Run as a different user` are not visible