### PR TITLE
Feature: Show BitLocker options in main menu for drives

### DIFF
--- a/src/Files.App/Helpers/MenuFlyout/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/MenuFlyout/ContextFlyoutItemHelper.cs
@@ -1,8 +1,9 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Files.App.Data.Commands;
+using Files.App.Helpers.ContextFlyouts;
 using Files.App.ViewModels.LayoutModes;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System.IO;
 using Windows.Storage;
@@ -75,7 +76,7 @@ namespace Files.App.Helpers
 			SelectedItemsPropertiesViewModel? selectedItemsPropertiesViewModel,
 			List<ListedItem> selectedItems,
 			CurrentInstanceViewModel currentInstanceViewModel,
-			ItemViewModel itemViewModel = null)
+			ItemViewModel? itemViewModel = null)
 		{
 			bool itemsSelected = itemViewModel is null;
 			bool canDecompress = selectedItems.Any() && selectedItems.All(x => x.IsArchive)
@@ -633,6 +634,22 @@ namespace Files.App.Helpers
 			}
 
 			return list;
+		}
+
+		public static void SwapPlaceholderWithShellOption(CommandBarFlyout contextMenu, string placeholderName, ContextMenuFlyoutItemViewModel? replacingItem, int position)
+		{
+			var placeholder = contextMenu.SecondaryCommands.Where(x => Equals((x as AppBarButton)?.Tag, placeholderName)).FirstOrDefault() as AppBarButton;
+			if (placeholder is not null)
+				placeholder.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+
+			if (replacingItem is not null)
+			{
+				var (_, bitLockerCommands) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(new List<ContextMenuFlyoutItemViewModel>() { replacingItem });
+				contextMenu.SecondaryCommands.Insert(
+					position,
+					bitLockerCommands.FirstOrDefault()
+				);
+			}
 		}
 	}
 }

--- a/src/Files.App/Helpers/MenuFlyout/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/MenuFlyout/ContextFlyoutItemHelper.cs
@@ -89,6 +89,8 @@ namespace Files.App.Helpers
 				Path.GetFileName(selectedItems.Count is 1 ? selectedItems[0].ItemPath : Path.GetDirectoryName(selectedItems[0].ItemPath))
 				?? string.Empty;
 
+			bool isDriveRoot = itemViewModel?.CurrentFolder is not null && (itemViewModel.CurrentFolder.ItemPath == Path.GetPathRoot(itemViewModel.CurrentFolder.ItemPath));
+
 			return new List<ContextMenuFlyoutItemViewModel>()
 			{
 				new ContextMenuFlyoutItemViewModel()
@@ -539,6 +541,22 @@ namespace Files.App.Helpers
 					},
 					ShowInSearchPage = true,
 					ShowItem = itemsSelected && userSettingsService.GeneralSettingsService.ShowSendToMenu
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
+					Text = "TurnOnBitLocker".GetLocalizedResource(),
+					Tag = "TurnOnBitLockerPlaceholder",
+					CollapseLabel = true,
+					IsEnabled = false,
+					ShowItem = isDriveRoot
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
+					Text = "ManageBitLocker".GetLocalizedResource(),
+					Tag = "ManageBitLockerPlaceholder",
+					CollapseLabel = true,
+					ShowItem = isDriveRoot,
+					IsEnabled = false
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{

--- a/src/Files.App/Helpers/MenuFlyout/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/MenuFlyout/ContextFlyoutItemHelper.cs
@@ -638,7 +638,9 @@ namespace Files.App.Helpers
 
 		public static void SwapPlaceholderWithShellOption(CommandBarFlyout contextMenu, string placeholderName, ContextMenuFlyoutItemViewModel? replacingItem, int position)
 		{
-			var placeholder = contextMenu.SecondaryCommands.Where(x => Equals((x as AppBarButton)?.Tag, placeholderName)).FirstOrDefault() as AppBarButton;
+			var placeholder = contextMenu.SecondaryCommands
+															.Where(x => Equals((x as AppBarButton)?.Tag, placeholderName))
+															.FirstOrDefault() as AppBarButton;
 			if (placeholder is not null)
 				placeholder.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
 

--- a/src/Files.App/Helpers/MenuFlyout/ShellContextMenuHelper.cs
+++ b/src/Files.App/Helpers/MenuFlyout/ShellContextMenuHelper.cs
@@ -269,6 +269,38 @@ namespace Files.App.Helpers
 					(showSendToMenu || !UserSettingsService.GeneralSettingsService.ShowSendToMenu))
 					shellMenuItems.Remove(sendToItem);
 
+				var turnOnBitLocker = shellMenuItems.FirstOrDefault(x => x.Tag is Win32ContextMenuItem { CommandString: "encrypt-bde-elev" });
+				var turnOnBitLockerPlaceholder = itemContextMenuFlyout.SecondaryCommands.Where(x => Equals((x as AppBarButton)?.Tag, "TurnOnBitLockerPlaceholder")).FirstOrDefault() as AppBarButton;
+				if (turnOnBitLockerPlaceholder is not null)
+					turnOnBitLockerPlaceholder.Visibility = Visibility.Collapsed;
+
+				if (turnOnBitLocker is not null)
+				{
+					shellMenuItems.Remove(turnOnBitLocker);
+
+					var (_, bitLockerCommands) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(new List<ContextMenuFlyoutItemViewModel>() { turnOnBitLocker });
+					itemContextMenuFlyout.SecondaryCommands.Insert(
+						itemContextMenuFlyout.SecondaryCommands.Count - 2,
+						bitLockerCommands.FirstOrDefault()
+					);
+				}
+
+				var manageBitLocker = shellMenuItems.FirstOrDefault(x => x.Tag is Win32ContextMenuItem { CommandString: "manage-bde" });
+				var manageBitLockerPlaceholder = itemContextMenuFlyout.SecondaryCommands.Where(x => Equals((x as AppBarButton)?.Tag, "ManageBitLockerPlaceholder")).FirstOrDefault() as AppBarButton;
+				if (manageBitLockerPlaceholder is not null)
+					manageBitLockerPlaceholder.Visibility = Visibility.Collapsed;
+
+				if (manageBitLocker is not null)
+				{
+					shellMenuItems.Remove(manageBitLocker);
+
+					var (_, manageBitLockerCommands) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(new List<ContextMenuFlyoutItemViewModel>() { manageBitLocker });
+					itemContextMenuFlyout.SecondaryCommands.Insert(
+						itemContextMenuFlyout.SecondaryCommands.Count - 2,
+						manageBitLockerCommands.FirstOrDefault()
+					);
+				}
+
 				sendToItem = showSendToMenu && UserSettingsService.GeneralSettingsService.ShowSendToMenu ? sendToItem : null;
 
 				if (!UserSettingsService.GeneralSettingsService.MoveShellExtensionsToSubMenu)

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3429,4 +3429,10 @@
   <data name="ShortcutItemWorkingDir" xml:space="preserve">
     <value>Start in:</value>
   </data>
+  <data name="TurnOnBitLocker" xml:space="preserve">
+    <value>Turn on BitLocker</value>	
+  </data>
+  <data name="ManageBitLocker" xml:space="preserve">
+    <value>Manage BitLocker</value>
+  </data>
 </root>

--- a/src/Files.App/UserControls/SidebarControl.xaml.cs
+++ b/src/Files.App/UserControls/SidebarControl.xaml.cs
@@ -303,6 +303,20 @@ namespace Files.App.UserControls
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
+					Text = "TurnOnBitLocker".GetLocalizedResource(),
+					Tag = "TurnOnBitLockerPlaceholder",
+					ShowItem = isDriveItem,
+					IsEnabled = false
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
+					Text = "ManageBitLocker".GetLocalizedResource(),
+					Tag = "ManageBitLockerPlaceholder",
+					ShowItem = isDriveItem,
+					IsEnabled = false
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
 					ItemType = ContextMenuFlyoutItemType.Separator,
 					Tag = "OverflowSeparator",
 					IsHidden = !options.ShowShellItems,

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -244,6 +244,18 @@ namespace Files.App.UserControls.Widgets
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
+					Text = "TurnOnBitLocker".GetLocalizedResource(),
+					Tag = "TurnOnBitLockerPlaceholder",
+					IsEnabled = false
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
+					Text = "ManageBitLocker".GetLocalizedResource(),
+					Tag = "ManageBitLockerPlaceholder",
+					IsEnabled = false
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
 					ItemType = ContextMenuFlyoutItemType.Separator,
 					Tag = "OverflowSeparator",
 				},

--- a/src/Files.App/Views/LayoutModes/BaseLayout.cs
+++ b/src/Files.App/Views/LayoutModes/BaseLayout.cs
@@ -723,7 +723,9 @@ namespace Files.App.Views.LayoutModes
 		{
 			var openWithMenuItem = shellMenuItems.FirstOrDefault(x => x.Tag is Win32ContextMenuItem { CommandString: "openas" });
 			var sendToMenuItem = shellMenuItems.FirstOrDefault(x => x.Tag is Win32ContextMenuItem { CommandString: "sendto" });
-			var shellMenuItemsFiltered = shellMenuItems.Where(x => x != openWithMenuItem && x != sendToMenuItem).ToList();
+			var turnOnBitLockerMenuItem = shellMenuItems.FirstOrDefault(x => x.Tag is Win32ContextMenuItem { CommandString: "encrypt-bde-elev" });
+			var manageBitLockerMenuItem = shellMenuItems.FirstOrDefault(x => x.Tag is Win32ContextMenuItem { CommandString: "manage-bde" });
+			var shellMenuItemsFiltered = shellMenuItems.Where(x => x != openWithMenuItem && x != sendToMenuItem && x != turnOnBitLockerMenuItem && x != manageBitLockerMenuItem).ToList();
 			var mainShellMenuItems = shellMenuItemsFiltered.RemoveFrom(!UserSettingsService.GeneralSettingsService.MoveShellExtensionsToSubMenu ? int.MaxValue : shiftPressed ? 6 : 0);
 			var overflowShellMenuItemsUnfiltered = shellMenuItemsFiltered.Except(mainShellMenuItems).ToList();
 			var overflowShellMenuItems = overflowShellMenuItemsUnfiltered.Where(
@@ -754,6 +756,32 @@ namespace Files.App.Views.LayoutModes
 
 				// Set items max width to current menu width (#5555)
 				mainItems.OfType<FrameworkElement>().ForEach(x => x.MaxWidth = itemsControl.ActualWidth - Constants.UI.ContextMenuLabelMargin);
+			}
+
+			var turnOnBitLockerPlaceholder = contextMenuFlyout.SecondaryCommands.Where(x => Equals((x as AppBarButton)?.Tag, "TurnOnBitLockerPlaceholder")).FirstOrDefault() as AppBarButton;
+			if (turnOnBitLockerPlaceholder is not null)
+				turnOnBitLockerPlaceholder.Visibility = Visibility.Collapsed;
+
+			if (turnOnBitLockerMenuItem is not null)
+			{
+				var (_, bitLockerCommands) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(new List<ContextMenuFlyoutItemViewModel>() { turnOnBitLockerMenuItem });
+				contextMenuFlyout.SecondaryCommands.Insert(
+					contextMenuFlyout.SecondaryCommands.Count - 2,
+					bitLockerCommands.FirstOrDefault()
+				);
+			}
+
+			var manageBitLockerPlaceholder = contextMenuFlyout.SecondaryCommands.Where(x => Equals((x as AppBarButton)?.Tag, "ManageBitLockerPlaceholder")).FirstOrDefault() as AppBarButton;
+			if (manageBitLockerPlaceholder is not null)
+				manageBitLockerPlaceholder.Visibility = Visibility.Collapsed;
+
+			if (manageBitLockerMenuItem is not null)
+			{
+				var (_, manageBitLockerCommands) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(new List<ContextMenuFlyoutItemViewModel>() { manageBitLockerMenuItem });
+				contextMenuFlyout.SecondaryCommands.Insert(
+					contextMenuFlyout.SecondaryCommands.Count - 2,
+					manageBitLockerCommands.FirstOrDefault()
+				);
 			}
 
 			var overflowItem = contextMenuFlyout.SecondaryCommands.FirstOrDefault(x => x is AppBarButton appBarButton && (appBarButton.Tag as string) == "ItemOverflow") as AppBarButton;

--- a/src/Files.App/Views/LayoutModes/BaseLayout.cs
+++ b/src/Files.App/Views/LayoutModes/BaseLayout.cs
@@ -758,31 +758,18 @@ namespace Files.App.Views.LayoutModes
 				mainItems.OfType<FrameworkElement>().ForEach(x => x.MaxWidth = itemsControl.ActualWidth - Constants.UI.ContextMenuLabelMargin);
 			}
 
-			var turnOnBitLockerPlaceholder = contextMenuFlyout.SecondaryCommands.Where(x => Equals((x as AppBarButton)?.Tag, "TurnOnBitLockerPlaceholder")).FirstOrDefault() as AppBarButton;
-			if (turnOnBitLockerPlaceholder is not null)
-				turnOnBitLockerPlaceholder.Visibility = Visibility.Collapsed;
-
-			if (turnOnBitLockerMenuItem is not null)
-			{
-				var (_, bitLockerCommands) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(new List<ContextMenuFlyoutItemViewModel>() { turnOnBitLockerMenuItem });
-				contextMenuFlyout.SecondaryCommands.Insert(
-					contextMenuFlyout.SecondaryCommands.Count - 2,
-					bitLockerCommands.FirstOrDefault()
-				);
-			}
-
-			var manageBitLockerPlaceholder = contextMenuFlyout.SecondaryCommands.Where(x => Equals((x as AppBarButton)?.Tag, "ManageBitLockerPlaceholder")).FirstOrDefault() as AppBarButton;
-			if (manageBitLockerPlaceholder is not null)
-				manageBitLockerPlaceholder.Visibility = Visibility.Collapsed;
-
-			if (manageBitLockerMenuItem is not null)
-			{
-				var (_, manageBitLockerCommands) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(new List<ContextMenuFlyoutItemViewModel>() { manageBitLockerMenuItem });
-				contextMenuFlyout.SecondaryCommands.Insert(
-					contextMenuFlyout.SecondaryCommands.Count - 2,
-					manageBitLockerCommands.FirstOrDefault()
-				);
-			}
+			ContextFlyoutItemHelper.SwapPlaceholderWithShellOption(
+				contextMenuFlyout,
+				"TurnOnBitLockerPlaceholder",
+				turnOnBitLockerMenuItem,
+				contextMenuFlyout.SecondaryCommands.Count - 2
+			);
+			ContextFlyoutItemHelper.SwapPlaceholderWithShellOption(
+				contextMenuFlyout,
+				"ManageBitLockerPlaceholder",
+				manageBitLockerMenuItem,
+				contextMenuFlyout.SecondaryCommands.Count - 2
+			);
 
 			var overflowItem = contextMenuFlyout.SecondaryCommands.FirstOrDefault(x => x is AppBarButton appBarButton && (appBarButton.Tag as string) == "ItemOverflow") as AppBarButton;
 			if (overflowItem is not null)


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11303 

**Moved options**
- Turn on BitLocker
- Manage BitLocker

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Right click on a local drive (Home, Sidebar or root folder)
   3. See that BitLocker options are visible in the main menu
   4. Right click a cloud drive (e.g. Google Drive)
   5. See that BitLocker options are not visible