### PR TITLE
Code Quality: Removed WinUIEx dependency

### DIFF
--- a/.github/NOTICE.md
+++ b/.github/NOTICE.md
@@ -199,35 +199,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-## INI File Parser
-
-**Source**: [https://github.com/rickyah/ini-parser](https://github.com/rickyah/ini-parser)
-
-### License
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2008 Ricardo Amores Hernández
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-```
-
 ## SevenZipSharp
 
 **Source**: [https://github.com/files-community/SevenZipSharp](https://github.com/files-community/SevenZipSharp)
@@ -643,36 +614,6 @@ A "contributor" is any person that distributes its contribution under this licen
 (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
 (D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
 (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
-```
-
-## WinUIEx
-
-**Source**: [https://github.com/dotMorten/WinUIEx](https://github.com/dotMorten/WinUIEx)
-
-### License
-
-```
-MIT License
-
-Copyright (c) 2021 Morten Nielsen
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 ```
 
 ## libgit2sharp

--- a/src/Files.App/Data/Contexts/Window/WindowContext.cs
+++ b/src/Files.App/Data/Contexts/Window/WindowContext.cs
@@ -25,15 +25,18 @@ namespace Files.App.Data.Contexts
 			IsRunningAsAdmin = WindowsSecurityService.IsAppElevated();
 			CanDragAndDrop = WindowsSecurityService.CanDragAndDrop();
 
-			MainWindow.Instance.PresenterChanged += Window_PresenterChanged;
+			MainWindow.Instance.AppWindow.Changed += AppWindow_Changed;
 		}
 
-		private void Window_PresenterChanged(object? sender, AppWindowPresenter e)
+		private void AppWindow_Changed(AppWindow sender, AppWindowChangedEventArgs args)
 		{
-			SetProperty(
-				ref isCompactOverlay,
-				e.Kind is AppWindowPresenterKind.CompactOverlay,
-				nameof(IsCompactOverlay));
+			if (args.DidPresenterChange)
+			{
+				SetProperty(
+					ref isCompactOverlay,
+					sender.Presenter.Kind is AppWindowPresenterKind.CompactOverlay,
+					nameof(IsCompactOverlay));
+			}
 		}
 	}
 }

--- a/src/Files.App/Data/Items/WindowEx.cs
+++ b/src/Files.App/Data/Items/WindowEx.cs
@@ -213,15 +213,14 @@ namespace Files.App.Data.Items
 			IPropertySet values;
 			oldDataExists = false;
 
-			// TODO: Remove this after a couple of months past
-			if (!useNewStore && _applicationDataContainer.Containers.TryGetValue("WinUIEx", out var oldDataContainer))
+			if (_applicationDataContainer.Containers.TryGetValue("Files", out var dataContainer))
+			{
+				values = dataContainer.Values;
+			}
+			else if (!useNewStore && _applicationDataContainer.Containers.TryGetValue("WinUIEx", out var oldDataContainer))
 			{
 				values = oldDataContainer.Values;
 				oldDataExists = true;
-			}
-			else if (_applicationDataContainer.Containers.TryGetValue("Files", out var dataContainer))
-			{
-				values = dataContainer.Values;
 			}
 			else
 			{
@@ -241,14 +240,11 @@ namespace Files.App.Data.Items
 				MONITORINFOEXW info = default;
 				info.monitorInfo.cbSize = (uint)Marshal.SizeOf<MONITORINFOEXW>();
 
-				//fixed (MONITORINFOEXW* pInfo = &info)
-				//{
-					PInvoke.GetMonitorInfo(monitor, (MONITORINFO*)&info);
+				PInvoke.GetMonitorInfo(monitor, (MONITORINFO*)&info);
 
-					monitors.Add(new(
-						info.szDevice.ToString(),
-						new(new Point(rect->left, rect->top), new Point(rect->right, rect->bottom))));
-				//}
+				monitors.Add(new(
+					info.szDevice.ToString(),
+					new(new Point(rect->left, rect->top), new Point(rect->right, rect->bottom))));
 
 				return true;
 			});

--- a/src/Files.App/Data/Items/WindowEx.cs
+++ b/src/Files.App/Data/Items/WindowEx.cs
@@ -95,6 +95,8 @@ namespace Files.App.Data.Items
 			WindowHandle = WinRT.Interop.WindowNative.GetWindowHandle(this);
 			MinWidth = minWidth;
 			MinHeight = minHeight;
+			IsMaximizable = true;
+   			IsMinimizable = true;
 
 			RestoreWindowPlacementData();
 

--- a/src/Files.App/Data/Items/WindowEx.cs
+++ b/src/Files.App/Data/Items/WindowEx.cs
@@ -4,30 +4,54 @@
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using System.Runtime.InteropServices;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.Storage;
 using Windows.Win32;
 using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Files.App.Data.Items
 {
+	/// <summary>
+	/// Represents base <see cref="Window"/> class to extend its features.
+	/// </summary>
 	public unsafe class WindowEx : Window
 	{
 		private readonly WNDPROC _oldWndProc;
 		private readonly WNDPROC _newWndProc;
 
+		private readonly ApplicationDataContainer _applicationDataContainer = ApplicationData.Current.LocalSettings;
+
+		/// <summary>
+		/// Gets hWnd of this <see cref="Window"/>.
+		/// </summary>
 		public nint WindowHandle { get; }
 
+		/// <summary>
+		/// Gets or sets min width of this <see cref="Window"/>.
+		/// </summary>
 		public int MinWidth { get; set; }
+
+		/// <summary>
+		/// Gets or sets min height of this <see cref="Window"/>.
+		/// </summary>
 		public int MinHeight { get; set; }
 
 		private bool _IsMaximizable = true;
+		/// <summary>
+		/// Gets or sets a value that indicates whether this <see cref="Window"/> can be maximizable.
+		/// </summary>
 		public bool IsMaximizable
 		{
 			get => _IsMaximizable;
 			set
 			{
 				_IsMaximizable = value;
-				UpdateOverlappedPresenter((c) => c.IsMaximizable = value);
+
+				if (AppWindow.Presenter is OverlappedPresenter overlapped)
+					overlapped.IsMaximizable = value;
 
 				if (value)
 				{
@@ -46,34 +70,195 @@ namespace Files.App.Data.Items
 		}
 
 		private bool _IsMinimizable = true;
+		/// <summary>
+		/// Gets or sets a value that indicates whether this <see cref="Window"/> can be minimizable.
+		/// </summary>
 		public bool IsMinimizable
 		{
 			get => _IsMinimizable;
 			set
 			{
-				_IsMaximizable = value;
-				UpdateOverlappedPresenter((c) => c.IsMinimizable = value);
+				_IsMinimizable = value;
+
+				if (AppWindow.Presenter is OverlappedPresenter overlapped)
+					overlapped.IsMinimizable = value;
 			}
 		}
 
+		/// <summary>
+		/// Initializes <see cref="WindowEx"/> class.
+		/// </summary>
+		/// <param name="minWidth">Min width to set when initialized.</param>
+		/// <param name="minHeight">Min height to set when initialized.</param>
 		public unsafe WindowEx(int minWidth = 400, int minHeight = 300)
 		{
 			WindowHandle = WinRT.Interop.WindowNative.GetWindowHandle(this);
 			MinWidth = minWidth;
 			MinHeight = minHeight;
 
+			RestoreWindowPlacementData();
+
 			_newWndProc = new(NewWindowProc);
 			var pNewWndProc = Marshal.GetFunctionPointerForDelegate(_newWndProc);
 			var pOldWndProc = PInvoke.SetWindowLongPtr(new(WindowHandle), WINDOW_LONG_PTR_INDEX.GWL_WNDPROC, pNewWndProc);
 			_oldWndProc = Marshal.GetDelegateForFunctionPointer<WNDPROC>(pOldWndProc);
+
+			Closed += (s, e) => { StoreWindowPlacementData(); };
 		}
 
-		private void UpdateOverlappedPresenter(Action<OverlappedPresenter> action)
+		private unsafe void StoreWindowPlacementData()
 		{
-			if (AppWindow.Presenter is OverlappedPresenter overlapped)
-				action(overlapped);
+			// Save window placement only for MainWindow
+			if (!GetType().Name.Equals(nameof(MainWindow), StringComparison.OrdinalIgnoreCase))
+				return;
+
+			// Store monitor info
+			using var data = new SystemIO.MemoryStream();
+			using var sw = new SystemIO.BinaryWriter(data);
+
+			var monitors = GetAllMonitorInfo();
+			int nMonitors = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CMONITORS);
+			sw.Write(nMonitors);
+
+			foreach (var monitor in monitors)
+			{
+				sw.Write(monitor.Item1);
+				sw.Write(monitor.Item2.Left);
+				sw.Write(monitor.Item2.Top);
+				sw.Write(monitor.Item2.Right);
+				sw.Write(monitor.Item2.Bottom);
+			}
+
+			WINDOWPLACEMENT placement = default;
+			PInvoke.GetWindowPlacement(new(WindowHandle), ref placement);
+
+			int structSize = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
+			IntPtr buffer = Marshal.AllocHGlobal(structSize);
+			Marshal.StructureToPtr(placement, buffer, false);
+			byte[] placementData = new byte[structSize];
+			Marshal.Copy(buffer, placementData, 0, structSize);
+			Marshal.FreeHGlobal(buffer);
+
+			sw.Write(placementData);
+			sw.Flush();
+
+			var values = GetDataStore(out _, true);
+
+			if (_applicationDataContainer.Containers.ContainsKey("WinUIEx"))
+				_applicationDataContainer.Values.Remove("WinUIEx");
+
+			values["MainWindowPlacementData"] = Convert.ToBase64String(data.ToArray());
+		}
+
+		private void RestoreWindowPlacementData()
+		{
+			// Save window placement only for MainWindow
+			if (!GetType().Name.Equals(nameof(MainWindow), StringComparison.OrdinalIgnoreCase))
+				return;
+
+			var values = GetDataStore(out var oldDataExists, false);
+
+			byte[]? data = null;
+			if (values.TryGetValue(oldDataExists ? "WindowPersistance_FilesMainWindow" : "MainWindowPlacementData", out object? value))
+			{
+				if (value is string base64)
+					data = Convert.FromBase64String(base64);
+			}
+
+			if (data is null)
+				return;
+
+			SystemIO.BinaryReader br = new(new SystemIO.MemoryStream(data));
+
+			// Check if monitor layout changed since we stored position
+			var monitors = GetAllMonitorInfo();
+			int monitorCount = br.ReadInt32();
+			int nMonitors = PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CMONITORS);
+			if (monitorCount != nMonitors)
+				return;
+
+			for (int i = 0; i < monitorCount; i++)
+			{
+				var pMonitor = monitors[i];
+				br.ReadString();
+				if (pMonitor.Item2.Left != br.ReadDouble() ||
+					pMonitor.Item2.Top != br.ReadDouble() ||
+					pMonitor.Item2.Right != br.ReadDouble() ||
+					pMonitor.Item2.Bottom != br.ReadDouble())
+					return;
+			}
+
+			int structSize = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
+			byte[] placementData = br.ReadBytes(structSize);
+			IntPtr buffer = Marshal.AllocHGlobal(structSize);
+			Marshal.Copy(placementData, 0, buffer, structSize);
+			var windowPlacementData = (WINDOWPLACEMENT)Marshal.PtrToStructure(buffer, typeof(WINDOWPLACEMENT))!;
+
+			Marshal.FreeHGlobal(buffer);
+
+			// Ignore anything by maximized or normal
+			if (windowPlacementData.showCmd == (SHOW_WINDOW_CMD)0x0002 /*SW_INVALIDATE*/ &&
+				windowPlacementData.flags == WINDOWPLACEMENT_FLAGS.WPF_RESTORETOMAXIMIZED)
+				windowPlacementData.showCmd = SHOW_WINDOW_CMD.SW_MAXIMIZE;
+			else if (windowPlacementData.showCmd != SHOW_WINDOW_CMD.SW_MAXIMIZE)
+				windowPlacementData.showCmd = SHOW_WINDOW_CMD.SW_NORMAL;
+
+			PInvoke.SetWindowPlacement(new(WindowHandle), in windowPlacementData);
+
+			return;
+		}
+
+		private IPropertySet GetDataStore(out bool oldDataExists, bool useNewStore = true)
+		{
+			IPropertySet values;
+			oldDataExists = false;
+
+			// TODO: Remove this after a couple of months past
+			if (!useNewStore && _applicationDataContainer.Containers.TryGetValue("WinUIEx", out var oldDataContainer))
+			{
+				values = oldDataContainer.Values;
+				oldDataExists = true;
+			}
+			else if (_applicationDataContainer.Containers.TryGetValue("Files", out var dataContainer))
+			{
+				values = dataContainer.Values;
+			}
 			else
-				throw new NotSupportedException($"'{AppWindow.Presenter.Kind}' presenter is not supported.");
+			{
+				values = _applicationDataContainer.CreateContainer(
+					"Files",
+					ApplicationDataCreateDisposition.Always).Values;
+			}
+
+			return values;
+		}
+
+		private unsafe List<Tuple<string, Rect>> GetAllMonitorInfo()
+		{
+			List<Tuple<string, Rect>> monitors = [];
+			MONITORENUMPROC callback = new((HMONITOR monitor, HDC deviceContext, RECT* rect, LPARAM data) =>
+			{
+				MONITORINFOEXW info = default;
+				info.monitorInfo.cbSize = (uint)Marshal.SizeOf<MONITORINFOEXW>();
+
+				//fixed (MONITORINFOEXW* pInfo = &info)
+				//{
+					PInvoke.GetMonitorInfo(monitor, (MONITORINFO*)&info);
+
+					monitors.Add(new(
+						info.szDevice.ToString(),
+						new(new Point(rect->left, rect->top), new Point(rect->right, rect->bottom))));
+				//}
+
+				return true;
+			});
+
+			LPARAM lParam = default;
+			bool ok = PInvoke.EnumDisplayMonitors(new(nint.Zero), (RECT*)null, callback, lParam);
+			if (!ok)
+				Marshal.ThrowExceptionForHR(Marshal.GetLastWin32Error());
+
+			return monitors;
 		}
 
 		private LRESULT NewWindowProc(HWND param0, uint param1, WPARAM param2, LPARAM param3)

--- a/src/Files.App/Data/Items/WindowEx.cs
+++ b/src/Files.App/Data/Items/WindowEx.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Files Community
+// Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
 using Microsoft.UI.Windowing;
@@ -55,11 +55,11 @@ namespace Files.App.Data.Items
 
 				if (value)
 				{
-					// NOTE:
-					//  Indicates to the Shell that the window should not be treated as full-screen.
 					// WORKAROUND:
 					//  https://github.com/microsoft/microsoft-ui-xaml/issues/8431
-					//  Not to mess up the taskbar when being full-screen mode.
+					// NOTE:
+					//  Indicates to the Shell that the window should not be treated as full-screen
+					//  not to mess up the taskbar when being full-screen mode.
 					//  This property should only be set if the "Automatically hide the taskbar" in Windows 11,
 					//  or "Automatically hide the taskbar in desktop mode" in Windows 10 is enabled.
 					//  Setting this property when the setting is disabled will result in the taskbar overlapping the application.

--- a/src/Files.App/Data/Items/WindowEx.cs
+++ b/src/Files.App/Data/Items/WindowEx.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) 2024 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using System.Runtime.InteropServices;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Files.App.Data.Items
+{
+	public unsafe class WindowEx : Window
+	{
+		private readonly WNDPROC _oldWndProc;
+		private readonly WNDPROC _newWndProc;
+
+		public nint WindowHandle { get; }
+
+		public int MinWidth { get; set; }
+		public int MinHeight { get; set; }
+
+		private bool _IsMaximizable = true;
+		public bool IsMaximizable
+		{
+			get => _IsMaximizable;
+			set
+			{
+				_IsMaximizable = value;
+				UpdateOverlappedPresenter((c) => c.IsMaximizable = value);
+
+				if (value)
+				{
+					// NOTE:
+					//  Indicates to the Shell that the window should not be treated as full-screen.
+					// WORKAROUND:
+					//  https://github.com/microsoft/microsoft-ui-xaml/issues/8431
+					//  Not to mess up the taskbar when being full-screen mode.
+					//  This property should only be set if the "Automatically hide the taskbar" in Windows 11,
+					//  or "Automatically hide the taskbar in desktop mode" in Windows 10 is enabled.
+					//  Setting this property when the setting is disabled will result in the taskbar overlapping the application.
+					if (AppLifecycleHelper.IsAutoHideTaskbarEnabled())
+						Win32PInvoke.SetPropW(WindowHandle, "NonRudeHWND", new IntPtr(1));
+				}
+			}
+		}
+
+		private bool _IsMinimizable = true;
+		public bool IsMinimizable
+		{
+			get => _IsMinimizable;
+			set
+			{
+				_IsMaximizable = value;
+				UpdateOverlappedPresenter((c) => c.IsMinimizable = value);
+			}
+		}
+
+		public unsafe WindowEx(int minWidth = 400, int minHeight = 300)
+		{
+			WindowHandle = WinRT.Interop.WindowNative.GetWindowHandle(this);
+			MinWidth = minWidth;
+			MinHeight = minHeight;
+
+			_newWndProc = new(NewWindowProc);
+			var pNewWndProc = Marshal.GetFunctionPointerForDelegate(_newWndProc);
+			var pOldWndProc = PInvoke.SetWindowLongPtr(new(WindowHandle), WINDOW_LONG_PTR_INDEX.GWL_WNDPROC, pNewWndProc);
+			_oldWndProc = Marshal.GetDelegateForFunctionPointer<WNDPROC>(pOldWndProc);
+		}
+
+		private void UpdateOverlappedPresenter(Action<OverlappedPresenter> action)
+		{
+			if (AppWindow.Presenter is OverlappedPresenter overlapped)
+				action(overlapped);
+			else
+				throw new NotSupportedException($"'{AppWindow.Presenter.Kind}' presenter is not supported.");
+		}
+
+		private LRESULT NewWindowProc(HWND param0, uint param1, WPARAM param2, LPARAM param3)
+		{
+			switch (param1)
+			{
+				case 0x0024: /*WM_GETMINMAXINFO*/
+					{
+						var dpi = PInvoke.GetDpiForWindow(new(param0));
+						float scalingFactor = (float)dpi / 96;
+
+						var minMaxInfo = Marshal.PtrToStructure<MINMAXINFO>(param3);
+						minMaxInfo.ptMinTrackSize.X = (int)(MinWidth * scalingFactor);
+						minMaxInfo.ptMinTrackSize.Y = (int)(MinHeight * scalingFactor);
+						Marshal.StructureToPtr(minMaxInfo, param3, true);
+						break;
+					}
+			}
+
+			return PInvoke.CallWindowProc(_oldWndProc, param0, param1, param2, param3);
+		}
+	}
+}

--- a/src/Files.App/Data/Items/WindowEx.cs
+++ b/src/Files.App/Data/Items/WindowEx.cs
@@ -30,14 +30,14 @@ namespace Files.App.Data.Items
 		public nint WindowHandle { get; }
 
 		/// <summary>
-		/// Gets or sets min width of this <see cref="Window"/>.
+		/// Gets min width of this <see cref="Window"/>.
 		/// </summary>
-		public int MinWidth { get; set; }
+		public int MinWidth { get; }
 
 		/// <summary>
-		/// Gets or sets min height of this <see cref="Window"/>.
+		/// Gets min height of this <see cref="Window"/>.
 		/// </summary>
-		public int MinHeight { get; set; }
+		public int MinHeight { get; }
 
 		private bool _IsMaximizable = true;
 		/// <summary>

--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -85,7 +85,6 @@
         <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
         <PackageReference Include="TagLibSharp" Version="2.3.0" />
         <PackageReference Include="Tulpep.ActiveDirectoryObjectPicker" Version="3.0.11" />
-        <PackageReference Include="WinUIEx" Version="2.3.4" />
         <PackageReference Include="Vanara.Windows.Extensions" Version="4.0.1" />
         <PackageReference Include="Vanara.Windows.Shell" Version="4.0.1" />
         <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />

--- a/src/Files.App/MainWindow.xaml
+++ b/src/Files.App/MainWindow.xaml
@@ -1,9 +1,9 @@
 ﻿<!--  Copyright (c) 2024 Files Community. Licensed under the MIT License. See the LICENSE.  -->
-<winuiex:WindowEx
+<items:WindowEx
 	x:Class="Files.App.MainWindow"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:items="using:Files.App.Data.Items"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:winuiex="using:WinUIEx"
 	mc:Ignorable="d" />

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -6,11 +6,9 @@ using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
-using Microsoft.UI.Xaml.Navigation;
 using System.Runtime.InteropServices;
 using Windows.ApplicationModel.Activation;
 using Windows.Storage;
-using WinUIEx;
 using IO = System.IO;
 
 namespace Files.App
@@ -20,39 +18,17 @@ namespace Files.App
 		private static MainWindow? _Instance;
 		public static MainWindow Instance => _Instance ??= new();
 
-		public IntPtr WindowHandle { get; }
-
-		private MainWindow()
+		public MainWindow() : base(minWidth: 516, minHeight: 416)
 		{
-			WindowHandle = this.GetWindowHandle();
-
 			InitializeComponent();
 
-			EnsureEarlyWindow();
-		}
-
-		private void EnsureEarlyWindow()
-		{
-			// Set PersistenceId
-			PersistenceId = "FilesMainWindow";
-
-			// Set minimum sizes
-			MinHeight = 416;
-			MinWidth = 516;
-
-			AppWindow.Title = "Files";
-			AppWindow.SetIcon(AppLifecycleHelper.AppIconPath);
-			AppWindow.TitleBar.ExtendsContentIntoTitleBar = true;
+			ExtendsContentIntoTitleBar = true;
+			Title = "Files";
 			AppWindow.TitleBar.ButtonBackgroundColor = Colors.Transparent;
 			AppWindow.TitleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
-
-			// Workaround for full screen window messing up the taskbar
-			// https://github.com/microsoft/microsoft-ui-xaml/issues/8431
-			// This property should only be set if the "Automatically hide the taskbar" in Windows 11,
-			// or "Automatically hide the taskbar in desktop mode" in Windows 10 is enabled.
-			// Setting this property when the setting is disabled will result in the taskbar overlapping the application
-			if (AppLifecycleHelper.IsAutoHideTaskbarEnabled()) 
-				Win32PInvoke.SetPropW(WindowHandle, "NonRudeHWND", new IntPtr(1));
+			AppWindow.TitleBar.ButtonPressedBackgroundColor = Colors.Transparent;
+			AppWindow.TitleBar.ButtonHoverBackgroundColor = Colors.Transparent;
+			AppWindow.SetIcon(AppLifecycleHelper.AppIconPath);
 		}
 
 		public void ShowSplashScreen()
@@ -209,8 +185,9 @@ namespace Files.App
 				Activate();
 			}
 
-			if (Windows.Win32.PInvoke.IsIconic(new(WindowHandle)))
-				Instance.Restore(); // Restore window if minimized
+			if (Windows.Win32.PInvoke.IsIconic(new(WindowHandle)) &&
+				AppWindow.Presenter is OverlappedPresenter presenter)
+				presenter.Restore(); // Restore window if minimized
 		}
 
 		private Frame? EnsureWindowIsInitialized()
@@ -224,7 +201,10 @@ namespace Files.App
 				{
 					// Create a Frame to act as the navigation context and navigate to the first page
 					rootFrame = new() { CacheSize = 1 };
-					rootFrame.NavigationFailed += OnNavigationFailed;
+					rootFrame.NavigationFailed += (s, e) =>
+					{
+						throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
+					};
 
 					// Place the frame in the current Window
 					Instance.Content = rootFrame;
@@ -237,14 +217,6 @@ namespace Files.App
 				return null;
 			}
 		}
-
-		/// <summary>
-		/// Invoked when Navigation to a certain page fails
-		/// </summary>
-		/// <param name="sender">The Frame which failed navigation</param>
-		/// <param name="e">Details about the navigation failure</param>
-		private void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
-			=> throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
 
 		private async Task InitializeFromCmdLineArgsAsync(Frame rootFrame, ParsedCommands parsedCommands, string activationPath = "")
 		{

--- a/src/Files.App/NativeMethods.txt
+++ b/src/Files.App/NativeMethods.txt
@@ -98,3 +98,8 @@ FindWindow
 SendMessage
 IsWindowVisible
 COPYDATASTRUCT
+SetWindowLongPtr
+GetDpiForWindow
+CallWindowProc
+MINMAXINFO
+SUBCLASSPROC

--- a/src/Files.App/NativeMethods.txt
+++ b/src/Files.App/NativeMethods.txt
@@ -103,3 +103,11 @@ GetDpiForWindow
 CallWindowProc
 MINMAXINFO
 SUBCLASSPROC
+SetWindowPlacement
+GetWindowPlacement
+WINDOWPLACEMENT
+GetSystemMetrics
+MONITORENUMPROC
+EnumDisplayMonitors
+MONITORINFOEXW
+GetMonitorInfo

--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -9,7 +9,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.Windows.ApplicationModel.Resources;
 using System.Collections.Concurrent;
-using Windows.ApplicationModel;
 using Windows.Graphics;
 using Windows.Win32;
 
@@ -37,7 +36,7 @@ namespace Files.App.Utils.Storage
 			=> WinRT.Interop.WindowNative.GetWindowHandle(w);
 
 		private static TaskCompletionSource? PropertiesWindowsClosingTCS;
-		private static readonly BlockingCollection<WinUIEx.WindowEx> WindowCache = [];
+		private static readonly BlockingCollection<WindowEx> WindowCache = [];
 
 		/// <summary>
 		/// Open properties window
@@ -99,11 +98,10 @@ namespace Files.App.Utils.Storage
 
 			var frame = new Frame
 			{
-				RequestedTheme = (ElementTheme)AppThemeModeService.AppThemeMode
+				RequestedTheme = AppThemeModeService.AppThemeMode
 			};
 
-			WinUIEx.WindowEx propertiesWindow;
-			if (!WindowCache.TryTake(out propertiesWindow!))
+			if (!WindowCache.TryTake(out var propertiesWindow))
 			{
 				propertiesWindow = new();
 				propertiesWindow.Closed += PropertiesWindow_Closed;
@@ -113,8 +111,7 @@ namespace Files.App.Utils.Storage
 			propertiesWindow.IsMaximizable = false;
 			propertiesWindow.MinWidth = 460;
 			propertiesWindow.MinHeight = 550;
-			propertiesWindow.Width = 800;
-			propertiesWindow.Height = 550;
+			propertiesWindow.AppWindow.Resize(new(800, 550));
 			propertiesWindow.Content = frame;
 			propertiesWindow.SystemBackdrop = new AppSystemBackdrop(true);
 
@@ -127,7 +124,7 @@ namespace Files.App.Utils.Storage
 			appWindow.SetIcon(AppLifecycleHelper.AppIconPath);
 
 			frame.Navigate(
-				typeof(Views.Properties.MainPropertiesPage),
+				typeof(MainPropertiesPage),
 				new PropertiesPageNavigationParameter
 				{
 					Parameter = item,
@@ -160,7 +157,7 @@ namespace Files.App.Utils.Storage
 		// So instead of destroying the Window object, cache it and reuse it as a workaround.
 		private static void PropertiesWindow_Closed(object sender, WindowEventArgs args)
 		{
-			if (!App.AppModel.IsMainWindowClosed && sender is WinUIEx.WindowEx window)
+			if (!App.AppModel.IsMainWindowClosed && sender is WindowEx window)
 			{
 				args.Handled = true;
 

--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -103,14 +103,12 @@ namespace Files.App.Utils.Storage
 
 			if (!WindowCache.TryTake(out var propertiesWindow))
 			{
-				propertiesWindow = new();
+				propertiesWindow = new(460, 550);
 				propertiesWindow.Closed += PropertiesWindow_Closed;
 			}
 
 			propertiesWindow.IsMinimizable = false;
 			propertiesWindow.IsMaximizable = false;
-			propertiesWindow.MinWidth = 460;
-			propertiesWindow.MinHeight = 550;
 			propertiesWindow.AppWindow.Resize(new(800, 550));
 			propertiesWindow.Content = frame;
 			propertiesWindow.SystemBackdrop = new AppSystemBackdrop(true);

--- a/src/Files.App/ViewModels/Settings/AboutViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AboutViewModel.cs
@@ -69,7 +69,6 @@ namespace Files.App.ViewModels.Settings
 				new ("https://github.com/CommunityToolkit/WindowsCommunityToolkit", "Windows Community Toolkit 7.x"),
 				new ("https://github.com/mono/taglib-sharp", "TagLibSharp"),
 				new ("https://github.com/Tulpep/Active-Directory-Object-Picker", "ActiveDirectoryObjectPicker"),
-				new ("https://github.com/dotMorten/WinUIEx", "WinUIEx"),
 				new ("https://github.com/PowerShell/MMI", "MMI"),
 				new ("https://github.com/microsoft/CsWin32", "CsWin32"),
 				new ("https://github.com/microsoft/CsWinRT", "CsWinRT"),


### PR DESCRIPTION
### Summary

As WinAppSdk has been improved, thanks to its team, we have reached at a point where we can move to WinAppSdk with a little Win32 API. Shout out to outgoing WinUIEx, which has been giving us the fundamental and powerful features since our initial migration for almost two years.

Note to someone who are looking for the same achievement:
- **Backdrop**: replaced with WinAppSdk
- **Window Size**: replaced with WinAppSdk
- **IsMaximizable/IsMinimizable**: replaced with WinAppSdk
- **MinWidth/MinHeight**: Implemented custom WndProc via CsWin32 using MINMAXSIZEINFO in WindowEx
- **Last window placement**: Saved/restored to ApplicationDataContainer (WINDOWPLACEMENT as base64) in WindowEx

### Resolved / Related Issues

- Closes #12358

### Steps used to test these changes

1. Open Files app
2. Resize to be minimum (see if min size info is set)
3. Terminate the app
4. Lunch the app again (see if the last window placement is kept)
5. Open properties window of a file (see if you can resize but can't maximize)
6. See caption buttons of both windows have the correct brush now and even after you switch theme
7. Enable 'Automatically hide taskbar' in Windows settings
8. Enter F11 on the app
9. Try to hover over on the bottom of the monitor (see taskbar fades in)