### PR TITLE
Code Quality: Gave priority to registry when loading Seer Pro settings

### DIFF
--- a/src/Files.App/Services/PreviewPopupProviders/SeerProProvider.cs
+++ b/src/Files.App/Services/PreviewPopupProviders/SeerProProvider.cs
@@ -72,8 +72,8 @@ namespace Files.App.Services.PreviewPopupProviders
 			var keyName = @"HKEY_CURRENT_USER\Software\Corey\Seer";
 			var value = Registry.GetValue(keyName, "tracking_file", null);
 
-			if (value?.ToString() == "false")
-				return Task.FromResult(false);
+			if (bool.TryParse(value?.ToString(), out var result))
+				return Task.FromResult(result);
 
 			// List of possible paths for the Seer Pro settings file
 			string[] paths =


### PR DESCRIPTION
This fixes the reason why it didn't work well in my environment.

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Related to #15339 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
