### PR TITLE
Feature: Load network icon instead of a folder icon

### DIFF
--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Storage;
+using Windows.Storage.FileProperties;
 using Windows.Storage.Streams;
 using ByteSize = ByteSizeLib.ByteSize;
 
@@ -292,8 +293,11 @@ namespace Files.App.Data.Items
 			}
 			else
 			{
-				if (!string.IsNullOrEmpty(DeviceID) && !string.Equals(DeviceID, "network-folder"))
-					IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(DeviceID, 24);
+				if (string.Equals(DeviceID, "network-folder"))
+					IconData ??= await FileThumbnailHelper.LoadIconFromStorageItemAsync(Root, 16u, ThumbnailMode.ListView, ThumbnailOptions.UseCurrentScale);
+
+				if (!string.IsNullOrEmpty(DeviceID))
+					IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(DeviceID, 16);
 
 				if (Root is not null)
 				{

--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -6,12 +6,10 @@ using Files.Core.Storage;
 using Files.Core.Storage.Enums;
 using Files.Core.Storage.LocatableStorage;
 using Files.Core.Storage.NestedStorage;
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Storage;
-using Windows.Storage.FileProperties;
 using Windows.Storage.Streams;
 using ByteSize = ByteSizeLib.ByteSize;
 
@@ -293,10 +291,7 @@ namespace Files.App.Data.Items
 			}
 			else
 			{
-				if (string.Equals(DeviceID, "network-folder"))
-					IconData ??= await FileThumbnailHelper.LoadIconFromStorageItemAsync(Root, 16u, ThumbnailMode.ListView, ThumbnailOptions.UseCurrentScale);
-
-				if (!string.IsNullOrEmpty(DeviceID))
+				if (!string.IsNullOrEmpty(DeviceID) && !string.Equals(DeviceID, "network-folder"))
 					IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(DeviceID, 16);
 
 				if (Root is not null)
@@ -304,6 +299,10 @@ namespace Files.App.Data.Items
 					using var thumbnail = await DriveHelpers.GetThumbnailAsync(Root);
 					IconData ??= await thumbnail.ToByteArrayAsync();
 				}
+
+				if (string.Equals(DeviceID, "network-folder"))
+					IconData ??= UIHelpers.GetSidebarIconResourceInfo(Constants.ImageRes.NetworkDrives).IconData;
+
 				IconData ??= UIHelpers.GetSidebarIconResourceInfo(Constants.ImageRes.Folder).IconData;
 			}
 			Icon ??= await IconData.ToBitmapAsync();


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13219...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Confirm the network item has the correct icon

**Screenshots (optional)**
![image](https://github.com/files-community/Files/assets/39923744/e4769458-d8e2-4457-93d8-113afca8e897)
