### PR TITLE
Fix: Fixed issue where double-clicking on column headers would navigate up

### DIFF
--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml
@@ -245,6 +245,7 @@
 							Padding="16,0,0,0"
 							BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
 							BorderThickness="0,0,0,1"
+							DoubleTapped="FileListHeader_DoubleTapped"
 							PointerPressed="Grid_PointerPressed">
 
 							<!--  Header Grid MenuFlyout  -->

--- a/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
+++ b/src/Files.App/Views/LayoutModes/DetailsLayoutBrowser.xaml.cs
@@ -902,6 +902,12 @@ namespace Files.App.Views.LayoutModes
 				args.TryCancel();
 		}
 
+		private void FileListHeader_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+		{
+			// Fixes an issue where double clicking the column header would navigate back as if clicking on empty space
+			e.Handled = true;
+		}
+
 		private static GitProperties GetEnabledGitProperties(ColumnsViewModel columnsViewModel)
 		{
 			var enableStatus = !columnsViewModel.GitStatusColumn.IsHidden && !columnsViewModel.GitStatusColumn.UserCollapsed;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13789 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Open a folder
   3. Double click open space
   4. Confirm that it navigates to parent folder
   5. Double click column header
   6. Confirm that only ascending/descending order is being changed
