### PR TITLE
Code Quality: Pin WinRT server object to prevent object reference being invalid

### DIFF
--- a/src/Files.App.Server/AppInstanceMonitor.cs
+++ b/src/Files.App.Server/AppInstanceMonitor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 
 namespace Files.App.Server;
@@ -8,6 +9,7 @@ namespace Files.App.Server;
 public sealed class AppInstanceMonitor
 {
 	private static int processCount = 0;
+	internal static ConcurrentDictionary<int, ConcurrentBag<IDisposable>> AppInstanceResources = new();
 
 	public static void StartMonitor(int processId)
 	{
@@ -19,9 +21,17 @@ public sealed class AppInstanceMonitor
 
 	private static void Process_Exited(object? sender, EventArgs e)
 	{
-		if (sender is Process process)
+		if (sender is Process { Id: var processId } process)
 		{
 			process.Dispose();
+
+			if (AppInstanceResources.TryRemove(processId, out var instances))
+			{
+				foreach (var instance in instances)
+				{
+					instance.Dispose();
+				}
+			}
 
 			if (Interlocked.Decrement(ref processCount) == 0)
 			{

--- a/src/Files.App.Server/Database/FileTagsDatabase.cs
+++ b/src/Files.App.Server/Database/FileTagsDatabase.cs
@@ -50,7 +50,7 @@ namespace Files.App.Server.Database
 
 		public FileTagsDatabase()
 		{
-			throw new NotSupportedException($"Instantiate {nameof(FileTagsDatabase)} by non-parameterized constructor is not supported.");
+			throw new NotSupportedException($"Instantiating {nameof(FileTagsDatabase)} by non-parameterized constructor is not supported.");
 		}
 
 		public FileTagsDatabase(int processId)

--- a/src/Files.App.Server/Database/FileTagsDatabase.cs
+++ b/src/Files.App.Server/Database/FileTagsDatabase.cs
@@ -6,6 +6,7 @@ using Files.Shared.Extensions;
 using LiteDB;
 using Microsoft.Win32;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using Windows.ApplicationModel;
@@ -17,12 +18,15 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Files.App.Server.Database
 {
-	public sealed class FileTagsDatabase
+	public sealed class FileTagsDatabase : IDisposable
 	{
 		private readonly static string FileTagsKey = @$"Software\Files Community\{Package.Current.Id.FullName}\v1\FileTags";
 		
 		private readonly static string FileTagsDbPath = Path.Combine(ApplicationData.Current.LocalFolder.Path, "filetags.db");
 		private const string FileTagsCollectionName = "taggedfiles";
+
+		private readonly GCHandle _handle;
+		private bool _disposed = false;
 
 		static FileTagsDatabase()
 		{
@@ -41,6 +45,25 @@ namespace Files.App.Server.Database
 				}
 
 				File.Delete(FileTagsDbPath);
+			}
+		}
+
+		public FileTagsDatabase()
+		{
+			throw new NotSupportedException($"Instantiate {nameof(FileTagsDatabase)} by non-parameterized constructor is not supported.");
+		}
+
+		public FileTagsDatabase(int processId)
+		{
+			_handle = GCHandle.Alloc(this, GCHandleType.Pinned);
+
+			if (AppInstanceMonitor.AppInstanceResources.TryGetValue(processId, out var instances))
+			{
+				instances.Add(this);
+			}
+			else
+			{
+				AppInstanceMonitor.AppInstanceResources[processId] = [this];
 			}
 		}
 
@@ -277,6 +300,15 @@ namespace Files.App.Server.Database
 				}
 
 				IterateKeys(list, CombineKeys(path, subKey), depth + 1);
+			}
+		}
+
+		public void Dispose()
+		{
+			if (!_disposed)
+			{
+				_disposed = true;
+				_handle.Free();
 			}
 		}
 	}

--- a/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
+++ b/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
@@ -5,6 +5,7 @@ using Files.App.Server.Data;
 using LiteDB;
 using Microsoft.Win32;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Windows.ApplicationModel;
 using Windows.Storage;
 using static Files.App.Server.Data.LayoutPreferencesRegistry;
@@ -13,12 +14,15 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Files.App.Server.Database
 {
-	public sealed class LayoutPreferencesDatabase
+	public sealed class LayoutPreferencesDatabase : IDisposable
 	{
 		private readonly static string LayoutSettingsKey = @$"Software\Files Community\{Package.Current.Id.FullName}\v1\LayoutPreferences";
 
 		private readonly static string LayoutSettingsDbPath = Path.Combine(ApplicationData.Current.LocalFolder.Path, "user_settings.db");
 		private const string LayoutSettingsCollectionName = "layoutprefs";
+
+		private readonly GCHandle _handle;
+		private bool _disposed = false;
 
 		static LayoutPreferencesDatabase()
 		{
@@ -34,6 +38,25 @@ namespace Files.App.Server.Database
 				}
 
 				File.Delete(LayoutSettingsDbPath);
+			}
+		}
+
+		public LayoutPreferencesDatabase()
+		{
+			throw new NotSupportedException($"Instantiate {nameof(FileTagsDatabase)} by non-parameterized constructor is not supported.");
+		}
+
+		public LayoutPreferencesDatabase(int processId)
+		{
+			_handle = GCHandle.Alloc(this, GCHandleType.Pinned);
+
+			if (AppInstanceMonitor.AppInstanceResources.TryGetValue(processId, out var instances))
+			{
+				instances.Add(this);
+			}
+			else
+			{
+				AppInstanceMonitor.AppInstanceResources[processId] = [this];
 			}
 		}
 
@@ -196,6 +219,15 @@ namespace Files.App.Server.Database
 			}
 
 			return null;
+		}
+
+		public void Dispose()
+		{
+			if (!_disposed)
+			{
+				_disposed = true;
+				_handle.Free();
+			}
 		}
 	}
 }

--- a/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
+++ b/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
@@ -43,7 +43,7 @@ namespace Files.App.Server.Database
 
 		public LayoutPreferencesDatabase()
 		{
-			throw new NotSupportedException($"Instantiate {nameof(FileTagsDatabase)} by non-parameterized constructor is not supported.");
+			throw new NotSupportedException($"Instantiating {nameof(LayoutPreferencesDatabase)} by non-parameterized constructor is not supported.");
 		}
 
 		public LayoutPreferencesDatabase(int processId)

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesDatabaseManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesDatabaseManager.cs
@@ -11,7 +11,7 @@ namespace Files.App.Helpers
 	public class LayoutPreferencesDatabaseManager
 	{
 		// Fields
-		private readonly Server.Database.LayoutPreferencesDatabase _database = new();
+		private readonly Server.Database.LayoutPreferencesDatabase _database = new(Environment.ProcessId);
 
 		private DetailsLayoutColumnItem FromDatabaseEntity(Server.Data.ColumnPreferencesItem entry)
 		{

--- a/src/Files.App/Utils/FileTags/FileTagsHelper.cs
+++ b/src/Files.App/Utils/FileTags/FileTagsHelper.cs
@@ -12,9 +12,9 @@ namespace Files.App.Utils.FileTags
 {
 	public static class FileTagsHelper
 	{
-		private static readonly Lazy<Server.Database.FileTagsDatabase> dbInstance = new(() => new());
+		private static readonly Server.Database.FileTagsDatabase dbInstance = new(Environment.ProcessId);
 
-		public static Server.Database.FileTagsDatabase GetDbInstance() => dbInstance.Value;
+		public static Server.Database.FileTagsDatabase GetDbInstance() => dbInstance;
 
 		public static string[] ReadFileTag(string filePath)
 		{


### PR DESCRIPTION
**Resolved / Related Issues**

The potential AV coming from `FileTagsDatabase` and `LayoutPreferencesDatabase` can be caused by CsWinRT who may not pin the server object, so that the object reference holding by the client can become invalid which can lead to access violation and crash the process.

This is a workaround to CsWinRT. Let's see if this resolves the `COMException` crashing issue.

/cc: @yair100 @hishitetsu 