### PR TITLE
Code Quality: Add Dummy update service for dev builds

### DIFF
--- a/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
+++ b/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
@@ -175,8 +175,10 @@ namespace Files.App.Helpers
 					.AddSingleton<IAddItemService, AddItemService>()
 #if STABLE || PREVIEW
 					.AddSingleton<IUpdateService, SideloadUpdateService>()
-#else
+#elif STORE
 					.AddSingleton<IUpdateService, UpdateService>()
+#else
+					.AddSingleton<IUpdateService, DummyUpdateService>()
 #endif
 					.AddSingleton<IPreviewPopupService, PreviewPopupService>()
 					.AddSingleton<IDateTimeFormatterFactory, DateTimeFormatterFactory>()

--- a/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
+++ b/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
@@ -176,7 +176,7 @@ namespace Files.App.Helpers
 #if STABLE || PREVIEW
 					.AddSingleton<IUpdateService, SideloadUpdateService>()
 #elif STORE
-					.AddSingleton<IUpdateService, UpdateService>()
+					.AddSingleton<IUpdateService, StoreUpdateService>()
 #else
 					.AddSingleton<IUpdateService, DummyUpdateService>()
 #endif

--- a/src/Files.App/Services/DummyUpdateService.cs
+++ b/src/Files.App/Services/DummyUpdateService.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.App.Services
+{
+	internal sealed class DummyUpdateService : IUpdateService
+	{
+		public bool IsUpdateAvailable => false;
+
+		public bool IsUpdating => false;
+
+		public bool IsAppUpdated => true;
+
+		public bool IsReleaseNotesAvailable => true;
+
+		public event PropertyChangedEventHandler? PropertyChanged;
+
+		public Task CheckAndUpdateFilesLauncherAsync()
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task CheckForUpdatesAsync()
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task CheckLatestReleaseNotesAsync(CancellationToken cancellationToken = default)
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task DownloadMandatoryUpdatesAsync()
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task DownloadUpdatesAsync()
+		{
+			return Task.CompletedTask;
+		}
+
+		public Task<string?> GetLatestReleaseNotesAsync(CancellationToken cancellationToken = default)
+		{
+			// No localization for dev-only string
+			return Task.FromResult((string?)"No release notes available for Dev build.");
+		}
+	}
+}

--- a/src/Files.App/Services/DummyUpdateService.cs
+++ b/src/Files.App/Services/DummyUpdateService.cs
@@ -16,7 +16,7 @@ namespace Files.App.Services
 
 		public bool IsReleaseNotesAvailable => true;
 
-		public event PropertyChangedEventHandler? PropertyChanged;
+		public event PropertyChangedEventHandler? PropertyChanged { add { } remove { } }
 
 		public Task CheckAndUpdateFilesLauncherAsync()
 		{

--- a/src/Files.App/Services/StoreUpdateService.cs
+++ b/src/Files.App/Services/StoreUpdateService.cs
@@ -13,7 +13,7 @@ using WinRT.Interop;
 
 namespace Files.App.Services
 {
-	internal sealed class UpdateService : ObservableObject, IUpdateService
+	internal sealed class StoreUpdateService : ObservableObject, IUpdateService
 	{
 		private StoreContext? _storeContext;
 		private List<StorePackageUpdate>? _updatePackages;
@@ -46,7 +46,7 @@ namespace Files.App.Services
 			get => SystemInformation.Instance.IsAppUpdated;
 		}
 
-		public UpdateService()
+		public StoreUpdateService()
 		{
 			_updatePackages = [];
 		}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

Currently, the Dev build attempts to check for updates from the store on launch, which always fails and results in a native exception that pauses the app. This PR introduces a no-op implementation of IUpdateService used when running in Dev mode. It also renames UpdateService to StoreUpdateService for clarity.

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files Dev
2. Checked for exception in kernelbase.dll on startup