### PR TITLE
Fix: Fixed issue where refocusing Details View would sometimes scroll

### DIFF
--- a/src/Files.App/Data/Behaviors/StickyHeaderBehavior.cs
+++ b/src/Files.App/Data/Behaviors/StickyHeaderBehavior.cs
@@ -157,9 +157,6 @@ namespace Files.App.Data.Behaviors
 			headerElement.SizeChanged -= ScrollHeader_SizeChanged;
 			headerElement.SizeChanged += ScrollHeader_SizeChanged;
 
-			_scrollViewer.GotFocus -= ScrollViewer_GotFocus;
-			_scrollViewer.GotFocus += ScrollViewer_GotFocus;
-
 			var compositor = _scrollProperties.Compositor;
 
 			if (_animationProperties is null)
@@ -202,9 +199,6 @@ namespace Files.App.Data.Behaviors
 			if (HeaderElement is FrameworkElement element)
 				element.SizeChanged -= ScrollHeader_SizeChanged;
 
-			if (_scrollViewer is not null)
-				_scrollViewer.GotFocus -= ScrollViewer_GotFocus;
-
 			StopAnimation();
 		}
 
@@ -230,39 +224,6 @@ namespace Files.App.Data.Behaviors
 		private void ScrollHeader_SizeChanged(object sender, SizeChangedEventArgs e)
 		{
 			AssignAnimation();
-		}
-
-		private void ScrollViewer_GotFocus(object sender, RoutedEventArgs e)
-		{
-			var scroller = (ScrollViewer)sender;
-
-			object focusedElement;
-
-			if (IsXamlRootAvailable && scroller.XamlRoot is not null)
-			{
-				focusedElement = FocusManager.GetFocusedElement(scroller.XamlRoot);
-			}
-			else
-			{
-				focusedElement = FocusManager.GetFocusedElement();
-			}
-
-			// To prevent Popups (Flyouts...) from triggering the autoscroll, we check if the focused element has a valid parent.
-			// Popups have no parents, whereas a normal Item would have the ListView as a parent.
-			if (focusedElement is UIElement element && VisualTreeHelper.GetParent(element) is not null)
-			{
-				// NOTE: Ignore if element is child of header
-				if (!element.FindAscendants().Any(x => x == HeaderElement))
-				{
-					FrameworkElement header = (FrameworkElement)HeaderElement;
-
-					var point = element.TransformToVisual(scroller).TransformPoint(new Point(0, 0));
-
-					// NOTE: Do not change scroller horizontal offset
-					if (point.Y < header.ActualHeight)
-						scroller.ChangeView(scroller.HorizontalOffset, scroller.VerticalOffset - (header.ActualHeight - point.Y), 1, false);
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13220...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Open folder with a lot of items (using Details View)
   2. Remove focus from window
   3. Hover over window without focusing it and scroll
   4. Refocus the window and confirm that it doesn't auto scroll

**Screenshots (optional)**
Add screenshots here.
