### PR TITLE
Fix: Fixed an issue with Nutstore cloud drive detection

### DIFF
--- a/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
+++ b/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
@@ -270,18 +270,23 @@ namespace Files.App.Utils.Cloud
 				string iconPath = Path.Combine(programFilesFolder, "Nutstore", "Nutstore.exe");
 				var iconFile = Win32Helper.ExtractSelectedIconsFromDLL(iconPath, new List<int>() { 101 }).FirstOrDefault();
 
-				// get every folder under the Nutstore folder in %userprofile%
-				var mainFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Nutstore");
-				var nutstoreFolders = Directory.GetDirectories(mainFolder, "Nutstore", SearchOption.AllDirectories);
-				foreach (var nutstoreFolder in nutstoreFolders)
+				using var syncRootMangerKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\SyncRootManager");
+				if (syncRootMangerKey is not null)
 				{
-					var folderName = Path.GetFileName(nutstoreFolder);
-					if (folderName is not null && folderName.StartsWith("Nutstore", StringComparison.OrdinalIgnoreCase))
+					var syncRootIds = syncRootMangerKey.GetSubKeyNames();
+					foreach (var syncRootId in syncRootIds)
 					{
+						if (!syncRootId.StartsWith("Nutstore-")) continue;
+
+						var sid = syncRootId.Split('!')[1];
+						using var syncRootKey = syncRootMangerKey.OpenSubKey($@"{syncRootId}\UserSyncRoots");
+						var userSyncRoot = syncRootKey?.GetValue(sid)?.ToString();
+						if (string.IsNullOrEmpty(userSyncRoot)) continue;
+
 						results.Add(new CloudProvider(CloudProviders.Nutstore)
 						{
 							Name = $"Nutstore",
-							SyncFolder = nutstoreFolder,
+							SyncFolder = userSyncRoot,
 							IconData = iconFile?.IconData
 						});
 					}


### PR DESCRIPTION
Hi, I'm a developer at the company [Nutstore](https://www.jianguoyun.com/), I've found out that the cloud drive detection logic for Nutstore in PR #10890 is incorrect. 

Searching all the sub-directories named "Nutstore" in `%userprofile%` can be extremely time-consuming and will likely cause the Files app the stop responding, it may also result in multiple incorrect Nutstore cloud drive entries. 

Querying the registry entries in `SyncRootManager` is a more efficient way to detect the root dir of the Nutstore cloud drive.