### PR TITLE
Feature: Added support for cycling tabs via mouse scrolling

### DIFF
--- a/src/Files.App/UserControls/TabBar/TabBar.xaml
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml
@@ -74,6 +74,7 @@
 			CanReorderTabs="{x:Bind AllowTabsDrag, Mode=OneWay}"
 			DragLeave="TabView_DragLeave"
 			IsAddTabButtonVisible="False"
+			PointerWheelChanged="TabView_PointerWheelChanged"
 			SelectedIndex="{x:Bind root:App.AppModel.TabStripSelectedIndex, Mode=TwoWay}"
 			SelectionChanged="TabView_SelectionChanged"
 			TabCloseRequested="TabView_TabCloseRequested"

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -274,9 +274,7 @@ namespace Files.App.UserControls.TabBar
 			{
 				// Scroll up, select the next tab
 				if (HorizontalTabView.SelectedIndex < HorizontalTabView.TabItems.Count - 1)
-				{
 					HorizontalTabView.SelectedIndex++;
-				}
 			}
 			else
 			{

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -266,6 +266,30 @@ namespace Files.App.UserControls.TabBar
 				(args.Item as TabBarItem)?.Unload();
 		}
 
+		private void TabView_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
+		{
+			var delta = e.GetCurrentPoint(null).Properties.MouseWheelDelta;
+
+			if (delta > 0)
+			{
+				// Scroll up, select the next tab
+				if (HorizontalTabView.SelectedIndex < HorizontalTabView.TabItems.Count - 1)
+				{
+					HorizontalTabView.SelectedIndex++;
+				}
+			}
+			else
+			{
+				// Scroll down, select the previous tab
+				if (HorizontalTabView.SelectedIndex > 0)
+				{
+					HorizontalTabView.SelectedIndex--;
+				}
+			}
+
+			e.Handled = true;
+		}
+
 		private void TabItemContextMenu_Opening(object sender, object e)
 		{
 			MenuItemMoveTabToNewWindow.IsEnabled = Items.Count > 1;

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -280,9 +280,7 @@ namespace Files.App.UserControls.TabBar
 			{
 				// Scroll down, select the previous tab
 				if (HorizontalTabView.SelectedIndex > 0)
-				{
 					HorizontalTabView.SelectedIndex--;
-				}
 			}
 
 			e.Handled = true;


### PR DESCRIPTION
Babies first pull request. So forgive me if I accidently something.

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes [Feature: Cycle tabs via mouse scrolling #13550](https://github.com/files-community/Files/issues/13550)

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Create multiple tabs.
   3. Hover pointer over tab and use mousewheel to cycle tabs.
   4. Use mousewheel everywhere else to make sure no other mousewheel behaviour is changed.