### PR TITLE
Fix: Fixed crash when calculating window bounds

### DIFF
--- a/src/Files.App/Views/PaneHolderPage.xaml.cs
+++ b/src/Files.App/Views/PaneHolderPage.xaml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Files.App.UserControls.TabBar;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -80,7 +79,15 @@ namespace Files.App.Views
 			=> IsRightPaneVisible;
 
 		public bool IsMultiPaneEnabled
-			=> MainWindow.Instance.Bounds.Width > DualPaneWidthThreshold;
+		{
+			get
+			{
+				if (App.AppModel.IsMainWindowClosed == true)
+					return false;
+				else
+					return MainWindow.Instance.Bounds.Width > DualPaneWidthThreshold;
+			}
+		}
 
 		private NavigationParams _NavParamsLeft;
 		public NavigationParams NavParamsLeft

--- a/src/Files.App/Views/PaneHolderPage.xaml.cs
+++ b/src/Files.App/Views/PaneHolderPage.xaml.cs
@@ -82,7 +82,7 @@ namespace Files.App.Views
 		{
 			get
 			{
-				if (App.AppModel.IsMainWindowClosed == true)
+				if (App.AppModel.IsMainWindowClosed)
 					return false;
 				else
 					return MainWindow.Instance.Bounds.Width > DualPaneWidthThreshold;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- Fixes `System.Runtime.InteropServices.COMException: The operation identifier is not valid. The WinUI Desktop Window object has already been closed`