### PR TITLE
Fix: Fixed crash when closing the GitHub login modal

### DIFF
--- a/src/Files.App/Dialogs/GitHubLoginDialog.xaml.cs
+++ b/src/Files.App/Dialogs/GitHubLoginDialog.xaml.cs
@@ -40,11 +40,14 @@ namespace Files.App.Dialogs
 		{
 			args.Cancel = true;
 
-			var data = new DataPackage();
-			data.SetText(ViewModel.UserCode);
+			SafetyExtensions.IgnoreExceptions(() =>
+			{
+				var data = new DataPackage();
+				data.SetText(ViewModel.UserCode);
 
-			Clipboard.SetContent(data);
-			Clipboard.Flush();
+				Clipboard.SetContent(data);
+				Clipboard.Flush();
+			});
 		}
 
 		private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
```cs
WinRT
ExceptionHelpers.<ThrowExceptionForHR>g__Throw|39_0 (Int32 hr)
ABI.Windows.ApplicationModel.DataTransfer
IClipboardStaticsMethods.Flush (IObjectReference _obj)
Files.App.Dialogs
GitHubLoginDialog.ContentDialog_PrimaryButtonClick (ContentDialog sender, ContentDialogButtonClickEventArgs args)
ABI.Windows.Foundation
TypedEventHandler`2.Do_Abi_Invoke[TSenderAbi,TResultAbi] (Void* thisPtr, TSenderAbi sender, TResultAbi args)
```