### PR TITLE
Fix: Fixed issue where the privacy policy link was broken

### DIFF
--- a/src/Files.App/Constants.cs
+++ b/src/Files.App/Constants.cs
@@ -210,7 +210,7 @@ namespace Files.App
 			public const string DocumentationUrl = @"https://files.community/docs";
 			public const string FeatureRequestUrl = @"https://github.com/files-community/Files/issues/new?labels=feature+request&template=feature_request.yml";
 			public const string BugReportUrl = @"https://github.com/files-community/Files/issues/new?labels=bug&template=bug_report.yml";
-			public const string PrivacyPolicyUrl = @"https://github.com/files-community/Files/blob/main/Privacy.md";
+			public const string PrivacyPolicyUrl = @"https://github.com/files-community/Files/blob/main/.github/PRIVACY.md";
 			public const string SupportUsUrl = @"https://github.com/sponsors/yaira2";
 		}
 


### PR DESCRIPTION
## Summary

As the title.

## Steps To Validate Changes

1. Launch the app
2. Go to Settings
3. Go to About page
4. Click the link button

## PR Checklist

- [x] **Development**: Closes #14583
- [ ] **Approval**: Have discussed with and got approval from the team[^1]
- [x] **Tests**: Tested accessibility on the local end
- [x] **Deployment**: Deployed the app on the local end
- [ ] **Localization**: Modified en-US string resources[^2]
- [ ] **Co-authors**: _N/A_

## Screenshots

_N/A_

[^1]: If the request hasn't been agreed by the team, this work might be rejected. Make sure that you get approval from the team before opening any PR related the request.
[^2]: If you removed any en-US string resources, make sure that there are no references of those resources. When you add a new en-US string resources, do not make any changes on other languages' resources; [Crowdin](https://crowdin.com/project/files-app) will do that, instead.