### PR TITLE
Fix: Fixed COMException in ItemsAdded_CollectionChanged - part 2

### DIFF
--- a/src/Files.App/Extensions/DispatcherQueueExtensions.cs
+++ b/src/Files.App/Extensions/DispatcherQueueExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using CommunityToolkit.WinUI;
 using Microsoft.UI.Dispatching;
-using System;
-using System.Threading.Tasks;
 
 namespace Files.App.Extensions
 {
@@ -14,7 +12,7 @@ namespace Files.App.Extensions
 			if (dispatcher is not null)
 				return dispatcher.EnqueueAsync(function, priority);
 			else
-				return function();
+				return SafetyExtensions.IgnoreExceptions(function, App.Logger);
 		}
 
 		public static Task<T> EnqueueOrInvokeAsync<T>(this DispatcherQueue? dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
@@ -22,7 +20,7 @@ namespace Files.App.Extensions
 			if (dispatcher is not null)
 				return dispatcher.EnqueueAsync(function, priority);
 			else
-				return function();
+				return SafetyExtensions.IgnoreExceptions(function, App.Logger);
 		}
 
 		public static Task EnqueueOrInvokeAsync(this DispatcherQueue? dispatcher, Action function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
@@ -31,7 +29,7 @@ namespace Files.App.Extensions
 				return dispatcher.EnqueueAsync(function, priority);
 			else
 			{
-				function();
+				SafetyExtensions.IgnoreExceptions(function, App.Logger);
 				return Task.CompletedTask;
 			}
 		}
@@ -41,7 +39,7 @@ namespace Files.App.Extensions
 			if (dispatcher is not null)
 				return dispatcher.EnqueueAsync(function, priority);
 			else
-				return Task.FromResult(function());
+				return Task.FromResult(SafetyExtensions.IgnoreExceptions(function, App.Logger));
 		}
 
 	}

--- a/src/Files.App/Extensions/DispatcherQueueExtensions.cs
+++ b/src/Files.App/Extensions/DispatcherQueueExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.WinUI;
 using Microsoft.UI.Dispatching;
+using System.Runtime.InteropServices;
 
 namespace Files.App.Extensions
 {
@@ -12,7 +13,7 @@ namespace Files.App.Extensions
 			if (dispatcher is not null)
 				return dispatcher.EnqueueAsync(function, priority);
 			else
-				return SafetyExtensions.IgnoreExceptions(function, App.Logger);
+				return SafetyExtensions.IgnoreExceptions(function, App.Logger, typeof(COMException));
 		}
 
 		public static Task<T> EnqueueOrInvokeAsync<T>(this DispatcherQueue? dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
@@ -20,7 +21,7 @@ namespace Files.App.Extensions
 			if (dispatcher is not null)
 				return dispatcher.EnqueueAsync(function, priority);
 			else
-				return SafetyExtensions.IgnoreExceptions(function, App.Logger);
+				return SafetyExtensions.IgnoreExceptions(function, App.Logger, typeof(COMException));
 		}
 
 		public static Task EnqueueOrInvokeAsync(this DispatcherQueue? dispatcher, Action function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
@@ -29,7 +30,7 @@ namespace Files.App.Extensions
 				return dispatcher.EnqueueAsync(function, priority);
 			else
 			{
-				SafetyExtensions.IgnoreExceptions(function, App.Logger);
+				SafetyExtensions.IgnoreExceptions(function, App.Logger, typeof(COMException));
 				return Task.CompletedTask;
 			}
 		}
@@ -39,7 +40,7 @@ namespace Files.App.Extensions
 			if (dispatcher is not null)
 				return dispatcher.EnqueueAsync(function, priority);
 			else
-				return Task.FromResult(SafetyExtensions.IgnoreExceptions(function, App.Logger));
+				return Task.FromResult(SafetyExtensions.IgnoreExceptions(function, App.Logger, typeof(COMException)));
 		}
 
 	}

--- a/src/Files.Shared/Extensions/SafetyExtensions.cs
+++ b/src/Files.Shared/Extensions/SafetyExtensions.cs
@@ -9,7 +9,7 @@ namespace Files.Shared.Extensions
 {
 	public static class SafetyExtensions
 	{
-		public static bool IgnoreExceptions(Action action, ILogger? logger = null)
+		public static bool IgnoreExceptions(Action action, ILogger? logger = null, Type? exceptionToIgnore = null)
 		{
 			try
 			{
@@ -18,13 +18,18 @@ namespace Files.Shared.Extensions
 			}
 			catch (Exception ex)
 			{
-				logger?.LogInformation(ex, ex.Message);
+				if (exceptionToIgnore is null || exceptionToIgnore.IsAssignableFrom(ex.GetType()))
+				{
+					logger?.LogInformation(ex, ex.Message);
 
-				return false;
+					return false;
+				}
+				else
+					throw;
 			}
 		}
 
-		public static async Task<bool> IgnoreExceptions(Func<Task> action, ILogger? logger = null)
+		public static async Task<bool> IgnoreExceptions(Func<Task> action, ILogger? logger = null, Type? exceptionToIgnore = null)
 		{
 			try
 			{
@@ -34,13 +39,18 @@ namespace Files.Shared.Extensions
 			}
 			catch (Exception ex)
 			{
-				logger?.LogInformation(ex, ex.Message);
+				if (exceptionToIgnore is null || exceptionToIgnore.IsAssignableFrom(ex.GetType()))
+				{
+					logger?.LogInformation(ex, ex.Message);
 
-				return false;
+					return false;
+				}
+				else
+					throw;
 			}
 		}
 
-		public static T? IgnoreExceptions<T>(Func<T> action, ILogger? logger = null)
+		public static T? IgnoreExceptions<T>(Func<T> action, ILogger? logger = null, Type? exceptionToIgnore = null)
 		{
 			try
 			{
@@ -48,13 +58,18 @@ namespace Files.Shared.Extensions
 			}
 			catch (Exception ex)
 			{
-				logger?.LogInformation(ex, ex.Message);
+				if (exceptionToIgnore is null || exceptionToIgnore.IsAssignableFrom(ex.GetType()))
+				{
+					logger?.LogInformation(ex, ex.Message);
 
-				return default;
+					return default;
+				}
+				else
+					throw;
 			}
 		}
 
-		public static async Task<T?> IgnoreExceptions<T>(Func<Task<T>> action, ILogger? logger = null)
+		public static async Task<T?> IgnoreExceptions<T>(Func<Task<T>> action, ILogger? logger = null, Type? exceptionToIgnore = null)
 		{
 			try
 			{
@@ -62,9 +77,14 @@ namespace Files.Shared.Extensions
 			}
 			catch (Exception ex)
 			{
-				logger?.LogInformation(ex, ex.Message);
+				if (exceptionToIgnore is null || exceptionToIgnore.IsAssignableFrom(ex.GetType()))
+				{
+					logger?.LogInformation(ex, ex.Message);
 
-				return default;
+					return default;
+				}
+				else
+					throw;
 			}
 		}
 


### PR DESCRIPTION
Most of the COMExceptions are caused by the unavailability of DispatcherQueue, so I ignored them in that case. It is not normal when DispatcherQueue is not available and it may not work correctly after ignoring the exception, but avoiding crashes may allow the user to continue using the application.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related to #14439

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?