### PR TITLE
Fix: Fixed issue where opening properties would download OneDrive files

### DIFF
--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -41,9 +41,9 @@ namespace Files.App.Utils
 				tooltipBuilder.AppendLine($"{"NameWithColon".GetLocalizedResource()} {Name}");
 				tooltipBuilder.AppendLine($"{"ItemType".GetLocalizedResource()} {itemType}");
 				tooltipBuilder.Append($"{"ToolTipDescriptionDate".GetLocalizedResource()} {ItemDateModified}");
-				if(!string.IsNullOrWhiteSpace(FileSize))
+				if (!string.IsNullOrWhiteSpace(FileSize))
 					tooltipBuilder.Append($"{Environment.NewLine}{"SizeLabel".GetLocalizedResource()} {FileSize}");
-				if(SyncStatusUI.LoadSyncStatus)
+				if (SyncStatusUI.LoadSyncStatus)
 					tooltipBuilder.Append($"{Environment.NewLine}{"syncStatusColumn/Header".GetLocalizedResource()}: {syncStatusUI.SyncStatusString}");
 
 				return tooltipBuilder.ToString();
@@ -401,6 +401,10 @@ namespace Files.App.Utils
 
 		private bool CheckElevationRights()
 		{
+			// Avoid downloading file to check elevation
+			if (SyncStatusUI.SyncStatus != CloudDriveSyncStatus.FileOnline)
+				return false;
+
 			return IsShortcut
 				? ElevationHelpers.IsElevationRequired(((ShortcutItem)this).TargetPath)
 				: ElevationHelpers.IsElevationRequired(this.ItemPath);

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -402,7 +402,7 @@ namespace Files.App.Utils
 		private bool CheckElevationRights()
 		{
 			// Avoid downloading file to check elevation
-			if (SyncStatusUI.SyncStatus == CloudDriveSyncStatus.FileOnline)
+			if (SyncStatusUI.SyncStatus is CloudDriveSyncStatus.FileOnline or CloudDriveSyncStatus.FolderOnline)
 				return false;
 
 			return IsShortcut

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -402,7 +402,7 @@ namespace Files.App.Utils
 		private bool CheckElevationRights()
 		{
 			// Avoid downloading file to check elevation
-			if (SyncStatusUI.SyncStatus != CloudDriveSyncStatus.FileOnline)
+			if (SyncStatusUI.SyncStatus == CloudDriveSyncStatus.FileOnline)
 				return false;
 
 			return IsShortcut

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2328,6 +2328,9 @@
   <data name="CalculationError" xml:space="preserve">
     <value>An error occurred during the calculation</value>
   </data>
+  <data name="CalculationOnlineFileHashError" xml:space="preserve">
+    <value>Hashes aren't available for online files</value>
+  </data>
   <data name="Algorithm" xml:space="preserve">
     <value>Algorithm</value>
   </data>

--- a/src/Files.App/ViewModels/Properties/HashesViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/HashesViewModel.cs
@@ -69,7 +69,7 @@ namespace Files.App.ViewModels.Properties
 			}
 
 			// Don't calculate hashes for online files
-			if (_item.SyncStatusUI.SyncStatus == CloudDriveSyncStatus.FileOnline)
+			if (_item.SyncStatusUI.SyncStatus is CloudDriveSyncStatus.FileOnline or CloudDriveSyncStatus.FolderOnline)
 			{
 				hashInfoItem.HashValue = "CalculationOnlineFileHashError".GetLocalizedResource();
 				return;

--- a/src/Files.App/ViewModels/Properties/HashesViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/HashesViewModel.cs
@@ -1,20 +1,8 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.DependencyInjection;
-using CommunityToolkit.Mvvm.Input;
-using CommunityToolkit.WinUI;
-using Files.App.Extensions;
-using Files.App.Utils;
-using Files.Shared.Extensions;
 using Files.Shared.Helpers;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
-using System.Linq;
-using System.Threading;
 using System.Windows.Input;
 
 namespace Files.App.ViewModels.Properties
@@ -78,6 +66,13 @@ namespace Files.App.ViewModels.Properties
 			{
 				ShowHashes[hashInfoItem.Algorithm] = hashInfoItem.IsEnabled;
 				UserSettingsService.GeneralSettingsService.ShowHashesDictionary = ShowHashes;
+			}
+
+			// Don't calculate hashes for online files
+			if (_item.SyncStatusUI.SyncStatus == CloudDriveSyncStatus.FileOnline)
+			{
+				hashInfoItem.HashValue = "CalculationOnlineFileHashError".GetLocalizedResource();
+				return;
 			}
 
 			if (hashInfoItem.HashValue is null && hashInfoItem.IsEnabled)

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -99,7 +99,7 @@ namespace Files.App.ViewModels.Properties
 			ViewModel.ItemSize = Item.FileSizeBytes.ToLongSizeString();
 
 			// Only load the size for items on the device
-			if (Item.SyncStatusUI.SyncStatus != CloudDriveSyncStatus.FileOnline)
+			if (Item.SyncStatusUI.SyncStatus is not CloudDriveSyncStatus.FileOnline and not CloudDriveSyncStatus.FolderOnline)
 				ViewModel.ItemSizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ??
 				   string.Empty;
 

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -97,8 +97,11 @@ namespace Files.App.ViewModels.Properties
 
 			ViewModel.ItemSizeVisibility = true;
 			ViewModel.ItemSize = Item.FileSizeBytes.ToLongSizeString();
-			ViewModel.ItemSizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ??
-				string.Empty;
+
+			// Only load the size for items on the device
+			if (Item.SyncStatusUI.SyncStatus != CloudDriveSyncStatus.FileOnline)
+				ViewModel.ItemSizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ??
+				   string.Empty;
 
 			var fileIconData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.ItemPath, 80, Windows.Storage.FileProperties.ThumbnailMode.DocumentsView, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail, false);
 			if (fileIconData is not null)

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -134,15 +134,14 @@ namespace Files.App.ViewModels.Properties
 			if (Item.IsShortcut)
 				return;
 
-			if (FileExtensionHelpers.IsBrowsableZipFile(Item.FileExtension, out _))
-			{
-				if (await ZipStorageFolder.FromPathAsync(Item.ItemPath) is ZipStorageFolder zipFolder)
-				{
-					var uncompressedSize = await zipFolder.GetUncompressedSize();
-					ViewModel.UncompressedItemSize = uncompressedSize.ToLongSizeString();
-					ViewModel.UncompressedItemSizeBytes = uncompressedSize;
-				}
-			}
+			if (Item.SyncStatusUI.SyncStatus is not CloudDriveSyncStatus.FileOnline and not CloudDriveSyncStatus.FolderOnline)
+				if (FileExtensionHelpers.IsBrowsableZipFile(Item.FileExtension, out _))
+					if (await ZipStorageFolder.FromPathAsync(Item.ItemPath) is ZipStorageFolder zipFolder)
+					{
+						var uncompressedSize = await zipFolder.GetUncompressedSize();
+						ViewModel.UncompressedItemSize = uncompressedSize.ToLongSizeString();
+						ViewModel.UncompressedItemSizeBytes = uncompressedSize;
+					}
 
 			if (file.Properties is not null)
 				GetOtherPropertiesAsync(file.Properties);

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -111,10 +111,11 @@ namespace Files.App.ViewModels.Properties
 			{
 				ViewModel.ItemCreatedTimestampReal = storageFolder.DateCreated;
 				if (storageFolder.Properties is not null)
-				{
 					GetOtherPropertiesAsync(storageFolder.Properties);
-				}
-				GetFolderSizeAsync(storageFolder.Path, TokenSource.Token);
+
+				// Only load the size for items on the device
+				if (Item.SyncStatusUI.SyncStatus != CloudDriveSyncStatus.FileOnline)
+					GetFolderSizeAsync(storageFolder.Path, TokenSource.Token);
 			}
 			else if (Item.ItemPath.Equals(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
 			{

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -88,12 +88,9 @@ namespace Files.App.ViewModels.Properties
 				ViewModel.ItemSize = Item.FileSizeBytes.ToLongSizeString();
 
 				// Only load the size for items on the device
-				if (Item.SyncStatusUI.SyncStatus != CloudDriveSyncStatus.FileOnline)
-				{
-					var sizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath);
-					if (sizeOnDisk is not null)
-						ViewModel.ItemSizeOnDisk = ((long)sizeOnDisk).ToLongSizeString();
-				}
+				if (Item.SyncStatusUI.SyncStatus is not CloudDriveSyncStatus.FileOnline and not CloudDriveSyncStatus.FolderOnline)
+					ViewModel.ItemSizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ??
+					   string.Empty;
 
 				ViewModel.ItemCreatedTimestampReal = Item.ItemDateCreatedReal;
 				ViewModel.ItemAccessedTimestampReal = Item.ItemDateAccessedReal;

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -88,9 +88,8 @@ namespace Files.App.ViewModels.Properties
 				ViewModel.ItemSize = Item.FileSizeBytes.ToLongSizeString();
 
 				// Only load the size for items on the device
-				if (Item.SyncStatusUI.SyncStatus is not CloudDriveSyncStatus.FileOnline and not CloudDriveSyncStatus.FolderOnline)
-					ViewModel.ItemSizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ??
-					   string.Empty;
+				ViewModel.ItemSizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ??
+				   string.Empty;
 
 				ViewModel.ItemCreatedTimestampReal = Item.ItemDateCreatedReal;
 				ViewModel.ItemAccessedTimestampReal = Item.ItemDateAccessedReal;

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -39,7 +39,7 @@ namespace Files.App.ViewModels.Properties
 				ViewModel.ItemType = Item.ItemType;
 				ViewModel.ItemLocation = (Item as RecycleBinItem)?.ItemOriginalFolder ??
 					(Path.IsPathRooted(Item.ItemPath) ? Path.GetDirectoryName(Item.ItemPath) : Item.ItemPath);
-				ViewModel.ItemModifiedTimestampReal= Item.ItemDateModifiedReal;
+				ViewModel.ItemModifiedTimestampReal = Item.ItemDateModifiedReal;
 				ViewModel.ItemCreatedTimestampReal = Item.ItemDateCreatedReal;
 				ViewModel.LoadCustomIcon = Item.LoadCustomIcon;
 				ViewModel.CustomIconSource = Item.CustomIconSource;
@@ -86,11 +86,15 @@ namespace Files.App.ViewModels.Properties
 			{
 				ViewModel.ItemSizeVisibility = true;
 				ViewModel.ItemSize = Item.FileSizeBytes.ToLongSizeString();
-				var sizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath);
-				if (sizeOnDisk is not null)
+
+				// Only load the size for items on the device
+				if (Item.SyncStatusUI.SyncStatus != CloudDriveSyncStatus.FileOnline)
 				{
-					ViewModel.ItemSizeOnDisk = ((long)sizeOnDisk).ToLongSizeString();
+					var sizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath);
+					if (sizeOnDisk is not null)
+						ViewModel.ItemSizeOnDisk = ((long)sizeOnDisk).ToLongSizeString();
 				}
+
 				ViewModel.ItemCreatedTimestampReal = Item.ItemDateCreatedReal;
 				ViewModel.ItemAccessedTimestampReal = Item.ItemDateAccessedReal;
 				if (Item.IsLinkItem || string.IsNullOrWhiteSpace(((ShortcutItem)Item).TargetPath))
@@ -144,7 +148,9 @@ namespace Files.App.ViewModels.Properties
 			}
 			else
 			{
-				GetFolderSizeAsync(folderPath, TokenSource.Token);
+				// Only load the size for items on the device
+				if (Item.SyncStatusUI.SyncStatus != CloudDriveSyncStatus.FileOnline)
+					GetFolderSizeAsync(folderPath, TokenSource.Token);
 			}
 		}
 

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -111,7 +111,9 @@ namespace Files.App.ViewModels.Properties
 					GetOtherPropertiesAsync(storageFolder.Properties);
 
 				// Only load the size for items on the device
-				if (Item.SyncStatusUI.SyncStatus is not CloudDriveSyncStatus.FileOnline and not CloudDriveSyncStatus.FolderOnline)
+				if (Item.SyncStatusUI.SyncStatus is not CloudDriveSyncStatus.FileOnline and not 
+					CloudDriveSyncStatus.FolderOnline and not
+					CloudDriveSyncStatus.FolderOfflinePartial)
 					GetFolderSizeAsync(storageFolder.Path, TokenSource.Token);
 			}
 			else if (Item.ItemPath.Equals(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -86,8 +86,11 @@ namespace Files.App.ViewModels.Properties
 			{
 				ViewModel.ItemSizeVisibility = true;
 				ViewModel.ItemSize = Item.FileSizeBytes.ToLongSizeString();
-				ViewModel.ItemSizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ??
-				   string.Empty;
+
+				// Only load the size for items on the device
+				if (Item.SyncStatusUI.SyncStatus is not CloudDriveSyncStatus.FileOnline and not CloudDriveSyncStatus.FolderOnline)
+					ViewModel.ItemSizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ??
+					   string.Empty;
 
 				ViewModel.ItemCreatedTimestampReal = Item.ItemDateCreatedReal;
 				ViewModel.ItemAccessedTimestampReal = Item.ItemDateAccessedReal;

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -86,8 +86,6 @@ namespace Files.App.ViewModels.Properties
 			{
 				ViewModel.ItemSizeVisibility = true;
 				ViewModel.ItemSize = Item.FileSizeBytes.ToLongSizeString();
-
-				// Only load the size for items on the device
 				ViewModel.ItemSizeOnDisk = NativeFileOperationsHelper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ??
 				   string.Empty;
 

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -111,7 +111,7 @@ namespace Files.App.ViewModels.Properties
 					GetOtherPropertiesAsync(storageFolder.Properties);
 
 				// Only load the size for items on the device
-				if (Item.SyncStatusUI.SyncStatus != CloudDriveSyncStatus.FileOnline)
+				if (Item.SyncStatusUI.SyncStatus is not CloudDriveSyncStatus.FileOnline and not CloudDriveSyncStatus.FolderOnline)
 					GetFolderSizeAsync(storageFolder.Path, TokenSource.Token);
 			}
 			else if (Item.ItemPath.Equals(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -148,9 +148,7 @@ namespace Files.App.ViewModels.Properties
 			}
 			else
 			{
-				// Only load the size for items on the device
-				if (Item.SyncStatusUI.SyncStatus != CloudDriveSyncStatus.FileOnline)
-					GetFolderSizeAsync(folderPath, TokenSource.Token);
+				GetFolderSizeAsync(folderPath, TokenSource.Token);
 			}
 		}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13006
Closes #13593


**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open properties for a non OneDrive file/folder and confirm "Size on disk" is calculated
   2. Open properties for a downloaded OneDrive file/folder and confirm "Size on disk" is calculated
   3. Open properties for a non downloaded OneDrive file/folder and confirm "Size on disk" isn't calculated
   4. Open hash page for online file and confirm the file isn't downloaded
   5. Open hash page for offline file and confirm the hash is displayed

**Screenshots (optional)**
Add screenshots here.
