### PR TITLE
Code Quality: Convert Multiple Localized Strings to ICU Message Format | Fix word order problem

### DIFF
--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -455,7 +455,7 @@
   <data name="PropertiesFilesAndFoldersCountString" xml:space="preserve">
     <value>{0, number} {0, plural, one {file} other {files}}, {1, number} {1, plural, one {folder} other {folders}}</value>
   </data>
-  <data name="PropertiesFilesAndFoldersAndLocationsCountString" xml:space="preserve">
+  <data name="PropertiesFilesAndFoldersAndLocationsCount" xml:space="preserve">
     <value>{0, number} {0, plural, one {file} other {files}}, {1, number} {1, plural, one {folder} other {folders}} from {2, number} {2, plural, one {location} other {locations}}</value>
   </data>
   <data name="BaseLayoutContextFlyoutRunAsAnotherUser.Text" xml:space="preserve">

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -1239,7 +1239,7 @@
     <value>{0, plural, one {There is one conflicting file name} other {There are # conflicting file names}}</value>
   </data>
   <data name="ConflictingItemsDialogSubtitleConflictsNonConflicts" xml:space="preserve">
-    <value>{0, plural, one {, and one outgoing item} other {, and # outgoing items}}</value>
+    <value>{0, plural, one {There is one conflicting file name} other {There are # conflicting file names}}, and {1, plural, one {one outgoing item} other {# outgoing items}}</value>
   </data>
   <data name="ConflictingItemsDialogTitle" xml:space="preserve">
     <value>Conflicting {0, plural, one {file name} other {file names}}</value>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -455,8 +455,8 @@
   <data name="PropertiesFilesAndFoldersCountString" xml:space="preserve">
     <value>{0, number} {0, plural, one {file} other {files}}, {1, number} {1, plural, one {folder} other {folders}}</value>
   </data>
-  <data name="PropertiesLocationsCountString" xml:space="preserve">
-    <value>from {0, number} {0, plural, one {location} other {locations}}</value>
+  <data name="PropertiesFilesAndFoldersAndLocationsCountString" xml:space="preserve">
+    <value>{0, number} {0, plural, one {file} other {files}}, {1, number} {1, plural, one {folder} other {folders}} from {2, number} {2, plural, one {location} other {locations}}</value>
   </data>
   <data name="BaseLayoutContextFlyoutRunAsAnotherUser.Text" xml:space="preserve">
     <value>Run as another user</value>

--- a/src/Files.App/ViewModels/Dialogs/FileSystemDialog/FileSystemDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/FileSystemDialog/FileSystemDialogViewModel.cs
@@ -151,14 +151,10 @@ namespace Files.App.ViewModels.Dialogs.FileSystemDialog
 			{
 				titleText = "ConflictingItemsDialogTitle".GetLocalizedFormatResource(totalCount);
 
-				var descriptionLocalized = new StringBuilder();
-				descriptionLocalized.Append("ConflictingItemsDialogSubtitleConflicts".GetLocalizedFormatResource(conflictingItems.Count));
+				descriptionText = nonConflictingItems.Count > 0
+					? "ConflictingItemsDialogSubtitleConflictsNonConflicts".GetLocalizedFormatResource(conflictingItems.Count, nonConflictingItems.Count)
+					: "ConflictingItemsDialogSubtitleConflicts".GetLocalizedFormatResource(conflictingItems.Count);
 
-				if (nonConflictingItems.Count > 0)
-					descriptionLocalized.Append("ConflictingItemsDialogSubtitleConflictsNonConflicts".GetLocalizedFormatResource(nonConflictingItems.Count));
-
-				descriptionLocalized.Append('.');
-				descriptionText = descriptionLocalized.ToString();
 				primaryButtonText = "ConflictingItemsDialogPrimaryButtonText".ToLocalized();
 				secondaryButtonText = "Cancel".ToLocalized();
 			}

--- a/src/Files.App/ViewModels/Properties/Items/BaseProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/BaseProperties.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.UI.Dispatching;
 using System.IO;
+using System.Resources;
 using System.Text;
 using Windows.Storage.FileProperties;
 using static Files.App.Helpers.Win32Helper;
@@ -122,16 +123,9 @@ namespace Files.App.ViewModels.Properties
 
 		public void SetItemsCountString()
 		{
-			var resourceText = new StringBuilder();
-			resourceText.Append("PropertiesFilesAndFoldersCountString".GetLocalizedFormatResource(ViewModel.FilesCount, ViewModel.FoldersCount));
-
-			if (ViewModel.LocationsCount > 0)
-			{
-				resourceText.Append(' ');
-				resourceText.Append("PropertiesLocationsCountString".GetLocalizedFormatResource(ViewModel.LocationsCount));
-			}
-
-			ViewModel.FilesAndFoldersCountString = resourceText.ToString();
+			ViewModel.FilesAndFoldersCountString = ViewModel.LocationsCount > 0
+				? "PropertiesFilesAndFoldersAndLocationsCountString".GetLocalizedFormatResource(ViewModel.FilesCount, ViewModel.FoldersCount, ViewModel.LocationsCount)
+				: "PropertiesFilesAndFoldersCountString".GetLocalizedFormatResource(ViewModel.FilesCount, ViewModel.FoldersCount);
 		}
 	}
 }

--- a/src/Files.App/ViewModels/Properties/Items/BaseProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/BaseProperties.cs
@@ -122,7 +122,7 @@ namespace Files.App.ViewModels.Properties
 		public void SetItemsCountString()
 		{
 			ViewModel.FilesAndFoldersCountString = ViewModel.LocationsCount > 0
-				? "PropertiesFilesAndFoldersAndLocationsCountString".GetLocalizedFormatResource(ViewModel.FilesCount, ViewModel.FoldersCount, ViewModel.LocationsCount)
+				? "PropertiesFilesAndFoldersAndLocationsCount".GetLocalizedFormatResource(ViewModel.FilesCount, ViewModel.FoldersCount, ViewModel.LocationsCount)
 				: "PropertiesFilesAndFoldersCountString".GetLocalizedFormatResource(ViewModel.FilesCount, ViewModel.FoldersCount);
 		}
 	}

--- a/src/Files.App/ViewModels/Properties/Items/BaseProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/BaseProperties.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.UI.Dispatching;
 using System.IO;
-using System.Resources;
-using System.Text;
 using Windows.Storage.FileProperties;
 using static Files.App.Helpers.Win32Helper;
 using FileAttributes = System.IO.FileAttributes;


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- From #15503 
- From https://github.com/files-community/Files/pull/15507#discussion_r1621631346
- From https://github.com/files-community/Files/pull/15514#discussion_r1621613569

TODO list: https://github.com/files-community/Files/issues/15503#issuecomment-2138404595

**Fix word order problem**
<details><summary>☑️ ConflictingItemsDialogSubtitleMultipleConflictsMultipleNonConflicts, ConflictingItemsDialogSubtitleSingleConflictMultipleNonConflicts, ConflictingItemsDialogSubtitleSingleConflictNoNonConflicts, ConflictingItemsDialogSubtitleMultipleConflictsNoNonConflicts ----> <b>ConflictingItemsDialogSubtitleConflicts</b>, <b>ConflictingItemsDialogSubtitleConflictsNonConflicts</b></summary>
<p>

https://github.com/files-community/Files/blob/af0ab75334fc38273042201bc73119dd4e470b26/src/Files.App/Strings/en-US/Resources.resw#L1260-L1262
https://github.com/files-community/Files/blob/af0ab75334fc38273042201bc73119dd4e470b26/src/Files.App/Strings/en-US/Resources.resw#L1266-L1268
https://github.com/files-community/Files/blob/af0ab75334fc38273042201bc73119dd4e470b26/src/Files.App/Strings/en-US/Resources.resw#L1290-L1295

</p>
</details>
<details ><summary>☑️ PropertiesFilesFoldersAndLocationsCountString ----> <b>PropertiesFilesAndFoldersAndLocationsCountString</b></summary>
<p>

https://github.com/files-community/Files/blob/af0ab75334fc38273042201bc73119dd4e470b26/src/Files.App/Strings/en-US/Resources.resw#L474-L476

</p>
</details>