### PR TITLE
Fix: Fixed issue where coping or moving a folder would cause the contents of the destination folder to be empty

### DIFF
--- a/src/Files.App/Helpers/EnumConversionHelpers.cs
+++ b/src/Files.App/Helpers/EnumConversionHelpers.cs
@@ -18,6 +18,17 @@ namespace Files.App.Helpers
 			};
 		}
 
+		public static NameCollisionOption ConvertBack(this CreationCollisionOption option)
+		{
+			return option switch
+			{
+				CreationCollisionOption.FailIfExists => NameCollisionOption.FailIfExists,
+				CreationCollisionOption.GenerateUniqueName => NameCollisionOption.GenerateUniqueName,
+				CreationCollisionOption.ReplaceExisting => NameCollisionOption.ReplaceExisting,
+				_ => NameCollisionOption.GenerateUniqueName,
+			};
+		}
+
 		public static NameCollisionOption Convert(this FileNameConflictResolveOptionType option)
 		{
 			return option switch

--- a/src/Files.App/Utils/Storage/Operations/FilesystemOperations.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemOperations.cs
@@ -806,17 +806,23 @@ namespace Files.App.Utils.Storage
 
 		private async static Task<BaseStorageFolder> CloneDirectoryAsync(BaseStorageFolder sourceFolder, BaseStorageFolder destinationFolder, string sourceRootName, CreationCollisionOption collision = CreationCollisionOption.FailIfExists)
 		{
-			BaseStorageFolder createdRoot = await destinationFolder.CreateFolderAsync(sourceRootName, collision);
+			BaseStorageFolder createdRoot;
+			if (collision is CreationCollisionOption.ReplaceExisting)
+				// Dont't delete the contents of the folder
+				createdRoot = await destinationFolder.CreateFolderAsync(sourceRootName, CreationCollisionOption.OpenIfExists);
+			else
+				createdRoot = await destinationFolder.CreateFolderAsync(sourceRootName, collision);
+
 			destinationFolder = createdRoot;
 
 			foreach (BaseStorageFile fileInSourceDir in await sourceFolder.GetFilesAsync())
 			{
-				await fileInSourceDir.CopyAsync(destinationFolder, fileInSourceDir.Name, NameCollisionOption.GenerateUniqueName);
+				await fileInSourceDir.CopyAsync(destinationFolder, fileInSourceDir.Name, collision.ConvertBack());
 			}
 
 			foreach (BaseStorageFolder folderinSourceDir in await sourceFolder.GetFoldersAsync())
 			{
-				await CloneDirectoryAsync(folderinSourceDir, destinationFolder, folderinSourceDir.Name);
+				await CloneDirectoryAsync(folderinSourceDir, destinationFolder, folderinSourceDir.Name, collision);
 			}
 
 			return createdRoot;


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #15010 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?