### PR TITLE
Code Quality: Various fixes to the WinRT server call

### DIFF
--- a/src/Files.App.Server/NativeMethods.json
+++ b/src/Files.App.Server/NativeMethods.json
@@ -4,7 +4,7 @@
 	"$schema": "https://aka.ms/CsWin32.schema.json",
 
 	// Emit COM interfaces instead of structs, and allow generation of non-blittable structs for the sake of an easier to use API.
-	"allowMarshaling": true,
+	"allowMarshaling": false,
 
 	// A value indicating whether to generate APIs judged to be unnecessary or redundant given the target framework.
 	// This is useful for multi-targeting projects that need a consistent set of APIs across target frameworks
@@ -24,5 +24,5 @@
 	"className": "PInvoke",
 
 	// A value indicating whether to expose the generated APIs publicly (as opposed to internally).
-	"public": true
+	"public": false
 }

--- a/src/Files.App.Server/NativeMethods.txt
+++ b/src/Files.App.Server/NativeMethods.txt
@@ -6,4 +6,3 @@ RoRevokeActivationFactories
 WindowsCreateString
 WindowsDeleteString
 RoInitialize
-RoUninitialize

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
@@ -506,9 +506,7 @@ namespace Files.App.Data.Models
 				path = path.TrimPath() ?? string.Empty;
 
 				if (path.StartsWith("tag:", StringComparison.Ordinal))
-				{
 					return GetLayoutPreferencesFromDatabase("Home", null);
-				}
 
 				var folderFRN = NativeFileOperationsHelper.GetFolderFRN(path);
 

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
@@ -505,6 +505,11 @@ namespace Files.App.Data.Models
 			{
 				path = path.TrimPath() ?? string.Empty;
 
+				if (path.StartsWith("tag:", StringComparison.Ordinal))
+				{
+					return GetLayoutPreferencesFromDatabase("Home", null);
+				}
+
 				var folderFRN = NativeFileOperationsHelper.GetFolderFRN(path);
 
 				return GetLayoutPreferencesFromDatabase(path, folderFRN)

--- a/src/Files.App/Utils/Storage/StorageItems/SystemStorageFile.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/SystemStorageFile.cs
@@ -84,7 +84,7 @@ namespace Files.App.Utils.Storage
 						return destFile;
 					}
 				}
-				catch (UnauthorizedAccessException ex) // shortcuts & .url
+				catch (UnauthorizedAccessException) // shortcuts & .url
 				{
 					if (!string.IsNullOrEmpty(destFolder.Path))
 					{
@@ -102,7 +102,7 @@ namespace Files.App.Utils.Storage
 							return new NativeStorageFile(destination, desiredNewName, DateTime.Now);
 						}
 					}
-					throw ex;
+					throw;
 				}
 			});
 		}


### PR DESCRIPTION
**Resolved / Related Issues**

- Do not call `RoUninitialize` as this will be automatically done on the process exit
- Correct the path for `tag:*` to `Home` while getting the layout preferences
- Kill hanging server at startup

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?
   1. Open app ...
   2. Click settings button ...

**Screenshots (optional)**
Add screenshots here.
