### PR TITLE
Feature: Added app name to the splash screen

### DIFF
--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -75,6 +75,8 @@ namespace Files.App
 
 			var rootFrame = EnsureWindowIsInitialized();
 
+			return;
+
 			switch (activatedEventArgs)
 			{
 				case ILaunchActivatedEventArgs launchArgs:

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -75,8 +75,6 @@ namespace Files.App
 
 			var rootFrame = EnsureWindowIsInitialized();
 
-			return;
-
 			switch (activatedEventArgs)
 			{
 				case ILaunchActivatedEventArgs launchArgs:

--- a/src/Files.App/Views/SplashScreenPage.xaml
+++ b/src/Files.App/Views/SplashScreenPage.xaml
@@ -19,8 +19,8 @@
 			Stretch="None">
 			<Image
 				x:Name="SplashScreenImage"
-				ImageFailed="SplashScreenImage_ImageFailed"
-				ImageOpened="SplashScreenImage_ImageOpened"
+				ImageFailed="Image_ImageFailed"
+				ImageOpened="Image_ImageOpened"
 				Source="\Assets\AppTiles\Dev\SplashScreen.png" />
 		</Viewbox>
 

--- a/src/Files.App/Views/SplashScreenPage.xaml
+++ b/src/Files.App/Views/SplashScreenPage.xaml
@@ -9,16 +9,38 @@
 	mc:Ignorable="d">
 
 	<Grid>
-		<Image
-			x:Name="MainSplashScreenImage"
-			Width="420"
-			ImageFailed="Image_ImageFailed"
-			ImageOpened="Image_ImageOpened"
-			Source="\Assets\AppTiles\Dev\SplashScreen.png" />
+		<!--  Splash Screen Image  -->
+		<Viewbox
+			x:Name="SplashScreenImageViewbox"
+			Width="620"
+			Height="300"
+			HorizontalAlignment="Center"
+			VerticalAlignment="Center"
+			Stretch="None">
+			<Image
+				x:Name="SplashScreenImage"
+				ImageFailed="SplashScreenImage_ImageFailed"
+				ImageOpened="SplashScreenImage_ImageOpened"
+				Source="\Assets\AppTiles\Dev\SplashScreen.png" />
+		</Viewbox>
 
+		<!--  Branch Label  -->
+		<TextBlock
+			x:Name="SplashScreenBranchLabel"
+			Margin="0,164,0,0"
+			HorizontalAlignment="Center"
+			VerticalAlignment="Center"
+			FontSize="20"
+			Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+			LineHeight="32">
+			<Run FontWeight="SemiBold" Text="Files" />
+			<Run FontWeight="SemiLight" Text="Preview" />
+		</TextBlock>
+
+		<!--  Loading Indicator  -->
 		<ProgressRing
-			x:Name="MainProgressRing"
-			Margin="0,0,0,88"
+			x:Name="SplashScreenLoadingProgressRing"
+			Margin="0,0,0,48"
 			VerticalAlignment="Bottom"
 			Foreground="{ThemeResource ApplicationForegroundThemeBrush}"
 			IsIndeterminate="True" />
@@ -27,10 +49,10 @@
 			<VisualStateGroup x:Name="SizeChangesState">
 				<VisualState>
 					<VisualState.StateTriggers>
-						<AdaptiveTrigger MinWindowWidth="640" />
+						<AdaptiveTrigger MinWindowHeight="500" />
 					</VisualState.StateTriggers>
 					<VisualState.Setters>
-						<Setter Target="MainSplashScreenImage.Width" Value="480" />
+						<Setter Target="SplashScreenLoadingProgressRing.Margin" Value="0,0,0,88" />
 					</VisualState.Setters>
 				</VisualState>
 			</VisualStateGroup>

--- a/src/Files.App/Views/SplashScreenPage.xaml.cs
+++ b/src/Files.App/Views/SplashScreenPage.xaml.cs
@@ -24,12 +24,12 @@ namespace Files.App.Views
 			InitializeComponent();
 		}
 
-		private void SplashScreenImage_ImageOpened(object sender, RoutedEventArgs e)
+		private void Image_ImageOpened(object sender, RoutedEventArgs e)
 		{
 			App.SplashScreenLoadingTCS?.TrySetResult();
 		}
 
-		private void SplashScreenImage_ImageFailed(object sender, RoutedEventArgs e)
+		private void Image_ImageFailed(object sender, RoutedEventArgs e)
 		{
 			App.SplashScreenLoadingTCS?.TrySetResult();
 		}

--- a/src/Files.App/Views/SplashScreenPage.xaml.cs
+++ b/src/Files.App/Views/SplashScreenPage.xaml.cs
@@ -11,17 +11,25 @@ namespace Files.App.Views
 	/// </summary>
 	public sealed partial class SplashScreenPage : Page
 	{
+		private string BranchLabel =>
+			ApplicationService.AppEnvironment switch
+			{
+				AppEnvironment.Dev => "Dev",
+				AppEnvironment.Preview => "Preview",
+				_ => string.Empty,
+			};
+
 		public SplashScreenPage()
 		{
 			InitializeComponent();
 		}
 
-		private void Image_ImageOpened(object sender, RoutedEventArgs e)
+		private void SplashScreenImage_ImageOpened(object sender, RoutedEventArgs e)
 		{
 			App.SplashScreenLoadingTCS?.TrySetResult();
 		}
 
-		private void Image_ImageFailed(object sender, RoutedEventArgs e)
+		private void SplashScreenImage_ImageFailed(object sender, RoutedEventArgs e)
 		{
 			App.SplashScreenLoadingTCS?.TrySetResult();
 		}


### PR DESCRIPTION
## Summary

During this few months tiral of initial splash screen, user have never complained about it. However, we noticed the blurry of the image and then @mdtauk suggested great idea to add the build branch name under the splash screen image.

## Task Checklist

- [x] Fixed image blurry
- [x] Added the label of the build branch
- [x] Clean up
- [ ] Apply requested changes

## Known Issues

_N/A_

## PR Checklist

- [x] **Closes**: _N/A_
- [x] **Approval**: Have discussed with and got approval from the team[^1]
- [x] **Tests**: Tested accessibility on the local end
- [x] **Deployment**: Deployed the app on the local end
- [ ] **Localization**: Modified en-US string resources[^2]
- [x] **Co-authors**: @mdtauk

## Steps To Validate Changes

1. Launch the app
2. See the splash screen, which will be shown in second you launched and only for few moments

## Screenshots

![image](https://github.com/files-community/Files/assets/62196528/dd4e138f-66ce-438c-a753-d2e6f3495c04)

[^1]: If the request hasn't been agreed by the team, this work might be rejected. Make sure that you get approval from the team before opening any PR related the request.
[^2]: If you removed any en-US string resources, make sure that there are no references of those resources. When you add a new en-US string resources, do not make any changes on other languages' resources; [Crowdin](https://crowdin.com/project/files-app) will do that, instead.