### PR TITLE
Code Quality: Added default icon sizes to LayoutSettingsService

### DIFF
--- a/src/Files.App/Helpers/Layout/LayoutPreferencesItem.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesItem.cs
@@ -19,7 +19,13 @@ namespace Files.App.Helpers
 		public bool SortDirectoriesAlongsideFiles;
 		public bool SortFilesFirst;
 		public bool IsAdaptiveLayoutOverridden;
-		public int GridViewSize;
+
+		// Icon sizes
+		public int IconSizeDetailsView;
+		public int IconSizeListView;
+		public int IconSizeTilesView;
+		public int IconSizeGridView;
+		public int IconSizeColumnsView;
 
 		public FolderLayoutModes LayoutMode;
 
@@ -37,7 +43,11 @@ namespace Files.App.Helpers
 			var defaultLayout = UserSettingsService.FoldersSettingsService.DefaultLayoutMode;
 
 			LayoutMode = defaultLayout is FolderLayoutModes.Adaptive ? FolderLayoutModes.DetailsView : defaultLayout;
-			GridViewSize = UserSettingsService.LayoutSettingsService.DefaultGridViewSize;
+			IconSizeDetailsView = UserSettingsService.LayoutSettingsService.DefaultIconSizeDetailsView;
+			IconSizeListView = UserSettingsService.LayoutSettingsService.DefaultIconSizeListView;
+			IconSizeTilesView = UserSettingsService.LayoutSettingsService.DefaulIconSizeTilesView;
+			IconSizeGridView = UserSettingsService.LayoutSettingsService.DefaulIconSizeGridView;
+			IconSizeColumnsView = UserSettingsService.LayoutSettingsService.DefaultIconSizeColumnsView;
 			DirectorySortOption = UserSettingsService.FoldersSettingsService.DefaultSortOption;
 			DirectoryGroupOption = UserSettingsService.FoldersSettingsService.DefaultGroupOption;
 			DirectorySortDirection = UserSettingsService.FoldersSettingsService.DefaultDirectorySortDirection;
@@ -68,11 +78,11 @@ namespace Files.App.Helpers
 			ColumnsViewModel.DateCreatedColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.DateCreatedColumnWidth;
 			ColumnsViewModel.ItemTypeColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.TypeColumnWidth;
 			ColumnsViewModel.SizeColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.SizeColumnWidth;
-			ColumnsViewModel.GitStatusColumn.UserLengthPixels= UserSettingsService.FoldersSettingsService.GitStatusColumnWidth;
-			ColumnsViewModel.GitLastCommitDateColumn.UserLengthPixels= UserSettingsService.FoldersSettingsService.GitLastCommitDateColumnWidth;
-			ColumnsViewModel.GitLastCommitMessageColumn.UserLengthPixels= UserSettingsService.FoldersSettingsService.GitLastCommitMessageColumnWidth;
-			ColumnsViewModel.GitCommitAuthorColumn.UserLengthPixels= UserSettingsService.FoldersSettingsService.GitCommitAuthorColumnWidth;
-			ColumnsViewModel.GitLastCommitShaColumn.UserLengthPixels= UserSettingsService.FoldersSettingsService.GitLastCommitShaColumnWidth;
+			ColumnsViewModel.GitStatusColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.GitStatusColumnWidth;
+			ColumnsViewModel.GitLastCommitDateColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.GitLastCommitDateColumnWidth;
+			ColumnsViewModel.GitLastCommitMessageColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.GitLastCommitMessageColumnWidth;
+			ColumnsViewModel.GitCommitAuthorColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.GitCommitAuthorColumnWidth;
+			ColumnsViewModel.GitLastCommitShaColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.GitLastCommitShaColumnWidth;
 			ColumnsViewModel.TagColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.TagColumnWidth;
 			ColumnsViewModel.DateDeletedColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.DateDeletedColumnWidth;
 			ColumnsViewModel.PathColumn.UserLengthPixels = UserSettingsService.FoldersSettingsService.PathColumnWidth;
@@ -94,7 +104,11 @@ namespace Files.App.Helpers
 			{
 				return (
 					item.LayoutMode == LayoutMode &&
-					item.GridViewSize == GridViewSize &&
+					item.IconSizeDetailsView == IconSizeDetailsView &&
+					item.IconSizeListView == IconSizeListView &&
+					item.IconSizeTilesView == IconSizeTilesView &&
+					item.IconSizeGridView == IconSizeGridView &&
+					item.IconSizeColumnsView == IconSizeColumnsView &&
 					item.DirectoryGroupOption == DirectoryGroupOption &&
 					item.DirectorySortOption == DirectorySortOption &&
 					item.DirectorySortDirection == DirectorySortDirection &&
@@ -113,7 +127,11 @@ namespace Files.App.Helpers
 			HashCode hash = new();
 
 			hash.Add(LayoutMode);
-			hash.Add(GridViewSize);
+			hash.Add(IconSizeDetailsView);
+			hash.Add(IconSizeListView);
+			hash.Add(IconSizeTilesView);
+			hash.Add(IconSizeGridView);
+			hash.Add(IconSizeColumnsView);
 			hash.Add(DirectoryGroupOption);
 			hash.Add(DirectorySortOption);
 			hash.Add(DirectorySortDirection);

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
@@ -42,11 +42,11 @@ namespace Files.App.Data.Models
 
 		public int GridViewSize
 		{
-			get => LayoutPreferencesItem.GridViewSize;
+			get => LayoutPreferencesItem.IconSizeGridView;
 			set
 			{
 				// Size down
-				if (value < LayoutPreferencesItem.GridViewSize)
+				if (value < LayoutPreferencesItem.IconSizeGridView)
 				{
 					// Size down from List to Details
 					if (LayoutMode == FolderLayoutModes.ListView)
@@ -74,7 +74,7 @@ namespace Files.App.Data.Models
 					{
 						// Set grid size to allow immediate UI update
 						var newValue = (value >= Constants.Browser.GridViewBrowser.GridViewSizeSmall) ? value : Constants.Browser.GridViewBrowser.GridViewSizeSmall;
-						SetProperty(ref LayoutPreferencesItem.GridViewSize, newValue, nameof(GridViewSize));
+						SetProperty(ref LayoutPreferencesItem.IconSizeGridView, newValue, nameof(GridViewSize));
 
 						// Only update layout mode if it isn't already in grid view
 						if (LayoutMode != FolderLayoutModes.GridView)
@@ -92,7 +92,7 @@ namespace Files.App.Data.Models
 					}
 				}
 				// Size up
-				else if (value > LayoutPreferencesItem.GridViewSize)
+				else if (value > LayoutPreferencesItem.IconSizeGridView)
 				{
 					// Size up from Details to List
 					if (LayoutMode == FolderLayoutModes.DetailsView)
@@ -112,7 +112,7 @@ namespace Files.App.Data.Models
 					{
 						// Set grid size to allow immediate UI update
 						var newValue = (LayoutMode == FolderLayoutModes.TilesView) ? Constants.Browser.GridViewBrowser.GridViewSizeSmall : (value <= Constants.Browser.GridViewBrowser.GridViewSizeLarge) ? value : Constants.Browser.GridViewBrowser.GridViewSizeLarge;
-						SetProperty(ref LayoutPreferencesItem.GridViewSize, newValue, nameof(GridViewSize));
+						SetProperty(ref LayoutPreferencesItem.IconSizeGridView, newValue, nameof(GridViewSize));
 
 						// Only update layout mode if it isn't already in grid view
 						if (LayoutMode != FolderLayoutModes.GridView)
@@ -329,13 +329,17 @@ namespace Files.App.Data.Models
 					=> Constants.DefaultIconSizes.Large,
 				FolderLayoutModes.TilesView
 					=> Constants.Browser.GridViewBrowser.TilesView,
-				_ when GridViewSize <= Constants.Browser.GridViewBrowser.GridViewSizeSmall
-					=> Constants.Browser.GridViewBrowser.GridViewSizeSmall,
-				_ when GridViewSize <= Constants.Browser.GridViewBrowser.GridViewSizeMedium
-					=> Constants.Browser.GridViewBrowser.GridViewSizeMedium,
-				_ when GridViewSize <= Constants.Browser.GridViewBrowser.GridViewSizeLarge
-					=> Constants.Browser.GridViewBrowser.GridViewSizeLarge,
-				_ => Constants.Browser.GridViewBrowser.GridViewSizeLarge,
+				_ when GridViewSize <= 64
+					=> 64,
+				_ when GridViewSize <= 72
+					=> 72,
+				_ when GridViewSize <= 96
+					=> 96,
+				_ when GridViewSize <= 128
+					=> 128,
+				_ when GridViewSize <= 180
+					=> 180,
+				_ => 256,
 			};
 		}
 
@@ -431,7 +435,7 @@ namespace Files.App.Data.Models
 
 			LayoutModeChangeRequested?.Invoke(this, new LayoutModeEventArgs(FolderLayoutModes.TilesView, GridViewSize));
 		}
-		
+
 		public void ToggleLayoutModeList(bool manuallySet)
 		{
 			IsAdaptiveLayoutEnabled &= !manuallySet;
@@ -534,7 +538,11 @@ namespace Files.App.Data.Models
 			else
 			{
 				UserSettingsService.FoldersSettingsService.DefaultLayoutMode = preferencesItem.LayoutMode;
-				UserSettingsService.LayoutSettingsService.DefaultGridViewSize = preferencesItem.GridViewSize;
+				UserSettingsService.LayoutSettingsService.DefaultIconSizeDetailsView = preferencesItem.IconSizeDetailsView;
+				UserSettingsService.LayoutSettingsService.DefaultIconSizeListView = preferencesItem.IconSizeListView;
+				UserSettingsService.LayoutSettingsService.DefaulIconSizeTilesView = preferencesItem.IconSizeTilesView;
+				UserSettingsService.LayoutSettingsService.DefaulIconSizeGridView = preferencesItem.IconSizeGridView;
+				UserSettingsService.LayoutSettingsService.DefaultIconSizeColumnsView = preferencesItem.IconSizeColumnsView;
 
 				// Do not save options which only work in recycle bin or cloud folders or search results as global
 				if (preferencesItem.DirectorySortOption != SortOption.Path &&

--- a/src/Files.App/Services/Settings/LayoutSettingsService.cs
+++ b/src/Files.App/Services/Settings/LayoutSettingsService.cs
@@ -1,9 +1,6 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Files.App.Utils.Serialization;
-using Files.Core.Services.Settings;
-
 namespace Files.App.Services.Settings
 {
 	internal sealed class LayoutSettingsService : BaseObservableJsonSettings, ILayoutSettingsService
@@ -14,9 +11,33 @@ namespace Files.App.Services.Settings
 			RegisterSettingsContext(settingsSharingContext);
 		}
 
-		public int DefaultGridViewSize
+		public int DefaultIconSizeDetailsView
+		{
+			get => (int)Get((long)Constants.DefaultIconSizes.Large);
+			set => Set((long)value);
+		}
+
+		public int DefaultIconSizeListView
+		{
+			get => (int)Get((long)Constants.DefaultIconSizes.Large);
+			set => Set((long)value);
+		}
+
+		public int DefaulIconSizeTilesView
 		{
 			get => (int)Get((long)Constants.Browser.GridViewBrowser.GridViewSizeMedium);
+			set => Set((long)value);
+		}
+
+		public int DefaulIconSizeGridView
+		{
+			get => (int)Get((long)Constants.Browser.GridViewBrowser.GridViewSizeMedium);
+			set => Set((long)value);
+		}
+
+		public int DefaultIconSizeColumnsView
+		{
+			get => (int)Get((long)Constants.DefaultIconSizes.Large);
 			set => Set((long)value);
 		}
 	}

--- a/src/Files.Core/Services/Settings/ILayoutSettingsService.cs
+++ b/src/Files.Core/Services/Settings/ILayoutSettingsService.cs
@@ -1,12 +1,33 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using System.ComponentModel;
-
 namespace Files.Core.Services.Settings
 {
 	public interface ILayoutSettingsService : IBaseSettingsService, INotifyPropertyChanged
 	{
-		int DefaultGridViewSize { get; set; }
+		/// <summary>
+		/// Default icon size in the Details View
+		/// </summary>
+		int DefaultIconSizeDetailsView { get; set; }
+
+		/// <summary>
+		/// Default icon size in the List View
+		/// </summary>
+		int DefaultIconSizeListView { get; set; }
+
+		/// <summary>
+		/// Default icon size in the Tiles View
+		/// </summary>
+		int DefaulIconSizeTilesView { get; set; }
+
+		/// <summary>
+		/// Default icon size in the Grid View
+		/// </summary>
+		int DefaulIconSizeGridView { get; set; }
+
+		/// <summary>
+		/// Default icon size in the Columns View
+		/// </summary>
+		int DefaultIconSizeColumnsView { get; set; }
 	}
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related #10492

**Validation**
How did you test these changes?
- [ ] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Switch to Grid View
   2. Change icon size (ctrl + +/-)
   3. Navigate to a different folder and then back to the original folder
   4. Confirm the custom size is used

**Screenshots (optional)**
Add screenshots here.
