### PR TITLE
Feature: Copy multiple item paths at once

### DIFF
--- a/src/Files.App/Actions/FileSystem/CopyPathAction.cs
+++ b/src/Files.App/Actions/FileSystem/CopyPathAction.cs
@@ -30,8 +30,8 @@ namespace Files.App.Actions
 		{
 			if (context.ShellPage?.SlimContentPage is not null)
 			{
-				var path = context.ShellPage.SlimContentPage.SelectedItem is not null
-					? context.ShellPage.SlimContentPage.SelectedItem.ItemPath
+				var path = context.ShellPage.SlimContentPage.SelectedItems is not null
+					? context.ShellPage.SlimContentPage.SelectedItems.Select(x => x.ItemPath).Aggregate((accum, current) => accum + "\n" + current)
 					: context.ShellPage.FilesystemViewModel.WorkingDirectory;
 
 				if (FtpHelpers.IsFtpPath(path))

--- a/src/Files.App/Helpers/MenuFlyout/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/MenuFlyout/ContextFlyoutItemHelper.cs
@@ -440,7 +440,7 @@ namespace Files.App.Helpers
 				}.Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(commands.CopyPath)
 				{
-					IsVisible = itemsSelected && selectedItems.Count == 1 && !currentInstanceViewModel.IsPageTypeRecycleBin,
+					IsVisible = itemsSelected && !currentInstanceViewModel.IsPageTypeRecycleBin,
 				}.Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(commands.CreateFolderWithSelection)
 				{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13527 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Select multiple items
   3. Copy item paths

**Screenshots (optional)**
Add screenshots here.
