### PR TITLE
Fix: Fixed issue where deleted items were displayed in tag search results

### DIFF
--- a/src/Files.App/Services/FileTagsService.cs
+++ b/src/Files.App/Services/FileTagsService.cs
@@ -42,7 +42,7 @@ namespace Files.App.Services
 		{
 			foreach (var item in FileTagsHelper.GetDbInstance().GetAll())
 			{
-				if (!item.Tags.Contains(tagUid))
+				if (!item.Tags.Contains(tagUid) || RecycleBinHelpers.IsPathUnderRecycleBin(item.FilePath))
 					continue;
 
 				var storable = await StorageService.TryGetStorableAsync(item.FilePath, cancellationToken);

--- a/src/Files.App/Utils/Storage/Search/FolderSearch.cs
+++ b/src/Files.App/Utils/Storage/Search/FolderSearch.cs
@@ -198,6 +198,8 @@ namespace Files.App.Utils.Storage
 			var dbInstance = FileTagsHelper.GetDbInstance();
 			var matches = dbInstance.GetAllUnderPath(folder)
 				.Where(x => tags.All(x.Tags.Contains));
+			if (string.IsNullOrEmpty(folder))
+				matches = matches.Where(x => !RecycleBinHelpers.IsPathUnderRecycleBin(x.FilePath));
 
 			foreach (var match in matches)
 			{


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13193 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Deleted items are no longer displayed in the tags widget.
   2. If you press `View more` buttons or `Tags` sidebar items, you will notice deleted items are no longer displayed in tag search results.