### PR TITLE
Fix: Switch focus to Files when activating window

### DIFF
--- a/src/Files.App/Helpers/Interop/InteropHelpers.cs
+++ b/src/Files.App/Helpers/Interop/InteropHelpers.cs
@@ -28,8 +28,8 @@ namespace Files.App.Helpers
 		[DllImport("kernel32.dll")]
 		public static extern bool SetEvent(IntPtr hEvent);
 
-		[DllImport("USER32.DLL")]
-		public static extern bool SetForegroundWindow(IntPtr hWnd);
+		[DllImport("user32.dll", SetLastError = true)]
+		public static extern void SwitchToThisWindow(IntPtr hWnd, bool altTab);
 
 		[DllImport("ole32.dll")]
 		public static extern uint CoWaitForMultipleObjects(uint dwFlags, uint dwMilliseconds, ulong nHandles, IntPtr[] pHandles, out uint dwIndex);

--- a/src/Files.App/Helpers/Interop/InteropHelpers.cs
+++ b/src/Files.App/Helpers/Interop/InteropHelpers.cs
@@ -28,6 +28,9 @@ namespace Files.App.Helpers
 		[DllImport("kernel32.dll")]
 		public static extern bool SetEvent(IntPtr hEvent);
 
+		[DllImport("USER32.DLL")]
+		public static extern bool SetForegroundWindow(IntPtr hWnd);
+
 		[DllImport("ole32.dll")]
 		public static extern uint CoWaitForMultipleObjects(uint dwFlags, uint dwMilliseconds, ulong nHandles, IntPtr[] pHandles, out uint dwIndex);
 

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -97,8 +97,8 @@ namespace Files.App
 					}
 					else if (!(string.IsNullOrEmpty(launchArgs.Arguments) && MainPageViewModel.AppInstances.Count > 0))
 					{
-						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), launchArgs.Arguments);
 						InteropHelpers.SwitchToThisWindow(WindowHandle, true);
+						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), launchArgs.Arguments);
 					}
 					else
 					{
@@ -176,8 +176,8 @@ namespace Files.App
 					}
 					for (; index < fileArgs.Files.Count; index++)
 					{
-						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), fileArgs.Files[index].Path);
 						InteropHelpers.SwitchToThisWindow(WindowHandle, true);
+						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), fileArgs.Files[index].Path);
 					}
 					break;
 			}
@@ -238,8 +238,8 @@ namespace Files.App
 
 				if (rootFrame.Content is MainPage && MainPageViewModel.AppInstances.Any())
 				{
-					await mainPageViewModel.AddNewTabByParamAsync(typeof(PaneHolderPage), paneNavigationArgs);
 					InteropHelpers.SwitchToThisWindow(WindowHandle, true);
+					await mainPageViewModel.AddNewTabByParamAsync(typeof(PaneHolderPage), paneNavigationArgs);
 				}
 				else
 					rootFrame.Navigate(typeof(MainPage), paneNavigationArgs, new SuppressNavigationTransitionInfo());

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -98,6 +98,7 @@ namespace Files.App
 					else if (!(string.IsNullOrEmpty(launchArgs.Arguments) && MainPageViewModel.AppInstances.Count > 0))
 					{
 						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), launchArgs.Arguments);
+						InteropHelpers.SetForegroundWindow(WindowHandle);
 					}
 					else
 					{

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -98,7 +98,7 @@ namespace Files.App
 					else if (!(string.IsNullOrEmpty(launchArgs.Arguments) && MainPageViewModel.AppInstances.Count > 0))
 					{
 						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), launchArgs.Arguments);
-						InteropHelpers.SetForegroundWindow(WindowHandle);
+						InteropHelpers.SwitchToThisWindow(WindowHandle, true);
 					}
 					else
 					{
@@ -177,7 +177,7 @@ namespace Files.App
 					for (; index < fileArgs.Files.Count; index++)
 					{
 						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), fileArgs.Files[index].Path);
-						InteropHelpers.SetForegroundWindow(WindowHandle);
+						InteropHelpers.SwitchToThisWindow(WindowHandle, true);
 					}
 					break;
 			}
@@ -239,7 +239,7 @@ namespace Files.App
 				if (rootFrame.Content is MainPage && MainPageViewModel.AppInstances.Any())
 				{
 					await mainPageViewModel.AddNewTabByParamAsync(typeof(PaneHolderPage), paneNavigationArgs);
-					InteropHelpers.SetForegroundWindow(WindowHandle);
+					InteropHelpers.SwitchToThisWindow(WindowHandle, true);
 				}
 				else
 					rootFrame.Navigate(typeof(MainPage), paneNavigationArgs, new SuppressNavigationTransitionInfo());

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -174,9 +174,10 @@ namespace Files.App
 						rootFrame.Navigate(typeof(MainPage), fileArgs.Files.First().Path, new SuppressNavigationTransitionInfo());
 						index = 1;
 					}
+					else
+						InteropHelpers.SwitchToThisWindow(WindowHandle, true);
 					for (; index < fileArgs.Files.Count; index++)
 					{
-						InteropHelpers.SwitchToThisWindow(WindowHandle, true);
 						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), fileArgs.Files[index].Path);
 					}
 					break;

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -177,6 +177,7 @@ namespace Files.App
 					for (; index < fileArgs.Files.Count; index++)
 					{
 						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), fileArgs.Files[index].Path);
+						InteropHelpers.SetForegroundWindow(WindowHandle);
 					}
 					break;
 			}

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -237,7 +237,10 @@ namespace Files.App
 				};
 
 				if (rootFrame.Content is MainPage && MainPageViewModel.AppInstances.Any())
+				{
 					await mainPageViewModel.AddNewTabByParamAsync(typeof(PaneHolderPage), paneNavigationArgs);
+					InteropHelpers.SetForegroundWindow(WindowHandle);
+				}
 				else
 					rootFrame.Navigate(typeof(MainPage), paneNavigationArgs, new SuppressNavigationTransitionInfo());
 			}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #10844...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app and set as the default file manager
   2. Minimize window or switch focus to another window
   3. Use the `open file location` option in another app and see if Files is brought to the foreground

**Screenshots (optional)**
Add screenshots here.
