### PR TITLE
Fix: Fixed crash when two paths were entered on the command line

### DIFF
--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -78,10 +78,16 @@ namespace Files.App.Utils.Git
 
 			try
 			{
-				return
-					Repository.IsValid(path)
-						? path
-						: GetGitRepositoryPath(PathNormalization.GetParentDir(path), root);
+				if (Repository.IsValid(path))
+					return path;
+				else
+				{
+					var parentDir = PathNormalization.GetParentDir(path);
+					if (parentDir == path)
+						return null;
+					else
+						return GetGitRepositoryPath(parentDir, root);
+				}
 			}
 			catch (Exception ex) when (ex is LibGit2SharpException or EncoderFallbackException)
 			{


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15597

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Enter `files C: C:` on the command line
2. No longer crashes, will display an error dialog
