### PR TITLE
Fix: Fixed issue where placeholders used the thumbnail instead of the icon

### DIFF
--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -973,7 +973,13 @@ namespace Files.App.Data.Models
 						item.FileImage = await iconInfo.IconData.ToBitmapAsync();
 
 						// Add the file icon to the DefaultIcons list
-						if (!DefaultIcons.ContainsKey(item.FileExtension.ToLowerInvariant()) && !string.IsNullOrEmpty(item.FileExtension))
+						if
+						(
+							!DefaultIcons.ContainsKey(item.FileExtension.ToLowerInvariant()) && 
+							!string.IsNullOrEmpty(item.FileExtension) &&
+							!item.IsShortcut &&
+							!item.IsExecutable
+						)
 						{
 							var fileIcon = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize, false, true);
 							var bitmapImage = await fileIcon.IconData.ToBitmapAsync();

--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -977,7 +977,7 @@ namespace Files.App.Data.Models
 						{
 							var fileIcon = await FileThumbnailHelper.LoadIconAndOverlayAsync(item.ItemPath, thumbnailSize, false, true);
 							var bitmapImage = await fileIcon.IconData.ToBitmapAsync();
-							DefaultIcons.Add(item.FileExtension.ToLowerInvariant(), bitmapImage);
+							DefaultIcons.TryAdd(item.FileExtension.ToLowerInvariant(), bitmapImage);
 						}
 
 					}, Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);

--- a/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
@@ -129,9 +129,12 @@ namespace Files.App.ViewModels.UserControls
 					else
 						SelectedItem = null;
 
-					var shouldUpdatePreview = ((MainWindow.Instance.Content as Frame)?.Content as MainPage)?.ViewModel.ShouldPreviewPaneBeActive;
-					if (shouldUpdatePreview == true)
-						_ = UpdateSelectedItemPreviewAsync();
+					if (!App.AppModel.IsMainWindowClosed)
+					{
+						var shouldUpdatePreview = ((MainWindow.Instance.Content as Frame)?.Content as MainPage)?.ViewModel.ShouldPreviewPaneBeActive;
+						if (shouldUpdatePreview == true)
+							_ = UpdateSelectedItemPreviewAsync();
+					}
 					break;
 			}
 		}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- This fixes an issue where placeholders for Office Documents and other file formats were created based on the thumbnail instead of the icon.
- This PR also adds placeholders for images files