### PR TITLE
Code Quality: Moved static methods from MainPageViewModel to NavigationHelpers

### DIFF
--- a/src/Files.App/Actions/Navigation/DuplicateCurrentTabAction.cs
+++ b/src/Files.App/Actions/Navigation/DuplicateCurrentTabAction.cs
@@ -7,8 +7,6 @@ namespace Files.App.Actions
 	{
 		private readonly IMultitaskingContext context;
 
-		private readonly MainPageViewModel mainPageViewModel;
-
 		public string Label
 			=> "DuplicateTab".GetLocalizedResource();
 
@@ -18,16 +16,25 @@ namespace Files.App.Actions
 		public DuplicateCurrentTabAction()
 		{
 			context = Ioc.Default.GetRequiredService<IMultitaskingContext>();
-			mainPageViewModel = Ioc.Default.GetRequiredService<MainPageViewModel>();
 		}
 
 		public async Task ExecuteAsync()
 		{
 			var arguments = context.CurrentTabItem.NavigationParameter;
+
 			if (arguments is null)
-				await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), "Home");
+			{
+				await NavigationHelpers.AddNewTabByPathAsync(
+					typeof(PaneHolderPage),
+					"Home");
+			}
 			else
-				await mainPageViewModel.AddNewTabByParamAsync(arguments.InitialPageType, arguments.NavigationParameter, context.CurrentTabIndex + 1);
+			{
+				await NavigationHelpers.AddNewTabByParamAsync(
+					arguments.InitialPageType,
+					arguments.NavigationParameter,
+					context.CurrentTabIndex + 1);
+			}
 		}
 	}
 }

--- a/src/Files.App/Actions/Navigation/DuplicateCurrentTabAction.cs
+++ b/src/Files.App/Actions/Navigation/DuplicateCurrentTabAction.cs
@@ -24,9 +24,7 @@ namespace Files.App.Actions
 
 			if (arguments is null)
 			{
-				await NavigationHelpers.AddNewTabByPathAsync(
-					typeof(PaneHolderPage),
-					"Home");
+				await NavigationHelpers.AddNewTabByPathAsync(typeof(PaneHolderPage), "Home");
 			}
 			else
 			{

--- a/src/Files.App/Actions/Navigation/DuplicateSelectedTabAction.cs
+++ b/src/Files.App/Actions/Navigation/DuplicateSelectedTabAction.cs
@@ -7,8 +7,6 @@ namespace Files.App.Actions
 	{
 		private readonly IMultitaskingContext context;
 
-		private readonly MainPageViewModel mainPageViewModel;
-
 		public string Label
 			=> "DuplicateTab".GetLocalizedResource();
 
@@ -21,16 +19,20 @@ namespace Files.App.Actions
 		public DuplicateSelectedTabAction()
 		{
 			context = Ioc.Default.GetRequiredService<IMultitaskingContext>();
-			mainPageViewModel = Ioc.Default.GetRequiredService<MainPageViewModel>();
 		}
 
 		public async Task ExecuteAsync()
 		{
 			var arguments = context.SelectedTabItem.NavigationParameter;
+
 			if (arguments is null)
-				await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), "Home");
+			{
+				await NavigationHelpers.AddNewTabByPathAsync(typeof(PaneHolderPage), "Home");
+			}
 			else
-				await mainPageViewModel.AddNewTabByParamAsync(arguments.InitialPageType, arguments.NavigationParameter, context.SelectedTabIndex + 1);
+			{
+				await NavigationHelpers.AddNewTabByParamAsync(arguments.InitialPageType, arguments.NavigationParameter, context.SelectedTabIndex + 1);
+			}
 		}
 	}
 }

--- a/src/Files.App/Actions/Navigation/NewTabAction.cs
+++ b/src/Files.App/Actions/Navigation/NewTabAction.cs
@@ -5,8 +5,6 @@ namespace Files.App.Actions
 {
 	internal class NewTabAction : IAction
 	{
-		private readonly MainPageViewModel mainPageViewModel;
-
 		public string Label
 			=> "NewTab".GetLocalizedResource();
 
@@ -18,12 +16,11 @@ namespace Files.App.Actions
 
 		public NewTabAction()
 		{
-			mainPageViewModel = Ioc.Default.GetRequiredService<MainPageViewModel>();
 		}
 
 		public Task ExecuteAsync()
 		{
-			return mainPageViewModel.AddNewTabAsync();
+			return NavigationHelpers.AddNewTabAsync();
 		}
 	}
 }

--- a/src/Files.App/Actions/Navigation/OpenDirectoryInNewTabAction.cs
+++ b/src/Files.App/Actions/Navigation/OpenDirectoryInNewTabAction.cs
@@ -9,8 +9,6 @@ namespace Files.App.Actions
 
 		private readonly IUserSettingsService userSettingsService;
 
-		private readonly MainPageViewModel _mainPageViewModel;
-
 		public string Label
 			=> "OpenInNewTab".GetLocalizedResource();
 
@@ -31,7 +29,6 @@ namespace Files.App.Actions
 		{
 			context = Ioc.Default.GetRequiredService<IContentPageContext>();
 			userSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
-			_mainPageViewModel = Ioc.Default.GetRequiredService<MainPageViewModel>();
 
 			context.PropertyChanged += Context_PropertyChanged;
 		}
@@ -45,7 +42,7 @@ namespace Files.App.Actions
 			{
 				await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
-					await _mainPageViewModel.AddNewTabByPathAsync(
+					await NavigationHelpers.AddNewTabByPathAsync(
 						typeof(PaneHolderPage),
 						(listedItem as ShortcutItem)?.TargetPath ?? listedItem.ItemPath);
 				},

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -39,7 +39,7 @@ namespace Files.App
 		private static bool ShowErrorNotification = false;
 		public static string OutputPath { get; set; }
 		public static CommandBarFlyout? LastOpenedFlyout { get; set; }
-		public static TaskCompletionSource? SplashScreenLoadingTCS { get; private set; }
+		public static TaskComletionSource? SplashScreenLoadingTCS { get; private set; }
 
 		public static StorageHistoryWrapper HistoryWrapper { get; } = new();
 		public static AppModel AppModel { get; private set; }

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -39,7 +39,7 @@ namespace Files.App
 		private static bool ShowErrorNotification = false;
 		public static string OutputPath { get; set; }
 		public static CommandBarFlyout? LastOpenedFlyout { get; set; }
-		public static TaskComletionSource? SplashScreenLoadingTCS { get; private set; }
+		public static TaskCompletionSource? SplashScreenLoadingTCS { get; private set; }
 
 		public static StorageHistoryWrapper HistoryWrapper { get; } = new();
 		public static AppModel AppModel { get; private set; }

--- a/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
@@ -162,7 +162,7 @@ namespace Files.App.Helpers
 				// If localized string is empty use the library name.
 				tabLocationHeader = string.IsNullOrEmpty(libName) ? library.Text : libName;
 			}
-			else if (WSLDistroManager.TryGetDistro(currentPath, out LocatableWSLItem? wslDistro) && currentPath.Equals(wslDistro.Path))
+			else if (WSLDistroManager.TryGetDistro(currentPath, out WslDistroItem? wslDistro) && currentPath.Equals(wslDistro.Path))
 			{
 				tabLocationHeader = wslDistro.Text;
 				iconSource.ImageSource = new BitmapImage(wslDistro.Icon);
@@ -178,8 +178,8 @@ namespace Files.App.Helpers
 				}
 				else if (PathNormalization.NormalizePath(PathNormalization.GetPathRoot(currentPath)) == normalizedCurrentPath) // If path is a drive's root
 				{
-					var matchingDrive = NetworkDrivesViewModel.Drives.Cast<LocatableDriveItem>().FirstOrDefault(netDrive => normalizedCurrentPath.Contains(PathNormalization.NormalizePath(netDrive.Path), StringComparison.OrdinalIgnoreCase));
-					matchingDrive ??= DrivesViewModel.Drives.Cast<LocatableDriveItem>().FirstOrDefault(drive => normalizedCurrentPath.Contains(PathNormalization.NormalizePath(drive.Path), StringComparison.OrdinalIgnoreCase));
+					var matchingDrive = NetworkDrivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(netDrive => normalizedCurrentPath.Contains(PathNormalization.NormalizePath(netDrive.Path), StringComparison.OrdinalIgnoreCase));
+					matchingDrive ??= DrivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(drive => normalizedCurrentPath.Contains(PathNormalization.NormalizePath(drive.Path), StringComparison.OrdinalIgnoreCase));
 					tabLocationHeader = matchingDrive is not null ? matchingDrive.Text : normalizedCurrentPath;
 				}
 				else

--- a/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
@@ -3,6 +3,8 @@
 
 using Files.Shared.Helpers;
 using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Storage;
 using Windows.Storage.Search;
 using Windows.System;
@@ -11,16 +13,249 @@ namespace Files.App.Helpers
 {
 	public static class NavigationHelpers
 	{
-		private static readonly IUserSettingsService userSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
-		private static readonly MainPageViewModel mainPageViewModel = Ioc.Default.GetRequiredService<MainPageViewModel>();
+		private static MainPageViewModel MainPageViewModel { get; } = Ioc.Default.GetRequiredService<MainPageViewModel>();
+		private static DrivesViewModel DrivesViewModel { get; } = Ioc.Default.GetRequiredService<DrivesViewModel>();
+		private static NetworkDrivesViewModel NetworkDrivesViewModel { get; } = Ioc.Default.GetRequiredService<NetworkDrivesViewModel>();
+
 		public static Task OpenPathInNewTab(string? path)
-			=> mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), path);
+		{
+			return AddNewTabByPathAsync(typeof(PaneHolderPage), path);
+		}
+
+		public static Task AddNewTabAsync()
+		{
+			return AddNewTabByPathAsync(typeof(PaneHolderPage), "Home");
+		}
+
+		public static async Task AddNewTabByPathAsync(Type type, string? path, int atIndex = -1)
+		{
+			if (string.IsNullOrEmpty(path))
+			{
+				path = "Home";
+			}
+			// Support drives launched through jump list by stripping away the question mark at the end.
+			else if (path.EndsWith("\\?"))
+			{
+				path = path.Remove(path.Length - 1);
+			}
+
+			var tabItem = new TabBarItem()
+			{
+				Header = null,
+				IconSource = null,
+				Description = null,
+				ToolTipText = null,
+				NavigationParameter = new CustomTabViewItemParameter()
+				{
+					InitialPageType = type,
+					NavigationParameter = path
+				}
+			};
+
+			tabItem.ContentChanged += Control_ContentChanged;
+
+			await UpdateTabInfoAsync(tabItem, path);
+
+			var index = atIndex == -1 ? MainPageViewModel.AppInstances.Count : atIndex;
+
+			MainPageViewModel.AppInstances.Insert(index, tabItem);
+
+			App.AppModel.TabStripSelectedIndex = index;
+		}
+
+		public static async Task AddNewTabByParamAsync(Type type, object tabViewItemArgs, int atIndex = -1)
+		{
+			var tabItem = new Files.App.UserControls.TabBar.TabBarItem()
+			{
+				Header = null,
+				IconSource = null,
+				Description = null,
+				ToolTipText = null
+			};
+
+			tabItem.NavigationParameter = new CustomTabViewItemParameter()
+			{
+				InitialPageType = type,
+				NavigationParameter = tabViewItemArgs
+			};
+
+			tabItem.ContentChanged += Control_ContentChanged;
+
+			await UpdateTabInfoAsync(tabItem, tabViewItemArgs);
+
+			var index = atIndex == -1 ? MainPageViewModel.AppInstances.Count : atIndex;
+			MainPageViewModel.AppInstances.Insert(index, tabItem);
+			App.AppModel.TabStripSelectedIndex = index;
+		}
+
+		private static async Task UpdateTabInfoAsync(TabBarItem tabItem, object navigationArg)
+		{
+			tabItem.AllowStorageItemDrop = true;
+
+			(string, IconSource, string) result = (null, null, null);
+			if (navigationArg is PaneNavigationArguments paneArgs)
+			{
+				if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
+				{
+					var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+					var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
+					result = ($"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}",
+						leftTabInfo.tabIcon,
+						$"{leftTabInfo.toolTipText} | {rightTabInfo.toolTipText}");
+				}
+				else
+				{
+					result = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+				}
+			}
+			else if (navigationArg is string pathArgs)
+			{
+				result = await GetSelectedTabInfoAsync(pathArgs);
+			}
+
+			// Don't update tabItem if the contents of the tab have already changed
+			if (result.Item1 is not null &&
+				(navigationArg is PaneNavigationArguments && navigationArg as PaneNavigationArguments == tabItem.NavigationParameter.NavigationParameter as PaneNavigationArguments
+				|| navigationArg is string && navigationArg as string == tabItem.NavigationParameter.NavigationParameter as string))
+				(tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = result;
+		}
+
+		public static async Task<(string tabLocationHeader, IconSource tabIcon, string toolTipText)> GetSelectedTabInfoAsync(string currentPath)
+		{
+			string? tabLocationHeader;
+			var iconSource = new ImageIconSource();
+			string toolTipText = currentPath;
+
+			if (string.IsNullOrEmpty(currentPath) || currentPath == "Home")
+			{
+				tabLocationHeader = "Home".GetLocalizedResource();
+				iconSource.ImageSource = new BitmapImage(new Uri(Constants.FluentIconsPaths.HomeIcon));
+			}
+			else if (currentPath.Equals(Constants.UserEnvironmentPaths.DesktopPath, StringComparison.OrdinalIgnoreCase))
+			{
+				tabLocationHeader = "Desktop".GetLocalizedResource();
+			}
+			else if (currentPath.Equals(Constants.UserEnvironmentPaths.DownloadsPath, StringComparison.OrdinalIgnoreCase))
+			{
+				tabLocationHeader = "Downloads".GetLocalizedResource();
+			}
+			else if (currentPath.Equals(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
+			{
+				tabLocationHeader = "RecycleBin".GetLocalizedResource();
+
+				// Use 48 for higher resolution, the other items look fine with 16.
+				var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 48u, Windows.Storage.FileProperties.ThumbnailMode.ListView, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale, true);
+				if (iconData is not null)
+					iconSource.ImageSource = await iconData.ToBitmapAsync();
+			}
+			else if (currentPath.Equals(Constants.UserEnvironmentPaths.MyComputerPath, StringComparison.OrdinalIgnoreCase))
+			{
+				tabLocationHeader = "ThisPC".GetLocalizedResource();
+			}
+			else if (currentPath.Equals(Constants.UserEnvironmentPaths.NetworkFolderPath, StringComparison.OrdinalIgnoreCase))
+			{
+				tabLocationHeader = "SidebarNetworkDrives".GetLocalizedResource();
+			}
+			else if (App.LibraryManager.TryGetLibrary(currentPath, out LibraryLocationItem library))
+			{
+				var libName = System.IO.Path.GetFileNameWithoutExtension(library.Path).GetLocalizedResource();
+				// If localized string is empty use the library name.
+				tabLocationHeader = string.IsNullOrEmpty(libName) ? library.Text : libName;
+			}
+			else if (WSLDistroManager.TryGetDistro(currentPath, out LocatableWSLItem? wslDistro) && currentPath.Equals(wslDistro.Path))
+			{
+				tabLocationHeader = wslDistro.Text;
+				iconSource.ImageSource = new BitmapImage(wslDistro.Icon);
+			}
+			else
+			{
+				var normalizedCurrentPath = PathNormalization.NormalizePath(currentPath);
+				var matchingCloudDrive = CloudDrivesManager.Drives.FirstOrDefault(x => normalizedCurrentPath.Equals(PathNormalization.NormalizePath(x.Path), StringComparison.OrdinalIgnoreCase));
+				if (matchingCloudDrive is not null)
+				{
+					iconSource.ImageSource = matchingCloudDrive.Icon;
+					tabLocationHeader = matchingCloudDrive.Text;
+				}
+				else if (PathNormalization.NormalizePath(PathNormalization.GetPathRoot(currentPath)) == normalizedCurrentPath) // If path is a drive's root
+				{
+					var matchingDrive = NetworkDrivesViewModel.Drives.Cast<LocatableDriveItem>().FirstOrDefault(netDrive => normalizedCurrentPath.Contains(PathNormalization.NormalizePath(netDrive.Path), StringComparison.OrdinalIgnoreCase));
+					matchingDrive ??= DrivesViewModel.Drives.Cast<LocatableDriveItem>().FirstOrDefault(drive => normalizedCurrentPath.Contains(PathNormalization.NormalizePath(drive.Path), StringComparison.OrdinalIgnoreCase));
+					tabLocationHeader = matchingDrive is not null ? matchingDrive.Text : normalizedCurrentPath;
+				}
+				else
+				{
+					tabLocationHeader = currentPath.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar).Split('\\', StringSplitOptions.RemoveEmptyEntries).Last();
+
+					FilesystemResult<StorageFolderWithPath> rootItem = await FilesystemTasks.Wrap(() => DriveHelpers.GetRootFromPathAsync(currentPath));
+					if (rootItem)
+					{
+						BaseStorageFolder currentFolder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(currentPath, rootItem));
+						if (currentFolder is not null && !string.IsNullOrEmpty(currentFolder.DisplayName))
+							tabLocationHeader = currentFolder.DisplayName;
+					}
+				}
+			}
+
+			if (iconSource.ImageSource is null)
+			{
+				var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 16u, Windows.Storage.FileProperties.ThumbnailMode.ListView, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale, true);
+				if (iconData is not null)
+					iconSource.ImageSource = await iconData.ToBitmapAsync();
+			}
+
+			return (tabLocationHeader, iconSource, toolTipText);
+		}
+
+		public static async Task UpdateInstancePropertiesAsync(object navigationArg)
+		{
+			await SafetyExtensions.IgnoreExceptions(async () =>
+			{
+				string windowTitle = string.Empty;
+				if (navigationArg is PaneNavigationArguments paneArgs)
+				{
+					if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
+					{
+						var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+						var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
+						windowTitle = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
+					}
+					else
+					{
+						(windowTitle, _, _) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
+					}
+				}
+				else if (navigationArg is string pathArgs)
+				{
+					(windowTitle, _, _) = await GetSelectedTabInfoAsync(pathArgs);
+				}
+
+				if (MainPageViewModel.AppInstances.Count > 1)
+					windowTitle = $"{windowTitle} ({MainPageViewModel.AppInstances.Count})";
+
+				if (navigationArg == MainPageViewModel.SelectedTabItem?.NavigationParameter?.NavigationParameter)
+					MainWindow.Instance.AppWindow.Title = $"{windowTitle} - Files";
+			});
+		}
+
+		public static async void Control_ContentChanged(object? sender, CustomTabViewItemParameter e)
+		{
+			if (sender is null)
+				return;
+
+			var matchingTabItem = MainPageViewModel.AppInstances.SingleOrDefault(x => x == (TabBarItem)sender);
+			if (matchingTabItem is null)
+				return;
+
+			await UpdateTabInfoAsync(matchingTabItem, e.NavigationParameter);
+		}
 
 		public static Task<bool> OpenPathInNewWindowAsync(string? path)
 		{
 			if (string.IsNullOrWhiteSpace(path))
 				return Task.FromResult(false);
+
 			var folderUri = new Uri($"files-uwp:?folder={Uri.EscapeDataString(path)}");
+
 			return Launcher.LaunchUriAsync(folderUri).AsTask();
 		}
 
@@ -221,27 +456,27 @@ namespace Files.App.Helpers
 
 		private static async Task<FilesystemResult> OpenLibrary(string path, IShellPage associatedInstance, IEnumerable<string>? selectItems, bool forceOpenInNewTab)
 		{
-			IUserSettingsService userSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
+			IUserSettingsService UserSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
 
 			var opened = (FilesystemResult)false;
 			bool isHiddenItem = NativeFileOperationsHelper.HasFileAttribute(path, System.IO.FileAttributes.Hidden);
 			if (isHiddenItem)
 			{
-				await OpenPath(forceOpenInNewTab, userSettingsService.FoldersSettingsService.OpenFoldersInNewTab, path, associatedInstance);
+				await OpenPath(forceOpenInNewTab, UserSettingsService.FoldersSettingsService.OpenFoldersInNewTab, path, associatedInstance);
 				opened = (FilesystemResult)true;
 			}
 			else if (App.LibraryManager.TryGetLibrary(path, out LibraryLocationItem library))
 			{
 				opened = (FilesystemResult)await library.CheckDefaultSaveFolderAccess();
 				if (opened)
-					await OpenPathAsync(forceOpenInNewTab, userSettingsService.FoldersSettingsService.OpenFoldersInNewTab, path, library.Text, associatedInstance, selectItems);
+					await OpenPathAsync(forceOpenInNewTab, UserSettingsService.FoldersSettingsService.OpenFoldersInNewTab, path, library.Text, associatedInstance, selectItems);
 			}
 			return opened;
 		}
 
 		private static async Task<FilesystemResult> OpenDirectory(string path, IShellPage associatedInstance, IEnumerable<string>? selectItems, ShellLinkItem shortcutInfo, bool forceOpenInNewTab)
 		{
-			IUserSettingsService userSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
+			IUserSettingsService UserSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
 
 			var opened = (FilesystemResult)false;
 			bool isHiddenItem = NativeFileOperationsHelper.HasFileAttribute(path, System.IO.FileAttributes.Hidden);
@@ -256,13 +491,13 @@ namespace Files.App.Helpers
 				}
 				else
 				{
-					await OpenPath(forceOpenInNewTab, userSettingsService.FoldersSettingsService.OpenFoldersInNewTab, shortcutInfo.TargetPath, associatedInstance, selectItems);
+					await OpenPath(forceOpenInNewTab, UserSettingsService.FoldersSettingsService.OpenFoldersInNewTab, shortcutInfo.TargetPath, associatedInstance, selectItems);
 					opened = (FilesystemResult)true;
 				}
 			}
 			else if (isHiddenItem)
 			{
-				await OpenPath(forceOpenInNewTab, userSettingsService.FoldersSettingsService.OpenFoldersInNewTab, path, associatedInstance);
+				await OpenPath(forceOpenInNewTab, UserSettingsService.FoldersSettingsService.OpenFoldersInNewTab, path, associatedInstance);
 				opened = (FilesystemResult)true;
 			}
 			else
@@ -278,7 +513,7 @@ namespace Files.App.Helpers
 					opened = (FilesystemResult)FolderHelpers.CheckFolderAccessWithWin32(path);
 
 				if (opened)
-					await OpenPath(forceOpenInNewTab, userSettingsService.FoldersSettingsService.OpenFoldersInNewTab, path, associatedInstance, selectItems);
+					await OpenPath(forceOpenInNewTab, UserSettingsService.FoldersSettingsService.OpenFoldersInNewTab, path, associatedInstance, selectItems);
 				else
 					await Win32Helpers.InvokeWin32ComponentAsync(path, associatedInstance);
 			}

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -71,8 +71,6 @@ namespace Files.App
 			// Set system backdrop
 			SystemBackdrop = new AppSystemBackdrop();
 
-			mainPageViewModel = Ioc.Default.GetRequiredService<MainPageViewModel>();
-
 			var rootFrame = EnsureWindowIsInitialized();
 
 			switch (activatedEventArgs)
@@ -98,7 +96,7 @@ namespace Files.App
 					else if (!(string.IsNullOrEmpty(launchArgs.Arguments) && MainPageViewModel.AppInstances.Count > 0))
 					{
 						InteropHelpers.SwitchToThisWindow(WindowHandle, true);
-						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), launchArgs.Arguments);
+						await NavigationHelpers.AddNewTabByPathAsync(typeof(PaneHolderPage), launchArgs.Arguments);
 					}
 					else
 					{
@@ -178,7 +176,7 @@ namespace Files.App
 						InteropHelpers.SwitchToThisWindow(WindowHandle, true);
 					for (; index < fileArgs.Files.Count; index++)
 					{
-						await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), fileArgs.Files[index].Path);
+						await NavigationHelpers.AddNewTabByPathAsync(typeof(PaneHolderPage), fileArgs.Files[index].Path);
 					}
 					break;
 
@@ -250,7 +248,7 @@ namespace Files.App
 				if (rootFrame.Content is MainPage && MainPageViewModel.AppInstances.Any())
 				{
 					InteropHelpers.SwitchToThisWindow(WindowHandle, true);
-					await mainPageViewModel.AddNewTabByParamAsync(typeof(PaneHolderPage), paneNavigationArgs);
+					await NavigationHelpers.AddNewTabByParamAsync(typeof(PaneHolderPage), paneNavigationArgs);
 				}
 				else
 					rootFrame.Navigate(typeof(MainPage), paneNavigationArgs, new SuppressNavigationTransitionInfo());

--- a/src/Files.App/UserControls/TabBar/BaseTabBar.cs
+++ b/src/Files.App/UserControls/TabBar/BaseTabBar.cs
@@ -11,8 +11,6 @@ namespace Files.App.UserControls.TabBar
 	/// </summary>
 	public abstract class BaseTabBar : UserControl, ITabBar
 	{
-		protected readonly MainPageViewModel mainPageViewModel = Ioc.Default.GetRequiredService<MainPageViewModel>();
-
 		protected ITabBarItemContent CurrentSelectedAppInstance;
 
 		public static event EventHandler<ITabBar>? OnLoaded;
@@ -124,7 +122,7 @@ namespace Files.App.UserControls.TabBar
 				IsRestoringClosedTab = true;
 				var lastTab = RecentlyClosedTabs.Pop();
 				foreach (var item in lastTab)
-					await mainPageViewModel.AddNewTabByParamAsync(item.InitialPageType, item.NavigationParameter);
+					await NavigationHelpers.AddNewTabByParamAsync(item.InitialPageType, item.NavigationParameter);
 
 				IsRestoringClosedTab = false;
 			}

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -197,7 +197,7 @@ namespace Files.App.UserControls.TabBar
 				return;
 
 			if (!e.DataView.Properties.TryGetValue(TabPathIdentifier, out object tabViewItemPathObj) ||
-				!(tabViewItemPathObj is string tabViewItemString))
+				tabViewItemPathObj is not string tabViewItemString)
 				return;
 
 			var index = -1;
@@ -215,7 +215,7 @@ namespace Files.App.UserControls.TabBar
 
 			var tabViewItemArgs = CustomTabViewItemParameter.Deserialize(tabViewItemString);
 			ApplicationData.Current.LocalSettings.Values[TabDropHandledIdentifier] = true;
-			await mainPageViewModel.AddNewTabByParamAsync(tabViewItemArgs.InitialPageType, tabViewItemArgs.NavigationParameter, index);
+			await NavigationHelpers.AddNewTabByParamAsync(tabViewItemArgs.InitialPageType, tabViewItemArgs.NavigationParameter, index);
 		}
 
 		private void TabView_TabDragCompleted(TabView sender, TabViewTabDragCompletedEventArgs args)

--- a/src/Files.App/UserControls/TabBar/TabBarItem.cs
+++ b/src/Files.App/UserControls/TabBar/TabBarItem.cs
@@ -86,9 +86,7 @@ namespace Files.App.UserControls.TabBar
 
 		public void Unload()
 		{
-			MainPageViewModel mainPageViewModel = Ioc.Default.GetRequiredService<MainPageViewModel>();
-
-			ContentChanged -= mainPageViewModel.Control_ContentChanged;
+			ContentChanged -= NavigationHelpers.Control_ContentChanged;
 
 			Dispose();
 		}

--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -1,294 +1,63 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Navigation;
 using System.Windows.Input;
 using Windows.System;
 
 namespace Files.App.ViewModels
 {
+	/// <summary>
+	/// Represents ViewModel of <see cref="MainPage"/>.
+	/// </summary>
 	public class MainPageViewModel : ObservableObject
 	{
-		private IUserSettingsService userSettingsService;
-		private IAppearanceSettingsService appearanceSettingsService;
-		private readonly DrivesViewModel drivesViewModel;
-		private readonly NetworkDrivesViewModel networkDrivesViewModel;
-		private IResourcesService resourcesService;
+		// Dependency injections
+
+		private IAppearanceSettingsService AppearanceSettingsService { get; } = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
+		private NetworkDrivesViewModel NetworkDrivesViewModel { get; } = Ioc.Default.GetRequiredService<NetworkDrivesViewModel>();
+		private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
+		private IResourcesService ResourcesService { get; } = Ioc.Default.GetRequiredService<IResourcesService>();
+		private DrivesViewModel DrivesViewModel { get; } = Ioc.Default.GetRequiredService<DrivesViewModel>();
+
+		// Properties
+
+		public static ObservableCollection<TabBarItem> AppInstances { get; private set; } = new();
+
+		public List<ITabBar> MultitaskingControls { get; } = new();
 
 		public ITabBar? MultitaskingControl { get; set; }
 
-		public List<ITabBar> MultitaskingControls { get; } = new List<ITabBar>();
-
-		public static ObservableCollection<Files.App.UserControls.TabBar.TabBarItem> AppInstances { get; private set; } = new ObservableCollection<Files.App.UserControls.TabBar.TabBarItem>();
-
-		private Files.App.UserControls.TabBar.TabBarItem? selectedTabItem;
-		public Files.App.UserControls.TabBar.TabBarItem? SelectedTabItem
+		private TabBarItem? selectedTabItem;
+		public TabBarItem? SelectedTabItem
 		{
 			get => selectedTabItem;
 			set => SetProperty(ref selectedTabItem, value);
 		}
 
-		public ICommand NavigateToNumberedTabKeyboardAcceleratorCommand { get; private set; }
-		public IAsyncRelayCommand OpenNewWindowAcceleratorCommand { get; private set; }
+		// Commands
 
-		public MainPageViewModel(
-			IUserSettingsService userSettings,
-			IAppearanceSettingsService appearanceSettings,
-			IResourcesService resources,
-			DrivesViewModel drivesViewModel,
-			NetworkDrivesViewModel networkDrivesViewModel)
+		public ICommand NavigateToNumberedTabKeyboardAcceleratorCommand { get; }
+		public ICommand OpenNewWindowAcceleratorCommand { get; }
+
+		// Constructor
+
+		public MainPageViewModel()
 		{
-			userSettingsService = userSettings;
-			appearanceSettingsService = appearanceSettings;
-			this.drivesViewModel = drivesViewModel;
-			this.networkDrivesViewModel = networkDrivesViewModel;
-			resourcesService = resources;
-			// Create commands
-			NavigateToNumberedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(NavigateToNumberedTabKeyboardAccelerator);
-			OpenNewWindowAcceleratorCommand = new AsyncRelayCommand<KeyboardAcceleratorInvokedEventArgs>(OpenNewWindowAcceleratorAsync);
+			NavigateToNumberedTabKeyboardAcceleratorCommand = new RelayCommand<KeyboardAcceleratorInvokedEventArgs>(ExecuteNavigateToNumberedTabKeyboardAcceleratorCommand);
+			OpenNewWindowAcceleratorCommand = new AsyncRelayCommand<KeyboardAcceleratorInvokedEventArgs>(ExecuteOpenNewWindowAcceleratorCommand);
 		}
 
-		private void NavigateToNumberedTabKeyboardAccelerator(KeyboardAcceleratorInvokedEventArgs? e)
-		{
-			int indexToSelect = 0;
-			switch (e!.KeyboardAccelerator.Key)
-			{
-				case VirtualKey.Number1:
-					indexToSelect = 0;
-					break;
-
-				case VirtualKey.Number2:
-					indexToSelect = 1;
-					break;
-
-				case VirtualKey.Number3:
-					indexToSelect = 2;
-					break;
-
-				case VirtualKey.Number4:
-					indexToSelect = 3;
-					break;
-
-				case VirtualKey.Number5:
-					indexToSelect = 4;
-					break;
-
-				case VirtualKey.Number6:
-					indexToSelect = 5;
-					break;
-
-				case VirtualKey.Number7:
-					indexToSelect = 6;
-					break;
-
-				case VirtualKey.Number8:
-					indexToSelect = 7;
-					break;
-
-				case VirtualKey.Number9:
-					// Select the last tab
-					indexToSelect = AppInstances.Count - 1;
-					break;
-			}
-
-			// Only select the tab if it is in the list
-			if (indexToSelect < AppInstances.Count)
-				App.AppModel.TabStripSelectedIndex = indexToSelect;
-			e.Handled = true;
-		}
-
-		private async Task OpenNewWindowAcceleratorAsync(KeyboardAcceleratorInvokedEventArgs? e)
-		{
-			var filesUWPUri = new Uri("files-uwp:");
-			await Launcher.LaunchUriAsync(filesUWPUri);
-			e!.Handled = true;
-		}
-
-		public async Task AddNewTabByPathAsync(Type type, string? path, int atIndex = -1)
-		{
-			if (string.IsNullOrEmpty(path))
-				path = "Home";
-			else if (path.EndsWith("\\?")) // Support drives launched through jump list by stripping away the question mark at the end.
-				path = path.Remove(path.Length - 1);
-
-			var tabItem = new Files.App.UserControls.TabBar.TabBarItem()
-			{
-				Header = null,
-				IconSource = null,
-				Description = null,
-				ToolTipText = null
-			};
-			tabItem.NavigationParameter = new CustomTabViewItemParameter()
-			{
-				InitialPageType = type,
-				NavigationParameter = path
-			};
-			tabItem.ContentChanged += Control_ContentChanged;
-			await UpdateTabInfoAsync(tabItem, path);
-			var index = atIndex == -1 ? AppInstances.Count : atIndex;
-			AppInstances.Insert(index, tabItem);
-			App.AppModel.TabStripSelectedIndex = index;
-		}
-
-		public async Task UpdateInstancePropertiesAsync(object navigationArg)
-		{
-			await SafetyExtensions.IgnoreExceptions(async () =>
-			{
-				string windowTitle = string.Empty;
-				if (navigationArg is PaneNavigationArguments paneArgs)
-				{
-					if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
-					{
-						var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-						var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
-						windowTitle = $"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}";
-					}
-					else
-					{
-						(windowTitle, _, _) = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-					}
-				}
-				else if (navigationArg is string pathArgs)
-				{
-					(windowTitle, _, _) = await GetSelectedTabInfoAsync(pathArgs);
-				}
-
-				if (AppInstances.Count > 1)
-					windowTitle = $"{windowTitle} ({AppInstances.Count})";
-
-				if (navigationArg == SelectedTabItem?.NavigationParameter?.NavigationParameter)
-					MainWindow.Instance.AppWindow.Title = $"{windowTitle} - Files";
-			});
-		}
-
-		public async Task UpdateTabInfoAsync(Files.App.UserControls.TabBar.TabBarItem tabItem, object navigationArg)
-		{
-			tabItem.AllowStorageItemDrop = true;
-
-			(string, IconSource, string) result = (null, null, null);
-			if (navigationArg is PaneNavigationArguments paneArgs)
-			{
-				if (!string.IsNullOrEmpty(paneArgs.LeftPaneNavPathParam) && !string.IsNullOrEmpty(paneArgs.RightPaneNavPathParam))
-				{
-					var leftTabInfo = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-					var rightTabInfo = await GetSelectedTabInfoAsync(paneArgs.RightPaneNavPathParam);
-					result = ($"{leftTabInfo.tabLocationHeader} | {rightTabInfo.tabLocationHeader}",
-						leftTabInfo.tabIcon,
-						$"{leftTabInfo.toolTipText} | {rightTabInfo.toolTipText}");
-				}
-				else
-				{
-					result = await GetSelectedTabInfoAsync(paneArgs.LeftPaneNavPathParam);
-				}
-			}
-			else if (navigationArg is string pathArgs)
-			{
-				result = await GetSelectedTabInfoAsync(pathArgs);
-			}
-
-			// Don't update tabItem if the contents of the tab have already changed
-			if (result.Item1 is not null && 
-				(navigationArg is PaneNavigationArguments && navigationArg as PaneNavigationArguments == tabItem.NavigationParameter.NavigationParameter as PaneNavigationArguments
-				|| navigationArg is string && navigationArg as string == tabItem.NavigationParameter.NavigationParameter as string))
-				(tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = result;
-		}
-
-		public async Task<(string tabLocationHeader, IconSource tabIcon, string toolTipText)> GetSelectedTabInfoAsync(string currentPath)
-		{
-			string? tabLocationHeader;
-			var iconSource = new ImageIconSource();
-			string toolTipText = currentPath;
-
-			if (string.IsNullOrEmpty(currentPath) || currentPath == "Home")
-			{
-				tabLocationHeader = "Home".GetLocalizedResource();
-				iconSource.ImageSource = new BitmapImage(new Uri(Constants.FluentIconsPaths.HomeIcon));
-			}
-			else if (currentPath.Equals(Constants.UserEnvironmentPaths.DesktopPath, StringComparison.OrdinalIgnoreCase))
-			{
-				tabLocationHeader = "Desktop".GetLocalizedResource();
-			}
-			else if (currentPath.Equals(Constants.UserEnvironmentPaths.DownloadsPath, StringComparison.OrdinalIgnoreCase))
-			{
-				tabLocationHeader = "Downloads".GetLocalizedResource();
-			}
-			else if (currentPath.Equals(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
-			{
-				tabLocationHeader = "RecycleBin".GetLocalizedResource();
-
-				// Use 48 for higher resolution, the other items look fine with 16.
-				var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 48u, Windows.Storage.FileProperties.ThumbnailMode.ListView, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale, true);
-				if (iconData is not null)
-					iconSource.ImageSource = await iconData.ToBitmapAsync();
-			}
-			else if (currentPath.Equals(Constants.UserEnvironmentPaths.MyComputerPath, StringComparison.OrdinalIgnoreCase))
-			{
-				tabLocationHeader = "ThisPC".GetLocalizedResource();
-			}
-			else if (currentPath.Equals(Constants.UserEnvironmentPaths.NetworkFolderPath, StringComparison.OrdinalIgnoreCase))
-			{
-				tabLocationHeader = "SidebarNetworkDrives".GetLocalizedResource();
-			}
-			else if (App.LibraryManager.TryGetLibrary(currentPath, out LibraryLocationItem library))
-			{
-				var libName = System.IO.Path.GetFileNameWithoutExtension(library.Path).GetLocalizedResource();
-				// If localized string is empty use the library name.
-				tabLocationHeader = string.IsNullOrEmpty(libName) ? library.Text : libName;
-			}
-			else if (WSLDistroManager.TryGetDistro(currentPath, out WslDistroItem? wslDistro) && currentPath.Equals(wslDistro.Path))
-			{
-				tabLocationHeader = wslDistro.Text;
-				iconSource.ImageSource = new BitmapImage(wslDistro.Icon);
-			}
-			else
-			{
-				var normalizedCurrentPath = PathNormalization.NormalizePath(currentPath);
-				var matchingCloudDrive = CloudDrivesManager.Drives.FirstOrDefault(x => normalizedCurrentPath.Equals(PathNormalization.NormalizePath(x.Path), StringComparison.OrdinalIgnoreCase));
-				if (matchingCloudDrive is not null)
-				{
-					iconSource.ImageSource = matchingCloudDrive.Icon;
-					tabLocationHeader = matchingCloudDrive.Text;
-				}
-				else if (PathNormalization.NormalizePath(PathNormalization.GetPathRoot(currentPath)) == normalizedCurrentPath) // If path is a drive's root
-				{
-					var matchingDrive = networkDrivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(netDrive => normalizedCurrentPath.Contains(PathNormalization.NormalizePath(netDrive.Path), StringComparison.OrdinalIgnoreCase));
-					matchingDrive ??= drivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(drive => normalizedCurrentPath.Contains(PathNormalization.NormalizePath(drive.Path), StringComparison.OrdinalIgnoreCase));
-					tabLocationHeader = matchingDrive is not null ? matchingDrive.Text : normalizedCurrentPath;
-				}
-				else
-				{
-					tabLocationHeader = currentPath.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar).Split('\\', StringSplitOptions.RemoveEmptyEntries).Last();
-
-					FilesystemResult<StorageFolderWithPath> rootItem = await FilesystemTasks.Wrap(() => DriveHelpers.GetRootFromPathAsync(currentPath));
-					if (rootItem)
-					{
-						BaseStorageFolder currentFolder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(currentPath, rootItem));
-						if (currentFolder is not null && !string.IsNullOrEmpty(currentFolder.DisplayName))
-							tabLocationHeader = currentFolder.DisplayName;
-					}
-				}
-			}
-
-			if (iconSource.ImageSource is null)
-			{
-				var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(currentPath, 16u, Windows.Storage.FileProperties.ThumbnailMode.ListView, Windows.Storage.FileProperties.ThumbnailOptions.UseCurrentScale, true);
-				if (iconData is not null)
-					iconSource.ImageSource = await iconData.ToBitmapAsync();
-			}
-
-			return (tabLocationHeader, iconSource, toolTipText);
-		}
+		// Methods
 
 		public async Task OnNavigatedToAsync(NavigationEventArgs e)
 		{
 			if (e.NavigationMode == NavigationMode.Back)
 				return;
 
-			//Initialize the static theme helper to capture a reference to this window
-			//to handle theme changes without restarting the app
+			// Initialize the static theme helper to capture a reference to this window
+			// to handle theme changes without restarting the app
 			var isInitialized = ThemeHelper.Initialize();
 
 			var parameter = e.Parameter;
@@ -304,57 +73,57 @@ namespace Files.App.ViewModels
 				try
 				{
 					// add last session tabs to closed tabs stack if those tabs are not about to be opened
-					if (!userSettingsService.AppSettingsService.RestoreTabsOnStartup && !userSettingsService.GeneralSettingsService.ContinueLastSessionOnStartUp && userSettingsService.GeneralSettingsService.LastSessionTabList != null)
+					if (!UserSettingsService.AppSettingsService.RestoreTabsOnStartup && !UserSettingsService.GeneralSettingsService.ContinueLastSessionOnStartUp && UserSettingsService.GeneralSettingsService.LastSessionTabList != null)
 					{
-						var items = new CustomTabViewItemParameter[userSettingsService.GeneralSettingsService.LastSessionTabList.Count];
+						var items = new CustomTabViewItemParameter[UserSettingsService.GeneralSettingsService.LastSessionTabList.Count];
 						for (int i = 0; i < items.Length; i++)
-							items[i] = CustomTabViewItemParameter.Deserialize(userSettingsService.GeneralSettingsService.LastSessionTabList[i]);
+							items[i] = CustomTabViewItemParameter.Deserialize(UserSettingsService.GeneralSettingsService.LastSessionTabList[i]);
 
 						BaseTabBar.PushRecentTab(items);
 					}
 
-					if (userSettingsService.AppSettingsService.RestoreTabsOnStartup)
+					if (UserSettingsService.AppSettingsService.RestoreTabsOnStartup)
 					{
-						userSettingsService.AppSettingsService.RestoreTabsOnStartup = false;
-						if (userSettingsService.GeneralSettingsService.LastSessionTabList is not null)
+						UserSettingsService.AppSettingsService.RestoreTabsOnStartup = false;
+						if (UserSettingsService.GeneralSettingsService.LastSessionTabList is not null)
 						{
-							foreach (string tabArgsString in userSettingsService.GeneralSettingsService.LastSessionTabList)
+							foreach (string tabArgsString in UserSettingsService.GeneralSettingsService.LastSessionTabList)
 							{
 								var tabArgs = CustomTabViewItemParameter.Deserialize(tabArgsString);
-								await AddNewTabByParamAsync(tabArgs.InitialPageType, tabArgs.NavigationParameter);
+								await NavigationHelpers.AddNewTabByParamAsync(tabArgs.InitialPageType, tabArgs.NavigationParameter);
 							}
 
-							if (!userSettingsService.GeneralSettingsService.ContinueLastSessionOnStartUp)
-								userSettingsService.GeneralSettingsService.LastSessionTabList = null;
+							if (!UserSettingsService.GeneralSettingsService.ContinueLastSessionOnStartUp)
+								UserSettingsService.GeneralSettingsService.LastSessionTabList = null;
 						}
 					}
-					else if (userSettingsService.GeneralSettingsService.OpenSpecificPageOnStartup &&
-						userSettingsService.GeneralSettingsService.TabsOnStartupList is not null)
+					else if (UserSettingsService.GeneralSettingsService.OpenSpecificPageOnStartup &&
+						UserSettingsService.GeneralSettingsService.TabsOnStartupList is not null)
 					{
-						foreach (string path in userSettingsService.GeneralSettingsService.TabsOnStartupList)
-							await AddNewTabByPathAsync(typeof(PaneHolderPage), path);
+						foreach (string path in UserSettingsService.GeneralSettingsService.TabsOnStartupList)
+							await NavigationHelpers.AddNewTabByPathAsync(typeof(PaneHolderPage), path);
 					}
-					else if (userSettingsService.GeneralSettingsService.ContinueLastSessionOnStartUp &&
-						userSettingsService.GeneralSettingsService.LastSessionTabList is not null)
+					else if (UserSettingsService.GeneralSettingsService.ContinueLastSessionOnStartUp &&
+						UserSettingsService.GeneralSettingsService.LastSessionTabList is not null)
 					{
-						foreach (string tabArgsString in userSettingsService.GeneralSettingsService.LastSessionTabList)
+						foreach (string tabArgsString in UserSettingsService.GeneralSettingsService.LastSessionTabList)
 						{
 							var tabArgs = CustomTabViewItemParameter.Deserialize(tabArgsString);
-							await AddNewTabByParamAsync(tabArgs.InitialPageType, tabArgs.NavigationParameter);
+							await NavigationHelpers.AddNewTabByParamAsync(tabArgs.InitialPageType, tabArgs.NavigationParameter);
 						}
 
 						var defaultArg = new CustomTabViewItemParameter() { InitialPageType = typeof(PaneHolderPage), NavigationParameter = "Home" };
 
-						userSettingsService.GeneralSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
+						UserSettingsService.GeneralSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
 					}
 					else
 					{
-						await AddNewTabAsync();
+						await NavigationHelpers.AddNewTabAsync();
 					}
 				}
 				catch
 				{
-					await AddNewTabAsync();
+					await NavigationHelpers.AddNewTabAsync();
 				}
 			}
 			else
@@ -363,88 +132,79 @@ namespace Files.App.ViewModels
 				{
 					try
 					{
-						if (userSettingsService.GeneralSettingsService.OpenSpecificPageOnStartup &&
-								userSettingsService.GeneralSettingsService.TabsOnStartupList is not null)
+						if (UserSettingsService.GeneralSettingsService.OpenSpecificPageOnStartup &&
+								UserSettingsService.GeneralSettingsService.TabsOnStartupList is not null)
 						{
-							foreach (string path in userSettingsService.GeneralSettingsService.TabsOnStartupList)
-								await AddNewTabByPathAsync(typeof(PaneHolderPage), path);
+							foreach (string path in UserSettingsService.GeneralSettingsService.TabsOnStartupList)
+								await NavigationHelpers.AddNewTabByPathAsync(typeof(PaneHolderPage), path);
 						}
-						else if (userSettingsService.GeneralSettingsService.ContinueLastSessionOnStartUp &&
-							userSettingsService.GeneralSettingsService.LastSessionTabList is not null)
+						else if (UserSettingsService.GeneralSettingsService.ContinueLastSessionOnStartUp &&
+							UserSettingsService.GeneralSettingsService.LastSessionTabList is not null)
 						{
-							foreach (string tabArgsString in userSettingsService.GeneralSettingsService.LastSessionTabList)
+							foreach (string tabArgsString in UserSettingsService.GeneralSettingsService.LastSessionTabList)
 							{
 								var tabArgs = CustomTabViewItemParameter.Deserialize(tabArgsString);
-								await AddNewTabByParamAsync(tabArgs.InitialPageType, tabArgs.NavigationParameter);
+								await NavigationHelpers.AddNewTabByParamAsync(tabArgs.InitialPageType, tabArgs.NavigationParameter);
 							}
 
 							var defaultArg = new CustomTabViewItemParameter() { InitialPageType = typeof(PaneHolderPage), NavigationParameter = "Home" };
 
-							userSettingsService.GeneralSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
+							UserSettingsService.GeneralSettingsService.LastSessionTabList = new List<string> { defaultArg.Serialize() };
 						}
 					}
 					catch { }
 				}
 
 				if (parameter is string navArgs)
-					await AddNewTabByPathAsync(typeof(PaneHolderPage), navArgs);
+					await NavigationHelpers.AddNewTabByPathAsync(typeof(PaneHolderPage), navArgs);
 				else if (parameter is PaneNavigationArguments paneArgs)
-					await AddNewTabByParamAsync(typeof(PaneHolderPage), paneArgs);
+					await NavigationHelpers.AddNewTabByParamAsync(typeof(PaneHolderPage), paneArgs);
 				else if (parameter is CustomTabViewItemParameter tabArgs)
-					await AddNewTabByParamAsync(tabArgs.InitialPageType, tabArgs.NavigationParameter);
+					await NavigationHelpers.AddNewTabByParamAsync(tabArgs.InitialPageType, tabArgs.NavigationParameter);
 			}
 
 			if (isInitialized)
 			{
 				// Load the app theme resources
-				resourcesService.LoadAppResources(appearanceSettingsService);
+				ResourcesService.LoadAppResources(AppearanceSettingsService);
 
 				await Task.WhenAll(
-					drivesViewModel.UpdateDrivesAsync(),
-					networkDrivesViewModel.UpdateDrivesAsync());
+					DrivesViewModel.UpdateDrivesAsync(),
+					NetworkDrivesViewModel.UpdateDrivesAsync());
 			}
 		}
 
-		public Task AddNewTabAsync()
-		{
-			return AddNewTabByPathAsync(typeof(PaneHolderPage), "Home");
-		}
+		// Command methods
 
-		public async Task AddNewTabByParamAsync(Type type, object tabViewItemArgs, int atIndex = -1)
+		private void ExecuteNavigateToNumberedTabKeyboardAcceleratorCommand(KeyboardAcceleratorInvokedEventArgs? e)
 		{
-			var tabItem = new Files.App.UserControls.TabBar.TabBarItem()
+			int indexToSelect = e!.KeyboardAccelerator.Key switch
 			{
-				Header = null,
-				IconSource = null,
-				Description = null,
-				ToolTipText = null
+				VirtualKey.Number1 => 0,
+				VirtualKey.Number2 => 1,
+				VirtualKey.Number3 => 2,
+				VirtualKey.Number4 => 3,
+				VirtualKey.Number5 => 4,
+				VirtualKey.Number6 => 5,
+				VirtualKey.Number7 => 6,
+				VirtualKey.Number8 => 7,
+				VirtualKey.Number9 => AppInstances.Count - 1,
+				_ => AppInstances.Count - 1,
 			};
 
-			tabItem.NavigationParameter = new CustomTabViewItemParameter()
-			{
-				InitialPageType = type,
-				NavigationParameter = tabViewItemArgs
-			};
+			// Only select the tab if it is in the list
+			if (indexToSelect < AppInstances.Count)
+				App.AppModel.TabStripSelectedIndex = indexToSelect;
 
-			tabItem.ContentChanged += Control_ContentChanged;
-
-			await UpdateTabInfoAsync(tabItem, tabViewItemArgs);
-
-			var index = atIndex == -1 ? AppInstances.Count : atIndex;
-			AppInstances.Insert(index, tabItem);
-			App.AppModel.TabStripSelectedIndex = index;
+			e.Handled = true;
 		}
 
-		public async void Control_ContentChanged(object? sender, CustomTabViewItemParameter e)
+		private async Task ExecuteOpenNewWindowAcceleratorCommand(KeyboardAcceleratorInvokedEventArgs? e)
 		{
-			if (sender is null)
-				return;
+			await Launcher.LaunchUriAsync(new Uri("files-uwp:"));
 
-			var matchingTabItem = AppInstances.SingleOrDefault(x => x == (Files.App.UserControls.TabBar.TabBarItem)sender);
-			if (matchingTabItem is null)
-				return;
-
-			await UpdateTabInfoAsync(matchingTabItem, e.NavigationParameter);
+			e!.Handled = true;
 		}
+
 	}
 }

--- a/src/Files.App/ViewModels/UserControls/ToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/ToolbarViewModel.cs
@@ -21,8 +21,6 @@ namespace Files.App.ViewModels.UserControls
 
 		private readonly IDialogService _dialogService = Ioc.Default.GetRequiredService<IDialogService>();
 
-		private readonly MainPageViewModel mainPageViewModel = Ioc.Default.GetRequiredService<MainPageViewModel>();
-
 		private readonly DrivesViewModel drivesViewModel = Ioc.Default.GetRequiredService<DrivesViewModel>();
 
 		public IUpdateService UpdateService { get; } = Ioc.Default.GetService<IUpdateService>()!;
@@ -504,7 +502,7 @@ namespace Files.App.ViewModels.UserControls
 			{
 				await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 				{
-					await mainPageViewModel.AddNewTabByPathAsync(typeof(PaneHolderPage), itemTappedPath);
+					await NavigationHelpers.AddNewTabByPathAsync(typeof(PaneHolderPage), itemTappedPath);
 				}, DispatcherQueuePriority.Low);
 				e.Handled = true;
 				pointerRoutedEventArgs = null;

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -166,7 +166,7 @@ namespace Files.App.Views
 			UpdateStatusBarProperties();
 			LoadPaneChanged();
 			UpdateNavToolbarProperties();
-			await ViewModel.UpdateInstancePropertiesAsync(paneArgs);
+			await NavigationHelpers.UpdateInstancePropertiesAsync(paneArgs);
 		}
 
 		public void MultitaskingControl_CurrentInstanceChanged(object? sender, CurrentInstanceChangedEventArgs e)
@@ -185,7 +185,7 @@ namespace Files.App.Views
 			UpdateStatusBarProperties();
 			UpdateNavToolbarProperties();
 			LoadPaneChanged();
-			ViewModel.UpdateInstancePropertiesAsync(navArgs);
+			NavigationHelpers.UpdateInstancePropertiesAsync(navArgs);
 
 			e.CurrentInstance.ContentChanged -= TabItemContent_ContentChanged;
 			e.CurrentInstance.ContentChanged += TabItemContent_ContentChanged;


### PR DESCRIPTION
## Summary

As the title

## Task Checklist

- [x] Removed MainPageViewModel DI references

## Steps To Validate Changes

1. Launch the app
2. Add a new tab
3. Go to Home
4. Go to a folder
5. See tab info is being changed accordingly.

## Known Issues

_N/A_

## PR Checklist

- [ ] **Development**: _N/A_
- [x] **Approval**: Have discussed with and got approval from the team[^1]
- [x] **Tests**: Tested accessibility on the local end
- [x] **Deployment**: Deployed the app on the local end
- [ ] **Localization**: Modified en-US string resources[^2]
- [ ] **Co-authors**: _N/A_

## Screenshots

_N/A_

[^1]: If the request hasn't been agreed by the team, this work might be rejected. Make sure that you get approval from the team before opening any PR related the request.
[^2]: If you removed any en-US string resources, make sure that there are no references of those resources. When you add a new en-US string resources, do not make any changes on other languages' resources; [Crowdin](https://crowdin.com/project/files-app) will do that, instead.