### PR TITLE
Fix: Fixed issue where Format Drive option was visible for Cloud Drives

### DIFF
--- a/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
+++ b/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
@@ -117,7 +117,6 @@ namespace Files.App.Data.Models
 			get => driveFileSystem;
 			set
 			{
-				DriveFileSystemVisibility = true;
 				SetProperty(ref driveFileSystem, value);
 			}
 		}

--- a/src/Files.App/ViewModels/Properties/BasePropertiesPage.cs
+++ b/src/Files.App/ViewModels/Properties/BasePropertiesPage.cs
@@ -39,7 +39,10 @@ namespace Files.App.ViewModels.Properties
 				var props = new DriveProperties(ViewModel, drive, AppInstance);
 				BaseProperties = props;
 
-				ViewModel.FormatVisibility = !(props.Drive.Type == DriveType.Network || string.Equals(props.Drive.Path, "C:\\", StringComparison.OrdinalIgnoreCase));
+				ViewModel.FormatVisibility = !(props.Drive.Type == DriveType.Network
+					|| props.Drive.Type == DriveType.CloudDrive 
+					|| string.Equals(props.Drive.Path, "C:\\", StringComparison.OrdinalIgnoreCase));
+				ViewModel.DriveFileSystemVisibility = props.Drive.Type != DriveType.CloudDrive;
 				ViewModel.CleanupDriveCommand = new AsyncRelayCommand(() => StorageSenseHelper.OpenStorageSenseAsync(props.Drive.Path));
 				ViewModel.FormatDriveCommand = new RelayCommand(async () =>
 				{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14522...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open properties for a cloud drive and confirm "format drive" is hidden
   2. Open properties for non cloud drive and confirm "format drive" is visible

**Screenshots (optional)**
Add screenshots here.
