### PR TITLE
Feature: Added support for hiding compression options from the context menu

### DIFF
--- a/src/Files.App/Helpers/MenuFlyout/ContextFlyoutItemHelper.cs
+++ b/src/Files.App/Helpers/MenuFlyout/ContextFlyoutItemHelper.cs
@@ -515,7 +515,7 @@ namespace Files.App.Helpers
 						new ContextMenuFlyoutItemViewModelBuilder(commands.CompressIntoZip).Build(),
 						new ContextMenuFlyoutItemViewModelBuilder(commands.CompressIntoSevenZip).Build(),
 					},
-					ShowItem = itemsSelected && CompressHelper.CanCompress(selectedItems)
+					ShowItem = userSettingsService.GeneralSettingsService.ShowCompressionOptions && itemsSelected && CompressHelper.CanCompress(selectedItems)
 				},
 				new ContextMenuFlyoutItemViewModel
 				{
@@ -532,7 +532,7 @@ namespace Files.App.Helpers
 						new ContextMenuFlyoutItemViewModelBuilder(commands.DecompressArchiveHere).Build(),
 						new ContextMenuFlyoutItemViewModelBuilder(commands.DecompressArchiveToChildFolder).Build(),
 					},
-					ShowItem = CompressHelper.CanDecompress(selectedItems)
+					ShowItem = userSettingsService.GeneralSettingsService.ShowCompressionOptions && CompressHelper.CanDecompress(selectedItems)
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{

--- a/src/Files.App/Services/Settings/GeneralSettingsService.cs
+++ b/src/Files.App/Services/Settings/GeneralSettingsService.cs
@@ -187,6 +187,12 @@ namespace Files.App.Services.Settings
 			set => Set(value);
 		}
 
+		public bool ShowCompressionOptions
+		{
+			get => Get(true);
+			set => Set(value);
+		}
+
 		public bool ShowSendToMenu
 		{
 			get => Get(true);

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2229,6 +2229,9 @@
   <data name="ShowEditTagsMenu" xml:space="preserve">
     <value>Show edit tags flyout</value>
   </data>
+  <data name="ShowCompressionOptions" xml:space="preserve">
+    <value>Show compression options</value>
+  </data>
   <data name="ShowSendToMenu" xml:space="preserve">
     <value>Show Send To menu</value>
   </data>

--- a/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
@@ -423,6 +423,19 @@ namespace Files.App.ViewModels.Settings
 			}
 		}
 
+		public bool ShowCompressionOptions
+		{
+			get => UserSettingsService.GeneralSettingsService.ShowCompressionOptions;
+			set
+			{
+				if (value == UserSettingsService.GeneralSettingsService.ShowCompressionOptions)
+					return;
+
+				UserSettingsService.GeneralSettingsService.ShowCompressionOptions = value;
+				OnPropertyChanged();
+			}
+		}
+
 		public bool ShowSendToMenu
 		{
 			get => UserSettingsService.GeneralSettingsService.ShowSendToMenu;

--- a/src/Files.App/Views/Settings/GeneralPage.xaml
+++ b/src/Files.App/Views/Settings/GeneralPage.xaml
@@ -294,6 +294,14 @@
 								Style="{StaticResource RightAlignedToggleSwitchStyle}" />
 						</local:SettingsBlockControl>
 
+						<!--  Compression options  -->
+						<local:SettingsBlockControl Title="{helpers:ResourceString Name=ShowCompressionOptions}" HorizontalAlignment="Stretch">
+							<ToggleSwitch
+								AutomationProperties.Name="{helpers:ResourceString Name=ShowCompressionOptions}"
+								IsOn="{x:Bind ViewModel.ShowCompressionOptions, Mode=TwoWay}"
+								Style="{StaticResource RightAlignedToggleSwitchStyle}" />
+						</local:SettingsBlockControl>
+
 						<!--  Send To  -->
 						<local:SettingsBlockControl Title="{helpers:ResourceString Name=ShowSendToMenu}" HorizontalAlignment="Stretch">
 							<ToggleSwitch

--- a/src/Files.Core/Services/Settings/IGeneralSettingsService.cs
+++ b/src/Files.Core/Services/Settings/IGeneralSettingsService.cs
@@ -170,6 +170,11 @@ namespace Files.Core.Services.Settings
 		bool ShowOpenInNewPane { get; set; }
 
 		/// <summary>
+		/// Gets or sets a value indicating whether or not to show the compression options e.g. create archive, extract files.
+		/// </summary>
+		bool ShowCompressionOptions { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating whether or not to show the Send To menu.
 		/// </summary>
 		bool ShowSendToMenu { get; set; }


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14305 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Compress/Extract get displayed in the context menu, when option is turned on (default behavior)
   2. Compress/Extract is hidden in the context menu if the option has been deactivated in the settings

**Screenshots (optional)**
![image](https://github.com/files-community/Files/assets/56681014/48e16c7c-17d5-48ec-8120-06366092cc50)

