### PR TITLE
Feature: Added an option to keep Files running in the background for quicker startup time

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -178,18 +178,22 @@ namespace Files.App
 				FileTagsHelper.UpdateTagsDb();
 			});
 
-			// Check for required updates
-			var updateService = Ioc.Default.GetRequiredService<IUpdateService>();
-			await updateService.CheckForUpdates();
-			await updateService.DownloadMandatoryUpdates();
-			await updateService.CheckAndUpdateFilesLauncherAsync();
-			await updateService.CheckLatestReleaseNotesAsync();
+			await CheckForRequiredUpdates();
 
 			static async Task OptionalTask(Task task, bool condition)
 			{
 				if (condition)
 					await task;
 			}
+		}
+
+		private static async Task CheckForRequiredUpdates()
+		{
+			var updateService = Ioc.Default.GetRequiredService<IUpdateService>();
+			await updateService.CheckForUpdates();
+			await updateService.DownloadMandatoryUpdates();
+			await updateService.CheckAndUpdateFilesLauncherAsync();
+			await updateService.CheckLatestReleaseNotesAsync();
 		}
 
 		/// <summary>
@@ -331,6 +335,9 @@ namespace Files.App
 					Program.Pool.Dispose();
 					MainWindow.Instance.AppWindow.Show();
 					MainWindow.Instance.Activate();
+
+					_ = CheckForRequiredUpdates();
+
 					MainWindow.Instance.EnsureWindowIsInitialized().Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
 				}
 

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -306,7 +306,7 @@ namespace Files.App
 				!Process.GetProcessesByName("Files").Any(x => x.Id != Process.GetCurrentProcess().Id))
 			{
 				// Close open content dialogs
-				var contentDialogs = VisualTreeHelper.GetOpenPopups(Window.Current);
+				var contentDialogs = VisualTreeHelper.GetOpenPopups(MainWindow.Instance);
 				foreach (var popup in contentDialogs)
 					if (popup.Child is ContentDialog)
 						((ContentDialog)popup.Child).Hide();

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -326,10 +326,12 @@ namespace Files.App
 				// Wait for all properties windows to close
 				await FilePropertiesHelpers.WaitClosingAll();
 
+				// Sleep current instance
 				Program.Pool = new(0, 1, "Files-Instance");
 				Thread.Yield();
 				if (Program.Pool.WaitOne())
 				{
+					// Resume the instance
 					Program.Pool.Dispose();
 					MainWindow.Instance.AppWindow.Show();
 					MainWindow.Instance.Activate();

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.Windows.AppLifecycle;
 using System.IO;
@@ -316,6 +317,12 @@ namespace Files.App
 
 				// Wait for all properties windows to close
 				await FilePropertiesHelpers.WaitClosingAll();
+
+				// Close open content dialogs
+				var contentDialogs = VisualTreeHelper.GetOpenPopups(Window.Current);
+				foreach (var popup in contentDialogs)
+					if (popup.Child is ContentDialog)
+						((ContentDialog)popup.Child).Hide();
 
 				Program.Pool = new(0, 1, "Files-Instance");
 				Thread.Yield();

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -301,7 +301,8 @@ namespace Files.App
 				return;
 			}
 
-			if (Ioc.Default.GetRequiredService<IUserSettingsService>().GeneralSettingsService.LeaveAppRunning)
+			if (Ioc.Default.GetRequiredService<IUserSettingsService>().GeneralSettingsService.LeaveAppRunning &&
+				!Process.GetProcessesByName("Files").Any(x => x.Id != Process.GetCurrentProcess().Id))
 			{
 				// Cache the window istead of closing it
 				MainWindow.Instance.AppWindow.Hide();

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -3,6 +3,7 @@
 
 using CommunityToolkit.WinUI.Helpers;
 using CommunityToolkit.WinUI.Notifications;
+using Files.App.Helpers;
 using Files.App.Services.DateTimeFormatter;
 using Files.App.Services.Settings;
 using Files.App.Storage.FtpStorage;
@@ -310,10 +311,7 @@ namespace Files.App
 				!Process.GetProcessesByName("Files").Any(x => x.Id != Process.GetCurrentProcess().Id))
 			{
 				// Close open content dialogs
-				var contentDialogs = VisualTreeHelper.GetOpenPopups(MainWindow.Instance);
-				foreach (var popup in contentDialogs)
-					if (popup.Child is ContentDialog)
-						((ContentDialog)popup.Child).Hide();
+				UIHelpers.CloseAllDialogs();
 
 				// Cache the window istead of closing it
 				MainWindow.Instance.AppWindow.Hide();

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -41,7 +41,7 @@ namespace Files.App
 		private static bool ShowErrorNotification = false;
 		public static string OutputPath { get; set; }
 		public static CommandBarFlyout? LastOpenedFlyout { get; set; }
-		public static TaskCompletionSource? SplashScreenLoadingTCS { get; set; }
+		public static TaskCompletionSource? SplashScreenLoadingTCS { get; private set; }
 
 		public static StorageHistoryWrapper HistoryWrapper { get; } = new();
 		public static AppModel AppModel { get; private set; }
@@ -312,6 +312,9 @@ namespace Files.App
 				MainPageViewModel.AppInstances.ForEach(tabItem => tabItem.Unload());
 				MainPageViewModel.AppInstances.Clear();
 				await Task.Delay(100);
+
+				// Wait for all properties windows to close
+				await FilePropertiesHelpers.WaitClosingAll();
 
 				Program.Pool = new(0, 1, "Files-Instance");
 				Thread.Yield();

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -305,6 +305,12 @@ namespace Files.App
 			if (Ioc.Default.GetRequiredService<IUserSettingsService>().GeneralSettingsService.LeaveAppRunning &&
 				!Process.GetProcessesByName("Files").Any(x => x.Id != Process.GetCurrentProcess().Id))
 			{
+				// Close open content dialogs
+				var contentDialogs = VisualTreeHelper.GetOpenPopups(Window.Current);
+				foreach (var popup in contentDialogs)
+					if (popup.Child is ContentDialog)
+						((ContentDialog)popup.Child).Hide();
+
 				// Cache the window istead of closing it
 				MainWindow.Instance.AppWindow.Hide();
 				args.Handled = true;
@@ -317,12 +323,6 @@ namespace Files.App
 
 				// Wait for all properties windows to close
 				await FilePropertiesHelpers.WaitClosingAll();
-
-				// Close open content dialogs
-				var contentDialogs = VisualTreeHelper.GetOpenPopups(Window.Current);
-				foreach (var popup in contentDialogs)
-					if (popup.Child is ContentDialog)
-						((ContentDialog)popup.Child).Hide();
 
 				Program.Pool = new(0, 1, "Files-Instance");
 				Thread.Yield();

--- a/src/Files.App/Data/Contexts/Multitasking/MultitaskingContext.cs
+++ b/src/Files.App/Data/Contexts/Multitasking/MultitaskingContext.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using CommunityToolkit.Mvvm.ComponentModel;
 using Files.App.UserControls.MultitaskingControl;
-using Files.App.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using System.Collections.Specialized;
-using System.ComponentModel;
 
 namespace Files.App.Data.Contexts
 {
@@ -46,7 +43,8 @@ namespace Files.App.Data.Contexts
 		}
 		private void AppModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			UpdateCurrentTabIndex();
+			if (e.PropertyName is nameof(AppModel.TabStripSelectedIndex))
+				UpdateCurrentTabIndex();
 		}
 		private void BaseMultitaskingControl_OnLoaded(object? sender, IMultitaskingControl control)
 		{

--- a/src/Files.App/Data/Models/AppModel.cs
+++ b/src/Files.App/Data/Models/AppModel.cs
@@ -33,19 +33,13 @@ namespace Files.App.Data.Models
 			get => tabStripSelectedIndex;
 			set
 			{
-				if (value >= 0)
-				{
-					if (tabStripSelectedIndex != value)
-					{
-						SetProperty(ref tabStripSelectedIndex, value);
-					}
+				SetProperty(ref tabStripSelectedIndex, value);
 
-					if (value < MainPageViewModel.AppInstances.Count)
-					{
-						Frame rootFrame = (Frame)MainWindow.Instance.Content;
-						var mainView = (MainPage)rootFrame.Content;
-						mainView.ViewModel.SelectedTabItem = MainPageViewModel.AppInstances[value];
-					}
+				if (value >= 0 && value < MainPageViewModel.AppInstances.Count)
+				{
+					Frame rootFrame = (Frame)MainWindow.Instance.Content;
+					var mainView = (MainPage)rootFrame.Content;
+					mainView.ViewModel.SelectedTabItem = MainPageViewModel.AppInstances[value];
 				}
 			}
 		}

--- a/src/Files.App/Helpers/UI/UIHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIHelpers.cs
@@ -2,20 +2,10 @@
 // Licensed under the MIT License. See the LICENSE.
 
 using CommunityToolkit.WinUI.Notifications;
-using Files.App.Extensions;
-using Files.App.Utils.Shell;
-using Files.Core.ViewModels.Dialogs;
-using Files.Shared;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Windows.UI.Notifications;
 
 namespace Files.App.Helpers
@@ -130,7 +120,7 @@ namespace Files.App.Helpers
 
 		public static void CloseAllDialogs()
 		{
-			var openedDialogs = VisualTreeHelper.GetOpenPopups(MainWindow.Instance);
+			var openedDialogs = VisualTreeHelper.GetOpenPopupsForXamlRoot(MainWindow.Instance.Content.XamlRoot);
 
 			foreach (var item in openedDialogs)
 			{

--- a/src/Files.App/MainWindow.xaml
+++ b/src/Files.App/MainWindow.xaml
@@ -6,5 +6,4 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:winuiex="using:WinUIEx"
-	Closed="MainWindow_Closed"
 	mc:Ignorable="d" />

--- a/src/Files.App/MainWindow.xaml
+++ b/src/Files.App/MainWindow.xaml
@@ -6,4 +6,5 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:winuiex="using:WinUIEx"
+	Closed="MainWindow_Closed"
 	mc:Ignorable="d" />

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -176,7 +176,7 @@ namespace Files.App
 				rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
 		}
 
-		private Frame EnsureWindowIsInitialized()
+		public Frame EnsureWindowIsInitialized()
 		{
 			// NOTE:
 			//  Do not repeat app initialization when the Window already has content,
@@ -283,30 +283,6 @@ namespace Files.App
 						App.OutputPath = command.Payload;
 						break;
 				}
-			}
-		}
-
-		private void MainWindow_Closed(object sender, WindowEventArgs args)
-		{
-			if (!Ioc.Default.GetRequiredService<IUserSettingsService>()?.GeneralSettingsService.LeaveAppRunning ?? true)
-				return;
-
-			AppWindow.Hide();
-
-			// Save and clear all tabs
-			App.SaveSessionTabs();
-			MainPageViewModel.AppInstances.ForEach(tabItem => tabItem.Unload());
-			MainPageViewModel.AppInstances.Clear();
-
-			args.Handled = true;
-			Program.Pool = new(0, 1, "Files-Instance");
-			Thread.Yield();
-			if (Program.Pool.WaitOne())
-			{
-				Program.Pool.Dispose();
-				AppWindow.Show();
-				Activate();
-				EnsureWindowIsInitialized().Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
 			}
 		}
 	}

--- a/src/Files.App/Program.cs
+++ b/src/Files.App/Program.cs
@@ -21,6 +21,7 @@ namespace Files.App
 			Pool = new(0, 1, "Files-Instance", out var isNew);
 			if (!isNew)
 			{
+				// Resume cached instance
 				Pool.Release();
 				Environment.Exit(0);
 			}

--- a/src/Files.App/Program.cs
+++ b/src/Files.App/Program.cs
@@ -14,6 +14,19 @@ namespace Files.App
 {
 	internal class Program
 	{
+		public static Semaphore Pool;
+
+		static Program()
+		{
+			Pool = new(0, 1, "Files-Instance", out var isNew);
+			if (!isNew)
+			{
+				Pool.Release();
+				Environment.Exit(0);
+			}
+			Pool.Dispose();
+		}
+
 		// Note:
 		//  We can't declare Main to be async because in a WinUI app
 		//  This prevents Narrator from reading XAML elements

--- a/src/Files.App/Services/Settings/GeneralSettingsService.cs
+++ b/src/Files.App/Services/Settings/GeneralSettingsService.cs
@@ -208,6 +208,12 @@ namespace Files.App.Services.Settings
 			set => Set(value);
 		}
 
+		public bool LeaveAppRunning
+		{
+			get => Get(false);
+			set => Set(value);
+		}
+
 		public FileNameConflictResolveOptionType ConflictsResolveOption
 		{
 			get => (FileNameConflictResolveOptionType)Get((long)FileNameConflictResolveOptionType.GenerateNewName);

--- a/src/Files.App/Services/Settings/GeneralSettingsService.cs
+++ b/src/Files.App/Services/Settings/GeneralSettingsService.cs
@@ -260,6 +260,7 @@ namespace Files.App.Services.Settings
 				case nameof(ShowOpenInNewTab):
 				case nameof(ShowOpenInNewWindow):
 				case nameof(ShowOpenInNewPane):
+				case nameof(LeaveAppRunning):
 				case nameof(ConflictsResolveOption):
 				case nameof(ShowHashesDictionary):
 					Analytics.TrackEvent($"Set {e.SettingName} to {e.NewValue}");

--- a/src/Files.App/Services/Settings/GeneralSettingsService.cs
+++ b/src/Files.App/Services/Settings/GeneralSettingsService.cs
@@ -210,7 +210,7 @@ namespace Files.App.Services.Settings
 
 		public bool LeaveAppRunning
 		{
-			get => Get(false);
+			get => Get(true);
 			set => Set(value);
 		}
 

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3447,4 +3447,7 @@
   <data name="FilesRunningAsAdminContent" xml:space="preserve">
     <value>Due to platform limitations, drag and drop isn't available when running Files as administrator.</value>
   </data>
+  <data name="SettingsLeaveAppRunning" xml:space="preserve">
+    <value>Leave app running in the background when the window is closed</value>
+  </data>
 </root>

--- a/src/Files.App/ViewModels/Settings/AdvancedViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AdvancedViewModel.cs
@@ -297,6 +297,20 @@ namespace Files.App.ViewModels.Settings
 			set => SetProperty(ref canOpenOnWindowsStartup, value);
 		}
 
+		public bool LeaveAppRunning
+		{
+			get => UserSettingsService.GeneralSettingsService.LeaveAppRunning;
+			set
+			{
+				if (value != UserSettingsService.GeneralSettingsService.LeaveAppRunning)
+				{
+					UserSettingsService.GeneralSettingsService.LeaveAppRunning = value;
+
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		public async Task OpenFilesOnWindowsStartup()
 		{
 			var stateMode = await ReadState();

--- a/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
+++ b/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
@@ -1,11 +1,6 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using CommunityToolkit.Mvvm.DependencyInjection;
-using CommunityToolkit.WinUI;
-using Files.App.Data.Parameters;
-using Files.App.Helpers;
-using Files.App.ViewModels;
 using Files.App.ViewModels.Properties;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
@@ -13,8 +8,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
-using System;
-using System.Threading.Tasks;
 using Windows.System;
 using Windows.UI;
 
@@ -45,9 +38,6 @@ namespace Files.App.Views.Properties
 			AppWindow = parameter.AppWindow;
 			Window = parameter.Window;
 
-			AppSettings = Ioc.Default.GetRequiredService<SettingsViewModel>();
-			AppSettings.ThemeModeChanged += AppSettings_ThemeModeChanged;
-
 			base.OnNavigatedTo(e);
 
 			MainPropertiesViewModel = new(Window, AppWindow, MainContentFrame, BaseProperties, parameter);
@@ -55,6 +45,8 @@ namespace Files.App.Views.Properties
 
 		private void Page_Loaded(object sender, RoutedEventArgs e)
 		{
+			AppSettings = Ioc.Default.GetRequiredService<SettingsViewModel>();
+			AppSettings.ThemeModeChanged += AppSettings_ThemeModeChanged;
 			Window.Closed += Window_Closed;
 
 			UpdatePageLayout();
@@ -89,6 +81,9 @@ namespace Files.App.Views.Properties
 
 		private async void AppSettings_ThemeModeChanged(object? sender, EventArgs e)
 		{
+			if (Parent is null)
+				return;
+
 			await DispatcherQueue.EnqueueOrInvokeAsync(() =>
 			{
 				((Frame)Parent).RequestedTheme = ThemeHelper.RootTheme;

--- a/src/Files.App/Views/Settings/AdvancedPage.xaml
+++ b/src/Files.App/Views/Settings/AdvancedPage.xaml
@@ -98,6 +98,17 @@
 				</ToggleSwitch>
 			</local:SettingsBlockControl>
 
+			<!--  Leave App Running  -->
+			<local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsLeaveAppRunning}" HorizontalAlignment="Stretch">
+				<local:SettingsBlockControl.Icon>
+					<FontIcon Glyph="&#xE708;" />
+				</local:SettingsBlockControl.Icon>
+				<ToggleSwitch
+					AutomationProperties.Name="{helpers:ResourceString Name=SettingsLeaveAppRunning}"
+					IsOn="{x:Bind ViewModel.LeaveAppRunning, Mode=TwoWay}"
+					Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+			</local:SettingsBlockControl>
+
 			<!--  Experimental Settings  -->
 			<TextBlock
 				Padding="0,16,0,4"

--- a/src/Files.App/Views/Settings/AdvancedPage.xaml
+++ b/src/Files.App/Views/Settings/AdvancedPage.xaml
@@ -101,7 +101,7 @@
 			<!--  Leave App Running  -->
 			<local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsLeaveAppRunning}" HorizontalAlignment="Stretch">
 				<local:SettingsBlockControl.Icon>
-					<FontIcon Glyph="&#xE708;" />
+					<FontIcon Glyph="&#xE8E6;" />
 				</local:SettingsBlockControl.Icon>
 				<ToggleSwitch
 					AutomationProperties.Name="{helpers:ResourceString Name=SettingsLeaveAppRunning}"

--- a/src/Files.Core/Services/Settings/IGeneralSettingsService.cs
+++ b/src/Files.Core/Services/Settings/IGeneralSettingsService.cs
@@ -170,6 +170,11 @@ namespace Files.Core.Services.Settings
 		bool ShowSendToMenu { get; set; }
 
 		/// <summary>
+		/// Gets or sets a value indicating whether or not to leave app running in the background.
+		/// </summary>
+		bool LeaveAppRunning { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating the default option to resolve conflicts.
 		/// </summary>
 		FileNameConflictResolveOptionType ConflictsResolveOption { get; set; }


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12614 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Turn on "Leave app running in the background when the window is closed" in Advanced settings
   2. Close and restart the app.
   3. The app will launch quicker.

**Known Issues**
 - [X] ~~When only one tab is opened, the tab is not visually selected.~~
![image](https://github.com/files-community/Files/assets/66369541/42089643-7d9a-455a-822e-a6d1b2139ce7)
 - [X] ~~Closing the main window while a property window is still open freezes the property window until the next time the main window is opened.~~
 - [X] ~~The content flashes while it loads.~~