### PR TITLE
Feature: Close settings dialog when opening the log location

### DIFF
--- a/src/Files.App/ViewModels/Settings/AboutViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AboutViewModel.cs
@@ -53,6 +53,7 @@ namespace Files.App.ViewModels.Settings
 		{
 			await Launcher.LaunchFolderAsync(ApplicationData.Current.LocalFolder).AsTask();
 
+			// TODO: Move this to an application service
 			// Detect if Files is set as the default file manager
 			using var subkey = Registry.ClassesRoot.OpenSubKey(@"Folder\shell\open\command");
 			var command = (string?)subkey?.GetValue(string.Empty);

--- a/src/Files.App/ViewModels/Settings/AboutViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AboutViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See the LICENSE.
 
 using CommunityToolkit.WinUI.Helpers;
+using Microsoft.Win32;
 using System.Windows.Input;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.DataTransfer;
@@ -48,9 +49,19 @@ namespace Files.App.ViewModels.Settings
 			OpenCrowdinCommand = new AsyncRelayCommand(DoOpenCrowdin);
 		}
 
-		private Task<bool> OpenLogLocation()
+		private async Task<bool> OpenLogLocation()
 		{
-			return Launcher.LaunchFolderAsync(ApplicationData.Current.LocalFolder).AsTask();
+			await Launcher.LaunchFolderAsync(ApplicationData.Current.LocalFolder).AsTask();
+
+			// Detect if Files is set as the default file manager
+			using var subkey = Registry.ClassesRoot.OpenSubKey(@"Folder\shell\open\command");
+			var command = (string?)subkey?.GetValue(string.Empty);
+
+			// Close the settings dialog if Files is the deault file manager
+			if (!string.IsNullOrEmpty(command) && command.Contains("Files.App.Launcher.exe"))
+				UIHelpers.CloseAllDialogs();
+
+			return true;
 		}
 
 		public Task DoOpenDocumentation()
@@ -82,7 +93,7 @@ namespace Files.App.ViewModels.Settings
 		{
 			return Launcher.LaunchUriAsync(new Uri(Constants.ExternalUrl.PrivacyPolicyUrl)).AsTask();
 		}
-		
+
 
 		public Task DoOpenCrowdin()
 		{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15415

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files > Settings > About
2. Clicked on "Open Log Location"
3. Confirmed the location opened in File Explorer, and that the Settings Dialog stayed open
4. Set Files as the default file manager
5. Clicked on "Open Log Location"
6. Confirmed the location opening in Files, and that the Settings Dialog closed
