### PR TITLE
Fix: Issue#13284 Command Palette doesn't display the Select All option

### DIFF
--- a/src/Files.App.Launcher/Files.App.Launcher.vcxproj
+++ b/src/Files.App.Launcher/Files.App.Launcher.vcxproj
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  Copyright (c) 2023 Files Community. Licensed under the MIT License. See the LICENSE.  -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.221104.6\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.221104.6\build\native\Microsoft.Windows.CppWinRT.props')" />
-
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|arm64">
       <Configuration>Debug</Configuration>
@@ -78,7 +76,6 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
@@ -86,7 +83,6 @@
     <RootNamespace>FilesAppLauncher</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -95,7 +91,6 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>..\..\artifacts\$(Configuration)\$(Platform)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)'!='Debug'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -105,9 +100,7 @@
     <LinkIncremental>false</LinkIncremental>
     <OutDir>..\..\artifacts\$(Configuration)\$(Platform)\$(MSBuildProjectName)\</OutDir>
   </PropertyGroup>
-
   <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -126,14 +119,12 @@
         certutil -hashfile "$(ProjectDir)..\..\src\Files.App\Assets\FilesOpenDialog\$(TargetFileName)" SHA256|findstr /R /V "^SHA256 ^CertUtil"&gt;"$(ProjectDir)..\..\src\Files.App\Assets\FilesOpenDialog\$(TargetFileName).sha256"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -146,7 +137,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Sideload|Win32'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -159,7 +149,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Store|Win32'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -172,7 +161,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Preview|Win32'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -185,7 +173,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Stable|Win32'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -198,21 +185,18 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm64'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -225,7 +209,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Sideload|x64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -238,7 +221,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Store|x64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -251,7 +233,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Preview|x64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -264,7 +245,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Stable|x64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -277,7 +257,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -290,7 +269,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Sideload|arm64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -303,7 +281,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Store|arm64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -316,7 +293,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Preview|arm64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -329,7 +305,6 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Stable|arm64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -342,23 +317,23 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
-
   <ItemGroup>
-    <ClCompile Include="FilesLauncher.cpp" />
-    <ClCompile Include="OpenInFolder.cpp" />
+    <ClCompile Include="FilesLauncher.cpp">
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">C:\Users\Jerrod\Tools\wil-master;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ClCompile Include="OpenInFolder.cpp">
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">C:\Users\Jerrod\Tools\cppwinrt-master;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
     <ClInclude Include="OpenInFolder.h" />
     <None Include="packages.config" />
   </ItemGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.221104.6\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.221104.6\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
-
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references a NuGet package that is not on this computer. To download those packages, use Restore NuGet Packages. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
@@ -367,5 +342,4 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.221104.6\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.221104.6\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.221104.6\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.221104.6\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
-
 </Project>

--- a/src/Files.App/Actions/Content/Selection/SelectAllAction.cs
+++ b/src/Files.App/Actions/Content/Selection/SelectAllAction.cs
@@ -25,11 +25,14 @@ namespace Files.App.Actions
 		{
 			get
 			{
-				/*var page = context.ShellPage;
+				var page = context.ShellPage;
+				 
 				bool isCommandPaletteOpen = page.ToolbarViewModel.IsCommandPaletteOpen;
+				if (isCommandPaletteOpen)
+					return true;
 				if (page is null)
 					return false;
-				if (context.PageType is ContentPageTypes.Home)
+				if (context.PageType is ContentPageTypes.Home && !isCommandPaletteOpen)
 					return false;
 
 				int itemCount = page.FilesystemViewModel.FilesAndFolders.Count;
@@ -40,9 +43,7 @@ namespace Files.App.Actions
 				bool isEditing = page.ToolbarViewModel.IsEditModeEnabled;
 				bool isRenaming = page.SlimContentPage.IsRenamingItem;
 
-				return (!isEditing && !isRenaming) || isCommandPaletteOpen;*/
-				//return isCommandPaletteOpen;
-				return true;
+				return (!isEditing && !isRenaming);
 			}
 		}
 

--- a/src/Files.App/Actions/Content/Selection/SelectAllAction.cs
+++ b/src/Files.App/Actions/Content/Selection/SelectAllAction.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+using Files.App.ViewModels.UserControls;
+
 namespace Files.App.Actions
 {
 	internal class SelectAllAction : IAction
@@ -23,22 +25,24 @@ namespace Files.App.Actions
 		{
 			get
 			{
-				if (context.PageType is ContentPageTypes.Home)
-					return false;
-
-				var page = context.ShellPage;
+				/*var page = context.ShellPage;
+				bool isCommandPaletteOpen = page.ToolbarViewModel.IsCommandPaletteOpen;
 				if (page is null)
+					return false;
+				if (context.PageType is ContentPageTypes.Home)
 					return false;
 
 				int itemCount = page.FilesystemViewModel.FilesAndFolders.Count;
 				int selectedItemCount = context.SelectedItems.Count;
-				if (itemCount == selectedItemCount)
+				if (itemCount == selectedItemCount && !isCommandPaletteOpen)
 					return false;
 
 				bool isEditing = page.ToolbarViewModel.IsEditModeEnabled;
 				bool isRenaming = page.SlimContentPage.IsRenamingItem;
 
-				return !isEditing && !isRenaming;
+				return (!isEditing && !isRenaming) || isCommandPaletteOpen;*/
+				//return isCommandPaletteOpen;
+				return true;
 			}
 		}
 

--- a/src/Files.App/Data/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Data/Commands/Manager/ICommandManager.cs
@@ -9,168 +9,149 @@ namespace Files.App.Data.Commands
 		IRichCommand this[string code] { get; }
 		IRichCommand this[HotKey customHotKey] { get; }
 
-		IRichCommand None { get; }
-
-		IRichCommand OpenHelp { get; }
-		IRichCommand ToggleFullScreen { get; }
-		IRichCommand EnterCompactOverlay { get; }
-		IRichCommand ExitCompactOverlay { get; }
-		IRichCommand ToggleCompactOverlay { get; }
-		IRichCommand Search { get; }
-		IRichCommand SearchUnindexedItems { get; }
-		IRichCommand EditPath { get; }
-		IRichCommand Redo { get; }
-		IRichCommand Undo { get; }
-
-		IRichCommand ToggleShowHiddenItems { get; }
-		IRichCommand ToggleShowFileExtensions { get; }
-		IRichCommand TogglePreviewPane { get; }
-
-		IRichCommand CopyItem { get; }
-		IRichCommand CopyPath { get; }
-		IRichCommand CutItem { get; }
-		IRichCommand PasteItem { get; }
-		IRichCommand PasteItemToSelection { get; }
-		IRichCommand DeleteItem { get; }
-		IRichCommand DeleteItemPermanently { get; }
-		IRichCommand SelectAll { get; }
-		IRichCommand InvertSelection { get; }
-		IRichCommand ClearSelection { get; }
-		IRichCommand ToggleSelect { get; }
-		IRichCommand ShareItem { get; }
-		IRichCommand CreateFolder { get; }
-		IRichCommand CreateFolderWithSelection { get; }
 		IRichCommand AddItem { get; }
-		IRichCommand CreateShortcut { get; }
-		IRichCommand CreateShortcutFromDialog { get; }
-		IRichCommand EmptyRecycleBin { get; }
-		IRichCommand RestoreRecycleBin { get; }
-		IRichCommand RestoreAllRecycleBin { get; }
-		IRichCommand FormatDrive { get; }
-		IRichCommand OpenItem { get; }
-		IRichCommand OpenItemWithApplicationPicker { get; }
-		IRichCommand OpenParentFolder { get; }
-		IRichCommand OpenFileLocation { get; }
-		IRichCommand RefreshItems { get; }
-		IRichCommand Rename { get; }
-
-		IRichCommand PinToStart { get; }
-		IRichCommand UnpinFromStart { get; }
-		IRichCommand PinItemToFavorites { get; }
-		IRichCommand UnpinItemFromFavorites { get; }
-
-		IRichCommand SetAsWallpaperBackground { get; }
-		IRichCommand SetAsSlideshowBackground { get; }
-		IRichCommand SetAsLockscreenBackground { get; }
-
-		IRichCommand InstallFont { get; }
-		IRichCommand InstallInfDriver { get; }
-		IRichCommand InstallCertificate { get; }
-
-		IRichCommand RunAsAdmin { get; }
-		IRichCommand RunAsAnotherUser { get; }
-		IRichCommand RunWithPowershell { get; }
-
-		IRichCommand LaunchPreviewPopup { get; }
-
-		IRichCommand CompressIntoArchive { get; }
-		IRichCommand CompressIntoSevenZip { get; }
-		IRichCommand CompressIntoZip { get; }
-		IRichCommand DecompressArchive { get; }
-		IRichCommand DecompressArchiveHere { get; }
-		IRichCommand DecompressArchiveToChildFolder { get; }
-
-		IRichCommand RotateLeft { get; }
-		IRichCommand RotateRight { get; }
-
-		IRichCommand OpenInVS { get; }
-		IRichCommand OpenInVSCode { get; }
-		IRichCommand OpenProperties { get; }
-		IRichCommand OpenSettings { get; }
-		IRichCommand OpenTerminal { get; }
-		IRichCommand OpenTerminalAsAdmin { get; }
-		IRichCommand OpenCommandPalette { get; }
-
-		IRichCommand LayoutDecreaseSize { get; }
-		IRichCommand LayoutIncreaseSize { get; }
-		IRichCommand LayoutDetails { get; }
-		IRichCommand LayoutTiles { get; }
-		IRichCommand LayoutGridSmall { get; }
-		IRichCommand LayoutGridMedium { get; }
-		IRichCommand LayoutGridLarge { get; }
-		IRichCommand LayoutColumns { get; }
-		IRichCommand LayoutAdaptive { get; }
-
-		IRichCommand SortByName { get; }
-		IRichCommand SortByDateModified { get; }
-		IRichCommand SortByDateCreated { get; }
-		IRichCommand SortBySize { get; }
-		IRichCommand SortByType { get; }
-		IRichCommand SortBySyncStatus { get; }
-		IRichCommand SortByTag { get; }
-		IRichCommand SortByPath { get; }
-		IRichCommand SortByOriginalFolder { get; }
-		IRichCommand SortByDateDeleted { get; }
-		IRichCommand SortAscending { get; }
-		IRichCommand SortDescending { get; }
-		IRichCommand ToggleSortDirection { get; }
-		IRichCommand ToggleSortDirectoriesAlongsideFiles { get; }
-
-		IRichCommand GroupByNone { get; }
-		IRichCommand GroupByName { get; }
-		IRichCommand GroupByDateModified { get; }
-		IRichCommand GroupByDateCreated { get; }
-		IRichCommand GroupBySize { get; }
-		IRichCommand GroupByType { get; }
-		IRichCommand GroupBySyncStatus { get; }
-		IRichCommand GroupByTag { get; }
-		IRichCommand GroupByOriginalFolder { get; }
-		IRichCommand GroupByDateDeleted { get; }
-		IRichCommand GroupByFolderPath { get; }
-		IRichCommand GroupByDateModifiedYear { get; }
-		IRichCommand GroupByDateModifiedMonth { get; }
-		IRichCommand GroupByDateCreatedYear { get; }
-		IRichCommand GroupByDateCreatedMonth { get; }
-		IRichCommand GroupByDateDeletedYear { get; }
-		IRichCommand GroupByDateDeletedMonth { get; }
-		IRichCommand GroupAscending { get; }
-		IRichCommand GroupDescending { get; }
-		IRichCommand ToggleGroupDirection { get; }
-		IRichCommand GroupByYear { get; }
-		IRichCommand GroupByMonth { get; }
-		IRichCommand ToggleGroupByDateUnit { get; }
-
-		IRichCommand NewTab { get; }
-		IRichCommand NavigateBack { get; }
-		IRichCommand NavigateForward { get; }
-		IRichCommand NavigateUp { get; }
-
-		IRichCommand DuplicateCurrentTab { get; }
-		IRichCommand DuplicateSelectedTab { get; }
+		IRichCommand ClearSelection { get; }
+		IRichCommand CloseOtherTabsCurrent { get; }
+		IRichCommand CloseOtherTabsSelected { get; }
+		IRichCommand ClosePane { get; }
+		IRichCommand CloseSelectedTab { get; }
 		IRichCommand CloseTabsToTheLeftCurrent { get; }
 		IRichCommand CloseTabsToTheLeftSelected { get; }
 		IRichCommand CloseTabsToTheRightCurrent { get; }
 		IRichCommand CloseTabsToTheRightSelected { get; }
-		IRichCommand CloseOtherTabsCurrent { get; }
-		IRichCommand CloseOtherTabsSelected { get; }
-		IRichCommand OpenDirectoryInNewPaneAction { get; }
-		IRichCommand OpenDirectoryInNewTabAction { get; }
-		IRichCommand OpenInNewWindowItemAction { get; }
-		IRichCommand ReopenClosedTab { get; }
-		IRichCommand PreviousTab { get; }
-		IRichCommand NextTab { get; }
-		IRichCommand CloseSelectedTab { get; }
-		IRichCommand OpenNewPane { get; }
-		IRichCommand ClosePane { get; }
-    
-		IRichCommand PlayAll { get; }
-
+		IRichCommand CompressIntoArchive { get; }
+		IRichCommand CompressIntoSevenZip { get; }
+		IRichCommand CompressIntoZip { get; }
+		IRichCommand CopyItem { get; }
+		IRichCommand CopyPath { get; }
+		IRichCommand CreateFolder { get; }
+		IRichCommand CreateFolderWithSelection { get; }
+		IRichCommand CreateShortcut { get; }
+		IRichCommand CreateShortcutFromDialog { get; }
+		IRichCommand CutItem { get; }
+		IRichCommand DecompressArchive { get; }
+		IRichCommand DecompressArchiveHere { get; }
+		IRichCommand DecompressArchiveToChildFolder { get; }
+		IRichCommand DeleteItem { get; }
+		IRichCommand DeleteItemPermanently { get; }
+		IRichCommand DuplicateCurrentTab { get; }
+		IRichCommand DuplicateSelectedTab { get; }
+		IRichCommand EditPath { get; }
+		IRichCommand EmptyRecycleBin { get; }
+		IRichCommand EnterCompactOverlay { get; }
+		IRichCommand ExitCompactOverlay { get; }
+		IRichCommand FormatDrive { get; }
 		IRichCommand GitFetch { get; }
 		IRichCommand GitInit { get; }
 		IRichCommand GitPull { get; }
 		IRichCommand GitPush { get; }
 		IRichCommand GitSync { get; }
-
+		IRichCommand GroupAscending { get; }
+		IRichCommand GroupByDateCreated { get; }
+		IRichCommand GroupByDateCreatedMonth { get; }
+		IRichCommand GroupByDateCreatedYear { get; }
+		IRichCommand GroupByDateDeleted { get; }
+		IRichCommand GroupByDateDeletedMonth { get; }
+		IRichCommand GroupByDateDeletedYear { get; }
+		IRichCommand GroupByDateModified { get; }
+		IRichCommand GroupByDateModifiedMonth { get; }
+		IRichCommand GroupByDateModifiedYear { get; }
+		IRichCommand GroupByFolderPath { get; }
+		IRichCommand GroupByMonth { get; }
+		IRichCommand GroupByName { get; }
+		IRichCommand GroupByNone { get; }
+		IRichCommand GroupByOriginalFolder { get; }
+		IRichCommand GroupBySize { get; }
+		IRichCommand GroupBySyncStatus { get; }
+		IRichCommand GroupByTag { get; }
+		IRichCommand GroupByType { get; }
+		IRichCommand GroupByYear { get; }
+		IRichCommand GroupDescending { get; }
+		IRichCommand InstallCertificate { get; }
+		IRichCommand InstallFont { get; }
+		IRichCommand InstallInfDriver { get; }
+		IRichCommand InvertSelection { get; }
+		IRichCommand LaunchPreviewPopup { get; }
+		IRichCommand LayoutAdaptive { get; }
+		IRichCommand LayoutColumns { get; }
+		IRichCommand LayoutDecreaseSize { get; }
+		IRichCommand LayoutDetails { get; }
+		IRichCommand LayoutGridLarge { get; }
+		IRichCommand LayoutGridMedium { get; }
+		IRichCommand LayoutGridSmall { get; }
+		IRichCommand LayoutIncreaseSize { get; }
+		IRichCommand LayoutTiles { get; }
+		IRichCommand NavigateBack { get; }
+		IRichCommand NavigateForward { get; }
+		IRichCommand NavigateUp { get; }
+		IRichCommand NewTab { get; }
+		IRichCommand NextTab { get; }
+		IRichCommand None { get; }
 		IRichCommand OpenAllTaggedItems { get; }
+		IRichCommand OpenCommandPalette { get; }
+		IRichCommand OpenDirectoryInNewPaneAction { get; }
+		IRichCommand OpenDirectoryInNewTabAction { get; }
+		IRichCommand OpenFileLocation { get; }
+		IRichCommand OpenHelp { get; }
+		IRichCommand OpenInNewWindowItemAction { get; }
+		IRichCommand OpenInVS { get; }
+		IRichCommand OpenInVSCode { get; }
+		IRichCommand OpenItem { get; }
+		IRichCommand OpenItemWithApplicationPicker { get; }
+		IRichCommand OpenNewPane { get; }
+		IRichCommand OpenParentFolder { get; }
+		IRichCommand OpenProperties { get; }
+		IRichCommand OpenSettings { get; }
+		IRichCommand OpenTerminal { get; }
+		IRichCommand OpenTerminalAsAdmin { get; }
+		IRichCommand PasteItem { get; }
+		IRichCommand PasteItemToSelection { get; }
+		IRichCommand PinItemToFavorites { get; }
+		IRichCommand PinToStart { get; }
+		IRichCommand PlayAll { get; }
+		IRichCommand PreviousTab { get; }
+		IRichCommand Redo { get; }
+		IRichCommand RefreshItems { get; }
+		IRichCommand Rename { get; }
+		IRichCommand ReopenClosedTab { get; }
+		IRichCommand RestoreAllRecycleBin { get; }
+		IRichCommand RestoreRecycleBin { get; }
+		IRichCommand RotateLeft { get; }
+		IRichCommand RotateRight { get; }
+		IRichCommand RunAsAdmin { get; }
+		IRichCommand RunAsAnotherUser { get; }
+		IRichCommand RunWithPowershell { get; }
+		IRichCommand Search { get; }
+		IRichCommand SearchUnindexedItems { get; }
+		IRichCommand SelectAll { get; }
+		IRichCommand SetAsLockscreenBackground { get; }
+		IRichCommand SetAsSlideshowBackground { get; }
+		IRichCommand SetAsWallpaperBackground { get; }
+		IRichCommand ShareItem { get; }
+		IRichCommand SortAscending { get; }
+		IRichCommand SortByDateCreated { get; }
+		IRichCommand SortByDateDeleted { get; }
+		IRichCommand SortByDateModified { get; }
+		IRichCommand SortByName { get; }
+		IRichCommand SortByOriginalFolder { get; }
+		IRichCommand SortByPath { get; }
+		IRichCommand SortBySize { get; }
+		IRichCommand SortBySyncStatus { get; }
+		IRichCommand SortByTag { get; }
+		IRichCommand SortByType { get; }
+		IRichCommand SortDescending { get; }
+		IRichCommand ToggleCompactOverlay { get; }
+		IRichCommand ToggleFullScreen { get; }
+		IRichCommand ToggleGroupByDateUnit { get; }
+		IRichCommand ToggleGroupDirection { get; }
+		IRichCommand TogglePreviewPane { get; }
+		IRichCommand ToggleSelect { get; }
+		IRichCommand ToggleShowFileExtensions { get; }
+		IRichCommand ToggleShowHiddenItems { get; }
+		IRichCommand ToggleSortDirection { get; }
+		IRichCommand ToggleSortDirectoriesAlongsideFiles { get; }
+		IRichCommand Undo { get; }
+		IRichCommand UnpinFromStart { get; }
+		IRichCommand UnpinItemFromFavorites { get; }
 	}
 }

--- a/src/Files.App/UserControls/IAddressToolbar.cs
+++ b/src/Files.App/UserControls/IAddressToolbar.cs
@@ -13,6 +13,8 @@ namespace Files.App.UserControls
 
 		public bool IsEditModeEnabled { get; set; }
 
+		public bool IsCommandPaletteOpen { get; set; }
+
 		public bool CanRefresh { get; set; }
 
 		public bool CanCopyPathInPage { get; set; }
@@ -36,6 +38,8 @@ namespace Files.App.UserControls
 		public event ToolbarQuerySubmittedEventHandler PathBoxQuerySubmitted;
 
 		public event EventHandler EditModeEnabled;
+
+		public event EventHandler CommandPaletteOpened;
 
 		public event ItemDraggedOverPathItemEventHandler ItemDraggedOverPathItem;
 

--- a/src/Files.App/ViewModels/UserControls/ToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/ToolbarViewModel.cs
@@ -39,6 +39,8 @@ namespace Files.App.ViewModels.UserControls
 
 		public delegate void PathBoxItemDroppedEventHandler(object sender, PathBoxItemDroppedEventArgs e);
 
+		public event EventHandler? CommandPaletteOpened;
+
 		public event ToolbarPathItemInvokedEventHandler? ToolbarPathItemInvoked;
 
 		public event ToolbarFlyoutOpenedEventHandler? ToolbarFlyoutOpened;
@@ -60,6 +62,22 @@ namespace Files.App.ViewModels.UserControls
 		public event EventHandler? RefreshWidgetsRequested;
 
 		public ObservableCollection<PathBoxItem> PathComponents { get; } = new();
+
+		private bool _isCommandPaletteOpen;
+
+		public bool IsCommandPaletteOpen
+		{
+			get => _isCommandPaletteOpen;
+			set
+			{
+				if (SetProperty(ref _isCommandPaletteOpen, value) && value) // Only invoke when value changes to true
+				{
+					CommandPaletteOpened?.Invoke(this, EventArgs.Empty);
+
+					// You can add additional logic here if needed
+				}
+			}
+		}
 
 		private bool isUpdating;
 		public bool IsUpdating
@@ -150,6 +168,7 @@ namespace Files.App.ViewModels.UserControls
 		}
 
 		private string? pathText;
+
 		public string? PathText
 		{
 			get => pathText;
@@ -512,6 +531,7 @@ namespace Files.App.ViewModels.UserControls
 
 		public void OpenCommandPalette()
 		{
+			IsCommandPaletteOpen = true;  // Set to true when opened
 			PathText = ">";
 			ManualEntryBoxLoaded = true;
 			ClickablePathLoaded = false;

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -136,7 +136,7 @@ namespace Files.App.Views.Shells
 
 					if (!value && SlimContentPage is not ColumnViewBrowser)
 						ToolbarViewModel.IsEditModeEnabled = false;
-
+						ToolbarViewModel.IsCommandPaletteOpen = false;
 					NotifyPropertyChanged(nameof(IsCurrentInstance));
 				}
 			}

--- a/src/Files.App/Views/Shells/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/Shells/ColumnShellPage.xaml.cs
@@ -139,6 +139,11 @@ namespace Files.App.Views.Shells
 					if (!ToolbarViewModel.IsEditModeEnabled && !ContentPage.IsRenamingItem && !InstanceViewModel.IsPageTypeSearchResults && !ToolbarViewModel.SearchHasFocus)
 						await UIFilesystemHelpers.PasteItemAsync(FilesystemViewModel.WorkingDirectory, this);
 					break;
+
+				// Ctrl + Shift + P, Toggle Command Palette
+				case (true, true, false, true, VirtualKey.P):
+					ToolbarViewModel.IsCommandPaletteOpen = !ToolbarViewModel.IsCommandPaletteOpen;
+					break;
 			}
 		}
 

--- a/src/Files.App/Views/Shells/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/Shells/ModernShellPage.xaml.cs
@@ -197,6 +197,11 @@ namespace Files.App.Views.Shells
 					if (!ToolbarViewModel.IsEditModeEnabled && !ContentPage.IsRenamingItem && !InstanceViewModel.IsPageTypeSearchResults && !ToolbarViewModel.SearchHasFocus)
 						await UIFilesystemHelpers.PasteItemAsync(FilesystemViewModel.WorkingDirectory, this);
 					break;
+
+				// Ctrl + Shift + P, Toggle Command Palette
+				case (true, true, false, _, VirtualKey.P):
+					ToolbarViewModel.IsCommandPaletteOpen = !ToolbarViewModel.IsCommandPaletteOpen;
+					break;
 			}
 		}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13284 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [X] Did you implement any design changes to an existing feature?

ToolbarViewModel.cs revised to include event for CommandPaletteOpened. OpenCommandPalette() function revised to include the boolean. 
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
  

**Screenshots (optional)**
Add screenshots here.
![Screenshot 2023-09-02 132700](https://github.com/files-community/Files/assets/117103373/33e36e23-7d94-4cb9-90ee-e5ce07d2ed44)
