### PR TITLE
Fix: Fixed TextBox background when renaming items

### DIFF
--- a/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml
+++ b/src/Files.App/Views/LayoutModes/ColumnViewBase.xaml
@@ -291,7 +291,11 @@
 									BeforeTextChanging="ItemNameTextBox_BeforeTextChanging"
 									TextAlignment="Left"
 									TextWrapping="Wrap"
-									Visibility="Collapsed" />
+									Visibility="Collapsed">
+									<TextBox.Resources>
+										<SolidColorBrush x:Key="TextControlBackgroundFocused" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
+									</TextBox.Resources>
+								</TextBox>
 
 								<Grid Grid.Column="2">
 									<StackPanel Orientation="Horizontal" Spacing="4">

--- a/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/GridViewBrowser.xaml
@@ -411,7 +411,11 @@
 							Canvas.ZIndex="1"
 							Text="{x:Bind Name, Mode=OneWay}"
 							TextWrapping="Wrap"
-							Visibility="Collapsed" />
+							Visibility="Collapsed">
+							<TextBox.Resources>
+								<SolidColorBrush x:Key="TextControlBackgroundFocused" Color="{ThemeResource SolidBackgroundFillColorSecondary}" />
+							</TextBox.Resources>
+						</TextBox>
 
 						<TextBlock
 							Grid.Row="1"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13796...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Rename file in the details layout & tiles layout and confirm the textbox background isn't transparent

**Screenshots (optional)**
Add screenshots here.
