### PR TITLE
Fix: Fixed issue where details layout headers weren't always "sticky"

### DIFF
--- a/src/Files.App/Data/Behaviors/StickyHeaderBehavior.cs
+++ b/src/Files.App/Data/Behaviors/StickyHeaderBehavior.cs
@@ -36,6 +36,19 @@ namespace Files.App.Data.Behaviors
 
 		private InsetClip? _contentClip;
 
+		private readonly DispatcherTimer _assignAnimationTimer;
+
+		public StickyHeaderBehavior()
+		{
+			_assignAnimationTimer = new();
+			_assignAnimationTimer.Interval = TimeSpan.FromMilliseconds(200);
+			_assignAnimationTimer.Tick += (sender, e) =>
+			{
+				AssignAnimation();
+				_assignAnimationTimer.Stop();
+			};
+		}
+
 		/// <summary>
 		/// The UIElement that will be faded.
 		/// </summary>
@@ -92,7 +105,9 @@ namespace Files.App.Data.Behaviors
 		private static void PropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
 			var b = d as StickyHeaderBehavior;
-			b?.AssignAnimation();
+
+			// For some reason, the assignment needs to be delayed. (#14237)
+			b?._assignAnimationTimer.Start();
 		}
 
 		/// <summary>


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14237

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?