### PR TITLE
Fix: Fixed an issue where the Layout Picker UI is broken up in a certain localization

### DIFF
--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -930,12 +930,12 @@
 									IsThumbToolTipEnabled="False" />-->
 								<StackPanel
 									x:Name="TilesViewSizeInfo"
-									MaxWidth="300"
+									HorizontalAlignment="Left"
 									Orientation="Horizontal"
 									Spacing="8"
 									Visibility="{x:Bind ViewModel.IsTilesLayout, Mode=OneWay}">
 									<FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE946;" />
-									<TextBlock Text="{helpers:ResourceString Name=TilesViewSizeInfo}" />
+									<TextBlock MaxWidth="360" Text="{helpers:ResourceString Name=TilesViewSizeInfo}" />
 								</StackPanel>
 
 								<!--  Grid  -->

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -930,10 +930,10 @@
 									IsThumbToolTipEnabled="False" />-->
 								<StackPanel
 									x:Name="TilesViewSizeInfo"
+									MaxWidth="300"
 									Orientation="Horizontal"
 									Spacing="8"
-									Visibility="{x:Bind ViewModel.IsTilesLayout, Mode=OneWay}"
-									MaxWidth="300">
+									Visibility="{x:Bind ViewModel.IsTilesLayout, Mode=OneWay}">
 									<FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE946;" />
 									<TextBlock Text="{helpers:ResourceString Name=TilesViewSizeInfo}" />
 								</StackPanel>

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -932,7 +932,8 @@
 									x:Name="TilesViewSizeInfo"
 									Orientation="Horizontal"
 									Spacing="8"
-									Visibility="{x:Bind ViewModel.IsTilesLayout, Mode=OneWay}">
+									Visibility="{x:Bind ViewModel.IsTilesLayout, Mode=OneWay}"
+									MaxWidth="300">
 									<FontIcon FontFamily="Segoe Fluent Icons" Glyph="&#xE946;" />
 									<TextBlock Text="{helpers:ResourceString Name=TilesViewSizeInfo}" />
 								</StackPanel>


### PR DESCRIPTION
## Summary

As the title.

## PR Checklist

- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14880
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Change language to Italian
   2. Go to a folder in a Tiles layout
   3. Open the Layout Picker

## Screenshots

Before|After
---|---
![image](https://github.com/files-community/Files/assets/62196528/4f756a33-55c5-4e28-91d4-3a3876a71cd7)|![image](https://github.com/files-community/Files/assets/62196528/7643c191-d565-4fa7-9cab-bbe0179f011b)
