### PR TITLE
Fix: Fixed issue where renaming in the conflict dialog would leave the copy status in process

### DIFF
--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -317,8 +317,6 @@ namespace Files.App.Utils.Storage
 
 			banner.Progress.ReportStatus(FileSystemStatusCode.Success);
 
-			await Task.Yield();
-
 			if (registerHistory && history is not null && source.Any((item) => !string.IsNullOrWhiteSpace(item.Path)))
 			{
 				foreach (var item in history.Source.Zip(history.Destination, (k, v) => new { Key = k, Value = v }).ToDictionary(k => k.Key, v => v.Value))
@@ -329,13 +327,13 @@ namespace Files.App.Utils.Storage
 						{
 							var renameHistory = await filesystemOperations.RenameAsync(item.Value, item2.CustomName, NameCollisionOption.FailIfExists, banner.ProgressEventSource, token);
 							history.Destination[history.Source.IndexOf(item.Key)] = renameHistory.Destination[0];
-
-							await Task.Yield();
 						}
 					}
 				}
 				App.HistoryWrapper.AddHistory(history);
 			}
+
+			await Task.Yield();
 
 			var itemsCount = banner.TotalItemsCount;
 

--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -329,6 +329,8 @@ namespace Files.App.Utils.Storage
 						{
 							var renameHistory = await filesystemOperations.RenameAsync(item.Value, item2.CustomName, NameCollisionOption.FailIfExists, banner.ProgressEventSource, token);
 							history.Destination[history.Source.IndexOf(item.Key)] = renameHistory.Destination[0];
+
+							await Task.Yield();
 						}
 					}
 				}


### PR DESCRIPTION
**Resolved / Related Issues**
- [X] Were these changes approved in an issue or discussion with the project maintainers? In order to prevent extra work, feature requests and changes to the codebase must be approved before the pull request will be reviewed. This prevents extra work for the contributors and maintainers.
   Closes #15303 

**Validation**
How did you test these changes?
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? You can use Accessibility Insights for this.
- [ ] Did you remove any strings from the en-us resource file?
   - [ ] Did you search the solution to see if the string is still being used? 
- [ ] Did you implement any design changes to an existing feature?
   - [ ] Was this change approved?
- [x] Are there any other steps that were used to validate these changes?
1. Copied conflicting file
2. Renamed the file in the conflicts dialog
3. Confirmed the operation completed in the status center