### PR TITLE
Fix: Fixed InvalidOperationException when removing page from BackStack

### DIFF
--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -625,8 +625,7 @@ namespace Files.App.Views.Shells
 
 		public void RemoveLastPageFromBackStack()
 		{
-			if (ItemDisplay.BackStack.Count > 0)
-				ItemDisplay.BackStack.Remove(ItemDisplay.BackStack.Last());
+			ItemDisplay.BackStack.Remove(ItemDisplay.BackStack.LastOrDefault());
 		}
 
 		public void RaiseContentChanged(IShellPage instance, CustomTabViewItemParameter args)

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -625,7 +625,8 @@ namespace Files.App.Views.Shells
 
 		public void RemoveLastPageFromBackStack()
 		{
-			ItemDisplay.BackStack.Remove(ItemDisplay.BackStack.Last());
+			if (ItemDisplay.BackStack.Count > 0)
+				ItemDisplay.BackStack.Remove(ItemDisplay.BackStack.Last());
 		}
 
 		public void RaiseContentChanged(IShellPage instance, CustomTabViewItemParameter args)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

```
System.Linq
ThrowHelper.ThrowNoElementsException ()
System.Linq
Enumerable.Last[TSource] (IEnumerable`1 source)
Files.App.Views.Shells
BaseShellPage.RemoveLastPageFromBackStack ()
Files.App.Views.Layouts
BaseLayoutPage.BaseFolderSettings_LayoutModeChangeRequested (Object sender, LayoutModeEventArgs e)
Files.App.Data.Models
LayoutPreferencesManager.set_GridViewSize (Int32 value)
Files.App.ViewModels.Layouts
BaseLayoutViewModel.PointerWheelChanged (PointerRoutedEventArgs e)
CommunityToolkit.Mvvm.Input
RelayCommand`1.Execute (Object parameter)
Microsoft.Xaml.Interactions.Core
InvokeCommandAction.Execute (Object sender, Object parameter)
```