### PR TITLE
Fix: Fixed crash that would occur when deleting or restoring files

### DIFF
--- a/src/Files.App/Data/Items/LocationItem.cs
+++ b/src/Files.App/Data/Items/LocationItem.cs
@@ -87,7 +87,7 @@ namespace Files.App.Data.Items
 		public bool IsHeader { get; set; }
 
 		private object toolTip = "";
-		public object ToolTip
+		public virtual object ToolTip
 		{
 			get => toolTip;
 			set
@@ -109,7 +109,10 @@ namespace Files.App.Data.Items
 	{
 		public void RefreshSpaceUsed(object sender, FileSystemEventArgs e)
 		{
-			SpaceUsed = RecycleBinHelpers.GetSize();
+			MainWindow.Instance.DispatcherQueue.TryEnqueue(() =>
+			{
+				SpaceUsed = RecycleBinHelpers.GetSize();
+			});
 		}
 
 		private ulong spaceUsed;
@@ -118,8 +121,14 @@ namespace Files.App.Data.Items
 			get => spaceUsed;
 			set
 			{
-				SetProperty(ref spaceUsed, value);
+				if (SetProperty(ref spaceUsed, value))
+					OnPropertyChanged(nameof(ToolTip));
 			}
+		}
+
+		public override object ToolTip
+		{
+			get => SpaceUsed.ToSizeString();
 		}
 
 		public RecycleBinLocationItem()

--- a/src/Files.App/Data/Models/SidebarPinnedModel.cs
+++ b/src/Files.App/Data/Models/SidebarPinnedModel.cs
@@ -97,11 +97,6 @@ namespace Files.App.Data.Models
 			locationItem.IsDefaultLocation = false;
 			locationItem.Text = res.Result?.DisplayName ?? Path.GetFileName(path.TrimEnd('\\'));
 
-			if(locationItem is RecycleBinLocationItem recycleBinItem)
-			{
-				recycleBinItem.ToolTip = recycleBinItem.SpaceUsed.ToSizeString();
-			}
-
 			if (res || (FilesystemResult)FolderHelpers.CheckFolderAccessWithWin32(path))
 			{
 				locationItem.IsInvalid = false;


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13192 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Deleting one or multiple files does not crash the app
   2. Restoring a file from the recycle bin does not crash the app
   3. Permanently deleting a file from the recycle bin does no crash the app
   4. Deleting/Restoring a file updates the Tooltip of the Sidebar item
