### PR TITLE
Feature: Added 2gb splitting size for archives

### DIFF
--- a/src/Files.App/Dialogs/CreateArchiveDialog.xaml.cs
+++ b/src/Files.App/Dialogs/CreateArchiveDialog.xaml.cs
@@ -189,6 +189,7 @@ namespace Files.App.Dialogs
 				new(ArchiveSplittingSizes.Cd650, ToSizeText(650), "CD".GetLocalizedResource()),
 				new(ArchiveSplittingSizes.Cd700, ToSizeText(700), "CD".GetLocalizedResource()),
 				new(ArchiveSplittingSizes.Mo1024, ToSizeText(1024)),
+				new(ArchiveSplittingSizes.Mo2048, ToSizeText(2048)),
 				new(ArchiveSplittingSizes.Fat4092, ToSizeText(4092), "FAT".GetLocalizedResource()),
 				new(ArchiveSplittingSizes.Dvd4480, ToSizeText(4480), "DVD".GetLocalizedResource()),
 				new(ArchiveSplittingSizes.Mo5120, ToSizeText(5120)),

--- a/src/Files.App/Utils/Archives/CompressArchiveModel.cs
+++ b/src/Files.App/Utils/Archives/CompressArchiveModel.cs
@@ -54,6 +54,7 @@ namespace Files.App.Utils.Archives
 			ArchiveSplittingSizes.Mo10 => 10 * 1000 * 1000L,
 			ArchiveSplittingSizes.Mo100 => 100 * 1000 * 1000L,
 			ArchiveSplittingSizes.Mo1024 => 1024 * 1000 * 1000L,
+			ArchiveSplittingSizes.Mo2048 => 2048 * 1000 * 1000L,
 			ArchiveSplittingSizes.Mo5120 => 5120 * 1000 * 1000L,
 			ArchiveSplittingSizes.Fat4092 => 4092 * 1000 * 1000L,
 			ArchiveSplittingSizes.Cd650 => 650 * 1000 * 1000L,

--- a/src/Files.Core/Data/Enums/ArchiveSplittingSizes.cs
+++ b/src/Files.Core/Data/Enums/ArchiveSplittingSizes.cs
@@ -29,6 +29,11 @@ namespace Files.Core.Data.Enums
 		Mo1024,
 
 		/// <summary>
+		/// Split into each 2 GB.
+		/// </summary>
+		Mo2048,
+
+		/// <summary>
 		/// Split into each 5 GB.
 		/// </summary>
 		Mo5120,


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14132...

**Validation**
How did you test these changes?
- [ ] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Select some files and select the compress option
   2. Change the splitting size to 2gb and confirm it works as intended

**Screenshots (optional)**
Add screenshots here.
