### PR TITLE
Fix: Fixed issue where opening tags from the sidebar would default to the Details View

### DIFF
--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -506,9 +506,11 @@ namespace Files.App.Views.Shells
 
 		public void NavigateToPath(string navigationPath, NavigationArguments? navArgs = null)
 		{
-			var layout = navigationPath.StartsWith("tag:")
-				? typeof(DetailsLayoutPage)
-				: FolderSettings.GetLayoutType(navigationPath);
+			var layout = FolderSettings.GetLayoutType(navigationPath);
+
+			// Don't use Columns Layout for displaying tags
+			if (navigationPath.StartsWith("tag:") && layout == typeof(ColumnsLayoutPage))
+				layout = typeof(DetailsLayoutPage);
 
 			NavigateToPath(navigationPath, layout, navArgs);
 		}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14511...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Set default layout to Tiles
   2. Open tag from the sidebar and confirm it uses the Tiles layout
   3. Set default layout to Columns
   4. Open tag from the sidebar and confirm it uses Details

**Screenshots (optional)**
Add screenshots here.
