### PR TITLE
Fix: Fixed crash that would occur when clicking an item on the Tags widget

### DIFF
--- a/src/Files.App/Data/Items/WidgetFileTagCardItem.cs
+++ b/src/Files.App/Data/Items/WidgetFileTagCardItem.cs
@@ -59,7 +59,7 @@ namespace Files.App.Data.Items
 			ClickCommand = new AsyncRelayCommand<object?>(ClickAsync);
 		}
 
-		private Task ClickAsync(object? cancellationToken)
+		private Task ClickAsync(object? param)
 		{
 			return _openAction(_associatedStorable.Id);
 		}

--- a/src/Files.App/Data/Items/WidgetFileTagCardItem.cs
+++ b/src/Files.App/Data/Items/WidgetFileTagCardItem.cs
@@ -56,10 +56,10 @@ namespace Files.App.Data.Items
 			_Path = associatedStorable.TryGetPath();
 			Item = this;
 
-			ClickCommand = new AsyncRelayCommand<CancellationToken?>(ClickAsync);
+			ClickCommand = new AsyncRelayCommand<object?>(ClickAsync);
 		}
 
-		private Task ClickAsync(CancellationToken? cancellationToken)
+		private Task ClickAsync(object? cancellationToken)
 		{
 			return _openAction(_associatedStorable.Id);
 		}

--- a/src/Files.App/Data/Items/WidgetFileTagCardItem.cs
+++ b/src/Files.App/Data/Items/WidgetFileTagCardItem.cs
@@ -56,10 +56,10 @@ namespace Files.App.Data.Items
 			_Path = associatedStorable.TryGetPath();
 			Item = this;
 
-			ClickCommand = new AsyncRelayCommand<CancellationToken>(ClickAsync);
+			ClickCommand = new AsyncRelayCommand<CancellationToken?>(ClickAsync);
 		}
 
-		private Task ClickAsync(CancellationToken cancellationToken)
+		private Task ClickAsync(CancellationToken? cancellationToken)
 		{
 			return _openAction(_associatedStorable.Id);
 		}

--- a/src/Files.App/Data/Items/WidgetFileTagCardItem.cs
+++ b/src/Files.App/Data/Items/WidgetFileTagCardItem.cs
@@ -56,10 +56,10 @@ namespace Files.App.Data.Items
 			_Path = associatedStorable.TryGetPath();
 			Item = this;
 
-			ClickCommand = new AsyncRelayCommand<object?>(ClickAsync);
+			ClickCommand = new AsyncRelayCommand(ClickAsync);
 		}
 
-		private Task ClickAsync(object? param)
+		private Task ClickAsync()
 		{
 			return _openAction(_associatedStorable.Id);
 		}

--- a/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml.cs
+++ b/src/Files.App/UserControls/Widgets/FileTagsWidget.xaml.cs
@@ -96,7 +96,7 @@ namespace Files.App.UserControls.Widgets
 			});
 		}
 
-		private async void FileTagItem_ItemClick(object sender, ItemClickEventArgs e)
+		private void FileTagItem_ItemClick(object sender, ItemClickEventArgs e)
 		{
 			if (e.ClickedItem is WidgetFileTagCardItem itemViewModel)
 				itemViewModel.ClickCommand.Execute(null);


### PR DESCRIPTION
https://appcenter.ms/orgs/FilesApp/apps/Files/crashes/errors/526177982u/overview

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?