### PR TITLE
Fix: Fixed NullReferenceException with SetSelectedPathOrNavigate

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBrowser.xaml.cs
@@ -115,7 +115,7 @@ namespace Files.App.Views.LayoutModes
 				SearchUnindexedItems = navigationArguments.SearchUnindexedItems,
 				SearchPathParam = navigationArguments.SearchPathParam,
 				NavPathParam = path,
-				SelectItems = path == navigationArguments.NavPathParam? navigationArguments.SelectItems : null
+				SelectItems = path == navigationArguments.NavPathParam ? navigationArguments.SelectItems : null
 			});
 
 			var index = 0;
@@ -127,7 +127,7 @@ namespace Files.App.Views.LayoutModes
 				{
 					Column = ++index,
 					NavPathParam = path,
-					SelectItems = path == navigationArguments.NavPathParam? navigationArguments.SelectItems : null
+					SelectItems = path == navigationArguments.NavPathParam ? navigationArguments.SelectItems : null
 				});
 			}
 		}
@@ -406,15 +406,15 @@ namespace Files.App.Views.LayoutModes
 					}
 				}
 			}
-			if (PathNormalization.NormalizePath(ParentShellPageInstance.FilesystemViewModel.WorkingDirectory) !=
-				PathNormalization.NormalizePath(e.ItemPath))
-			{
+
+			if (ParentShellPageInstance is null)
+				return;
+
+			if (NormalizePath(ParentShellPageInstance.FilesystemViewModel.WorkingDirectory) !=
+				NormalizePath(e.ItemPath))
 				ParentShellPageInstance.NavigateToPath(e.ItemPath);
-			}
 			else
-			{
 				DismissOtherBlades(0);
-			}
 		}
 
 		public IShellPage ActiveColumnShellPage


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/103315946u/overview

**Validation**
How did you test these changes?
- [ ] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Screenshots (optional)**
Add screenshots here.
