### PR TITLE
Code Quality: Disable composite ReadyToRun for server

### DIFF
--- a/src/Files.App.Server/Files.App.Server.csproj
+++ b/src/Files.App.Server/Files.App.Server.csproj
@@ -20,9 +20,7 @@
         <CsWinRTComponent>true</CsWinRTComponent>
         <CsWinRTWindowsMetadata>10.0.22621.0</CsWinRTWindowsMetadata>
         <ApplicationManifest>app.manifest</ApplicationManifest>
-        <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-        <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-        <PublishReadyToRunComposite Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRunComposite>
+        <PublishReadyToRun>False</PublishReadyToRun>
         <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
         <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
         <CsWinRTEnableLogging>true</CsWinRTEnableLogging>


### PR DESCRIPTION
Found some random crashes only happens with composite R2R. Disable it for now.