### PR TITLE
Fix: Fixed an issue with dropping multiple items onto executable files

### DIFF
--- a/src/Files.App/Helpers/Environment/SoftwareHelpers.cs
+++ b/src/Files.App/Helpers/Environment/SoftwareHelpers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See the LICENSE.
 
 using Microsoft.Win32;
+using System.IO;
 
 namespace Files.App.Helpers
 {
@@ -28,6 +29,32 @@ namespace Files.App.Helpers
 			key.Close();
 
 			return true;
+		}
+
+		public static bool IsPythonInstalled()
+		{
+			try
+			{
+				ProcessStartInfo psi = new ProcessStartInfo();
+				psi.FileName = "python";
+				psi.Arguments = "--version";
+				psi.RedirectStandardOutput = true;
+				psi.UseShellExecute = false;
+				psi.CreateNoWindow = true;
+
+				using (Process process = Process.Start(psi))
+				{
+					using (StreamReader reader = process.StandardOutput)
+					{
+						string result = reader.ReadToEnd();
+						return result.Contains("Python");
+					}
+				}
+			}
+			catch
+			{
+				return false;
+			}
 		}
 
 		private static bool ContainsName(RegistryKey? key, string find)

--- a/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
@@ -316,42 +316,15 @@ namespace Files.App.Helpers
 			}
 		}
 
-		public static async Task OpenItemsWithExecutableAsync(IShellPage associatedInstance, IEnumerable<IStorageItemWithPath> items, string executable)
+		public static async Task OpenItemsWithExecutableAsync(IShellPage associatedInstance, IEnumerable<IStorageItemWithPath> items, string executablePath)
 		{
 			// Don't open files and folders inside recycle bin
 			if (associatedInstance.FilesystemViewModel.WorkingDirectory.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.Ordinal) ||
 				associatedInstance.SlimContentPage is null)
-			{
 				return;
-			}
 
-			foreach (var item in items)
-			{
-				try
-				{
-					await OpenPath(executable, associatedInstance, FilesystemItemType.File, false, false, args: $"\"{item.Path}\"");
-				}
-				catch (Exception e)
-				{
-					// This is to try and figure out the root cause of AppCenter error #985932119u
-					App.Logger.LogWarning(e, e.Message);
-				}
-			}
-		}
-
-		public static async Task OpenItemsWithPythonAsync(IShellPage associatedInstance, IEnumerable<IStorageItemWithPath> items, string pythonScriptPath)
-		{
-			// Don't open files and folders inside recycle bin
-			if (associatedInstance.FilesystemViewModel.WorkingDirectory.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.Ordinal) ||
-								associatedInstance.SlimContentPage is null)
-			{
-				return;
-			}
-
-			foreach (var item in items)
-			{
-				await Win32Helpers.InvokeWin32ComponentAsync(pythonScriptPath, associatedInstance, arguments: $"\"{item.Path}\"");
-			}
+			var arguments = string.Join(" ", items.Select(item => $"\"{item.Path}\""));
+			await Win32Helpers.InvokeWin32ComponentAsync(executablePath, associatedInstance, arguments);
 		}
 
 		/// <summary>

--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -255,16 +255,10 @@ namespace Files.App.Utils.Storage
 				else if (operation.HasFlag(DataPackageOperation.Link))
 				{
 					// Open with piggybacks off of the link operation, since there isn't one for it
-					if (isTargetExecutable)
+					if (isTargetExecutable || isTargetPythonFile)
 					{
 						var items = await GetDraggedStorageItems(packageView);
 						NavigationHelpers.OpenItemsWithExecutableAsync(associatedInstance, items, destination);
-						return ReturnResult.Success;
-					}
-					else if (isTargetPythonFile)
-					{
-						var items = await GetDraggedStorageItems(packageView);
-						NavigationHelpers.OpenItemsWithPythonAsync(associatedInstance, items, destination);
 						return ReturnResult.Success;
 					}
 					else

--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -258,7 +258,7 @@ namespace Files.App.Utils.Storage
 					if (isTargetExecutable || isTargetPythonFile)
 					{
 						var items = await GetDraggedStorageItems(packageView);
-						if (isTargetPythonFile && SoftwareHelpers.IsPythonInstalled())
+						if (isTargetPythonFile && !SoftwareHelpers.IsPythonInstalled())
 							return ReturnResult.Cancelled;
 						NavigationHelpers.OpenItemsWithExecutableAsync(associatedInstance, items, destination);
 						return ReturnResult.Success;

--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -258,6 +258,8 @@ namespace Files.App.Utils.Storage
 					if (isTargetExecutable || isTargetPythonFile)
 					{
 						var items = await GetDraggedStorageItems(packageView);
+						if (isTargetPythonFile && SoftwareHelpers.IsPythonInstalled())
+							return ReturnResult.Cancelled;
 						NavigationHelpers.OpenItemsWithExecutableAsync(associatedInstance, items, destination);
 						return ReturnResult.Success;
 					}

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1259,7 +1259,9 @@ namespace Files.App.Views.Layouts
 				return;
 
 			UninitializeDrag(container);
-			if ((item.PrimaryItemAttribute == StorageItemTypes.Folder && !RecycleBinHelpers.IsPathUnderRecycleBin(item.ItemPath)) || item.IsExecutable || item.IsPythonFile)
+			if ((item.PrimaryItemAttribute == StorageItemTypes.Folder && !RecycleBinHelpers.IsPathUnderRecycleBin(item.ItemPath))
+				|| item.IsExecutable
+				|| (item.IsPythonFile && SoftwareHelpers.IsPythonInstalled()))
 			{
 				container.AllowDrop = true;
 				container.AddHandler(UIElement.DragOverEvent, Item_DragOverEventHandler, true);

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1261,7 +1261,7 @@ namespace Files.App.Views.Layouts
 			UninitializeDrag(container);
 			if ((item.PrimaryItemAttribute == StorageItemTypes.Folder && !RecycleBinHelpers.IsPathUnderRecycleBin(item.ItemPath))
 				|| item.IsExecutable
-				|| (item.IsPythonFile && SoftwareHelpers.IsPythonInstalled()))
+				|| item.IsPythonFile)
 			{
 				container.AllowDrop = true;
 				container.AddHandler(UIElement.DragOverEvent, Item_DragOverEventHandler, true);


### PR DESCRIPTION
…also checks to see if python is installed on system before allowing the drop like in File Explorer.
*removed redundant code*

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14033 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Create 4 types of files: test.py, test.bat, test.cmd, test.exe. Each created to test incoming arguments list.
![image](https://github.com/files-community/Files/assets/28791910/3c4c1052-a53a-4cdc-9ed2-c22aba6d8d0e)
![image](https://github.com/files-community/Files/assets/28791910/972a7fc4-eb7b-4433-97c5-8b6d00ce210a)
![image](https://github.com/files-community/Files/assets/28791910/a1f20a45-2e3d-4a2f-abfb-e11db804746d)
![image](https://github.com/files-community/Files/assets/28791910/46771db1-0ade-4b77-b1cd-2ce3d300b9d1)

Tested dragging and dropping multiple files to each of them to verify changes:
![image](https://github.com/files-community/Files/assets/28791910/60a0d981-a7ac-4eaa-a517-82a8b0f1f5b4)

Also validated that when python is not installed, the user cannot drop files onto the python file.


