### PR TITLE
Fix: Fixed crash that would occur when dragging an image from the browser

### DIFF
--- a/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
+++ b/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
@@ -219,7 +219,7 @@ namespace Files.App.Utils.StatusCenter
 			long totalSize = 0)
 		{
 			string? sourceDir = string.Empty;
-			
+
 			if (source is not null && source.Any())
 				sourceDir = PathNormalization.GetParentDir(source.First().Path);
 
@@ -498,9 +498,15 @@ namespace Files.App.Utils.StatusCenter
 
 			if (card.Source is not null && card.Source.Any())
 			{
-				sourcePath = PathNormalization.GetParentDir(card.Source.First());
-				sourceDirName = sourcePath.Split('\\').Last();
-				sourceFileName = card.Source.First().Split('\\').Last();
+				// Include null check for items that don't have a parrent dir
+				// This can happen when dragging an image from the browser
+				// https://github.com/files-community/Files/issues/13590
+				if (card.Source.First() != null)
+				{
+					sourcePath = PathNormalization.GetParentDir(card.Source.First());
+					sourceDirName = sourcePath.Split('\\').Last();
+					sourceFileName = card.Source.First().Split('\\').Last();
+				}
 			}
 
 			if (card.Destination is not null && card.Destination.Any())

--- a/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
+++ b/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
@@ -498,7 +498,7 @@ namespace Files.App.Utils.StatusCenter
 
 			if (card.Source is not null && card.Source.Any())
 			{
-				// Include null check for items that don't have a parrent dir
+				// Include null check for items that don't have a parent dir
 				// This can happen when dragging an image from the browser
 				// https://github.com/files-community/Files/issues/13590
 				if (card.Source.First() != null)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13590...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open any folder
   2. Drag image from the browser into the folder
   3. Confirm the image is copied without crashing the app

**Screenshots (optional)**
Add screenshots here.
