### PR TITLE
Fix: Fixed issue where resuming didn't work once it failed

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -116,12 +116,12 @@ namespace Files.App
 		/// <summary>
 		/// Invoked when the application is activated.
 		/// </summary>
-		public void OnActivated(AppActivationArguments activatedEventArgs)
+		public async Task OnActivatedAsync(AppActivationArguments activatedEventArgs)
 		{
 			Logger.LogInformation($"The app is being activated. Activation type: {activatedEventArgs.Data.GetType().Name}");
 
 			// InitializeApplication accesses UI, needs to be called on UI thread
-			_ = MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(()
+			await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(()
 				=> MainWindow.Instance.InitializeApplicationAsync(activatedEventArgs.Data));
 		}
 

--- a/src/Files.App/Program.cs
+++ b/src/Files.App/Program.cs
@@ -158,12 +158,12 @@ namespace Files.App
 			});
 		}
 
-		private static void OnActivated(object? sender, AppActivationArguments args)
+		private static async void OnActivated(object? sender, AppActivationArguments args)
 		{
 			if (App.Current is App thisApp)
 			{
 				// WINUI3: Verify if needed or OnLaunched is called
-				thisApp.OnActivated(args);
+				await thisApp.OnActivatedAsync(args);
 			}
 		}
 


### PR DESCRIPTION
This doesn't fix the issue of occasional failures to resume the app, but it will allow resuming to work again without killing the process.

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Turn "Leave app running" on.
   2. Repeatedly exit and restart the application until the application fails to resume.
   3. Start the app again. It will show the splash screen.
   4. Exit the app.
   5. Start the app one more time. 
   6. The splash screen no longer appears and resuming works correctly. Without this fix, the splash spreen continues to appear.