### PR TITLE
Fix: Fixed issue where the back button in the Properties window wasn't working properly

### DIFF
--- a/src/Files.App/ViewModels/Properties/MainPropertiesViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/MainPropertiesViewModel.cs
@@ -22,8 +22,7 @@ namespace Files.App.ViewModels.Properties
 			set
 			{
 				if (SetProperty(ref _SelectedNavigationViewItem, value) &&
-					!_selectionChangedAutomatically &&
-					_previousPageName != value.ItemType.ToString())
+					!_selectionChangedAutomatically)
 				{
 					var parameter = new PropertiesPageNavigationParameter()
 					{
@@ -90,8 +89,6 @@ namespace Files.App.ViewModels.Properties
 
 		private bool _selectionChangedAutomatically { get; set; }
 
-		private string _previousPageName { get; set; }
-
 		public IRelayCommand DoBackwardNavigationCommand { get; }
 		public IAsyncRelayCommand SaveChangedPropertiesCommand { get; }
 		public IRelayCommand CancelChangedPropertiesCommand { get; }
@@ -127,12 +124,12 @@ namespace Files.App.ViewModels.Properties
 			var pageTag = ((Page)_mainFrame.Content).Tag.ToString();
 
 			_selectionChangedAutomatically = true;
-			_previousPageName = pageTag;
 
 			// Move selection indicator
-			SelectedNavigationViewItem =
+			_SelectedNavigationViewItem =
 				NavigationViewItems.First(x => string.Equals(x.ItemType.ToString(), pageTag, StringComparison.CurrentCultureIgnoreCase))
 				?? NavigationViewItems.First();
+			OnPropertyChanged(nameof(SelectedNavigationViewItem));
 		}
 
 		private async Task ExecuteSaveChangedPropertiesCommand()


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12277 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Open a properties window.
   2. Click Security.
   3. Click Advanced permissions.
   4. Click the back button.
   5. Click General.
   6. Click Security.
   7. The security page will be displayed properly. 