### PR TITLE
Fix: Fixed NullReferenceException in Item_Opening

### DIFF
--- a/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
+++ b/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
@@ -62,7 +62,7 @@ namespace Files.App.UserControls.Menus
 
 			// go through each tag and find the common one for all files
 			var commonFileTags = SelectedItems
-				.Select(x => x.FileTags ?? Enumerable.Empty<string>())
+				.Select(x => x?.FileTags ?? Enumerable.Empty<string>())
 				.Aggregate((x, y) => x.Intersect(y))
 				.Select(x => Items.FirstOrDefault(y => x == ((TagViewModel)y.Tag)?.Uid));
 


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14776

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?