### PR TITLE
Fix: Fixed issue where tab headers sometimes didn't match actual content

### DIFF
--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -165,24 +165,31 @@ namespace Files.App.ViewModels
 		public async Task UpdateTabInfo(TabItem tabItem, object navigationArg)
 		{
 			tabItem.AllowStorageItemDrop = true;
+
+			(string, IconSource, string) result = (null, null, null);
 			if (navigationArg is PaneNavigationArguments paneArgs)
 			{
 				if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
 				{
 					var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
 					var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
-					tabItem.Header = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
-					tabItem.IconSource = leftTabInfo.tabIcon;
+					result = ($"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}",
+						leftTabInfo.tabIcon,
+						$"{leftTabInfo.toolTipText} | {rightTabInfo.toolTipText}");
 				}
 				else
 				{
-					(tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+					result = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
 				}
 			}
 			else if (navigationArg is string pathArgs)
 			{
-				(tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = await GetSelectedTabInfoAsync(pathArgs);
+				result = await GetSelectedTabInfoAsync(pathArgs);
 			}
+
+			// Don't update tabItem if the contents of the tab have already changed
+			if (result.Item1 is not null && navigationArg == tabItem.TabItemArguments.NavigationArg)
+				(tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = result;
 		}
 
 		public async Task<(string tabLocationHeader, IconSource tabIcon, string toolTipText)> GetSelectedTabInfoAsync(string currentPath)


### PR DESCRIPTION
This PR also fixes the issue of tab tooltips not updating in case of dual pane.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12939 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Open the home page.
   2. Click a sidebar item (ex: Documents).
   3. Quickly click Home on the sidebar.
   4. The tab header is no longer displayed with the contents of 2.