### PR TITLE
Fix: Prompt for credentials when a network share access is denied

### DIFF
--- a/src/Files.App/Utils/Global/NetworkDrivesAPI.cs
+++ b/src/Files.App/Utils/Global/NetworkDrivesAPI.cs
@@ -135,7 +135,7 @@ namespace Files.App.Utils
 
 			Win32Error connectionError = WNetAddConnection3(HWND.NULL, nr, null, null, 0);  // if creds are saved, this will return NO_ERROR
 
-			if (connectionError == Win32Error.ERROR_LOGON_FAILURE)
+			if (connectionError == Win32Error.ERROR_LOGON_FAILURE || connectionError == Win32Error.ERROR_ACCESS_DENIED)
 			{
 				var dialog = DynamicDialogFactory.GetFor_CredentialEntryDialog(path);
 				await dialog.ShowAsync();


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14903

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Launch Files with a low-privileged user account
   2. Access a server adminsitrative share (\\myserver\c$)

**Screenshots (optional)**
![Capture d’écran 2024-03-05 103721](https://github.com/files-community/Files/assets/8030500/6c323d0c-0172-4e7b-aa8e-63a4ccc87088)


