### PR TITLE
Fix: Fixed NullReferenceException when renaming files

### DIFF
--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -253,20 +253,27 @@ namespace Files.App.Views.Layouts
 			{
 				Popup? popup = gridViewItem.FindDescendant("EditPopup") as Popup;
 				TextBlock? textBlock = gridViewItem.FindDescendant("ItemName") as TextBlock;
-				popup!.IsOpen = false;
-				textBlock!.Opacity = (textBlock.DataContext as ListedItem)!.Opacity;
+
+				if (popup is not null)
+					popup.IsOpen = false;
+
+				if (textBlock is not null)
+					textBlock.Opacity = (textBlock.DataContext as ListedItem)!.Opacity;
 			}
 			else if (FolderSettings.LayoutMode == FolderLayoutModes.TilesView)
 			{
 				TextBlock? textBlock = gridViewItem.FindDescendant("ItemName") as TextBlock;
+
 				textBox.Visibility = Visibility.Collapsed;
-				textBlock!.Visibility = Visibility.Visible;
+
+				if (textBlock is not null)
+					textBlock.Visibility = Visibility.Visible;
 			}
 
 			// Unsubscribe from events
 			if (textBox is not null)
 			{
-				textBox!.LostFocus -= RenameTextBox_LostFocus;
+				textBox.LostFocus -= RenameTextBox_LostFocus;
 				textBox.KeyDown -= RenameTextBox_KeyDown;
 			}
 

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -430,15 +430,17 @@ namespace Files.App.Views.Layouts
 						if (FolderSettings.LayoutMode == FolderLayoutModes.GridView)
 						{
 							Popup popup = gridViewItem.FindDescendant("EditPopup") as Popup;
-							var textBox = popup.Child as TextBox;
+							var textBox = popup?.Child as TextBox;
 
-							await CommitRenameAsync(textBox);
+							if (textBox is not null)
+								await CommitRenameAsync(textBox);
 						}
 						else
 						{
 							var textBox = gridViewItem.FindDescendant("TileViewTextBoxItemName") as TextBox;
 
-							await CommitRenameAsync(textBox);
+							if (textBox is not null)
+								await CommitRenameAsync(textBox);
 						}
 					}
 				}


### PR DESCRIPTION
## Fixed NullReferenceException when renaming files
```
Files.App.Views.Layouts
GridLayoutPage.EndRename (TextBox textBox)
Files.App.Views.Layouts
BaseGroupableLayoutPage.CommitRenameAsync (TextBox textBox)
Files.App.Views.Layouts
GridLayoutPage.FileList_ItemTapped (Object sender, TappedRoutedEventArgs e)
```