### PR TITLE
Fix: Fixed NullReferenceException in DuplicateSelectedTabAction.ExecuteAsync

### DIFF
--- a/src/Files.App/Actions/Navigation/DuplicateSelectedTabAction.cs
+++ b/src/Files.App/Actions/Navigation/DuplicateSelectedTabAction.cs
@@ -3,7 +3,7 @@
 
 namespace Files.App.Actions
 {
-	internal class DuplicateSelectedTabAction : IAction
+	internal class DuplicateSelectedTabAction : ObservableObject, IAction
 	{
 		private readonly IMultitaskingContext context;
 
@@ -16,9 +16,13 @@ namespace Files.App.Actions
 		public HotKey HotKey
 			=> new(Keys.K, KeyModifiers.CtrlShift);
 
+		public bool IsExecutable
+			=> context.SelectedTabItem is not null;
+
 		public DuplicateSelectedTabAction()
 		{
 			context = Ioc.Default.GetRequiredService<IMultitaskingContext>();
+			context.PropertyChanged += MultitaskingContext_PropertyChanged;
 		}
 
 		public async Task ExecuteAsync()
@@ -33,6 +37,12 @@ namespace Files.App.Actions
 			{
 				await NavigationHelpers.AddNewTabByParamAsync(arguments.InitialPageType, arguments.NavigationParameter, context.SelectedTabIndex + 1);
 			}
+		}
+
+		private void MultitaskingContext_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == nameof(IMultitaskingContext.SelectedTabItem))
+				OnPropertyChanged(nameof(IsExecutable));
 		}
 	}
 }


### PR DESCRIPTION
```
Files.App.Actions
DuplicateSelectedTabAction.ExecuteAsync ()
Files.App.Views
MainPage.OnPreviewKeyDownAsync (KeyRoutedEventArgs e)
Files.App.Views
MainPage.OnPreviewKeyDown (KeyRoutedEventArgs e)
System.Threading.Tasks.Task
<>c.<ThrowAsync>b__128_0 (Object state)
Microsoft.UI.Dispatching.DispatcherQueueSynchronizationContext
<>c__DisplayClass2_0.<Post>b__0 ()
WinRT
ExceptionHelpers.<ThrowExceptionForHR>g__Throw|39_0 (Int32 hr)
ABI.Windows.ApplicationModel.Core
IUnhandledErrorMethods.Propagate (IObjectReference _obj)
Microsoft.AppCenter.Utils
ApplicationLifecycleHelperWinUI.<ctor>b__0_3 (Object sender, UnhandledErrorDetectedEventArgs eventArgs)
```

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?