### PR TITLE
Fix: Fixed crash when dragging files from GMail

### DIFF
--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -780,7 +780,8 @@ namespace Files.App.Utils.Storage
 			// https://learn.microsoft.com/windows/win32/shell/clipboard#cf_hdrop
 			if (packageView.Contains("FileDrop"))
 			{
-				var fileDropData = await packageView.GetDataAsync("FileDrop");
+				var fileDropData = await SafetyExtensions.IgnoreExceptions(
+					() => packageView.GetDataAsync("FileDrop").AsTask());
 				if (fileDropData is IRandomAccessStream stream)
 				{
 					stream.Seek(0);


### PR DESCRIPTION
**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13473

NB: this change fixes the crash but the attachment is created as an internet shortcut (.url) file instead of an actual file like explorer does.

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Drag attachment from web GMail to Files
