### PR TITLE
Fix: Fixed issue where drive folders in sidebar have wrong properies category

### DIFF
--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -202,6 +202,14 @@ namespace Files.App.Data.Items
 		{
 			get
 			{
+				if (Section == SectionType.Favorites)
+				{
+					return new OpacityIcon()
+					{
+						Style = Application.Current.Resources["SidebarFavouritesPinnedIcon"] as Style
+					};
+				}
+
 				if (!IsRemovable)
 					return null; // Removable items don't need the eject button
 

--- a/src/Files.App/Data/Models/SidebarPinnedModel.cs
+++ b/src/Files.App/Data/Models/SidebarPinnedModel.cs
@@ -135,7 +135,9 @@ namespace Files.App.Data.Models
 		{
 			var normalizedPath = PathNormalization.NormalizePath(path);
 			var matchingDrive = NetworkDrivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(netDrive => normalizedPath.Contains(PathNormalization.NormalizePath(netDrive.Path), StringComparison.OrdinalIgnoreCase));
-			matchingDrive ??= await CloudDrivesManager.CreateCloudDriveFromProviderAsync((await cloudDetector.DetectCloudProvidersAsync()).First(x => x.SyncFolder == path));
+			var cloudDriveProvider = (await cloudDetector.DetectCloudProvidersAsync()).FirstOrDefault(x => x.SyncFolder == path);
+			if (cloudDriveProvider is not null)
+				matchingDrive ??= await CloudDrivesManager.CreateCloudDriveFromProviderAsync(cloudDriveProvider);
 			matchingDrive ??= DrivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(drive => normalizedPath.Contains(PathNormalization.NormalizePath(drive.Path), StringComparison.OrdinalIgnoreCase));
 
 			if (matchingDrive is not null)

--- a/src/Files.App/Data/Models/SidebarPinnedModel.cs
+++ b/src/Files.App/Data/Models/SidebarPinnedModel.cs
@@ -59,13 +59,13 @@ namespace Files.App.Data.Models
 		/// <summary>
 		/// Returns the index of the location item in the navigation sidebar
 		/// </summary>
-		/// <param name="locationItem">The location item</param>
+		/// <param name="item">The location item</param>
 		/// <returns>Index of the item</returns>
-		public int IndexOfItem(INavigationControlItem locationItem)
+		public int IndexOfItem(INavigationControlItem item)
 		{
 			lock (favoriteList)
 			{
-				return favoriteList.FindIndex(x => x.Path == locationItem.Path);
+				return favoriteList.FindIndex(x => x.Path == item.Path);
 			}
 		}
 
@@ -173,7 +173,7 @@ namespace Files.App.Data.Models
 				if (favoriteList.Any(x => x.Path == item.Path))
 					return;
 
-				var lastItem = favoriteList.LastOrDefault(x => x.ItemType is NavigationControlItemType.Location);
+				var lastItem = favoriteList.LastOrDefault();
 				insertIndex = lastItem is not null ? favoriteList.IndexOf(lastItem) + 1 : 0;
 				favoriteList.Insert(insertIndex, item);
 			}

--- a/src/Files.App/Dialogs/ReorderSidebarItemsDialog.xaml
+++ b/src/Files.App/Dialogs/ReorderSidebarItemsDialog.xaml
@@ -21,7 +21,7 @@
 		<ListView x:Name="SidebarNavView" ItemsSource="{x:Bind ViewModel.SidebarFavoriteItems, Mode=OneWay}">
 
 			<ListView.ItemTemplate>
-				<DataTemplate x:DataType="dataitems:LocationItem">
+				<DataTemplate x:DataType="dataitems:INavigationControlItem">
 					<Grid
 						AllowDrop="True"
 						AutomationProperties.AutomationId="{x:Bind Text}"
@@ -48,8 +48,7 @@
 							HorizontalAlignment="Right"
 							DataContext="{x:Bind}"
 							Glyph="&#xE76F;"
-							PointerPressed="MoveItemAsync"
-							Visibility="{x:Bind IsPinned}" />
+							PointerPressed="MoveItemAsync" />
 
 					</Grid>
 				</DataTemplate>

--- a/src/Files.App/Dialogs/ReorderSidebarItemsDialog.xaml.cs
+++ b/src/Files.App/Dialogs/ReorderSidebarItemsDialog.xaml.cs
@@ -43,32 +43,32 @@ namespace Files.App.Dialogs
 
 		private void ListViewItem_DragStarting(object sender, DragStartingEventArgs e)
 		{
-			if (sender is not Grid nav || nav.DataContext is not LocationItem)
+			if (sender is not Grid nav || nav.DataContext is not INavigationControlItem)
 				return;
 
 			// Adding the original Location item dragged to the DragEvents data view
-			e.Data.Properties.Add("sourceLocationItem", nav);
+			e.Data.Properties.Add("sourceItem", nav);
 			e.AllowedOperations = DataPackageOperation.Move;
 		}
 
 		private void ListViewItem_DragOver(object sender, DragEventArgs e)
 		{
-			if ((sender as Grid)?.DataContext is not LocationItem locationItem)
+			if ((sender as Grid)?.DataContext is not INavigationControlItem item)
 				return;
 			var deferral = e.GetDeferral();
 			
-			if ((e.DataView.Properties["sourceLocationItem"] as Grid)?.DataContext is LocationItem sourceLocationItem)
+			if ((e.DataView.Properties["sourceItem"] as Grid)?.DataContext is INavigationControlItem sourceItem)
 			{
-				DragOver_SetCaptions(sourceLocationItem, locationItem, e);
+				DragOver_SetCaptions(sourceItem, item, e);
 			}
 
 			deferral.Complete();
 		}
 
-		private void DragOver_SetCaptions(LocationItem senderLocationItem, LocationItem sourceLocationItem, DragEventArgs e)
+		private void DragOver_SetCaptions(INavigationControlItem senderItem, INavigationControlItem sourceItem, DragEventArgs e)
 		{
 			// If the location item is the same as the original dragged item
-			if (sourceLocationItem.CompareTo(senderLocationItem) == 0)
+			if (sourceItem.CompareTo(senderItem) == 0)
 			{
 				e.AcceptedOperation = DataPackageOperation.None;
 				e.DragUIOverride.IsCaptionVisible = false;
@@ -83,11 +83,11 @@ namespace Files.App.Dialogs
 
 		private void ListViewItem_Drop(object sender, DragEventArgs e)
 		{
-			if (sender is not Grid navView || navView.DataContext is not LocationItem locationItem)
+			if (sender is not Grid navView || navView.DataContext is not INavigationControlItem item)
 				return;
 
-			if ((e.DataView.Properties["sourceLocationItem"] as Grid)?.DataContext is LocationItem sourceLocationItem)
-				ViewModel.SidebarFavoriteItems.Move(ViewModel.SidebarFavoriteItems.IndexOf(sourceLocationItem), ViewModel.SidebarFavoriteItems.IndexOf(locationItem));
+			if ((e.DataView.Properties["sourceItem"] as Grid)?.DataContext is INavigationControlItem sourceItem)
+				ViewModel.SidebarFavoriteItems.Move(ViewModel.SidebarFavoriteItems.IndexOf(sourceItem), ViewModel.SidebarFavoriteItems.IndexOf(item));
 		}
 
 		public new async Task<DialogResult> ShowAsync()

--- a/src/Files.App/ViewModels/Dialogs/ReorderSidebarItemsDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/ReorderSidebarItemsDialogViewModel.cs
@@ -14,11 +14,11 @@ namespace Files.App.ViewModels.Dialogs
 		public string HeaderText = "ReorderSidebarItemsDialogText".GetLocalizedResource();
 		public ICommand PrimaryButtonCommand { get; private set; }
 
-		public ObservableCollection<LocationItem> SidebarFavoriteItems = new(App.QuickAccessManager.Model.favoriteList
-			.Where(x => x is LocationItem loc && loc.Section is SectionType.Favorites && !loc.IsHeader)
-			.Cast<LocationItem>());
+		public ObservableCollection<INavigationControlItem> SidebarFavoriteItems = new(App.QuickAccessManager.Model.favoriteList
+			.Where(x => x is INavigationControlItem loc && loc.Section is SectionType.Favorites)
+			.Cast<INavigationControlItem>());
 
-		public ReorderSidebarItemsDialogViewModel() 
+		public ReorderSidebarItemsDialogViewModel()
 		{
 			//App.Logger.LogWarning(string.Join(", ", SidebarFavoriteItems.Select(x => x.Path)));
 			PrimaryButtonCommand = new RelayCommand(SaveChanges);


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14530 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. pin a drive to the side bar
   2. right click to open the properties window

**Screenshots (optional)**
![image](https://github.com/files-community/Files/assets/49156174/ad9e3b8c-669c-48da-a460-9428cd938f72)

