### PR TITLE
Feature: Open archives from the home page in the same tab

### DIFF
--- a/src/Files.App/Utils/RecentItem/RecentItem.cs
+++ b/src/Files.App/Utils/RecentItem/RecentItem.cs
@@ -51,7 +51,7 @@ namespace Files.App.Utils.RecentItem
 			LinkPath = linkItem.FilePath;
 			RecentPath = linkItem.TargetPath;
 			Name = NameOrPathWithoutExtension(linkItem.FileName);
-			Type = linkItem.IsFolder ? StorageItemTypes.Folder : StorageItemTypes.File;
+			Type = linkItem.IsFolder ? StorageItemTypes.Folder : ZipStorageFolder.IsZipPath(LinkPath) ? StorageItemTypes.Folder : StorageItemTypes.File;
 			FolderImg = linkItem.IsFolder;
 			FileIconVis = !linkItem.IsFolder;
 			LastModified = linkItem.ModifiedDate;
@@ -67,7 +67,7 @@ namespace Files.App.Utils.RecentItem
 			LinkPath = ShellStorageFolder.IsShellPath(fileItem.FilePath) ? fileItem.RecyclePath : fileItem.FilePath; // use true path on disk for shell items
 			RecentPath = LinkPath; // intentionally the same
 			Name = NameOrPathWithoutExtension(fileItem.FileName);
-			Type = fileItem.IsFolder ? StorageItemTypes.Folder : StorageItemTypes.File;
+			Type = fileItem.IsFolder ? StorageItemTypes.Folder : ZipStorageFolder.IsZipPath(LinkPath) ? StorageItemTypes.Folder : StorageItemTypes.File;
 			FolderImg = fileItem.IsFolder;
 			FileIconVis = !fileItem.IsFolder;
 			LastModified = fileItem.ModifiedDate;


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #11517 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app 
   2. In Home page scroll to an archive in Recent files.
   3. Open archive.

**Screenshots (optional)**
Archive in Recent files
![files_recents_archive](https://github.com/files-community/Files/assets/146449314/d010d29f-45b7-41dd-a17c-e5ab4bba0ffd)

Archive opened from Recent files
![files_archive_opened](https://github.com/files-community/Files/assets/146449314/357625ba-0329-4d6a-8f73-484b848b6fe8)
