### PR TITLE
Code Quality: UseCurrentScale for properties window

### DIFF
--- a/src/Files.App/Services/ImagingService.cs
+++ b/src/Files.App/Services/ImagingService.cs
@@ -15,7 +15,7 @@ namespace Files.App.Services
 			if (storable is not ILocatableStorable locatableStorable)
 				return null;
 
-			var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(locatableStorable.Path, 24u, ThumbnailMode.ListView);
+			var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(locatableStorable.Path, 24u, ThumbnailMode.ListView, ThumbnailOptions.ResizeThumbnail);
 			if (iconData is null)
 				return null;
 
@@ -30,7 +30,7 @@ namespace Files.App.Services
 
 		public async Task<IImageModel?> GetImageModelFromPathAsync(string filePath, uint thumbnailSize = 64)
 		{
-			if (await FileThumbnailHelper.LoadIconFromPathAsync(filePath, thumbnailSize, ThumbnailMode.ListView) is byte[] imageBuffer)
+			if (await FileThumbnailHelper.LoadIconFromPathAsync(filePath, thumbnailSize, ThumbnailMode.ListView, ThumbnailOptions.ResizeThumbnail) is byte[] imageBuffer)
 				return await GetImageModelFromDataAsync(imageBuffer);
 
 			return null;

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -41,7 +41,7 @@ namespace Files.App.UserControls.Widgets
 		{
 			// Try load thumbnail using ListView mode
 			if (thumbnailData is null || thumbnailData.Length == 0)
-				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.Path, Convert.ToUInt32(Constants.Widgets.WidgetIconSize), Windows.Storage.FileProperties.ThumbnailMode.SingleItem);
+				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.Path, Convert.ToUInt32(Constants.Widgets.WidgetIconSize), Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
 
 			// Thumbnail is still null, use DriveItem icon (loaded using SingleItem mode)
 			if (thumbnailData is null || thumbnailData.Length == 0)

--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -79,7 +79,7 @@ namespace Files.App.UserControls.Widgets
 		{
 			if (thumbnailData is null || thumbnailData.Length == 0)
 			{
-				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Path, Convert.ToUInt32(Constants.Widgets.WidgetIconSize), Windows.Storage.FileProperties.ThumbnailMode.SingleItem);
+				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Path, Convert.ToUInt32(Constants.Widgets.WidgetIconSize), Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
 			}
 			if (thumbnailData is not null && thumbnailData.Length > 0)
 			{

--- a/src/Files.App/Utils/RecentItem/RecentItem.cs
+++ b/src/Files.App/Utils/RecentItem/RecentItem.cs
@@ -76,7 +76,7 @@ namespace Files.App.Utils.RecentItem
 
 		public async Task LoadRecentItemIcon()
 		{
-			var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(RecentPath, 96u, ThumbnailMode.SingleItem);
+			var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(RecentPath, 96u, ThumbnailMode.SingleItem, ThumbnailOptions.ResizeThumbnail);
 			if (iconData is null)
 			{
 				EmptyImgVis = true;

--- a/src/Files.App/Utils/Shell/ContextMenu.cs
+++ b/src/Files.App/Utils/Shell/ContextMenu.cs
@@ -236,6 +236,7 @@ namespace Files.App.Utils.Shell
 
 						if (bitmap is not null)
 						{
+							// Make the icon background transparent
 							Color backgroundColor = bitmap.GetPixel(1, 1);
 							bitmap.MakeTransparent(backgroundColor);
 

--- a/src/Files.App/Utils/Shell/ContextMenu.cs
+++ b/src/Files.App/Utils/Shell/ContextMenu.cs
@@ -237,7 +237,7 @@ namespace Files.App.Utils.Shell
 						if (bitmap is not null)
 						{
 							// Make the icon background transparent
-							Color backgroundColor = bitmap.GetPixel(1, 1);
+							Color backgroundColor = bitmap.GetPixel(0, 0);
 							bitmap.MakeTransparent(backgroundColor);
 
 							byte[] bitmapData = (byte[])new ImageConverter().ConvertTo(bitmap, typeof(byte[]));

--- a/src/Files.App/Utils/Shell/ContextMenu.cs
+++ b/src/Files.App/Utils/Shell/ContextMenu.cs
@@ -236,6 +236,9 @@ namespace Files.App.Utils.Shell
 
 						if (bitmap is not null)
 						{
+							Color backgroundColor = bitmap.GetPixel(1, 1);
+							bitmap.MakeTransparent(backgroundColor);
+
 							byte[] bitmapData = (byte[])new ImageConverter().ConvertTo(bitmap, typeof(byte[]));
 							menuItem.Icon = bitmapData;
 						}

--- a/src/Files.App/Utils/Storage/Helpers/FileThumbnailHelper.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FileThumbnailHelper.cs
@@ -45,14 +45,14 @@ namespace Files.App.Utils.Storage
 			return null;
 		}
 
-		public static async Task<byte[]> LoadIconFromPathAsync(string filePath, uint thumbnailSize, ThumbnailMode thumbnailMode, bool isFolder = false)
+		public static async Task<byte[]> LoadIconFromPathAsync(string filePath, uint thumbnailSize, ThumbnailMode thumbnailMode, ThumbnailOptions thumbnailOptions, bool isFolder = false)
 		{
 			if (!FileExtensionHelpers.IsShortcutOrUrlFile(filePath))
 			{
 				var item = await StorageHelpers.ToStorageItem<IStorageItem>(filePath);
 				if (item is not null)
 				{
-					var iconData = await LoadIconFromStorageItemAsync(item, thumbnailSize, thumbnailMode, ThumbnailOptions.ResizeThumbnail);
+					var iconData = await LoadIconFromStorageItemAsync(item, thumbnailSize, thumbnailMode, thumbnailOptions);
 					if (iconData is not null)
 					{
 						return iconData;

--- a/src/Files.App/Utils/Storage/Search/FolderSearch.cs
+++ b/src/Files.App/Utils/Storage/Search/FolderSearch.cs
@@ -386,7 +386,7 @@ namespace Files.App.Utils.Storage
 			}
 			if (listedItem is not null && MaxItemCount > 0) // Only load icon for searchbox suggestions
 			{
-				_ = FileThumbnailHelper.LoadIconFromPathAsync(listedItem.ItemPath, ThumbnailSize, ThumbnailMode.ListView, isFolder)
+				_ = FileThumbnailHelper.LoadIconFromPathAsync(listedItem.ItemPath, ThumbnailSize, ThumbnailMode.ListView, ThumbnailOptions.ResizeThumbnail, isFolder)
 					.ContinueWith((t) =>
 					{
 						if (t.IsCompletedSuccessfully && t.Result is not null)

--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -258,7 +258,7 @@ namespace Files.App.ViewModels
 
 			if (iconSource.ImageSource is null)
 			{
-				var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 24u, Windows.Storage.FileProperties.ThumbnailMode.ListView, true);
+				var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 24u, Windows.Storage.FileProperties.ThumbnailMode.ListView, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail, true);
 				if (iconData is not null)
 					iconSource.ImageSource = await iconData.ToBitmapAsync();
 			}

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -99,7 +99,7 @@ namespace Files.App.ViewModels.Properties
 			ViewModel.ItemSizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ??
 				string.Empty;
 
-			var fileIconData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.ItemPath, 80, Windows.Storage.FileProperties.ThumbnailMode.DocumentsView, false);
+			var fileIconData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.ItemPath, 80, Windows.Storage.FileProperties.ThumbnailMode.DocumentsView, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail, false);
 			if (fileIconData is not null)
 			{
 				ViewModel.IconData = fileIconData;

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -74,7 +74,7 @@ namespace Files.App.ViewModels.Properties
 			ViewModel.IsHidden = NativeFileOperationsHelper.HasFileAttribute(
 				Item.ItemPath, System.IO.FileAttributes.Hidden);
 
-			var fileIconData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.ItemPath, 80, Windows.Storage.FileProperties.ThumbnailMode.SingleItem, true);
+			var fileIconData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.ItemPath, 80, Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale, true);
 			if (fileIconData is not null)
 			{
 				ViewModel.IconData = fileIconData;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13218...

**Validation**
How did you test these changes?
- [ ] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open properties window for a folder
   2. Confirm the thumbnail doesn't have a black background

**Screenshots (optional)**
Add screenshots here.
