### PR TITLE
Fix: Fixed NullReferenceException in MainPageViewModel.UpdateInstancePropertiesAsync

### DIFF
--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -135,30 +135,33 @@ namespace Files.App.ViewModels
 
 		public async Task UpdateInstancePropertiesAsync(object navigationArg)
 		{
-			string windowTitle = string.Empty;
-			if (navigationArg is PaneNavigationArguments paneArgs)
+			await SafetyExtensions.IgnoreExceptions(async () =>
 			{
-				if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
+				string windowTitle = string.Empty;
+				if (navigationArg is PaneNavigationArguments paneArgs)
 				{
-					var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-					var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
-					windowTitle = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
+					if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
+					{
+						var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+						var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
+						windowTitle = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
+					}
+					else
+					{
+						(windowTitle, _, _) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+					}
 				}
-				else
+				else if (navigationArg is string pathArgs)
 				{
-					(windowTitle, _, _) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+					(windowTitle, _, _) = await GetSelectedTabInfoAsync(pathArgs);
 				}
-			}
-			else if (navigationArg is string pathArgs)
-			{
-				(windowTitle, _, _) = await GetSelectedTabInfoAsync(pathArgs);
-			}
 
-			if (AppInstances.Count > 1)
-				windowTitle = $"{windowTitle} ({AppInstances.Count})";
+				if (AppInstances.Count > 1)
+					windowTitle = $"{windowTitle} ({AppInstances.Count})";
 
-			if (navigationArg == SelectedTabItem?.NavigationParameter?.NavigationParameter)
-				MainWindow.Instance.AppWindow.Title = $"{windowTitle} - Files";
+				if (navigationArg == SelectedTabItem?.NavigationParameter?.NavigationParameter)
+					MainWindow.Instance.AppWindow.Title = $"{windowTitle} - Files";
+			});
 		}
 
 		public async Task UpdateTabInfoAsync(Files.App.UserControls.TabBar.TabBarItem tabItem, object navigationArg)


### PR DESCRIPTION
I don't know why an exception is thrown, but since this process only updates the window title, I ignore the exception when it is thrown.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/2912768630u/overview

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?