### PR TITLE
Fix: Fixed exception that would sometimes occur when sharing items

### DIFF
--- a/src/Files.App/Actions/Content/Share/ShareItemAction.cs
+++ b/src/Files.App/Actions/Content/Share/ShareItemAction.cs
@@ -33,9 +33,7 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync()
 		{
-			ShareItemHelpers.ShareItems(context.SelectedItems);
-
-			return Task.CompletedTask;
+			return ShareItemHelpers.ShareItemsAsync(context.SelectedItems);
 		}
 
 		private bool IsContextPageTypeAdaptedToCommand()

--- a/src/Files.App/Helpers/ShareItemHelpers.cs
+++ b/src/Files.App/Helpers/ShareItemHelpers.cs
@@ -3,11 +3,13 @@
 
 using Files.App.Extensions;
 using Files.App.Utils;
+using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
+using Windows.Foundation.Metadata;
 using Windows.Storage;
 
 namespace Files.App.Helpers
@@ -19,7 +21,7 @@ namespace Files.App.Helpers
 				(!item.IsShortcut || item.IsLinkItem) &&
 				(item.PrimaryItemAttribute != StorageItemTypes.Folder || item.IsArchive);
 
-		public static void ShareItems(IEnumerable<ListedItem> itemsToShare)
+		public static async void ShareItems(IEnumerable<ListedItem> itemsToShare)
 		{
 			var interop = DataTransferManager.As<IDataTransferManagerInterop>();
 			IntPtr result = interop.GetForWindow(MainWindow.Instance.WindowHandle, InteropHelpers.DataTransferManagerInteropIID);
@@ -27,7 +29,24 @@ namespace Files.App.Helpers
 			var manager = WinRT.MarshalInterface<DataTransferManager>.FromAbi(result);
 			manager.DataRequested += new TypedEventHandler<DataTransferManager, DataRequestedEventArgs>(Manager_DataRequested);
 
-			interop.ShowShareUIForWindow(MainWindow.Instance.WindowHandle);
+			try
+			{
+				interop.ShowShareUIForWindow(MainWindow.Instance.WindowHandle);
+			}
+			catch (Exception ex)
+			{
+				var errorDialog = new ContentDialog()
+				{
+					Title = "FaildToShareItems".GetLocalizedResource(),
+					Content = ex.Message,
+					PrimaryButtonText = "OK".GetLocalizedResource(),
+				};
+
+				if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+					errorDialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
+
+				await errorDialog.TryShowAsync();
+			}
 
 			async void Manager_DataRequested(DataTransferManager sender, DataRequestedEventArgs args)
 			{

--- a/src/Files.App/Helpers/ShareItemHelpers.cs
+++ b/src/Files.App/Helpers/ShareItemHelpers.cs
@@ -21,7 +21,7 @@ namespace Files.App.Helpers
 				(!item.IsShortcut || item.IsLinkItem) &&
 				(item.PrimaryItemAttribute != StorageItemTypes.Folder || item.IsArchive);
 
-		public static async void ShareItems(IEnumerable<ListedItem> itemsToShare)
+		public static async Task ShareItemsAsync(IEnumerable<ListedItem> itemsToShare)
 		{
 			var interop = DataTransferManager.As<IDataTransferManagerInterop>();
 			IntPtr result = interop.GetForWindow(MainWindow.Instance.WindowHandle, InteropHelpers.DataTransferManagerInteropIID);

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3662,4 +3662,7 @@
   <data name="FailedToRotateImage" xml:space="preserve">
     <value>Failed to rotate the image</value>
   </data>
+  <data name="FaildToShareItems" xml:space="preserve">
+    <value>Failed to share items</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- Fixes https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/601897681u/overview

```
Files.App.Helpers
IDataTransferManagerInterop.ShowShareUIForWindow (IntPtr appWindow)
Files.App.Helpers
ShareItemHelpers.ShareItems (IEnumerable`1 itemsToShare)
Files.App.Actions
ShareItemAction.ExecuteAsync ()
Files.App.Data.Commands.CommandManager
ActionCommand.ExecuteAsync ()
Files.App.Data.Commands.CommandManager
ActionCommand.Execute (Object parameter)
System.Threading.Tasks.Task
<>c.<ThrowAsync>b__128_0 (Object state)
```