### PR TITLE
Fix: Fixed NullReferenceException in BaseDeleteAction.DeleteItemsAsync

### DIFF
--- a/src/Files.App/Actions/FileSystem/BaseDeleteAction.cs
+++ b/src/Files.App/Actions/FileSystem/BaseDeleteAction.cs
@@ -34,7 +34,8 @@ namespace Files.App.Actions
 							? FilesystemItemType.File
 							: FilesystemItemType.Directory));
 
-			if (context.ShellPage is IShellPage shellPage) {
+			if (context.ShellPage is IShellPage shellPage)
+			{
 				await shellPage.FilesystemHelpers.DeleteItemsAsync(items, settings.DeleteConfirmationPolicy, permanently, true);
 				await shellPage.FilesystemViewModel.ApplyFilesAndFoldersChangesAsync();
 			}

--- a/src/Files.App/Actions/FileSystem/BaseDeleteAction.cs
+++ b/src/Files.App/Actions/FileSystem/BaseDeleteAction.cs
@@ -34,9 +34,10 @@ namespace Files.App.Actions
 							? FilesystemItemType.File
 							: FilesystemItemType.Directory));
 
-			await context.ShellPage!.FilesystemHelpers.DeleteItemsAsync(items, settings.DeleteConfirmationPolicy, permanently, true);
-
-			await context.ShellPage.FilesystemViewModel.ApplyFilesAndFoldersChangesAsync();
+			if (context.ShellPage is IShellPage shellPage) {
+				await shellPage.FilesystemHelpers.DeleteItemsAsync(items, settings.DeleteConfirmationPolicy, permanently, true);
+				await shellPage.FilesystemViewModel.ApplyFilesAndFoldersChangesAsync();
+			}
 		}
 
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15462 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
