### PR TITLE
Revert "Code Quality: Pin WinRT server object to prevent object reference being invalid"

### DIFF
--- a/src/Files.App.Server/AppInstanceMonitor.cs
+++ b/src/Files.App.Server/AppInstanceMonitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using System.Collections.Concurrent;
 using System.Diagnostics;
 
 namespace Files.App.Server;
@@ -9,7 +8,6 @@ namespace Files.App.Server;
 public sealed class AppInstanceMonitor
 {
 	private static int processCount = 0;
-	internal static ConcurrentDictionary<int, ConcurrentBag<IDisposable>> AppInstanceResources = new();
 
 	public static void StartMonitor(int processId)
 	{
@@ -21,17 +19,9 @@ public sealed class AppInstanceMonitor
 
 	private static void Process_Exited(object? sender, EventArgs e)
 	{
-		if (sender is Process { Id: var processId } process)
+		if (sender is Process process)
 		{
 			process.Dispose();
-
-			if (AppInstanceResources.TryRemove(processId, out var instances))
-			{
-				foreach (var instance in instances)
-				{
-					instance.Dispose();
-				}
-			}
 
 			if (Interlocked.Decrement(ref processCount) == 0)
 			{

--- a/src/Files.App.Server/Database/FileTagsDatabase.cs
+++ b/src/Files.App.Server/Database/FileTagsDatabase.cs
@@ -6,7 +6,6 @@ using Files.Shared.Extensions;
 using LiteDB;
 using Microsoft.Win32;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using Windows.ApplicationModel;
@@ -18,15 +17,12 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Files.App.Server.Database
 {
-	public sealed class FileTagsDatabase : IDisposable
+	public sealed class FileTagsDatabase
 	{
 		private readonly static string FileTagsKey = @$"Software\Files Community\{Package.Current.Id.FullName}\v1\FileTags";
 		
 		private readonly static string FileTagsDbPath = Path.Combine(ApplicationData.Current.LocalFolder.Path, "filetags.db");
 		private const string FileTagsCollectionName = "taggedfiles";
-
-		private readonly GCHandle _handle;
-		private bool _disposed = false;
 
 		static FileTagsDatabase()
 		{
@@ -45,25 +41,6 @@ namespace Files.App.Server.Database
 				}
 
 				File.Delete(FileTagsDbPath);
-			}
-		}
-
-		public FileTagsDatabase()
-		{
-			throw new NotSupportedException($"Instantiating {nameof(FileTagsDatabase)} by non-parameterized constructor is not supported.");
-		}
-
-		public FileTagsDatabase(int processId)
-		{
-			_handle = GCHandle.Alloc(this, GCHandleType.Pinned);
-
-			if (AppInstanceMonitor.AppInstanceResources.TryGetValue(processId, out var instances))
-			{
-				instances.Add(this);
-			}
-			else
-			{
-				AppInstanceMonitor.AppInstanceResources[processId] = [this];
 			}
 		}
 
@@ -300,15 +277,6 @@ namespace Files.App.Server.Database
 				}
 
 				IterateKeys(list, CombineKeys(path, subKey), depth + 1);
-			}
-		}
-
-		public void Dispose()
-		{
-			if (!_disposed)
-			{
-				_disposed = true;
-				_handle.Free();
 			}
 		}
 	}

--- a/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
+++ b/src/Files.App.Server/Database/LayoutPreferencesDatabase.cs
@@ -5,7 +5,6 @@ using Files.App.Server.Data;
 using LiteDB;
 using Microsoft.Win32;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Windows.ApplicationModel;
 using Windows.Storage;
 using static Files.App.Server.Data.LayoutPreferencesRegistry;
@@ -14,15 +13,12 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Files.App.Server.Database
 {
-	public sealed class LayoutPreferencesDatabase : IDisposable
+	public sealed class LayoutPreferencesDatabase
 	{
 		private readonly static string LayoutSettingsKey = @$"Software\Files Community\{Package.Current.Id.FullName}\v1\LayoutPreferences";
 
 		private readonly static string LayoutSettingsDbPath = Path.Combine(ApplicationData.Current.LocalFolder.Path, "user_settings.db");
 		private const string LayoutSettingsCollectionName = "layoutprefs";
-
-		private readonly GCHandle _handle;
-		private bool _disposed = false;
 
 		static LayoutPreferencesDatabase()
 		{
@@ -38,25 +34,6 @@ namespace Files.App.Server.Database
 				}
 
 				File.Delete(LayoutSettingsDbPath);
-			}
-		}
-
-		public LayoutPreferencesDatabase()
-		{
-			throw new NotSupportedException($"Instantiating {nameof(LayoutPreferencesDatabase)} by non-parameterized constructor is not supported.");
-		}
-
-		public LayoutPreferencesDatabase(int processId)
-		{
-			_handle = GCHandle.Alloc(this, GCHandleType.Pinned);
-
-			if (AppInstanceMonitor.AppInstanceResources.TryGetValue(processId, out var instances))
-			{
-				instances.Add(this);
-			}
-			else
-			{
-				AppInstanceMonitor.AppInstanceResources[processId] = [this];
 			}
 		}
 
@@ -219,15 +196,6 @@ namespace Files.App.Server.Database
 			}
 
 			return null;
-		}
-
-		public void Dispose()
-		{
-			if (!_disposed)
-			{
-				_disposed = true;
-				_handle.Free();
-			}
 		}
 	}
 }

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesDatabaseManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesDatabaseManager.cs
@@ -11,7 +11,7 @@ namespace Files.App.Helpers
 	public class LayoutPreferencesDatabaseManager
 	{
 		// Fields
-		private readonly Server.Database.LayoutPreferencesDatabase _database = new(Environment.ProcessId);
+		private readonly Server.Database.LayoutPreferencesDatabase _database = new();
 
 		private DetailsLayoutColumnItem FromDatabaseEntity(Server.Data.ColumnPreferencesItem entry)
 		{

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesDatabaseManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesDatabaseManager.cs
@@ -11,7 +11,7 @@ namespace Files.App.Helpers
 	public class LayoutPreferencesDatabaseManager
 	{
 		// Fields
-		private readonly Server.Database.LayoutPreferencesDatabase _database = new();
+		private static readonly Lazy<Server.Database.LayoutPreferencesDatabase> dbInstance = new(() => new());
 
 		private DetailsLayoutColumnItem FromDatabaseEntity(Server.Data.ColumnPreferencesItem entry)
 		{
@@ -116,27 +116,27 @@ namespace Files.App.Helpers
 		// Methods
 		public LayoutPreferencesItem? GetPreferences(string filePath, ulong? frn = null)
 		{
-			return FromDatabaseEntity(_database.GetPreferences(filePath, frn));
+			return FromDatabaseEntity(dbInstance.Value.GetPreferences(filePath, frn));
 		}
 
 		public void SetPreferences(string filePath, ulong? frn, LayoutPreferencesItem? preferencesItem)
 		{
-			_database.SetPreferences(filePath, frn, ToDatabaseEntity(preferencesItem));
+			dbInstance.Value.SetPreferences(filePath, frn, ToDatabaseEntity(preferencesItem));
 		}
 
 		public void ResetAll()
 		{
-			_database.ResetAll();
+			dbInstance.Value.ResetAll();
 		}
 
 		public void Import(string json)
 		{
-			_database.Import(json);
+			dbInstance.Value.Import(json);
 		}
 
 		public string Export()
 		{
-			return _database.Export();
+			return dbInstance.Value.Export();
 		}
 	}
 }

--- a/src/Files.App/Utils/FileTags/FileTagsHelper.cs
+++ b/src/Files.App/Utils/FileTags/FileTagsHelper.cs
@@ -12,9 +12,9 @@ namespace Files.App.Utils.FileTags
 {
 	public static class FileTagsHelper
 	{
-		private static readonly Server.Database.FileTagsDatabase dbInstance = new(Environment.ProcessId);
+		private static readonly Lazy<Server.Database.FileTagsDatabase> dbInstance = new(() => new());
 
-		public static Server.Database.FileTagsDatabase GetDbInstance() => dbInstance;
+		public static Server.Database.FileTagsDatabase GetDbInstance() => dbInstance.Value;
 
 		public static string[] ReadFileTag(string filePath)
 		{


### PR DESCRIPTION
Reverts files-community/Files#15324

This doesn't seem to fix the CsWinRT crashing issue.

In addition, make initialization of `LayoutPreferencesDatabase` lazy.