### PR TITLE
Fix: Fixed issue where the app would crash when opening the properties window twice

### DIFF
--- a/src/Files.App/Helpers/UI/DragZoneHelper.cs
+++ b/src/Files.App/Helpers/UI/DragZoneHelper.cs
@@ -25,7 +25,12 @@ namespace Files.App.Helpers
 			// UIElement.RasterizationScale is always 1
 			var source = InputNonClientPointerSource.GetForWindowId(window.AppWindow.Id);
 			var uiElement = window.Content;
-			var scaleFactor = uiElement.XamlRoot.RasterizationScale;
+			var xamlRoot = uiElement?.XamlRoot;
+
+			if (xamlRoot is null)
+				return;
+
+			var scaleFactor = xamlRoot.RasterizationScale;
 			var size = window.AppWindow.Size;
 			// If the number of regions is 0 or 1, AppWindow will automatically reset to the default region next time, but if it is >=2, it will not and need to be manually cleared
 			source.ClearRegionRects(NonClientRegionKind.Passthrough);

--- a/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
+++ b/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
@@ -52,7 +52,7 @@ namespace Files.App.Views.Properties
 
 			UpdatePageLayout();
 			Window.RaiseSetTitleBarDragRegion(SetTitleBarDragRegion);
-			Window.AppWindow.Changed += (_, _) => Window.RaiseSetTitleBarDragRegion(SetTitleBarDragRegion);
+			Window.AppWindow.Changed += AppWindow_Changed;
 		}
 
 		private int SetTitleBarDragRegion(InputNonClientPointerSource source, SizeInt32 size, double scaleFactor, Func<UIElement, RectInt32?, RectInt32> getScaledRect)
@@ -116,12 +116,18 @@ namespace Files.App.Views.Properties
 		{
 			AppSettings.ThemeModeChanged -= AppSettings_ThemeModeChanged;
 			Window.Closed -= Window_Closed;
+			Window.AppWindow.Changed -= AppWindow_Changed;
 
 			if (MainPropertiesViewModel.ChangedPropertiesCancellationTokenSource is not null &&
 				!MainPropertiesViewModel.ChangedPropertiesCancellationTokenSource.IsCancellationRequested)
 			{
 				MainPropertiesViewModel.ChangedPropertiesCancellationTokenSource.Cancel();
 			}
+		}
+
+		private void AppWindow_Changed(AppWindow sender, AppWindowChangedEventArgs e)
+		{
+			Window.RaiseSetTitleBarDragRegion(SetTitleBarDragRegion);
 		}
 
 		public override async Task<bool> SaveChangesAsync()


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14384 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?