### PR TITLE
Fix: Fixed issue where options in the conflicts dialog could change when scrolling

### DIFF
--- a/src/Files.App/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files.App/Dialogs/FilesystemOperationDialog.xaml
@@ -104,15 +104,15 @@
 				</Grid>
 
 				<!--  Options  -->
+				<!--  x:Load cannot be used (#14000)  -->
 				<ComboBox
 					x:Name="ConflictOptions"
 					Grid.Column="2"
 					Width="200"
 					HorizontalAlignment="Right"
 					VerticalAlignment="Center"
-					x:Load="{x:Bind IsConflict, Mode=OneWay}"
-					Loaded="ConflictOptions_Loaded"
-					SelectedIndex="{x:Bind ConflictResolveOption, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay, Converter={StaticResource ConflictResolveOptionToIndexConverter}}">
+					SelectedIndex="{x:Bind ConflictResolveOption, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay, Converter={StaticResource ConflictResolveOptionToIndexConverter}}"
+					Visibility="{x:Bind IsConflict, Mode=OneWay}">
 					<ComboBox.Items>
 						<ComboBoxItem Content="{helpers:ResourceString Name=GenerateNewName}" />
 						<ComboBoxItem Content="{helpers:ResourceString Name=ReplaceExisting}" />

--- a/src/Files.App/Dialogs/FilesystemOperationDialog.xaml.cs
+++ b/src/Files.App/Dialogs/FilesystemOperationDialog.xaml.cs
@@ -106,19 +106,6 @@ namespace Files.App.Dialogs
 			(sender as TextBox)?.Focus(FocusState.Programmatic);
 		}
 
-		private void ConflictOptions_Loaded(object sender, RoutedEventArgs e)
-		{
-			if (sender is ComboBox comboBox)
-				comboBox.SelectedIndex = ViewModel.LoadConflictResolveOption() switch
-				{
-					FileNameConflictResolveOptionType.None => -1,
-					FileNameConflictResolveOptionType.GenerateNewName => 0,
-					FileNameConflictResolveOptionType.ReplaceExisting => 1,
-					FileNameConflictResolveOptionType.Skip => 2,
-					_ => -1
-				};
-		}
-
 		private void FilesystemOperationDialog_Opened(ContentDialog sender, ContentDialogOpenedEventArgs args)
 		{
 			UpdateDialogLayout();

--- a/src/Files.Core/ViewModels/Dialogs/FileSystemDialog/FileSystemDialogViewModel.cs
+++ b/src/Files.Core/ViewModels/Dialogs/FileSystemDialog/FileSystemDialogViewModel.cs
@@ -59,11 +59,18 @@ namespace Files.Core.ViewModels.Dialogs.FileSystemDialog
 
 			_dialogClosingCts = new();
 
+			_AggregatedResolveOption = _userSettingsService.GeneralSettingsService.ConflictsResolveOption;
+
 			_messenger = new WeakReferenceMessenger();
 			_messenger.Register(this);
 
 			foreach (var item in items)
+			{
+				if (item is FileSystemDialogConflictItemViewModel conflictItem && conflictItem.IsConflict)
+					conflictItem.ConflictResolveOption = _AggregatedResolveOption;
+
 				item.Messenger = _messenger;
+			}
 
 			Items = new(items);
 
@@ -109,11 +116,6 @@ namespace Files.Core.ViewModels.Dialogs.FileSystemDialog
 						? first
 						: FileNameConflictResolveOptionType.None;
 			}
-		}
-
-		public FileNameConflictResolveOptionType LoadConflictResolveOption()
-		{
-			return _userSettingsService.GeneralSettingsService.ConflictsResolveOption;
 		}
 
 		public void SaveConflictResolveOption()


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14000 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?