### PR TITLE
Fix: Don't open subfolders when using selection rectangle in column view

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -214,7 +214,11 @@ namespace Files.App.Views.LayoutModes
 			}
 
 			if (isDragging)
+			{
 				CloseFolder();
+				return;
+
+			}
 
 			if (SelectedItems?.Count == 1 && SelectedItem?.PrimaryItemAttribute is StorageItemTypes.Folder && openedFolderPresenter != FileList.ContainerFromItem(SelectedItem))
 			{

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -36,9 +36,7 @@ namespace Files.App.Views.LayoutModes
 
 		private ListViewItem? openedFolderPresenter;
 
-		// Used to disable opening the first folder when selected by the selection rectangle (#13418)
-		// When an item is selected via selection rectangle, the open subfolder is closed, and selected folders are not opened
-		// If only a single folder is selected by the end, it is opened
+		// Indicates if the selection rectangle is currently being dragged
 		private bool isDragging = false;
 
 		public ColumnViewBase() : base()
@@ -229,7 +227,7 @@ namespace Files.App.Views.LayoutModes
 				if (openedFolderPresenter == FileList.ContainerFromItem(SelectedItem))
 					return;
 
-				// Only open folder if selected through tap
+				// Open the selected folder if selected through tap
 				if (UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick && !isDragging)
 					ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
 				else
@@ -503,11 +501,12 @@ namespace Files.App.Views.LayoutModes
 		protected override void SelectionRectangle_SelectionEnded(object? sender, EventArgs e)
 		{
 			isDragging = false;
-			// Open selected folder only if drag resulted in a single folder being selected
+			// Open selected folder (if only one folder is selected) after the user finishes dragging the selection rectangle
 			if (SelectedItems?.Count is 1
 				&& SelectedItem is not null
 				&& SelectedItem.PrimaryItemAttribute is StorageItemTypes.Folder)
 				ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
+
 			base.SelectionRectangle_SelectionEnded(sender, e);
 		}
 

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -217,7 +217,6 @@ namespace Files.App.Views.LayoutModes
 			{
 				CloseFolder();
 				return;
-
 			}
 
 			if (SelectedItems?.Count == 1 && SelectedItem?.PrimaryItemAttribute is StorageItemTypes.Folder && openedFolderPresenter != FileList.ContainerFromItem(SelectedItem))
@@ -232,7 +231,6 @@ namespace Files.App.Views.LayoutModes
 				|| openedFolderPresenter != null && ParentShellPageInstance != null &&
 				!ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.Contains(FileList.ItemFromContainer(openedFolderPresenter)))
 			{
-
 				CloseFolder();
 			}
 		}

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -37,7 +37,7 @@ namespace Files.App.Views.LayoutModes
 		private ListViewItem? openedFolderPresenter;
 
 		// Indicates if the selection rectangle is currently being dragged
-		private bool isDragging = false;
+		private bool isDraggingSelectionRectangle = false;
 
 		public ColumnViewBase() : base()
 		{
@@ -218,7 +218,7 @@ namespace Files.App.Views.LayoutModes
 			if (SelectedItems?.Count == 1 && SelectedItem?.PrimaryItemAttribute is StorageItemTypes.Folder)
 			{
 				// Close any open folder
-				if (isDragging)
+				if (isDraggingSelectionRectangle)
 				{
 					CloseFolder();
 					return;
@@ -228,7 +228,7 @@ namespace Files.App.Views.LayoutModes
 					return;
 
 				// Open the selected folder if selected through tap
-				if (UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick && !isDragging)
+				if (UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick && !isDraggingSelectionRectangle)
 					ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
 				else
 					CloseFolder();
@@ -237,7 +237,7 @@ namespace Files.App.Views.LayoutModes
 				|| SelectedItem?.PrimaryItemAttribute is StorageItemTypes.File
 				|| openedFolderPresenter != null && ParentShellPageInstance != null
 				&& !ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.Contains(FileList.ItemFromContainer(openedFolderPresenter))
-				&& !isDragging) // Skip closing if dragging since nothing should be open 
+				&& !isDraggingSelectionRectangle) // Skip closing if dragging since nothing should be open 
 			{
 				CloseFolder();
 			}
@@ -500,7 +500,7 @@ namespace Files.App.Views.LayoutModes
 
 		protected override void SelectionRectangle_SelectionEnded(object? sender, EventArgs e)
 		{
-			isDragging = false;
+			isDraggingSelectionRectangle = false;
 			// Open selected folder (if only one folder is selected) after the user finishes dragging the selection rectangle
 			if (SelectedItems?.Count is 1
 				&& SelectedItem is not null
@@ -512,7 +512,7 @@ namespace Files.App.Views.LayoutModes
 
 		private void SelectionRectangle_SelectionStarted(object sender, EventArgs e)
 		{
-			isDragging = true;
+			isDraggingSelectionRectangle = true;
 		}
 
 		internal void ClearSelectionIndicator()

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -43,6 +43,7 @@ namespace Files.App.Views.LayoutModes
 			InitializeComponent();
 			var selectionRectangle = RectangleSelection.Create(FileList, SelectionRectangle, FileList_SelectionChanged);
 			selectionRectangle.SelectionStarted += SelectionRectangle_SelectionStarted;
+			selectionRectangle.SelectionEnded += SelectionRectangle_SelectionEnded;
 			ItemInvoked += ColumnViewBase_ItemInvoked;
 			GotFocus += ColumnViewBase_GotFocus;
 
@@ -494,6 +495,9 @@ namespace Files.App.Views.LayoutModes
 		protected override void SelectionRectangle_SelectionEnded(object? sender, EventArgs e)
 		{
 			isDragging = false;
+			var lastItem = SelectedItems?.LastOrDefault();
+			if(lastItem is not null && lastItem?.PrimaryItemAttribute is StorageItemTypes.Folder)
+				ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (lastItem is ShortcutItem sht ? sht.TargetPath : lastItem.ItemPath), ListView = FileList }, EventArgs.Empty);
 			base.SelectionRectangle_SelectionEnded(sender, e);
 		}
 

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -42,7 +42,6 @@ namespace Files.App.Views.LayoutModes
 		{
 			InitializeComponent();
 			var selectionRectangle = RectangleSelection.Create(FileList, SelectionRectangle, FileList_SelectionChanged);
-			selectionRectangle.SelectionEnded += SelectionRectangle_SelectionEnded1;
 			selectionRectangle.SelectionStarted += SelectionRectangle_SelectionStarted;
 			ItemInvoked += ColumnViewBase_ItemInvoked;
 			GotFocus += ColumnViewBase_GotFocus;
@@ -489,7 +488,7 @@ namespace Files.App.Views.LayoutModes
 			}
 		}
 
-		private void SelectionRectangle_SelectionEnded1(object sender, EventArgs e)
+		protected override void SelectionRectangle_SelectionEnded(object? sender, EventArgs e)
 		{
 			isDragging = false;
 			base.SelectionRectangle_SelectionEnded(sender, e);

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -217,7 +217,7 @@ namespace Files.App.Views.LayoutModes
 
 			if (SelectedItems?.Count == 1 && SelectedItem?.PrimaryItemAttribute is StorageItemTypes.Folder)
 			{
-				// Close any open folder
+				// // Prevents the first selected folder from opening if the user is currently dragging the selection rectangle (#13418)
 				if (isDraggingSelectionRectangle)
 				{
 					CloseFolder();

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -36,7 +36,7 @@ namespace Files.App.Views.LayoutModes
 
 		private ListViewItem? openedFolderPresenter;
 
-		// Used to disable opening folders when selected by the selection rectangle (#13418)
+		// Used to disable opening the first folder when selected by the selection rectangle (#13418)
 		// When an item is selected via selection rectangle, the open subfolder is closed, and selected folders are not opened
 		// If only a single folder is selected by the end, it is opened
 		private bool isDragging = false;
@@ -219,12 +219,15 @@ namespace Files.App.Views.LayoutModes
 
 			if (SelectedItems?.Count == 1 && SelectedItem?.PrimaryItemAttribute is StorageItemTypes.Folder)
 			{
-				// Checking if folder is unchanged explicitly so that it's not opened again
-				if (isDragging && openedFolderPresenter == FileList.ContainerFromItem(SelectedItem))
+				// Close any open folder
+				if (isDragging)
 				{
 					CloseFolder();
 					return;
 				}
+
+				if (openedFolderPresenter == FileList.ContainerFromItem(SelectedItem))
+					return;
 
 				// Only open folder if selected through tap
 				if (UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick && !isDragging)
@@ -500,7 +503,7 @@ namespace Files.App.Views.LayoutModes
 		protected override void SelectionRectangle_SelectionEnded(object? sender, EventArgs e)
 		{
 			isDragging = false;
-			// Open folder only if drag results in a single folder being selected
+			// Open selected folder only if drag resulted in a single folder being selected
 			if (SelectedItems?.Count is 1
 				&& SelectedItem is not null
 				&& SelectedItem.PrimaryItemAttribute is StorageItemTypes.Folder)

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -213,23 +213,24 @@ namespace Files.App.Views.LayoutModes
 				presenter!.Background = this.Resources["ListViewItemBackgroundSelected"] as SolidColorBrush;
 			}
 
-			if (isDragging)
+			if (SelectedItems?.Count == 1 && SelectedItem?.PrimaryItemAttribute is StorageItemTypes.Folder)
 			{
-				CloseFolder();
-				return;
-			}
+				if (isDragging && openedFolderPresenter == FileList.ContainerFromItem(SelectedItem))
+				{
+					CloseFolder();
+					return;
+				}
 
-			if (SelectedItems?.Count == 1 && SelectedItem?.PrimaryItemAttribute is StorageItemTypes.Folder && openedFolderPresenter != FileList.ContainerFromItem(SelectedItem))
-			{
-				if (UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick)
+				if (UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick && !isDragging)
 					ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
 				else
 					CloseFolder();
 			}
 			else if (SelectedItems?.Count > 1
 				|| SelectedItem?.PrimaryItemAttribute is StorageItemTypes.File
-				|| openedFolderPresenter != null && ParentShellPageInstance != null &&
-				!ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.Contains(FileList.ItemFromContainer(openedFolderPresenter)))
+				|| openedFolderPresenter != null && ParentShellPageInstance != null
+				&& !ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.Contains(FileList.ItemFromContainer(openedFolderPresenter))
+				&& !isDragging)
 			{
 				CloseFolder();
 			}

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -495,9 +495,10 @@ namespace Files.App.Views.LayoutModes
 		protected override void SelectionRectangle_SelectionEnded(object? sender, EventArgs e)
 		{
 			isDragging = false;
-			var lastItem = SelectedItems?.LastOrDefault();
-			if(lastItem is not null && lastItem?.PrimaryItemAttribute is StorageItemTypes.Folder)
-				ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (lastItem is ShortcutItem sht ? sht.TargetPath : lastItem.ItemPath), ListView = FileList }, EventArgs.Empty);
+			if (SelectedItems?.Count is 1
+				&& SelectedItem is not null
+				&& SelectedItem.PrimaryItemAttribute is StorageItemTypes.Folder)
+				ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (SelectedItem is ShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
 			base.SelectionRectangle_SelectionEnded(sender, e);
 		}
 

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -36,11 +36,14 @@ namespace Files.App.Views.LayoutModes
 
 		private ListViewItem? openedFolderPresenter;
 
+		private bool isDragging = false;
+
 		public ColumnViewBase() : base()
 		{
 			InitializeComponent();
 			var selectionRectangle = RectangleSelection.Create(FileList, SelectionRectangle, FileList_SelectionChanged);
-			selectionRectangle.SelectionEnded += SelectionRectangle_SelectionEnded;
+			selectionRectangle.SelectionEnded += SelectionRectangle_SelectionEnded1;
+			selectionRectangle.SelectionStarted += SelectionRectangle_SelectionStarted;
 			ItemInvoked += ColumnViewBase_ItemInvoked;
 			GotFocus += ColumnViewBase_GotFocus;
 
@@ -211,6 +214,9 @@ namespace Files.App.Views.LayoutModes
 				presenter!.Background = this.Resources["ListViewItemBackgroundSelected"] as SolidColorBrush;
 			}
 
+			if (isDragging)
+				CloseFolder();
+
 			if (SelectedItems?.Count == 1 && SelectedItem?.PrimaryItemAttribute is StorageItemTypes.Folder && openedFolderPresenter != FileList.ContainerFromItem(SelectedItem))
 			{
 				if (UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick)
@@ -223,6 +229,7 @@ namespace Files.App.Views.LayoutModes
 				|| openedFolderPresenter != null && ParentShellPageInstance != null &&
 				!ParentShellPageInstance.FilesystemViewModel.FilesAndFolders.Contains(FileList.ItemFromContainer(openedFolderPresenter)))
 			{
+
 				CloseFolder();
 			}
 		}
@@ -480,6 +487,17 @@ namespace Files.App.Views.LayoutModes
 					parent.FolderSettings.ToggleLayoutModeAdaptive();
 					break;
 			}
+		}
+
+		private void SelectionRectangle_SelectionEnded1(object sender, EventArgs e)
+		{
+			isDragging = false;
+			base.SelectionRectangle_SelectionEnded(sender, e);
+		}
+
+		private void SelectionRectangle_SelectionStarted(object sender, EventArgs e)
+		{
+			isDragging = true;
 		}
 
 		internal void ClearSelectionIndicator()


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13418

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Screenshots (optional)**
https://github.com/files-community/Files/assets/59918974/6d086769-1fe8-4e15-a6d4-b3fb88821369


