### PR TITLE
Fix: Fixed potential COMException when updating preview pane selection

### DIFF
--- a/src/Files.App/Views/LayoutModes/BaseLayout.cs
+++ b/src/Files.App/Views/LayoutModes/BaseLayout.cs
@@ -1448,7 +1448,7 @@ namespace Files.App.Views.LayoutModes
 				InfoPaneViewModel.SelectedItem = value?.Count == 1 ? value.First() : null;
 
 				// Check if the preview pane is open before updating the model
-				if (InfoPaneViewModel.IsEnabled)
+				if (InfoPaneViewModel.IsEnabled && !App.AppModel.IsMainWindowClosed)
 				{
 					var isPaneEnabled = ((MainWindow.Instance.Content as Frame)?.Content as MainPage)?.ShouldPreviewPaneBeActive ?? false;
 					if (isPaneEnabled)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- Fixed com exception when updating preview pane selection

`The WinUI Desktop Window object has already been closed`