### PR TITLE
Fix: Fixed an issue where video bitrate was displayed in plain text

### DIFF
--- a/src/Files.App/ViewModels/Properties/Items/CombinedFileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/CombinedFileProperties.cs
@@ -34,6 +34,10 @@ namespace Files.App.ViewModels.Properties
 
 				// Find Encoding Bitrate property and convert it to kbps
 				var encodingBitrate = list.Find(x => x.Property == "System.Audio.EncodingBitrate");
+
+				if (encodingBitrate?.Value is null)
+					encodingBitrate = list.Find(x => x.Property == "System.Video.EncodingBitrate");
+
 				if (encodingBitrate?.Value is not null)
 				{
 					var sizes = new string[] { "Bps", "KBps", "MBps", "GBps" };

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -172,6 +172,10 @@ namespace Files.App.ViewModels.Properties
 
 			// Find Encoding Bitrate property and convert it to kbps
 			var encodingBitrate = list.Find(x => x.Property == "System.Audio.EncodingBitrate");
+
+			if (encodingBitrate?.Value is null)
+				encodingBitrate = list.Find(x => x.Property == "System.Video.EncodingBitrate");
+
 			if (encodingBitrate?.Value is not null)
 			{
 				var sizes = new string[] { "Bps", "KBps", "MBps", "GBps" };


### PR DESCRIPTION
## Summary

![image](https://github.com/files-community/Files/assets/62196528/d8c13b25-f34c-498d-b2b9-812db156e17e)

## PR Checklist

- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14892
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Go to properties window of a video file
   2. Go to Details tab
   3. See the bitrate is shown in formatted text

## Screenshots

_None_