### PR TITLE
Code Quality: Use constructor instead of collection expression for the properties window cache

### DIFF
--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -37,7 +37,7 @@ namespace Files.App.Utils.Storage
 			=> WinRT.Interop.WindowNative.GetWindowHandle(w);
 
 		private static TaskCompletionSource? PropertiesWindowsClosingTCS;
-		private static BlockingCollection<WinUIEx.WindowEx> WindowCache = [];
+		private static BlockingCollection<WinUIEx.WindowEx> WindowCache = new();
 
 		/// <summary>
 		/// Open properties window


### PR DESCRIPTION
This may fix the following exception.
![image](https://github.com/files-community/Files/assets/66369541/843d7ea8-46f2-4c25-aff1-b2442f350b5b)


**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
