### PR TITLE
Fix: Fixed issue where Open on Startup didn't display a message when disabled

### DIFF
--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3587,4 +3587,7 @@
   <data name="NoFileOperations" xml:space="preserve">
     <value>No ongoing file operations</value>
   </data>
+  <data name="OpenOnStartupDisabled" xml:space="preserve">
+    <value>The option to open Files on Windows Startup is not available due to your system settings or group policy. To re-enable, open the startup page in Task Manager.</value>
+  </data>
 </root>

--- a/src/Files.App/Views/Settings/AdvancedPage.xaml
+++ b/src/Files.App/Views/Settings/AdvancedPage.xaml
@@ -3,6 +3,7 @@
 	x:Class="Files.App.Views.Settings.AdvancedPage"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:helpers="using:Files.App.Helpers"
 	xmlns:i="using:Microsoft.Xaml.Interactivity"
@@ -13,6 +14,7 @@
 	mc:Ignorable="d">
 
 	<Page.Resources>
+		<converters:BoolNegationConverter x:Key="BoolNegationConverter" />
 		<ResourceDictionary Source="/ResourceDictionaries/RightAlignedToggleSwitchStyle.xaml" />
 	</Page.Resources>
 
@@ -81,22 +83,34 @@
 			</local:SettingsBlockControl>
 
 			<!--  Open on Windows startup  -->
-			<local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsOpenInLogin}" HorizontalAlignment="Stretch">
-				<local:SettingsBlockControl.Icon>
-					<FontIcon Glyph="&#xE7E8;" />
-				</local:SettingsBlockControl.Icon>
-				<ToggleSwitch
-					AutomationProperties.Name="{helpers:ResourceString Name=SettingsOpenInLogin}"
-					IsEnabled="{x:Bind ViewModel.CanOpenOnWindowsStartup, Mode=OneWay}"
-					IsOn="{x:Bind ViewModel.OpenOnWindowsStartup, Mode=TwoWay}"
-					Style="{StaticResource RightAlignedToggleSwitchStyle}">
-					<i:Interaction.Behaviors>
-						<icore:EventTriggerBehavior EventName="Toggled">
-							<icore:InvokeCommandAction Command="{x:Bind ViewModel.OpenFilesOnWindowsStartupCommand, Mode=OneWay}" />
-						</icore:EventTriggerBehavior>
-					</i:Interaction.Behaviors>
-				</ToggleSwitch>
-			</local:SettingsBlockControl>
+			<StackPanel>
+				<!--  Startup disabled InfoBar  -->
+				<InfoBar
+					x:Load="{x:Bind ViewModel.CanOpenOnWindowsStartup, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+					IsClosable="False"
+					IsIconVisible="True"
+					IsOpen="True"
+					Message="{helpers:ResourceString Name=OpenOnStartupDisabled}"
+					Severity="Warning" />
+
+				<!--  Setting block  -->
+				<local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsOpenInLogin}" HorizontalAlignment="Stretch">
+					<local:SettingsBlockControl.Icon>
+						<FontIcon Glyph="&#xE7E8;" />
+					</local:SettingsBlockControl.Icon>
+					<ToggleSwitch
+						AutomationProperties.Name="{helpers:ResourceString Name=SettingsOpenInLogin}"
+						IsEnabled="{x:Bind ViewModel.CanOpenOnWindowsStartup, Mode=OneWay}"
+						IsOn="{x:Bind ViewModel.OpenOnWindowsStartup, Mode=TwoWay}"
+						Style="{StaticResource RightAlignedToggleSwitchStyle}">
+						<i:Interaction.Behaviors>
+							<icore:EventTriggerBehavior EventName="Toggled">
+								<icore:InvokeCommandAction Command="{x:Bind ViewModel.OpenFilesOnWindowsStartupCommand, Mode=OneWay}" />
+							</icore:EventTriggerBehavior>
+						</i:Interaction.Behaviors>
+					</ToggleSwitch>
+				</local:SettingsBlockControl>
+			</StackPanel>
 
 			<!--  Leave App Running  -->
 			<local:SettingsBlockControl Title="{helpers:ResourceString Name=SettingsLeaveAppRunning}" HorizontalAlignment="Stretch">

--- a/src/Files.App/Views/Settings/AdvancedPage.xaml
+++ b/src/Files.App/Views/Settings/AdvancedPage.xaml
@@ -14,8 +14,13 @@
 	mc:Ignorable="d">
 
 	<Page.Resources>
-		<converters:BoolNegationConverter x:Key="BoolNegationConverter" />
-		<ResourceDictionary Source="/ResourceDictionaries/RightAlignedToggleSwitchStyle.xaml" />
+		<ResourceDictionary>
+			<ResourceDictionary.MergedDictionaries>
+				<ResourceDictionary Source="/ResourceDictionaries/RightAlignedToggleSwitchStyle.xaml" />
+			</ResourceDictionary.MergedDictionaries>
+
+			<converters:BoolNegationConverter x:Key="BoolNegationConverter" />
+		</ResourceDictionary>
 	</Page.Resources>
 
 	<Page.DataContext>

--- a/src/Files.App/Views/Settings/AdvancedPage.xaml
+++ b/src/Files.App/Views/Settings/AdvancedPage.xaml
@@ -86,6 +86,7 @@
 			<StackPanel>
 				<!--  Startup disabled InfoBar  -->
 				<InfoBar
+					x:Name="OpenOnStartupInfoBar"
 					x:Load="{x:Bind ViewModel.CanOpenOnWindowsStartup, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
 					IsClosable="False"
 					IsIconVisible="True"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #7679...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open Files settings
   2. Enable the option to open Files on Windows Startup
   3. Open the startup settings in Windows (via the settings app)
   4. Turn off the startup option for Files
   5. Go back to Files and confirm there is an info bar explaining why the setting is disabled in Files

**Screenshots (optional)**
Add screenshots here.
