### PR TITLE
Fix: Fixed issue where changing focus in column view caused extra animation

### DIFF
--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
@@ -483,18 +483,7 @@ namespace Files.App.Views.Layouts
 					await CommitRenameAsync(textBox);
 				}
 
-				if (isItemFolder && UserSettingsService.FoldersSettingsService.ColumnLayoutOpenFoldersWithOneClick)
-				{
-					ItemInvoked?.Invoke(
-						new ColumnParam
-						{
-							Source = this,
-							NavPathParam = (item is ShortcutItem sht ? sht.TargetPath : item!.ItemPath),
-							ListView = FileList
-						},
-						EventArgs.Empty);
-				}
-				else if (!IsRenamingItem && isItemFile)
+				if (!IsRenamingItem && isItemFile)
 				{
 					CheckDoubleClick(item!);
 				}


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #15230

Removes double call to ItemInvoked on ItemTapped(). ItemInvoked is already called by SelectionChanged().

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
