### PR TITLE
Feature: Scroll to the selected file when using "Open file location"

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -114,7 +114,8 @@ namespace Files.App.Views.LayoutModes
 				SearchQuery = navigationArguments.SearchQuery,
 				SearchUnindexedItems = navigationArguments.SearchUnindexedItems,
 				SearchPathParam = navigationArguments.SearchPathParam,
-				NavPathParam = path
+				NavPathParam = path,
+				SelectItems = path == navigationArguments.NavPathParam? navigationArguments.SelectItems : null
 			});
 
 			var index = 0;
@@ -125,7 +126,8 @@ namespace Files.App.Views.LayoutModes
 				frame.Navigate(typeof(ColumnShellPage), new ColumnParam
 				{
 					Column = ++index,
-					NavPathParam = path
+					NavPathParam = path,
+					SelectItems = path == navigationArguments.NavPathParam? navigationArguments.SelectItems : null
 				});
 			}
 		}

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -72,9 +72,10 @@ namespace Files.App.Views.LayoutModes
 
 		protected override void ItemManipulationModel_FocusSelectedItemsInvoked(object? sender, EventArgs e)
 		{
-			if (SelectedItems.Any())
+			if (SelectedItems?.Any() ?? false)
 			{
 				FileList.ScrollIntoView(SelectedItems.Last());
+				ContentScroller?.ChangeView(null, FileList.Items.IndexOf(SelectedItems.Last()) * Convert.ToInt32(Application.Current.Resources["ListItemHeight"]), null, false);
 				(FileList.ContainerFromItem(SelectedItems.Last()) as ListViewItem)?.Focus(FocusState.Keyboard);
 			}
 		}

--- a/src/Files.App/Views/Shells/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/Shells/ColumnShellPage.xaml.cs
@@ -66,7 +66,8 @@ namespace Files.App.Views.Shells
 					NavPathParam = ColumnParams.NavPathParam,
 					SearchUnindexedItems = ColumnParams.SearchUnindexedItems,
 					SearchPathParam = ColumnParams.SearchPathParam,
-					AssociatedTabInstance = this
+					AssociatedTabInstance = this,
+					SelectItems = ColumnParams.SelectItems
 				});
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #9390

**Layout**
- Grid/Tiles -> Already implemented
- Details -> Implemented in this PR
- Columns ->Implemented in this PR

**Other fixes**
- `Open file location` was not selecting any item in columns layout

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Right click a shortcut
   3. Click on `Open item location`
