### PR TITLE
Feature: Lazy load Git properties for better performance

### DIFF
--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -569,6 +569,13 @@ namespace Files.App.Utils
 
 	public class GitItem : ListedItem
 	{
+		private volatile int gitPropertiesInitialized = 0;
+		public bool GitPropertiesInitialized
+		{
+			get => gitPropertiesInitialized == 1;
+			set => Interlocked.Exchange(ref gitPropertiesInitialized, value ? 1 : 0);
+		}
+
 		private Style? _UnmergedGitStatusIcon;
 		public Style? UnmergedGitStatusIcon
 		{

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -569,11 +569,18 @@ namespace Files.App.Utils
 
 	public class GitItem : ListedItem
 	{
-		private volatile int gitPropertiesInitialized = 0;
-		public bool GitPropertiesInitialized
+		private volatile int statusPropertiesInitialized = 0;
+		public bool StatusPropertiesInitialized
 		{
-			get => gitPropertiesInitialized == 1;
-			set => Interlocked.Exchange(ref gitPropertiesInitialized, value ? 1 : 0);
+			get => statusPropertiesInitialized == 1;
+			set => Interlocked.Exchange(ref statusPropertiesInitialized, value ? 1 : 0);
+		}
+
+		private volatile int commitPropertiesInitialized = 0;
+		public bool CommitPropertiesInitialized
+		{
+			get => commitPropertiesInitialized == 1;
+			set => Interlocked.Exchange(ref commitPropertiesInitialized, value ? 1 : 0);
 		}
 
 		private Style? _UnmergedGitStatusIcon;

--- a/src/Files.App/Data/Models/GitItemModel.cs
+++ b/src/Files.App/Data/Models/GitItemModel.cs
@@ -14,7 +14,7 @@ namespace Files.App.Data.Models
 		/// <remarks>
 		/// This is often showed as A(Added), D(Deleted), M(Modified), U(Untracked) in VS Code.
 		/// </remarks>
-		public ChangeKind Status { get; init; }
+		public ChangeKind? Status { get; init; }
 		
 		/// <summary>
 		/// Gets or initializes file change kind icon

--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -75,11 +75,12 @@ namespace Files.App.Data.Models
 			get => _EnabledGitProperties;
 			set
 			{
-				if (SetProperty(ref _EnabledGitProperties, value) && value != GitProperties.None)
+				if (SetProperty(ref _EnabledGitProperties, value) && value is not GitProperties.None)
 				{
 					filesAndFolders.ToList().ForEach(async item => {
 						if (item is GitItem gitItem &&
-							!(gitItem.StatusPropertiesInitialized && gitItem.CommitPropertiesInitialized))
+							(!gitItem.StatusPropertiesInitialized && value is GitProperties.All or GitProperties.Status
+							|| !gitItem.CommitPropertiesInitialized && value is GitProperties.All or GitProperties.Commit))
 						{
 							try
 							{

--- a/src/Files.App/Services/Settings/FoldersSettingsService.cs
+++ b/src/Files.App/Services/Settings/FoldersSettingsService.cs
@@ -215,7 +215,7 @@ namespace Files.App.Services.Settings
 
 		public bool ShowGitCommitAuthorColumn
 		{
-			get => Get(true);
+			get => Get(false);
 			set => Set(value);
 		}
 

--- a/src/Files.App/Views/LayoutModes/BaseLayout.cs
+++ b/src/Files.App/Views/LayoutModes/BaseLayout.cs
@@ -473,6 +473,9 @@ namespace Files.App.Views.LayoutModes
 
 			ItemContextMenuFlyout.Opening += ItemContextFlyout_Opening;
 			BaseContextMenuFlyout.Opening += BaseContextFlyout_Opening;
+
+			// Git properties are not loaded by default
+			ParentShellPageInstance.FilesystemViewModel.IsGitPropertiesEnabled = false;
 		}
 
 		public void SetSelectedItemsOnNavigation()

--- a/src/Files.App/Views/LayoutModes/BaseLayout.cs
+++ b/src/Files.App/Views/LayoutModes/BaseLayout.cs
@@ -475,7 +475,7 @@ namespace Files.App.Views.LayoutModes
 			BaseContextMenuFlyout.Opening += BaseContextFlyout_Opening;
 
 			// Git properties are not loaded by default
-			ParentShellPageInstance.FilesystemViewModel.IsGitPropertiesEnabled = false;
+			ParentShellPageInstance.FilesystemViewModel.EnabledGitProperties = GitProperties.None;
 		}
 
 		public void SetSelectedItemsOnNavigation()

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -123,12 +123,7 @@ namespace Files.App.Views.LayoutModes
 				ColumnsViewModel.GitLastCommitShaColumn = FolderSettings.ColumnsViewModel.GitLastCommitShaColumn;
 			}
 
-			ParentShellPageInstance.FilesystemViewModel.IsGitPropertiesEnabled =
-				!ColumnsViewModel.GitStatusColumn.IsHidden && !ColumnsViewModel.GitStatusColumn.UserCollapsed
-				|| !ColumnsViewModel.GitLastCommitDateColumn.IsHidden && !ColumnsViewModel.GitLastCommitDateColumn.UserCollapsed
-				|| !ColumnsViewModel.GitLastCommitMessageColumn.IsHidden && !ColumnsViewModel.GitLastCommitMessageColumn.UserCollapsed
-				|| !ColumnsViewModel.GitCommitAuthorColumn.IsHidden && !ColumnsViewModel.GitCommitAuthorColumn.UserCollapsed
-				|| !ColumnsViewModel.GitLastCommitShaColumn.IsHidden && !ColumnsViewModel.GitLastCommitShaColumn.UserCollapsed;
+			ParentShellPageInstance.FilesystemViewModel.EnabledGitProperties = GetEnabledGitProperties(ColumnsViewModel);
 
 			currentIconSize = FolderSettings.GetIconSize();
 			FolderSettings.LayoutModeChangeRequested += FolderSettings_LayoutModeChangeRequested;
@@ -565,13 +560,7 @@ namespace Files.App.Views.LayoutModes
 		private void ToggleMenuFlyoutItem_Click(object sender, RoutedEventArgs e)
 		{
 			FolderSettings.ColumnsViewModel = ColumnsViewModel;
-
-			ParentShellPageInstance.FilesystemViewModel.IsGitPropertiesEnabled =
-				!ColumnsViewModel.GitStatusColumn.IsHidden && !ColumnsViewModel.GitStatusColumn.UserCollapsed
-				|| !ColumnsViewModel.GitLastCommitDateColumn.IsHidden && !ColumnsViewModel.GitLastCommitDateColumn.UserCollapsed
-				|| !ColumnsViewModel.GitLastCommitMessageColumn.IsHidden && !ColumnsViewModel.GitLastCommitMessageColumn.UserCollapsed
-				|| !ColumnsViewModel.GitCommitAuthorColumn.IsHidden && !ColumnsViewModel.GitCommitAuthorColumn.UserCollapsed
-				|| !ColumnsViewModel.GitLastCommitShaColumn.IsHidden && !ColumnsViewModel.GitLastCommitShaColumn.UserCollapsed;
+			ParentShellPageInstance.FilesystemViewModel.EnabledGitProperties = GetEnabledGitProperties(ColumnsViewModel);
 		}
 
 		private void GridSplitter_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
@@ -895,6 +884,22 @@ namespace Files.App.Views.LayoutModes
 			// Fixes an issue where clicking an empty space would scroll to the top of the file list
 			if (args.NewFocusedElement == FileList)
 				args.TryCancel();
+		}
+
+		private static GitProperties GetEnabledGitProperties(ColumnsViewModel columnsViewModel)
+		{
+			var enableStatus = !columnsViewModel.GitStatusColumn.IsHidden && !columnsViewModel.GitStatusColumn.UserCollapsed;
+			var enableCommit = !columnsViewModel.GitLastCommitDateColumn.IsHidden && !columnsViewModel.GitLastCommitDateColumn.UserCollapsed
+				|| !columnsViewModel.GitLastCommitMessageColumn.IsHidden && !columnsViewModel.GitLastCommitMessageColumn.UserCollapsed
+				|| !columnsViewModel.GitCommitAuthorColumn.IsHidden && !columnsViewModel.GitCommitAuthorColumn.UserCollapsed
+				|| !columnsViewModel.GitLastCommitShaColumn.IsHidden && !columnsViewModel.GitLastCommitShaColumn.UserCollapsed;
+			return (enableStatus, enableCommit) switch
+			{
+				(true, true) => GitProperties.All,
+				(true, false) => GitProperties.Status,
+				(false, true) => GitProperties.Commit,
+				(false, false) => GitProperties.None
+			};
 		}
 	}
 }

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See the LICENSE.
 
 using CommunityToolkit.WinUI.UI;
-using Files.App.Data.Commands;
 using Files.App.UserControls.Selection;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
@@ -123,6 +122,13 @@ namespace Files.App.Views.LayoutModes
 				ColumnsViewModel.GitCommitAuthorColumn = FolderSettings.ColumnsViewModel.GitCommitAuthorColumn;
 				ColumnsViewModel.GitLastCommitShaColumn = FolderSettings.ColumnsViewModel.GitLastCommitShaColumn;
 			}
+
+			ParentShellPageInstance.FilesystemViewModel.IsGitPropertiesEnabled =
+				!ColumnsViewModel.GitStatusColumn.IsHidden && !ColumnsViewModel.GitStatusColumn.UserCollapsed
+				|| !ColumnsViewModel.GitLastCommitDateColumn.IsHidden && !ColumnsViewModel.GitLastCommitDateColumn.UserCollapsed
+				|| !ColumnsViewModel.GitLastCommitMessageColumn.IsHidden && !ColumnsViewModel.GitLastCommitMessageColumn.UserCollapsed
+				|| !ColumnsViewModel.GitCommitAuthorColumn.IsHidden && !ColumnsViewModel.GitCommitAuthorColumn.UserCollapsed
+				|| !ColumnsViewModel.GitLastCommitShaColumn.IsHidden && !ColumnsViewModel.GitLastCommitShaColumn.UserCollapsed;
 
 			currentIconSize = FolderSettings.GetIconSize();
 			FolderSettings.LayoutModeChangeRequested += FolderSettings_LayoutModeChangeRequested;
@@ -559,6 +565,13 @@ namespace Files.App.Views.LayoutModes
 		private void ToggleMenuFlyoutItem_Click(object sender, RoutedEventArgs e)
 		{
 			FolderSettings.ColumnsViewModel = ColumnsViewModel;
+
+			ParentShellPageInstance.FilesystemViewModel.IsGitPropertiesEnabled =
+				!ColumnsViewModel.GitStatusColumn.IsHidden && !ColumnsViewModel.GitStatusColumn.UserCollapsed
+				|| !ColumnsViewModel.GitLastCommitDateColumn.IsHidden && !ColumnsViewModel.GitLastCommitDateColumn.UserCollapsed
+				|| !ColumnsViewModel.GitLastCommitMessageColumn.IsHidden && !ColumnsViewModel.GitLastCommitMessageColumn.UserCollapsed
+				|| !ColumnsViewModel.GitCommitAuthorColumn.IsHidden && !ColumnsViewModel.GitCommitAuthorColumn.UserCollapsed
+				|| !ColumnsViewModel.GitLastCommitShaColumn.IsHidden && !ColumnsViewModel.GitLastCommitShaColumn.UserCollapsed;
 		}
 
 		private void GridSplitter_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13182 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   Git properties will not be loaded in the following cases.
      * The layout is other than the details layout.
      * All Git columns are hidden in the details layout.
   When the above cases are no longer met, Git properties loading will begin.