### PR TITLE
Fix: Fixed alignment of the add tab button

### DIFF
--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -142,13 +142,14 @@
 				TabStripVisibility="Visible"
 				Visibility="Visible">
 				<tabbar:TabBar.FooterElement>
+					<!--  Height is not divisble by four in order to properly align the button  -->
 					<Button
 						x:Name="HorizontalMultitaskingControlAddButton"
-						Width="32"
-						Height="32"
+						Width="30"
+						Height="30"
 						Padding="8"
 						HorizontalAlignment="Left"
-						VerticalAlignment="Bottom"
+						VerticalAlignment="Center"
 						AllowDrop="True"
 						AutomationProperties.Name="{x:Bind Commands.NewTab.AutomationName}"
 						Background="Transparent"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
- [ ] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #15181...

**Validation**
How did you test these changes?
- [ ] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app, hover over add tab button and confirm it doesn't overlap border

**Screenshots (optional)**
Add screenshots here.
