### PR TITLE
Fix: `filestags.json` doesn't export probably

### DIFF
--- a/src/Files.App/Services/Settings/FileTagsSettingsService.cs
+++ b/src/Files.App/Services/Settings/FileTagsSettingsService.cs
@@ -148,8 +148,12 @@ namespace Files.App.Services.Settings
 
 		public override object ExportSettings()
 		{
-			// Return string in Json format
-			return JsonSettingsSerializer.SerializeToJson(FileTagList);
+			var settings = new Dictionary<string, object>
+			{
+				{"FileTagList", FileTagList}
+			};
+			// Serialize settings to JSON format
+			return JsonSettingsSerializer.SerializeToJson(settings);
 		}
 
 		private int GetTagIndex(string uid)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14995

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Create a tag
   2. Export from Files settings > Advanced > Export
   3. Import settings
   4. Restart Files

**Screenshots (optional)**
Add screenshots here.
