### PR TITLE
Fix: Fixed an issue where HWiNFO64.exe wouldn't open

### DIFF
--- a/src/Files.App/Utils/Shell/LaunchHelper.cs
+++ b/src/Files.App/Utils/Shell/LaunchHelper.cs
@@ -129,6 +129,11 @@ namespace Files.App.Utils.Shell
 
 					return true;
 				}
+				catch (Win32Exception ex) when (ex.NativeErrorCode == 50)
+				{
+					// ShellExecute return code 50 (ERROR_NOT_SUPPORTED) for some exes (#15179)
+					return Win32Helper.RunPowershellCommand($"\"{application}\"", false);
+				}
 				catch (Win32Exception)
 				{
 					try


### PR DESCRIPTION
**Resolved / Related Issues**
- [x] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #15179

ShellExecute fails to open HWiNFO64.exe for some reason. The store version of powershell also has the same issue with that file. Here's a workarpund.
NB: will popup UAC prompt twice, but the app starts. Tested with portable version of HWiNFO64.exe.

**Validation**
How did you test these changes?
- [x] Did you build the app and test your changes?
