### PR TITLE
Fix: Fixed issue with editing properties of multiple items at the same time

### DIFF
--- a/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
+++ b/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
@@ -663,8 +663,8 @@ namespace Files.App.Data.Models
 			set => SetProperty(ref fileProperties, value);
 		}
 
-		private bool isReadOnly;
-		public bool IsReadOnly
+		private bool? isReadOnly;
+		public bool? IsReadOnly
 		{
 			get => isReadOnly;
 			set
@@ -675,8 +675,8 @@ namespace Files.App.Data.Models
 			}
 		}
 
-		private bool isReadOnlyEditedValue;
-		public bool IsReadOnlyEditedValue
+		private bool? isReadOnlyEditedValue;
+		public bool? IsReadOnlyEditedValue
 		{
 			get => isReadOnlyEditedValue;
 			set
@@ -693,8 +693,8 @@ namespace Files.App.Data.Models
 			set => SetProperty(ref isReadOnlyEnabled, value);
 		}
 
-		private bool isHidden;
-		public bool IsHidden
+		private bool? isHidden;
+		public bool? IsHidden
 		{
 			get => isHidden;
 			set
@@ -704,8 +704,8 @@ namespace Files.App.Data.Models
 			}
 		}
 
-		private bool isHiddenEditedValue;
-		public bool IsHiddenEditedValue
+		private bool? isHiddenEditedValue;
+		public bool? IsHiddenEditedValue
 		{
 			get => isHiddenEditedValue;
 			set => SetProperty(ref isHiddenEditedValue, value);

--- a/src/Files.App/ViewModels/Properties/Items/CombinedProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/CombinedProperties.cs
@@ -59,9 +59,23 @@ namespace Files.App.ViewModels.Properties
 		public override async Task GetSpecialPropertiesAsync()
 		{
 			if (List.All(x => x.PrimaryItemAttribute == StorageItemTypes.File))
-				ViewModel.IsReadOnly = List.All(x => NativeFileOperationsHelper.HasFileAttribute(x.ItemPath, System.IO.FileAttributes.ReadOnly));
+			{
+				var fileAttributesReadOnly = List.Select(x => NativeFileOperationsHelper.HasFileAttribute(x.ItemPath, System.IO.FileAttributes.ReadOnly));
+				if (fileAttributesReadOnly.All(x => x))
+					ViewModel.IsReadOnly = true;
+				else if (!fileAttributesReadOnly.Any(x => x))
+					ViewModel.IsReadOnly = false;
+				else
+					ViewModel.IsReadOnly = null;
+			}
 
-			ViewModel.IsHidden = List.All(x => NativeFileOperationsHelper.HasFileAttribute(x.ItemPath, System.IO.FileAttributes.Hidden));
+			var fileAttributesHidden = List.Select(x => NativeFileOperationsHelper.HasFileAttribute(x.ItemPath, System.IO.FileAttributes.Hidden));
+			if (fileAttributesHidden.All(x => x))
+				ViewModel.IsHidden = true;
+			else if (!fileAttributesHidden.Any(x => x))
+				ViewModel.IsHidden = false;
+			else
+				ViewModel.IsHidden = null;
 
 			ViewModel.LastSeparatorVisibility = false;
 			ViewModel.ItemSizeVisibility = true;
@@ -122,30 +136,36 @@ namespace Files.App.ViewModels.Properties
 			{
 				case "IsReadOnly":
 					{
-						if (ViewModel.IsReadOnly)
+						if (ViewModel.IsReadOnly is not null)
 						{
-							List.ForEach(x => NativeFileOperationsHelper.SetFileAttribute(
-								x.ItemPath, System.IO.FileAttributes.ReadOnly));
-						}
-						else
-						{
-							List.ForEach(x => NativeFileOperationsHelper.UnsetFileAttribute(
-								x.ItemPath, System.IO.FileAttributes.ReadOnly));
+							if ((bool)ViewModel.IsReadOnly)
+							{
+								List.ForEach(x => NativeFileOperationsHelper.SetFileAttribute(
+									x.ItemPath, System.IO.FileAttributes.ReadOnly));
+							}
+							else
+							{
+								List.ForEach(x => NativeFileOperationsHelper.UnsetFileAttribute(
+									x.ItemPath, System.IO.FileAttributes.ReadOnly));
+							}
 						}
 					}
 					break;
 
 				case "IsHidden":
 					{
-						if (ViewModel.IsHidden)
+						if (ViewModel.IsHidden is not null)
 						{
-							List.ForEach(x => NativeFileOperationsHelper.SetFileAttribute(
-								x.ItemPath, System.IO.FileAttributes.Hidden));
-						}
-						else
-						{
-							List.ForEach(x => NativeFileOperationsHelper.UnsetFileAttribute(
-								x.ItemPath, System.IO.FileAttributes.Hidden));
+							if ((bool)ViewModel.IsHidden)
+							{
+								List.ForEach(x => NativeFileOperationsHelper.SetFileAttribute(
+									x.ItemPath, System.IO.FileAttributes.Hidden));
+							}
+							else
+							{
+								List.ForEach(x => NativeFileOperationsHelper.UnsetFileAttribute(
+									x.ItemPath, System.IO.FileAttributes.Hidden));
+							}
 						}
 
 					}

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -278,19 +278,9 @@ namespace Files.App.ViewModels.Properties
 					if (ViewModel.IsReadOnly is not null)
 					{
 						if ((bool)ViewModel.IsReadOnly)
-						{
-							NativeFileOperationsHelper.SetFileAttribute(
-								Item.ItemPath,
-								System.IO.FileAttributes.ReadOnly
-							);
-						}
+							NativeFileOperationsHelper.SetFileAttribute(Item.ItemPath, System.IO.FileAttributes.ReadOnly);
 						else
-						{
-							NativeFileOperationsHelper.UnsetFileAttribute(
-								Item.ItemPath,
-								System.IO.FileAttributes.ReadOnly
-							);
-						}
+							NativeFileOperationsHelper.UnsetFileAttribute(Item.ItemPath, System.IO.FileAttributes.ReadOnly);
 					}
 
 					break;
@@ -299,19 +289,9 @@ namespace Files.App.ViewModels.Properties
 					if (ViewModel.IsHidden is not null)
 					{
 						if ((bool)ViewModel.IsHidden)
-						{
-							NativeFileOperationsHelper.SetFileAttribute(
-								Item.ItemPath,
-								System.IO.FileAttributes.Hidden
-							);
-						}
+							NativeFileOperationsHelper.SetFileAttribute(Item.ItemPath,	System.IO.FileAttributes.Hidden);
 						else
-						{
-							NativeFileOperationsHelper.UnsetFileAttribute(
-								Item.ItemPath,
-								System.IO.FileAttributes.Hidden
-							);
-						}
+							NativeFileOperationsHelper.UnsetFileAttribute(Item.ItemPath, System.IO.FileAttributes.Hidden);
 					}
 
 					break;

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -275,37 +275,43 @@ namespace Files.App.ViewModels.Properties
 			switch (e.PropertyName)
 			{
 				case nameof(ViewModel.IsReadOnly):
-					if (ViewModel.IsReadOnly)
+					if (ViewModel.IsReadOnly is not null)
 					{
-						NativeFileOperationsHelper.SetFileAttribute(
-							Item.ItemPath,
-							System.IO.FileAttributes.ReadOnly
-						);
-					}
-					else
-					{
-						NativeFileOperationsHelper.UnsetFileAttribute(
-							Item.ItemPath,
-							System.IO.FileAttributes.ReadOnly
-						);
+						if ((bool)ViewModel.IsReadOnly)
+						{
+							NativeFileOperationsHelper.SetFileAttribute(
+								Item.ItemPath,
+								System.IO.FileAttributes.ReadOnly
+							);
+						}
+						else
+						{
+							NativeFileOperationsHelper.UnsetFileAttribute(
+								Item.ItemPath,
+								System.IO.FileAttributes.ReadOnly
+							);
+						}
 					}
 
 					break;
 
 				case nameof(ViewModel.IsHidden):
-					if (ViewModel.IsHidden)
+					if (ViewModel.IsHidden is not null)
 					{
-						NativeFileOperationsHelper.SetFileAttribute(
-							Item.ItemPath,
-							System.IO.FileAttributes.Hidden
-						);
-					}
-					else
-					{
-						NativeFileOperationsHelper.UnsetFileAttribute(
-							Item.ItemPath,
-							System.IO.FileAttributes.Hidden
-						);
+						if ((bool)ViewModel.IsHidden)
+						{
+							NativeFileOperationsHelper.SetFileAttribute(
+								Item.ItemPath,
+								System.IO.FileAttributes.Hidden
+							);
+						}
+						else
+						{
+							NativeFileOperationsHelper.UnsetFileAttribute(
+								Item.ItemPath,
+								System.IO.FileAttributes.Hidden
+							);
+						}
 					}
 
 					break;

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -203,15 +203,9 @@ namespace Files.App.ViewModels.Properties
 					if (ViewModel.IsHidden is not null)
 					{
 						if ((bool)ViewModel.IsHidden)
-						{
-							NativeFileOperationsHelper.SetFileAttribute(
-								Item.ItemPath, System.IO.FileAttributes.Hidden);
-						}
+							NativeFileOperationsHelper.SetFileAttribute(Item.ItemPath, System.IO.FileAttributes.Hidden);
 						else
-						{
-							NativeFileOperationsHelper.UnsetFileAttribute(
-								Item.ItemPath, System.IO.FileAttributes.Hidden);
-						}
+							NativeFileOperationsHelper.UnsetFileAttribute(Item.ItemPath, System.IO.FileAttributes.Hidden);
 					}
 					break;
 

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -200,15 +200,18 @@ namespace Files.App.ViewModels.Properties
 			switch (e.PropertyName)
 			{
 				case "IsHidden":
-					if (ViewModel.IsHidden)
+					if (ViewModel.IsHidden is not null)
 					{
-						NativeFileOperationsHelper.SetFileAttribute(
-							Item.ItemPath, System.IO.FileAttributes.Hidden);
-					}
-					else
-					{
-						NativeFileOperationsHelper.UnsetFileAttribute(
-							Item.ItemPath, System.IO.FileAttributes.Hidden);
+						if ((bool)ViewModel.IsHidden)
+						{
+							NativeFileOperationsHelper.SetFileAttribute(
+								Item.ItemPath, System.IO.FileAttributes.Hidden);
+						}
+						else
+						{
+							NativeFileOperationsHelper.UnsetFileAttribute(
+								Item.ItemPath, System.IO.FileAttributes.Hidden);
+						}
 					}
 					break;
 

--- a/src/Files.App/ViewModels/Properties/Items/LibraryProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/LibraryProperties.cs
@@ -144,13 +144,9 @@ namespace Files.App.ViewModels.Properties
 					if (ViewModel.IsReadOnly is not null)
 					{
 						if ((bool)ViewModel.IsReadOnly)
-						{
 							NativeFileOperationsHelper.SetFileAttribute(Library.ItemPath, System.IO.FileAttributes.ReadOnly);
-						}
 						else
-						{
 							NativeFileOperationsHelper.UnsetFileAttribute(Library.ItemPath, System.IO.FileAttributes.ReadOnly);
-						}
 					}
 
 					break;
@@ -159,13 +155,9 @@ namespace Files.App.ViewModels.Properties
 					if (ViewModel.IsHidden is not null)
 					{
 						if ((bool)ViewModel.IsHidden)
-						{
 							NativeFileOperationsHelper.SetFileAttribute(Library.ItemPath, System.IO.FileAttributes.Hidden);
-						}
 						else
-						{
 							NativeFileOperationsHelper.UnsetFileAttribute(Library.ItemPath, System.IO.FileAttributes.Hidden);
-						}
 					}
 
 					break;

--- a/src/Files.App/ViewModels/Properties/Items/LibraryProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/LibraryProperties.cs
@@ -141,25 +141,31 @@ namespace Files.App.ViewModels.Properties
 			switch (e.PropertyName)
 			{
 				case "IsReadOnly":
-					if (ViewModel.IsReadOnly)
+					if (ViewModel.IsReadOnly is not null)
 					{
-						NativeFileOperationsHelper.SetFileAttribute(Library.ItemPath, System.IO.FileAttributes.ReadOnly);
-					}
-					else
-					{
-						NativeFileOperationsHelper.UnsetFileAttribute(Library.ItemPath, System.IO.FileAttributes.ReadOnly);
+						if ((bool)ViewModel.IsReadOnly)
+						{
+							NativeFileOperationsHelper.SetFileAttribute(Library.ItemPath, System.IO.FileAttributes.ReadOnly);
+						}
+						else
+						{
+							NativeFileOperationsHelper.UnsetFileAttribute(Library.ItemPath, System.IO.FileAttributes.ReadOnly);
+						}
 					}
 
 					break;
 
 				case "IsHidden":
-					if (ViewModel.IsHidden)
+					if (ViewModel.IsHidden is not null)
 					{
-						NativeFileOperationsHelper.SetFileAttribute(Library.ItemPath, System.IO.FileAttributes.Hidden);
-					}
-					else
-					{
-						NativeFileOperationsHelper.UnsetFileAttribute(Library.ItemPath, System.IO.FileAttributes.Hidden);
+						if ((bool)ViewModel.IsHidden)
+						{
+							NativeFileOperationsHelper.SetFileAttribute(Library.ItemPath, System.IO.FileAttributes.Hidden);
+						}
+						else
+						{
+							NativeFileOperationsHelper.UnsetFileAttribute(Library.ItemPath, System.IO.FileAttributes.Hidden);
+						}
 					}
 
 					break;

--- a/src/Files.App/Views/Properties/GeneralPage.xaml.cs
+++ b/src/Files.App/Views/Properties/GeneralPage.xaml.cs
@@ -181,8 +181,7 @@ namespace Files.App.Views.Properties
 				}
 
 				ViewModel.IsReadOnly = ViewModel.IsReadOnlyEditedValue;
-				if (ViewModel.IsHiddenEditedValue is not null)
-					ViewModel.IsHidden = (bool)ViewModel.IsHiddenEditedValue;
+				ViewModel.IsHidden = ViewModel.IsHiddenEditedValue;
 
 				if (!GetNewName(out var newName))
 					return true;

--- a/src/Files.App/Views/Properties/GeneralPage.xaml.cs
+++ b/src/Files.App/Views/Properties/GeneralPage.xaml.cs
@@ -156,7 +156,7 @@ namespace Files.App.Views.Properties
 				if (itemMM is not null) // null on homepage
 				{
 					await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
-						UIFilesystemHelpers.SetHiddenAttributeItem(item, ViewModel.IsHidden, itemMM)
+						UIFilesystemHelpers.SetHiddenAttributeItem(item, ViewModel.IsHiddenEditedValue, itemMM)
 					);
 				}
 

--- a/src/Files.App/Views/Properties/GeneralPage.xaml.cs
+++ b/src/Files.App/Views/Properties/GeneralPage.xaml.cs
@@ -132,8 +132,11 @@ namespace Files.App.Views.Properties
 					foreach (var fileOrFolder in fileOrFolders)
 					{
 						await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
-							UIFilesystemHelpers.SetHiddenAttributeItem(fileOrFolder, ViewModel.IsHidden, itemMM)
+							UIFilesystemHelpers.SetHiddenAttributeItem(fileOrFolder, ViewModel.IsHiddenEditedValue, itemMM)
 						);
+						ViewModel.IsHidden = ViewModel.IsHiddenEditedValue;
+
+						ViewModel.IsReadOnly = ViewModel.IsReadOnlyEditedValue;
 
 						if (ViewModel.IsAblumCoverModified)
 						{

--- a/src/Files.App/Views/Properties/GeneralPage.xaml.cs
+++ b/src/Files.App/Views/Properties/GeneralPage.xaml.cs
@@ -131,10 +131,14 @@ namespace Files.App.Views.Properties
 				{
 					foreach (var fileOrFolder in fileOrFolders)
 					{
-						await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
-							UIFilesystemHelpers.SetHiddenAttributeItem(fileOrFolder, ViewModel.IsHiddenEditedValue, itemMM)
-						);
-						ViewModel.IsHidden = ViewModel.IsHiddenEditedValue;
+						if (ViewModel.IsHiddenEditedValue is not null)
+						{
+							var isHiddenEditedValue = (bool)ViewModel.IsHiddenEditedValue;
+							await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
+								UIFilesystemHelpers.SetHiddenAttributeItem(fileOrFolder, isHiddenEditedValue, itemMM)
+							);
+							ViewModel.IsHidden = isHiddenEditedValue;
+						}
 
 						ViewModel.IsReadOnly = ViewModel.IsReadOnlyEditedValue;
 
@@ -156,10 +160,10 @@ namespace Files.App.Views.Properties
 			{
 				// Handle the visibility attribute for a single file
 				var itemMM = AppInstance?.SlimContentPage?.ItemManipulationModel;
-				if (itemMM is not null) // null on homepage
+				if (itemMM is not null && ViewModel.IsHiddenEditedValue is not null) // null on homepage
 				{
 					await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
-						UIFilesystemHelpers.SetHiddenAttributeItem(item, ViewModel.IsHiddenEditedValue, itemMM)
+						UIFilesystemHelpers.SetHiddenAttributeItem(item, (bool)ViewModel.IsHiddenEditedValue, itemMM)
 					);
 				}
 
@@ -177,7 +181,8 @@ namespace Files.App.Views.Properties
 				}
 
 				ViewModel.IsReadOnly = ViewModel.IsReadOnlyEditedValue;
-				ViewModel.IsHidden = ViewModel.IsHiddenEditedValue;
+				if (ViewModel.IsHiddenEditedValue is not null)
+					ViewModel.IsHidden = (bool)ViewModel.IsHiddenEditedValue;
 
 				if (!GetNewName(out var newName))
 					return true;


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14900 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?

**Test Cases**
 Hidden status is saved and displayed correctly directly in the UI if only one file is selected
- Select a file, open properties, select hidden + save
- The file is now displayed directly in the list as hidden
- Open properties again and check whether hidden status is set
 
Hidden status is saved and displayed correctly directly in the UI when multiple files are selected
- Select multiple files, select hidden + save
- The files are now displayed directly in the list as hidden
- Open properties again and check whether hidden status is set

**Screenshots (optional)**
Add screenshots here.
