### PR TITLE
Fix: Fixed null ref in OpenProperties

### DIFF
--- a/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -243,10 +243,11 @@ namespace Files.App.UserControls.Widgets
 
 		private void OpenProperties(RecentItem item)
 		{
-			if (item is null)
+			var flyout = HomePageContext.ItemContextFlyoutMenu;
+
+			if (item is null || flyout is null)
 				return;
 
-			var flyout = HomePageContext.ItemContextFlyoutMenu;
 			EventHandler<object> flyoutClosed = null!;
 			flyoutClosed = async (s, e) =>
 			{

--- a/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/RecentFilesWidget.xaml.cs
@@ -243,6 +243,9 @@ namespace Files.App.UserControls.Widgets
 
 		private void OpenProperties(RecentItem item)
 		{
+			if (item is null)
+				return;
+
 			var flyout = HomePageContext.ItemContextFlyoutMenu;
 			EventHandler<object> flyoutClosed = null!;
 			flyoutClosed = async (s, e) =>


### PR DESCRIPTION
Fixed System.NullReferenceException in RecentFilesWidget.OpenProperties (RecentItem item)