### PR TITLE
Fix: Fixed the mini search button visual state

### DIFF
--- a/src/Files.App/UserControls/AddressToolbar.xaml
+++ b/src/Files.App/UserControls/AddressToolbar.xaml
@@ -554,7 +554,7 @@
 						<triggers:IsEqualStateTrigger Value="{x:Bind ShowSearchBox, Mode=OneWay}" To="False" />
 					</VisualState.StateTriggers>
 					<VisualState.Setters>
-						<Setter Target="SearchButton.Visibility" Value="Visible" />
+						<Setter Target="ShowSearchButton.Visibility" Value="Visible" />
 						<Setter Target="SearchRegion.(Grid.Column)" Value="1" />
 						<Setter Target="SearchRegion.Width" Value="NaN" />
 					</VisualState.Setters>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Fixed an issue where the mini search button wasn't shown on smaller windows

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Make window smaller
   2. Confirm the mini search button is shown

**Screenshots (optional)**
Add screenshots here.
