### PR TITLE
Fix: Fixed NullReferenceException with ColumnViewBase.EndRename

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -169,6 +169,9 @@ namespace Files.App.Views.LayoutModes
 
 		protected override void EndRename(TextBox textBox)
 		{
+			FileNameTeachingTip.IsOpen = false;
+			IsRenamingItem = false;
+
 			// Unsubscribe from events
 			if (textBox is not null)
 			{
@@ -189,9 +192,6 @@ namespace Files.App.Views.LayoutModes
 				textBox!.Visibility = Visibility.Collapsed;
 				textBlock!.Visibility = Visibility.Visible;
 			}
-
-			FileNameTeachingTip.IsOpen = false;
-			IsRenamingItem = false;
 		}
 
 		public override void ResetItemOpacity()

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -169,6 +169,13 @@ namespace Files.App.Views.LayoutModes
 
 		protected override void EndRename(TextBox textBox)
 		{
+			// Unsubscribe from events
+			if (textBox is not null)
+			{
+				textBox!.LostFocus -= RenameTextBox_LostFocus;
+				textBox.KeyDown -= RenameTextBox_KeyDown;
+			}
+
 			if (textBox is not null && textBox.Parent is not null)
 			{
 				ListViewItem? listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
@@ -181,13 +188,6 @@ namespace Files.App.Views.LayoutModes
 				TextBlock? textBlock = listViewItem.FindDescendant("ItemName") as TextBlock;
 				textBox!.Visibility = Visibility.Collapsed;
 				textBlock!.Visibility = Visibility.Visible;
-			}
-
-			// Unsubscribe from events
-			if (textBox is not null)
-			{
-				textBox!.LostFocus -= RenameTextBox_LostFocus;
-				textBox.KeyDown -= RenameTextBox_KeyDown;
 			}
 
 			FileNameTeachingTip.IsOpen = false;

--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml.cs
@@ -3,6 +3,7 @@
 
 using CommunityToolkit.WinUI.UI;
 using Files.App.UserControls.Selection;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -13,9 +14,8 @@ using System.IO;
 using Windows.Storage;
 using Windows.System;
 using Windows.UI.Core;
-using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
 using static Files.App.Constants;
-using Microsoft.UI.Dispatching;
+using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
 
 namespace Files.App.Views.LayoutModes
 {
@@ -171,11 +171,14 @@ namespace Files.App.Views.LayoutModes
 		{
 			if (textBox is not null && textBox.Parent is not null)
 			{
-				// Re-focus selected list item
-				var listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
-				listViewItem?.Focus(FocusState.Programmatic);
+				ListViewItem? listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+				if (listViewItem is null)
+					return;
 
-				var textBlock = listViewItem?.FindDescendant("ItemName") as TextBlock;
+				// Re-focus selected list item
+				listViewItem.Focus(FocusState.Programmatic);
+
+				TextBlock? textBlock = listViewItem.FindDescendant("ItemName") as TextBlock;
 				textBox!.Visibility = Visibility.Collapsed;
 				textBlock!.Visibility = Visibility.Visible;
 			}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/634160407u/overview

```
Files.App.Views.LayoutModes
ColumnViewBase.EndRename (TextBox textBox)
Files.App.Views.LayoutModes
StandardViewBase.CommitRenameAsync (TextBox textBox)
Files.App.Views.LayoutModes
StandardViewBase.RenameTextBox_LostFocus (Object sender, RoutedEventArgs e)
System.Threading.Tasks.Task
<>c.<ThrowAsync>b__128_0 (Object state)
```