### PR TITLE
Fixed: Eject_Option_for_External_Hard_Drives- Bug #13250

### DIFF
--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -18,6 +18,7 @@ namespace Files.App.Data.Items
 	public class DriveItem : ObservableObject, INavigationControlItem, ILocatableFolder
 	{
 		private BitmapImage icon;
+		public static bool is_C_Drive = false;
 		public BitmapImage Icon
 		{
 			get => icon;
@@ -46,7 +47,7 @@ namespace Files.App.Data.Items
 		public Visibility ItemVisibility { get; set; } = Visibility.Visible;
 
 		public bool IsRemovable
-			=> Type == DriveType.Removable || Type == DriveType.CDRom;
+			=> Type == DriveType.Removable || Type == DriveType.CDRom || (Type == DriveType.Fixed && is_C_Drive);
 
 		public bool IsNetwork
 			=> Type == DriveType.Network;
@@ -228,6 +229,7 @@ namespace Files.App.Data.Items
 		public static async Task<DriveItem> CreateFromPropertiesAsync(StorageFolder root, string deviceId, string label, DriveType type, IRandomAccessStream imageStream = null)
 		{
 			var item = new DriveItem();
+			is_C_Drive = (item.Type == DriveType.Fixed && !(string.Equals(root.Path, "C:\\", StringComparison.OrdinalIgnoreCase)));
 
 			if (imageStream is not null)
 				item.IconData = await imageStream.ToByteArrayAsync();


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [ X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...Bug: Eject option isn't displayed for external hard drives #13250 

**Validation**
How did you test these changes?
- [X ] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ X] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Screenshots (optional)**
**External Hard Drive Eject Option:**
<img width="587" alt="Disk_Drive_Eject" src="https://github.com/files-community/Files/assets/122647305/54fb089f-e197-46e3-a70e-3b560bd7b0af">

**External Hard Drive Properties:**
<img width="587" alt="Fixed_Disk_Drive" src="https://github.com/files-community/Files/assets/122647305/ecf3d0a6-cd12-4575-aa6a-065584dc931d">




