### PR TITLE
Feature: Added support for displaying total duration when selecting multiple video files

### DIFF
--- a/src/Files.App/ViewModels/Properties/Items/CombinedFileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/CombinedFileProperties.cs
@@ -51,7 +51,13 @@ namespace Files.App.ViewModels.Properties
 				var props = queries.SelectMany(query => query!.First(section => section.Key == group.Key));
 				foreach (FileProperty prop in group)
 				{
-					if (props.Where(x => x.Property == prop.Property).Any(x => !Equals(x.Value, prop.Value)))
+					if (prop.Property == "System.Media.Duration")
+					{
+						ulong totalDuration = 0;
+						props.Where(x => x.Property == prop.Property).ForEach(x => totalDuration += (ulong)x.Value);
+						prop.Value = totalDuration;
+					}
+					else if (props.Where(x => x.Property == prop.Property).Any(x => !Equals(x.Value, prop.Value)))
 					{
 						// Has multiple values
 						prop.Value = prop.IsReadOnly ? "MultipleValues".GetLocalizedResource() : null;


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15468 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Select multiple media files.
2. Open properties window and select Details tab.
3. See duration.