### PR TITLE
Fix: Fixed issue where thumbnails would sometimes fail to load in OneDrive

### DIFF
--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -1069,7 +1069,10 @@ namespace Files.App.Data.Models
 									var cancellationTokenSource = new CancellationTokenSource(3000);
 									// Loop until cached thumbnail is loaded or timeout is reached
 									while (!await LoadItemThumbnailAsync(item, thumbnailSize, matchingStorageFile))
+									{
+										await Task.Delay(100);
 										cancellationTokenSource.Token.ThrowIfCancellationRequested();
+									}
 								}
 							}
 

--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -1070,8 +1070,8 @@ namespace Files.App.Data.Models
 									// Loop until cached thumbnail is loaded or timeout is reached
 									while (!await LoadItemThumbnailAsync(item, thumbnailSize, matchingStorageFile))
 									{
-										await Task.Delay(100);
 										cancellationTokenSource.Token.ThrowIfCancellationRequested();
+										await Task.Delay(100);
 									}
 								}
 							}

--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -941,11 +941,8 @@ namespace Files.App.Data.Models
 		}
 
 		// ThumbnailSize is set to 96 so that unless we override it, mode is in turn set to SingleItem
-		private async Task LoadItemThumbnailAsync(ListedItem item, uint thumbnailSize = 96, IStorageItem? matchingStorageItem = null)
+		private async Task<bool> LoadItemThumbnailAsync(ListedItem item, uint thumbnailSize = 96, IStorageItem? matchingStorageItem = null)
 		{
-			var wasIconLoaded = false;
-
-
 			if (item.IsLibrary || item.PrimaryItemAttribute == StorageItemTypes.File || item.IsArchive)
 			{
 				var getIconOnly = UserSettingsService.FoldersSettingsService.ShowThumbnails == false;
@@ -972,6 +969,8 @@ namespace Files.App.Data.Models
 						item.ShieldIcon = await GetShieldIcon();
 					}, Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
 				}
+
+				return iconInfo.isIconCached;
 			}
 			else
 			{
@@ -993,6 +992,8 @@ namespace Files.App.Data.Models
 						item.ShieldIcon = await GetShieldIcon();
 					}, Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
 				}
+
+				return iconInfo.isIconCached;
 			}
 		}
 
@@ -1044,12 +1045,12 @@ namespace Files.App.Data.Models
 								if (matchingStorageFile is not null)
 								{
 									cts.Token.ThrowIfCancellationRequested();
-									await LoadItemThumbnailAsync(item, thumbnailSize, matchingStorageFile);
 
 									var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageFile);
 									var fileFRN = await FileTagsHelper.GetFileFRN(matchingStorageFile);
 									var fileTag = FileTagsHelper.ReadFileTag(item.ItemPath);
 									var itemType = (item.ItemType == "Folder".GetLocalizedResource()) ? item.ItemType : matchingStorageFile.DisplayType;
+
 									cts.Token.ThrowIfCancellationRequested();
 
 									await dispatcherQueue.EnqueueOrInvokeAsync(() =>
@@ -1064,6 +1065,11 @@ namespace Files.App.Data.Models
 
 									SetFileTag(item);
 									wasSyncStatusLoaded = true;
+
+									var cancellationTokenSource = new CancellationTokenSource(3000);
+									// Loop until cached thumbnail is loaded or timeout is reached
+									while (!await LoadItemThumbnailAsync(item, thumbnailSize, matchingStorageFile))
+										cancellationTokenSource.Token.ThrowIfCancellationRequested();
 								}
 							}
 

--- a/src/Files.App/Utils/Shell/Win32API.cs
+++ b/src/Files.App/Utils/Shell/Win32API.cs
@@ -242,15 +242,13 @@ namespace Files.App.Utils.Shell
 		/// <param name="getOverlay"></param>
 		/// <param name="onlyGetOverlay"></param>
 		/// <returns></returns>
-		public static (byte[]? icon, byte[]? overlay, bool isIconCached) GetFileIconAndOverlay
-		(
+		public static (byte[]? icon, byte[]? overlay, bool isIconCached) GetFileIconAndOverlay(
 			string path,
 			int thumbnailSize,
 			bool isFolder,
 			bool getIconOnly,
 			bool getOverlay = true,
-			bool onlyGetOverlay = false
-		)
+			bool onlyGetOverlay = false)
 		{
 			byte[]? iconData = null, overlayData = null;
 			bool isIconCached = false;

--- a/src/Files.App/Utils/Shell/Win32API.cs
+++ b/src/Files.App/Utils/Shell/Win32API.cs
@@ -228,9 +228,31 @@ namespace Files.App.Utils.Shell
 
 		private static readonly object _lock = new object();
 
-		public static (byte[]? icon, byte[]? overlay) GetFileIconAndOverlay(string path, int thumbnailSize, bool isFolder, bool getIconOnly, bool getOverlay = true, bool onlyGetOverlay = false)
+		/// <summary>
+		/// Returns an icon when a thumbnail isn't available or if getIconOnly is true
+		/// Returns an icon overlay when getOverlay is true
+		/// Returns a boolean indicating if the icon/thumbnail is cached
+		/// </summary>
+		/// <param name="path"></param>
+		/// <param name="thumbnailSize"></param>
+		/// <param name="isFolder"></param>
+		/// <param name="getIconOnly"></param>
+		/// <param name="getOverlay"></param>
+		/// <param name="onlyGetOverlay"></param>
+		/// <returns></returns>
+		public static (byte[]? icon, byte[]? overlay, bool isIconCached) GetFileIconAndOverlay
+		(
+			string path,
+			int thumbnailSize,
+			bool isFolder,
+			bool getIconOnly,
+			bool getOverlay = true,
+			bool onlyGetOverlay = false
+		)
 		{
 			byte[]? iconData = null, overlayData = null;
+			bool isIconCached = false;
+
 			var entry = _iconAndOverlayCache.GetOrAdd(path, _ => new());
 
 			if (entry.TryGetValue(thumbnailSize, out var cacheEntry))
@@ -242,34 +264,36 @@ namespace Files.App.Utils.Shell
 					(!getOverlay && iconData is not null) ||
 					(overlayData is not null && iconData is not null))
 				{
-					return (iconData, overlayData);
+					return (iconData, overlayData, true);
 				}
 			}
 
 			try
 			{
-				if (!onlyGetOverlay)
+				// Attempt to get file icon/thumbnail using IShellItemImageFactory GetImage
+				using var shellItem = SafetyExtensions.IgnoreExceptions(()
+					=> ShellFolderExtensions.GetShellItemFromPathOrPIDL(path));
+
+				if (shellItem is not null && shellItem.IShellItem is Shell32.IShellItemImageFactory shellFactory)
 				{
-					using var shellItem = SafetyExtensions.IgnoreExceptions(()
-						=> ShellFolderExtensions.GetShellItemFromPathOrPIDL(path));
+					var flags = Shell32.SIIGBF.SIIGBF_BIGGERSIZEOK;
 
-					if (shellItem is not null && shellItem.IShellItem is Shell32.IShellItemImageFactory fctry)
+					if (getIconOnly)
+						flags |= Shell32.SIIGBF.SIIGBF_ICONONLY;
+					else
+						flags |= Shell32.SIIGBF.SIIGBF_THUMBNAILONLY;
+
+					var hres = shellFactory.GetImage(new SIZE(thumbnailSize, thumbnailSize), flags, out var hbitmap);
+					if (hres == HRESULT.S_OK)
 					{
-						var flags = Shell32.SIIGBF.SIIGBF_BIGGERSIZEOK;
+						using var image = GetBitmapFromHBitmap(hbitmap);
+						if (image is not null)
+							iconData = (byte[]?)new ImageConverter().ConvertTo(image, typeof(byte[]));
 
-						if (getIconOnly)
-							flags |= Shell32.SIIGBF.SIIGBF_ICONONLY;
-
-						var hres = fctry.GetImage(new SIZE(thumbnailSize, thumbnailSize), flags, out var hbitmap);
-						if (hres == HRESULT.S_OK)
-						{
-							using var image = GetBitmapFromHBitmap(hbitmap);
-							if (image is not null)
-								iconData = (byte[]?)new ImageConverter().ConvertTo(image, typeof(byte[]));
-						}
-
-						//Marshal.ReleaseComObject(fctry);
+						isIconCached = true;
 					}
+
+					Marshal.ReleaseComObject(shellFactory);
 				}
 
 				if (getOverlay || (!onlyGetOverlay && iconData is null))
@@ -284,7 +308,7 @@ namespace Files.App.Utils.Shell
 						Shell32.SHGetFileInfo(pidl, 0, ref shfi, Shell32.SHFILEINFO.Size, Shell32.SHGFI.SHGFI_PIDL | flags) :
 						Shell32.SHGetFileInfo(path, isFolder ? FileAttributes.Directory : 0, ref shfi, Shell32.SHFILEINFO.Size, flags | (useFileAttibutes ? Shell32.SHGFI.SHGFI_USEFILEATTRIBUTES : 0));
 					if (ret == IntPtr.Zero)
-						return (iconData, null);
+						return (iconData, null, isIconCached);
 
 					User32.DestroyIcon(shfi.hIcon);
 
@@ -299,7 +323,7 @@ namespace Files.App.Utils.Shell
 					lock (_lock)
 					{
 						if (!Shell32.SHGetImageList(imageListSize, typeof(ComCtl32.IImageList).GUID, out var imageListOut).Succeeded)
-							return (iconData, null);
+							return (iconData, null, isIconCached);
 
 						var imageList = (ComCtl32.IImageList)imageListOut;
 
@@ -352,11 +376,11 @@ namespace Files.App.Utils.Shell
 						Marshal.ReleaseComObject(imageList);
 					}
 
-					return (iconData, overlayData);
+					return (iconData, overlayData, isIconCached);
 				}
 				else
 				{
-					return (iconData, null);
+					return (iconData, null, isIconCached);
 				}
 			}
 			finally

--- a/src/Files.App/Utils/Shell/Win32API.cs
+++ b/src/Files.App/Utils/Shell/Win32API.cs
@@ -229,9 +229,11 @@ namespace Files.App.Utils.Shell
 		private static readonly object _lock = new object();
 
 		/// <summary>
-		/// Returns an icon when a thumbnail isn't available or if getIconOnly is true
-		/// Returns an icon overlay when getOverlay is true
-		/// Returns a boolean indicating if the icon/thumbnail is cached
+		/// Returns an icon when a thumbnail isn't available or if getIconOnly is true.
+		/// <br/>
+		/// Returns an icon overlay when getOverlay is true.
+		/// <br/>
+		/// Returns a boolean indicating if the icon/thumbnail is cached.
 		/// </summary>
 		/// <param name="path"></param>
 		/// <param name="thumbnailSize"></param>

--- a/src/Files.App/Utils/Storage/Helpers/FileThumbnailHelper.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FileThumbnailHelper.cs
@@ -9,17 +9,12 @@ namespace Files.App.Utils.Storage
 {
 	public static class FileThumbnailHelper
 	{
-		public static Task<(byte[] IconData, byte[] OverlayData)> LoadIconAndOverlayAsync(string filePath, uint thumbnailSize, bool isFolder = false, bool getIconOnly = false)
-			=> Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, isFolder, getIconOnly, true, false));
-
-		public static async Task<byte[]> LoadOverlayAsync(string filePath, uint thumbnailSize)
-		{
-			return (await Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, false, false, true, true))).overlay;
-		}
+		public static Task<(byte[] IconData, byte[] OverlayData, bool isIconCached)> LoadIconAndOverlayAsync(string filePath, uint thumbnailSize, bool isFolder = false, bool getIconOnly = false)
+			=> Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, isFolder, getIconOnly));
 
 		public static async Task<byte[]> LoadIconWithoutOverlayAsync(string filePath, uint thumbnailSize, bool isFolder, bool getIconOnly)
 		{
-			return (await Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, isFolder, getIconOnly, false))).icon;
+			return (await Win32API.StartSTATask(() => Win32API.GetFileIconAndOverlay(filePath, (int)thumbnailSize, isFolder, getIconOnly))).icon;
 		}
 
 		public static async Task<byte[]> LoadIconFromStorageItemAsync(IStorageItem item, uint thumbnailSize, ThumbnailMode thumbnailMode, ThumbnailOptions thumbnailOptions)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14437...

**Validation**
How did you test these changes?
- [ ] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Confirm file icon is displayed and then replaced once the thumbnail is loaded

**Screenshots (optional)**
Add screenshots here.
