### PR TITLE
Feature: Added support to switch between items using arrow keys in the conflicts dialog

### DIFF
--- a/src/Files.App/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files.App/Dialogs/FilesystemOperationDialog.xaml
@@ -99,6 +99,7 @@
 						x:Load="{x:Bind IsTextBoxVisible, Mode=OneWay}"
 						Loaded="NameEdit_Loaded"
 						LostFocus="NameEdit_LostFocus"
+						PreviewKeyDown="NameEdit_PreviewKeyDown"
 						Text="{x:Bind CustomName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 				</Grid>
 


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #9057

**Details**
Please, note that the former line 121 (`conflictItem.CustomName = string.Empty;`) was removed from `EndRename()` as it was causing a crash.
Steps to reproduce (Stable or Preview):
- Reach the `Conflicts dialog`
- Click on an item to rename it and then click away
- Repeat until eventually Files crashes (the number of required iterations depends on the depth of the destination. e.g.  `C:\Users\USERNAME\Documents\files.txt` should take 5 cycles)

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Copy & paste some files that require the `Conflict dialog`
   2. Click on an item name
   3. Use `Up` & `Down` arrows to move between the names
   4. Mark some items with `Skip`
   5. Check that you don't land on them using arrows

**Screenshots (optional)**

https://github.com/files-community/Files/assets/102259289/03caa45f-0bdf-45ce-9f21-2e74a539f5ce
