### PR TITLE
Feature: Added support for clicking links when previewing markdown files

### DIFF
--- a/src/Files.App/UserControls/FilePreviews/MarkdownPreview.xaml
+++ b/src/Files.App/UserControls/FilePreviews/MarkdownPreview.xaml
@@ -7,6 +7,7 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:local="using:Files.App.UserControls.FilePreviews"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	DataContext="{x:Bind ViewModel, Mode=OneWay}"
 	mc:Ignorable="d">
 
 	<UserControl.Resources>
@@ -17,11 +18,12 @@
 		</ResourceDictionary>
 	</UserControl.Resources>
 
-	<Border>
-		<ScrollViewer>
+	<ScrollViewer>
 
-			<controls:MarkdownTextBlock Text="{x:Bind ViewModel.TextValue, Mode=OneWay}" />
+		<controls:MarkdownTextBlock
+			x:Name="PreviewMarkdownTextBlock"
+			LinkClicked="PreviewMarkdownTextBlock_LinkClicked"
+			Text="{x:Bind ViewModel.TextValue, Mode=OneWay}" />
 
-		</ScrollViewer>
-	</Border>
+	</ScrollViewer>
 </UserControl>

--- a/src/Files.App/UserControls/FilePreviews/MarkdownPreview.xaml.cs
+++ b/src/Files.App/UserControls/FilePreviews/MarkdownPreview.xaml.cs
@@ -1,19 +1,27 @@
+// Copyright (c) 2024 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
+using CommunityToolkit.WinUI.UI.Controls;
 using Files.App.ViewModels.Previews;
 using Microsoft.UI.Xaml.Controls;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
+using Windows.System;
 
 namespace Files.App.UserControls.FilePreviews
 {
 	public sealed partial class MarkdownPreview : UserControl
 	{
+		private MarkdownPreviewViewModel ViewModel { get; set; }
+
 		public MarkdownPreview(MarkdownPreviewViewModel model)
 		{
 			ViewModel = model;
 			InitializeComponent();
 		}
 
-		private MarkdownPreviewViewModel ViewModel { get; set; }
+		private async void PreviewMarkdownTextBlock_LinkClicked(object sender, LinkClickedEventArgs e)
+		{
+			if (Uri.TryCreate(e.Link, UriKind.Absolute, out Uri? link))
+				await Launcher.LaunchUriAsync(link);
+		}
 	}
 }


### PR DESCRIPTION
### Resolved / Related Issues

https://discord.com/channels/725513575971684472/725514946112127057/1256186521124605962

### Steps used to test these changes

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open Files app
2. Select a markdown
3. View preview of it
4. Click on a link