### PR TITLE
Fix: Crash caused by useless predicate.

### DIFF
--- a/src/Files.App (Package)/Package.appxmanifest
+++ b/src/Files.App (Package)/Package.appxmanifest
@@ -168,7 +168,6 @@
                 <ActivatableClass ActivatableClassId="Files.App.Server.AppInstanceMonitor" />
                 <ActivatableClass ActivatableClassId="Files.App.Server.Database.FileTagsDatabase" />
                 <ActivatableClass ActivatableClassId="Files.App.Server.Database.LayoutPreferencesDatabase" />
-                <ActivatableClass ActivatableClassId="Files.App.Server.Database.LayoutPreferencesFilterPredicate" />
                 <ActivatableClass ActivatableClassId="Files.App.Server.Database.LayoutPreferencesUpdateAction" />
                 <ActivatableClass ActivatableClassId="Files.App.Server.Data.ColumnPreferences" />
                 <ActivatableClass ActivatableClassId="Files.App.Server.Data.ColumnPreferencesItem" />

--- a/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
+++ b/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
@@ -75,18 +75,11 @@ namespace Files.App.Server.Database
 			}
 		}
 
-		public void ResetAll(LayoutPreferencesFilterPredicate? predicate)
+		public void ResetAll()
 		{
 			var col = _database.GetCollection<LayoutPreferences>(LayoutPreferences);
 
-			if (predicate is null)
-			{
-				col.DeleteAll();
-			}
-			else
-			{
-				col.DeleteMany(x => predicate(x));
-			}
+			col.DeleteAll();
 		}
 
 		public void ApplyToAll(LayoutPreferencesUpdateAction updateAction, LayoutPreferencesFilterPredicate? predicate)

--- a/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
+++ b/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
@@ -82,11 +82,11 @@ namespace Files.App.Server.Database
 			col.DeleteAll();
 		}
 
-		public void ApplyToAll(LayoutPreferencesUpdateAction updateAction, LayoutPreferencesFilterPredicate? predicate)
+		public void ApplyToAll(LayoutPreferencesUpdateAction updateAction)
 		{
 			var col = _database.GetCollection<LayoutPreferences>(LayoutPreferences);
 
-			var allDocs = predicate is null ? col.FindAll() : col.Find(x => predicate(x));
+			var allDocs = col.FindAll();
 
 			foreach (var doc in allDocs)
 			{
@@ -152,6 +152,5 @@ namespace Files.App.Server.Database
 		}
 	}
 
-	public delegate bool LayoutPreferencesFilterPredicate(LayoutPreferences preference);
 	public delegate void LayoutPreferencesUpdateAction(LayoutPreferences preference);
 }

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesDatabaseManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesDatabaseManager.cs
@@ -135,9 +135,9 @@ namespace Files.App.Helpers
 			_database.SetPreferences(filePath, frn, ToDatabaseEntity(preferencesItem));
 		}
 
-		public void ResetAll(Func<LayoutPreferencesDatabaseItem, bool>? predicate = null)
+		public void ResetAll()
 		{
-			_database.ResetAll(item => predicate?.Invoke(FromDatabaseEntity(item)) ?? true);
+			_database.ResetAll();
 		}
 
 		public void ApplyToAll(Action<LayoutPreferencesDatabaseItem> updateAction, Func<LayoutPreferencesDatabaseItem, bool>? predicate = null)

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesDatabaseManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesDatabaseManager.cs
@@ -140,10 +140,9 @@ namespace Files.App.Helpers
 			_database.ResetAll();
 		}
 
-		public void ApplyToAll(Action<LayoutPreferencesDatabaseItem> updateAction, Func<LayoutPreferencesDatabaseItem, bool>? predicate = null)
+		public void ApplyToAll(Action<LayoutPreferencesDatabaseItem> updateAction)
 		{
-			_database.ApplyToAll(item => updateAction.Invoke(FromDatabaseEntity(item)),
-				item => predicate?.Invoke(FromDatabaseEntity(item)) ?? true);
+			_database.ApplyToAll(item => updateAction.Invoke(FromDatabaseEntity(item)));
 		}
 
 		public void Import(string json)


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
  Not approved, but I think a crash should be fixed👀, this closes #15124

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
1. Open settings
2. Toggle the option

https://github.com/files-community/Files/assets/52143624/f9e3f7c6-522d-48e9-af53-4a72fc379151

**Additional info**
This is the stacktrace of the crash
```cs
2024-04-05 20:19:11.0801|Error|System.Runtime.InteropServices.COMException (0x80131509)
   at WinRT.ExceptionHelpers.<ThrowExceptionForHR>g__Throw|39_0(Int32 hr)
   at ABI.Files.App.Server.Database.ILayoutPreferencesDatabaseClassMethods.ResetAll(IObjectReference _obj, LayoutPreferencesFilterPredicate predicate)
   at Files.App.Server.Database.LayoutPreferencesDatabase.ResetAll(LayoutPreferencesFilterPredicate predicate)
   at Files.App.Helpers.LayoutPreferencesDatabaseManager.ResetAll(Func`2 predicate)
   at Files.App.ViewModels.Settings.LayoutViewModel.ResetLayoutPreferences()
   at Files.App.ViewModels.Settings.LayoutViewModel.set_SyncFolderPreferencesAcrossDirectories(Boolean value)
   at Files.App.Views.Settings.LayoutPage.LayoutPage_obj1_Bindings.UpdateTwoWay_15_IsOn()
   at Files.App.Views.Settings.LayoutPage.LayoutPage_obj1_Bindings.LayoutPage_obj1_BindingsTracking.<RegisterTwoWayListener_15>b__19_0(DependencyObject sender, DependencyProperty prop)
   at ABI.Microsoft.UI.Xaml.DependencyPropertyChangedCallback.Do_Abi_Invoke(IntPtr thisPtr, IntPtr sender, IntPtr dp)
```

