### PR TITLE
Feature: Added `Ctrl` + `Alt` + `V` shortcut to duplicate selected items

### DIFF
--- a/src/Files.App/Actions/FileSystem/DuplicateItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/DuplicateItemAction.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) 2023 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
+namespace Files.App.Actions
+{
+	internal class DuplicateItemAction : ObservableObject, IAction
+	{
+		private readonly IContentPageContext context;
+
+		public string Label
+			=> "Duplicate".GetLocalizedResource();
+
+		public string Description
+			=> "DuplicateItemDescription".GetLocalizedResource();
+
+		public RichGlyph Glyph
+			=> new(opacityStyle: "ColorIconCopy");
+
+		public HotKey HotKey
+			=> new(Keys.V, KeyModifiers.MenuCtrl);
+
+		public bool IsExecutable
+			=> GetIsExecutable();
+
+		public DuplicateItemAction()
+		{
+			context = Ioc.Default.GetRequiredService<IContentPageContext>();
+
+			context.PropertyChanged += Context_PropertyChanged;
+		}
+
+		public async Task ExecuteAsync()
+		{
+			if (context.ShellPage is null)
+				return;
+
+			// Copy selected items
+			await UIFilesystemHelpers.CopyItemAsync(context.ShellPage);
+
+			// Paste copied items
+			string path = context.ShellPage.FilesystemViewModel.WorkingDirectory;
+			await UIFilesystemHelpers.PasteItemAsync(path, context.ShellPage);
+		}
+
+		public bool GetIsExecutable()
+		{
+			return
+				context.HasSelection &&
+				context.PageType != ContentPageTypes.Home &&
+				context.PageType != ContentPageTypes.RecycleBin &&
+				context.PageType != ContentPageTypes.SearchResults;
+		}
+
+		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName is nameof(IContentPageContext.PageType) || e.PropertyName is nameof(IContentPageContext.HasSelection))
+				OnPropertyChanged(nameof(IsExecutable));
+		}
+	}
+}

--- a/src/Files.App/Data/Commands/CommandCodes.cs
+++ b/src/Files.App/Data/Commands/CommandCodes.cs
@@ -31,6 +31,7 @@ namespace Files.App.Data.Commands
 		CopyPath,
 		CopyPathWithQuotes,
 		CutItem,
+		DuplicateItem,
 		PasteItem,
 		PasteItemToSelection,
 		DeleteItem,

--- a/src/Files.App/Data/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Data/Commands/Manager/CommandManager.cs
@@ -79,6 +79,7 @@ namespace Files.App.Data.Commands
 		public IRichCommand CopyPath => commands[CommandCodes.CopyPath];
 		public IRichCommand CopyPathWithQuotes => commands[CommandCodes.CopyPathWithQuotes];
 		public IRichCommand CutItem => commands[CommandCodes.CutItem];
+		public IRichCommand DuplicateItem => commands[CommandCodes.DuplicateItem];
 		public IRichCommand PasteItem => commands[CommandCodes.PasteItem];
 		public IRichCommand PasteItemToSelection => commands[CommandCodes.PasteItemToSelection];
 		public IRichCommand DeleteItem => commands[CommandCodes.DeleteItem];
@@ -243,6 +244,7 @@ namespace Files.App.Data.Commands
 			[CommandCodes.CopyPath] = new CopyPathAction(),
 			[CommandCodes.CopyPathWithQuotes] = new CopyPathWithQuotesAction(),
 			[CommandCodes.CutItem] = new CutItemAction(),
+			[CommandCodes.DuplicateItem] = new DuplicateItemAction(),
 			[CommandCodes.PasteItem] = new PasteItemAction(),
 			[CommandCodes.PasteItemToSelection] = new PasteItemToSelectionAction(),
 			[CommandCodes.DeleteItem] = new DeleteItemAction(),

--- a/src/Files.App/Data/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Data/Commands/Manager/ICommandManager.cs
@@ -32,6 +32,7 @@ namespace Files.App.Data.Commands
 		IRichCommand CopyPath { get; }
 		IRichCommand CopyPathWithQuotes { get; }
 		IRichCommand CutItem { get; }
+		IRichCommand DuplicateItem { get; }
 		IRichCommand PasteItem { get; }
 		IRichCommand PasteItemToSelection { get; }
 		IRichCommand DeleteItem { get; }

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2430,6 +2430,12 @@
   <data name="CutItemDescription" xml:space="preserve">
     <value>Cut item(s) to clipboard</value>
   </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>Duplicate</value>
+  </data>
+  <data name="DuplicateItemDescription" xml:space="preserve">
+    <value>Duplicate selected items</value>
+  </data>
   <data name="PasteItemDescription" xml:space="preserve">
     <value>Paste item(s) from clipboard to current folder</value>
   </data>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14135...

**Validation**
How did you test these changes?
- [ ] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Confirm the duplicate items action is only enabled when items are selected
   2. Confirm the action copies and pastes the selected items

**Screenshots (optional)**
Add screenshots here.
