### PR TITLE
Fix: Always set content dialog root

### DIFF
--- a/src/Files.App/Actions/Content/Archives/Compress/CompressIntoArchiveAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Compress/CompressIntoArchiveAction.cs
@@ -3,6 +3,7 @@
 
 using Files.App.Dialogs;
 using Microsoft.UI.Xaml.Controls;
+using Windows.Foundation.Metadata;
 
 namespace Files.App.Actions
 {
@@ -29,6 +30,9 @@ namespace Files.App.Actions
 			{
 				FileName = fileName,
 			};
+
+			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+				dialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
 
 			var result = await dialog.TryShowAsync();
 

--- a/src/Files.App/Services/UpdateService.cs
+++ b/src/Files.App/Services/UpdateService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml.Controls;
 using System.IO;
 using System.Net.Http;
+using Windows.Foundation.Metadata;
 using Windows.Services.Store;
 using Windows.Storage;
 using WinRT.Interop;
@@ -145,6 +146,9 @@ namespace Files.App.Services
 				CloseButtonText = "Close".GetLocalizedResource(),
 				PrimaryButtonText = "ConsentDialogPrimaryButtonText".GetLocalizedResource()
 			};
+
+			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+				dialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
 
 			ContentDialogResult result = await dialog.TryShowAsync();
 

--- a/src/Files.App/Utils/Archives/DecompressHelper.cs
+++ b/src/Files.App/Utils/Archives/DecompressHelper.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Xaml.Controls;
 using SevenZip;
 using System.IO;
 using System.Text;
+using Windows.Foundation.Metadata;
 using Windows.Storage;
 
 namespace Files.App.Utils.Archives
@@ -145,6 +146,9 @@ namespace Files.App.Utils.Archives
 			};
 			decompressArchiveDialog.ViewModel = decompressArchiveViewModel;
 
+			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+				decompressArchiveDialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
+
 			ContentDialogResult option = await decompressArchiveDialog.TryShowAsync();
 			if (option != ContentDialogResult.Primary)
 				return;
@@ -196,6 +200,9 @@ namespace Files.App.Utils.Archives
 
 					decompressArchiveDialog.ViewModel = decompressArchiveViewModel;
 
+					if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+						decompressArchiveDialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
+
 					ContentDialogResult option = await decompressArchiveDialog.TryShowAsync();
 					if (option != ContentDialogResult.Primary)
 						return;
@@ -232,6 +239,9 @@ namespace Files.App.Utils.Archives
 						ShowPathSelection = false
 					};
 					decompressArchiveDialog.ViewModel = decompressArchiveViewModel;
+
+					if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+						decompressArchiveDialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
 
 					ContentDialogResult option = await decompressArchiveDialog.TryShowAsync();
 					if (option != ContentDialogResult.Primary)

--- a/src/Files.App/Utils/RecycleBin/RecycleBinHelpers.cs
+++ b/src/Files.App/Utils/RecycleBin/RecycleBinHelpers.cs
@@ -4,6 +4,7 @@
 using Microsoft.UI.Xaml.Controls;
 using System.Text.RegularExpressions;
 using Vanara.PInvoke;
+using Windows.Foundation.Metadata;
 using Windows.Storage;
 
 namespace Files.App.Utils.RecycleBin
@@ -25,7 +26,7 @@ namespace Files.App.Utils.RecycleBin
 		{
 			return (ulong)Win32Shell.QueryRecycleBin().BinSize;
 		}
-		
+
 		public static async Task<bool> IsRecycleBinItem(IStorageItem item)
 		{
 			List<ShellFileItem> recycleBinItems = await EnumerateRecycleBin();
@@ -54,6 +55,9 @@ namespace Files.App.Utils.RecycleBin
 				SecondaryButtonText = "Cancel".GetLocalizedResource(),
 				DefaultButton = ContentDialogButton.Primary
 			};
+
+			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+				ConfirmEmptyBinDialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
 
 			// If the operation is approved by the user
 			if (userSettingsService.FoldersSettingsService.DeleteConfirmationPolicy is DeleteConfirmationPolicies.Never ||
@@ -102,6 +106,9 @@ namespace Files.App.Utils.RecycleBin
 				SecondaryButtonText = "Cancel".GetLocalizedResource(),
 				DefaultButton = ContentDialogButton.Primary
 			};
+
+			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+				ConfirmEmptyBinDialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
 
 			ContentDialogResult result = await ConfirmEmptyBinDialog.TryShowAsync();
 

--- a/src/Files.App/Utils/Storage/Operations/FilesystemOperations.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemOperations.cs
@@ -5,6 +5,7 @@ using Files.Shared.Helpers;
 using Microsoft.UI.Xaml.Controls;
 using System.IO;
 using System.Text;
+using Windows.Foundation.Metadata;
 using Windows.Storage;
 
 namespace Files.App.Utils.Storage
@@ -145,6 +146,9 @@ namespace Files.App.Utils.Storage
 						//PrimaryButtonText = "Skip".GetLocalizedResource(),
 						CloseButtonText = "Cancel".GetLocalizedResource()
 					};
+
+					if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+						dialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
 
 					ContentDialogResult result = await dialog.TryShowAsync();
 
@@ -344,6 +348,9 @@ namespace Files.App.Utils.Storage
 						//PrimaryButtonText = "Skip".GetLocalizedResource(),
 						CloseButtonText = "Cancel".GetLocalizedResource()
 					};
+
+					if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+						dialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
 
 					ContentDialogResult result = await dialog.TryShowAsync();
 

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -14,6 +14,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using System.Runtime.CompilerServices;
 using Windows.ApplicationModel;
+using Windows.Foundation.Metadata;
 using Windows.Services.Store;
 using WinRT.Interop;
 using VirtualKey = Windows.System.VirtualKey;
@@ -77,6 +78,9 @@ namespace Files.App.Views
 				PrimaryButtonText = "Yes".ToLocalized(),
 				SecondaryButtonText = "No".ToLocalized()
 			};
+
+			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+				promptForReviewDialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
 
 			var result = await promptForReviewDialog.TryShowAsync();
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- Fix potential crashes that could occur if the root isn't set