### PR TITLE
Fix: Correct load os language for `MessageFormatExtensions`

### DIFF
--- a/src/Files.App/Extensions/MessageFormatExtensions.cs
+++ b/src/Files.App/Extensions/MessageFormatExtensions.cs
@@ -15,7 +15,7 @@ namespace Files.App.Extensions
 		private static readonly ResourceMap resourcesTree = new ResourceManager().MainResourceMap.TryGetSubtree("Resources");
 
 		// CultureInfo based on the application's primary language override
-		private static readonly CultureInfo locale = new(ApplicationLanguages.PrimaryLanguageOverride);
+		private static readonly CultureInfo locale = ApplicationLanguages.PrimaryLanguageOverride == string.Empty ? CultureInfo.InstalledUICulture : new(ApplicationLanguages.PrimaryLanguageOverride);
 
 		// Message formatter with caching enabled, using the current UI culture's two-letter ISO language name
 		private static readonly MessageFormatter formatter = new(useCache: true, locale: locale.TwoLetterISOLanguageName);

--- a/src/Files.App/Extensions/MessageFormatExtensions.cs
+++ b/src/Files.App/Extensions/MessageFormatExtensions.cs
@@ -15,7 +15,10 @@ namespace Files.App.Extensions
 		private static readonly ResourceMap resourcesTree = new ResourceManager().MainResourceMap.TryGetSubtree("Resources");
 
 		// CultureInfo based on the application's primary language override
-		private static readonly CultureInfo locale = ApplicationLanguages.PrimaryLanguageOverride == string.Empty ? CultureInfo.InstalledUICulture : new(ApplicationLanguages.PrimaryLanguageOverride);
+		private static readonly CultureInfo locale =
+			ApplicationLanguages.PrimaryLanguageOverride == string.Empty
+				? CultureInfo.InstalledUICulture
+				: new(ApplicationLanguages.PrimaryLanguageOverride);
 
 		// Message formatter with caching enabled, using the current UI culture's two-letter ISO language name
 		private static readonly MessageFormatter formatter = new(useCache: true, locale: locale.TwoLetterISOLanguageName);

--- a/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
@@ -152,6 +152,11 @@ namespace Files.App.ViewModels.Settings
 				.ThenBy(language => language.LanguageName);
 			AppLanguages = new ObservableCollection<AppLanguageItem>(appLanguages);
 
+			// Add default language
+			var osDefaultLanguage = new AppLanguageItem(CultureInfo.InstalledUICulture.Name);
+			if (AppLanguages.Select(language => language.LanguageName.Contains(osDefaultLanguage.LanguageName)).Any())
+				AppLanguages[0].LanguagID = osDefaultLanguage.LanguagID;
+
 			string languageID = ApplicationLanguages.PrimaryLanguageOverride;
 			SelectedAppLanguageIndex = AppLanguages
 				.IndexOf(AppLanguages.FirstOrDefault(dl => dl.LanguagID == languageID) ?? AppLanguages.First());

--- a/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
@@ -154,7 +154,8 @@ namespace Files.App.ViewModels.Settings
 
 			// Add default language
 			var osDefaultLanguage = new AppLanguageItem(CultureInfo.InstalledUICulture.Name);
-			if (AppLanguages.Select(language => language.LanguageName.Contains(osDefaultLanguage.LanguageName)).Any())
+			if (AppLanguages.Select(language =>
+				language.LanguageName.Contains(osDefaultLanguage.LanguageName)).Any())
 				AppLanguages[0].LanguagID = osDefaultLanguage.LanguagID;
 
 			string languageID = ApplicationLanguages.PrimaryLanguageOverride;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15440

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. The default language for `MessageFormatExtensions` is loaded as the default OS language
