### PR TITLE
Fix: Fixed crash in FTP folders

### DIFF
--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -168,7 +168,7 @@ namespace Files.App.Data.Models
 				pathRoot = Path.GetPathRoot(WorkingDirectory);
 			}
 
-			GitDirectory = pathRoot is null ? null : GitHelpers.GetGitRepositoryPath(WorkingDirectory, pathRoot);
+			GitDirectory = GitHelpers.GetGitRepositoryPath(WorkingDirectory, pathRoot);
 			IsValidGitDirectory = !string.IsNullOrEmpty(GitHelpers.GetRepositoryHeadName(GitDirectory));
 
 			OnPropertyChanged(nameof(WorkingDirectory));

--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -64,6 +64,9 @@ namespace Files.App.Utils.Git
 
 		public static string? GetGitRepositoryPath(string? path, string root)
 		{
+			if (string.IsNullOrEmpty(root))
+				return null;
+
 			if (root.EndsWith('\\'))
 				root = root.Substring(0, root.Length - 1);
 
@@ -491,7 +494,7 @@ namespace Files.App.Utils.Git
 			repoRootPath = path;
 
 			var rootPath = SystemIO.Path.GetPathRoot(path);
-			if (rootPath is null)
+			if (string.IsNullOrEmpty(rootPath))
 				return false;
 
 			var repositoryRootPath = GetGitRepositoryPath(path, rootPath);


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

This PR fixes an issue where app would crash with "stack overflow exception" when trying to detect Git repo in FTP folders.

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
