### PR TITLE
Fix: Fixed issue where folders sizes weren't calculated when opening Properties from the sidebar

### DIFF
--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -1642,8 +1642,14 @@ namespace Files.App.Data.Models
 					});
 
 					rootFolder ??= await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderFromPathAsync(path));
-					if (rootFolder?.DisplayName is not null)
-						currentFolder.ItemNameRaw = rootFolder.DisplayName;
+					if (rootFolder is not null)
+					{
+						if (rootFolder.DisplayName is not null)
+							currentFolder.ItemNameRaw = rootFolder.DisplayName;
+
+						var syncStatus = await CheckCloudDriveSyncStatusAsync(rootFolder);
+						currentFolder.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
+					}
 
 					return 0;
 				}

--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -1691,7 +1691,7 @@ namespace Files.App.Data.Models
 				.FirstOrDefault()?.ItemPath;
 		}
 
-		private async Task<CloudDriveSyncStatus> CheckCloudDriveSyncStatusAsync(IStorageItem item)
+		public async Task<CloudDriveSyncStatus> CheckCloudDriveSyncStatusAsync(IStorageItem item)
 		{
 			int? syncStatus = null;
 			if (item is BaseStorageFile file && file.Properties is not null)

--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -1647,8 +1647,11 @@ namespace Files.App.Data.Models
 						if (rootFolder.DisplayName is not null)
 							currentFolder.ItemNameRaw = rootFolder.DisplayName;
 
-						var syncStatus = await CheckCloudDriveSyncStatusAsync(rootFolder);
-						currentFolder.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
+						if (!string.Equals(path, Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
+						{
+							var syncStatus = await CheckCloudDriveSyncStatusAsync(rootFolder);
+							currentFolder.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
+						}
 					}
 
 					return 0;

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -908,12 +908,14 @@ namespace Files.App.ViewModels.UserControls
 						ItemType = "Folder".GetLocalizedResource(),
 					};
 
-					BaseStorageFolder matchingStorageFolder = await PaneHolder.ActivePane.FilesystemViewModel.GetFolderFromPathAsync(locationItem.Path);
-
-					if (matchingStorageFolder is not null)
+					if (!string.Equals(locationItem.Path, Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
 					{
-						var syncStatus = await PaneHolder.ActivePane.FilesystemViewModel.CheckCloudDriveSyncStatusAsync(matchingStorageFolder);
-						listedItem.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
+						BaseStorageFolder matchingStorageFolder = await PaneHolder.ActivePane.FilesystemViewModel.GetFolderFromPathAsync(locationItem.Path);
+						if (matchingStorageFolder is not null)
+						{
+							var syncStatus = await PaneHolder.ActivePane.FilesystemViewModel.CheckCloudDriveSyncStatusAsync(matchingStorageFolder);
+							listedItem.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
+						}
 					}
 
 					FilePropertiesHelpers.OpenPropertiesWindow(listedItem, PaneHolder.ActivePane);

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -891,7 +891,7 @@ namespace Files.App.ViewModels.UserControls
 		private void OpenProperties(CommandBarFlyout menu)
 		{
 			EventHandler<object> flyoutClosed = null!;
-			flyoutClosed = (s, e) =>
+			flyoutClosed = async (s, e) =>
 			{
 				menu.Closed -= flyoutClosed;
 				if (rightClickedItem is DriveItem)
@@ -900,13 +900,21 @@ namespace Files.App.ViewModels.UserControls
 					FilePropertiesHelpers.OpenPropertiesWindow(new LibraryItem(library), PaneHolder.ActivePane);
 				else if (rightClickedItem is LocationItem locationItem)
 				{
-					ListedItem listedItem = new ListedItem(null!)
+					var listedItem = new ListedItem(null!)
 					{
 						ItemPath = locationItem.Path,
 						ItemNameRaw = locationItem.Text,
 						PrimaryItemAttribute = StorageItemTypes.Folder,
 						ItemType = "Folder".GetLocalizedResource(),
 					};
+
+					BaseStorageFolder matchingStorageFolder = await PaneHolder.ActivePane.FilesystemViewModel.GetFolderFromPathAsync(locationItem.Path);
+
+					if (matchingStorageFolder is not null)
+					{
+						var syncStatus = await PaneHolder.ActivePane.FilesystemViewModel.CheckCloudDriveSyncStatusAsync(matchingStorageFolder);
+						listedItem.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
+					}
 
 					FilePropertiesHelpers.OpenPropertiesWindow(listedItem, PaneHolder.ActivePane);
 				}

--- a/src/Files.App/Views/HomePage.xaml.cs
+++ b/src/Files.App/Views/HomePage.xaml.cs
@@ -245,7 +245,7 @@ namespace Files.App.Views
 			AppInstance.PaneHolder?.OpenPathInNewPane(e.Path);
 		}
 
-		private void QuickAccessWidget_CardPropertiesInvoked(object sender, QuickAccessCardEventArgs e)
+		private async void QuickAccessWidget_CardPropertiesInvoked(object sender, QuickAccessCardEventArgs e)
 		{
 			ListedItem listedItem = new(null!)
 			{
@@ -254,6 +254,14 @@ namespace Files.App.Views
 				PrimaryItemAttribute = StorageItemTypes.Folder,
 				ItemType = "Folder".GetLocalizedResource(),
 			};
+
+			BaseStorageFolder matchingStorageFolder = await AppInstance.FilesystemViewModel.GetFolderFromPathAsync(e.Item.Path);
+
+			if (matchingStorageFolder is not null)
+			{
+				var syncStatus = await AppInstance.FilesystemViewModel.CheckCloudDriveSyncStatusAsync(matchingStorageFolder);
+				listedItem.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
+			}
 
 			FilePropertiesHelpers.OpenPropertiesWindow(listedItem, AppInstance);
 		}

--- a/src/Files.App/Views/HomePage.xaml.cs
+++ b/src/Files.App/Views/HomePage.xaml.cs
@@ -255,12 +255,14 @@ namespace Files.App.Views
 				ItemType = "Folder".GetLocalizedResource(),
 			};
 
-			BaseStorageFolder matchingStorageFolder = await AppInstance.FilesystemViewModel.GetFolderFromPathAsync(e.Item.Path);
-
-			if (matchingStorageFolder is not null)
+			if (!string.Equals(e.Item.Path, Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
 			{
-				var syncStatus = await AppInstance.FilesystemViewModel.CheckCloudDriveSyncStatusAsync(matchingStorageFolder);
-				listedItem.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
+				BaseStorageFolder matchingStorageFolder = await AppInstance.FilesystemViewModel.GetFolderFromPathAsync(e.Item.Path);
+				if (matchingStorageFolder is not null)
+				{
+					var syncStatus = await AppInstance.FilesystemViewModel.CheckCloudDriveSyncStatusAsync(matchingStorageFolder);
+					listedItem.SyncStatusUI = CloudDriveSyncStatusUI.FromCloudDriveSyncStatus(syncStatus);
+				}
 			}
 
 			FilePropertiesHelpers.OpenPropertiesWindow(listedItem, AppInstance);


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13823

**Bug fixed in:**
- Sidebar
- Quick Access Widget
- Current folder (Toolbar or right-click context menu)

**Underlying issue**
Folders opened with one of the methods above were always classified as `FolderOnline` (default value)

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open app 
   2. Open properties of a pinned folder
   3. Open properties of a quick access folder from the `Home` widget
   4. Open properties of the current folder (using the toolbar button or the right-click context menu)
   5. Check size is being calculated by each `Properties` window

