### PR TITLE
Fix: Handle InvalidOperationException in RunPowershellCommandAsync

### DIFF
--- a/src/Files.App/Utils/Shell/Win32API.cs
+++ b/src/Files.App/Utils/Shell/Win32API.cs
@@ -387,6 +387,10 @@ namespace Files.App.Utils.Shell
 			{
 				return false;
 			}
+			catch (InvalidOperationException)
+			{
+				return false;
+			}
 			catch (Win32Exception)
 			{
 				// If user cancels UAC

--- a/src/Files.App/Utils/Shell/Win32API.cs
+++ b/src/Files.App/Utils/Shell/Win32API.cs
@@ -387,8 +387,9 @@ namespace Files.App.Utils.Shell
 			{
 				return false;
 			}
-			catch (InvalidOperationException)
+			catch (InvalidOperationException ex)
 			{
+				App.Logger.LogWarning(ex, ex.Message);
 				return false;
 			}
 			catch (Win32Exception)


### PR DESCRIPTION
### Handle InvalidOperationException in RunPowershellCommandAsync

```
System.InvalidOperationException: No process is associated with this object
System.Diagnostics
Process.WaitForExitAsync (CancellationToken cancellationToken)
Files.App.Utils.Shell
Win32API.RunPowershellCommandAsync (String command, Boolean runAsAdmin)
```