### PR TITLE
Fix: Disabled media preview for FTP

### DIFF
--- a/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
@@ -6,7 +6,6 @@ using Files.App.ViewModels.Previews;
 using Files.Shared.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System.Windows.Input;
 using Windows.Storage;
 
 namespace Files.App.ViewModels.UserControls
@@ -206,7 +205,8 @@ namespace Files.App.ViewModels.UserControls
 
 			var ext = item.FileExtension.ToLowerInvariant();
 
-			if (FileExtensionHelpers.IsAudioFile(ext) || FileExtensionHelpers.IsVideoFile(ext))
+			if (item.IsFtpItem == false &&
+				(FileExtensionHelpers.IsAudioFile(ext) || FileExtensionHelpers.IsVideoFile(ext)))
 			{
 				var model = new MediaPreviewViewModel(item);
 				await model.LoadAsync();

--- a/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
@@ -205,7 +205,7 @@ namespace Files.App.ViewModels.UserControls
 
 			var ext = item.FileExtension.ToLowerInvariant();
 
-			if (item.IsFtpItem == false &&
+			if (!item.IsFtpItem &&
 				(FileExtensionHelpers.IsAudioFile(ext) || FileExtensionHelpers.IsVideoFile(ext)))
 			{
 				var model = new MediaPreviewViewModel(item);


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13817...

**Validation**
How did you test these changes?
- [ ] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Select media file in FTP location
   2. Confirm the media preview isn't shown

**Screenshots (optional)**
Add screenshots here.
