### PR TITLE
Feature: Added dimensions to tooltip when hovering over image files

### DIFF
--- a/src/Files.App/Actions/Content/Background/BaseSetAsAction.cs
+++ b/src/Files.App/Actions/Content/Background/BaseSetAsAction.cs
@@ -17,7 +17,7 @@ namespace Files.App.Actions
 			context.ShellPage is not null &&
 			context.PageType != ContentPageTypes.RecycleBin &&
 			context.PageType != ContentPageTypes.ZipFolder &&
-			(context.ShellPage?.SlimContentPage?.SelectedItemsPropertiesViewModel?.IsSelectedItemImage ?? false);
+			(context.ShellPage?.SlimContentPage?.SelectedItemsPropertiesViewModel?.CanSelectedItemBeManipulated ?? false);
 
 		public BaseSetAsAction()
 		{

--- a/src/Files.App/Actions/Content/Background/BaseSetAsAction.cs
+++ b/src/Files.App/Actions/Content/Background/BaseSetAsAction.cs
@@ -17,7 +17,7 @@ namespace Files.App.Actions
 			context.ShellPage is not null &&
 			context.PageType != ContentPageTypes.RecycleBin &&
 			context.PageType != ContentPageTypes.ZipFolder &&
-			(context.ShellPage?.SlimContentPage?.SelectedItemsPropertiesViewModel?.CanSelectedItemBeManipulated ?? false);
+			(context.ShellPage?.SlimContentPage?.SelectedItemsPropertiesViewModel?.IsCompatibleToSetAsWindowsWallpaper ?? false);
 
 		public BaseSetAsAction()
 		{

--- a/src/Files.App/Actions/Content/ImageManipulation/BaseRotateAction.cs
+++ b/src/Files.App/Actions/Content/ImageManipulation/BaseRotateAction.cs
@@ -21,7 +21,7 @@ namespace Files.App.Actions
 
 		public bool IsExecutable =>
 			IsContextPageTypeAdaptedToCommand() &&
-			(context.ShellPage?.SlimContentPage?.SelectedItemsPropertiesViewModel?.CanSelectedItemBeManipulated ?? false);
+			(context.ShellPage?.SlimContentPage?.SelectedItemsPropertiesViewModel?.IsCompatibleToSetAsWindowsWallpaper ?? false);
 
 		public BaseRotateAction()
 		{

--- a/src/Files.App/Actions/Content/ImageManipulation/BaseRotateAction.cs
+++ b/src/Files.App/Actions/Content/ImageManipulation/BaseRotateAction.cs
@@ -21,7 +21,7 @@ namespace Files.App.Actions
 
 		public bool IsExecutable =>
 			IsContextPageTypeAdaptedToCommand() &&
-			(context.ShellPage?.SlimContentPage?.SelectedItemsPropertiesViewModel?.IsSelectedItemImage ?? false);
+			(context.ShellPage?.SlimContentPage?.SelectedItemsPropertiesViewModel?.CanSelectedItemBeManipulated ?? false);
 
 		public BaseRotateAction()
 		{

--- a/src/Files.App/Data/Factories/ContentPageContextFlyoutFactory.cs
+++ b/src/Files.App/Data/Factories/ContentPageContextFlyoutFactory.cs
@@ -405,7 +405,7 @@ namespace Files.App.Data.Factories
 				new ContextMenuFlyoutItemViewModel()
 				{
 					Text = "BaseLayoutItemContextFlyoutSetAs/Text".GetLocalizedResource(),
-					ShowItem = itemsSelected && (selectedItemsPropertiesViewModel?.IsSelectedItemImage ?? false),
+					ShowItem = itemsSelected && (selectedItemsPropertiesViewModel?.CanSelectedItemBeManipulated ?? false),
 					ShowInSearchPage = true,
 					Items =
 					[
@@ -419,13 +419,13 @@ namespace Files.App.Data.Factories
 				{
 					IsVisible = !currentInstanceViewModel.IsPageTypeRecycleBin
 								&& !currentInstanceViewModel.IsPageTypeZipFolder
-								&& (selectedItemsPropertiesViewModel?.IsSelectedItemImage ?? false)
+								&& (selectedItemsPropertiesViewModel?.CanSelectedItemBeManipulated ?? false)
 				}.Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(Commands.RotateRight)
 				{
 					IsVisible = !currentInstanceViewModel.IsPageTypeRecycleBin
 								&& !currentInstanceViewModel.IsPageTypeZipFolder
-								&& (selectedItemsPropertiesViewModel?.IsSelectedItemImage ?? false)
+								&& (selectedItemsPropertiesViewModel?.CanSelectedItemBeManipulated ?? false)
 				}.Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(Commands.RunAsAdmin).Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(Commands.RunAsAnotherUser).Build(),

--- a/src/Files.App/Data/Factories/ContentPageContextFlyoutFactory.cs
+++ b/src/Files.App/Data/Factories/ContentPageContextFlyoutFactory.cs
@@ -405,7 +405,7 @@ namespace Files.App.Data.Factories
 				new ContextMenuFlyoutItemViewModel()
 				{
 					Text = "BaseLayoutItemContextFlyoutSetAs/Text".GetLocalizedResource(),
-					ShowItem = itemsSelected && (selectedItemsPropertiesViewModel?.CanSelectedItemBeManipulated ?? false),
+					ShowItem = itemsSelected && (selectedItemsPropertiesViewModel?.IsCompatibleToSetAsWindowsWallpaper ?? false),
 					ShowInSearchPage = true,
 					Items =
 					[
@@ -419,13 +419,13 @@ namespace Files.App.Data.Factories
 				{
 					IsVisible = !currentInstanceViewModel.IsPageTypeRecycleBin
 								&& !currentInstanceViewModel.IsPageTypeZipFolder
-								&& (selectedItemsPropertiesViewModel?.CanSelectedItemBeManipulated ?? false)
+								&& (selectedItemsPropertiesViewModel?.IsCompatibleToSetAsWindowsWallpaper ?? false)
 				}.Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(Commands.RotateRight)
 				{
 					IsVisible = !currentInstanceViewModel.IsPageTypeRecycleBin
 								&& !currentInstanceViewModel.IsPageTypeZipFolder
-								&& (selectedItemsPropertiesViewModel?.CanSelectedItemBeManipulated ?? false)
+								&& (selectedItemsPropertiesViewModel?.IsCompatibleToSetAsWindowsWallpaper ?? false)
 				}.Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(Commands.RunAsAdmin).Build(),
 				new ContextMenuFlyoutItemViewModelBuilder(Commands.RunAsAnotherUser).Build(),

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -412,7 +412,6 @@ namespace Files.App.Utils
 		public bool IsArchive => this is ZipItem;
 		public bool IsAlternateStream => this is AlternateStreamItem;
 		public bool IsGitItem => this is GitItem;
-		public virtual bool IsImage => FileExtensionHelpers.IsImageFile(ItemPath);
 		public virtual bool IsExecutable => FileExtensionHelpers.IsExecutableFile(ItemPath);
 		public virtual bool IsScriptFile => FileExtensionHelpers.IsScriptFile(ItemPath);
 		public bool IsPinned => App.QuickAccessManager.Model.PinnedFolders.Contains(itemPath);

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -45,7 +45,7 @@ namespace Files.App.Utils
 				tooltipBuilder.Append($"{"ToolTipDescriptionDate".GetLocalizedResource()} {ItemDateModified}");
 				if (!string.IsNullOrWhiteSpace(FileSize))
 					tooltipBuilder.Append($"{Environment.NewLine}{"SizeLabel".GetLocalizedResource()} {FileSize}");
-				if (IsImage && ImageWidth > 0 && ImageHeight > 0)
+				if (!string.IsNullOrWhiteSpace(DimensionsDisplay))
 					tooltipBuilder.Append($"{Environment.NewLine}{"PropertyDimensions".GetLocalizedResource()}: {DimensionsDisplay}");
 				if (SyncStatusUI.LoadSyncStatus)
 					tooltipBuilder.Append($"{Environment.NewLine}{"syncStatusColumn/Header".GetLocalizedResource()}: {syncStatusUI.SyncStatusString}");

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -350,7 +350,7 @@ namespace Files.App.Utils
 			}
 		}
 
-		public string DimensionsDisplay => IsImage ? $"{ImageWidth} \u00D7 {ImageHeight}" : string.Empty;
+		public string DimensionsDisplay => IsImage && ImageWidth > 0 && ImageHeight > 0 ? $"{ImageWidth} \u00D7 {ImageHeight}" : string.Empty;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ListedItem" /> class.

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -6,6 +6,7 @@ using Files.Shared.Helpers;
 using FluentFTP;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
+using System.Drawing;
 using System.IO;
 using System.Text;
 using Windows.Storage;
@@ -328,29 +329,40 @@ namespace Files.App.Utils
 			set => SetProperty(ref itemProperties, value);
 		}
 
-		private int imageWidth;
-		public int ImageWidth
+		public string DimensionsDisplay
 		{
-			get => imageWidth;
-			set
+			get
 			{
-				SetProperty(ref imageWidth, value);
-				OnPropertyChanged(nameof(DimensionsDisplay));
+				int imageHeight = 0;
+				int imageWidth = 0;
+
+				var isImageFile = FileExtensionHelpers.IsImageFile(FileExtension);
+				if (isImageFile)
+				{
+					try
+					{
+						// TODO: Consider to use 'System.Kind' instead.
+						using FileStream fileStream = new(ItemPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+						using Image image = Image.FromStream(fileStream, false, false);
+
+						if (image is not null)
+						{
+							imageHeight = image.Height;
+							imageWidth = image.Width;
+						}
+					}
+					catch { }
+				}
+
+
+				return
+					isImageFile &&
+					imageWidth > 0 &&
+					imageHeight > 0
+						? $"{imageWidth} \uE711 {imageHeight}"
+						: string.Empty;
 			}
 		}
-
-		private int imageHeight;
-		public int ImageHeight
-		{
-			get => imageHeight;
-			set
-			{
-				SetProperty(ref imageHeight, value);
-				OnPropertyChanged(nameof(DimensionsDisplay));
-			}
-		}
-
-		public string DimensionsDisplay => IsImage && ImageWidth > 0 && ImageHeight > 0 ? $"{ImageWidth} \u00D7 {ImageHeight}" : string.Empty;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ListedItem" /> class.

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -45,6 +45,8 @@ namespace Files.App.Utils
 				tooltipBuilder.Append($"{"ToolTipDescriptionDate".GetLocalizedResource()} {ItemDateModified}");
 				if (!string.IsNullOrWhiteSpace(FileSize))
 					tooltipBuilder.Append($"{Environment.NewLine}{"SizeLabel".GetLocalizedResource()} {FileSize}");
+				if (IsImage && ImageWidth > 0 && ImageHeight > 0)
+					tooltipBuilder.Append($"{Environment.NewLine}{"PropertyDimensions".GetLocalizedResource()}: {DimensionsDisplay}");
 				if (SyncStatusUI.LoadSyncStatus)
 					tooltipBuilder.Append($"{Environment.NewLine}{"syncStatusColumn/Header".GetLocalizedResource()}: {syncStatusUI.SyncStatusString}");
 
@@ -326,6 +328,30 @@ namespace Files.App.Utils
 			set => SetProperty(ref itemProperties, value);
 		}
 
+		private int imageWidth;
+		public int ImageWidth
+		{
+			get => imageWidth;
+			set
+			{
+				SetProperty(ref imageWidth, value);
+				OnPropertyChanged(nameof(DimensionsDisplay));
+			}
+		}
+
+		private int imageHeight;
+		public int ImageHeight
+		{
+			get => imageHeight;
+			set
+			{
+				SetProperty(ref imageHeight, value);
+				OnPropertyChanged(nameof(DimensionsDisplay));
+			}
+		}
+
+		public string DimensionsDisplay => IsImage ? $"{ImageWidth} \u00D7 {ImageHeight}" : string.Empty;
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ListedItem" /> class.
 		/// </summary>
@@ -374,6 +400,7 @@ namespace Files.App.Utils
 		public bool IsArchive => this is ZipItem;
 		public bool IsAlternateStream => this is AlternateStreamItem;
 		public bool IsGitItem => this is GitItem;
+		public virtual bool IsImage => FileExtensionHelpers.IsImageFile(ItemPath);
 		public virtual bool IsExecutable => FileExtensionHelpers.IsExecutableFile(ItemPath);
 		public virtual bool IsScriptFile => FileExtensionHelpers.IsScriptFile(ItemPath);
 		public bool IsPinned => App.QuickAccessManager.Model.PinnedFolders.Contains(itemPath);

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -359,7 +359,7 @@ namespace Files.App.Utils
 					isImageFile &&
 					imageWidth > 0 &&
 					imageHeight > 0
-						? $"{imageWidth} \uE711 {imageHeight}"
+						? $"{imageWidth} \u00D7 {imageHeight}"
 						: string.Empty;
 			}
 		}

--- a/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
+++ b/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
@@ -530,7 +530,7 @@ namespace Files.App.Data.Models
 		}
 
 		private bool isSelectedItemImage = false;
-		public bool IsSelectedItemImage
+		public bool CanSelectedItemBeManipulated
 		{
 			get => isSelectedItemImage;
 			set => SetProperty(ref isSelectedItemImage, value);
@@ -546,7 +546,7 @@ namespace Files.App.Data.Models
 		public void CheckAllFileExtensions(List<string> itemExtensions)
 		{
 			// Checks if all the item extensions are image extensions of some kind.
-			IsSelectedItemImage = itemExtensions.TrueForAll(itemExtension => FileExtensionHelpers.IsImageFile(itemExtension));
+			CanSelectedItemBeManipulated = itemExtensions.TrueForAll(FileExtensionHelpers.IsManipulateableImageFile);
 			// Checks if there is only one selected item and if it's a shortcut.
 			IsSelectedItemShortcut = (itemExtensions.Count == 1) && (itemExtensions.TrueForAll(itemExtension => FileExtensionHelpers.IsShortcutFile(itemExtension)));
 		}

--- a/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
+++ b/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
@@ -530,7 +530,7 @@ namespace Files.App.Data.Models
 		}
 
 		private bool isSelectedItemImage = false;
-		public bool CanSelectedItemBeManipulated
+		public bool IsCompatibleToSetAsWindowsWallpaper
 		{
 			get => isSelectedItemImage;
 			set => SetProperty(ref isSelectedItemImage, value);
@@ -546,7 +546,7 @@ namespace Files.App.Data.Models
 		public void CheckAllFileExtensions(List<string> itemExtensions)
 		{
 			// Checks if all the item extensions are image extensions of some kind.
-			CanSelectedItemBeManipulated = itemExtensions.TrueForAll(FileExtensionHelpers.IsCompatibleToSetAsWindowsWallpaper);
+			IsCompatibleToSetAsWindowsWallpaper = itemExtensions.TrueForAll(FileExtensionHelpers.IsCompatibleToSetAsWindowsWallpaper);
 			// Checks if there is only one selected item and if it's a shortcut.
 			IsSelectedItemShortcut = (itemExtensions.Count == 1) && (itemExtensions.TrueForAll(itemExtension => FileExtensionHelpers.IsShortcutFile(itemExtension)));
 		}

--- a/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
+++ b/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
@@ -546,7 +546,7 @@ namespace Files.App.Data.Models
 		public void CheckAllFileExtensions(List<string> itemExtensions)
 		{
 			// Checks if all the item extensions are image extensions of some kind.
-			CanSelectedItemBeManipulated = itemExtensions.TrueForAll(FileExtensionHelpers.IsManipulateableImageFile);
+			CanSelectedItemBeManipulated = itemExtensions.TrueForAll(FileExtensionHelpers.IsCompatibleToSetAsWindowsWallpaper);
 			// Checks if there is only one selected item and if it's a shortcut.
 			IsSelectedItemShortcut = (itemExtensions.Count == 1) && (itemExtensions.TrueForAll(itemExtension => FileExtensionHelpers.IsShortcutFile(itemExtension)));
 		}

--- a/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
+++ b/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
@@ -397,8 +397,6 @@ namespace Files.App.Utils.Storage
 						ItemPath = itemPath,
 						FileSize = itemSize,
 						FileSizeBytes = itemSizeBytes,
-						ImageHeight = imageHeight,
-						ImageWidth = imageWidth
 					};
 				}
 			}

--- a/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
+++ b/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
@@ -396,7 +396,7 @@ namespace Files.App.Utils.Storage
 						ItemType = itemType,
 						ItemPath = itemPath,
 						FileSize = itemSize,
-						FileSizeBytes = itemSizeBytes,
+						FileSizeBytes = itemSizeBytes
 					};
 				}
 			}

--- a/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
+++ b/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using System.Drawing;
 using Files.App.Services.SizeProvider;
 using Files.Shared.Helpers;
 using System.IO;
@@ -259,23 +258,6 @@ namespace Files.App.Utils.Storage
 			{
 				itemFileExtension = Path.GetExtension(itemPath);
 				itemType = itemFileExtension.Trim('.') + " " + itemType;
-			}
-
-			int imageHeight = 0;
-			int imageWidth = 0;
-			if (FileExtensionHelpers.IsImageFile(itemFileExtension))
-			{
-				try
-				{
-					await using FileStream fileStream = new(itemPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-					using Image image = Image.FromStream(fileStream, false, false);
-					if (image is not null)
-					{
-						imageHeight = image.Height;
-						imageWidth = image.Width;
-					}
-				}
-				catch { }
 			}
 
 			bool itemThumbnailImgVis = false;

--- a/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
+++ b/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+using System.Drawing;
 using Files.App.Services.SizeProvider;
 using Files.Shared.Helpers;
 using System.IO;
@@ -260,6 +261,23 @@ namespace Files.App.Utils.Storage
 				itemType = itemFileExtension.Trim('.') + " " + itemType;
 			}
 
+			int imageHeight = 0;
+			int imageWidth = 0;
+			if (FileExtensionHelpers.IsImageFile(itemFileExtension))
+			{
+				try
+				{
+					await using FileStream fileStream = new(itemPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+					using Image image = Image.FromStream(fileStream, false, false);
+					if (image is not null)
+					{
+						imageHeight = image.Height;
+						imageWidth = image.Width;
+					}
+				}
+				catch { }
+			}
+
 			bool itemThumbnailImgVis = false;
 			bool itemEmptyImgVis = true;
 
@@ -396,7 +414,9 @@ namespace Files.App.Utils.Storage
 						ItemType = itemType,
 						ItemPath = itemPath,
 						FileSize = itemSize,
-						FileSizeBytes = itemSizeBytes
+						FileSizeBytes = itemSizeBytes,
+						ImageHeight = imageHeight,
+						ImageWidth = imageWidth
 					};
 				}
 			}

--- a/src/Files.Shared/Helpers/FileExtensionHelpers.cs
+++ b/src/Files.Shared/Helpers/FileExtensionHelpers.cs
@@ -32,9 +32,19 @@ namespace Files.Shared.Helpers
 		/// <returns><c>true</c> if the fileExtensionToCheck is an image; otherwise, <c>false</c>.</returns>
 		public static bool IsImageFile(string? fileExtensionToCheck)
 		{
+			return HasExtension(fileExtensionToCheck, ".png", ".bmp", ".jpg", ".jpeg", ".jfif", ".gif", ".tiff", ".tif", ".webp");
+		}
+
+		/// <summary>
+		/// Checks if the file can be set as wallpaper.
+		/// </summary>
+		/// <param name="fileExtensionToCheck">The file extension to check.</param>
+		/// <returns><c>true</c> if the fileExtensionToCheck is an image; otherwise, <c>false</c>.</returns>
+		public static bool IsManipulateableImageFile(string? fileExtensionToCheck)
+		{
 			return HasExtension(fileExtensionToCheck, ".png", ".bmp", ".jpg", ".jpeg", ".jfif", ".gif", ".tiff", ".tif");
 		}
-		
+
 		/// <summary>
 		/// Check if the file extension is an audio file.
 		/// </summary>

--- a/src/Files.Shared/Helpers/FileExtensionHelpers.cs
+++ b/src/Files.Shared/Helpers/FileExtensionHelpers.cs
@@ -40,7 +40,7 @@ namespace Files.Shared.Helpers
 		/// </summary>
 		/// <param name="fileExtensionToCheck">The file extension to check.</param>
 		/// <returns><c>true</c> if the fileExtensionToCheck is an image; otherwise, <c>false</c>.</returns>
-		public static bool IsManipulateableImageFile(string? fileExtensionToCheck)
+		public static bool IsCompatibleToSetAsWindowsWallpaper(string? fileExtensionToCheck)
 		{
 			return HasExtension(fileExtensionToCheck, ".png", ".bmp", ".jpg", ".jpeg", ".jfif", ".gif", ".tiff", ".tif");
 		}


### PR DESCRIPTION
### Resolved / Related Issues

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #14975

### Steps used to test these changes

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open Files app
2. Hover over an image file
3. See if it is corrupt image or dimention property is unavailable it wont be shown