### PR TITLE
Code Quality: Avoid unnecessary shell folder fetching

### DIFF
--- a/src/Files.App/Helpers/Win32/Win32Helper.Shell.cs
+++ b/src/Files.App/Helpers/Win32/Win32Helper.Shell.cs
@@ -17,7 +17,7 @@ namespace Files.App.Helpers
 
 		private readonly static ShellFolder _controlPanelCategoryView = new("::{26EE0668-A00A-44D7-9371-BEB064C98683}");
 
-		public static async Task<(ShellFileItem Folder, List<ShellFileItem> Enumerate)> GetShellFolderAsync(string path, string action, int from, int count, params string[] properties)
+		public static async Task<(ShellFileItem Folder, List<ShellFileItem> Enumerate)> GetShellFolderAsync(string path, bool getFolder, bool getEnumerate, int from, int count, params string[] properties)
 		{
 			if (path.StartsWith("::{", StringComparison.Ordinal))
 			{
@@ -43,9 +43,10 @@ namespace Files.App.Helpers
 						return (null, flc);
 					}
 
-					folder = ShellFolderExtensions.GetShellFileItem(shellFolder);
+					if (getFolder)
+						folder = ShellFolderExtensions.GetShellFileItem(shellFolder);
 
-					if (action == "Enumerate")
+					if (getEnumerate)
 					{
 						foreach (var folderItem in shellFolder.Skip(from).Take(count))
 						{

--- a/src/Files.App/Services/QuickAccessService.cs
+++ b/src/Files.App/Services/QuickAccessService.cs
@@ -12,7 +12,7 @@ namespace Files.App.Services
 
 		public async Task<IEnumerable<ShellFileItem>> GetPinnedFoldersAsync()
 		{
-			var result = (await Win32Helper.GetShellFolderAsync(guid, "Enumerate", 0, int.MaxValue, "System.Home.IsPinned")).Enumerate
+			var result = (await Win32Helper.GetShellFolderAsync(guid, false, true, 0, int.MaxValue, "System.Home.IsPinned")).Enumerate
 				.Where(link => link.IsFolder);
 			return result;
 		}

--- a/src/Files.App/Utils/RecentItem/RecentItems.cs
+++ b/src/Files.App/Utils/RecentItem/RecentItems.cs
@@ -109,7 +109,7 @@ namespace Files.App.Utils.RecentItem
 		/// </summary>
 		public async Task<List<RecentItem>> ListRecentFilesAsync()
 		{
-			return (await Win32Helper.GetShellFolderAsync(QuickAccessGuid, "Enumerate", 0, int.MaxValue)).Enumerate
+			return (await Win32Helper.GetShellFolderAsync(QuickAccessGuid, false, true, 0, int.MaxValue)).Enumerate
 				.Where(link => !link.IsFolder)
 				.Select(link => new RecentItem(link, ShowFileExtensions)).ToList();
 		}

--- a/src/Files.App/Utils/RecycleBin/RecycleBinHelpers.cs
+++ b/src/Files.App/Utils/RecycleBin/RecycleBinHelpers.cs
@@ -19,7 +19,7 @@ namespace Files.App.Utils.RecycleBin
 
 		public static async Task<List<ShellFileItem>> EnumerateRecycleBin()
 		{
-			return (await Win32Helper.GetShellFolderAsync(Constants.UserEnvironmentPaths.RecycleBinPath, "Enumerate", 0, int.MaxValue)).Enumerate;
+			return (await Win32Helper.GetShellFolderAsync(Constants.UserEnvironmentPaths.RecycleBinPath, false, true, 0, int.MaxValue)).Enumerate;
 		}
 
 		public static ulong GetSize()

--- a/src/Files.App/Utils/Storage/StorageItems/ShellStorageFolder.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/ShellStorageFolder.cs
@@ -108,7 +108,7 @@ namespace Files.App.Utils.Storage
 
 		protected static async Task<(ShellFileItem Folder, List<ShellFileItem> Items)> GetFolderAndItems(string path, bool enumerate, int startIndex = 0, int maxItemsToRetrieve = int.MaxValue)
 		{
-			return await Win32Helper.GetShellFolderAsync(path, enumerate ? "Enumerate" : "Query", startIndex, maxItemsToRetrieve);
+			return await Win32Helper.GetShellFolderAsync(path, !enumerate, enumerate, startIndex, maxItemsToRetrieve);
 		}
 
 		public override IAsyncOperation<StorageFolder> ToStorageFolderAsync() => throw new NotSupportedException();


### PR DESCRIPTION
This avoids unnecessarily fetching its parent shell folder when retrieving recent items. If #13116 is caused by an exception when fetching the shell folder, the issue could be fixed.

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related to #13116

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?