### PR TITLE
Fix: Handle format exception raised by Convert.ToInt32

### DIFF
--- a/src/Files.App/ViewModels/Properties/Items/FileProperty.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperty.cs
@@ -228,7 +228,22 @@ namespace Files.App.ViewModels.Properties
 			if (EnumeratedList is not null)
 			{
 				var value = "";
-				return EnumeratedList.TryGetValue(Convert.ToInt32(Value), out value) ? value.GetLocalizedResource() : null;
+				int valueKey;
+
+				try
+				{
+					valueKey = Convert.ToInt32(Value);
+				}
+				catch
+				{
+					if (!int.TryParse(Value.ToString(), out valueKey))
+					{
+						return null;
+					}
+				}
+
+				return EnumeratedList.TryGetValue(valueKey, out value) ? value.GetLocalizedResource() : null;
+
 			}
 
 			if (DisplayFunction is not null)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes (https://github.com/files-community/Files/issues/13663)

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Tested code snippet in external test project to ensure System.FormatException was handled

**Screenshots (optional)**
Add screenshots here.
