### PR TITLE
Fix: Fixed crash that would occur when opening a large bitrate audio file

### DIFF
--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -166,7 +166,7 @@ namespace Files.App.ViewModels.Properties
 			if (encodingBitrate?.Value is not null)
 			{
 				var sizes = new string[] { "Bps", "KBps", "MBps", "GBps" };
-				var order = (int)Math.Floor(Math.Log((uint)encodingBitrate.Value, 1024));
+				var order = Math.Min((int)Math.Floor(Math.Log((uint)encodingBitrate.Value, 1024)), 3);
 				var readableSpeed = (uint)encodingBitrate.Value / Math.Pow(1024, order);
 				encodingBitrate.Value = $"{readableSpeed:0.##} {sizes[order]}";
 			}


### PR DESCRIPTION
This does not solve the issue of the audio file not showing the play button, but it does solve the crashing issue.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related to #13674 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?