### PR TITLE
Fix: Fixed NullReferenceException in Item_Opening

### DIFF
--- a/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
+++ b/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
@@ -62,7 +62,7 @@ namespace Files.App.UserControls.Menus
 			}
 		}
 
-		private void Item_Opening(object sender, object e)
+		private void Item_Opening(object? sender, object e)
 		{
 			Opening -= Item_Opening;
 

--- a/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
+++ b/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
@@ -1,20 +1,11 @@
 ﻿// Copyright (c) 2023 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using CommunityToolkit.Mvvm.DependencyInjection;
-using Files.App.Utils;
-using Files.App.Helpers;
-using Files.Core.Services.Settings;
-using Files.Core.ViewModels.FileTags;
-using Files.Shared.Extensions;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using static Files.App.Helpers.MenuFlyoutHelper;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.Media;
+using static Files.App.Helpers.MenuFlyoutHelper;
 
 namespace Files.App.UserControls.Menus
 {
@@ -46,7 +37,8 @@ namespace Files.App.UserControls.Menus
 
 			SelectedItems = selectedItems;
 
-			Opening += Item_Opening;
+			if (SelectedItems is not null)
+				Opening += Item_Opening;
 		}
 
 		private void TagItem_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
+++ b/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
@@ -37,8 +37,7 @@ namespace Files.App.UserControls.Menus
 
 			SelectedItems = selectedItems;
 
-			if (SelectedItems is not null)
-				Opening += Item_Opening;
+			Opening += Item_Opening;
 		}
 
 		private void TagItem_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -58,11 +57,14 @@ namespace Files.App.UserControls.Menus
 		{
 			Opening -= Item_Opening;
 
+			if (SelectedItems is null)
+				return;
+
 			// go through each tag and find the common one for all files
 			var commonFileTags = SelectedItems
-				.Select(x => x.FileTags ?? Enumerable.Empty<string>())
-				.Aggregate((x, y) => x.Intersect(y))
-				.Select(x => Items.FirstOrDefault(y => x == ((TagViewModel)y.Tag)?.Uid));
+			.Select(x => x.FileTags ?? Enumerable.Empty<string>())
+			.Aggregate((x, y) => x.Intersect(y))
+			.Select(x => Items.FirstOrDefault(y => x == ((TagViewModel)y.Tag)?.Uid));
 
 			commonFileTags.OfType<ToggleMenuFlyoutItem>().ForEach(x => x.IsChecked = true);
 		}

--- a/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
+++ b/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
@@ -62,9 +62,9 @@ namespace Files.App.UserControls.Menus
 
 			// go through each tag and find the common one for all files
 			var commonFileTags = SelectedItems
-			.Select(x => x.FileTags ?? Enumerable.Empty<string>())
-			.Aggregate((x, y) => x.Intersect(y))
-			.Select(x => Items.FirstOrDefault(y => x == ((TagViewModel)y.Tag)?.Uid));
+				.Select(x => x.FileTags ?? Enumerable.Empty<string>())
+				.Aggregate((x, y) => x.Intersect(y))
+				.Select(x => Items.FirstOrDefault(y => x == ((TagViewModel)y.Tag)?.Uid));
 
 			commonFileTags.OfType<ToggleMenuFlyoutItem>().ForEach(x => x.IsChecked = true);
 		}


### PR DESCRIPTION
Fixed `System.NullReferenceException: Object reference not set to an instance of an object`

**Stacktrace**
```csharp
Files.App.UserControls.Menus
FileTagsContextMenu.Item_Opening (Object sender, Object e)
```