### PR TITLE
Fix: Fixed crash that would occur when Git path contained an emoji

### DIFF
--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -8,6 +8,7 @@ using Microsoft.AppCenter.Analytics;
 using Microsoft.Extensions.Logging;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -95,7 +96,7 @@ namespace Files.App.Utils.Git
 						? path
 						: GetGitRepositoryPath(PathNormalization.GetParentDir(path), root);
 			}
-			catch (LibGit2SharpException ex)
+			catch (Exception ex) when (ex is LibGit2SharpException or EncoderFallbackException)
 			{
 				_logger.LogWarning(ex.Message);
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- Fixed crash that would occur when Git path contained an emoji
```
StrictFilePathMarshaler.MarshalManagedToNative (Object managedObj)
/_/LibGit2Sharp/Core/FilePathMarshaler.cs, line 76
System.Text.EncoderFallbackException: Unable to translate Unicode character \\uDC83 at index 24 to specified code page
```