### PR TITLE
Fix: Fixed COMException in BaseLayoutViewModel.DropAsync

### DIFF
--- a/src/Files.App/ViewModels/LayoutModes/BaseLayoutViewModel.cs
+++ b/src/Files.App/ViewModels/LayoutModes/BaseLayoutViewModel.cs
@@ -164,17 +164,13 @@ namespace Files.App.ViewModels.LayoutModes
 
 		public async Task DropAsync(DragEventArgs e)
 		{
-			var deferral = e.GetDeferral();
+			e.Handled = true;
 
 			if (FilesystemHelpers.HasDraggedStorageItems(e.DataView))
 			{
 				await _associatedInstance.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, _associatedInstance.FilesystemViewModel.WorkingDirectory, false, true);
-				e.Handled = true;
-
 				await _associatedInstance.RefreshIfNoWatcherExistsAsync();
 			}
-
-			deferral.Complete();
 		}
 
 		public void Dispose()


### PR DESCRIPTION
I don't believe it needs `deferral` in the first place since there are no events that should wait for the completion of the drop event.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13822 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?