### PR TITLE
Feature: Show error message when copying/moving large file to FAT32

### DIFF
--- a/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
+++ b/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
@@ -280,5 +280,20 @@ namespace Files.App.Helpers
 			});
 			return dialog;
 		}
+
+		public static DynamicDialog GetFor_FileTooLargeDialog(string? sourcePath, string? destinationRoot)
+		{
+			return new DynamicDialog(new DynamicDialogViewModel()
+			{
+				TitleText = "StatusCopyFailed".GetLocalizedResource(),
+				SubtitleText = string.Format(
+					"FileTooLargeDescription".GetLocalizedResource(),
+					sourcePath,
+					destinationRoot
+				),
+				PrimaryButtonText = "OK",
+				DynamicButtons = DynamicDialogButtons.Primary
+			});
+		}
 	}
 }

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3429,4 +3429,7 @@
   <data name="ShortcutItemWorkingDir" xml:space="preserve">
     <value>Start in:</value>
   </data>
+  <data name="FileTooLargeDescription" xml:space="preserve">
+    <value>File "{0}" is too large to be copied to drive "{1}"</value>
+  </data>
 </root>

--- a/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
+++ b/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
@@ -166,6 +166,13 @@ namespace Files.App.Utils.Storage
 								await sourceMatch.Select(x => FileNameConflictResolveOptionType.ReplaceExisting).ToListAsync(), progress, cancellationToken);
 					}
 				}
+				else if (copyResult.Items.FirstOrDefault(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.FileTooLarge) is ShellOperationItemResult failingItem)
+				{
+					await DynamicDialogFactory.GetFor_FileTooLargeDialog(
+						failingItem.Source,
+						Path.GetPathRoot(failingItem.Destination)
+					).TryShowAsync();
+				}
 				// ADS
 				else if (copyResult.Items.All(x => x.HResult == -1))
 				{

--- a/src/Files.Core/Data/Enums/CopyEngineResult.cs
+++ b/src/Files.Core/Data/Enums/CopyEngineResult.cs
@@ -36,7 +36,7 @@ namespace Files.Core.Data.Enums
 		public const int COPYENGINE_E_ALREADY_EXISTS_SYSTEM = -2144927701;
 		public const int COPYENGINE_E_ALREADY_EXISTS_FOLDER = -2144927700;
 		// File too big
-		//public const int COPYENGINE_E_FILE_TOO_LARGE = -2144927731;
+		public const int COPYENGINE_E_FILE_TOO_LARGE = -2144927731;
 		//public const int COPYENGINE_E_REMOVABLE_FULL = -2144927730;
 		//public const int COPYENGINE_E_DISK_FULL = -2144927694;
 		//public const int COPYENGINE_E_DISK_FULL_CLEAN = -2144927693;
@@ -78,6 +78,7 @@ namespace Files.Core.Data.Enums
 				CopyEngineResult.COPYENGINE_E_ALREADY_EXISTS_READONLY => FileSystemStatusCode.AlreadyExists,
 				CopyEngineResult.COPYENGINE_E_ALREADY_EXISTS_SYSTEM => FileSystemStatusCode.AlreadyExists,
 				CopyEngineResult.COPYENGINE_E_ALREADY_EXISTS_FOLDER => FileSystemStatusCode.AlreadyExists,
+				CopyEngineResult.COPYENGINE_E_FILE_TOO_LARGE => FileSystemStatusCode.FileTooLarge,
 				CopyEngineResult.COPYENGINE_E_FILE_IS_FLD_DEST => FileSystemStatusCode.NotAFile,
 				CopyEngineResult.COPYENGINE_E_FLD_IS_FILE_DEST => FileSystemStatusCode.NotAFolder,
 				CopyEngineResult.COPYENGINE_E_SHARING_VIOLATION_SRC => FileSystemStatusCode.InUse,

--- a/src/Files.Core/Data/Enums/FileSystemStatusCode.cs
+++ b/src/Files.Core/Data/Enums/FileSystemStatusCode.cs
@@ -64,6 +64,11 @@ namespace Files.Core.Data.Enums
 		/// <summary>
 		/// InProgress
 		/// </summary>
-		InProgress = 1024
+		InProgress = 1024,
+
+		/// <summary>
+		/// FileTooLarge
+		/// </summary>
+		FileTooLarge = 2048
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #4884 

**Open for discussion**
If there are more "large files", should we show all of them in the dialog?
Should we add a `Continue excluding large files` button?

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Copy a file larger than 4GB
   3. Paste it into a FAT32 drive

**Screenshots (optional)**
![Screenshot 2023-08-06 110719](https://github.com/files-community/Files/assets/102259289/bf3536fa-03b0-4706-b62e-d32a75bf9c59)
