### PR TITLE
Code Quality: Bring properties window to foreground on loaded

### DIFF
--- a/src/Files.App/Data/Contexts/SideBar/ISideBarContext.cs
+++ b/src/Files.App/Data/Contexts/SideBar/ISideBarContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+using Microsoft.UI.Xaml.Controls;
+
 namespace Files.App.Data.Contexts
 {
 	/// <summary>
@@ -12,6 +14,11 @@ namespace Files.App.Data.Contexts
 		/// Gets the last sidebar right clicked item
 		/// </summary>
 		INavigationControlItem? RightClickedItem { get; }
+
+		/// <summary>
+		/// The last opened sidebar item's context menu instance
+		/// </summary>
+		CommandBarFlyout? ItemContextFlyoutMenu { get; }
 
 		/// <summary>
 		/// Gets the value that indicates whether any item has been right clicked

--- a/src/Files.App/Data/Contexts/SideBar/SideBarContext.cs
+++ b/src/Files.App/Data/Contexts/SideBar/SideBarContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+using Microsoft.UI.Xaml.Controls;
+
 namespace Files.App.Data.Contexts
 {
 	/// <inheritdoc cref="ISidebarContext"/>
@@ -15,6 +17,9 @@ namespace Files.App.Data.Contexts
 
 		private INavigationControlItem? _RightClickedItem = null;
 		public INavigationControlItem? RightClickedItem => _RightClickedItem;
+
+		private CommandBarFlyout? itemContextFlyoutMenu = null;
+		public CommandBarFlyout? ItemContextFlyoutMenu => itemContextFlyoutMenu;
 
 		public bool IsItemRightClicked =>
 			_RightClickedItem is not null;
@@ -32,14 +37,16 @@ namespace Files.App.Data.Contexts
 			SidebarViewModel.RightClickedItemChanged += SidebarControl_RightClickedItemChanged;
 		}
 
-		public void SidebarControl_RightClickedItemChanged(object? sender, INavigationControlItem? e)
+		public void SidebarControl_RightClickedItemChanged(object? sender, SidebarRightClickedItemChangedEventArgs e)
 		{
-			if (SetProperty(ref _RightClickedItem, e, nameof(RightClickedItem)))
+			if (SetProperty(ref _RightClickedItem, e.Item, nameof(RightClickedItem)))
 			{
 				OnPropertyChanged(nameof(IsItemRightClicked));
 				OnPropertyChanged(nameof(PinnedFolderItemIndex));
 				OnPropertyChanged(nameof(IsPinnedFolderItem));
 				OnPropertyChanged(nameof(OpenDriveItem));
+
+				SetProperty(ref itemContextFlyoutMenu, e.Flyout, nameof(ItemContextFlyoutMenu));
 			}
 		}
 	}

--- a/src/Files.App/Data/EventArguments/SidebarRightClickedItemChangedEventArgs.cs
+++ b/src/Files.App/Data/EventArguments/SidebarRightClickedItemChangedEventArgs.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2024 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
+using Microsoft.UI.Xaml.Controls;
+
+namespace Files.App.Data.EventArguments
+{
+	public sealed class SidebarRightClickedItemChangedEventArgs
+	{
+		public INavigationControlItem? Item { get; set; }
+
+		public CommandBarFlyout? Flyout { get; set; }
+
+		public SidebarRightClickedItemChangedEventArgs(INavigationControlItem? item = null, CommandBarFlyout? flyout = null)
+		{
+			Item = item;
+			Flyout = flyout;
+		}
+	}
+}

--- a/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
+++ b/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
@@ -12,6 +12,7 @@ using Microsoft.UI.Xaml.Navigation;
 using Windows.System;
 using Windows.UI;
 using Microsoft.UI.Input;
+using WinUIEx;
 
 namespace Files.App.Views.Properties
 {
@@ -54,6 +55,8 @@ namespace Files.App.Views.Properties
 			base.OnNavigatedTo(e);
 
 			MainPropertiesViewModel = new(Window, MainContentFrame, BaseProperties, parameter);
+
+			Win32Helper.BringToForegroundEx(new(parameter.Window.GetWindowHandle()));
 		}
 
 		private void Page_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
### Resolved / Related Issues

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #13697 

### Steps used to test these changes

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open Files app
2. Open file properties window
3. See brought to foreground