### PR TITLE
Fix: Fixed issue of overlapping brushes leaving gap in the Columns View

### DIFF
--- a/src/Files.App/Helpers/Layout/LayoutSizeKindHelper.cs
+++ b/src/Files.App/Helpers/Layout/LayoutSizeKindHelper.cs
@@ -103,17 +103,17 @@ namespace Files.App.Helpers
 			switch (columnsViewSizeKind)
 			{
 				case ColumnsViewSizeKind.Compact:
-					return 28;
+					return 24;
 				case ColumnsViewSizeKind.Small:
-					return 36;
+					return 32;
 				case ColumnsViewSizeKind.Medium:
-					return 40;
-				case ColumnsViewSizeKind.Large:
-					return 44;
-				case ColumnsViewSizeKind.ExtraLarge:
-					return 48;
-				default:
 					return 36;
+				case ColumnsViewSizeKind.Large:
+					return 40;
+				case ColumnsViewSizeKind.ExtraLarge:
+					return 44;
+				default:
+					return 32;
 			}
 		}
 

--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml
@@ -206,6 +206,7 @@
 							<Grid
 								x:Name="FilesRootGrid"
 								Height="{Binding RowHeight, ElementName=PageRoot, Mode=OneWay}"
+								Margin="0,2,0,2"
 								Padding="12,0,12,0"
 								HorizontalAlignment="Stretch"
 								VerticalAlignment="Center"

--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
@@ -92,8 +92,7 @@ namespace Files.App.Views.Layouts
 				return;
 
 			openedFolderPresenter.Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
-			var presenter = openedFolderPresenter.FindDescendant<Grid>()!;
-			presenter!.Background = new SolidColorBrush(Microsoft.UI.Colors.Transparent);
+			SetFolderBackground(openedFolderPresenter, new SolidColorBrush(Microsoft.UI.Colors.Transparent));
 			openedFolderPresenter = null;
 		}
 
@@ -157,8 +156,8 @@ namespace Files.App.Views.Layouts
 			if (args.Item is ListedItem item && columnsOwner?.OwnerPath is string ownerPath
 				&& (ownerPath == item.ItemPath || ownerPath.StartsWith(item.ItemPath) && ownerPath[item.ItemPath.Length] is '/' or '\\'))
 			{
-				var presenter = args.ItemContainer.FindDescendant<Grid>()!;
-				presenter!.Background = this.Resources["ListViewItemBackgroundSelected"] as SolidColorBrush;
+				SetFolderBackground(args.ItemContainer as ListViewItem, this.Resources["ListViewItemBackgroundSelected"] as SolidColorBrush);
+
 				openedFolderPresenter = FileList.ContainerFromItem(item) as ListViewItem;
 				FileList.ContainerContentChanging -= HighlightPathDirectory;
 			}
@@ -279,8 +278,7 @@ namespace Files.App.Views.Layouts
 
 			if (e.RemovedItems.Count > 0 && openedFolderPresenter != null)
 			{
-				var presenter = openedFolderPresenter.FindDescendant<Grid>()!;
-				presenter!.Background = this.Resources["ListViewItemBackgroundSelected"] as SolidColorBrush;
+				SetFolderBackground(openedFolderPresenter, this.Resources["ListViewItemBackgroundSelected"] as SolidColorBrush);
 			}
 
 			if (SelectedItems?.Count == 1 && SelectedItem?.PrimaryItemAttribute is StorageItemTypes.Folder)
@@ -591,6 +589,17 @@ namespace Files.App.Views.Layouts
 			LockPreviewPaneContent = true;
 			FileList.SelectedItem = null;
 			LockPreviewPaneContent = false;
+		}
+
+		private static void SetFolderBackground(ListViewItem? lvi, SolidColorBrush? backgroundColor)
+		{
+			if (lvi == null || backgroundColor == null) return;
+
+
+			if (lvi.FindDescendant<Grid>() is Grid presenter)
+			{
+				presenter.Background = backgroundColor;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #issue...
Discussed with @yair100 , this PR aims to fix the small gap visible on the items that are part of the path but are not the last item when they are hovered as shown on the screenshot below:
![Screenshot of small gap on hovered item](https://github.com/files-community/Files/assets/16122379/cbe6ed05-dad3-496c-a7b6-edc15772eaa8)

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Screenshots (optional)**
Add screenshots here.
