### PR TITLE
Code Quality: Fixed non-thread-safe code in BulkConcurrentObservableCollection.cs - part 4

### DIFF
--- a/src/Files.App/Utils/Storage/Collection/BulkConcurrentObservableCollection.cs
+++ b/src/Files.App/Utils/Storage/Collection/BulkConcurrentObservableCollection.cs
@@ -480,9 +480,9 @@ namespace Files.App.Utils.Storage
 			lock (syncRoot)
 			{
 				result = func.Invoke(collection);
-			}
 
-			ReplaceRange(0, result);
+				ReplaceRange(0, result);
+			}
 		}
 
 		public void OrderOne(Func<List<T>, IEnumerable<T>> func, T item)
@@ -491,12 +491,12 @@ namespace Files.App.Utils.Storage
 			lock (syncRoot)
 			{
 				result = func.Invoke(collection).ToList();
-			}
 
-			Remove(item);
-			var index = result.IndexOf(item);
-			if (index != -1)
-				Insert(index, item);
+				Remove(item);
+				var index = result.IndexOf(item);
+				if (index != -1)
+					Insert(index, item);
+			}
 		}
 
 		int IList.Add(object? value)

--- a/src/Files.App/Utils/Storage/Collection/BulkConcurrentObservableCollection.cs
+++ b/src/Files.App/Utils/Storage/Collection/BulkConcurrentObservableCollection.cs
@@ -12,8 +12,6 @@ namespace Files.App.Utils.Storage
 		protected bool isBulkOperationStarted;
 		private readonly object syncRoot = new object();
 		private readonly List<T> collection = new List<T>();
-		private readonly List<T> bulkNewItems = new List<T>();
-		private readonly List<T> bulkOldItems = new List<T>();
 
 		// When 'GroupOption' is set to 'None' or when a folder is opened, 'GroupedCollection' is assigned 'null' by 'ItemGroupKeySelector'
 		public BulkConcurrentObservableCollection<GroupedCollection<T>>? GroupedCollection { get; private set; }
@@ -144,22 +142,11 @@ namespace Files.App.Utils.Storage
 		{
 			if (IsGrouped)
 			{
-				if (!isBulkOperationStarted)
-				{
-					if (e.NewItems is not null)
-						AddItemsToGroup(e.NewItems.Cast<T>());
+				if (e.NewItems is not null)
+					AddItemsToGroup(e.NewItems.Cast<T>());
 
-					if (e.OldItems is not null)
-						RemoveItemsFromGroup(e.OldItems.Cast<T>());
-				}
-				else
-				{
-					if (e.NewItems is not null)
-						bulkNewItems.AddRange(e.NewItems.Cast<T>());
-
-					if (e.OldItems is not null)
-						bulkOldItems.AddRange(e.OldItems.Cast<T>());
-				}
+				if (e.OldItems is not null)
+					RemoveItemsFromGroup(e.OldItems.Cast<T>());
 			}
 		}
 
@@ -239,9 +226,6 @@ namespace Files.App.Utils.Storage
 
 		public virtual void EndBulkOperation()
 		{
-			List<T> newItems;
-			List<T> oldItems;
-
 			lock (syncRoot)
 			{
 				if (!isBulkOperationStarted)
@@ -251,19 +235,10 @@ namespace Files.App.Utils.Storage
 				GroupedCollection?.ForEach(gp => gp.EndBulkOperation());
 				GroupedCollection?.EndBulkOperation();
 
-				newItems = bulkNewItems.ToList();
-				oldItems = bulkOldItems.ToList();
-				bulkNewItems.Clear();
-				bulkOldItems.Clear();
-
 				OnCollectionChanged(EventArgsCache.ResetCollectionChanged);
 			}
 
-			if (IsGrouped)
-			{
-				AddItemsToGroup(newItems);
-				RemoveItemsFromGroup(oldItems);
-			}
+			UpdateGroups(EventArgsCache.ResetCollectionChanged);
 		}
 
 		public void Add(T? item)


### PR DESCRIPTION
This reverts commit 4e6f024337f7defd7eb86a21f5545fd71c0d6f71 and adds another fix.

Sorry, part 3 doesn't seem to make sense, so I would like to revert and add another fix.