### PR TITLE
GitHub: Force to run tests regardless of the build job outcome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         }
       continue-on-error: true
     
-    - name: Fail the job if the XamlStyler found unformatted file(s)
+    - name: Fail if necessary
       if: steps.check-step.outcome == 'failure'
       run: exit 1
 
@@ -174,6 +174,7 @@ jobs:
         path: ${{ env.ARTIFACTS_STAGING_DIR }}
 
   test:
+    if: always()
     needs: [build]
     runs-on: windows-latest
     strategy:
@@ -188,6 +189,10 @@ jobs:
       pull-requests: write
 
     steps:
+
+    - if: contains(join(needs.*.result, ','), 'failure')
+      name: Fail if necessary
+      run: exit 1
 
     - name: Checkout the repository
       uses: actions/checkout@v3

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -39,7 +39,7 @@ namespace Files.App
 		private static bool ShowErrorNotification = false;
 		public static string OutputPath { get; set; }
 		public static CommandBarFlyout? LastOpenedFlyout { get; set; }
-		public static TaskCompletionSorce? SplashScreenLoadingTCS { get; private set; }
+		public static TaskCompletionSource? SplashScreenLoadingTCS { get; private set; }
 
 		public static StorageHistoryWrapper HistoryWrapper { get; } = new();
 		public static AppModel AppModel { get; private set; }

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -39,7 +39,7 @@ namespace Files.App
 		private static bool ShowErrorNotification = false;
 		public static string OutputPath { get; set; }
 		public static CommandBarFlyout? LastOpenedFlyout { get; set; }
-		public static TaskCompletionSource? SplashScreenLoadingTCS { get; private set; }
+		public static TaskCompletionSorce? SplashScreenLoadingTCS { get; private set; }
 
 		public static StorageHistoryWrapper HistoryWrapper { get; } = new();
 		public static AppModel AppModel { get; private set; }


### PR DESCRIPTION
## Summary

Previous check suite was ugly looking. So fixed.

## Task Checklist

- [x] Force to run tests regardless of the build job outcome

## Steps To Validate Changes

_N/A_

## Known Issues

_N/A_

## PR Checklist

- [ ] **Development**: _N/A_
- [ ] **Approval**: Have discussed with and got approval from the team[^1]
- [x] **Tests**: Tested accessibility on the local end
- [x] **Deployment**: Deployed the app on the local end
- [ ] **Localization**: Modified en-US string resources[^2]
- [ ] **Co-authors**: _N/A_

## Screenshots

Before:
![image](https://github.com/files-community/Files/assets/62196528/654ecfba-276f-4a9d-a70e-4a7bf99d7500)

After:
![image](https://github.com/files-community/Files/assets/62196528/827fd6ba-bfbd-42ae-a927-277e4dca16b8)


[^1]: If the request hasn't been agreed by the team, this work might be rejected. Make sure that you get approval from the team before opening any PR related the request.
[^2]: If you removed any en-US string resources, make sure that there are no references of those resources. When you add a new en-US string resources, do not make any changes on other languages' resources; [Crowdin](https://crowdin.com/project/files-app) will do that, instead.