### PR TITLE
Fix: Fixed potential crash when opening properties for recent files

### DIFF
--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -352,7 +352,7 @@
     <value>The file you are attempting to access may have been moved or deleted.</value>
   </data>
   <data name="CannotAccessPropertiesTitle" xml:space="preserve">
-    <value>Cannot open properties for this file.</value>
+    <value>Cannot open properties for this file</value>
   </data>
   <data name="CannotAccessPropertiesContent" xml:space="preserve">
     <value>The file you are attempting to access may have been moved or deleted.</value>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -351,6 +351,12 @@
   <data name="FileNotFoundDialog.Text" xml:space="preserve">
     <value>The file you are attempting to access may have been moved or deleted.</value>
   </data>
+  <data name="CannotAccessPropertiesTitle" xml:space="preserve">
+    <value>Cannot open properties for this file.</value>
+  </data>
+  <data name="CannotAccessPropertiesContent" xml:space="preserve">
+    <value>The file you are attempting to access may have been moved or deleted.</value>
+  </data>
   <data name="FileNotFoundDialog.Title" xml:space="preserve">
     <value>File Not Found</value>
   </data>

--- a/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Xaml.Input;
 using System.Collections.Specialized;
 using System.IO;
 using System.Runtime.CompilerServices;
+using Windows.Foundation.Metadata;
 using Windows.System;
 
 namespace Files.App.UserControls.Widgets
@@ -247,8 +248,15 @@ namespace Files.App.UserControls.Widgets
 			flyoutClosed = async (s, e) =>
 			{
 				flyout!.Closed -= flyoutClosed;
-				var listedItem = await UniversalStorageEnumerator.AddFileAsync(await BaseStorageFile.GetFileFromPathAsync(item.Path), null, default);
-				FilePropertiesHelpers.OpenPropertiesWindow(listedItem, associatedInstance);
+
+				BaseStorageFile file = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFileFromPathAsync(item.Path));
+				if (file is null)
+					await RemoveRecentItemAsync(item);
+				else
+				{
+					var listedItem = await UniversalStorageEnumerator.AddFileAsync(file, null, default);
+					FilePropertiesHelpers.OpenPropertiesWindow(listedItem, associatedInstance);
+				}
 			};
 			flyout!.Closed += flyoutClosed;
 		}

--- a/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -251,7 +251,19 @@ namespace Files.App.UserControls.Widgets
 
 				BaseStorageFile file = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFileFromPathAsync(item.Path));
 				if (file is null)
-					await RemoveRecentItemAsync(item);
+				{
+					ContentDialog dialog = new()
+					{
+						Title = "CannotAccessPropertiesTitle".GetLocalizedResource(),
+						Content = "CannotAccessPropertiesContent".GetLocalizedResource(),
+						PrimaryButtonText = "Ok".GetLocalizedResource()
+					};
+
+					if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+						dialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
+
+					await dialog.TryShowAsync();
+				}
 				else
 				{
 					var listedItem = await UniversalStorageEnumerator.AddFileAsync(file, null, default);


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14512...

**Validation**
How did you test these changes?
- [ ] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open file from removable storage device
   2. Eject the storage device
   3. Right click the recent file and try opening properties
   4. Confirm that an error prompt is displayed

**Screenshots (optional)**
Add screenshots here.
