### PR TITLE
Code Quality: Refactored context menu loading for WASDK 1.4

### DIFF
--- a/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml.cs
@@ -114,7 +114,7 @@ namespace Files.App.UserControls.Widgets
 				rightClickedItem: item);
 		}
 
-		private async void LoadContextMenu(
+		private void LoadContextMenu(
 			FrameworkElement element,
 			RightTappedRoutedEventArgs e,
 			List<ContextMenuFlyoutItemViewModel> menuItems,
@@ -131,11 +131,20 @@ namespace Files.App.UserControls.Widgets
 
 			secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
 			ItemContextMenuFlyout = itemContextMenuFlyout;
-			itemContextMenuFlyout.ShowAt(element, new FlyoutShowOptions { Position = e.GetPosition(element) });
 			if (rightClickedItem is not null)
-				await ShellContextmenuHelper.LoadShellMenuItems(rightClickedItem.Path, itemContextMenuFlyout, showOpenWithMenu: true, showSendToMenu: true);
+			{
+				FlyouItemPath = rightClickedItem.Path;
+				ItemContextMenuFlyout.Opened += ItemContextMenuFlyout_Opened;
+			}
+			itemContextMenuFlyout.ShowAt(element, new FlyoutShowOptions { Position = e.GetPosition(element) });
 
 			e.Handled = true;
+		}
+
+		private async void ItemContextMenuFlyout_Opened(object? sender, object e)
+		{
+			ItemContextMenuFlyout.Opened -= ItemContextMenuFlyout_Opened;
+			await ShellContextmenuHelper.LoadShellMenuItems(FlyouItemPath, ItemContextMenuFlyout, showOpenWithMenu: true, showSendToMenu: true);
 		}
 
 		public override List<ContextMenuFlyoutItemViewModel> GetItemMenuItems(WidgetCardItem item, bool isPinned, bool isFolder = false)
@@ -220,7 +229,10 @@ namespace Files.App.UserControls.Widgets
 				new ContextMenuFlyoutItemViewModel()
 				{
 					Text = "Properties".GetLocalizedResource(),
-					Glyph = "\uE946",
+					OpacityIcon = new OpacityIconModel()
+					{
+						OpacityIconStyle = "ColorIconProperties",
+					},
 					Command = OpenPropertiesCommand,
 					CommandParameter = item,
 					ShowItem = isFolder

--- a/src/Files.App/UserControls/Widgets/HomePageWidget.cs
+++ b/src/Files.App/UserControls/Widgets/HomePageWidget.cs
@@ -1,21 +1,12 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using CommunityToolkit.Mvvm.DependencyInjection;
-using Files.App.Helpers;
 using Files.App.Helpers.ContextFlyouts;
-using Files.App.Services;
-using Files.App.ViewModels;
-using Files.Core.Services.Settings;
 using Files.Core.Storage;
-using Files.Shared.Extensions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Input;
 
 namespace Files.App.UserControls.Widgets
@@ -36,6 +27,7 @@ namespace Files.App.UserControls.Widgets
 		public ICommand UnpinFromFavoritesCommand;
 
 		protected CommandBarFlyout ItemContextMenuFlyout;
+		protected string FlyouItemPath;
 
 		public abstract List<ContextMenuFlyoutItemViewModel> GetItemMenuItems(WidgetCardItem item, bool isPinned, bool isFolder = false);
 
@@ -54,13 +46,18 @@ namespace Files.App.UserControls.Widgets
 
 			secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
 			ItemContextMenuFlyout = itemContextMenuFlyout;
+			FlyouItemPath = item.Path;
+			ItemContextMenuFlyout.Opened += ItemContextMenuFlyout_Opened;
 			itemContextMenuFlyout.ShowAt(widgetCardItem, new FlyoutShowOptions { Position = e.GetPosition(widgetCardItem) });
-
-			_ = ShellContextmenuHelper.LoadShellMenuItems(item.Path, itemContextMenuFlyout);
 
 			e.Handled = true;
 		}
 
+		private async void ItemContextMenuFlyout_Opened(object? sender, object e)
+		{
+			ItemContextMenuFlyout.Opened -= ItemContextMenuFlyout_Opened;
+			await ShellContextmenuHelper.LoadShellMenuItems(FlyouItemPath, ItemContextMenuFlyout);
+		}
 
 		public async Task OpenInNewTab(WidgetCardItem item)
 		{

--- a/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -1,30 +1,16 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using CommunityToolkit.Mvvm.Input;
-using CommunityToolkit.WinUI;
-using Files.App.Extensions;
-using Files.App.Utils;
-using Files.App.Helpers;
 using Files.App.Helpers.ContextFlyouts;
-using Files.App.ViewModels;
 using Files.App.ViewModels.Widgets;
-using Files.Shared.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Windows.System;
 
 namespace Files.App.UserControls.Widgets
@@ -135,9 +121,15 @@ namespace Files.App.UserControls.Widgets
 							 .ForEach(i => i.MinWidth = Constants.UI.ContextMenuItemsMaxWidth);
 
 			secondaryElements.ForEach(i => ItemContextMenuFlyout.SecondaryCommands.Add(i));
+			FlyouItemPath = item.Path;
+			ItemContextMenuFlyout.Opened += ItemContextMenuFlyout_Opened;
 			ItemContextMenuFlyout.ShowAt(element, new FlyoutShowOptions { Position = e.GetPosition(element) });
+		}
 
-			_ = ShellContextmenuHelper.LoadShellMenuItems(item.Path, ItemContextMenuFlyout, showOpenWithMenu: true, showSendToMenu: true);
+		private async void ItemContextMenuFlyout_Opened(object? sender, object e)
+		{
+			ItemContextMenuFlyout.Opened -= ItemContextMenuFlyout_Opened;
+			await ShellContextmenuHelper.LoadShellMenuItems(FlyouItemPath, ItemContextMenuFlyout, showOpenWithMenu: true, showSendToMenu: true);
 		}
 
 		public override List<ContextMenuFlyoutItemViewModel> GetItemMenuItems(WidgetCardItem item, bool isPinned, bool isFolder = false)

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -19,7 +19,6 @@ using Windows.System;
 using Windows.UI.Core;
 using Files.Core.Storage;
 using Files.Core.Storage.Extensions;
-using Files.App.Data.Items;
 
 namespace Files.App.ViewModels.UserControls
 {
@@ -663,7 +662,6 @@ namespace Files.App.ViewModels.UserControls
 		}
 
 		public async void HandleItemContextInvoked(object sender, ItemContextInvokedArgs args)
-
 		{
 			if (sender is not FrameworkElement sidebarItem) return;
 
@@ -700,10 +698,19 @@ namespace Files.App.ViewModels.UserControls
 								.ForEach(i => i.MinWidth = Constants.UI.ContextMenuItemsMaxWidth);
 
 			secondaryElements.ForEach(i => itemContextMenuFlyout.SecondaryCommands.Add(i));
-			itemContextMenuFlyout.ShowAt(sidebarItem, new FlyoutShowOptions { Position = args.Position });
-
 			if (item.MenuOptions.ShowShellItems)
-				_ = ShellContextmenuHelper.LoadShellMenuItems(rightClickedItem.Path, itemContextMenuFlyout, item.MenuOptions);
+				itemContextMenuFlyout.Opened += ItemContextMenuFlyout_Opened;
+
+			itemContextMenuFlyout.ShowAt(sidebarItem, new FlyoutShowOptions { Position = args.Position });
+		}
+
+		private async void ItemContextMenuFlyout_Opened(object? sender, object e)
+		{
+			if (sender is not CommandBarFlyout itemContextMenuFlyout)
+				return;
+
+			itemContextMenuFlyout.Opened -= ItemContextMenuFlyout_Opened;
+			await ShellContextmenuHelper.LoadShellMenuItems(rightClickedItem.Path, itemContextMenuFlyout, rightClickedItem.MenuOptions);
 		}
 
 		public async void HandleItemInvoked(object item)

--- a/src/Files.App/Views/LayoutModes/BaseLayout.cs
+++ b/src/Files.App/Views/LayoutModes/BaseLayout.cs
@@ -553,7 +553,10 @@ namespace Files.App.Views.LayoutModes
 				ParentShellPageInstance!.FilesystemViewModel.CancelLoadAndClearFiles();
 		}
 
-		public async void ItemContextFlyout_Opening(object? sender, object e)
+		private CancellationTokenSource? shellContextMenuItemCancellationToken;
+		private bool shiftPressed;
+
+		private async void ItemContextFlyout_Opening(object? sender, object e)
 		{
 			App.LastOpenedFlyout = sender as CommandBarFlyout;
 
@@ -564,7 +567,32 @@ namespace Files.App.Views.LayoutModes
 					ItemManipulationModel.SetSelectedItem(li);
 
 				if (IsItemSelected)
-					await LoadMenuItemsAsync();
+				{
+					// Reset menu max height
+					if (ItemContextMenuFlyout.GetValue(ContextMenuExtensions.ItemsControlProperty) is ItemsControl itc)
+						itc.MaxHeight = Constants.UI.ContextMenuMaxHeight;
+
+					shellContextMenuItemCancellationToken?.Cancel();
+					shellContextMenuItemCancellationToken = new CancellationTokenSource();
+					SelectedItemsPropertiesViewModel.CheckAllFileExtensions(SelectedItems!.Select(selectedItem => selectedItem?.FileExtension).ToList()!);
+
+					shiftPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+					var items = ContextFlyoutItemHelper.GetItemContextCommandsWithoutShellItems(currentInstanceViewModel: InstanceViewModel!, selectedItems: SelectedItems!, selectedItemsPropertiesViewModel: SelectedItemsPropertiesViewModel, commandsViewModel: CommandsViewModel!, shiftPressed: shiftPressed, itemViewModel: null);
+
+					ItemContextMenuFlyout.PrimaryCommands.Clear();
+					ItemContextMenuFlyout.SecondaryCommands.Clear();
+
+					var (primaryElements, secondaryElements) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(items);
+					AddCloseHandler(ItemContextMenuFlyout, primaryElements, secondaryElements);
+					primaryElements.ForEach(ItemContextMenuFlyout.PrimaryCommands.Add);
+					secondaryElements.OfType<FrameworkElement>().ForEach(i => i.MinWidth = Constants.UI.ContextMenuItemsMaxWidth); // Set menu min width
+					secondaryElements.ForEach(ItemContextMenuFlyout.SecondaryCommands.Add);
+
+					if (InstanceViewModel!.CanTagFilesInPage)
+						AddNewFileTagsToMenu(ItemContextMenuFlyout);
+
+					ItemContextMenuFlyout.Opened += ItemContextFlyout_Opened;
+				}
 			}
 			catch (Exception error)
 			{
@@ -572,9 +600,32 @@ namespace Files.App.Views.LayoutModes
 			}
 		}
 
-		private CancellationTokenSource? shellContextMenuItemCancellationToken;
+		private async void ItemContextFlyout_Opened(object? sender, object e)
+		{
+			ItemContextMenuFlyout.Opened -= ItemContextFlyout_Opened;
 
-		public async void BaseContextFlyout_Opening(object? sender, object e)
+			try
+			{
+				if (!InstanceViewModel.IsPageTypeZipFolder && !InstanceViewModel.IsPageTypeFtp)
+				{
+					var shellMenuItems = await ContextFlyoutItemHelper.GetItemContextShellCommandsAsync(workingDir: ParentShellPageInstance.FilesystemViewModel.WorkingDirectory, selectedItems: SelectedItems!, shiftPressed: shiftPressed, showOpenMenu: false, shellContextMenuItemCancellationToken.Token);
+					if (shellMenuItems.Any())
+						await AddShellMenuItemsAsync(shellMenuItems, ItemContextMenuFlyout, shiftPressed);
+					else
+						RemoveOverflow(ItemContextMenuFlyout);
+				}
+				else
+				{
+					RemoveOverflow(ItemContextMenuFlyout);
+				}
+			}
+			catch (Exception error)
+			{
+				Debug.WriteLine(error);
+			}
+		}
+
+		private async void BaseContextFlyout_Opening(object? sender, object e)
 		{
 			App.LastOpenedFlyout = sender as CommandBarFlyout;
 
@@ -589,7 +640,7 @@ namespace Files.App.Views.LayoutModes
 				shellContextMenuItemCancellationToken?.Cancel();
 				shellContextMenuItemCancellationToken = new CancellationTokenSource();
 
-				var shiftPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+				shiftPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
 				var items = ContextFlyoutItemHelper.GetItemContextCommandsWithoutShellItems(currentInstanceViewModel: InstanceViewModel!, selectedItems: new List<ListedItem> { ParentShellPageInstance!.FilesystemViewModel.CurrentFolder }, commandsViewModel: CommandsViewModel!, shiftPressed: shiftPressed, itemViewModel: ParentShellPageInstance!.FilesystemViewModel, selectedItemsPropertiesViewModel: null);
 
 				BaseContextMenuFlyout.PrimaryCommands.Clear();
@@ -605,6 +656,20 @@ namespace Files.App.Views.LayoutModes
 				secondaryElements.OfType<FrameworkElement>().ForEach(i => i.MinWidth = Constants.UI.ContextMenuItemsMaxWidth);
 				secondaryElements.ForEach(i => BaseContextMenuFlyout.SecondaryCommands.Add(i));
 
+				BaseContextMenuFlyout.Opened += BaseContextFlyout_Opened;
+			}
+			catch (Exception error)
+			{
+				Debug.WriteLine(error);
+			}
+		}
+
+		private async void BaseContextFlyout_Opened(object? sender, object e)
+		{
+			BaseContextMenuFlyout.Opened -= BaseContextFlyout_Opened;
+
+			try
+			{
 				if (!InstanceViewModel!.IsPageTypeSearchResults && !InstanceViewModel.IsPageTypeZipFolder && !InstanceViewModel.IsPageTypeFtp)
 				{
 					var shellMenuItems = await ContextFlyoutItemHelper.GetItemContextShellCommandsAsync(workingDir: ParentShellPageInstance.FilesystemViewModel.WorkingDirectory, selectedItems: new List<ListedItem>(), shiftPressed: shiftPressed, showOpenMenu: false, shellContextMenuItemCancellationToken.Token);
@@ -644,45 +709,6 @@ namespace Files.App.Views.LayoutModes
 			}
 
 			SelectedItemsPropertiesViewModel.ItemSizeVisibility = isSizeKnown;
-		}
-
-		private async Task LoadMenuItemsAsync()
-		{
-			// Reset menu max height
-			if (ItemContextMenuFlyout.GetValue(ContextMenuExtensions.ItemsControlProperty) is ItemsControl itc)
-				itc.MaxHeight = Constants.UI.ContextMenuMaxHeight;
-
-			shellContextMenuItemCancellationToken?.Cancel();
-			shellContextMenuItemCancellationToken = new CancellationTokenSource();
-			SelectedItemsPropertiesViewModel.CheckAllFileExtensions(SelectedItems!.Select(selectedItem => selectedItem?.FileExtension).ToList()!);
-
-			var shiftPressed = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
-			var items = ContextFlyoutItemHelper.GetItemContextCommandsWithoutShellItems(currentInstanceViewModel: InstanceViewModel!, selectedItems: SelectedItems!, selectedItemsPropertiesViewModel: SelectedItemsPropertiesViewModel, commandsViewModel: CommandsViewModel!, shiftPressed: shiftPressed, itemViewModel: null);
-
-			ItemContextMenuFlyout.PrimaryCommands.Clear();
-			ItemContextMenuFlyout.SecondaryCommands.Clear();
-
-			var (primaryElements, secondaryElements) = ItemModelListToContextFlyoutHelper.GetAppBarItemsFromModel(items);
-			AddCloseHandler(ItemContextMenuFlyout, primaryElements, secondaryElements);
-			primaryElements.ForEach(ItemContextMenuFlyout.PrimaryCommands.Add);
-			secondaryElements.OfType<FrameworkElement>().ForEach(i => i.MinWidth = Constants.UI.ContextMenuItemsMaxWidth); // Set menu min width
-			secondaryElements.ForEach(ItemContextMenuFlyout.SecondaryCommands.Add);
-
-			if (InstanceViewModel!.CanTagFilesInPage)
-				AddNewFileTagsToMenu(ItemContextMenuFlyout);
-
-			if (!InstanceViewModel.IsPageTypeZipFolder && !InstanceViewModel.IsPageTypeFtp)
-			{
-				var shellMenuItems = await ContextFlyoutItemHelper.GetItemContextShellCommandsAsync(workingDir: ParentShellPageInstance.FilesystemViewModel.WorkingDirectory, selectedItems: SelectedItems!, shiftPressed: shiftPressed, showOpenMenu: false, shellContextMenuItemCancellationToken.Token);
-				if (shellMenuItems.Any())
-					await AddShellMenuItemsAsync(shellMenuItems, ItemContextMenuFlyout, shiftPressed);
-				else
-					RemoveOverflow(ItemContextMenuFlyout);
-			}
-			else
-			{
-				RemoveOverflow(ItemContextMenuFlyout);
-			}
 		}
 
 		private void AddCloseHandler(CommandBarFlyout flyout, IList<ICommandBarElement> primaryElements, IList<ICommandBarElement> secondaryElements)


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   - Somehow, after updating WASDK to 1.4, a context menu would only show primary commands until shell extensions were loaded, so I worked around this issue by splitting the loading process.

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?