### PR TITLE
Code Quality: Bump CsWin32 to latest available

### DIFF
--- a/src/Files.App.Server/Files.App.Server.csproj
+++ b/src/Files.App.Server/Files.App.Server.csproj
@@ -40,7 +40,7 @@
         <Manifest Include="app.manifest" />
         <TrimmerRootAssembly Include="Files.App.Server" />
         <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.7" />
-        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.1.647-beta" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Files.App.Server/Helpers.cs
+++ b/src/Files.App.Server/Helpers.cs
@@ -3,6 +3,8 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.WinRT;
 using WinRT;
 
 namespace Files.App.Server;
@@ -10,33 +12,22 @@ namespace Files.App.Server;
 unsafe partial class Helpers
 {
 	[UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
-	public static int GetActivationFactory(void* activatableClassId, void** factory)
+	public static HRESULT GetActivationFactory(HSTRING activatableClassId, IActivationFactory** factory)
 	{
-		const int E_INVALIDARG = unchecked((int)0x80070057);
-		const int CLASS_E_CLASSNOTAVAILABLE = unchecked((int)0x80040111);
-		const int S_OK = 0;
-
-		if (activatableClassId is null || factory is null)
+		if (activatableClassId.IsNull || factory is null)
 		{
-			return E_INVALIDARG;
+			return HRESULT.E_INVALIDARG;
 		}
 
 		try
 		{
-			IntPtr obj = Module.GetActivationFactory(MarshalString.FromAbi((IntPtr)activatableClassId));
-
-			if ((void*)obj is null)
-			{
-				return CLASS_E_CLASSNOTAVAILABLE;
-			}
-
-			*factory = (void*)obj;
-			return S_OK;
+			*factory = (IActivationFactory*)Module.GetActivationFactory(MarshalString.FromAbi((IntPtr)activatableClassId));
+			return *factory is null ? HRESULT.CLASS_E_CLASSNOTAVAILABLE : HRESULT.S_OK;
 		}
 		catch (Exception e)
 		{
 			ExceptionHelpers.SetErrorInfo(e);
-			return ExceptionHelpers.GetHRForException(e);
+			return (HRESULT)ExceptionHelpers.GetHRForException(e);
 		}
 	}
 }

--- a/src/Files.App.Server/NativeMethods.txt
+++ b/src/Files.App.Server/NativeMethods.txt
@@ -1,8 +1,10 @@
 // Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+CLASS_E_CLASSNOTAVAILABLE
+E_INVALIDARG
+RoInitialize
 RoRegisterActivationFactories
 RoRevokeActivationFactories
 WindowsCreateString
 WindowsDeleteString
-RoInitialize

--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -90,7 +90,7 @@
         <PackageReference Include="Vanara.Windows.Shell" Version="4.0.1" />
         <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
         <PackageReference Include="Microsoft.Management.Infrastructure.Runtime.Win" Version="3.0.0" />
-        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.7" />
     </ItemGroup>
   

--- a/src/Files.App/Services/Storage/StorageNetworkService.cs
+++ b/src/Files.App/Services/Storage/StorageNetworkService.cs
@@ -184,7 +184,7 @@ namespace Files.App.Services
 			return
 				PInvoke.WNetCancelConnection2W(
 					drive.Path.TrimEnd('\\'),
-					(uint)NET_USE_CONNECT_FLAGS.CONNECT_UPDATE_PROFILE,
+					NET_CONNECT_FLAGS.CONNECT_UPDATE_PROFILE,
 					true)
 				is WIN32_ERROR.NO_ERROR;
 		}


### PR DESCRIPTION
This simplifies some of our code, and eliminates the compiler warnings we saw from the `Files.App.Server` project due to that version being particularly old.

**Resolved / Related Issues**

I'm actually volunteering this PR in response to an issue a Files community member filed against CsWin32, when it actually wasn't a bug there, but just old code in _this_ repo.

- Closes https://github.com/microsoft/CsWin32/issues/1214

**Steps used to test these changes**

I launched the program according to your README file, but the `Files.App.Server.dll` apparently never even loaded, so **I don't know how to test it.**