### PR TITLE
Code Quality: Fixed an issue where folder background image would remain when navigating to Home page

### DIFF
--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -1811,6 +1811,12 @@ namespace Files.App.ViewModels
 
 		public void CheckForBackgroundImage()
 		{
+			if (WorkingDirectory == "Home")
+			{
+				FolderBackgroundImageSource = null;
+				return;
+			}
+
 			var filesAppSection = DesktopIni?.FirstOrDefault(x => x.SectionName == "FilesApp");
 			if (filesAppSection is null || folderSettings.LayoutMode is FolderLayoutModes.ColumnView)
 			{

--- a/src/Files.App/Views/HomePage.xaml.cs
+++ b/src/Files.App/Views/HomePage.xaml.cs
@@ -52,6 +52,7 @@ namespace Files.App.Views
 
 			// Set path of working directory empty
 			await AppInstance.ShellViewModel.SetWorkingDirectoryAsync("Home");
+			AppInstance.ShellViewModel.CheckForBackgroundImage();
 
 			AppInstance.SlimContentPage?.StatusBarViewModel.UpdateGitInfo(false, string.Empty, null);
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open a folder that has a custom background image.
2. Navigate to Home.
3. See the background image disappears.