### PR TITLE
Fix: Fixed issue where the app could crash when adding items from external apps

### DIFF
--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -676,51 +676,8 @@ namespace Files.App.Data.Models
 				// run safely without needs of dispatching to UI thread
 				void ApplyChanges()
 				{
-					var startIndex = -1;
-					var tempList = new List<ListedItem>();
-
-					void ApplyBulkInsertEntries()
-					{
-						if (startIndex != -1)
-						{
-							FilesAndFolders.ReplaceRange(startIndex, tempList);
-							startIndex = -1;
-							tempList.Clear();
-						}
-					}
-
-					for (var i = 0; i < filesAndFoldersLocal.Count; i++)
-					{
-						if (addFilesCTS.IsCancellationRequested)
-							return;
-
-						if (i < FilesAndFolders.Count)
-						{
-							if (FilesAndFolders[i] != filesAndFoldersLocal[i])
-							{
-								if (startIndex == -1)
-									startIndex = i;
-
-								tempList.Add(filesAndFoldersLocal[i]);
-							}
-							else
-							{
-								ApplyBulkInsertEntries();
-							}
-						}
-						else
-						{
-							ApplyBulkInsertEntries();
-							FilesAndFolders.InsertRange(i, filesAndFoldersLocal.Skip(i));
-
-							break;
-						}
-					}
-
-					ApplyBulkInsertEntries();
-
-					if (FilesAndFolders.Count > filesAndFoldersLocal.Count)
-						FilesAndFolders.RemoveRange(filesAndFoldersLocal.Count, FilesAndFolders.Count - filesAndFoldersLocal.Count);
+					FilesAndFolders.Clear();
+					FilesAndFolders.AddRange(filesAndFoldersLocal);
 
 					if (folderSettings.DirectoryGroupOption != GroupOption.None)
 						OrderGroups();

--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -676,12 +676,14 @@ namespace Files.App.Data.Models
 				// run safely without needs of dispatching to UI thread
 				void ApplyChanges()
 				{
+					if (addFilesCTS.IsCancellationRequested)
+						return;
+
 					FilesAndFolders.Clear();
 					FilesAndFolders.AddRange(filesAndFoldersLocal);
 
 					if (folderSettings.DirectoryGroupOption != GroupOption.None)
 						OrderGroups();
-
 				}
 
 				void UpdateUI()


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14169 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Open Downloads folder in Files.
   2. Download several files at the same time that take about 10 seconds to download in Edge.
   3. Delete downloaded files from the downloads list in Edge.
   4. Repeat 2. and 3.
   5. No longer crash.