### PR TITLE
Fix: Fixed COMException in UpdateDateDisplayTimer_Tick

### DIFF
--- a/src/Files.App/Data/Models/AppModel.cs
+++ b/src/Files.App/Data/Models/AppModel.cs
@@ -77,6 +77,7 @@ namespace Files.App.Data.Models
 			OnPropertyChanged(nameof(PropertiesWindowCount));
 			return result;
 		}
+
 		public int DecrementPropertiesWindowCount()
 		{
 			var result = Interlocked.Decrement(ref propertiesWindowCount);

--- a/src/Files.App/Data/Models/AppModel.cs
+++ b/src/Files.App/Data/Models/AppModel.cs
@@ -70,6 +70,7 @@ namespace Files.App.Data.Models
 		{
 			get => propertiesWindowCount;
 		}
+
 		public int IncrementPropertiesWindowCount()
 		{
 			var result = Interlocked.Increment(ref propertiesWindowCount);

--- a/src/Files.App/Data/Models/AppModel.cs
+++ b/src/Files.App/Data/Models/AppModel.cs
@@ -65,6 +65,24 @@ namespace Files.App.Data.Models
 			set => SetProperty(ref isMainWindowClosed, value);
 		}
 
+		private int propertiesWindowCount = 0;
+		public int PropertiesWindowCount
+		{
+			get => propertiesWindowCount;
+		}
+		public int IncrementPropertiesWindowCount()
+		{
+			var result = Interlocked.Increment(ref propertiesWindowCount);
+			OnPropertyChanged(nameof(PropertiesWindowCount));
+			return result;
+		}
+		public int DecrementPropertiesWindowCount()
+		{
+			var result = Interlocked.Decrement(ref propertiesWindowCount);
+			OnPropertyChanged(nameof(PropertiesWindowCount));
+			return result;
+		}
+
 		private bool forceProcessTermination = false;
 		public bool ForceProcessTermination
 		{

--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -31,7 +31,6 @@ namespace Files.App.Utils.Storage
 		public static nint GetWindowHandle(Window w)
 			=> WinRT.Interop.WindowNative.GetWindowHandle(w);
 
-		private static int WindowCount = 0;
 		private static TaskCompletionSource? PropertiesWindowsClosingTCS;
 		private static BlockingCollection<WinUIEx.WindowEx> WindowCache = new();
 
@@ -145,7 +144,7 @@ namespace Files.App.Utils.Storage
 					+ Math.Max(0, Math.Min(displayArea.WorkArea.Height - appWindow.Size.Height, pointerPosition.Y - displayArea.WorkArea.Y)),
 			};
 
-			if (Interlocked.Increment(ref WindowCount) == 1)
+			if (App.AppModel.IncrementPropertiesWindowCount() == 1)
 				PropertiesWindowsClosingTCS = new();
 
 			appWindow.Move(appWindowPos);
@@ -164,12 +163,14 @@ namespace Files.App.Utils.Storage
 				window.Content = null;
 				WindowCache.Add(window);
 
-				if (Interlocked.Decrement(ref WindowCount) == 0)
+				if (App.AppModel.DecrementPropertiesWindowCount() == 0)
 				{
 					PropertiesWindowsClosingTCS!.TrySetResult();
 					PropertiesWindowsClosingTCS = null;
 				}
 			}
+			else
+				App.AppModel.DecrementPropertiesWindowCount();
 		}
 
 		/// <summary>

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -329,7 +329,8 @@ namespace Files.App.Views
 
 		private void UpdateDateDisplayTimer_Tick(object sender, object e)
 		{
-			PreviewPane?.ViewModel.UpdateDateDisplay();
+			if (!App.AppModel.IsMainWindowClosed)
+				PreviewPane?.ViewModel.UpdateDateDisplay();
 		}
 
 		private void Page_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/src/Files.App/Views/Properties/DetailsPage.xaml.cs
+++ b/src/Files.App/Views/Properties/DetailsPage.xaml.cs
@@ -79,6 +79,9 @@ namespace Files.App.Views.Properties
 
 		private void UpdateDateDisplayTimer_Tick(object sender, object e)
 		{
+			if (App.AppModel.PropertiesWindowCount == 0)
+				return;
+
 			ViewModel.PropertySections.ForEach(section => section.ForEach(property =>
 			{
 				if (property.Value is DateTimeOffset)

--- a/src/Files.App/Views/Properties/GeneralPage.xaml.cs
+++ b/src/Files.App/Views/Properties/GeneralPage.xaml.cs
@@ -47,6 +47,9 @@ namespace Files.App.Views.Properties
 
 		private void UpdateDateDisplayTimer_Tick(object sender, object e)
 		{
+			if (App.AppModel.PropertiesWindowCount == 0)
+				return;
+
 			// Reassign values to update date display
 			ViewModel.ItemCreatedTimestampReal = ViewModel.ItemCreatedTimestampReal;
 			ViewModel.ItemModifiedTimestampReal = ViewModel.ItemModifiedTimestampReal;

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -771,6 +771,9 @@ namespace Files.App.Views.Shells
 
 		private void UpdateDateDisplayTimer_Tick(object sender, object e)
 		{
+			if (App.AppModel.IsMainWindowClosed)
+				return;
+
 			if (userSettingsService.GeneralSettingsService.DateTimeFormat != _lastDateTimeFormats)
 			{
 				_lastDateTimeFormats = userSettingsService.GeneralSettingsService.DateTimeFormat;


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13725 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Set the interval of `_updateDateDisplayTimer` to 0.1sec to increase the frequency of COMException.
   2. Open Files, display the date, and close the window.
   3. It crashes quite often without the fix, but it never crashes with the fix.