### PR TITLE
Fix: Fixed crash that would occur at the start of a file operation if Explorer wasn't running

### DIFF
--- a/src/Files.App/Utils/Shell/Win32API.cs
+++ b/src/Files.App/Utils/Shell/Win32API.cs
@@ -576,6 +576,7 @@ namespace Files.App.Utils.Shell
 			}
 			catch (NotImplementedException)
 			{
+				// explorer.exe is not running as a shell
 				return null;
 			}
 

--- a/src/Files.App/Utils/Shell/Win32API.cs
+++ b/src/Files.App/Utils/Shell/Win32API.cs
@@ -570,7 +570,14 @@ namespace Files.App.Utils.Shell
 		public static Shell32.ITaskbarList4? CreateTaskbarObject()
 		{
 			var taskbar2 = new Shell32.ITaskbarList2();
-			taskbar2.HrInit();
+			try
+			{
+				taskbar2.HrInit();
+			}
+			catch (NotImplementedException)
+			{
+				return null;
+			}
 
 			return taskbar2 as Shell32.ITaskbarList4;
 		}

--- a/src/Files.App/Utils/Storage/Operations/FileOperationsHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FileOperationsHelpers.cs
@@ -947,14 +947,14 @@ namespace Files.App.Utils.Storage
 				public bool Canceled { get; set; }
 			}
 
-			private readonly Shell32.ITaskbarList4 taskbar;
+			private readonly Shell32.ITaskbarList4? taskbar;
 			private readonly ConcurrentDictionary<string, OperationWithProgress> operations;
 
 			public HWND OwnerWindow { get; set; }
 
 			public ProgressHandler()
 			{
-				taskbar = Win32API.CreateTaskbarObject()!;
+				taskbar = Win32API.CreateTaskbarObject();
 				operations = new ConcurrentDictionary<string, OperationWithProgress>();
 				operationsCompletedEvent = new ManualResetEvent(true);
 			}
@@ -1034,7 +1034,8 @@ namespace Files.App.Utils.Storage
 				if (disposing)
 				{
 					operationsCompletedEvent?.Dispose();
-					Marshal.ReleaseComObject(taskbar);
+					if (taskbar is not null)
+						Marshal.ReleaseComObject(taskbar);
 				}
 			}
 		}


### PR DESCRIPTION
I cannot reproduce the crash myself, but it seems to occur in environments where explorer.exe is not running as a shell (e.g. RemoteApp).

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13664

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?