### PR TITLE
Fix environment variables expansion for shortcuts

### DIFF
--- a/src/Files.App/Utils/Shell/ShellFolderExtensions.cs
+++ b/src/Files.App/Utils/Shell/ShellFolderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+using System;
 using System.IO;
 using Vanara.PInvoke;
 using Vanara.Windows.Shell;
@@ -127,8 +128,8 @@ namespace Files.App.Utils.Shell
 				IsFolder = !string.IsNullOrEmpty(linkItem.TargetPath) && linkItem.Target.IsFolder,
 				RunAsAdmin = linkItem.RunAsAdministrator,
 				Arguments = linkItem.Arguments,
-				WorkingDirectory = linkItem.WorkingDirectory,
-				TargetPath = linkItem.TargetPath
+				WorkingDirectory = Environment.ExpandEnvironmentVariables(linkItem.WorkingDirectory),
+				TargetPath = Environment.ExpandEnvironmentVariables(linkItem.TargetPath)
 			};
 
 			return link;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14410 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Create a shortcut and in its properties set/change its "Target:" field to `%WINDIR%\notepad.exe`
   2. Click the shortcut.
   3. In the stable version, nothing happens; after the modification, notepad.exe starts.

This modification applies to both "Destination (Target)" and "Start in".


