### PR TITLE
Fix: Fixed NullReferenceException in FilePropertiesHelpers.DestroyCachedWindows

### DIFF
--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -37,7 +37,7 @@ namespace Files.App.Utils.Storage
 			=> WinRT.Interop.WindowNative.GetWindowHandle(w);
 
 		private static TaskCompletionSource? PropertiesWindowsClosingTCS;
-		private static BlockingCollection<WinUIEx.WindowEx> WindowCache = new();
+		private static readonly BlockingCollection<WinUIEx.WindowEx> WindowCache = [];
 
 		/// <summary>
 		/// Open properties window
@@ -184,8 +184,11 @@ namespace Files.App.Utils.Storage
 		/// <returns></returns>
 		public static void DestroyCachedWindows()
 		{
-			while (WindowCache.TryTake(out var window))
+			while (WindowCache?.TryTake(out var window) ?? false)
 			{
+				if (window is null)
+					continue;
+
 				window.Closed -= PropertiesWindow_Closed;
 				window.Close();
 			}


### PR DESCRIPTION
I have no idea why NullReferenceException occurs, but it also occurs in v3.4.1, so I made it null safe.

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Related to #15337 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
