### PR TITLE
Fix: Fixed issue where properties window could not navigate to other pages after returning from advanced settings

### DIFF
--- a/src/Files.App/ViewModels/Properties/MainPropertiesViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/MainPropertiesViewModel.cs
@@ -21,8 +21,7 @@ namespace Files.App.ViewModels.Properties
 			get => _SelectedNavigationViewItem;
 			set
 			{
-				if (SetProperty(ref _SelectedNavigationViewItem, value) &&
-					!_selectionChangedAutomatically)
+				if (SetProperty(ref _SelectedNavigationViewItem, value))
 				{
 					var parameter = new PropertiesPageNavigationParameter
 					{
@@ -47,8 +46,6 @@ namespace Files.App.ViewModels.Properties
 
 					_mainFrame?.Navigate(page, parameter, new EntranceNavigationTransitionInfo());
 				}
-
-				_selectionChangedAutomatically = false;
 			}
 		}
 
@@ -85,8 +82,6 @@ namespace Files.App.ViewModels.Properties
 
 		private readonly PropertiesPageNavigationParameter _parameter;
 
-		private bool _selectionChangedAutomatically { get; set; }
-
 		public IRelayCommand DoBackwardNavigationCommand { get; }
 		public IAsyncRelayCommand SaveChangedPropertiesCommand { get; }
 		public IRelayCommand CancelChangedPropertiesCommand { get; }
@@ -119,8 +114,6 @@ namespace Files.App.ViewModels.Properties
 				_mainFrame.GoBack();
 
 			var pageTag = ((Page)_mainFrame.Content).Tag.ToString();
-
-			_selectionChangedAutomatically = true;
 
 			// Move selection indicator
 			_SelectedNavigationViewItem =


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #13257 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [X] Are there any other steps that were used to validate these changes?
   1. Open a properties window
   2. Navigate to Security
   3. Go to Advanced permissions
   4. Navigate back
   5. Navigate to other pages and it works now.