### PR TITLE
Feature: Switched away from GetThumbnailAsync API

### DIFF
--- a/src/Files.App/Constants.cs
+++ b/src/Files.App/Constants.cs
@@ -124,16 +124,13 @@ namespace Files.App
 			{
 				public const int GridViewIncrement = 20;
 
-				// Max achievable ctrl + scroll, not a default layout size
-				public const int GridViewSizeMax = 300;
-
 				public const int GridViewSizeLarge = 220;
 
 				public const int GridViewSizeMedium = 160;
 
 				public const int GridViewSizeSmall = 100;
 
-				public const int TilesView = 260;
+				public const int TilesView = 100;
 			}
 
 			public static class DetailsLayoutBrowser

--- a/src/Files.App/Constants.cs
+++ b/src/Files.App/Constants.cs
@@ -132,18 +132,18 @@ namespace Files.App
 
 				public const int TilesView = 100;
 			}
+		}
 
-			public static class DetailsLayoutBrowser
-			{
-				public const int DetailsViewSize = 32;
-			}
+		// Default icon sizes that are available for files and folders
+		public static class DefaultIconSizes
+		{
+			public const int Small = 16;
 
-			public static class ColumnViewBrowser
-			{
-				public const int ColumnViewSize = 32;
+			public const int Large = 32;
 
-				public const int ColumnViewSizeSmall = 24;
-			}
+			public const int ExtraLarge = 48;
+
+			public const int Jumbo = 256;
 		}
 
 		public static class Widgets
@@ -152,8 +152,6 @@ namespace Files.App
 			{
 				public const float LowStorageSpacePercentageThreshold = 90.0f;
 			}
-
-			public const int WidgetIconSize = 256;
 		}
 
 		public static class LocalSettings

--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -324,7 +324,7 @@ namespace Files.App.Data.Items
 			else
 			{
 				if (!string.IsNullOrEmpty(DeviceID) && !string.Equals(DeviceID, "network-folder"))
-					IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(DeviceID, 16, false, true);
+					IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(DeviceID, Constants.DefaultIconSizes.Large, false, true);
 
 				if (Root is not null)
 				{

--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -324,7 +324,7 @@ namespace Files.App.Data.Items
 			else
 			{
 				if (!string.IsNullOrEmpty(DeviceID) && !string.Equals(DeviceID, "network-folder"))
-					IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(DeviceID, 16);
+					IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(DeviceID, 16, false, true);
 
 				if (Root is not null)
 				{

--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -1249,7 +1249,7 @@ namespace Files.App.Data.Models
 			ImageSource? groupImage = null;
 			if (item.PrimaryItemAttribute != StorageItemTypes.Folder || item.IsArchive)
 			{
-				var headerIconInfo = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(item.ItemPath, 64u, false, true);
+				var headerIconInfo = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(item.ItemPath, Constants.DefaultIconSizes.ExtraLarge, false, true);
 
 				if (headerIconInfo is not null && !item.IsShortcut)
 					groupImage = await dispatcherQueue.EnqueueOrInvokeAsync(() => headerIconInfo.ToBitmapAsync(), Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);

--- a/src/Files.App/Data/Models/SidebarPinnedModel.cs
+++ b/src/Files.App/Data/Models/SidebarPinnedModel.cs
@@ -111,7 +111,7 @@ namespace Files.App.Data.Models
 
 				if (locationItem.IconData is null)
 				{
-					locationItem.IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(path, 48u);
+					locationItem.IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(path, 48u, false, true);
 
 					if (locationItem.IconData is not null)
 						locationItem.Icon = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => locationItem.IconData.ToBitmapAsync());

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
@@ -308,9 +308,9 @@ namespace Files.App.Data.Models
 			return LayoutMode switch
 			{
 				FolderLayoutModes.DetailsView
-					=> Constants.Browser.DetailsLayoutBrowser.DetailsViewSize,
+					=> Constants.DefaultIconSizes.Large,
 				FolderLayoutModes.ColumnView
-					=> Constants.Browser.ColumnViewBrowser.ColumnViewSize,
+					=> Constants.DefaultIconSizes.Large,
 				FolderLayoutModes.TilesView
 					=> Constants.Browser.GridViewBrowser.TilesView,
 				_ when GridViewSize <= Constants.Browser.GridViewBrowser.GridViewSizeSmall

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
@@ -97,7 +97,7 @@ namespace Files.App.Data.Models
 					else // Size up from tiles to grid
 					{
 						// Set grid size to allow immediate UI update
-						var newValue = (LayoutMode == FolderLayoutModes.TilesView) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeMax) ? value : Constants.Browser.GridViewBrowser.GridViewSizeMax;
+						var newValue = (LayoutMode == FolderLayoutModes.TilesView) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeLarge) ? value : Constants.Browser.GridViewBrowser.GridViewSizeLarge;
 						SetProperty(ref LayoutPreferencesItem.GridViewSize, newValue, nameof(GridViewSize));
 
 						// Only update layout mode if it isn't already in grid view
@@ -113,7 +113,7 @@ namespace Files.App.Data.Models
 						}
 
 						// Don't request a grid resize if it is already at the max size
-						if (value < Constants.Browser.GridViewBrowser.GridViewSizeMax)
+						if (value < Constants.Browser.GridViewBrowser.GridViewSizeLarge)
 							GridViewSizeChangeRequested?.Invoke(this, EventArgs.Empty);
 					}
 				}
@@ -312,14 +312,14 @@ namespace Files.App.Data.Models
 				FolderLayoutModes.ColumnView
 					=> Constants.Browser.ColumnViewBrowser.ColumnViewSize,
 				FolderLayoutModes.TilesView
-					=> Constants.Browser.GridViewBrowser.GridViewSizeSmall,
+					=> Constants.Browser.GridViewBrowser.TilesView,
 				_ when GridViewSize <= Constants.Browser.GridViewBrowser.GridViewSizeSmall
 					=> Constants.Browser.GridViewBrowser.GridViewSizeSmall,
 				_ when GridViewSize <= Constants.Browser.GridViewBrowser.GridViewSizeMedium
 					=> Constants.Browser.GridViewBrowser.GridViewSizeMedium,
 				_ when GridViewSize <= Constants.Browser.GridViewBrowser.GridViewSizeLarge
 					=> Constants.Browser.GridViewBrowser.GridViewSizeLarge,
-				_ => Constants.Browser.GridViewBrowser.GridViewSizeMax,
+				_ => Constants.Browser.GridViewBrowser.GridViewSizeLarge,
 			};
 		}
 

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -41,7 +41,7 @@ namespace Files.App.UserControls.Widgets
 		{
 			// Try load thumbnail using ListView mode
 			if (thumbnailData is null || thumbnailData.Length == 0)
-				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.Path, Convert.ToUInt32(Constants.DefaultIconSizes.ExtraLarge), Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
+				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.Path, Convert.ToUInt32(Constants.DefaultIconSizes.Jumbo), Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
 
 			// Thumbnail is still null, use DriveItem icon (loaded using SingleItem mode)
 			if (thumbnailData is null || thumbnailData.Length == 0)
@@ -52,7 +52,7 @@ namespace Files.App.UserControls.Widgets
 
 			// Thumbnail data is valid, set the item icon
 			if (thumbnailData is not null && thumbnailData.Length > 0)
-				Thumbnail = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(Constants.DefaultIconSizes.ExtraLarge));
+				Thumbnail = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(Constants.DefaultIconSizes.Jumbo));
 		}
 
 		public int CompareTo(DriveCardItem? other) => Item.Path.CompareTo(other?.Item?.Path);

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -41,7 +41,7 @@ namespace Files.App.UserControls.Widgets
 		{
 			// Try load thumbnail using ListView mode
 			if (thumbnailData is null || thumbnailData.Length == 0)
-				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.Path, Convert.ToUInt32(Constants.Widgets.WidgetIconSize), Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
+				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Item.Path, Convert.ToUInt32(Constants.DefaultIconSizes.ExtraLarge), Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
 
 			// Thumbnail is still null, use DriveItem icon (loaded using SingleItem mode)
 			if (thumbnailData is null || thumbnailData.Length == 0)
@@ -52,7 +52,7 @@ namespace Files.App.UserControls.Widgets
 
 			// Thumbnail data is valid, set the item icon
 			if (thumbnailData is not null && thumbnailData.Length > 0)
-				Thumbnail = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize));
+				Thumbnail = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(Constants.DefaultIconSizes.ExtraLarge));
 		}
 
 		public int CompareTo(DriveCardItem? other) => Item.Path.CompareTo(other?.Item?.Path);

--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -80,11 +80,11 @@ namespace Files.App.UserControls.Widgets
 		{
 			if (thumbnailData is null || thumbnailData.Length == 0)
 			{
-				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Path, Convert.ToUInt32(Constants.Widgets.WidgetIconSize), Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
+				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Path, Convert.ToUInt32(Constants.DefaultIconSizes.ExtraLarge), Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
 			}
 			if (thumbnailData is not null && thumbnailData.Length > 0)
 			{
-				Thumbnail = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(Constants.Widgets.WidgetIconSize));
+				Thumbnail = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(Constants.DefaultIconSizes.ExtraLarge));
 			}
 		}
 	}

--- a/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/QuickAccessWidget.xaml.cs
@@ -80,11 +80,11 @@ namespace Files.App.UserControls.Widgets
 		{
 			if (thumbnailData is null || thumbnailData.Length == 0)
 			{
-				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Path, Convert.ToUInt32(Constants.DefaultIconSizes.ExtraLarge), Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
+				thumbnailData = await FileThumbnailHelper.LoadIconFromPathAsync(Path, Convert.ToUInt32(Constants.DefaultIconSizes.Jumbo), Windows.Storage.FileProperties.ThumbnailMode.SingleItem, Windows.Storage.FileProperties.ThumbnailOptions.ResizeThumbnail);
 			}
 			if (thumbnailData is not null && thumbnailData.Length > 0)
 			{
-				Thumbnail = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(Constants.DefaultIconSizes.ExtraLarge));
+				Thumbnail = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(Constants.DefaultIconSizes.Jumbo));
 			}
 		}
 	}

--- a/src/Files.App/Utils/Cloud/CloudDrivesManager.cs
+++ b/src/Files.App/Utils/Cloud/CloudDrivesManager.cs
@@ -63,7 +63,7 @@ namespace Files.App.Utils.Cloud
 					ShowProperties = true,
 				};
 
-				var iconData = provider.IconData ?? await FileThumbnailHelper.LoadIconWithoutOverlayAsync(provider.SyncFolder, 24);
+				var iconData = provider.IconData ?? await FileThumbnailHelper.LoadIconWithoutOverlayAsync(provider.SyncFolder, 24, false, true);
 				if (iconData is not null)
 				{
 					cloudProviderItem.IconData = iconData;

--- a/src/Files.App/Utils/Cloud/CloudDrivesManager.cs
+++ b/src/Files.App/Utils/Cloud/CloudDrivesManager.cs
@@ -63,7 +63,7 @@ namespace Files.App.Utils.Cloud
 					ShowProperties = true,
 				};
 
-				var iconData = provider.IconData ?? await FileThumbnailHelper.LoadIconWithoutOverlayAsync(provider.SyncFolder, 24, false, true);
+				var iconData = provider.IconData ?? await FileThumbnailHelper.LoadIconWithoutOverlayAsync(provider.SyncFolder, Constants.DefaultIconSizes.Large, false, true);
 				if (iconData is not null)
 				{
 					cloudProviderItem.IconData = iconData;

--- a/src/Files.App/Utils/Library/LibraryLocationItem.cs
+++ b/src/Files.App/Utils/Library/LibraryLocationItem.cs
@@ -46,7 +46,7 @@ namespace Files.App.Utils.Library
 
 		public async Task LoadLibraryIconAsync()
 		{
-			IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Path, 24u);
+			IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Path, 24u, false, true);
 
 			if (IconData is not null)
 				Icon = await IconData.ToBitmapAsync();

--- a/src/Files.App/Utils/Library/LibraryLocationItem.cs
+++ b/src/Files.App/Utils/Library/LibraryLocationItem.cs
@@ -46,7 +46,7 @@ namespace Files.App.Utils.Library
 
 		public async Task LoadLibraryIconAsync()
 		{
-			IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Path, 24u, false, true);
+			IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Path, Constants.DefaultIconSizes.Large, false, true);
 
 			if (IconData is not null)
 				Icon = await IconData.ToBitmapAsync();

--- a/src/Files.App/Utils/RecentItem/RecentItem.cs
+++ b/src/Files.App/Utils/RecentItem/RecentItem.cs
@@ -76,7 +76,7 @@ namespace Files.App.Utils.RecentItem
 
 		public async Task LoadRecentItemIconAsync()
 		{
-			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(RecentPath, 96u, false, false);
+			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(RecentPath, Constants.DefaultIconSizes.Large, false, false);
 			if (iconData is not null)
 			{
 				EmptyImgVis = false;

--- a/src/Files.App/Utils/RecentItem/RecentItem.cs
+++ b/src/Files.App/Utils/RecentItem/RecentItem.cs
@@ -76,12 +76,8 @@ namespace Files.App.Utils.RecentItem
 
 		public async Task LoadRecentItemIconAsync()
 		{
-			var iconData = await FileThumbnailHelper.LoadIconFromPathAsync(RecentPath, 96u, ThumbnailMode.SingleItem, ThumbnailOptions.ResizeThumbnail);
-			if (iconData is null)
-			{
-				EmptyImgVis = true;
-			}
-			else
+			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(RecentPath, 96u, false, false);
+			if (iconData is not null)
 			{
 				EmptyImgVis = false;
 				FileImg = await iconData.ToBitmapAsync();

--- a/src/Files.App/Utils/Shell/Win32API.cs
+++ b/src/Files.App/Utils/Shell/Win32API.cs
@@ -228,7 +228,7 @@ namespace Files.App.Utils.Shell
 
 		private static readonly object _lock = new object();
 
-		public static (byte[]? icon, byte[]? overlay) GetFileIconAndOverlay(string path, int thumbnailSize, bool isFolder, bool getOverlay = true, bool onlyGetOverlay = false)
+		public static (byte[]? icon, byte[]? overlay) GetFileIconAndOverlay(string path, int thumbnailSize, bool isFolder, bool getIconOnly, bool getOverlay = true, bool onlyGetOverlay = false)
 		{
 			byte[]? iconData = null, overlayData = null;
 			var entry = _iconAndOverlayCache.GetOrAdd(path, _ => new());
@@ -256,7 +256,9 @@ namespace Files.App.Utils.Shell
 					if (shellItem is not null && shellItem.IShellItem is Shell32.IShellItemImageFactory fctry)
 					{
 						var flags = Shell32.SIIGBF.SIIGBF_BIGGERSIZEOK;
-						if (thumbnailSize < 80) flags |= Shell32.SIIGBF.SIIGBF_ICONONLY;
+
+						if (getIconOnly)
+							flags |= Shell32.SIIGBF.SIIGBF_ICONONLY;
 
 						var hres = fctry.GetImage(new SIZE(thumbnailSize, thumbnailSize), flags, out var hbitmap);
 						if (hres == HRESULT.S_OK)

--- a/src/Files.App/Utils/Storage/Helpers/FileThumbnailHelper.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FileThumbnailHelper.cs
@@ -9,17 +9,17 @@ namespace Files.App.Utils.Storage
 {
 	public static class FileThumbnailHelper
 	{
-		public static Task<(byte[] IconData, byte[] OverlayData)> LoadIconAndOverlayAsync(string filePath, uint thumbnailSize, bool isFolder = false)
-			=> Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, isFolder, true, false));
+		public static Task<(byte[] IconData, byte[] OverlayData)> LoadIconAndOverlayAsync(string filePath, uint thumbnailSize, bool isFolder = false, bool getIconOnly = false)
+			=> Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, isFolder, getIconOnly, true, false));
 
 		public static async Task<byte[]> LoadOverlayAsync(string filePath, uint thumbnailSize)
 		{
-			return (await Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, false, true, true))).overlay;
+			return (await Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, false, false, true, true))).overlay;
 		}
 
-		public static async Task<byte[]> LoadIconWithoutOverlayAsync(string filePath, uint thumbnailSize, bool isFolder = false)
+		public static async Task<byte[]> LoadIconWithoutOverlayAsync(string filePath, uint thumbnailSize, bool isFolder, bool getIconOnly)
 		{
-			return (await Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, isFolder, false))).icon;
+			return (await Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, isFolder, getIconOnly, false))).icon;
 		}
 
 		public static async Task<byte[]> LoadIconFromStorageItemAsync(IStorageItem item, uint thumbnailSize, ThumbnailMode thumbnailMode, ThumbnailOptions thumbnailOptions)
@@ -59,7 +59,7 @@ namespace Files.App.Utils.Storage
 					}
 				}
 			}
-			return await LoadIconWithoutOverlayAsync(filePath, thumbnailSize, isFolder);
+			return await LoadIconWithoutOverlayAsync(filePath, thumbnailSize, isFolder, false);
 		}
 	}
 }

--- a/src/Files.App/ViewModels/Properties/Items/DriveProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/DriveProperties.cs
@@ -56,10 +56,10 @@ namespace Files.App.ViewModels.Properties
 				}
 				else
 				{
-					ViewModel.IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Drive.Path, 80);
+					ViewModel.IconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Drive.Path, 80, false, false);
 				}
 
-				ViewModel.IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Drive.DeviceID, 80); // For network shortcuts
+				ViewModel.IconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Drive.DeviceID, 80, false, false); // For network shortcuts
 			}
 
 			if (diskRoot is null || diskRoot.Properties is null)

--- a/src/Files.App/ViewModels/Properties/Items/LibraryProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/LibraryProperties.cs
@@ -49,7 +49,7 @@ namespace Files.App.ViewModels.Properties
 			ViewModel.IsReadOnly = NativeFileOperationsHelper.HasFileAttribute(Library.ItemPath, System.IO.FileAttributes.ReadOnly);
 			ViewModel.IsHidden = NativeFileOperationsHelper.HasFileAttribute(Library.ItemPath, System.IO.FileAttributes.Hidden);
 
-			var fileIconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Library.ItemPath, 80);
+			var fileIconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Library.ItemPath, 80, false, false);
 			if (fileIconData is not null)
 			{
 				ViewModel.IconData = fileIconData;

--- a/src/Files.App/ViewModels/UserControls/Previews/BasePreviewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/BasePreviewModel.cs
@@ -85,7 +85,7 @@ namespace Files.App.ViewModels.Previews
 		public async virtual Task<List<FileProperty>> LoadPreviewAndDetailsAsync()
 		{
 			// Requesting sizes larger than 220 may result in a small thumbnail
-			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 220, false, false);
+			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, Constants.DefaultIconSizes.Jumbo, false, false);
 			if (iconData is not null)
 				await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () => FileImage = await iconData.ToBitmapAsync());
 			else

--- a/src/Files.App/ViewModels/UserControls/Previews/BasePreviewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/BasePreviewModel.cs
@@ -84,17 +84,12 @@ namespace Files.App.ViewModels.Previews
 		/// <returns>A list of details</returns>
 		public async virtual Task<List<FileProperty>> LoadPreviewAndDetailsAsync()
 		{
-			var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(Item.ItemFile, 256, ThumbnailMode.SingleItem, ThumbnailOptions.ResizeThumbnail);
-
-			iconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 256);
+			// Requesting sizes larger than 220 may result in a small thumbnail
+			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 220, false, false);
 			if (iconData is not null)
-			{
 				await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () => FileImage = await iconData.ToBitmapAsync());
-			}
 			else
-			{
 				FileImage ??= await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => new BitmapImage());
-			}
 
 			return new List<FileProperty>();
 		}

--- a/src/Files.App/ViewModels/UserControls/Previews/FolderPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/FolderPreviewViewModel.cs
@@ -30,9 +30,8 @@ namespace Files.App.ViewModels.Previews
 			Folder = await StorageFileExtensions.DangerousGetFolderFromPathAsync(Item.ItemPath, rootItem);
 			var items = await Folder.GetItemsAsync();
 
-			var iconData = await FileThumbnailHelper.LoadIconFromStorageItemAsync(Folder, 256, ThumbnailMode.SingleItem, ThumbnailOptions.ReturnOnlyIfCached);
-			iconData ??= await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 256, true);
-
+			// Requesting sizes larger than 220 may result in a thumbnail with a small folder
+			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 220, true, false);
 			if (iconData is not null)
 				Thumbnail = await iconData.ToBitmapAsync();
 

--- a/src/Files.App/ViewModels/UserControls/Previews/FolderPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/FolderPreviewViewModel.cs
@@ -31,7 +31,7 @@ namespace Files.App.ViewModels.Previews
 			var items = await Folder.GetItemsAsync();
 
 			// Requesting sizes larger than 220 may result in a thumbnail with a small folder
-			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 220, true, false);
+			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, Constants.DefaultIconSizes.Jumbo, true, false);
 			if (iconData is not null)
 				Thumbnail = await iconData.ToBitmapAsync();
 

--- a/src/Files.App/ViewModels/UserControls/Previews/ShortcutPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/ShortcutPreviewViewModel.cs
@@ -36,7 +36,7 @@ namespace Files.App.ViewModels.Previews
 
 		private async Task LoadItemThumbnailAsync()
 		{
-			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 256, false, false);
+			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, Constants.DefaultIconSizes.Jumbo, false, false);
 			if (iconData is not null)
 			{
 				FileImage = await iconData.ToBitmapAsync();

--- a/src/Files.App/ViewModels/UserControls/Previews/ShortcutPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/ShortcutPreviewViewModel.cs
@@ -36,7 +36,7 @@ namespace Files.App.ViewModels.Previews
 
 		private async Task LoadItemThumbnailAsync()
 		{
-			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 256);
+			var iconData = await FileThumbnailHelper.LoadIconWithoutOverlayAsync(Item.ItemPath, 256, false, false);
 			if (iconData is not null)
 			{
 				FileImage = await iconData.ToBitmapAsync();

--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
@@ -39,7 +39,7 @@ namespace Files.App.Views.Layouts
 
 		// Properties
 
-		protected override uint IconSize => Browser.ColumnViewBrowser.ColumnViewSizeSmall;
+		protected override uint IconSize => Constants.DefaultIconSizes.Large;
 		protected override ListViewBase ListViewBase => FileList;
 		protected override SemanticZoom RootZoom => RootGridZoom;
 

--- a/src/Files.App/Views/Layouts/ColumnsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnsLayoutPage.xaml.cs
@@ -20,7 +20,7 @@ namespace Files.App.Views.Layouts
 	{
 		// Properties
 
-		protected override uint IconSize => Browser.ColumnViewBrowser.ColumnViewSizeSmall;
+		protected override uint IconSize => Constants.DefaultIconSizes.Large;
 		protected override ItemsControl ItemsControl => ColumnHost;
 
 		public string? OwnerPath { get; private set; }

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -36,7 +36,7 @@ namespace Files.App.Views.Layouts
 		/// </summary>
 		public int GridViewItemMinWidth =>
 			FolderSettings.LayoutMode == FolderLayoutModes.TilesView
-				? Constants.Browser.GridViewBrowser.TilesView
+				? 260
 				: FolderSettings.GridViewSize;
 
 		public bool IsPointerOver


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- Simplified the code and improved the thumbnail quality
- Closes #14071
- Closes #10067

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Check that folder thumbnails display a preview of their contents (except for in the Details & Column layouts)
   2. Clear the thumbnail cache in Windows
   3. Check that opening a folder with images or office documents generates thumbnails (in OneDrive you might have to refresh the folder to display the thumbnails)
   4. Open a location with a lot of images (in the grid layout) and confirm that all the thumbnails are loaded
   5. Check that turning off the option to show thumbnails works as expected (it should auto refresh the current tab)
   6. Check that the preview/details pane shows the thumbnail for folders and images
   7. Check that the Recent Items widget loads the thumbnails as expected

**Screenshots (optional)**
![image](https://github.com/files-community/Files/assets/39923744/c5097582-8365-4212-8f28-e8ff26720a2f)
