### PR TITLE
Fix: Fixed NullReferenceException in RegistryHelpers.CombineKeys

### DIFF
--- a/src/Files.App/Utils/FileTags/FileTagsHelper.cs
+++ b/src/Files.App/Utils/FileTags/FileTagsHelper.cs
@@ -80,7 +80,7 @@ namespace Files.App.Utils.FileTags
 					}
 					else
 					{
-						dbInstance.SetTags(null, file.Frn, []);
+						dbInstance.SetTags(pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal), file.Frn, []);
 					}
 				}
 				else


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15574 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
