### PR TITLE
Fix: Fixed issue where drag and drop from Edge didn't work

### DIFF
--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -245,13 +245,13 @@ namespace Files.App.Utils.Storage
 				{
 					return await RecycleItemsFromClipboard(packageView, destination, UserSettingsService.FoldersSettingsService.DeleteConfirmationPolicy, registerHistory);
 				}
-				else if (operation.HasFlag(DataPackageOperation.Copy))
-				{
-					return await CopyItemsFromClipboard(packageView, destination, showDialog, registerHistory);
-				}
 				else if (operation.HasFlag(DataPackageOperation.Move))
 				{
 					return await MoveItemsFromClipboard(packageView, destination, showDialog, registerHistory);
+				}
+				else if (operation.HasFlag(DataPackageOperation.Copy))
+				{
+					return await CopyItemsFromClipboard(packageView, destination, showDialog, registerHistory);
 				}
 				else if (operation.HasFlag(DataPackageOperation.Link))
 				{

--- a/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
+++ b/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
@@ -123,7 +123,7 @@ namespace Files.App.ViewModels.Layouts
 					if (pwd.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.Ordinal))
 					{
 						e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), folderName);
-						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 						e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else if (e.Modifiers.HasFlag(DragDropModifiers.Alt) || e.Modifiers.HasFlag(DragDropModifiers.Control | DragDropModifiers.Shift))
@@ -139,7 +139,7 @@ namespace Files.App.ViewModels.Layouts
 					else if (e.Modifiers.HasFlag(DragDropModifiers.Shift))
 					{
 						e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), folderName);
-						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 						e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else if (draggedItems.Any(x =>
@@ -153,7 +153,7 @@ namespace Files.App.ViewModels.Layouts
 					else if (draggedItems.AreItemsInSameDrive(_associatedInstance.FilesystemViewModel.WorkingDirectory))
 					{
 						e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), folderName);
-						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 						e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else

--- a/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
+++ b/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
@@ -123,7 +123,8 @@ namespace Files.App.ViewModels.Layouts
 					if (pwd.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.Ordinal))
 					{
 						e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), folderName);
-						e.AcceptedOperation = DataPackageOperation.Move;
+						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else if (e.Modifiers.HasFlag(DragDropModifiers.Alt) || e.Modifiers.HasFlag(DragDropModifiers.Control | DragDropModifiers.Shift))
 					{
@@ -138,7 +139,8 @@ namespace Files.App.ViewModels.Layouts
 					else if (e.Modifiers.HasFlag(DragDropModifiers.Shift))
 					{
 						e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), folderName);
-						e.AcceptedOperation = DataPackageOperation.Move;
+						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else if (draggedItems.Any(x =>
 						x.Item is ZipStorageFile ||
@@ -151,7 +153,8 @@ namespace Files.App.ViewModels.Layouts
 					else if (draggedItems.AreItemsInSameDrive(_associatedInstance.FilesystemViewModel.WorkingDirectory))
 					{
 						e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), folderName);
-						e.AcceptedOperation = DataPackageOperation.Move;
+						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else
 					{

--- a/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
@@ -410,7 +410,7 @@ namespace Files.App.ViewModels.UserControls
 			{
 				e.DragUIOverride.IsCaptionVisible = true;
 				e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), pathBoxItem.Title);
-				// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+				// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 				e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 			}
 

--- a/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
@@ -410,7 +410,8 @@ namespace Files.App.ViewModels.UserControls
 			{
 				e.DragUIOverride.IsCaptionVisible = true;
 				e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), pathBoxItem.Title);
-				e.AcceptedOperation = DataPackageOperation.Move;
+				// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+				e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 			}
 
 			deferral.Complete();

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -1130,7 +1130,8 @@ namespace Files.App.ViewModels.UserControls
 					if (locationItem.Path.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.Ordinal))
 					{
 						captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
-						operationType = DataPackageOperation.Move;
+						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else if (rawEvent.Modifiers.HasFlag(DragDropModifiers.Alt) || rawEvent.Modifiers.HasFlag(DragDropModifiers.Control | DragDropModifiers.Shift))
 					{
@@ -1145,7 +1146,8 @@ namespace Files.App.ViewModels.UserControls
 					else if (rawEvent.Modifiers.HasFlag(DragDropModifiers.Shift))
 					{
 						captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
-						operationType = DataPackageOperation.Move;
+						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else if (storageItems.Any(x => x.Item is ZipStorageFile || x.Item is ZipStorageFolder)
 						|| ZipStorageFolder.IsZipPath(locationItem.Path))
@@ -1156,7 +1158,8 @@ namespace Files.App.ViewModels.UserControls
 					else if (locationItem.IsDefaultLocation || storageItems.AreItemsInSameDrive(locationItem.Path))
 					{
 						captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
-						operationType = DataPackageOperation.Move;
+						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else
 					{
@@ -1204,12 +1207,14 @@ namespace Files.App.ViewModels.UserControls
 				else if (args.RawEvent.Modifiers.HasFlag(DragDropModifiers.Shift))
 				{
 					captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), driveItem.Text);
-					operationType = DataPackageOperation.Move;
+					// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+					operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 				}
 				else if (storageItems.AreItemsInSameDrive(driveItem.Path))
 				{
 					captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), driveItem.Text);
-					operationType = DataPackageOperation.Move;
+					// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+					operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 				}
 				else
 				{

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -1130,7 +1130,7 @@ namespace Files.App.ViewModels.UserControls
 					if (locationItem.Path.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.Ordinal))
 					{
 						captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
-						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 						operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else if (rawEvent.Modifiers.HasFlag(DragDropModifiers.Alt) || rawEvent.Modifiers.HasFlag(DragDropModifiers.Control | DragDropModifiers.Shift))
@@ -1146,7 +1146,7 @@ namespace Files.App.ViewModels.UserControls
 					else if (rawEvent.Modifiers.HasFlag(DragDropModifiers.Shift))
 					{
 						captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
-						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 						operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else if (storageItems.Any(x => x.Item is ZipStorageFile || x.Item is ZipStorageFolder)
@@ -1158,7 +1158,7 @@ namespace Files.App.ViewModels.UserControls
 					else if (locationItem.IsDefaultLocation || storageItems.AreItemsInSameDrive(locationItem.Path))
 					{
 						captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
-						// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+						// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 						operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else
@@ -1207,13 +1207,13 @@ namespace Files.App.ViewModels.UserControls
 				else if (args.RawEvent.Modifiers.HasFlag(DragDropModifiers.Shift))
 				{
 					captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), driveItem.Text);
-					// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+					// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 					operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 				}
 				else if (storageItems.AreItemsInSameDrive(driveItem.Path))
 				{
 					captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), driveItem.Text);
-					// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+					// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 					operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 				}
 				else

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1045,7 +1045,7 @@ namespace Files.App.Views.Layouts
 						else if (e.Modifiers.HasFlag(DragDropModifiers.Shift))
 						{
 							e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), item.Name);
-							// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+							// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 							e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 						}
 						else if (draggedItems.Any(x => x.Item is ZipStorageFile || x.Item is ZipStorageFolder)
@@ -1057,7 +1057,7 @@ namespace Files.App.Views.Layouts
 						else if (draggedItems.AreItemsInSameDrive(item.ItemPath))
 						{
 							e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), item.Name);
-							// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+							// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 							e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 						}
 						else

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1045,7 +1045,8 @@ namespace Files.App.Views.Layouts
 						else if (e.Modifiers.HasFlag(DragDropModifiers.Shift))
 						{
 							e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), item.Name);
-							e.AcceptedOperation = DataPackageOperation.Move;
+							// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+							e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 						}
 						else if (draggedItems.Any(x => x.Item is ZipStorageFile || x.Item is ZipStorageFolder)
 							|| ZipStorageFolder.IsZipPath(item.ItemPath))
@@ -1056,7 +1057,8 @@ namespace Files.App.Views.Layouts
 						else if (draggedItems.AreItemsInSameDrive(item.ItemPath))
 						{
 							e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), item.Name);
-							e.AcceptedOperation = DataPackageOperation.Move;
+							// Some applications such as Edge can't raise the drop event by the Move flag, so we set the Copy flag as well.
+							e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 						}
 						else
 						{


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14008 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Download a file with Edge.
   2. Drag the downloaded file from the Downloads flyout and drop it to Files.
   3. The operation now works.