### PR TITLE
Fix: Display error when failing to initialize folder as git repo

### DIFF
--- a/src/Files.App/Actions/Git/GitInitAction.cs
+++ b/src/Files.App/Actions/Git/GitInitAction.cs
@@ -15,6 +15,7 @@ namespace Files.App.Actions
 
 		public bool IsExecutable => 
 			_context.Folder is not null &&
+			_context.Folder.ItemPath != SystemIO.Path.GetPathRoot(_context.Folder.ItemPath) &&
 			!_context.IsGitRepository;
 
 		public GitInitAction()
@@ -26,8 +27,7 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync()
 		{
-			GitHelpers.InitializeRepository(_context.Folder?.ItemPath);
-			return Task.CompletedTask;
+			return GitHelpers.InitializeRepository(_context.Folder?.ItemPath);
 		}
 
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
+++ b/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
@@ -280,5 +280,16 @@ namespace Files.App.Helpers
 			});
 			return dialog;
 		}
+
+		public static DynamicDialog GetFor_GitCannotInitializeqRepositoryHere()
+		{
+			return new DynamicDialog(new DynamicDialogViewModel()
+			{
+				TitleText = "Error".GetLocalizedResource(),
+				SubtitleText = "CannotInitializeGitRepositoryHere".GetLocalizedResource(),
+				PrimaryButtonText = "Close".GetLocalizedResource(),
+				DynamicButtons = DynamicDialogButtons.Primary
+			});
+		}
 	}
 }

--- a/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
+++ b/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
@@ -286,7 +286,7 @@ namespace Files.App.Helpers
 			return new DynamicDialog(new DynamicDialogViewModel()
 			{
 				TitleText = "Error".GetLocalizedResource(),
-				SubtitleText = "CannotInitializeGitRepositoryHere".GetLocalizedResource(),
+				SubtitleText = "CannotInitializeGitRepo".GetLocalizedResource(),
 				PrimaryButtonText = "Close".GetLocalizedResource(),
 				DynamicButtons = DynamicDialogButtons.Primary
 			});

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3526,7 +3526,7 @@
   <data name="ClearCompleted" xml:space="preserve">
     <value>Clear completed</value>
   </data>
-  <data name="CannotInitializeGitRepositoryHere" xml:space="preserve">
+  <data name="CannotInitializeGitRepo" xml:space="preserve">
     <value>Files can't initialize this directory as a Git repository.</value>
   </data>
 </root>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3526,4 +3526,7 @@
   <data name="ClearCompleted" xml:space="preserve">
     <value>Clear completed</value>
   </data>
+  <data name="CannotInitializeGitRepositoryHere" xml:space="preserve">
+    <value>Files can't initialize a Git repository here.</value>
+  </data>
 </root>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3527,6 +3527,6 @@
     <value>Clear completed</value>
   </data>
   <data name="CannotInitializeGitRepositoryHere" xml:space="preserve">
-    <value>Files can't initialize a Git repository here.</value>
+    <value>Files can't initialize this directory as a Git repository.</value>
   </data>
 </root>

--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -561,12 +561,20 @@ namespace Files.App.Utils.Git
 			return gitItemModel;
 		}
 
-		public static void InitializeRepository(string? path)
+		public static async Task InitializeRepository(string? path)
 		{
 			if (string.IsNullOrWhiteSpace(path))
 				return;
 
-			Repository.Init(path);
+			try
+			{
+				Repository.Init(path);
+			}
+			catch (LibGit2SharpException ex)
+			{
+				_logger.LogWarning(ex.Message);
+				await DynamicDialogFactory.GetFor_GitCannotInitializeqRepositoryHere().TryShowAsync();
+			}
 		}
 
 		private static IEnumerable<Branch> GetValidBranches(BranchCollection branches)
@@ -591,7 +599,7 @@ namespace Files.App.Utils.Git
 			try
 			{
 				return branch.TrackingDetails;
-			} 
+			}
 			catch (LibGit2SharpException)
 			{
 				return null;


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13280 

**Notes**
There's an issue with WSL: trying to initialize a git repository will throw an exception (path not owned by current user), still the repo will be initialized. Should we notify the user about this "error"?

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Try to digit `>Init` in the search bar of a drive root
   2. Try to initialize a git repository in WSL
