### PR TITLE
Fix: Fixed an issue where text on the Actions Settings page didn't wrap

### DIFF
--- a/src/Files.App/Views/Settings/ActionsPage.xaml
+++ b/src/Files.App/Views/Settings/ActionsPage.xaml
@@ -265,7 +265,7 @@
 										Style="{StaticResource CaptionTextBlockStyle}"
 										Text="{x:Bind CommandDescription}"
 										TextTrimming="CharacterEllipsis"
-										TextWrapping="NoWrap" />
+										TextWrapping="WrapWholeWords" />
 								</StackPanel>
 
 								<!--  Key Binding Control  -->


### PR DESCRIPTION
**Fix when the description text is not displayed in full**

From:
![image](https://github.com/files-community/Files/assets/84145589/def8918e-33ae-4ae5-910a-a6c6d3ce161a)
To:
![image](https://github.com/files-community/Files/assets/84145589/f5471805-d54c-4459-8c08-7929444e6dab)

