### PR TITLE
Fix: Prevent issue "WinUI Desktop Window object has already been closed"

### DIFF
--- a/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
@@ -6,6 +6,7 @@ using Files.App.ViewModels.Previews;
 using Files.Shared.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Sentry;
 using Windows.Storage;
 
 namespace Files.App.ViewModels.UserControls
@@ -13,6 +14,7 @@ namespace Files.App.ViewModels.UserControls
 	public sealed class InfoPaneViewModel : ObservableObject, IDisposable
 	{
 		private IInfoPaneSettingsService infoPaneSettingsService { get; } = Ioc.Default.GetRequiredService<IInfoPaneSettingsService>();
+		private IGeneralSettingsService generalSettingsService { get; } = Ioc.Default.GetRequiredService<IGeneralSettingsService>();
 		private IContentPageContext contentPageContext { get; } = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		private CancellationTokenSource loadCancellationTokenSource;
@@ -136,12 +138,27 @@ namespace Files.App.ViewModels.UserControls
 
 					SelectedItem = tempSelectedItem;
 
-					if (!App.AppModel.IsMainWindowClosed)
+					try
 					{
-						var shouldUpdatePreview = ((MainWindow.Instance.Content as Frame)?.Content as MainPage)?.ViewModel.ShouldPreviewPaneBeActive;
-						if (shouldUpdatePreview == true)
-							_ = UpdateSelectedItemPreviewAsync();
+						if (!App.AppModel.IsMainWindowClosed)
+						{
+							var shouldUpdatePreview = ((MainWindow.Instance.Content as Frame)?.Content as MainPage)?.ViewModel.ShouldPreviewPaneBeActive;
+							if (shouldUpdatePreview == true)
+								_ = UpdateSelectedItemPreviewAsync();
+						}
 					}
+					catch (Exception ex)
+					{
+						// Handle exception in case WinUI Windows is closed
+						// (see https://github.com/files-community/Files/issues/15599)
+
+						SentrySdk.CaptureException(ex, scope =>
+						{
+							scope.User.Id = generalSettingsService.UserId;
+							scope.Level = SentryLevel.Warning;
+						});
+					}
+
 					break;
 			}
 		}

--- a/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
@@ -159,7 +159,7 @@ namespace Files.App.ViewModels.UserControls
 							scope.Level = SentryLevel.Warning;
 						});
 
-						App.Logger.LogError(ex, ex.Message);
+						App.Logger.LogWarning(ex, ex.Message);
 					}
 
 					break;

--- a/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
@@ -4,6 +4,7 @@
 using Files.App.UserControls.FilePreviews;
 using Files.App.ViewModels.Previews;
 using Files.Shared.Helpers;
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Sentry;
@@ -157,6 +158,8 @@ namespace Files.App.ViewModels.UserControls
 							scope.User.Id = generalSettingsService.UserId;
 							scope.Level = SentryLevel.Warning;
 						});
+
+						App.Logger.LogError(ex, ex.Message);
 					}
 
 					break;

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -465,7 +465,9 @@ namespace Files.App.Views
 					scope.User.Id = generalSettingsService.UserId;
 					scope.Level = SentryLevel.Warning;
 				});
-			}			
+
+				App.Logger.LogError(ex, ex.Message);
+			}
 
 			UpdatePositioning();
 		}

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -454,6 +454,8 @@ namespace Files.App.Views
 				ViewModel.ShouldPreviewPaneBeDisplayed = (!isHomePage || isMultiPane) && isBigEnough;
 				ViewModel.ShouldPreviewPaneBeActive = UserSettingsService.InfoPaneSettingsService.IsEnabled && ViewModel.ShouldPreviewPaneBeDisplayed;
 				ViewModel.ShouldViewControlBeDisplayed = SidebarAdaptiveViewModel.PaneHolder?.ActivePane?.InstanceViewModel?.IsPageTypeNotHome ?? false;
+
+				UpdatePositioning();
 			}
 			catch (Exception ex)
 			{
@@ -468,8 +470,6 @@ namespace Files.App.Views
 
 				App.Logger.LogWarning(ex, ex.Message);
 			}
-
-			UpdatePositioning();
 		}
 
 		private async void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -466,7 +466,7 @@ namespace Files.App.Views
 					scope.Level = SentryLevel.Warning;
 				});
 
-				App.Logger.LogError(ex, ex.Message);
+				App.Logger.LogWarning(ex, ex.Message);
 			}
 
 			UpdatePositioning();

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -12,6 +12,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
+using Sentry;
 using System.Data;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.DataTransfer;
@@ -25,6 +26,7 @@ namespace Files.App.Views
 {
 	public sealed partial class MainPage : Page
 	{
+		private IGeneralSettingsService generalSettingsService { get; } = Ioc.Default.GetRequiredService<IGeneralSettingsService>();
 		public IUserSettingsService UserSettingsService { get; }
 
 		public ICommandManager Commands { get; }
@@ -442,14 +444,28 @@ namespace Files.App.Views
 
 		private void LoadPaneChanged()
 		{
-			var isHomePage = !(SidebarAdaptiveViewModel.PaneHolder?.ActivePane?.InstanceViewModel?.IsPageTypeNotHome ?? false);
-			var isMultiPane = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
-			var isBigEnough = !App.AppModel.IsMainWindowClosed &&
-				(MainWindow.Instance.Bounds.Width > 450 && MainWindow.Instance.Bounds.Height > 450 || RootGrid.ActualWidth > 700 && MainWindow.Instance.Bounds.Height > 360);
+			try
+			{
+				var isHomePage = !(SidebarAdaptiveViewModel.PaneHolder?.ActivePane?.InstanceViewModel?.IsPageTypeNotHome ?? false);
+				var isMultiPane = SidebarAdaptiveViewModel.PaneHolder?.IsMultiPaneActive ?? false;
+				var isBigEnough = !App.AppModel.IsMainWindowClosed &&
+					(MainWindow.Instance.Bounds.Width > 450 && MainWindow.Instance.Bounds.Height > 450 || RootGrid.ActualWidth > 700 && MainWindow.Instance.Bounds.Height > 360);
 
-			ViewModel.ShouldPreviewPaneBeDisplayed = (!isHomePage || isMultiPane) && isBigEnough;
-			ViewModel.ShouldPreviewPaneBeActive = UserSettingsService.InfoPaneSettingsService.IsEnabled && ViewModel.ShouldPreviewPaneBeDisplayed;
-			ViewModel.ShouldViewControlBeDisplayed = SidebarAdaptiveViewModel.PaneHolder?.ActivePane?.InstanceViewModel?.IsPageTypeNotHome ?? false;
+				ViewModel.ShouldPreviewPaneBeDisplayed = (!isHomePage || isMultiPane) && isBigEnough;
+				ViewModel.ShouldPreviewPaneBeActive = UserSettingsService.InfoPaneSettingsService.IsEnabled && ViewModel.ShouldPreviewPaneBeDisplayed;
+				ViewModel.ShouldViewControlBeDisplayed = SidebarAdaptiveViewModel.PaneHolder?.ActivePane?.InstanceViewModel?.IsPageTypeNotHome ?? false;
+			}
+			catch (Exception ex)
+			{
+				// Handle exception in case WinUI Windows is closed
+				// (see https://github.com/files-community/Files/issues/15599)
+
+				SentrySdk.CaptureException(ex, scope =>
+				{
+					scope.User.Id = generalSettingsService.UserId;
+					scope.Level = SentryLevel.Warning;
+				});
+			}			
 
 			UpdatePositioning();
 		}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15599

I'm not sure if this is the best fix, but it should at least prevent the crash.