### PR TITLE
Feature: Added support for bulk renaming items

### DIFF
--- a/src/Files.App/Actions/FileSystem/RenameAction.cs
+++ b/src/Files.App/Actions/FileSystem/RenameAction.cs
@@ -34,15 +34,8 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync(object? parameter = null)
 		{	
-			if (context.SelectedItems.Count == 1)
-			{
-				context.ShellPage?.SlimContentPage?.ItemManipulationModel.StartRenameItem();
-			}
-			else
-			{
-				context.ShellPage?.SlimContentPage?.ItemManipulationModel.StartRenameItems();
-			}
-
+			
+			context.ShellPage?.SlimContentPage?.ItemManipulationModel.StartRenameItem();
 			return Task.CompletedTask;
 		}
 

--- a/src/Files.App/Actions/FileSystem/RenameAction.cs
+++ b/src/Files.App/Actions/FileSystem/RenameAction.cs
@@ -33,15 +33,22 @@ namespace Files.App.Actions
 		}
 
 		public Task ExecuteAsync(object? parameter = null)
-		{
-			context.ShellPage?.SlimContentPage?.ItemManipulationModel.StartRenameItem();
+		{	
+			if (context.SelectedItems.Count == 1)
+			{
+				context.ShellPage?.SlimContentPage?.ItemManipulationModel.StartRenameItem();
+			}
+			else
+			{
+				context.ShellPage?.SlimContentPage?.ItemManipulationModel.StartRenameItems();
+			}
 
 			return Task.CompletedTask;
 		}
 
 		private bool IsSelectionValid()
 		{
-			return context.HasSelection && context.SelectedItems.Count == 1;
+			return context.HasSelection && context.SelectedItems.Count != 0;
 		}
 
 		private bool IsPageTypeValid()

--- a/src/Files.App/Data/Models/ItemManipulationModel.cs
+++ b/src/Files.App/Data/Models/ItemManipulationModel.cs
@@ -21,8 +21,6 @@ namespace Files.App.Data.Models
 
 		public event EventHandler StartRenameItemInvoked;
 
-		public event EventHandler StartRenameItemsInvoked;
-
 		public event EventHandler<ListedItem> ScrollIntoViewInvoked;
 
 		public event EventHandler ScrollToTopInvoked;
@@ -101,11 +99,6 @@ namespace Files.App.Data.Models
 		public void StartRenameItem()
 		{
 			StartRenameItemInvoked?.Invoke(this, EventArgs.Empty);
-		}
-
-		public void StartRenameItems()
-		{
-			StartRenameItemsInvoked?.Invoke(this, EventArgs.Empty);
 		}
 
 		public void ScrollIntoView(ListedItem item)

--- a/src/Files.App/Data/Models/ItemManipulationModel.cs
+++ b/src/Files.App/Data/Models/ItemManipulationModel.cs
@@ -21,6 +21,8 @@ namespace Files.App.Data.Models
 
 		public event EventHandler StartRenameItemInvoked;
 
+		public event EventHandler StartRenameItemsInvoked;
+
 		public event EventHandler<ListedItem> ScrollIntoViewInvoked;
 
 		public event EventHandler ScrollToTopInvoked;
@@ -99,6 +101,11 @@ namespace Files.App.Data.Models
 		public void StartRenameItem()
 		{
 			StartRenameItemInvoked?.Invoke(this, EventArgs.Empty);
+		}
+
+		public void StartRenameItems()
+		{
+			StartRenameItemsInvoked?.Invoke(this, EventArgs.Empty);
 		}
 
 		public void ScrollIntoView(ListedItem item)

--- a/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
@@ -291,7 +291,22 @@ namespace Files.App.Helpers
 				}
 				else
 				{
+					
+					int new_name_extension = newName.LastIndexOf('.');
+					if (new_name_extension != -1)
+					{
+						string newName_no_extension = newName.Substring(0, new_name_extension);
+						newName = string.Concat(newName_no_extension, item.FileExtension);
+
+					}
+					else
+					{
+						newName = string.Concat(newName, item.FileExtension);
+					}
+					
 					newName = item.ItemNameRaw.Replace(item.Name, newName, StringComparison.Ordinal);
+
+
 				}
 
 				if (item.ItemNameRaw == newName || string.IsNullOrEmpty(newName))

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -106,9 +106,15 @@ namespace Files.App.Views.Layouts
 		public IShellPage? ParentShellPageInstance { get; private set; }
 
 		public bool IsRenamingItem { get; set; }
+
+		public bool IsRenamingMultipleItems { get; set; }
+
 		public bool LockPreviewPaneContent { get; set; }
 
 		public ListedItem? RenamingItem { get; set; }
+
+		public List<ListedItem>? RenamingItems { get; set; }
+
 		public ListedItem? SelectedItem { get; private set; }
 
 		public string? OldItemName { get; set; }
@@ -1377,6 +1383,10 @@ namespace Files.App.Views.Layouts
 		}
 
 		virtual public void StartRenameItem()
+		{
+		}
+
+		virtual public void StartRenameItems()
 		{
 		}
 

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1386,10 +1386,6 @@ namespace Files.App.Views.Layouts
 		{
 		}
 
-		virtual public void StartRenameItems()
-		{
-		}
-
 		public void CheckRenameDoubleClick(object clickedItem)
 		{
 			if (clickedItem is ListedItem item)

--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
@@ -199,11 +199,6 @@ namespace Files.App.Views.Layouts
 			StartRenameItem("ListViewTextBoxItemName");
 		}
 
-		public override void StartRenameItems()
-		{
-			StartRenameItems("ListViewTextBoxItemName");
-		}
-
 		private async void ItemNameTextBox_BeforeTextChanging(TextBox textBox, TextBoxBeforeTextChangingEventArgs args)
 		{
 			if (IsRenamingItem || IsRenamingMultipleItems)
@@ -219,11 +214,7 @@ namespace Files.App.Views.Layouts
 		protected override void EndRename(TextBox textBox)
 		{
 			FileNameTeachingTip.IsOpen = false;
-			IsRenamingItem = false;
 			
-			
-
-			// Unsubscribe from events
 			if (textBox is not null)
 			{
 				textBox!.LostFocus -= RenameTextBox_LostFocus;
@@ -233,17 +224,7 @@ namespace Files.App.Views.Layouts
 			if (textBox is not null && textBox.Parent is not null)
 			{
 				ListViewItem? listViewItem;
-				if (!IsRenamingMultipleItems)
-				{
-					listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
-				}
-				else
-				{
-					ListedItem lastItem = RenamingItems.LastOrDefault();
-					if (lastItem is null)
-						return;
-					listViewItem = FileList.ContainerFromItem(lastItem) as ListViewItem;
-				}
+				listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
 				if (listViewItem is null)
 					return;
 

--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
@@ -124,10 +124,13 @@ namespace Files.App.Views.Layouts
 
 		protected override void ItemManipulationModel_AddSelectedItemInvoked(object? sender, ListedItem e)
 		{
-			if (NextRenameIndex != 0 && TryStartRenameNextItem(e))
-				return;
+			if (!IsRenamingMultipleItems)
+			{
+				if (NextRenameIndex != 0 && TryStartRenameNextItem(e))
+					return;
 
-			FileList?.SelectedItems.Add(e);
+				FileList?.SelectedItems.Add(e);
+			}
 		}
 
 		protected override void ItemManipulationModel_RemoveSelectedItemInvoked(object? sender, ListedItem e)
@@ -196,9 +199,14 @@ namespace Files.App.Views.Layouts
 			StartRenameItem("ListViewTextBoxItemName");
 		}
 
+		public override void StartRenameItems()
+		{
+			StartRenameItems("ListViewTextBoxItemName");
+		}
+
 		private async void ItemNameTextBox_BeforeTextChanging(TextBox textBox, TextBoxBeforeTextChangingEventArgs args)
 		{
-			if (IsRenamingItem)
+			if (IsRenamingItem || IsRenamingMultipleItems)
 			{
 				await ValidateItemNameInputTextAsync(textBox, args, (showError) =>
 				{
@@ -212,6 +220,8 @@ namespace Files.App.Views.Layouts
 		{
 			FileNameTeachingTip.IsOpen = false;
 			IsRenamingItem = false;
+			
+			
 
 			// Unsubscribe from events
 			if (textBox is not null)
@@ -222,7 +232,18 @@ namespace Files.App.Views.Layouts
 
 			if (textBox is not null && textBox.Parent is not null)
 			{
-				ListViewItem? listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+				ListViewItem? listViewItem;
+				if (!IsRenamingMultipleItems)
+				{
+					listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+				}
+				else
+				{
+					ListedItem lastItem = RenamingItems.LastOrDefault();
+					if (lastItem is null)
+						return;
+					listViewItem = FileList.ContainerFromItem(lastItem) as ListViewItem;
+				}
 				if (listViewItem is null)
 					return;
 
@@ -233,6 +254,7 @@ namespace Files.App.Views.Layouts
 				textBox!.Visibility = Visibility.Collapsed;
 				textBlock!.Visibility = Visibility.Visible;
 			}
+
 		}
 
 		public override void ResetItemOpacity()

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -326,23 +326,23 @@ namespace Files.App.Views.Layouts
 			}
 		}
 
+		override public void StartRenameItems()
+		{
+			
+			StartRenameItems("ItemNameTextBox");
+			
+		}
+
 		override public void StartRenameItem()
 		{
+			
 			StartRenameItem("ItemNameTextBox");
 
-			if (FileList.ContainerFromItem(RenamingItem) is not ListViewItem listViewItem)
-				return;
-
-			var textBox = listViewItem.FindDescendant("ItemNameTextBox") as TextBox;
-			if (textBox is null || textBox.FindParent<Grid>() is null)
-				return;
-
-			Grid.SetColumnSpan(textBox.FindParent<Grid>(), 8);
 		}
 
 		private void ItemNameTextBox_BeforeTextChanging(TextBox textBox, TextBoxBeforeTextChangingEventArgs args)
 		{
-			if (IsRenamingItem)
+			if (IsRenamingItem || IsRenamingMultipleItems)
 			{
 				ValidateItemNameInputTextAsync(textBox, args, (showError) =>
 				{
@@ -354,10 +354,27 @@ namespace Files.App.Views.Layouts
 
 		protected override void EndRename(TextBox textBox)
 		{
+			if (textBox is not null)
+			{
+				textBox.LostFocus -= RenameTextBox_LostFocus;
+				textBox.KeyDown -= RenameTextBox_KeyDown;
+			}
 			if (textBox is not null && textBox.FindParent<Grid>() is FrameworkElement parent)
 				Grid.SetColumnSpan(parent, 1);
 
-			ListViewItem? listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+			ListViewItem? listViewItem;
+
+			
+			listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+			
+			
+			if (listViewItem is null)
+			{	
+				IsRenamingMultipleItems = false;
+				IsRenamingItem = false;
+				return;
+			}
+			
 
 			if (textBox is null || listViewItem is null)
 			{
@@ -365,23 +382,21 @@ namespace Files.App.Views.Layouts
 			}
 			else
 			{
+				listViewItem?.Focus(FocusState.Programmatic);
 				TextBlock? textBlock = listViewItem.FindDescendant("ItemName") as TextBlock;
 				textBox.Visibility = Visibility.Collapsed;
 				textBlock!.Visibility = Visibility.Visible;
 			}
 
 			// Unsubscribe from events
-			if (textBox is not null)
-			{
-				textBox!.LostFocus -= RenameTextBox_LostFocus;
-				textBox.KeyDown -= RenameTextBox_KeyDown;
-			}
+			
 
 			FileNameTeachingTip.IsOpen = false;
 			IsRenamingItem = false;
+			IsRenamingMultipleItems = false;
 
 			// Re-focus selected list item
-			listViewItem?.Focus(FocusState.Programmatic);
+			
 		}
 
 		protected override async void FileList_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
@@ -404,7 +419,7 @@ namespace Files.App.Views.Layouts
 
 				await commands[hotKey].ExecuteAsync();
 			}
-			else if (e.Key == VirtualKey.Enter && !e.KeyStatus.IsMenuKeyDown)
+			else if (e.Key == VirtualKey.Enter && !e.KeyStatus.IsMenuKeyDown && !IsRenamingMultipleItems)
 			{
 				e.Handled = true;
 
@@ -429,7 +444,7 @@ namespace Files.App.Views.Layouts
 				FilePropertiesHelpers.OpenPropertiesWindow(ParentShellPageInstance);
 				e.Handled = true;
 			}
-			else if (e.Key == VirtualKey.Space)
+			else if (e.Key == VirtualKey.Space  && !IsRenamingMultipleItems)
 			{
 				if (!ParentShellPageInstance.ToolbarViewModel.IsEditModeEnabled)
 					e.Handled = true;
@@ -509,6 +524,16 @@ namespace Files.App.Views.Layouts
 						var textBox = listViewItem.FindDescendant("ItemNameTextBox") as TextBox;
 						if (textBox is not null)
 							await CommitRenameAsync(textBox);
+					}
+				}
+				if (IsRenamingMultipleItems)
+				{
+					ListViewItem? listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
+					if (listViewItem is not null)
+					{
+						var textBox = listViewItem.FindDescendant("ItemNameTextBox") as TextBox;
+						if (textBox is not null)
+							await CommitMultipleRenameAsync(textBox);
 					}
 				}
 				return;

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -326,13 +326,6 @@ namespace Files.App.Views.Layouts
 			}
 		}
 
-		override public void StartRenameItems()
-		{
-			
-			StartRenameItems("ItemNameTextBox");
-			
-		}
-
 		override public void StartRenameItem()
 		{
 			
@@ -392,8 +385,7 @@ namespace Files.App.Views.Layouts
 			
 
 			FileNameTeachingTip.IsOpen = false;
-			IsRenamingItem = false;
-			IsRenamingMultipleItems = false;
+			
 
 			// Re-focus selected list item
 			
@@ -516,7 +508,7 @@ namespace Files.App.Views.Layouts
 			var item = clickedItem?.DataContext as ListedItem;
 			if (item is null)
 			{
-				if (IsRenamingItem && RenamingItem is not null)
+				if ((IsRenamingItem && RenamingItem is not null) || (IsRenamingMultipleItems && RenamingItem is not null))
 				{
 					ListViewItem? listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
 					if (listViewItem is not null)
@@ -526,16 +518,7 @@ namespace Files.App.Views.Layouts
 							await CommitRenameAsync(textBox);
 					}
 				}
-				if (IsRenamingMultipleItems)
-				{
-					ListViewItem? listViewItem = FileList.ContainerFromItem(RenamingItem) as ListViewItem;
-					if (listViewItem is not null)
-					{
-						var textBox = listViewItem.FindDescendant("ItemNameTextBox") as TextBox;
-						if (textBox is not null)
-							await CommitMultipleRenameAsync(textBox);
-					}
-				}
+				
 				return;
 			}
 

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -283,8 +283,95 @@ namespace Files.App.Views.Layouts
 			}
 		}
 
+		override public void StartRenameItems()
+		{
+			RenamingItems = SelectedItems;
+			if (RenamingItems == null || RenamingItems.Count == 0)
+				return;
+			RenamingItem = RenamingItems.Last();
+			
+
+			int extensionLength = RenamingItem.FileExtension?.Length ?? 0;
+
+			if (FileList.ContainerFromItem(RenamingItem) is not GridViewItem gridViewItem)
+				return;
+
+			if (gridViewItem.FindDescendant("ItemName") is not TextBlock textBlock)
+				return;
+
+			TextBox? textBox = null;
+
+			// Handle layout differences between tiles browser and photo album
+			if (FolderSettings.LayoutMode == FolderLayoutModes.GridView)
+			{
+				if (gridViewItem.FindDescendant("EditPopup") is not Popup popup)
+					return;
+
+				textBox = popup.Child as TextBox;
+				if (textBox is null)
+					return;
+
+				textBox.Text = textBlock.Text;
+				textBlock.Opacity = 0;
+				popup.IsOpen = true;
+				OldItemName = textBlock.Text;
+			}
+			else if (FolderSettings.LayoutMode == FolderLayoutModes.ListView)
+			{
+				textBox = gridViewItem.FindDescendant("ListViewTextBoxItemName") as TextBox;
+				if (textBox is null)
+					return;
+
+				textBox.Text = textBlock.Text;
+				OldItemName = textBlock.Text;
+				textBlock.Visibility = Visibility.Collapsed;
+				textBox.Visibility = Visibility.Visible;
+
+				if (textBox.FindParent<Grid>() is null)
+				{
+					textBlock.Visibility = Visibility.Visible;
+					textBox.Visibility = Visibility.Collapsed;
+					return;
+				}
+			}
+			else
+			{
+				textBox = gridViewItem.FindDescendant("TileViewTextBoxItemName") as TextBox;
+				if (textBox is null)
+					return;
+
+				textBox.Text = textBlock.Text;
+				OldItemName = textBlock.Text;
+				textBlock.Visibility = Visibility.Collapsed;
+				textBox.Visibility = Visibility.Visible;
+
+				if (textBox.FindParent<Grid>() is null)
+				{
+					textBlock.Visibility = Visibility.Visible;
+					textBox.Visibility = Visibility.Collapsed;
+					return;
+				}
+			}
+
+			textBox.Focus(FocusState.Pointer);
+			textBox.LostFocus += RenameTextBox_LostFocus;
+			textBox.KeyDown += RenameTextBox_KeyDown;
+
+			int selectedTextLength = RenamingItem.Name.Length;
+			if (!RenamingItem.IsShortcut && UserSettingsService.FoldersSettingsService.ShowFileExtensions)
+				selectedTextLength -= extensionLength;
+
+			textBox.Select(0, selectedTextLength);
+			IsRenamingMultipleItems = true;
+		}
+
 		override public void StartRenameItem()
 		{
+			var selecteditems = SelectedItems;
+			if(selecteditems.Count > 1)
+			{
+				return;
+			}
 			RenamingItem = SelectedItem;
 			if (RenamingItem is null || FolderSettings is null)
 				return;
@@ -365,7 +452,7 @@ namespace Files.App.Views.Layouts
 
 		private void ItemNameTextBox_BeforeTextChanging(TextBox textBox, TextBoxBeforeTextChangingEventArgs args)
 		{
-			if (!IsRenamingItem)
+			if (!IsRenamingItem && !IsRenamingMultipleItems)
 				return;
 
 			ValidateItemNameInputTextAsync(textBox, args, (showError) =>
@@ -413,6 +500,7 @@ namespace Files.App.Views.Layouts
 
 			FileNameTeachingTip.IsOpen = false;
 			IsRenamingItem = false;
+			IsRenamingMultipleItems = false;
 
 			// Re-focus selected list item
 			gridViewItem?.Focus(FocusState.Programmatic);
@@ -437,7 +525,7 @@ namespace Files.App.Views.Layouts
 
 				await commands[hotKey].ExecuteAsync();
 			}
-			else if (e.Key == VirtualKey.Enter && !isFooterFocused && !e.KeyStatus.IsMenuKeyDown)
+			else if (e.Key == VirtualKey.Enter && !isFooterFocused && !e.KeyStatus.IsMenuKeyDown && !IsRenamingMultipleItems)
 			{
 				e.Handled = true;
 
@@ -460,7 +548,7 @@ namespace Files.App.Views.Layouts
 				FilePropertiesHelpers.OpenPropertiesWindow(ParentShellPageInstance);
 				e.Handled = true;
 			}
-			else if (e.Key == VirtualKey.Space)
+			else if (e.Key == VirtualKey.Space && !IsRenamingMultipleItems)
 			{
 				if (!ParentShellPageInstance.ToolbarViewModel.IsEditModeEnabled)
 					e.Handled = true;

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -283,96 +283,20 @@ namespace Files.App.Views.Layouts
 			}
 		}
 
-		override public void StartRenameItems()
-		{
-			RenamingItems = SelectedItems;
-			if (RenamingItems == null || RenamingItems.Count == 0)
-				return;
-			RenamingItem = RenamingItems.Last();
-			
-
-			int extensionLength = RenamingItem.FileExtension?.Length ?? 0;
-
-			if (FileList.ContainerFromItem(RenamingItem) is not GridViewItem gridViewItem)
-				return;
-
-			if (gridViewItem.FindDescendant("ItemName") is not TextBlock textBlock)
-				return;
-
-			TextBox? textBox = null;
-
-			// Handle layout differences between tiles browser and photo album
-			if (FolderSettings.LayoutMode == FolderLayoutModes.GridView)
-			{
-				if (gridViewItem.FindDescendant("EditPopup") is not Popup popup)
-					return;
-
-				textBox = popup.Child as TextBox;
-				if (textBox is null)
-					return;
-
-				textBox.Text = textBlock.Text;
-				textBlock.Opacity = 0;
-				popup.IsOpen = true;
-				OldItemName = textBlock.Text;
-			}
-			else if (FolderSettings.LayoutMode == FolderLayoutModes.ListView)
-			{
-				textBox = gridViewItem.FindDescendant("ListViewTextBoxItemName") as TextBox;
-				if (textBox is null)
-					return;
-
-				textBox.Text = textBlock.Text;
-				OldItemName = textBlock.Text;
-				textBlock.Visibility = Visibility.Collapsed;
-				textBox.Visibility = Visibility.Visible;
-
-				if (textBox.FindParent<Grid>() is null)
-				{
-					textBlock.Visibility = Visibility.Visible;
-					textBox.Visibility = Visibility.Collapsed;
-					return;
-				}
-			}
-			else
-			{
-				textBox = gridViewItem.FindDescendant("TileViewTextBoxItemName") as TextBox;
-				if (textBox is null)
-					return;
-
-				textBox.Text = textBlock.Text;
-				OldItemName = textBlock.Text;
-				textBlock.Visibility = Visibility.Collapsed;
-				textBox.Visibility = Visibility.Visible;
-
-				if (textBox.FindParent<Grid>() is null)
-				{
-					textBlock.Visibility = Visibility.Visible;
-					textBox.Visibility = Visibility.Collapsed;
-					return;
-				}
-			}
-
-			textBox.Focus(FocusState.Pointer);
-			textBox.LostFocus += RenameTextBox_LostFocus;
-			textBox.KeyDown += RenameTextBox_KeyDown;
-
-			int selectedTextLength = RenamingItem.Name.Length;
-			if (!RenamingItem.IsShortcut && UserSettingsService.FoldersSettingsService.ShowFileExtensions)
-				selectedTextLength -= extensionLength;
-
-			textBox.Select(0, selectedTextLength);
-			IsRenamingMultipleItems = true;
-		}
-
 		override public void StartRenameItem()
 		{
-			var selecteditems = SelectedItems;
-			if(selecteditems.Count > 1)
+			bool multipleRenameFlag = false;
+			if (SelectedItems.Count > 1)
 			{
-				return;
+				RenamingItem = SelectedItems.Last();
+				RenamingItems = SelectedItems;
+				multipleRenameFlag = true;
 			}
-			RenamingItem = SelectedItem;
+			else 
+			{ 				
+				RenamingItem = SelectedItem;
+			}
+			
 			if (RenamingItem is null || FolderSettings is null)
 				return;
 
@@ -447,7 +371,15 @@ namespace Files.App.Views.Layouts
 				selectedTextLength -= extensionLength;
 
 			textBox.Select(0, selectedTextLength);
-			IsRenamingItem = true;
+			if(multipleRenameFlag)
+			{
+				IsRenamingMultipleItems = true;
+			}
+			else
+			{
+				IsRenamingItem = true;
+			}
+			
 		}
 
 		private void ItemNameTextBox_BeforeTextChanging(TextBox textBox, TextBoxBeforeTextChangingEventArgs args)
@@ -499,8 +431,7 @@ namespace Files.App.Views.Layouts
 			}
 
 			FileNameTeachingTip.IsOpen = false;
-			IsRenamingItem = false;
-			IsRenamingMultipleItems = false;
+			
 
 			// Re-focus selected list item
 			gridViewItem?.Focus(FocusState.Programmatic);

--- a/src/Files.App/Views/Layouts/IBaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/IBaseLayoutPage.cs
@@ -10,6 +10,8 @@ namespace Files.App.Views.Layouts
 	{
 		bool IsRenamingItem { get; }
 
+		bool IsRenamingMultipleItems { get; }
+
 		bool IsItemSelected { get; }
 
 		bool IsMiddleClickToScrollEnabled { get; set; }

--- a/src/Files.App/Views/Properties/GeneralPage.xaml.cs
+++ b/src/Files.App/Views/Properties/GeneralPage.xaml.cs
@@ -150,6 +150,12 @@ namespace Files.App.Views.Properties
 								AppInstance?.FilesystemViewModel?.RefreshItems(null);
 							});
 						}
+						if (!GetNewName(out var newName))
+							continue;
+
+						await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
+							UIFilesystemHelpers.RenameFileItemAsync(fileOrFolder, ViewModel.ItemName, AppInstance, false)
+						);
 					}
 				}
 				return true;

--- a/tests/Files.InteractionTests/Tests/FolderTests.cs
+++ b/tests/Files.InteractionTests/Tests/FolderTests.cs
@@ -29,6 +29,8 @@ namespace Files.InteractionTests.Tests
 
 			CopyPasteFolderTest();
 
+			RenameMultipleFoldersTest();
+
 			DeleteFolderTest();
 		}
 
@@ -118,28 +120,58 @@ namespace Files.InteractionTests.Tests
 			Thread.Sleep(3000);
 		}
 
+		private void RenameMultipleFoldersTest()
+		{
+			// Select the "New Folder" folder and clicks the "rename" button on the toolbar
+			TestHelper.InvokeButtonByName("Renamed Folder");
+
+			// Press the ctrl button 
+			var action = new Actions(SessionManager.Session);
+			action.SendKeys(Keys.Control).Perform();
+
+			// Select the "New Folder - Copy" folder and clicks the "rename" button on the toolbar
+			TestHelper.InvokeButtonByName("Renamed Folder - Copy");
+
+			// Release the ctrl button
+			action = new Actions(SessionManager.Session);
+			action.KeyUp(Keys.Control).Perform();
+
+			// Click the "Rename" button on the toolbar
+			TestHelper.InvokeButtonById("InnerNavigationToolbarRenameButton");
+
+			// Type the new name into the inline text box
+			action = new Actions(SessionManager.Session);
+			action.SendKeys("Multiple Folder").Perform();
+
+			// Press the enter button to save the new name
+			action = new Actions(SessionManager.Session);
+			action.SendKeys(Keys.Enter).Perform();
+
+			// Wait for the folder to be renamed
+			Thread.Sleep(3000);
+
+		}
+
 		/// <summary>
 		/// Tests deleting folders
 		/// </summary>
 		private void DeleteFolderTest()
 		{
 			// Select the "Renamed Folder" folder and clicks the "delete" button on the toolbar
-			TestHelper.InvokeButtonByName("Renamed Folder");
-			TestHelper.InvokeButtonById("InnerNavigationToolbarDeleteButton");
+			TestHelper.InvokeButtonByName("Multiple Folder");
 
-			// Wait for prompt to show
-			Thread.Sleep(3000);
-
-			// Check for accessibility issues in the confirm delete prompt
-			AxeHelper.AssertNoAccessibilityErrors();
-
-			// Press the enter key to confirm
+			// Press the ctrl button
 			var action = new Actions(SessionManager.Session);
-			action.SendKeys(Keys.Enter).Perform();
+			action.SendKeys(Keys.Control).Perform();
 
+			// Select the "Renamed Folder (2)" folder 
+			TestHelper.InvokeButtonByName("Multiple Folder (2)");
 
-			// Select the "Renamed Folder - Copy" folder and clicks the "delete" button on the toolbar
-			TestHelper.InvokeButtonByName("Renamed Folder - Copy");
+			// Release the ctrl button
+			action = new Actions(SessionManager.Session);
+			action.KeyUp(Keys.Control).Perform();
+
+			// Click the "Delete" button on the toolbar
 			TestHelper.InvokeButtonById("InnerNavigationToolbarDeleteButton");
 
 			// Wait for prompt to show


### PR DESCRIPTION
**Resolved / Related Issues**

Previously, only one file could be renamed at the same time. We implemented the functionality of renaming multiple at the same time giving Files more flexibility and increased functionalities.

- Closes #8191 

**Steps used to test these changes**

1. Opened Files
2. Went to each layout view
3. Created different files and folders
4. Selected them all and renamed them at the same time.
