### PR TITLE
Fix: Fixed issue where the path bar would display wrong location at app startup

### DIFF
--- a/src/Files.App/Utils/Storage/Helpers/StorageFileExtensions.cs
+++ b/src/Files.App/Utils/Storage/Helpers/StorageFileExtensions.cs
@@ -280,9 +280,8 @@ namespace Files.App.Utils.Storage
 			else if (component.Contains(':', StringComparison.Ordinal))
 			{
 				var drivesViewModel = Ioc.Default.GetRequiredService<DrivesViewModel>();
-				var networkDrivesViewModel = Ioc.Default.GetRequiredService<NetworkDrivesViewModel>();
 
-				var drives = drivesViewModel.Drives.Concat(networkDrivesViewModel.Drives).Cast<DriveItem>().Concat(App.CloudDrivesManager.Drives);
+				var drives = drivesViewModel.Drives.Cast<DriveItem>();
 				var drive = drives.FirstOrDefault(y => y.ItemType is NavigationControlItemType.Drive && y.Path.Contains(component, StringComparison.OrdinalIgnoreCase));
 				title = drive is not null ? drive.Text : string.Format("DriveWithLetter".GetLocalizedResource(), component);
 			}


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13340 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

**Note**
The path bar will display the correct location, but will not display its volume label. This is because the drive information has not yet been loaded immediately after startup. I leave it as is because waiting for the drive information to be loaded slows down the page loading.