### PR TITLE
Fix: Fixed ArgumentOutOfRangeException in ItemViewModel

### DIFF
--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -698,51 +698,11 @@ namespace Files.App.Data.Models
 						{
 							FilesAndFolders.BeginBulkOperation();
 
-							var startIndex = -1;
-							var tempList = new List<ListedItem>();
+							if (addFilesCTS.IsCancellationRequested)
+								return;
 
-							void ApplyBulkInsertEntries()
-							{
-								if (startIndex != -1)
-								{
-									FilesAndFolders.ReplaceRange(startIndex, tempList);
-									startIndex = -1;
-									tempList.Clear();
-								}
-							}
-
-							for (var i = 0; i < filesAndFoldersLocal.Count; i++)
-							{
-								if (addFilesCTS.IsCancellationRequested)
-									return;
-
-								if (i < FilesAndFolders.Count)
-								{
-									if (FilesAndFolders[i] != filesAndFoldersLocal[i])
-									{
-										if (startIndex == -1)
-											startIndex = i;
-
-										tempList.Add(filesAndFoldersLocal[i]);
-									}
-									else
-									{
-										ApplyBulkInsertEntries();
-									}
-								}
-								else
-								{
-									ApplyBulkInsertEntries();
-									FilesAndFolders.InsertRange(i, filesAndFoldersLocal.Skip(i));
-
-									break;
-								}
-							}
-
-							ApplyBulkInsertEntries();
-
-							if (FilesAndFolders.Count > filesAndFoldersLocal.Count)
-								FilesAndFolders.RemoveRange(filesAndFoldersLocal.Count, FilesAndFolders.Count - filesAndFoldersLocal.Count);
+							FilesAndFolders.Clear();
+							FilesAndFolders.AddRange(filesAndFoldersLocal);
 
 							if (folderSettings.DirectoryGroupOption != GroupOption.None)
 								OrderGroups();
@@ -1015,7 +975,7 @@ namespace Files.App.Data.Models
 						// Add the file icon to the DefaultIcons list
 						if
 						(
-							!DefaultIcons.ContainsKey(item.FileExtension.ToLowerInvariant()) && 
+							!DefaultIcons.ContainsKey(item.FileExtension.ToLowerInvariant()) &&
 							!string.IsNullOrEmpty(item.FileExtension) &&
 							!item.IsShortcut &&
 							!item.IsExecutable

--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -789,10 +789,6 @@ namespace Files.App.Data.Models
 
 		private Task OrderFilesAndFoldersAsync()
 		{
-			// Sorting group contents is handled elsewhere
-			if (folderSettings.DirectoryGroupOption != GroupOption.None)
-				return Task.CompletedTask;
-
 			void OrderEntries()
 			{
 				if (filesAndFolders.Count == 0)
@@ -869,7 +865,7 @@ namespace Files.App.Data.Models
 				var isSemaphoreReleased = false;
 				try
 				{
-					await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
+					await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 					{
 						try
 						{
@@ -883,10 +879,6 @@ namespace Files.App.Data.Models
 									return;
 
 								OrderGroups();
-							}
-							else
-							{
-								await OrderFilesAndFoldersAsync();
 							}
 
 							if (token.IsCancellationRequested)


### PR DESCRIPTION
`BeginBulkOperation` suppresses `CollectionChanged` and allows changing the collection in non-UI threads. But changing the collection still needs to be done in UI threads, because changes in non-UI threads may not be seen from UI threads soon due to the memory cache.
This PR puts all `FilesAndFolders` operations into UI threads. This may affect UI performance, but `ArgumentOutOfRangeException` should no longer be thrown.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14169 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?