### PR TITLE
Code Quality: Downgrade LiteDB to fix transaction issue

### DIFF
--- a/src/Files.App.Server/Database/FileTagsDatabase.cs
+++ b/src/Files.App.Server/Database/FileTagsDatabase.cs
@@ -23,7 +23,7 @@ namespace Files.App.Server.Database
 
 			Database = new LiteDatabase(new ConnectionString(FileTagsDbPath)
 			{
-				Connection = ConnectionType.Shared,
+				Connection = ConnectionType.Direct,
 				Upgrade = true
 			});
 

--- a/src/Files.App.Server/Database/FileTagsDatabase.cs
+++ b/src/Files.App.Server/Database/FileTagsDatabase.cs
@@ -13,37 +13,29 @@ namespace Files.App.Server.Database
 {
 	public sealed class FileTagsDatabase
 	{
-		private static LiteDatabase _database = default!;
-		private static readonly object _lockObject = new();
-
 		private const string TaggedFiles = "taggedfiles";
+		private readonly static LiteDatabase Database;
+		private readonly static string FileTagsDbPath = Path.Combine(ApplicationData.Current.LocalFolder.Path, "filetags.db");
 
-		public static string FileTagsDbPath 
-			=> Path.Combine(ApplicationData.Current.LocalFolder.Path, "filetags.db");
-
-		public FileTagsDatabase()
+		static FileTagsDatabase()
 		{
-			lock (_lockObject)
+			SafetyExtensions.IgnoreExceptions(() => CheckDbVersion(FileTagsDbPath));
+
+			Database = new LiteDatabase(new ConnectionString(FileTagsDbPath)
 			{
-				if (_database is null)
-				{
-					SafetyExtensions.IgnoreExceptions(() => CheckDbVersion(FileTagsDbPath));
+				Connection = ConnectionType.Shared,
+				Upgrade = true
+			});
 
-					_database = new LiteDatabase(new ConnectionString(FileTagsDbPath)
-					{
-						Connection = ConnectionType.Direct,
-						Upgrade = true
-					});
-
-					UpdateDb();
-				}
-			}
+			UpdateDb();
 		}
+
+		public static string GetFileTagsDbPath() => FileTagsDbPath;
 
 		public void SetTags(string filePath, ulong? frn, [ReadOnlyArray] string[] tags)
 		{
 			// Get a collection (or create, if doesn't exist)
-			var col = _database.GetCollection<TaggedFile>(TaggedFiles);
+			var col = Database.GetCollection<TaggedFile>(TaggedFiles);
 
 			var tmp = FindTag(filePath, frn);
 			if (tmp is null)
@@ -81,7 +73,7 @@ namespace Files.App.Server.Database
 		private TaggedFile? FindTag(string? filePath, ulong? frn)
 		{
 			// Get a collection (or create, if doesn't exist)
-			var col = _database.GetCollection<TaggedFile>(TaggedFiles);
+			var col = Database.GetCollection<TaggedFile>(TaggedFiles);
 
 			if (filePath is not null)
 			{
@@ -122,7 +114,7 @@ namespace Files.App.Server.Database
 		public void UpdateTag(string oldFilePath, ulong? frn, string? newFilePath)
 		{
 			// Get a collection (or create, if doesn't exist)
-			var col = _database.GetCollection<TaggedFile>(TaggedFiles);
+			var col = Database.GetCollection<TaggedFile>(TaggedFiles);
 			var tmp = col.FindOne(x => x.FilePath == oldFilePath);
 			if (tmp is not null)
 			{
@@ -144,7 +136,7 @@ namespace Files.App.Server.Database
 		public void UpdateTag(ulong oldFrn, ulong? frn, string? newFilePath)
 		{
 			// Get a collection (or create, if doesn't exist)
-			var col = _database.GetCollection<TaggedFile>(TaggedFiles);
+			var col = Database.GetCollection<TaggedFile>(TaggedFiles);
 			var tmp = col.FindOne(x => x.Frn == oldFrn);
 			if (tmp is not null)
 			{
@@ -169,13 +161,13 @@ namespace Files.App.Server.Database
 
 		public IEnumerable<TaggedFile> GetAll()
 		{
-			var col = _database.GetCollection<TaggedFile>(TaggedFiles);
+			var col = Database.GetCollection<TaggedFile>(TaggedFiles);
 			return col.FindAll();
 		}
 
 		public IEnumerable<TaggedFile> GetAllUnderPath(string folderPath)
 		{
-			var col = _database.GetCollection<TaggedFile>(TaggedFiles);
+			var col = Database.GetCollection<TaggedFile>(TaggedFiles);
 			if (string.IsNullOrEmpty(folderPath))
 				return col.FindAll();
 			return col.Find(x => x.FilePath.StartsWith(folderPath, StringComparison.OrdinalIgnoreCase));
@@ -184,33 +176,33 @@ namespace Files.App.Server.Database
 		public void Import(string json)
 		{
 			var dataValues = JsonSerializer.DeserializeArray(json);
-			var col = _database.GetCollection(TaggedFiles);
+			var col = Database.GetCollection(TaggedFiles);
 			col.DeleteAll();
 			col.InsertBulk(dataValues.Select(x => x.AsDocument));
 		}
 
 		public string Export()
 		{
-			return JsonSerializer.Serialize(new BsonArray(_database.GetCollection(TaggedFiles).FindAll()));
+			return JsonSerializer.Serialize(new BsonArray(Database.GetCollection(TaggedFiles).FindAll()));
 		}
 
-		private void UpdateDb()
+		private static void UpdateDb()
 		{
-			if (_database.UserVersion == 0)
+			if (Database.UserVersion == 0)
 			{
-				var col = _database.GetCollection(TaggedFiles);
+				var col = Database.GetCollection(TaggedFiles);
 				foreach (var doc in col.FindAll())
 				{
 					doc["Tags"] = new BsonValue(new[] { doc["Tag"].AsString });
 					doc.Remove("Tags");
 					col.Update(doc);
 				}
-				_database.UserVersion = 1;
+				Database.UserVersion = 1;
 			}
 		}
 
 		// https://github.com/mbdavid/LiteDB/blob/master/LiteDB/Engine/Engine/Upgrade.cs
-		private void CheckDbVersion(string filename)
+		private static void CheckDbVersion(string filename)
 		{
 			var buffer = new byte[8192 * 2];
 			using (var stream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))

--- a/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
+++ b/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
@@ -18,7 +18,7 @@ namespace Files.App.Server.Database
 			Database = new(
 				new ConnectionString(LayoutSettingsDbPath)
 				{
-					Connection = ConnectionType.Shared,
+					Connection = ConnectionType.Direct,
 					Upgrade = true,
 				});
 		}

--- a/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
+++ b/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
@@ -9,25 +9,18 @@ namespace Files.App.Server.Database
 {
 	public sealed class LayoutPreferencesDatabase
 	{
-		private static LiteDatabase _database = default!;
-		private static readonly object _lockObject = new();
-
 		private const string LayoutPreferences = "layoutprefs";
+		private readonly static LiteDatabase Database;
+		private readonly static string LayoutSettingsDbPath = Path.Combine(ApplicationData.Current.LocalFolder.Path, "user_settings.db");
 
-		public static string LayoutSettingsDbPath
-			=> Path.Combine(ApplicationData.Current.LocalFolder.Path, "user_settings.db");
-
-		public LayoutPreferencesDatabase()
+		static LayoutPreferencesDatabase()
 		{
-			lock (_lockObject)
-			{
-				_database ??= new(
-					new ConnectionString(LayoutSettingsDbPath)
-					{
-						Connection = ConnectionType.Direct,
-						Upgrade = true,
-					});
-			}
+			Database = new(
+				new ConnectionString(LayoutSettingsDbPath)
+				{
+					Connection = ConnectionType.Shared,
+					Upgrade = true,
+				});
 		}
 
 		public LayoutPreferencesItem? GetPreferences(string? filePath, ulong? frn)
@@ -38,7 +31,7 @@ namespace Files.App.Server.Database
 		public void SetPreferences(string filePath, ulong? frn, LayoutPreferencesItem? preferencesItem)
 		{
 			// Get a collection (or create, if doesn't exist)
-			var col = _database.GetCollection<LayoutPreferences>(LayoutPreferences);
+			var col = Database.GetCollection<LayoutPreferences>(LayoutPreferences);
 
 			var tmp = FindPreferences(filePath, frn);
 
@@ -77,14 +70,14 @@ namespace Files.App.Server.Database
 
 		public void ResetAll()
 		{
-			var col = _database.GetCollection<LayoutPreferences>(LayoutPreferences);
+			var col = Database.GetCollection<LayoutPreferences>(LayoutPreferences);
 
 			col.DeleteAll();
 		}
 
 		public void ApplyToAll(LayoutPreferencesUpdateAction updateAction)
 		{
-			var col = _database.GetCollection<LayoutPreferences>(LayoutPreferences);
+			var col = Database.GetCollection<LayoutPreferences>(LayoutPreferences);
 
 			var allDocs = col.FindAll();
 
@@ -100,7 +93,7 @@ namespace Files.App.Server.Database
 		{
 			var dataValues = JsonSerializer.DeserializeArray(json);
 
-			var col = _database.GetCollection(LayoutPreferences);
+			var col = Database.GetCollection(LayoutPreferences);
 
 			col.DeleteAll();
 			col.InsertBulk(dataValues.Select(x => x.AsDocument));
@@ -108,13 +101,13 @@ namespace Files.App.Server.Database
 
 		public string Export()
 		{
-			return JsonSerializer.Serialize(new BsonArray(_database.GetCollection(LayoutPreferences).FindAll()));
+			return JsonSerializer.Serialize(new BsonArray(Database.GetCollection(LayoutPreferences).FindAll()));
 		}
 
 		private LayoutPreferences? FindPreferences(string? filePath, ulong? frn)
 		{
 			// Get a collection (or create, if doesn't exist)
-			var col = _database.GetCollection<LayoutPreferences>(LayoutPreferences);
+			var col = Database.GetCollection<LayoutPreferences>(LayoutPreferences);
 
 			if (filePath is not null)
 			{

--- a/src/Files.App.Server/Files.App.Server.csproj
+++ b/src/Files.App.Server/Files.App.Server.csproj
@@ -39,7 +39,8 @@
     <ItemGroup>
         <Manifest Include="app.manifest" />
         <TrimmerRootAssembly Include="Files.App.Server" />
-        <PackageReference Include="LiteDB" Version="5.0.19" />
+        <!-- Don't upgrade LiteDB until https://github.com/mbdavid/LiteDB/issues/2435 gets fixed -->
+        <PackageReference Include="LiteDB" Version="5.0.17" />
         <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.7" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.1.647-beta" PrivateAssets="all" />
     </ItemGroup>

--- a/src/Files.App/ViewModels/Settings/AdvancedViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AdvancedViewModel.cs
@@ -176,7 +176,7 @@ namespace Files.App.ViewModels.Settings
 					var fileTagsList = await zipFolder.GetFileAsync(Constants.LocalSettings.FileTagSettingsFileName);
 					string importTags = await fileTagsList.ReadTextAsync();
 					fileTagsSettingsService.ImportSettings(importTags);
-					var fileTagsDB = await zipFolder.GetFileAsync(Path.GetFileName(Server.Database.FileTagsDatabase.FileTagsDbPath));
+					var fileTagsDB = await zipFolder.GetFileAsync(Path.GetFileName(Server.Database.FileTagsDatabase.GetFileTagsDbPath()));
 					string importTagsDB = await fileTagsDB.ReadTextAsync();
 					var tagDbInstance = FileTagsHelper.GetDbInstance();
 					tagDbInstance.Import(importTagsDB);
@@ -224,7 +224,7 @@ namespace Files.App.ViewModels.Settings
 					await zipFolder.CreateFileAsync(new MemoryStream(exportTags), Constants.LocalSettings.FileTagSettingsFileName, CreationCollisionOption.ReplaceExisting);
 					var tagDbInstance = FileTagsHelper.GetDbInstance();
 					byte[] exportTagsDB = UTF8Encoding.UTF8.GetBytes(tagDbInstance.Export());
-					await zipFolder.CreateFileAsync(new MemoryStream(exportTagsDB), Path.GetFileName(Server.Database.FileTagsDatabase.FileTagsDbPath), CreationCollisionOption.ReplaceExisting);
+					await zipFolder.CreateFileAsync(new MemoryStream(exportTagsDB), Path.GetFileName(Server.Database.FileTagsDatabase.GetFileTagsDbPath()), CreationCollisionOption.ReplaceExisting);
 
 					// Export layout preferences DB
 					var layoutDbInstance = LayoutPreferencesManager.GetDatabaseManagerInstance();


### PR DESCRIPTION
**Resolved / Related Issues**
We hit https://github.com/mbdavid/LiteDB/issues/2435 which results in Files crashing. As a workaround, we may use `Shared` connection instead of `Direct`. It may slow down the query speed, but it no longer crashes.
   Closes #15203
   Closes #15172
   Closes #15157

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?

**Screenshots (optional)**
Add screenshots here.
