### PR TITLE
Feature: Display error when failing to calculate the hash of open files

### DIFF
--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2341,7 +2341,7 @@
     <value>An error occurred during the calculation</value>
   </data>
   <data name="CalculationErrorFileIsOpen" xml:space="preserve">
-    <value>An error occurred during the calculation, please close the file and try again.</value>
+    <value>Failed to calculate the hash, please close the file and try again.</value>
   </data>
   <data name="CalculationOnlineFileHashError" xml:space="preserve">
     <value>Hashes aren't available for online files</value>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2340,6 +2340,9 @@
   <data name="CalculationError" xml:space="preserve">
     <value>An error occurred during the calculation</value>
   </data>
+  <data name="CalculationErrorFileIsOpen" xml:space="preserve">
+    <value>An error occurred during the calculation, please close the file and try again.</value>
+  </data>
   <data name="CalculationOnlineFileHashError" xml:space="preserve">
     <value>Hashes aren't available for online files</value>
   </data>

--- a/src/Files.App/ViewModels/Properties/HashesViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/HashesViewModel.cs
@@ -103,6 +103,11 @@ namespace Files.App.ViewModels.Properties
 					{
 						// not an error
 					}
+					catch (IOException)
+					{
+						// File is currently open
+						hashInfoItem.HashValue = "CalculationErrorFileIsOpen".GetLocalizedResource();
+					}
 					catch (Exception)
 					{
 						hashInfoItem.HashValue = "CalculationError".GetLocalizedResource();


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13564...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open office document
   2. Right click and open properties for that file
   3. Switch to the hashes page and confirm it explains why the hashes can't be calculated

**Screenshots (optional)**
Add screenshots here.
