### PR TITLE
Fix: Fixed NullReferenceException in ColumnShellPage.NavigateToPath

### DIFF
--- a/src/Files.App/Views/Shells/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/Shells/ColumnShellPage.xaml.cs
@@ -174,7 +174,7 @@ namespace Files.App.Views.Shells
 
 		public override void NavigateToPath(string navigationPath, Type sourcePageType, NavigationArguments navArgs = null)
 		{
-			this.FindAscendant<ColumnsLayoutPage>().SetSelectedPathOrNavigate(navigationPath, sourcePageType, navArgs);
+			this.FindAscendant<ColumnsLayoutPage>()?.SetSelectedPathOrNavigate(navigationPath, sourcePageType, navArgs);
 		}
 
 		public override void NavigateHome()


### PR DESCRIPTION
Fixed NullReferenceException in ColumnShellPage.NavigateToPath

```
Files.App.Views.Shells
ColumnShellPage.NavigateToPath (String navigationPath, Type sourcePageType, NavigationArguments navArgs)
Files.App.Views.Shells
ColumnShellPage.ShellPage_NavigationRequested (Object sender, PathNavigationEventArgs e)
Files.App.ViewModels.UserControls
ToolbarViewModel.PathBoxItem_Tapped (Object sender, TappedRoutedEventArgs e)
```