### PR TITLE
Fix: Fixed issue where search results would sometimes use the Columns View

### DIFF
--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -498,7 +498,7 @@ namespace Files.App.Views.Shells
 			if (layout == typeof(ColumnsLayoutPage))
 				NavigateToPath(FilesystemViewModel.WorkingDirectory, typeof(DetailsLayoutPage), args);
 			else
-				ItemDisplay.Navigate(layout, args);
+				NavigateToPath(FilesystemViewModel.WorkingDirectory, layout, args);
 		}
 
 		public void NavigateWithArguments(Type sourcePageType, NavigationArguments navArgs)

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -493,10 +493,12 @@ namespace Files.App.Views.Shells
 				SearchQuery = query,
 			};
 
-			if (this is ColumnShellPage)
+			var layout = InstanceViewModel.FolderSettings.GetLayoutType(FilesystemViewModel.WorkingDirectory);
+
+			if (layout == typeof(ColumnsLayoutPage))
 				NavigateToPath(FilesystemViewModel.WorkingDirectory, typeof(DetailsLayoutPage), args);
 			else
-				ItemDisplay.Navigate(InstanceViewModel.FolderSettings.GetLayoutType(FilesystemViewModel.WorkingDirectory), args);
+				ItemDisplay.Navigate(layout, args);
 		}
 
 		public void NavigateWithArguments(Type sourcePageType, NavigationArguments navArgs)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13439...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Set folder location to use Columns View
   2. Submit a search and confirm it uses the Details View to display the results
   3. Submit another search and confirm it's still using the Details View
   4. Go back to the original location and confirm it uses the Columns View

**Screenshots (optional)**
Add screenshots here.
