### PR TITLE
Fix: Fixed conflict with svg thumbnails generated by PowerToys

### DIFF
--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -923,7 +923,9 @@ namespace Files.App.Data.Models
 			var returnIconOnly = UserSettingsService.FoldersSettingsService.ShowThumbnails == false || thumbnailSize < 48;
 
 			byte[]? result = null;
-			if (item.IsFolder)
+
+			// Folders and svg thumbnails take longer to generate
+			if (item.IsFolder || FileExtensionHelpers.IsSvgFile(item.FileExtension))
 			{
 				if (!returnIconOnly)
 				{

--- a/src/Files.App/Data/Models/ItemViewModel.cs
+++ b/src/Files.App/Data/Models/ItemViewModel.cs
@@ -924,8 +924,8 @@ namespace Files.App.Data.Models
 
 			byte[]? result = null;
 
-			// Folders and svg thumbnails take longer to generate
-			if (item.IsFolder || FileExtensionHelpers.IsSvgFile(item.FileExtension))
+			// Non-cached thumbnails take longer to generate
+			if (item.IsFolder || !FileExtensionHelpers.IsExecutableFile(item.FileExtension))
 			{
 				if (!returnIconOnly)
 				{

--- a/src/Files.Shared/Helpers/FileExtensionHelpers.cs
+++ b/src/Files.Shared/Helpers/FileExtensionHelpers.cs
@@ -164,16 +164,6 @@ namespace Files.Shared.Helpers
 		}
 
 		/// <summary>
-		/// Check if the file path is an svg file.
-		/// </summary>
-		/// <param name="filePathToCheck">The file path to check.</param>
-		/// <returns><c>true</c> if the filePathToCheck is an svg file; otherwise, <c>false</c>.</returns>
-		public static bool IsSvgFile(string? filePathToCheck)
-		{
-			return HasExtension(filePathToCheck, ".svg");
-		}
-
-		/// <summary>
 		/// Check if the file extension is a vhd disk file.
 		/// </summary>
 		/// <param name="fileExtensionToCheck">The file extension to check.</param>

--- a/src/Files.Shared/Helpers/FileExtensionHelpers.cs
+++ b/src/Files.Shared/Helpers/FileExtensionHelpers.cs
@@ -164,6 +164,16 @@ namespace Files.Shared.Helpers
 		}
 
 		/// <summary>
+		/// Check if the file path is an svg file.
+		/// </summary>
+		/// <param name="filePathToCheck">The file path to check.</param>
+		/// <returns><c>true</c> if the filePathToCheck is an svg file; otherwise, <c>false</c>.</returns>
+		public static bool IsSvgFile(string? filePathToCheck)
+		{
+			return HasExtension(filePathToCheck, ".svg");
+		}
+
+		/// <summary>
 		/// Check if the file extension is a vhd disk file.
 		/// </summary>
 		/// <param name="fileExtensionToCheck">The file extension to check.</param>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #15072...

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
   1. Enable svg thumbnails in PowerToys
   2. Clear thumbnail cache in Windows
   3. Open folder in Files with svgs and confirm a basic icon is displayed and then replaced with the thumbnail

**Screenshots (optional)**
Add screenshots here.
