### PR TITLE
Fix: Fixed an issue where online files were downloaded when loading tooltips

### DIFF
--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -46,7 +46,7 @@ namespace Files.App.Utils
 				tooltipBuilder.Append($"{"ToolTipDescriptionDate".GetLocalizedResource()} {ItemDateModified}");
 				if (!string.IsNullOrWhiteSpace(FileSize))
 					tooltipBuilder.Append($"{Environment.NewLine}{"SizeLabel".GetLocalizedResource()} {FileSize}");
-				if (!string.IsNullOrWhiteSpace(DimensionsDisplay))
+				if (SyncStatusUI.SyncStatus is not CloudDriveSyncStatus.FileOnline and not CloudDriveSyncStatus.FolderOnline && !string.IsNullOrWhiteSpace(DimensionsDisplay))
 					tooltipBuilder.Append($"{Environment.NewLine}{"PropertyDimensionsColon".GetLocalizedResource()} {DimensionsDisplay}");
 				if (SyncStatusUI.LoadSyncStatus)
 					tooltipBuilder.Append($"{Environment.NewLine}{"StatusWithColon".GetLocalizedResource()} {syncStatusUI.SyncStatusString}");

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -46,8 +46,8 @@ namespace Files.App.Utils
 				tooltipBuilder.Append($"{"ToolTipDescriptionDate".GetLocalizedResource()} {ItemDateModified}");
 				if (!string.IsNullOrWhiteSpace(FileSize))
 					tooltipBuilder.Append($"{Environment.NewLine}{"SizeLabel".GetLocalizedResource()} {FileSize}");
-				//if (!string.IsNullOrWhiteSpace(DimensionsDisplay))
-				//	tooltipBuilder.Append($"{Environment.NewLine}{"PropertyDimensionsColon".GetLocalizedResource()} {DimensionsDisplay}");
+				if (!string.IsNullOrWhiteSpace(DimensionsDisplay))
+					tooltipBuilder.Append($"{Environment.NewLine}{"PropertyDimensionsColon".GetLocalizedResource()} {DimensionsDisplay}");
 				if (SyncStatusUI.LoadSyncStatus)
 					tooltipBuilder.Append($"{Environment.NewLine}{"StatusWithColon".GetLocalizedResource()} {syncStatusUI.SyncStatusString}");
 
@@ -329,42 +329,40 @@ namespace Files.App.Utils
 			set => SetProperty(ref itemProperties, value);
 		}
 
-		// TODO fix issue where this is fetched when opening a directory
-		// Also make sure it only fetches info for downloaded files in OneDrive
-		//public string DimensionsDisplay
-		//{
-		//	get
-		//	{
-		//		int imageHeight = 0;
-		//		int imageWidth = 0;
+		public string DimensionsDisplay
+		{
+			get
+			{
+				int imageHeight = 0;
+				int imageWidth = 0;
 
-		//		var isImageFile = FileExtensionHelpers.IsImageFile(FileExtension);
-		//		if (isImageFile)
-		//		{
-		//			try
-		//			{
-		//				// TODO: Consider to use 'System.Kind' instead.
-		//				using FileStream fileStream = new(ItemPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-		//				using Image image = Image.FromStream(fileStream, false, false);
+				var isImageFile = FileExtensionHelpers.IsImageFile(FileExtension);
+				if (isImageFile)
+				{
+					try
+					{
+						// TODO: Consider to use 'System.Kind' instead.
+						using FileStream fileStream = new(ItemPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+						using Image image = Image.FromStream(fileStream, false, false);
 
-		//				if (image is not null)
-		//				{
-		//					imageHeight = image.Height;
-		//					imageWidth = image.Width;
-		//				}
-		//			}
-		//			catch { }
-		//		}
+						if (image is not null)
+						{
+							imageHeight = image.Height;
+							imageWidth = image.Width;
+						}
+					}
+					catch { }
+				}
 
 
-		//		return
-		//			isImageFile &&
-		//			imageWidth > 0 &&
-		//			imageHeight > 0
-		//				? $"{imageWidth} \u00D7 {imageHeight}"
-		//				: string.Empty;
-		//	}
-		//}
+				return
+					isImageFile &&
+					imageWidth > 0 &&
+					imageHeight > 0
+						? $"{imageWidth} \u00D7 {imageHeight}"
+						: string.Empty;
+			}
+		}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ListedItem" /> class.

--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml
@@ -213,8 +213,7 @@
 								CornerRadius="{StaticResource ControlCornerRadius}"
 								IsRightTapEnabled="True"
 								Loaded="Grid_Loaded"
-								PointerEntered="Grid_PointerEntered"
-								ToolTipService.ToolTip="{x:Bind ItemTooltipText, Mode=OneWay}">
+								PointerEntered="Grid_PointerEntered">
 								<Grid.ColumnDefinitions>
 									<ColumnDefinition Width="24" />
 									<ColumnDefinition Width="*" />

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml
@@ -103,8 +103,7 @@
 					Background="Transparent"
 					IsRightTapEnabled="True"
 					Loaded="Grid_Loaded"
-					PointerEntered="Grid_PointerEntered"
-					ToolTipService.ToolTip="{x:Bind ItemTooltipText, Mode=OneWay}">
+					PointerEntered="Grid_PointerEntered">
 					<Grid.RowDefinitions>
 						<RowDefinition Height="Auto" />
 						<RowDefinition Height="*" />
@@ -283,8 +282,7 @@
 					CornerRadius="{StaticResource ControlCornerRadius}"
 					IsRightTapEnabled="True"
 					Loaded="Grid_Loaded"
-					PointerEntered="Grid_PointerEntered"
-					ToolTipService.ToolTip="{x:Bind ItemTooltipText, Mode=OneWay}">
+					PointerEntered="Grid_PointerEntered">
 					<Grid.ColumnDefinitions>
 						<ColumnDefinition Width="Auto" />
 						<ColumnDefinition Width="*" />
@@ -442,8 +440,7 @@
 					ColumnSpacing="4"
 					IsRightTapEnabled="True"
 					Loaded="Grid_Loaded"
-					PointerEntered="Grid_PointerEntered"
-					ToolTipService.ToolTip="{x:Bind ItemTooltipText, Mode=OneWay}">
+					PointerEntered="Grid_PointerEntered">
 					<Grid.ColumnDefinitions>
 						<ColumnDefinition Width="Auto" />
 						<ColumnDefinition Width="68" />


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Put a breakpoint on ListedItem.cs line 49 and run Files in debug mode.
2. Confirm line 49 is executed only when the pointer is entered into an item.
3. Hover over an online image file.
4. Confirm that the tooltip doesn't show dimension.