### PR TITLE
Added ProgressBarColor property to DriveItem. Added additional const …

### DIFF
--- a/src/Files.App/Constants.cs
+++ b/src/Files.App/Constants.cs
@@ -144,6 +144,9 @@ namespace Files.App
 			public static class Drives
 			{
 				public const float LowStorageSpacePercentageThreshold = 90.0f;
+
+				public const float AlmostLowStoragePercentageThreshold = 80.0f;
+
 			}
 
 			public const int WidgetIconSize = 256;

--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -162,6 +162,8 @@ namespace Files.App.Data.Items
 
 				if (Type == DriveType.Fixed)
 					ShowStorageSense = percentageUsed >= Constants.Widgets.Drives.LowStorageSpacePercentageThreshold;
+
+				OnPropertyChanged(nameof(ProgressBarColor));
 			}
 		}
 
@@ -171,6 +173,10 @@ namespace Files.App.Data.Items
 			get => showStorageSense;
 			set => SetProperty(ref showStorageSense, value);
 		}
+
+		public string ProgressBarColor
+			// color for drive progress bar will be red when space used is between 90-100%, orange between 80-90%, and blue otherwise.
+			=> PercentageUsed >= Constants.Widgets.Drives.LowStorageSpacePercentageThreshold ? "Red" : PercentageUsed >= Constants.Widgets.Drives.AlmostLowStoragePercentageThreshold ? "Orange" : "Blue";
 
 		public string Id => DeviceID;
 

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml
@@ -86,6 +86,7 @@
 								VerticalContentAlignment="Stretch"
 								x:Load="{x:Bind Item.ShowDriveDetails, Mode=OneWay}"
 								AutomationProperties.AccessibilityView="Raw"
+								Foreground="{x:Bind Item.ProgressBarColor, Mode=OneWay}"
 								Maximum="{x:Bind Item.MaxSpace.GigaBytes, Mode=OneWay}"
 								Value="{x:Bind Item.SpaceUsed.GigaBytes, Mode=OneWay}" />
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes (https://github.com/files-community/Files/issues/13699)

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [X] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Click Home page
   3. Observe drive progress bar red if near full, orange if almost near full, blue otherwise

**Screenshots**
![image](https://github.com/files-community/Files/assets/90075917/a0b7661f-563f-438e-afd4-432993d191bc)
