### PR TITLE
Fix #14954: sorting by date types in ascending order corrected

### DIFF
--- a/src/Files.App/Utils/Storage/Collection/SortingHelper.cs
+++ b/src/Files.App/Utils/Storage/Collection/SortingHelper.cs
@@ -40,7 +40,7 @@ namespace Files.App.Utils.Storage
 
 			IOrderedEnumerable<ListedItem> ordered;
 
-			if (directorySortDirection == SortDirection.Ascending)
+			if ((directorySortDirection == SortDirection.Ascending && (directorySortOption != SortOption.DateModified && directorySortOption != SortOption.DateCreated)) ||	(directorySortDirection == SortDirection.Descending &&	(directorySortOption == SortOption.DateModified || directorySortOption == SortOption.DateCreated)))
 			{
 				ordered = directorySortOption switch
 				{


### PR DESCRIPTION
Previously, the sorting algorithm was exhibiting unexpected behavior where ascending and descending sorting directions were not intuitive. To address this issue, this commit introduces a fix to correctly handle the ascending and descending sorting directions, as it was addressed in the issue.

*Resolved / Related Issues*
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14954 

*Validation*
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
      i. Sorted some files and checked the order
**Screenshots**
![Screenshot 2024-04-06 190918](https://github.com/files-community/Files/assets/114589228/d4d5748a-2eca-4e4f-819b-ff903b7aaf5d)

