### PR TITLE
Fix: FIxed some changes in the properties window cannot be canceled

### DIFF
--- a/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
+++ b/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
@@ -558,7 +558,18 @@ namespace Files.App.Data.Models
 		public string ShortcutItemPath
 		{
 			get => shortcutItemPath;
-			set => SetProperty(ref shortcutItemPath, value);
+			set
+			{
+				SetProperty(ref shortcutItemPath, value);
+				ShortcutItemPathUserEditableValue = value;
+			}
+		}
+
+		private string shortcutItemPathUserEditableValue;
+		public string ShortcutItemPathUserEditableValue
+		{
+			get => shortcutItemPathUserEditableValue;
+			set => SetProperty(ref shortcutItemPathUserEditableValue, value);
 		}
 
 		private bool isShortcutItemPathReadOnly;
@@ -572,7 +583,18 @@ namespace Files.App.Data.Models
 		public string ShortcutItemWorkingDir
 		{
 			get => shortcutItemWorkingDir;
-			set => SetProperty(ref shortcutItemWorkingDir, value);
+			set
+			{
+				SetProperty(ref shortcutItemWorkingDir, value);
+				ShortcutItemWorkingDirUserEditableValue = value;
+			}
+		}
+
+		private string shortcutItemWorkingDirUserEditableValue;
+		public string ShortcutItemWorkingDirUserEditableValue
+		{
+			get => shortcutItemWorkingDirUserEditableValue;
+			set => SetProperty(ref shortcutItemWorkingDirUserEditableValue, value);
 		}
 
 		private bool shortcutItemWorkingDirVisibility = false;
@@ -589,6 +611,17 @@ namespace Files.App.Data.Models
 			set
 			{
 				SetProperty(ref shortcutItemArguments, value);
+				ShortcutItemArgumentsUserEditableValue = value;
+			}
+		}
+
+		private string shortcutItemArgumentsUserEditableValue;
+		public string ShortcutItemArgumentsUserEditableValue
+		{
+			get => shortcutItemArgumentsUserEditableValue;
+			set
+			{
+				SetProperty(ref shortcutItemArgumentsUserEditableValue, value);
 			}
 		}
 
@@ -648,6 +681,18 @@ namespace Files.App.Data.Models
 			{
 				IsReadOnlyEnabled = true;
 				SetProperty(ref isReadOnly, value);
+				IsReadOnlyUserEditableValue = value;
+			}
+		}
+
+		private bool isReadOnlyUserEditableValue;
+		public bool IsReadOnlyUserEditableValue
+		{
+			get => isReadOnlyUserEditableValue;
+			set
+			{
+				IsReadOnlyEnabled = true;
+				SetProperty(ref isReadOnlyUserEditableValue, value);
 			}
 		}
 
@@ -662,7 +707,18 @@ namespace Files.App.Data.Models
 		public bool IsHidden
 		{
 			get => isHidden;
-			set => SetProperty(ref isHidden, value);
+			set
+			{
+				SetProperty(ref isHidden, value);
+				IsHiddenUserEditableValue = value;
+			}
+		}
+
+		private bool isHiddenUserEditableValue;
+		public bool IsHiddenUserEditableValue
+		{
+			get => isHiddenUserEditableValue;
+			set => SetProperty(ref isHiddenUserEditableValue, value);
 		}
 
 		private bool runAsAdmin;
@@ -673,6 +729,18 @@ namespace Files.App.Data.Models
 			{
 				RunAsAdminEnabled = true;
 				SetProperty(ref runAsAdmin, value);
+				RunAsAdminUserEditableValue = value;
+			}
+		}
+
+		private bool runAsAdminUserEditableValue;
+		public bool RunAsAdminUserEditableValue
+		{
+			get => runAsAdminUserEditableValue;
+			set
+			{
+				RunAsAdminEnabled = true;
+				SetProperty(ref runAsAdminUserEditableValue, value);
 			}
 		}
 

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -266,7 +266,7 @@ namespace Files.App.ViewModels.Properties
 		{
 			switch (e.PropertyName)
 			{
-				case "IsReadOnly":
+				case nameof(ViewModel.IsReadOnly):
 					if (ViewModel.IsReadOnly)
 					{
 						NativeFileOperationsHelper.SetFileAttribute(
@@ -284,7 +284,7 @@ namespace Files.App.ViewModels.Properties
 
 					break;
 
-				case "IsHidden":
+				case nameof(ViewModel.IsHidden):
 					if (ViewModel.IsHidden)
 					{
 						NativeFileOperationsHelper.SetFileAttribute(
@@ -302,10 +302,10 @@ namespace Files.App.ViewModels.Properties
 
 					break;
 
-				case "RunAsAdmin":
-				case "ShortcutItemPath":
-				case "ShortcutItemWorkingDir":
-				case "ShortcutItemArguments":
+				case nameof(ViewModel.RunAsAdmin):
+				case nameof(ViewModel.ShortcutItemPath):
+				case nameof(ViewModel.ShortcutItemWorkingDir):
+				case nameof(ViewModel.ShortcutItemArguments):
 					if (string.IsNullOrWhiteSpace(ViewModel.ShortcutItemPath))
 						return;
 

--- a/src/Files.App/Views/Properties/GeneralPage.xaml
+++ b/src/Files.App/Views/Properties/GeneralPage.xaml
@@ -704,7 +704,7 @@
 							HorizontalAlignment="Right"
 							VerticalAlignment="Center"
 							AutomationProperties.Name="{helpers:ResourceString Name=ReadOnly}"
-							IsChecked="{x:Bind ViewModel.IsReadOnly, Mode=TwoWay}"
+							IsChecked="{x:Bind ViewModel.IsReadOnlyUserEditableValue, Mode=TwoWay}"
 							IsEnabled="{x:Bind ViewModel.IsReadOnlyEnabled, Mode=OneWay}" />
 
 						<!--  (Divider)  -->
@@ -731,7 +731,7 @@
 							HorizontalAlignment="Right"
 							VerticalAlignment="Center"
 							AutomationProperties.Name="{helpers:ResourceString Name=Hidden}"
-							IsChecked="{x:Bind ViewModel.IsHidden, Mode=TwoWay}" />
+							IsChecked="{x:Bind ViewModel.IsHiddenUserEditableValue, Mode=TwoWay}" />
 
 					</Grid>
 				</Expander.Content>

--- a/src/Files.App/Views/Properties/GeneralPage.xaml.cs
+++ b/src/Files.App/Views/Properties/GeneralPage.xaml.cs
@@ -173,6 +173,9 @@ namespace Files.App.Views.Properties
 					});
 				}
 
+				ViewModel.IsReadOnly = ViewModel.IsReadOnlyUserEditableValue;
+				ViewModel.IsHidden = ViewModel.IsHiddenUserEditableValue;
+
 				if (!GetNewName(out var newName))
 					return true;
 

--- a/src/Files.App/Views/Properties/ShortcutPage.xaml
+++ b/src/Files.App/Views/Properties/ShortcutPage.xaml
@@ -75,7 +75,7 @@
 					Grid.Column="1"
 					VerticalAlignment="Center"
 					IsReadOnly="{x:Bind ViewModel.IsShortcutItemPathReadOnly, Mode=OneWay}"
-					Text="{x:Bind ViewModel.ShortcutItemPath, Mode=TwoWay}"
+					Text="{x:Bind ViewModel.ShortcutItemPathUserEditableValue, Mode=TwoWay}"
 					Visibility="Visible" />
 			</Grid>
 
@@ -117,7 +117,7 @@
 					Grid.Column="1"
 					VerticalAlignment="Center"
 					x:Load="{x:Bind ViewModel.ShortcutItemArgumentsVisibility, Mode=OneWay}"
-					Text="{x:Bind ViewModel.ShortcutItemArguments, Mode=TwoWay}" />
+					Text="{x:Bind ViewModel.ShortcutItemArgumentsUserEditableValue, Mode=TwoWay}" />
 
 				<TextBlock
 					x:Name="PropertiesShortcutItemWorkingDir"
@@ -134,7 +134,7 @@
 					Grid.Column="1"
 					VerticalAlignment="Center"
 					x:Load="{x:Bind ViewModel.ShortcutItemWorkingDirVisibility, Mode=OneWay}"
-					Text="{x:Bind ViewModel.ShortcutItemWorkingDir, Mode=TwoWay}" />
+					Text="{x:Bind ViewModel.ShortcutItemWorkingDirUserEditableValue, Mode=TwoWay}" />
 			</Grid>
 
 			<settingsuc:SettingsBlockControl
@@ -144,7 +144,7 @@
 				x:Load="{x:Bind ViewModel.RunAsAdminEnabled, Mode=OneWay}">
 				<ToggleSwitch
 					AutomationProperties.Name="{helpers:ResourceString Name=RunAsAdministrator}"
-					IsOn="{x:Bind ViewModel.RunAsAdmin, Mode=TwoWay}"
+					IsOn="{x:Bind ViewModel.RunAsAdminUserEditableValue, Mode=TwoWay}"
 					Style="{StaticResource RightAlignedToggleSwitchStyle}" />
 			</settingsuc:SettingsBlockControl>
 

--- a/src/Files.App/Views/Properties/ShortcutPage.xaml.cs
+++ b/src/Files.App/Views/Properties/ShortcutPage.xaml.cs
@@ -1,12 +1,7 @@
 // Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using CommunityToolkit.WinUI;
-using Files.App.Extensions;
-using Files.App.Utils;
-using Files.App.Helpers;
 using Files.App.ViewModels.Properties;
-using System.Threading.Tasks;
 
 namespace Files.App.Views.Properties
 {
@@ -28,6 +23,11 @@ namespace Files.App.Views.Properties
 
 			if (shortcutItem is null)
 				return true;
+
+			ViewModel.RunAsAdmin = ViewModel.RunAsAdminUserEditableValue;
+			ViewModel.ShortcutItemPath = ViewModel.ShortcutItemPathUserEditableValue;
+			ViewModel.ShortcutItemWorkingDir = ViewModel.ShortcutItemWorkingDirUserEditableValue;
+			ViewModel.ShortcutItemArguments = ViewModel.ShortcutItemArgumentsUserEditableValue;
 
 			await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 				UIFilesystemHelpers.UpdateShortcutItemProperties(shortcutItem,


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13577 

**Notes**
I found out this bug would affect other properties as well:
- Is ReadOnly
- Is Hidden
- Should be RunAsAdmin (`shortcut`)
- Params (`shortcut`)
- Target path (`shortcut`)
- Working dir (`shortcut`)


**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open the file properties window.
   2. Check the Read-only checkbox.
   3. Press the Cancel button.
   4. Reopen the properties window.
   5. Repeat with `IsHidden` and with values in the `Shortcut` tab
