### PR TITLE
Fix: Fixed NullReferenceException with OpenPropertiesWindow

### DIFF
--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -41,6 +41,9 @@ namespace Files.App.Utils.Storage
 		/// <param name="associatedInstance">Associated main window instance</param>
 		public static void OpenPropertiesWindow(IShellPage associatedInstance)
 		{
+			if (associatedInstance is null)
+				return;
+
 			object item;
 
 			var page = associatedInstance.SlimContentPage;

--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -41,7 +41,8 @@ namespace Files.App.Utils.Storage
 		/// <param name="associatedInstance">Associated main window instance</param>
 		public static void OpenPropertiesWindow(IShellPage associatedInstance)
 		{
-			if (associatedInstance is null)
+			if (associatedInstance?.SlimContentPage is null ||
+				associatedInstance?.FilesystemViewModel is null)
 				return;
 
 			object item;

--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -41,8 +41,7 @@ namespace Files.App.Utils.Storage
 		/// <param name="associatedInstance">Associated main window instance</param>
 		public static void OpenPropertiesWindow(IShellPage associatedInstance)
 		{
-			if (associatedInstance?.SlimContentPage is null ||
-				associatedInstance?.FilesystemViewModel is null)
+			if (associatedInstance is null)
 				return;
 
 			object item;
@@ -50,7 +49,7 @@ namespace Files.App.Utils.Storage
 			var page = associatedInstance.SlimContentPage;
 
 			// Item(s) selected
-			if (page.IsItemSelected)
+			if (page is not null && page.IsItemSelected)
 			{
 				// Selected item(s)
 				item = page.SelectedItems?.Count is 1
@@ -61,7 +60,7 @@ namespace Files.App.Utils.Storage
 			else
 			{
 				// Instance's current folder
-				var folder = associatedInstance.FilesystemViewModel.CurrentFolder;
+				var folder = associatedInstance.FilesystemViewModel?.CurrentFolder;
 				if (folder is null)
 					return;
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/1504308570u/overview

```
Files.App.Utils.Storage
FilePropertiesHelpers.OpenPropertiesWindow (IShellPage associatedInstance)
Files.App.Actions
OpenPropertiesAction.ExecuteAsync ()
```