### PR TITLE
Fix: Fixed info pane state when resuming

### DIFF
--- a/src/Files.App/UserControls/Pane/InfoPane.xaml
+++ b/src/Files.App/UserControls/Pane/InfoPane.xaml
@@ -20,7 +20,7 @@
 	d:DesignHeight="300"
 	d:DesignWidth="400"
 	AutomationProperties.Name="{helpers:ResourceString Name=SelectedFilePreviewPane/AutomationProperties/Name}"
-	Loading="Root_Loading"
+	Loaded="Root_Loaded"
 	SizeChanged="Root_SizeChanged"
 	Unloaded="Root_Unloaded"
 	mc:Ignorable="d">

--- a/src/Files.App/UserControls/Pane/InfoPane.xaml.cs
+++ b/src/Files.App/UserControls/Pane/InfoPane.xaml.cs
@@ -52,8 +52,8 @@ namespace Files.App.UserControls
 
 		private string GetLocalizedResource(string resName) => resName.GetLocalizedResource();
 
-		private void Root_Loading(FrameworkElement sender, object args)
-			=> ViewModel.UpdateSelectedItemPreviewAsync();
+		private void Root_Loaded(object sender, RoutedEventArgs e)
+			=> ViewModel?.UpdateSelectedItemPreviewAsync();
 
 		private void Root_Unloaded(object sender, RoutedEventArgs e)
 		{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13065...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Display info pane
   2. Restart app and confirm the info pane displays the details for the current folder

**Screenshots (optional)**
Add screenshots here.
