### PR TITLE
Fix: Fixed an issue where non-cached windows sometimes had the wrong theme

### DIFF
--- a/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
+++ b/src/Files.App/Views/Properties/MainPropertiesPage.xaml.cs
@@ -61,6 +61,7 @@ namespace Files.App.Views.Properties
 			AppThemeModeService.AppThemeModeChanged += AppThemeModeService_AppThemeModeChanged;
 			Window.Closed += Window_Closed;
 
+			AppThemeModeService.ApplyResources();
 			UpdatePageLayout();
 			Window.RaiseSetTitleBarDragRegion(SetTitleBarDragRegion);
 			Window.AppWindow.Changed += AppWindow_Changed;


### PR DESCRIPTION
### Resolved / Related Issues

https://discord.com/channels/725513575971684472/725514946112127057/1256366789839818804

### Steps used to test these changes

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open Files app
2. Open a properties window
3. Deactivate
4. See the right foreground (follow the same steps in stable build)