### PR TITLE
Feature: Recognize Tilde as %USERPROFILE%

### DIFF
--- a/src/Files.App/Utils/Storage/Helpers/StorageFileExtensions.cs
+++ b/src/Files.App/Utils/Storage/Helpers/StorageFileExtensions.cs
@@ -302,7 +302,7 @@ namespace Files.App.Utils.Storage
 
 		private static string GetPathWithoutEnvironmentVariable(string path)
 		{
-			if (path.StartsWith("~\\", StringComparison.Ordinal))
+			if (path.StartsWith("~\\", StringComparison.Ordinal) || path.StartsWith("~/", StringComparison.Ordinal) || path.Equals("~", StringComparison.Ordinal))
 				path = $"{Constants.UserEnvironmentPaths.HomePath}{path.Remove(0, 1)}";
 
 			path = path.Replace("%temp%", Constants.UserEnvironmentPaths.TempPath, StringComparison.OrdinalIgnoreCase);

--- a/src/Files.App/ViewModels/UserControls/ToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/ToolbarViewModel.cs
@@ -664,6 +664,19 @@ namespace Files.App.ViewModels.UserControls
 			}
 		}
 
+		private static string NormalizePathInput(string currentInput, bool isFtp)
+		{
+			if (currentInput.Contains('/') && !isFtp)
+				currentInput = currentInput.Replace("/", "\\", StringComparison.Ordinal);
+
+			currentInput = currentInput.Replace("\\\\", "\\", StringComparison.Ordinal);
+
+			if (currentInput.StartsWith('\\') && !currentInput.StartsWith("\\\\", StringComparison.Ordinal))
+				currentInput = currentInput.Insert(0, "\\");
+
+			return currentInput;
+		}
+
 		public async Task CheckPathInputAsync(string currentInput, string currentSelectedPath, IShellPage shellPage)
 		{
 			if (currentInput.StartsWith('>'))
@@ -685,13 +698,7 @@ namespace Files.App.ViewModels.UserControls
 
 			var isFtp = FtpHelpers.IsFtpPath(currentInput);
 
-			if (currentInput.Contains('/') && !isFtp)
-				currentInput = currentInput.Replace("/", "\\", StringComparison.Ordinal);
-
-			currentInput = currentInput.Replace("\\\\", "\\", StringComparison.Ordinal);
-
-			if (currentInput.StartsWith('\\') && !currentInput.StartsWith("\\\\", StringComparison.Ordinal))
-				currentInput = currentInput.Insert(0, "\\");
+			currentInput = NormalizePathInput(currentInput, isFtp);
 
 			if (currentSelectedPath == currentInput || string.IsNullOrWhiteSpace(currentInput))
 				return;
@@ -810,8 +817,10 @@ namespace Files.App.ViewModels.UserControls
 					else
 					{
 						IsCommandPaletteOpen = false;
-						var isFtp = FtpHelpers.IsFtpPath(sender.Text);
-						var expandedPath = StorageFileExtensions.GetResolvedPath(sender.Text, isFtp);
+						var currentInput = sender.Text;
+						var isFtp = FtpHelpers.IsFtpPath(currentInput);
+						currentInput = NormalizePathInput(currentInput, isFtp);
+						var expandedPath = StorageFileExtensions.GetResolvedPath(currentInput, isFtp);
 						var folderPath = PathNormalization.GetParentDir(expandedPath) ?? expandedPath;
 						StorageFolderWithPath folder = await shellpage.FilesystemViewModel.GetFolderWithPathFromPathAsync(folderPath);
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14166 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Type the following cases into the toolbar: `~`, `~/`, `~\`
   3. They should all reference the same user profile folder. The forward/backslash cases should show files inside

**Screenshots (optional)**

Standalone-tilde support:
<img width="335" alt="image" src="https://github.com/files-community/Files/assets/12786951/32274f43-df0a-4493-8f15-1b508bc7acd2">

Forward-slash with tilde support:
<img width="350" alt="image" src="https://github.com/files-community/Files/assets/12786951/7472c4c7-2e39-438b-9cfd-c3974c099c40">

Example with sub-directories:
<img width="325" alt="image" src="https://github.com/files-community/Files/assets/12786951/921c6569-4a34-4dda-887c-1dd275ab71f4">

(Technically, this PR does two things, but it felt awkward without also supporting forward-slash.)