### PR TITLE
Fix: Fixed issue where tab selection got stuck on the sidebar

### DIFF
--- a/src/Files.App/UserControls/SideBar/SideBarView.xaml.cs
+++ b/src/Files.App/UserControls/SideBar/SideBarView.xaml.cs
@@ -142,7 +142,14 @@ namespace Files.App.UserControls.Sidebar
 
 		private void SidebarResizerControl_KeyDown(object sender, KeyRoutedEventArgs e)
 		{
-			if (e.Key == VirtualKey.Tab)
+			if
+			(
+				e.Key != VirtualKey.Space &&
+				e.Key != VirtualKey.Enter &&
+				e.Key != VirtualKey.Left &&
+				e.Key != VirtualKey.Right &&
+				e.Key != VirtualKey.Control
+			)
 				return;
 
 			var primaryInvocation = e.Key == VirtualKey.Space || e.Key == VirtualKey.Enter;
@@ -159,9 +166,8 @@ namespace Files.App.UserControls.Sidebar
 
 				// Left makes the pane smaller so we invert the increment
 				if (e.Key == VirtualKey.Left)
-				{
 					increment = -increment;
-				}
+
 				var newWidth = OpenPaneLength + increment;
 				UpdateDisplayModeForPaneWidth(newWidth);
 				e.Handled = true;
@@ -238,7 +244,7 @@ namespace Files.App.UserControls.Sidebar
 
 		private void MenuItemsHost_ElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
 		{
-			if(args.Element is SidebarItem sidebarItem)
+			if (args.Element is SidebarItem sidebarItem)
 			{
 				sidebarItem.HandleItemChange();
 			}

--- a/src/Files.App/UserControls/SideBar/SideBarView.xaml.cs
+++ b/src/Files.App/UserControls/SideBar/SideBarView.xaml.cs
@@ -142,6 +142,9 @@ namespace Files.App.UserControls.Sidebar
 
 		private void SidebarResizerControl_KeyDown(object sender, KeyRoutedEventArgs e)
 		{
+			if (e.Key == VirtualKey.Tab)
+				return;
+
 			var primaryInvocation = e.Key == VirtualKey.Space || e.Key == VirtualKey.Enter;
 			if (DisplayMode == SidebarDisplayMode.Expanded)
 			{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13548...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Use tab key until sidebar resizer is selected
   3. Confirm using the tab & tab + shift key combination moves the focus off the sidebar

**Screenshots (optional)**
Add screenshots here.
