### PR TITLE
Fix: Fixed Win32Exception in SetAsDefaultExplorerAsync

### DIFF
--- a/src/Files.App/Utils/Shell/Win32API.cs
+++ b/src/Files.App/Utils/Shell/Win32API.cs
@@ -375,10 +375,9 @@ namespace Files.App.Utils.Shell
 			using Process process = CreatePowershellProcess(command, runAsAdmin);
 			using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(30 * 1000));
 
-			process.Start();
-
 			try
 			{
+				process.Start();
 				await process.WaitForExitAsync(cts.Token);
 				return process.ExitCode == 0;
 			}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/2815342931u/overview

```
System.Diagnostics
Process.StartWithCreateProcess (ProcessStartInfo startInfo)
System.ComponentModel.Win32Exception: An error occurred trying to start process 'powershell.exe' with working directory 'C:\Windows\system32'. Access is denied.
```