### PR TITLE
Code Quality: Fixed an issue where items named "Home" had the wrong spacing

### DIFF
--- a/src/Files.App/UserControls/SideBar/SideBarControls.xaml
+++ b/src/Files.App/UserControls/SideBar/SideBarControls.xaml
@@ -234,7 +234,7 @@
 
 								<VisualState x:Name="NoExpansionWithPadding">
 									<VisualState.Setters>
-										<Setter Target="RootPanel.Margin" Value="0,0,0,16" />
+										<Setter Target="RootPanel.Margin" Value="0,0,0,12" />
 										<Setter Target="ItemDecoratorPresenter.Visibility" Value="Visible" />
 									</VisualState.Setters>
 								</VisualState>
@@ -251,7 +251,7 @@
 
 								<VisualState x:Name="Expanded">
 									<VisualState.Setters>
-										<Setter Target="RootPanel.Margin" Value="0,0,0,16" />
+										<Setter Target="RootPanel.Margin" Value="0,0,0,12" />
 										<Setter Target="ChildrenPresenter.Visibility" Value="Visible" />
 										<Setter Target="IconPresenter.Visibility" Value="Collapsed" />
 										<Setter Target="ExpandCollapseChevron.Visibility" Value="Visible" />
@@ -290,7 +290,7 @@
 													Value="{Binding ChildrenPresenterHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
 											</DoubleAnimationUsingKeyFrames>
 											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootPanel" Storyboard.TargetProperty="Margin">
-												<DiscreteObjectKeyFrame Value="0,0,0,16" />
+												<DiscreteObjectKeyFrame Value="0,0,0,12" />
 											</ObjectAnimationUsingKeyFrames>
 										</Storyboard>
 									</VisualTransition>

--- a/src/Files.App/UserControls/SideBar/SideBarItem.cs
+++ b/src/Files.App/UserControls/SideBar/SideBarItem.cs
@@ -22,7 +22,7 @@ namespace Files.App.UserControls.Sidebar
 		public bool CollapseEnabled => DisplayMode != SidebarDisplayMode.Compact;
 
 		// TODO: Do not use localized text for comparison. This is a workaround to avoid major refactoring for now, it should be done any time soon
-		public bool IsHomeItem => Item?.Text == "Home".GetLocalizedResource() && Owner?.MenuItemsSource is IList enumerable && enumerable.Contains(Item);
+		public bool IsHomeItem => Item?.Text == "Home".GetLocalizedResource() && Owner?.MenuItemsSource is IList enumerable && enumerable.IndexOf(Item) == 0;
 
 		private bool hasChildSelection => selectedChildItem != null;
 		private bool isPointerOver = false;

--- a/src/Files.App/UserControls/SideBar/SideBarItem.cs
+++ b/src/Files.App/UserControls/SideBar/SideBarItem.cs
@@ -21,8 +21,8 @@ namespace Files.App.UserControls.Sidebar
 		public bool IsGroupHeader => Item?.Children is not null;
 		public bool CollapseEnabled => DisplayMode != SidebarDisplayMode.Compact;
 
-		// TODO: Do not use localized text for comparison
-		public bool IsHomeItem => Item?.Text == "Home".GetLocalizedResource();
+		// TODO: Do not use localized text for comparison. This is a workaround to avoid major refactoring for now, it should be done any time soon
+		public bool IsHomeItem => Item?.Text == "Home".GetLocalizedResource() && Owner?.MenuItemsSource is IList enumerable && enumerable.Contains(Item);
 
 		private bool hasChildSelection => selectedChildItem != null;
 		private bool isPointerOver = false;

--- a/src/Files.App/UserControls/SideBar/SideBarView.properties.cs
+++ b/src/Files.App/UserControls/SideBar/SideBarView.properties.cs
@@ -78,6 +78,14 @@ namespace Files.App.UserControls.Sidebar
 		public static readonly DependencyProperty SelectedItemProperty =
 			DependencyProperty.Register(nameof(SelectedItem), typeof(ISidebarItemModel), typeof(SidebarView), new PropertyMetadata(null));
 
+		public object MenuItemsSource
+		{
+			get => (object)GetValue(MenuItemsSourceProperty);
+			set => SetValue(MenuItemsSourceProperty, value);
+		}
+		public static readonly DependencyProperty MenuItemsSourceProperty =
+			DependencyProperty.Register(nameof(MenuItemsSource), typeof(object), typeof(SidebarView), new PropertyMetadata(null));
+
 		public static void OnPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
 		{
 			if (sender is not SidebarView control) return;

--- a/src/Files.App/UserControls/SideBar/SideBarView.xaml
+++ b/src/Files.App/UserControls/SideBar/SideBarView.xaml
@@ -75,7 +75,7 @@
 						ElementPrepared="MenuItemsHost_ElementPrepared"
 						IsTabStop="True"
 						ItemTemplate="{StaticResource DefaultSidebarItemTemplate}"
-						ItemsSource="{x:Bind ViewModel.SidebarItems, Mode=OneWay}"
+						ItemsSource="{x:Bind MenuItemsSource, Mode=OneWay}"
 						VerticalCacheLength="100"
 						XYFocusKeyboardNavigation="Enabled" />
 				</ScrollViewer>

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -207,6 +207,7 @@
 			HorizontalContentAlignment="Stretch"
 			DisplayMode="{x:Bind SidebarAdaptiveViewModel.SidebarDisplayMode, Mode=TwoWay}"
 			Loaded="SidebarControl_Loaded"
+			MenuItemsSource="{x:Bind SidebarAdaptiveViewModel.SidebarItems, Mode=OneWay}"
 			OpenPaneLength="{x:Bind UserSettingsService.AppearanceSettingsService.SidebarWidth, Mode=TwoWay}"
 			SelectedItem="{x:Bind SidebarAdaptiveViewModel.SidebarSelectedItem, Mode=TwoWay}"
 			ViewModel="{x:Bind SidebarAdaptiveViewModel}">


### PR DESCRIPTION
### Resolved / Related Issues

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.

For the record, this was found by @yair100 in the latest preview build [v3.4.14](https://github.com/files-community/Files/commit/2085e7fd29176cf790012156983d5dbd0557e5db)

### Steps used to test these changes

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open Files app
2. See Home button doesnt have a spacing