### PR TITLE
Fix: Disable copy path when no items are selected

### DIFF
--- a/src/Files.App/Actions/FileSystem/CopyPathAction.cs
+++ b/src/Files.App/Actions/FileSystem/CopyPathAction.cs
@@ -21,6 +21,9 @@ namespace Files.App.Actions
 		public HotKey HotKey
 			=> new(Keys.C, KeyModifiers.CtrlShift);
 
+		public bool IsExecutable
+			=> context.HasSelection;
+
 		public CopyPathAction()
 		{
 			context = Ioc.Default.GetRequiredService<IContentPageContext>();


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Fixed crash with copy path action if no items are selected

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Use ctrl + shift + c shortcut when no items are selected and confirm app doesn't crash

**Screenshots (optional)**
Add screenshots here.
