### PR TITLE
Fix: Fixed issue where renaming a tag wouldn't save the new name

### DIFF
--- a/src/Files.App/Services/Settings/FileTagsSettingsService.cs
+++ b/src/Files.App/Services/Settings/FileTagsSettingsService.cs
@@ -101,22 +101,19 @@ namespace Files.App.Services.Settings
 
 		public void EditTag(string uid, string name, string color)
 		{
-			var (tag, index) = GetTagAndIndex(uid);
-			if (tag is null)
+			var index = GetTagIndex(uid);
+			if (index == -1)
 				return;
-
-			tag.Name = name;
-			tag.Color = color;
 
 			var oldTags = FileTagList.ToList();
 			oldTags.RemoveAt(index);
-			oldTags.Insert(index, tag);
+			oldTags.Insert(index, new TagViewModel(name, color, uid));
 			FileTagList = oldTags;
 		}
 
 		public void DeleteTag(string uid)
 		{
-			var (_, index) = GetTagAndIndex(uid);
+			var index = GetTagIndex(uid);
 			if (index == -1)
 				return;
 
@@ -155,22 +152,15 @@ namespace Files.App.Services.Settings
 			return JsonSettingsSerializer.SerializeToJson(FileTagList);
 		}
 
-		private (TagViewModel?, int) GetTagAndIndex(string uid)
+		private int GetTagIndex(string uid)
 		{
-			TagViewModel? tag = null;
-			int index = -1;
-
 			for (int i = 0; i < FileTagList.Count; i++)
 			{
 				if (FileTagList[i].Uid == uid)
-				{
-					tag = FileTagList[i];
-					index = i;
-					break;
-				}
+					return i;
 			}
 
-			return (tag, index);
+			return -1;
 		}
 
 		private void UntagAllFiles(string uid)

--- a/src/Files.Core/ViewModels/FileTags/TagViewModel.cs
+++ b/src/Files.Core/ViewModels/FileTags/TagViewModel.cs
@@ -30,7 +30,7 @@ namespace Files.Core.ViewModels.FileTags
 			if (obj is not TagViewModel vm)
 				return false;
 
-			return Uid == vm.Uid && Name == vm.Color && Color == vm.Color;
+			return Uid == vm.Uid && Name == vm.Name && Color == vm.Color;
 		}
 	}
 }

--- a/src/Files.Core/ViewModels/FileTags/TagViewModel.cs
+++ b/src/Files.Core/ViewModels/FileTags/TagViewModel.cs
@@ -24,13 +24,5 @@ namespace Files.Core.ViewModels.FileTags
 			Color = color;
 			Uid = uid;
 		}
-
-		public override bool Equals(object? obj)
-		{
-			if (obj is not TagViewModel vm)
-				return false;
-
-			return Uid == vm.Uid && Name == vm.Name && Color == vm.Color;
-		}
 	}
 }

--- a/src/Files.Core/ViewModels/FileTags/TagViewModel.cs
+++ b/src/Files.Core/ViewModels/FileTags/TagViewModel.cs
@@ -24,5 +24,13 @@ namespace Files.Core.ViewModels.FileTags
 			Color = color;
 			Uid = uid;
 		}
+
+		public override bool Equals(object? obj)
+		{
+			if (obj is not TagViewModel vm)
+				return false;
+
+			return Uid == vm.Uid && Name == vm.Color && Color == vm.Color;
+		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #12535 
   Related #14362 

**Notes**
When editing a tag, we need to instantiate a new `TagViewModel` so that `CachingJsonSettingsDatabase.SetValue() -> UpdateValueInCache()` will find a difference between the old and the new list, hence saving the changes.
Before we were making a shallow-copy of the tag, causing changes to affect the object in both the lists

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Rename/Change the color of two or more tags
   2. Save Changes
   3. Restart the app 
   4. Check that changes were applied