### PR TITLE
Feature: Show Lucid Link in the cloud drives section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,5 +332,3 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 Files.Extensions/nul
-
-/desktop.ini

--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,5 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 Files.Extensions/nul
+
+/desktop.ini

--- a/src/Files.App/Utils/Cloud/CloudProviders.cs
+++ b/src/Files.App/Utils/Cloud/CloudProviders.cs
@@ -43,6 +43,8 @@ namespace Files.App.Utils.Cloud
 
 		ownCloud,
 
-		ProtonDrive
+		ProtonDrive,
+
+		LucidLink
 	}
 }

--- a/src/Files.App/Utils/Cloud/Detector/CloudDetector.cs
+++ b/src/Files.App/Utils/Cloud/Detector/CloudDetector.cs
@@ -33,6 +33,7 @@ namespace Files.App.Utils.Cloud
 			yield return new BoxCloudDetector();
 			yield return new GenericCloudDetector();
 			yield return new SynologyDriveCloudDetector();
+			yield return new LucidLinkCloudDetector();
 		}
 	}
 }

--- a/src/Files.App/Utils/Cloud/Detector/LucidLinkCloudDetector.cs
+++ b/src/Files.App/Utils/Cloud/Detector/LucidLinkCloudDetector.cs
@@ -29,7 +29,7 @@ namespace Files.App.Utils.Cloud
 
 					string[] orgNameFilespaceName = syncFolder.Split(".");
 					string path = Path.Combine(@"C:\Volumes", orgNameFilespaceName[1], orgNameFilespaceName[0]);
-					string filespaceName = orgNameFilespaceName[1];
+					string filespaceName = orgNameFilespaceName[0];
 
 					string iconPath = Path.Combine(Environment.GetEnvironmentVariable("ProgramFiles"), "Lucid", "resources", "Logo.ico");
 					StorageFile iconFile = await FilesystemTasks.Wrap(() => StorageFile.GetFileFromPathAsync(iconPath).AsTask());

--- a/src/Files.App/Utils/Cloud/Detector/LucidLinkCloudDetector.cs
+++ b/src/Files.App/Utils/Cloud/Detector/LucidLinkCloudDetector.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2024 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
+using Files.App.Utils.Cloud;
+using System.IO;
+using System.Text.Json;
+using Windows.Storage;
+
+namespace Files.App.Utils.Cloud
+{
+	/// <summary>
+	/// Provides an utility for LucidLink Cloud detection.
+	/// </summary>
+	public sealed class LucidLinkCloudDetector : AbstractCloudDetector
+	{
+		protected override async IAsyncEnumerable<ICloudProvider> GetProviders()
+		{
+			string jsonPath = Path.Combine(Environment.GetEnvironmentVariable("UserProfile"), ".lucid", "app.json");
+
+			var configFile = await StorageFile.GetFileFromPathAsync(jsonPath);
+			using var jsonFile = JsonDocument.Parse(await FileIO.ReadTextAsync(configFile));
+			var jsonElem = jsonFile.RootElement;
+
+			if (jsonElem.TryGetProperty("filespaces", out JsonElement filespaces))
+			{
+				foreach (JsonElement inner in filespaces.EnumerateArray())
+				{
+					string syncFolder = inner.GetProperty("filespaceName").GetString();
+
+					string[] orgNameFilespaceName = syncFolder.Split(".");
+					string path = Path.Combine(@"C:\Volumes", orgNameFilespaceName[1], orgNameFilespaceName[0]);
+					string filespaceName = orgNameFilespaceName[1];
+
+					string iconPath = Path.Combine(Environment.GetEnvironmentVariable("ProgramFiles"), "Lucid", "resources", "Logo.ico");
+					StorageFile iconFile = await FilesystemTasks.Wrap(() => StorageFile.GetFileFromPathAsync(iconPath).AsTask());
+
+					yield return new CloudProvider(CloudProviders.LucidLink)
+					{
+						Name = $"Lucid Link ({filespaceName})",
+						SyncFolder = path,
+						IconData = iconFile is not null ? await iconFile.ToByteArrayAsync() : null,
+					};
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #14612 

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Additional comments**
There one issue to note and I believe it's on Lucid Link side. When Lucid Links close the share won't exist, Files still shows it in the cloud drives section but will give the not a folder error when clicked on. Windows File Explorer will also do the same if it was pinned and lucid link doesn't show. 

I'm also not able to test if multiple shares would show.

There also the question if it should show the file share name, organization name or both. Right now I'm match Windows File Explorer behavior