### PR TITLE
Fix: Fixed NullReferenceException in OpenDirectoryInNewTabAction

### DIFF
--- a/src/Files.App/Actions/Navigation/OpenDirectoryInNewTabAction.cs
+++ b/src/Files.App/Actions/Navigation/OpenDirectoryInNewTabAction.cs
@@ -38,8 +38,7 @@ namespace Files.App.Actions
 
 		public async Task ExecuteAsync()
 		{
-			if (context.ShellPage?.SlimContentPage is null ||
-				context.ShellPage.SlimContentPage?.SelectedItems is null)
+			if (context.ShellPage?.SlimContentPage?.SelectedItems is null)
 				return;
 
 			foreach (ListedItem listedItem in context.ShellPage.SlimContentPage.SelectedItems)

--- a/src/Files.App/Actions/Navigation/OpenDirectoryInNewTabAction.cs
+++ b/src/Files.App/Actions/Navigation/OpenDirectoryInNewTabAction.cs
@@ -38,7 +38,11 @@ namespace Files.App.Actions
 
 		public async Task ExecuteAsync()
 		{
-			foreach (ListedItem listedItem in context.ShellPage?.SlimContentPage?.SelectedItems)
+			if (context.ShellPage?.SlimContentPage is null ||
+				context.ShellPage.SlimContentPage?.SelectedItems is null)
+				return;
+
+			foreach (ListedItem listedItem in context.ShellPage.SlimContentPage.SelectedItems)
 			{
 				await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{

--- a/src/Files.App/Actions/Navigation/OpenDirectoryInNewTabAction.cs
+++ b/src/Files.App/Actions/Navigation/OpenDirectoryInNewTabAction.cs
@@ -21,6 +21,8 @@ namespace Files.App.Actions
 			=> new(opacityStyle: "ColorIconOpenInNewTab");
 
 		public bool IsExecutable =>
+			context.ShellPage is not null &&
+			context.ShellPage.SlimContentPage is not null &&
 			context.SelectedItems.Count <= 5 &&
 			context.SelectedItems.Where(x => x.IsFolder == true).Count() == context.SelectedItems.Count &&
 			userSettingsService.GeneralSettingsService.ShowOpenInNewTab;
@@ -36,7 +38,7 @@ namespace Files.App.Actions
 
 		public async Task ExecuteAsync()
 		{
-			foreach (ListedItem listedItem in context.ShellPage.SlimContentPage.SelectedItems)
+			foreach (ListedItem listedItem in context.ShellPage?.SlimContentPage?.SelectedItems)
 			{
 				await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/1495782651u/overview

```
Files.App.Actions
OpenDirectoryInNewTabAction.ExecuteAsync ()
Files.App.ViewModels.UserControls
ToolbarViewModel.CheckPathInputAsync (String currentInput, String currentSelectedPath, IShellPage shellPage)
Files.App.Views.Shells
BaseShellPage.NavigationToolbar_QuerySubmitted (Object sender, ToolbarQuerySubmittedEventArgs e)
System.Threading.Tasks.Task
<>c.<ThrowAsync>b__128_0 (Object state)
```