### PR TITLE
Fix: Fixed scroll position after page transitions

### DIFF
--- a/src/Files.App/Views/LayoutModes/BaseLayout.cs
+++ b/src/Files.App/Views/LayoutModes/BaseLayout.cs
@@ -176,7 +176,6 @@ namespace Files.App.Views.LayoutModes
 					if (jumpedToItem is not null)
 					{
 						ItemManipulationModel.SetSelectedItem(jumpedToItem);
-						ItemManipulationModel.ScrollIntoView(jumpedToItem);
 						ItemManipulationModel.FocusSelectedItems();
 					}
 

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -66,6 +66,7 @@ namespace Files.App.Views.LayoutModes
 		protected override void ItemManipulationModel_ScrollIntoViewInvoked(object? sender, ListedItem e)
 		{
 			FileList.ScrollIntoView(e);
+			// The item will be seen at the bottom of the page
 			ContentScroller?.ChangeView(
 				null,
 				(FileList.Items.IndexOf(e) + 1.5) * Convert.ToInt32(Application.Current.Resources["ListItemHeight"]) - ContentScroller?.ActualHeight + HeaderGrid.Height,

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -66,7 +66,11 @@ namespace Files.App.Views.LayoutModes
 		protected override void ItemManipulationModel_ScrollIntoViewInvoked(object? sender, ListedItem e)
 		{
 			FileList.ScrollIntoView(e);
-			ContentScroller?.ChangeView(null, FileList.Items.IndexOf(e) * Convert.ToInt32(Application.Current.Resources["ListItemHeight"]), null, true); // Scroll to index * item height
+			ContentScroller?.ChangeView(
+				null,
+				(FileList.Items.IndexOf(e) + 1.5) * Convert.ToInt32(Application.Current.Resources["ListItemHeight"]) - ContentScroller?.ActualHeight + HeaderGrid.Height,
+				null,
+				true);
 		}
 
 		protected override void ItemManipulationModel_FocusSelectedItemsInvoked(object? sender, EventArgs e)

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -65,22 +65,16 @@ namespace Files.App.Views.LayoutModes
 
 		protected override void ItemManipulationModel_ScrollIntoViewInvoked(object? sender, ListedItem e)
 		{
-			FileList.ScrollIntoView(e);
-			// The item will be seen at the bottom of the page
-			ContentScroller?.ChangeView(
-				null,
-				(FileList.Items.IndexOf(e) + 1.5) * Convert.ToInt32(Application.Current.Resources["ListItemHeight"]) - ContentScroller?.ActualHeight + HeaderGrid.Height,
-				null,
-				true);
+			(FileList.ContainerFromItem(e) as ListViewItem)?.StartBringIntoView();
 		}
 
 		protected override void ItemManipulationModel_FocusSelectedItemsInvoked(object? sender, EventArgs e)
 		{
 			if (SelectedItems?.Any() ?? false)
 			{
-				FileList.ScrollIntoView(SelectedItems.Last());
-				ContentScroller?.ChangeView(null, FileList.Items.IndexOf(SelectedItems.Last()) * Convert.ToInt32(Application.Current.Resources["ListItemHeight"]), null, false);
-				(FileList.ContainerFromItem(SelectedItems.Last()) as ListViewItem)?.Focus(FocusState.Keyboard);
+				var listViewItem = FileList.ContainerFromItem(SelectedItems.Last()) as ListViewItem;
+				listViewItem?.StartBringIntoView();
+				listViewItem?.Focus(FocusState.Keyboard);
 			}
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #5825

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Navigate to the root of Files' GitHub repository.
   2. Navigate to `artifacts` (next to `.github`).
   3. Navigate back.
   4. Scroll position will be top and `.github` will be seen.