### PR TITLE
Code Quality: Optimize the code logic for loading the file list

### DIFF
--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -1729,7 +1729,6 @@ namespace Files.App.ViewModels
 						List<ListedItem> fileList = await Win32StorageEnumerator.ListEntries(path, hFile, findData, cancellationToken, -1, intermediateAction: async (intermediateList) =>
 						{
 							filesAndFolders.AddRange(intermediateList);
-							await OrderFilesAndFoldersAsync();
 							await ApplyFilesAndFoldersChangesAsync();
 						});
 


### PR DESCRIPTION

**Resolved / Related Issues**

There's no need to perform reordering every time some files are loaded, because the interval between each reordering is 500ms, which is too short for users to see the sorted results before it's reordered again. This means that during the file loading process, the sorting results are useless to users, and it also causes a lot of extra CPU computational overhead, leading to lag in the file loading process. It's sufficient to perform a single sorting of all files only after the file list has finished loading completely.

- Closes #https://github.com/files-community/Files/issues/15830
- Opens #https://github.com/files-community/Files/issues/4180

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Create a new folder on the disk
2. Use a script to generate 100,000 small files inside this folder
3. Exit the folder, then re-enter the folder
4. Compare the file loading speed
