### PR TITLE
Feature: List all the SharePoint directories

### DIFF
--- a/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
+++ b/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
@@ -190,14 +190,16 @@ namespace Files.App.Utils.Cloud
 			var sharepointAccounts = new List<ICloudProvider>();
 			foreach (var account in oneDriveAccountsKey.GetSubKeyNames())
 			{
-				var accountKeyName = @$"{oneDriveAccountsKey.Name}\{account}";
-				var displayName = (string)Registry.GetValue(accountKeyName, "DisplayName", null);
-				var userFolderToExcludeFromResults = (string)Registry.GetValue(accountKeyName, "UserFolder", null);
-				var accountName = string.IsNullOrWhiteSpace(displayName) ? "SharePoint" : $"SharePoint - {displayName}";
+				var accountKey = oneDriveAccountsKey.OpenSubKey(account);
+				if (accountKey is null)
+				{
+					continue;
+				}
 
-				var sharePointSyncFolders = new List<string>();
-				var mountPointKeyName = @$"SOFTWARE\Microsoft\OneDrive\Accounts\{account}\ScopeIdToMountPointPathCache";
-				using (var mountPointsKey = Registry.CurrentUser.OpenSubKey(mountPointKeyName))
+				var userFolderToExcludeFromResults = (string)accountKey.GetValue("UserFolder", "");
+
+				var sharePointParentFolders = new List<DirectoryInfo>();
+				using (var mountPointsKey = accountKey.OpenSubKey("ScopeIdToMountPointPathCache"))
 				{
 					if (mountPointsKey is null)
 					{
@@ -207,25 +209,29 @@ namespace Files.App.Utils.Cloud
 					var valueNames = mountPointsKey.GetValueNames();
 					foreach (var valueName in valueNames)
 					{
-						var value = (string)Registry.GetValue(@$"HKEY_CURRENT_USER\{mountPointKeyName}", valueName, null);
-						if (!string.Equals(value, userFolderToExcludeFromResults, StringComparison.OrdinalIgnoreCase))
+						var directory = (string?)mountPointsKey.GetValue(valueName, null);
+						if (directory != null && !string.Equals(directory, userFolderToExcludeFromResults, StringComparison.OrdinalIgnoreCase))
 						{
-							sharePointSyncFolders.Add(value);
+							var parentFolder = Directory.GetParent(directory);
+							if (parentFolder != null)
+							{
+								sharePointParentFolders.Add(parentFolder);
+							}
 						}
 					}
 				}
 
-				sharePointSyncFolders.Sort(StringComparer.Ordinal);
-				foreach (var sharePointSyncFolder in sharePointSyncFolders)
+				sharePointParentFolders.Sort((left, right) => left.FullName.CompareTo(right.FullName));
+
+				foreach (var sharePointParentFolder in sharePointParentFolders)
 				{
-					var parentFolder = Directory.GetParent(sharePointSyncFolder)?.FullName ?? string.Empty;
-					if (!sharepointAccounts.Any(acc =>
-						string.Equals(acc.Name, accountName, StringComparison.OrdinalIgnoreCase)) && !string.IsNullOrWhiteSpace(parentFolder))
+					string name = $"SharePoint - {sharePointParentFolder.Name}";
+					if (!sharepointAccounts.Any(acc => string.Equals(acc.Name, name, StringComparison.OrdinalIgnoreCase)))
 					{
 						sharepointAccounts.Add(new CloudProvider(CloudProviders.OneDriveCommercial)
 						{
-							Name = accountName,
-							SyncFolder = parentFolder,
+							Name = name,
+							SyncFolder = sharePointParentFolder.FullName,
 						});
 					}
 				}

--- a/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
+++ b/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
@@ -212,9 +212,7 @@ namespace Files.App.Utils.Cloud
 						{
 							var parentFolder = Directory.GetParent(directory);
 							if (parentFolder != null)
-							{
 								sharePointParentFolders.Add(parentFolder);
-							}
 						}
 					}
 				}

--- a/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
+++ b/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
@@ -192,9 +192,7 @@ namespace Files.App.Utils.Cloud
 			{
 				var accountKey = oneDriveAccountsKey.OpenSubKey(account);
 				if (accountKey is null)
-				{
 					continue;
-				}
 
 				var userFolderToExcludeFromResults = (string)accountKey.GetValue("UserFolder", "");
 


### PR DESCRIPTION
I got a bit annoyed with Files only listing one of the Company SharePoint folders that I use, so I went and implemented this.

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #4966

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [x] Are there any other steps that were used to validate these changes?
   1. Open app
   2. Compare SharePoint listing between old and new versions and between the actual folders.

**Screenshots**
![image](https://github.com/files-community/Files/assets/29034492/541d7a7c-a8c7-433a-a0f2-80b2c87c66a5)

