### PR TITLE
Feature: Added support for "Thin acrylic" system backdrop

### DIFF
--- a/src/Files.App/Data/Enums/BackdropMaterialType.cs
+++ b/src/Files.App/Data/Enums/BackdropMaterialType.cs
@@ -26,6 +26,11 @@ namespace Files.App.Data.Enums
 		/// <summary>
 		/// Arcylic backdrop.
 		/// </summary>
-		Acrylic
+		Acrylic,
+
+		/// <summary>
+		/// Thin Acrylic backdrop.
+		/// </summary>
+		ThinAcrylic
 	}
 }

--- a/src/Files.App/Helpers/UI/AppSystemBackdrop.cs
+++ b/src/Files.App/Helpers/UI/AppSystemBackdrop.cs
@@ -2,12 +2,7 @@
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.UI;
 
 namespace Files.App.Helpers
@@ -47,11 +42,11 @@ namespace Files.App.Helpers
 		{
 			base.OnDefaultSystemBackdropConfigurationChanged(target, xamlRoot);
 			var configuration = GetDefaultSystemBackdropConfiguration(target, xamlRoot);
-			if (controller is not DesktopAcrylicController acrylicController || configuration.Theme == prevTheme)
+			if (controller is not DesktopAcrylicController acrylicController || acrylicController.Kind != DesktopAcrylicKind.Thin || configuration.Theme == prevTheme)
 				return;
 
 			prevTheme = configuration.Theme;
-			SetAcrylicBackdropProperties(acrylicController, configuration.Theme);
+			SetThinAcrylicBackdropProperties(acrylicController, configuration.Theme);
 		}
 
 		protected override void OnTargetDisconnected(ICompositionSupportsSystemBackdrop disconnectedTarget)
@@ -103,8 +98,17 @@ namespace Files.App.Helpers
 					};
 
 				case BackdropMaterialType.Acrylic:
-					var acrylicController = new DesktopAcrylicController();
-					SetAcrylicBackdropProperties(acrylicController, theme);
+					return new DesktopAcrylicController()
+					{
+						Kind = DesktopAcrylicKind.Base,
+					};
+
+				case BackdropMaterialType.ThinAcrylic:
+					var acrylicController = new DesktopAcrylicController()
+					{
+						Kind = DesktopAcrylicKind.Thin
+					};
+					SetThinAcrylicBackdropProperties(acrylicController, theme);
 					return acrylicController;
 
 				default:
@@ -112,9 +116,9 @@ namespace Files.App.Helpers
 			}
 		}
 
-		private void SetAcrylicBackdropProperties(DesktopAcrylicController controller, SystemBackdropTheme theme)
+		private void SetThinAcrylicBackdropProperties(DesktopAcrylicController controller, SystemBackdropTheme theme)
 		{
-			// This sets all properties to work around a bug where other properties stop updating when fallback color is changed
+			// This sets all properties to work around other properties not updating when fallback color is changed
 			// This uses the Thin Acrylic recipe from the WinUI Figma toolkit
 
 			switch(theme)

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3796,4 +3796,7 @@
   <data name="VerticalAlignment" xml:space="preserve">
     <value>Vertical alignment</value>
   </data>
+  <data name="ThinAcrylic" xml:space="preserve">
+    <value>Thin Acrylic</value>
+  </data>
 </root>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3798,6 +3798,7 @@
   </data>
   <data name="ThinAcrylic" xml:space="preserve">
     <value>Thin Acrylic</value>
+    <comment>This is a type of backdrop for the application background</comment>
   </data>
   <data name="AllLocations" xml:space="preserve">
     <value>Show for all locations</value>

--- a/src/Files.App/ViewModels/Settings/AppearanceViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AppearanceViewModel.cs
@@ -44,12 +44,10 @@ namespace Files.App.ViewModels.Settings
 				"DarkTheme".GetLocalizedResource()
 			];
 
-			// TODO: Re-add Solid and regular Mica when theming is revamped
-			//BackdropMaterialTypes.Add(BackdropMaterialType.Solid, "Solid".GetLocalizedResource());
-
+			BackdropMaterialTypes.Add(BackdropMaterialType.Solid, "None".GetLocalizedResource());
 			BackdropMaterialTypes.Add(BackdropMaterialType.Acrylic, "Acrylic".GetLocalizedResource());
-
-			//BackdropMaterialTypes.Add(BackdropMaterialType.Mica, "Mica".GetLocalizedResource());
+			BackdropMaterialTypes.Add(BackdropMaterialType.ThinAcrylic, "ThinAcrylic".GetLocalizedResource());
+			BackdropMaterialTypes.Add(BackdropMaterialType.Mica, "Mica".GetLocalizedResource());
 			BackdropMaterialTypes.Add(BackdropMaterialType.MicaAlt, "MicaAlt".GetLocalizedResource());
 
 			selectedBackdropMaterial = BackdropMaterialTypes[UserSettingsService.AppearanceSettingsService.AppThemeBackdropMaterial];


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

This PR adds all the available system backdrop options - None, Mica non-alt, and base Acrylic in addition to the existing Mica Alt and Thin Acrylic (called just Acrylic in the UI) options. Design aside, this is mainly for completeness in theming. Mica Alt is still the default option.

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15045

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files
2. Tested switching system backdrops
3. Tested switching themes

When switching themes with the system backdrop set to None, the background only updates after a resize or focusing another window. This is an issue with the way WinUI handles repainting the background.