### PR TITLE
Code Quality: Assign background/border properties in respective controls

### DIFF
--- a/src/Files.App/UserControls/InnerNavigationToolbar.xaml
+++ b/src/Files.App/UserControls/InnerNavigationToolbar.xaml
@@ -10,8 +10,6 @@
 	xmlns:local="using:Files.App.UserControls"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:wctconverters="using:CommunityToolkit.WinUI.UI.Converters"
-	d:DesignHeight="40"
-	d:DesignWidth="400"
 	DataContext="{x:Bind ViewModel, Mode=OneWay}"
 	mc:Ignorable="d">
 
@@ -55,7 +53,13 @@
 		</ResourceDictionary>
 	</UserControl.Resources>
 
-	<Grid x:Name="RootGrid">
+	<Grid
+		x:Name="RootGrid"
+		Background="{ThemeResource App.Theme.Toolbar.BackgroundBrush}"
+		BackgroundSizing="InnerBorderEdge"
+		BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+		BorderThickness="1"
+		CornerRadius="8">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="*" />
 			<ColumnDefinition Width="Auto" />

--- a/src/Files.App/UserControls/Pane/InfoPane.xaml
+++ b/src/Files.App/UserControls/Pane/InfoPane.xaml
@@ -15,10 +15,6 @@
 	xmlns:usercontrols="using:Files.App.UserControls"
 	x:Name="Root"
 	MinWidth="90"
-	HorizontalAlignment="Stretch"
-	VerticalAlignment="Stretch"
-	d:DesignHeight="300"
-	d:DesignWidth="400"
 	AutomationProperties.Name="{helpers:ResourceString Name=SelectedFilePreviewPane/AutomationProperties/Name}"
 	SizeChanged="Root_SizeChanged"
 	Unloaded="Root_Unloaded"
@@ -137,7 +133,12 @@
 		</ResourceDictionary>
 	</UserControl.Resources>
 
-	<Grid HorizontalAlignment="Stretch">
+	<Grid
+		Background="{ThemeResource App.Theme.InfoPane.BackgroundBrush}"
+		BackgroundSizing="InnerBorderEdge"
+		BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+		BorderThickness="1"
+		CornerRadius="8">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="2*" />

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml
@@ -83,8 +83,7 @@
 			TabItemsChanged="TabView_TabItemsChanged"
 			TabItemsSource="{x:Bind Items, Mode=OneWay}"
 			TabStripDragOver="TabView_TabStripDragOver"
-			TabStripDrop="TabView_TabStripDrop"
-			Visibility="{x:Bind TabStripVisibility, Mode=OneWay}">
+			TabStripDrop="TabView_TabStripDrop">
 
 			<!--  Item Template  -->
 			<TabView.TabItemTemplate>

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -35,19 +35,6 @@ namespace Files.App.UserControls.TabBar
 			set => SetValue(FooterElementProperty, value);
 		}
 
-		public static readonly DependencyProperty TabStripVisibilityProperty =
-			DependencyProperty.Register(
-				nameof(TabStripVisibility),
-				typeof(Visibility),
-				typeof(TabBar),
-				new PropertyMetadata(Visibility.Visible));
-
-		public Visibility TabStripVisibility
-		{
-			get => (Visibility)GetValue(TabStripVisibilityProperty);
-			set => SetValue(TabStripVisibilityProperty, value);
-		}
-
 		// Dragging makes the app crash when run as admin.
 		// For more information:
 		// - https://github.com/files-community/Files/issues/12390

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -132,7 +132,8 @@
 			Source="{x:Bind ViewModel.AppThemeBackgroundImageSource, Mode=OneWay}"
 			Stretch="{x:Bind ViewModel.AppThemeBackgroundImageFit, Mode=OneWay}" />
 
-		<Grid x:Name="RightMarginGrid" VerticalAlignment="Top">
+		<!--  Header Area  -->
+		<Grid>
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
@@ -141,15 +142,10 @@
 			<!--  Tab Control  -->
 			<tabbar:TabBar
 				x:Name="TabControl"
-				HorizontalAlignment="Stretch"
-				VerticalAlignment="Stretch"
 				HorizontalContentAlignment="Stretch"
-				x:FieldModifier="public"
 				x:Load="False"
 				Loaded="HorizontalMultitaskingControl_Loaded"
-				TabIndex="0"
-				TabStripVisibility="Visible"
-				Visibility="Visible">
+				TabIndex="0">
 				<tabbar:TabBar.FooterElement>
 					<!--  Height is not divisble by four in order to properly align the button  -->
 					<Button
@@ -203,7 +199,7 @@
 				Visibility="Collapsed" />
 		</Grid>
 
-		<!--  Root  -->
+		<!--  Content Area  -->
 		<sidebar:SidebarView
 			x:Name="SidebarControl"
 			Grid.Row="1"
@@ -241,23 +237,16 @@
 					</Grid.ColumnDefinitions>
 
 					<!--  File Navigation Toolbar  -->
-					<Border
+					<uc:InnerNavigationToolbar
+						x:Name="InnerNavigationToolbar"
 						Grid.Row="0"
 						Grid.ColumnSpan="3"
 						Margin="0,0,0,4"
-						Background="{ThemeResource App.Theme.Toolbar.BackgroundBrush}"
-						BackgroundSizing="InnerBorderEdge"
-						BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-						BorderThickness="1"
-						CornerRadius="8">
-						<uc:InnerNavigationToolbar
-							x:Name="InnerNavigationToolbar"
-							x:Load="False"
-							Loaded="NavToolbar_Loaded"
-							ShowPreviewPaneButton="{x:Bind ViewModel.ShouldPreviewPaneBeDisplayed, Mode=OneWay}"
-							ShowViewControlButton="{x:Bind ViewModel.ShouldViewControlBeDisplayed, Mode=OneWay}"
-							TabIndex="2" />
-					</Border>
+						x:Load="False"
+						Loaded="NavToolbar_Loaded"
+						ShowPreviewPaneButton="{x:Bind ViewModel.ShouldPreviewPaneBeDisplayed, Mode=OneWay}"
+						ShowViewControlButton="{x:Bind ViewModel.ShouldViewControlBeDisplayed, Mode=OneWay}"
+						TabIndex="2" />
 
 					<!--  Page Content  -->
 					<ContentPresenter
@@ -280,23 +269,15 @@
 						ResizeBehavior="BasedOnAlignment"
 						Style="{StaticResource DefaultGridSplitterStyle}" />
 
-					<!--  Preview Pane  -->
-					<Border
-						x:Name="InfoPaneContainer"
+					<!--  Info Pane  -->
+					<uc:InfoPane
+						x:Name="InfoPane"
 						Grid.Row="1"
 						Grid.Column="2"
+						HorizontalContentAlignment="Stretch"
 						x:Load="{x:Bind ViewModel.ShouldPreviewPaneBeActive, Mode=OneWay}"
-						Background="{ThemeResource App.Theme.InfoPane.BackgroundBrush}"
-						BackgroundSizing="InnerBorderEdge"
-						BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-						BorderThickness="1"
-						CornerRadius="8">
-						<uc:InfoPane
-							x:Name="PreviewPane"
-							HorizontalContentAlignment="Stretch"
-							Loaded="PreviewPane_Loaded"
-							Unloaded="PreviewPane_Unloaded" />
-					</Border>
+						Loaded="PreviewPane_Loaded"
+						Unloaded="PreviewPane_Unloaded" />
 
 					<!--  Status Bar  -->
 					<uc:StatusBar
@@ -306,6 +287,7 @@
 						x:Load="False"
 						ShowInfoText="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePaneOrColumn.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
 						Visibility="{x:Bind SidebarAdaptiveViewModel.PaneHolder.ActivePaneOrColumn.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}" />
+
 				</Grid>
 			</sidebar:SidebarView.InnerContent>
 		</sidebar:SidebarView>

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -139,7 +139,7 @@
 				<RowDefinition Height="Auto" />
 			</Grid.RowDefinitions>
 
-			<!--  Tab Control  -->
+			<!--  Tab Control (Lazy Load)  -->
 			<tabbar:TabBar
 				x:Name="TabControl"
 				HorizontalContentAlignment="Stretch"
@@ -173,7 +173,7 @@
 				</tabbar:TabBar.FooterElement>
 			</tabbar:TabBar>
 
-			<!--  Address Bar  -->
+			<!--  Address Bar (Lazy Load)  -->
 			<uc:AddressToolbar
 				x:Name="NavToolbar"
 				Grid.Row="1"
@@ -236,7 +236,7 @@
 						<ColumnDefinition x:Name="PaneColumn" Width="Auto" />
 					</Grid.ColumnDefinitions>
 
-					<!--  File Navigation Toolbar  -->
+					<!--  File Navigation Toolbar (Lazy Load)  -->
 					<uc:InnerNavigationToolbar
 						x:Name="InnerNavigationToolbar"
 						Grid.Row="0"
@@ -253,11 +253,10 @@
 						x:Name="PageContent"
 						Grid.Row="1"
 						Grid.Column="0"
-						HorizontalAlignment="Stretch"
 						HorizontalContentAlignment="Stretch"
 						Content="{x:Bind ViewModel.SelectedTabItem.ContentFrame, Mode=OneWay}" />
 
-					<!--  Preview Pane Splitter  -->
+					<!--  Preview Pane Splitter (Lazy Load)  -->
 					<toolkit:GridSplitter
 						x:Name="PaneSplitter"
 						Grid.Row="1"
@@ -269,7 +268,7 @@
 						ResizeBehavior="BasedOnAlignment"
 						Style="{StaticResource DefaultGridSplitterStyle}" />
 
-					<!--  Info Pane  -->
+					<!--  Info Pane (Lazy Load)  -->
 					<uc:InfoPane
 						x:Name="InfoPane"
 						Grid.Row="1"
@@ -279,7 +278,7 @@
 						Loaded="PreviewPane_Loaded"
 						Unloaded="PreviewPane_Unloaded" />
 
-					<!--  Status Bar  -->
+					<!--  Status Bar (Lazy Load)  -->
 					<uc:StatusBar
 						x:Name="StatusBar"
 						Grid.Row="4"

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -139,7 +139,7 @@
 				<RowDefinition Height="Auto" />
 			</Grid.RowDefinitions>
 
-			<!--  Tab Control (Lazy Load)  -->
+			<!--  Tab Control  -->
 			<tabbar:TabBar
 				x:Name="TabControl"
 				HorizontalContentAlignment="Stretch"
@@ -173,7 +173,7 @@
 				</tabbar:TabBar.FooterElement>
 			</tabbar:TabBar>
 
-			<!--  Address Bar (Lazy Load)  -->
+			<!--  Address Bar  -->
 			<uc:AddressToolbar
 				x:Name="NavToolbar"
 				Grid.Row="1"
@@ -236,7 +236,7 @@
 						<ColumnDefinition x:Name="PaneColumn" Width="Auto" />
 					</Grid.ColumnDefinitions>
 
-					<!--  File Navigation Toolbar (Lazy Load)  -->
+					<!--  File Navigation Toolbar  -->
 					<uc:InnerNavigationToolbar
 						x:Name="InnerNavigationToolbar"
 						Grid.Row="0"
@@ -256,7 +256,7 @@
 						HorizontalContentAlignment="Stretch"
 						Content="{x:Bind ViewModel.SelectedTabItem.ContentFrame, Mode=OneWay}" />
 
-					<!--  Preview Pane Splitter (Lazy Load)  -->
+					<!--  Preview Pane Splitter  -->
 					<toolkit:GridSplitter
 						x:Name="PaneSplitter"
 						Grid.Row="1"
@@ -268,7 +268,7 @@
 						ResizeBehavior="BasedOnAlignment"
 						Style="{StaticResource DefaultGridSplitterStyle}" />
 
-					<!--  Info Pane (Lazy Load)  -->
+					<!--  Info Pane  -->
 					<uc:InfoPane
 						x:Name="InfoPane"
 						Grid.Row="1"
@@ -278,7 +278,7 @@
 						Loaded="PreviewPane_Loaded"
 						Unloaded="PreviewPane_Unloaded" />
 
-					<!--  Status Bar (Lazy Load)  -->
+					<!--  Status Bar  -->
 					<uc:StatusBar
 						x:Name="StatusBar"
 						Grid.Row="4"

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -337,12 +337,12 @@ namespace Files.App.Views
 		private void UpdateDateDisplayTimer_Tick(object sender, object e)
 		{
 			if (!App.AppModel.IsMainWindowClosed)
-				PreviewPane?.ViewModel.UpdateDateDisplay();
+				InfoPane?.ViewModel.UpdateDateDisplay();
 		}
 
 		private void Page_SizeChanged(object sender, SizeChangedEventArgs e)
 		{
-			switch (PreviewPane?.Position)
+			switch (InfoPane?.Position)
 			{
 				case PreviewPanePositions.Right when ContentColumn.ActualWidth == ContentColumn.MinWidth:
 					UserSettingsService.InfoPaneSettingsService.VerticalSizePx += e.NewSize.Width - e.PreviousSize.Width;
@@ -369,7 +369,7 @@ namespace Files.App.Views
 		/// </summary>
 		private void UpdatePositioning()
 		{
-			if (PreviewPane is null || !ViewModel.ShouldPreviewPaneBeActive)
+			if (InfoPane is null || !ViewModel.ShouldPreviewPaneBeActive)
 			{
 				PaneRow.MinHeight = 0;
 				PaneRow.MaxHeight = double.MaxValue;
@@ -380,8 +380,8 @@ namespace Files.App.Views
 			}
 			else
 			{
-				PreviewPane.UpdatePosition(RootGrid.ActualWidth, RootGrid.ActualHeight);
-				switch (PreviewPane.Position)
+				InfoPane.UpdatePosition(RootGrid.ActualWidth, RootGrid.ActualHeight);
+				switch (InfoPane.Position)
 				{
 					case PreviewPanePositions.None:
 						PaneRow.MinHeight = 0;
@@ -390,24 +390,24 @@ namespace Files.App.Views
 						PaneColumn.Width = new GridLength(0);
 						break;
 					case PreviewPanePositions.Right:
-						InfoPaneContainer.SetValue(Grid.RowProperty, 1);
-						InfoPaneContainer.SetValue(Grid.ColumnProperty, 2);
+						InfoPane.SetValue(Grid.RowProperty, 1);
+						InfoPane.SetValue(Grid.ColumnProperty, 2);
 						PaneSplitter.SetValue(Grid.RowProperty, 1);
 						PaneSplitter.SetValue(Grid.ColumnProperty, 1);
 						PaneSplitter.Width = 2;
 						PaneSplitter.Height = RootGrid.ActualHeight;
 						PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeWestEast;
 						PaneSplitter.ChangeCursor(InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast));
-						PaneColumn.MinWidth = PreviewPane.MinWidth;
-						PaneColumn.MaxWidth = PreviewPane.MaxWidth;
+						PaneColumn.MinWidth = InfoPane.MinWidth;
+						PaneColumn.MaxWidth = InfoPane.MaxWidth;
 						PaneColumn.Width = new GridLength(UserSettingsService.InfoPaneSettingsService.VerticalSizePx, GridUnitType.Pixel);
 						PaneRow.MinHeight = 0;
 						PaneRow.MaxHeight = double.MaxValue;
 						PaneRow.Height = new GridLength(0);
 						break;
 					case PreviewPanePositions.Bottom:
-						InfoPaneContainer.SetValue(Grid.RowProperty, 3);
-						InfoPaneContainer.SetValue(Grid.ColumnProperty, 0);
+						InfoPane.SetValue(Grid.RowProperty, 3);
+						InfoPane.SetValue(Grid.ColumnProperty, 0);
 						PaneSplitter.SetValue(Grid.RowProperty, 2);
 						PaneSplitter.SetValue(Grid.ColumnProperty, 0);
 						PaneSplitter.Height = 2;
@@ -417,8 +417,8 @@ namespace Files.App.Views
 						PaneColumn.MinWidth = 0;
 						PaneColumn.MaxWidth = double.MaxValue;
 						PaneColumn.Width = new GridLength(0);
-						PaneRow.MinHeight = PreviewPane.MinHeight;
-						PaneRow.MaxHeight = PreviewPane.MaxHeight;
+						PaneRow.MinHeight = InfoPane.MinHeight;
+						PaneRow.MaxHeight = InfoPane.MaxHeight;
 						PaneRow.Height = new GridLength(UserSettingsService.InfoPaneSettingsService.HorizontalSizePx, GridUnitType.Pixel);
 						break;
 				}
@@ -427,13 +427,13 @@ namespace Files.App.Views
 
 		private void PaneSplitter_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
 		{
-			switch (PreviewPane?.Position)
+			switch (InfoPane?.Position)
 			{
 				case PreviewPanePositions.Right:
-					UserSettingsService.InfoPaneSettingsService.VerticalSizePx = PreviewPane.ActualWidth;
+					UserSettingsService.InfoPaneSettingsService.VerticalSizePx = InfoPane.ActualWidth;
 					break;
 				case PreviewPanePositions.Bottom:
-					UserSettingsService.InfoPaneSettingsService.HorizontalSizePx = PreviewPane.ActualHeight;
+					UserSettingsService.InfoPaneSettingsService.HorizontalSizePx = InfoPane.ActualHeight;
 					break;
 			}
 


### PR DESCRIPTION
### Summary

This makes the app content area look more appropriate when the window a bit stuck or hang on startup because background and border will be rendered actually loaded. Previously Inner toolbar background are rendered without inner controls are loaded, before it actually loaded.

- Assign background/border properties in respective controls
- Unwrap from `Border` element
- Removed unnecessary assignments to `d:DesignHeight`, `d:DesignWidth`, `TabStripVisibility (always true)` and so on.

### Resolved / Related Issues

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #

### Steps used to test these changes

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open Files app
2. See no crash and visual change