### PR TITLE
Fix: Fixed issue where some archives wouldn't be extracted properly

### DIFF
--- a/src/Files.App/Utils/Archives/ZipHelpers.cs
+++ b/src/Files.App/Utils/Archives/ZipHelpers.cs
@@ -94,7 +94,9 @@ namespace Files.App.Utils.Archives
 				if (cancellationToken.IsCancellationRequested) // Check if canceled
 					return;
 
-				string filePath = Path.Combine(destinationFolder.Path, entry.FileName);
+				var filePath = destinationFolder.Path;
+				foreach (var component in entry.FileName.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+					filePath = Path.Combine(filePath, component);
 
 				var hFile = NativeFileOperationsHelper.CreateFileForWrite(filePath);
 				if (hFile.IsInvalid)

--- a/src/Files.App/Utils/Storage/StorageItems/ZipStorageFolder.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/ZipStorageFolder.cs
@@ -228,7 +228,7 @@ namespace Files.App.Utils.Storage
 				var items = new List<IStorageItem>();
 				foreach (var entry in zipFile.ArchiveFileData) // Returns all items recursively
 				{
-					string winPath = System.IO.Path.GetFullPath(System.IO.Path.Combine(containerPath, entry.FileName));
+					string winPath = System.IO.Path.Combine(System.IO.Path.GetFullPath(containerPath), entry.FileName);
 					if (winPath.StartsWith(Path.WithEnding("\\"), StringComparison.Ordinal)) // Child of self
 					{
 						var split = winPath.Substring(Path.Length).Split('\\', StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12672 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   The problem occurs if the archive has a directory ending with space.
   Here is a sample zip file, an excerpt from the attached one in #12672. This has `Lesson 06 ` (not `Lesson 06`) folder and it causes the problem.
   [test.zip](https://github.com/files-community/Files/files/12395166/test.zip)
   This archive will now be extracted properly.
   This PR also fixes the issue where `Lesson06 ` is listed as a file aside from a folder when browsing inside the archive.