### PR TITLE
Fix: Removed gap between the divider line and details layout browser header

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -242,7 +242,7 @@
 							x:Name="HeaderGrid"
 							Height="40"
 							Margin="-8,0,-8,0"
-							Padding="16,0,0,0"
+							Padding="24,0,0,0"
 							BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
 							BorderThickness="0,0,0,1"
 							PointerPressed="Grid_PointerPressed">

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -241,7 +241,7 @@
 						<Grid
 							x:Name="HeaderGrid"
 							Height="40"
-							Margin="0"
+							Margin="-8,0,-8,0"
 							Padding="16,0,0,0"
 							BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
 							BorderThickness="0,0,0,1"


### PR DESCRIPTION
Reopening since this should remove the gap and still provide functionality for context menu/selection rectangle in the space to the left of the file list to work properly.

fixed https://github.com/files-community/Files/issues/13819

**Screenshots**

![Screenshot 2023-11-11 213621](https://github.com/files-community/Files/assets/11762008/05e34d43-30f1-4dee-993a-badbc28bdc6a)

![Screenshot 2023-11-11 213604](https://github.com/files-community/Files/assets/11762008/81bf3cf5-3398-4e5d-82b7-0b9db4e87c05)
