### PR TITLE
Feature: Switch settings dialog to tab

### DIFF
--- a/src/Files.App/Actions/Open/OpenSettingsAction.cs
+++ b/src/Files.App/Actions/Open/OpenSettingsAction.cs
@@ -5,10 +5,6 @@ namespace Files.App.Actions
 {
 	internal sealed class OpenSettingsAction : BaseUIAction, IAction
 	{
-		private readonly IDialogService dialogService = Ioc.Default.GetRequiredService<IDialogService>();
-
-		private readonly SettingsDialogViewModel viewModel = new();
-
 		public string Label
 			=> "Settings".GetLocalizedResource();
 
@@ -20,8 +16,9 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync()
 		{
-			var dialog = dialogService.GetDialog(viewModel);
-			return dialog.TryShowAsync();
+			NavigationHelpers.OpenSettings();
+
+			return Task.CompletedTask;
 		}
 	}
 }

--- a/src/Files.App/Data/Models/CurrentInstanceViewModel.cs
+++ b/src/Files.App/Data/Models/CurrentInstanceViewModel.cs
@@ -55,6 +55,18 @@ namespace Files.App.Data.Models
 			}
 		}
 
+		private bool _IsPageTypeSettings = false;
+		public bool IsPageTypeSettings
+		{
+			get => _IsPageTypeSettings;
+			set
+			{
+				SetProperty(ref _IsPageTypeSettings, value);
+				OnPropertyChanged(nameof(CanCreateFileInPage));
+				OnPropertyChanged(nameof(CanCopyPathInPage));
+			}
+		}
+
 		private bool isPageTypeMtpDevice = false;
 		public bool IsPageTypeMtpDevice
 		{

--- a/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+using Files.App.Dialogs;
 using Files.App.Server.Data.Enums;
 using Files.Shared.Helpers;
 using Microsoft.UI.Xaml.Controls;
@@ -13,6 +14,7 @@ namespace Files.App.Helpers
 {
 	public static class NavigationHelpers
 	{
+		private static IContentPageContext ContentPageContext { get; } = Ioc.Default.GetRequiredService<IContentPageContext>();
 		private static MainPageViewModel MainPageViewModel { get; } = Ioc.Default.GetRequiredService<MainPageViewModel>();
 		private static DrivesViewModel DrivesViewModel { get; } = Ioc.Default.GetRequiredService<DrivesViewModel>();
 		private static NetworkDrivesViewModel NetworkDrivesViewModel { get; } = Ioc.Default.GetRequiredService<NetworkDrivesViewModel>();
@@ -25,6 +27,12 @@ namespace Files.App.Helpers
 		public static Task AddNewTabAsync()
 		{
 			return AddNewTabByPathAsync(typeof(PaneHolderPage), "Home", true);
+		}
+
+		public static void OpenSettings()
+		{
+			if (ContentPageContext.ShellPage?.PaneHolder.ActivePane is IShellPage shellPage)
+				shellPage.NavigateToPath("Settings", typeof(MainSettingsPage));
 		}
 
 		public static async Task AddNewTabByPathAsync(Type type, string? path, bool focusNewTab, int atIndex = -1)

--- a/src/Files.App/Services/DialogService.cs
+++ b/src/Files.App/Services/DialogService.cs
@@ -28,7 +28,6 @@ namespace Files.App.Services
 				{ typeof(ElevateConfirmDialogViewModel), () => new ElevateConfirmDialog() },
 				{ typeof(FileSystemDialogViewModel), () => new FilesystemOperationDialog() },
 				{ typeof(DecompressArchiveDialogViewModel), () => new DecompressArchiveDialog() },
-				{ typeof(SettingsDialogViewModel), () => new SettingsDialog() },
 				{ typeof(CreateShortcutDialogViewModel), () => new CreateShortcutDialog() },
 				{ typeof(ReorderSidebarItemsDialogViewModel), () => new ReorderSidebarItemsDialog() },
 				{ typeof(AddBranchDialogViewModel), () => new AddBranchDialog() },

--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -57,7 +57,8 @@
 	<Grid
 		x:Name="RootGrid"
 		BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-		BorderThickness="0,0,0,1">
+		BorderThickness="0,0,0,1"
+		Visibility="{x:Bind ViewModel.InstanceViewModel.IsPageTypeSettings, Converter={StaticResource NegatedBoolToVisibilityConverter}, Mode=OneWay}">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="*" />
 			<ColumnDefinition Width="Auto" />

--- a/src/Files.App/UserControls/PathBreadcrumb.xaml.cs
+++ b/src/Files.App/UserControls/PathBreadcrumb.xaml.cs
@@ -7,9 +7,21 @@ using Microsoft.UI.Xaml.Input;
 
 namespace Files.App.UserControls
 {
-	[DependencyProperty<AddressToolbarViewModel>("ViewModel")]
 	public sealed partial class PathBreadcrumb : UserControl
 	{
+		public static readonly DependencyProperty ViewModelProperty =
+			DependencyProperty.Register(
+				nameof(ViewModel),
+				typeof(AddressToolbarViewModel),
+				typeof(PathBreadcrumb),
+				new(null));
+
+		public AddressToolbarViewModel ViewModel
+		{
+			get => (AddressToolbarViewModel)GetValue(ViewModelProperty);
+			set => SetValue(ViewModelProperty, value);
+		}
+
 		public PathBreadcrumb()
 		{
 			InitializeComponent();

--- a/src/Files.App/ViewModels/Settings/MainSettingsViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/MainSettingsViewModel.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-namespace Files.App.ViewModels.Dialogs
+namespace Files.App.ViewModels.Settings
 {
-	public sealed class SettingsDialogViewModel : ObservableObject
+	public sealed class MainSettingsViewModel : ObservableObject
 	{
 	}
 }

--- a/src/Files.App/Views/Settings/AboutPage.xaml
+++ b/src/Files.App/Views/Settings/AboutPage.xaml
@@ -20,17 +20,11 @@
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch"
 			Spacing="4">
-			<StackPanel.ChildrenTransitions>
-				<TransitionCollection>
-					<EntranceThemeTransition />
-				</TransitionCollection>
-			</StackPanel.ChildrenTransitions>
 
 			<!--  Title  -->
 			<TextBlock
-				Padding="0,0,0,12"
-				FontSize="24"
-				FontWeight="Medium"
+				Padding="0,0,0,8"
+				Style="{StaticResource SubtitleTextBlockStyle}"
 				Text="{helpers:ResourceString Name=About}" />
 
 			<!--  App Info  -->

--- a/src/Files.App/Views/Settings/AdvancedPage.xaml
+++ b/src/Files.App/Views/Settings/AdvancedPage.xaml
@@ -32,17 +32,11 @@
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch"
 			Spacing="4">
-			<StackPanel.ChildrenTransitions>
-				<TransitionCollection>
-					<EntranceThemeTransition />
-				</TransitionCollection>
-			</StackPanel.ChildrenTransitions>
 
 			<!--  Title  -->
 			<TextBlock
-				Padding="0,0,0,12"
-				FontSize="24"
-				FontWeight="Medium"
+				Padding="0,0,0,8"
+				Style="{StaticResource SubtitleTextBlockStyle}"
 				Text="{helpers:ResourceString Name=Advanced}" />
 
 			<!--  Export  -->

--- a/src/Files.App/Views/Settings/AppearancePage.xaml
+++ b/src/Files.App/Views/Settings/AppearancePage.xaml
@@ -90,17 +90,11 @@
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch"
 			Spacing="4">
-			<StackPanel.ChildrenTransitions>
-				<TransitionCollection>
-					<EntranceThemeTransition />
-				</TransitionCollection>
-			</StackPanel.ChildrenTransitions>
 
 			<!--  Title  -->
 			<TextBlock
-				Padding="0,0,0,12"
-				FontSize="24"
-				FontWeight="Medium"
+				Padding="0,0,0,8"
+				Style="{StaticResource SubtitleTextBlockStyle}"
 				Text="{helpers:ResourceString Name=Appearance}" />
 
 			<!--  Theme  -->

--- a/src/Files.App/Views/Settings/FoldersPage.xaml
+++ b/src/Files.App/Views/Settings/FoldersPage.xaml
@@ -23,17 +23,11 @@
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch"
 			Spacing="4">
-			<StackPanel.ChildrenTransitions>
-				<TransitionCollection>
-					<EntranceThemeTransition />
-				</TransitionCollection>
-			</StackPanel.ChildrenTransitions>
 
 			<!--  Title  -->
 			<TextBlock
-				Padding="0,0,0,12"
-				FontSize="24"
-				FontWeight="Medium"
+				Padding="0,0,0,8"
+				Style="{StaticResource SubtitleTextBlockStyle}"
 				Text="{helpers:ResourceString Name=FilesAndFolders}" />
 
 			<!--  Display  -->

--- a/src/Files.App/Views/Settings/GeneralPage.xaml
+++ b/src/Files.App/Views/Settings/GeneralPage.xaml
@@ -26,17 +26,11 @@
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch"
 			Spacing="4">
-			<StackPanel.ChildrenTransitions>
-				<TransitionCollection>
-					<EntranceThemeTransition />
-				</TransitionCollection>
-			</StackPanel.ChildrenTransitions>
 
 			<!--  Title  -->
 			<TextBlock
-				Padding="0,0,0,12"
-				FontSize="24"
-				FontWeight="Medium"
+				Padding="0,0,0,8"
+				Style="{StaticResource SubtitleTextBlockStyle}"
 				Text="{helpers:ResourceString Name=General}" />
 
 			<!--  Language settings  -->

--- a/src/Files.App/Views/Settings/GitPage.xaml
+++ b/src/Files.App/Views/Settings/GitPage.xaml
@@ -32,17 +32,11 @@
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch"
 			Spacing="4">
-			<StackPanel.ChildrenTransitions>
-				<TransitionCollection>
-					<EntranceThemeTransition />
-				</TransitionCollection>
-			</StackPanel.ChildrenTransitions>
 
 			<!--  Title  -->
 			<TextBlock
-				Padding="0,0,0,12"
-				FontSize="24"
-				FontWeight="Medium"
+				Padding="0,0,0,8"
+				Style="{StaticResource SubtitleTextBlockStyle}"
 				Text="{helpers:ResourceString Name=Git}" />
 
 			<!--  Connect to GitHub  -->

--- a/src/Files.App/Views/Settings/LayoutPage.xaml
+++ b/src/Files.App/Views/Settings/LayoutPage.xaml
@@ -23,17 +23,11 @@
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch"
 			Spacing="4">
-			<StackPanel.ChildrenTransitions>
-				<TransitionCollection>
-					<EntranceThemeTransition />
-				</TransitionCollection>
-			</StackPanel.ChildrenTransitions>
 
 			<!--  Title  -->
 			<TextBlock
-				Padding="0,0,0,12"
-				FontSize="24"
-				FontWeight="Medium"
+				Padding="0,0,0,8"
+				Style="{StaticResource SubtitleTextBlockStyle}"
 				Text="{helpers:ResourceString Name=Layout}" />
 
 			<!--  Folder Overrides  -->

--- a/src/Files.App/Views/Settings/MainSettingsPage.xaml
+++ b/src/Files.App/Views/Settings/MainSettingsPage.xaml
@@ -1,19 +1,15 @@
 ﻿<!--  Copyright (c) 2024 Files Community. Licensed under the MIT License. See the LICENSE.  -->
-<ContentDialog
-	x:Class="Files.App.Dialogs.SettingsDialog"
+<Page
+	x:Class="Files.App.Dialogs.MainSettingsPage"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:helpers="using:Files.App.Helpers"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	Closing="ContentDialog_Closing"
 	DataContext="{x:Bind ViewModel, Mode=OneWay}"
-	HighContrastAdjustment="None"
-	RequestedTheme="{x:Bind RootAppElement.RequestedTheme, Mode=OneWay}"
-	Style="{StaticResource DefaultContentDialogStyle}"
 	mc:Ignorable="d">
 
-	<ContentDialog.Resources>
+	<Page.Resources>
 		<ResourceDictionary>
 			<ResourceDictionary.MergedDictionaries>
 				<ResourceDictionary Source="ms-appx:///ResourceDictionaries/NavigationViewItemButtonStyle.xaml" />
@@ -25,7 +21,7 @@
 			<SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />
 
 		</ResourceDictionary>
-	</ContentDialog.Resources>
+	</Page.Resources>
 
 	<Grid
 		x:Name="ContainerGrid"
@@ -167,4 +163,4 @@
 		</NavigationView>
 
 	</Grid>
-</ContentDialog>
+</Page>

--- a/src/Files.App/Views/Settings/MainSettingsPage.xaml
+++ b/src/Files.App/Views/Settings/MainSettingsPage.xaml
@@ -6,7 +6,6 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:helpers="using:Files.App.Helpers"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	DataContext="{x:Bind ViewModel, Mode=OneWay}"
 	mc:Ignorable="d">
 
 	<Page.Resources>
@@ -15,68 +14,33 @@
 				<ResourceDictionary Source="ms-appx:///ResourceDictionaries/NavigationViewItemButtonStyle.xaml" />
 			</ResourceDictionary.MergedDictionaries>
 
-			<x:Double x:Key="ContentDialogMaxWidth">1100</x:Double>
-			<Thickness x:Key="ContentDialogPadding">0</Thickness>
 			<SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="Transparent" />
 			<SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />
 
 		</ResourceDictionary>
 	</Page.Resources>
 
-	<Grid
-		x:Name="ContainerGrid"
-		MaxHeight="790"
-		Background="{ThemeResource SolidBackgroundFillColorBaseBrush}">
-		<Grid.RowDefinitions>
-			<RowDefinition Height="44" />
-			<RowDefinition Height="*" />
-		</Grid.RowDefinitions>
-
-		<!--  Smokescreen for displaying a semi transparent background  -->
-		<Border
-			Grid.RowSpan="2"
-			HorizontalAlignment="Stretch"
-			VerticalAlignment="Stretch"
-			Background="{ThemeResource App.Theme.BackgroundBrush}"
-			Opacity=".4" />
-
-		<!--  Titlebar  -->
-		<Grid Grid.Row="0" Padding="8,0">
-			<TextBlock
-				Padding="8,0,0,0"
-				HorizontalAlignment="Left"
-				VerticalAlignment="Center"
-				FontWeight="SemiBold"
-				Text="{helpers:ResourceString Name=Settings}" />
-
-			<Button
-				x:Name="CloseSettingsDialogButton"
-				Width="36"
-				Height="36"
-				HorizontalAlignment="Right"
-				VerticalAlignment="Center"
-				AutomationProperties.Name="{helpers:ResourceString Name=Close}"
-				Background="Transparent"
-				BorderBrush="Transparent"
-				Click="CloseSettingsDialogButton_Click"
-				ToolTipService.Placement="Bottom"
-				ToolTipService.ToolTip="{helpers:ResourceString Name=Close}">
-				<FontIcon FontSize="12" Glyph="&#xE8BB;" />
-			</Button>
-		</Grid>
-
+	<Grid x:Name="ContainerGrid">
 		<!--  Settings Navigation View  -->
 		<NavigationView
 			x:Name="MainSettingsNavigationView"
-			Grid.Row="1"
 			IsBackButtonVisible="Collapsed"
 			IsBackEnabled="False"
 			IsPaneToggleButtonVisible="False"
 			IsSettingsVisible="False"
 			IsTitleBarAutoPaddingEnabled="False"
-			OpenPaneLength="260"
+			OpenPaneLength="240"
 			PaneDisplayMode="Left"
 			SelectionChanged="MainSettingsNavigationView_SelectionChanged">
+
+			<NavigationView.PaneHeader>
+				<TextBlock
+					Padding="18,8,0,8"
+					HorizontalAlignment="Left"
+					VerticalAlignment="Center"
+					Style="{StaticResource SubtitleTextBlockStyle}"
+					Text="{helpers:ResourceString Name=Settings}" />
+			</NavigationView.PaneHeader>
 
 			<!--  Menu Items  -->
 			<NavigationView.MenuItems>
@@ -157,7 +121,7 @@
 
 			<!--  Content Frame  -->
 			<ScrollViewer x:Name="SettingsContentScrollViewer">
-				<Frame x:Name="SettingsContentFrame" Padding="4,0,24,24" />
+				<Frame x:Name="SettingsContentFrame" Padding="4,12,24,24" />
 			</ScrollViewer>
 
 		</NavigationView>

--- a/src/Files.App/Views/Settings/MainSettingsPage.xaml.cs
+++ b/src/Files.App/Views/Settings/MainSettingsPage.xaml.cs
@@ -10,24 +10,17 @@ using System.Threading.Tasks;
 
 namespace Files.App.Dialogs
 {
-	public sealed partial class SettingsDialog : ContentDialog, IDialog<SettingsDialogViewModel>
+	public sealed partial class MainSettingsPage : Page
 	{
-		public SettingsDialogViewModel ViewModel { get; set; }
-
 		private FrameworkElement RootAppElement
 			=> (FrameworkElement)MainWindow.Instance.Content;
 
-		public SettingsDialog()
+		public MainSettingsPage()
 		{
 			InitializeComponent();
 
 			MainWindow.Instance.SizeChanged += Current_SizeChanged;
 			UpdateDialogLayout();
-		}
-
-		public new async Task<DialogResult> ShowAsync()
-		{
-			return (DialogResult)await base.ShowAsync();
 		}
 
 		private void Current_SizeChanged(object sender, WindowSizeChangedEventArgs e)
@@ -68,7 +61,6 @@ namespace Files.App.Dialogs
 
 		private void CloseSettingsDialogButton_Click(object sender, RoutedEventArgs e)
 		{
-			Hide();
 		}
 	}
 }

--- a/src/Files.App/Views/Settings/TagsPage.xaml
+++ b/src/Files.App/Views/Settings/TagsPage.xaml
@@ -37,17 +37,11 @@
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch"
 			Spacing="4">
-			<StackPanel.ChildrenTransitions>
-				<TransitionCollection>
-					<EntranceThemeTransition />
-				</TransitionCollection>
-			</StackPanel.ChildrenTransitions>
 
 			<!--  Title  -->
 			<TextBlock
-				Padding="0,0,0,12"
-				FontSize="24"
-				FontWeight="Medium"
+				Padding="0,0,0,8"
+				Style="{StaticResource SubtitleTextBlockStyle}"
 				Text="{helpers:ResourceString Name=FileTags}" />
 
 			<!--  Edit Tags  -->

--- a/src/Files.App/Views/Shells/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/Shells/ModernShellPage.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+using Files.App.Dialogs;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -332,7 +333,8 @@ namespace Files.App.Views.Shells
 
 				NavigationTransitionInfo transition = new SuppressNavigationTransitionInfo();
 
-				if (sourcePageType == typeof(HomePage) ||
+				if (sourcePageType == typeof(MainSettingsPage) ||
+					sourcePageType == typeof(HomePage) ||
 					ItemDisplayFrame.Content.GetType() == typeof(HomePage) &&
 					(sourcePageType == typeof(DetailsLayoutPage) || sourcePageType == typeof(GridLayoutPage)))
 				{


### PR DESCRIPTION
## Summary

As the title.

- [x] test what happens if settings is opened in multiple tabs
  - Working very well!!
- [ ] disable dual pane mode
- [ ] hide the status bar & preview pane
- [ ] create a colored icon to use for the tab
- [ ] settings is currently disabled in compact overlay mode, we'll need to figure out how to handle this
- [ ] decide if we should move the settings icon from the address bar to the sidebar
- [ ] add access keys back to settings menu

## PR Checklist

- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [x] Did you implement any design changes to an existing feature?
   - [x] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?

## Screenshots
