### PR TITLE
Fix: Fixed issue where pinned applications were executed in %windir%\System32

### DIFF
--- a/src/Files.App/Utils/Shell/LaunchHelper.cs
+++ b/src/Files.App/Utils/Shell/LaunchHelper.cs
@@ -106,7 +106,7 @@ namespace Files.App.Utils.Shell
 						Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User));
 				}
 
-				process.StartInfo.WorkingDirectory = workingDirectory ?? PathNormalization.GetParentDir(application);
+				process.StartInfo.WorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? PathNormalization.GetParentDir(application) : workingDirectory;
 				process.Start();
 
 				Win32API.BringToForeground(currentWindows);
@@ -120,7 +120,7 @@ namespace Files.App.Utils.Shell
 				process.StartInfo.FileName = application;
 				process.StartInfo.CreateNoWindow = true;
 				process.StartInfo.Arguments = arguments;
-				process.StartInfo.WorkingDirectory = workingDirectory ?? PathNormalization.GetParentDir(application);
+				process.StartInfo.WorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? PathNormalization.GetParentDir(application) : workingDirectory;
 
 				try
 				{

--- a/src/Files.App/Utils/Shell/LaunchHelper.cs
+++ b/src/Files.App/Utils/Shell/LaunchHelper.cs
@@ -106,7 +106,7 @@ namespace Files.App.Utils.Shell
 						Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User));
 				}
 
-				process.StartInfo.WorkingDirectory = workingDirectory;
+				process.StartInfo.WorkingDirectory = workingDirectory ?? PathNormalization.GetParentDir(application);
 				process.Start();
 
 				Win32API.BringToForeground(currentWindows);
@@ -120,7 +120,7 @@ namespace Files.App.Utils.Shell
 				process.StartInfo.FileName = application;
 				process.StartInfo.CreateNoWindow = true;
 				process.StartInfo.Arguments = arguments;
-				process.StartInfo.WorkingDirectory = workingDirectory;
+				process.StartInfo.WorkingDirectory = workingDirectory ?? PathNormalization.GetParentDir(application);
 
 				try
 				{


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14405 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Pin `C:\Windows\System32\WindowsPowerShell\v1.0\powershell_ise.exe`
   2. Execute pinned powershell_ise.exe
   3. The program will now be executed in `C:\Windows\System32\WindowsPowerShell\v1.0`, not `C:\Windows\System32`