### PR TITLE
Fix: Fixed COMException when removing focus from the path bar

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -167,6 +167,8 @@ namespace Files.App
 		/// </summary>
 		private void Window_Activated(object sender, WindowActivatedEventArgs args)
 		{
+			AppModel.IsMainWindowClosed = false;
+
 			// TODO(s): Is this code still needed?
 			if (args.WindowActivationState != WindowActivationState.CodeActivated ||
 				args.WindowActivationState != WindowActivationState.PointerActivated)

--- a/src/Files.App/UserControls/AddressToolbar.xaml.cs
+++ b/src/Files.App/UserControls/AddressToolbar.xaml.cs
@@ -95,6 +95,9 @@ namespace Files.App.UserControls
 		}
 		private void VisiblePath_LostFocus(object _, RoutedEventArgs e)
 		{
+			if (App.AppModel.IsMainWindowClosed)
+				return;
+
 			var element = FocusManager.GetFocusedElement(MainWindow.Instance.Content.XamlRoot);
 			if (element is FlyoutBase or AppBarButton or Popup)
 				return;


### PR DESCRIPTION
## Fixed COMException when removing focus from the path bar

`System.Runtime.InteropServices.COMException: The operation identifier is not valid. The WinUI Desktop Window object has already been closed`