### PR TITLE
Fix: Fixed issue where MenuFlyoutItemWithImage didn't use custom font

### DIFF
--- a/src/Files.App/ResourceDictionaries/MenuFlyoutSubItemWithImageStyle.xaml
+++ b/src/Files.App/ResourceDictionaries/MenuFlyoutSubItemWithImageStyle.xaml
@@ -7,6 +7,7 @@
 	<Style x:Key="MenuFlyoutSubItemWithImageStyle" TargetType="MenuFlyoutSubItem">
 		<Setter Property="Padding" Value="{ThemeResource MenuFlyoutItemThemePadding}" />
 		<Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+		<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="MenuFlyoutSubItem">

--- a/src/Files.App/UserControls/Menus/MenuFlyoutItemWithImage.xaml
+++ b/src/Files.App/UserControls/Menus/MenuFlyoutItemWithImage.xaml
@@ -14,6 +14,7 @@
 		<Style TargetType="local:MenuFlyoutItemWithImage">
 			<Setter Property="Padding" Value="{ThemeResource MenuFlyoutItemThemePadding}" />
 			<Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+			<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
 			<Setter Property="Template">
 				<Setter.Value>
 					<ControlTemplate TargetType="local:MenuFlyoutItemWithImage">


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related #12026...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Set custom font
   2. Right click context menu and confirm `MenuFlyoutItemWithImage` items use the custom font

**Screenshots (optional)**
Add screenshots here.
