### PR TITLE
Feature: Added storage sense option to all flyouts

### DIFF
--- a/src/Files.App/Actions/FileSystem/OpenStorageSenseAction.cs
+++ b/src/Files.App/Actions/FileSystem/OpenStorageSenseAction.cs
@@ -22,7 +22,7 @@ namespace Files.App.Actions
 			context.HasItem &&
 			!context.HasSelection &&
 			(drivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(x =>
-				string.Equals(x.Path, context.Folder?.ItemPath))?.MenuOptions.ShowFormatDrive ?? false);
+				string.Equals(x.Path, context.Folder?.ItemPath))?.MenuOptions.ShowStorageSense ?? false);
 
 		public OpenStorageSenseAction()
 		{

--- a/src/Files.App/Actions/FileSystem/OpenStorageSenseAction.cs
+++ b/src/Files.App/Actions/FileSystem/OpenStorageSenseAction.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2023 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
+namespace Files.App.Actions
+{
+	internal class OpenStorageSenseAction : BaseUIAction, IAction
+	{
+		private readonly IContentPageContext context;
+
+		private readonly DrivesViewModel drivesViewModel;
+
+		public string Label
+			=> "OpenStorageSense".GetLocalizedResource();
+
+		public string Description
+			=> "OpenStorageSense".GetLocalizedResource();
+
+		public RichGlyph Glyph
+			=> new();
+
+		public override bool IsExecutable =>
+			context.HasItem &&
+			!context.HasSelection &&
+			(drivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(x =>
+				string.Equals(x.Path, context.Folder?.ItemPath))?.MenuOptions.ShowFormatDrive ?? false);
+
+		public OpenStorageSenseAction()
+		{
+			context = Ioc.Default.GetRequiredService<IContentPageContext>();
+			drivesViewModel = Ioc.Default.GetRequiredService<DrivesViewModel>();
+
+			context.PropertyChanged += Context_PropertyChanged;
+		}
+
+		public async Task ExecuteAsync()
+		{
+			await StorageSenseHelper.OpenStorageSenseAsync(context.Folder?.ItemPath ?? string.Empty);
+		}
+
+		public void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName is nameof(IContentPageContext.HasItem))
+				OnPropertyChanged(nameof(IsExecutable));
+		}
+	}
+}

--- a/src/Files.App/Data/Commands/CommandCodes.cs
+++ b/src/Files.App/Data/Commands/CommandCodes.cs
@@ -41,6 +41,7 @@ namespace Files.App.Data.Commands
 		CreateShortcutFromDialog,
 		EmptyRecycleBin,
 		FormatDrive,
+		OpenStorageSense,
 		RestoreRecycleBin,
 		RestoreAllRecycleBin,
 		OpenItem,

--- a/src/Files.App/Data/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Data/Commands/Manager/CommandManager.cs
@@ -335,6 +335,7 @@ namespace Files.App.Data.Commands
 			[CommandCodes.NewWindow] = new NewWindowAction(),
 			[CommandCodes.NewTab] = new NewTabAction(),
 			[CommandCodes.FormatDrive] = new FormatDriveAction(),
+			[CommandCodes.OpenStorageSense] = new OpenStorageSenseAction(),
 			[CommandCodes.NavigateBack] = new NavigateBackAction(),
 			[CommandCodes.NavigateForward] = new NavigateForwardAction(),
 			[CommandCodes.NavigateUp] = new NavigateUpAction(),

--- a/src/Files.App/Data/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Data/Commands/Manager/CommandManager.cs
@@ -163,6 +163,7 @@ namespace Files.App.Data.Commands
 		public IRichCommand NewWindow => commands[CommandCodes.NewWindow];
 		public IRichCommand NewTab => commands[CommandCodes.NewTab];
 		public IRichCommand FormatDrive => commands[CommandCodes.FormatDrive];
+		public IRichCommand OpenStorageSense => commands[CommandCodes.OpenStorageSense];
 		public IRichCommand NavigateBack => commands[CommandCodes.NavigateBack];
 		public IRichCommand NavigateForward => commands[CommandCodes.NavigateForward];
 		public IRichCommand NavigateUp => commands[CommandCodes.NavigateUp];

--- a/src/Files.App/Data/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Data/Commands/Manager/ICommandManager.cs
@@ -49,6 +49,7 @@ namespace Files.App.Data.Commands
 		IRichCommand RestoreRecycleBin { get; }
 		IRichCommand RestoreAllRecycleBin { get; }
 		IRichCommand FormatDrive { get; }
+		IRichCommand OpenStorageSense { get; }
 		IRichCommand OpenItem { get; }
 		IRichCommand OpenItemWithApplicationPicker { get; }
 		IRichCommand OpenParentFolder { get; }

--- a/src/Files.App/Data/Contracts/INavigationControlItem.cs
+++ b/src/Files.App/Data/Contracts/INavigationControlItem.cs
@@ -57,5 +57,7 @@ namespace Files.App.Data.Contracts
 		public bool ShowFormatDrive { get; set; }
 
 		public bool ShowShellItems { get; set; }
+
+		public bool ShowStorageSense { get; set; }
 	}
 }

--- a/src/Files.App/Data/Factories/ContentPageContextFlyoutFactory.cs
+++ b/src/Files.App/Data/Factories/ContentPageContextFlyoutFactory.cs
@@ -367,6 +367,7 @@ namespace Files.App.Data.Factories
 					ShowInFtpPage = true
 				},
 				new ContextMenuFlyoutItemViewModelBuilder(Commands.FormatDrive).Build(),
+				new ContextMenuFlyoutItemViewModelBuilder(Commands.OpenStorageSense).Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(Commands.EmptyRecycleBin)
 				{
 					IsVisible = currentInstanceViewModel.IsPageTypeRecycleBin && !itemsSelected,

--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -249,7 +249,8 @@ namespace Files.App.Data.Items
 				ShowEjectDevice = item.IsRemovable,
 				ShowShellItems = true,
 				ShowFormatDrive = !(item.Type == DriveType.Network || string.Equals(root.Path, "C:\\", StringComparison.OrdinalIgnoreCase)),
-				ShowProperties = true
+				ShowProperties = true,
+				ShowStorageSense = true
 			};
 			item.Path = string.IsNullOrEmpty(root.Path) ? $"\\\\?\\{root.Name}\\" : root.Path;
 			item.DeviceID = deviceId;

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml.cs
@@ -83,6 +83,7 @@ namespace Files.App.UserControls.Widgets
 			UnpinFromFavoritesCommand = new AsyncRelayCommand<WidgetCardItem>(UnpinFromFavoritesAsync);
 			MapNetworkDriveCommand = new AsyncRelayCommand(DoNetworkMapDriveAsync); 
 			DisconnectNetworkDriveCommand = new RelayCommand<WidgetDriveCardItem>(DisconnectNetworkDrive);
+			GoToStorageSenseCommand = new AsyncRelayCommand<WidgetDriveCardItem>(ExecuteOpenStorageSenseCommand);
 		}
 
 		private async void Drives_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -178,6 +179,12 @@ namespace Files.App.UserControls.Widgets
 					Command = FormatDriveCommand,
 					CommandParameter = item,
 					ShowItem = options?.ShowFormatDrive ?? false
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
+					Text = "OpenStorageSense".GetLocalizedResource(),
+					Command = GoToStorageSenseCommand!,
+					CommandParameter = item
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
@@ -315,10 +322,20 @@ namespace Files.App.UserControls.Widgets
 			networkDrivesViewModel.DisconnectNetworkDrive(item.Item);
 		}
 
-		private void GoToStorageSense_Click(object sender, RoutedEventArgs e)
+		private async Task ExecuteOpenStorageSenseCommand(WidgetDriveCardItem? item)
 		{
-			string clickedCard = (sender as Button).Tag.ToString();
-			StorageSenseHelper.OpenStorageSenseAsync(clickedCard);
+			if (item is null || string.IsNullOrEmpty(item.Path))
+				return;
+
+			await StorageSenseHelper.OpenStorageSenseAsync(item.Path);
+		}
+
+		private async void GoToStorageSense_Click(object sender, RoutedEventArgs e)
+		{
+			if (sender is not Button button || button.DataContext is not WidgetDriveCardItem item)
+				return;
+
+			await ExecuteOpenStorageSenseCommand(item);
 		}
 
 		public async Task RefreshWidgetAsync()

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -267,6 +267,7 @@ namespace Files.App.ViewModels.UserControls
 			FormatDriveCommand = new RelayCommand(FormatDrive);
 			OpenPropertiesCommand = new RelayCommand<CommandBarFlyout>(OpenProperties);
 			ReorderItemsCommand = new AsyncRelayCommand(ReorderItemsAsync);
+			GoToStorageSenseCommand = new AsyncRelayCommand(ExecuteOpenStorageSenseCommand);
 		}
 
 		private Task CreateItemHomeAsync()
@@ -819,6 +820,8 @@ namespace Files.App.ViewModels.UserControls
 
 		private ICommand ReorderItemsCommand { get; }
 
+		private ICommand GoToStorageSenseCommand { get; }
+
 		private async Task OpenInNewPaneAsync()
 		{
 			if (await DriveHelpers.CheckEmptyDrive(rightClickedItem.Path))
@@ -886,6 +889,11 @@ namespace Files.App.ViewModels.UserControls
 			var dialog = new ReorderSidebarItemsDialogViewModel();
 			var dialogService = Ioc.Default.GetRequiredService<IDialogService>();
 			var result = await dialogService.ShowDialogAsync(dialog);
+		}
+
+		private async Task ExecuteOpenStorageSenseCommand()
+		{
+			await StorageSenseHelper.OpenStorageSenseAsync(rightClickedItem.Path);
 		}
 
 		private void OpenProperties(CommandBarFlyout menu)
@@ -1046,6 +1054,12 @@ namespace Files.App.ViewModels.UserControls
 					Command = FormatDriveCommand,
 					CommandParameter = item,
 					ShowItem = options.ShowFormatDrive
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
+					Text = "OpenStorageSense".GetLocalizedResource(),
+					Command = GoToStorageSenseCommand!,
+					ShowItem = options.ShowStorageSense
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{


### PR DESCRIPTION
## Summary

As the title. Met the requirements on the list.

## PR Checklist

- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #6996
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Launch the app
   2. Go to Home
   3. Right click a drive card
   4. See the item
   5. Go to a drive root page
   6. Right click without selection
   7. See the item
   8. Right click a drive item on the sidebar
   9. See the item

## Screenshots

![image](https://github.com/files-community/Files/assets/62196528/2f415df2-040f-43d7-884c-a73b673ec712)
