### PR TITLE
Code Quality: Avoid redundant OnPropertyChanged calls in ContentPageContext

### DIFF
--- a/src/Files.App/Data/Contexts/ContentPage/ContentPageContext.cs
+++ b/src/Files.App/Data/Contexts/ContentPage/ContentPageContext.cs
@@ -14,8 +14,6 @@ namespace Files.App.Data.Contexts
 
 		private ItemViewModel? filesystemViewModel;
 
-		private ListedItem? lastFolder;
-
 		public IShellPage? ShellPage => context?.PaneOrColumn;
 
 		public Type PageLayoutType => ShellPage?.CurrentPageType ?? typeof(DetailsLayoutPage);
@@ -86,7 +84,6 @@ namespace Files.App.Data.Contexts
 
 			if (filesystemViewModel is not null)
 				filesystemViewModel.PropertyChanged -= FilesystemViewModel_PropertyChanged;
-			lastFolder = filesystemViewModel?.CurrentFolder;
 			filesystemViewModel = null;
 
 			OnPropertyChanging(nameof(ShellPage));
@@ -110,10 +107,7 @@ namespace Files.App.Data.Contexts
 
 			Update();
 			OnPropertyChanged(nameof(ShellPage));
-
-			if (lastFolder != filesystemViewModel?.CurrentFolder)
-				OnPropertyChanged(nameof(Folder));
-			lastFolder = null;
+			OnPropertyChanged(nameof(Folder));
 		}
 
 		private void Page_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Files.App/Data/Contexts/ContentPage/ContentPageContext.cs
+++ b/src/Files.App/Data/Contexts/ContentPage/ContentPageContext.cs
@@ -14,6 +14,8 @@ namespace Files.App.Data.Contexts
 
 		private ItemViewModel? filesystemViewModel;
 
+		private ListedItem? lastFolder;
+
 		public IShellPage? ShellPage => context?.PaneOrColumn;
 
 		public Type PageLayoutType => ShellPage?.CurrentPageType ?? typeof(DetailsLayoutPage);
@@ -84,6 +86,7 @@ namespace Files.App.Data.Contexts
 
 			if (filesystemViewModel is not null)
 				filesystemViewModel.PropertyChanged -= FilesystemViewModel_PropertyChanged;
+			lastFolder = filesystemViewModel?.CurrentFolder;
 			filesystemViewModel = null;
 
 			OnPropertyChanging(nameof(ShellPage));
@@ -107,6 +110,10 @@ namespace Files.App.Data.Contexts
 
 			Update();
 			OnPropertyChanged(nameof(ShellPage));
+
+			if (lastFolder != filesystemViewModel?.CurrentFolder)
+				OnPropertyChanged(nameof(Folder));
+			lastFolder = null;
 		}
 
 		private void Page_PropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -196,7 +203,6 @@ namespace Files.App.Data.Contexts
 			UpdatePageType();
 			UpdateSelectedItems();
 
-			OnPropertyChanged(nameof(Folder));
 			OnPropertyChanged(nameof(HasItem));
 			OnPropertyChanged(nameof(CanGoBack));
 			OnPropertyChanged(nameof(CanGoForward));

--- a/src/Files.App/Data/Contexts/Page/PageContext.cs
+++ b/src/Files.App/Data/Contexts/Page/PageContext.cs
@@ -75,6 +75,9 @@ namespace Files.App.Data.Contexts
 
 		private void UpdateContent()
 		{
+			if (pane == page?.ActivePane && paneOrColumn == page?.ActivePaneOrColumn)
+				return;
+
 			Changing?.Invoke(this, EventArgs.Empty);
 
 			pane = page?.ActivePane;

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -461,6 +461,9 @@ namespace Files.App.Views
 		private void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+			if (propertyName == nameof(ShouldPreviewPaneBeActive) && ShouldPreviewPaneBeActive)
+				_ = Ioc.Default.GetRequiredService<InfoPaneViewModel>().UpdateSelectedItemPreviewAsync();
 		}
 
 		private void RootGrid_PreviewKeyDown(object sender, KeyRoutedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?