### PR TITLE
Fix: Fixed issue where certain drive icons didn't load on the home page widget

### DIFF
--- a/src/Files.App/Data/Items/WidgetDriveCardItem.cs
+++ b/src/Files.App/Data/Items/WidgetDriveCardItem.cs
@@ -32,6 +32,12 @@ namespace Files.App.Data.Items
 				true,
 				IconOptions.ReturnIconOnly | IconOptions.UseCurrentScale);
 
+			if (result is null)
+			{
+				using var thumbnail = await DriveHelpers.GetThumbnailAsync(Item.Root);
+				result ??= await thumbnail.ToByteArrayAsync();
+			}
+
 			thumbnailData = result;
 
 			var bitmapImage = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => thumbnailData.ToBitmapAsync(), Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14764 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Enable `Drives` widget
   2. Connect a phone
   3. Open Files Home page

**Screenshots (optional)**
![image](https://github.com/files-community/Files/assets/102259289/3d4c8758-4609-4841-8fae-79ae06b4e138)
