### PR TITLE
Fixed: Fixed issue where the new item dialog cannot be canceled

### DIFF
--- a/src/Files.App/Actions/FileSystem/AddItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/AddItemAction.cs
@@ -49,6 +49,8 @@ namespace Files.App.Actions
 					viewModel.ResultType.ItemInfo,
 					context.ShellPage!);
 			}
+
+			viewModel.ResultType.ItemType = AddItemDialogItemType.Cancel;
 		}
 
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13787

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?

- [x] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Follow steps to reproduce issue
   3. Verify issue no longer persists.

The issue was the  
```viewModel.ResultType.ItemType```  in the ```AddItemDIalog``` was not being reset to the default ```ResultType.ItemType.Cancel``` and was remaining whatever type was last selected before pressing cancel. If there is another place I should reset it to cancel please let me know and I will revise it.

