### PR TITLE
Code Quality: Improved loading of pinned folders and recent files

### DIFF
--- a/src/Files.App/Services/QuickAccessService.cs
+++ b/src/Files.App/Services/QuickAccessService.cs
@@ -8,7 +8,9 @@ namespace Files.App.Services
 {
 	internal sealed class QuickAccessService : IQuickAccessService
 	{
-		private readonly static string guid = "::{679f85cb-0220-4080-b29b-5540cc05aab6}";
+		// Quick access shell folder (::{679f85cb-0220-4080-b29b-5540cc05aab6}) contains recent files
+		// which are unnecessary for getting pinned folders, so we use frequent places shell folder instead.
+		private readonly static string guid = "::{3936e9e4-d92c-4eee-a85a-bc16d5ea0819}";
 
 		public async Task<IEnumerable<ShellFileItem>> GetPinnedFoldersAsync()
 		{

--- a/src/Files.App/Utils/RecentItem/RecentItems.cs
+++ b/src/Files.App/Utils/RecentItem/RecentItems.cs
@@ -109,7 +109,8 @@ namespace Files.App.Utils.RecentItem
 		/// </summary>
 		public async Task<List<RecentItem>> ListRecentFilesAsync()
 		{
-			return (await Win32Helper.GetShellFolderAsync(QuickAccessGuid, false, true, 0, int.MaxValue)).Enumerate
+			// Since the maximum number of recent files is 20, we set the count to 20 to avoid loading of unnecessary shell items.
+			return (await Win32Helper.GetShellFolderAsync(QuickAccessGuid, false, true, 0, 20)).Enumerate
 				.Where(link => !link.IsFolder)
 				.Select(link => new RecentItem(link, ShowFileExtensions)).ToList();
 		}

--- a/src/Files.App/Utils/RecentItem/RecentItemsManager.cs
+++ b/src/Files.App/Utils/RecentItem/RecentItemsManager.cs
@@ -11,7 +11,6 @@ namespace Files.App.Utils.RecentItem
 		private static readonly string recentItemsPath = Environment.GetFolderPath(Environment.SpecialFolder.Recent);
 		private static readonly string automaticDestinationsPath = Path.Combine(recentItemsPath, "AutomaticDestinations");
 		private const string QuickAccessJumpListFileName = "5f7b5f1e01b83767.automaticDestinations-ms";
-		private const string QuickAccessGuid = "::{679f85cb-0220-4080-b29b-5540cc05aab6}";
 		private DateTime quickAccessLastReadTime = DateTime.MinValue;
 		private FileSystemWatcher? quickAccessJumpListWatcher;
 


### PR DESCRIPTION
Currently we load pinned folders and recent files from the quick access shell folder. It contains both pinned folders and recent files, but it causes both loads to be affected when one of them goes wrong.
So I changed it to load pinned folders and recent files separately. This should allow pinned folders to be displayed without having to do workarounds such as disabling recent files. Also, recent files should be displayed before pinned folders have finished loading.

**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Related to #13116 
   Related to #13087 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [ ] Are there any other steps that were used to validate these changes?