### PR TITLE
Fix: Fixed an issue where dragging or opening multiple items would use the wrong sort mode

### DIFF
--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -220,17 +220,21 @@ namespace Files.App.Views.Layouts
 		private List<ListedItem>? selectedItems = [];
 		public List<ListedItem>? SelectedItems
 		{
-			get {
+			get
+			{
 				if (!isSelectedItemsSorted)
 				{
 					var orderedItems = SortingHelper.OrderFileList(selectedItems, FolderSettings.DirectorySortOption, FolderSettings.DirectorySortDirection, FolderSettings.SortDirectoriesAlongsideFiles, FolderSettings.SortFilesFirst).ToList();
 					selectedItems = orderedItems;
 					isSelectedItemsSorted = true;
 				}
-				if (SelectedItem is null || !selectedItems!.Contains(SelectedItem))
-					return selectedItems;
-				else
-					return selectedItems.SkipWhile(x => x != SelectedItem).Concat(selectedItems.TakeWhile(x => x != SelectedItem)).ToList();
+
+				return SelectedItem is null || !selectedItems!.Contains(SelectedItem)
+					? selectedItems
+					: selectedItems
+						.SkipWhile(x => x != SelectedItem)
+						.Concat(selectedItems.TakeWhile(x => x != SelectedItem))
+						.ToList();
 			}
 			internal set
 			{
@@ -274,7 +278,6 @@ namespace Files.App.Views.Layouts
 
 					NotifyPropertyChanged(nameof(SelectedItems));
 				}
-				
 				ParentShellPageInstance!.ToolbarViewModel.SelectedItems = value;
 			}
 		}
@@ -1194,7 +1197,7 @@ namespace Files.App.Views.Layouts
 			}
 		}
 
-		protected internal void FileListItem_PointerPressed(object sender, PointerRoutedEventArgs e)
+		protected void FileListItem_PointerPressed(object sender, PointerRoutedEventArgs e)
 		{
 			if (sender is not SelectorItem selectorItem)
 				return;

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -230,7 +230,8 @@ namespace Files.App.Views.Layouts
 				}
 				if (clickedItem is null || !selectedItems!.Contains(clickedItem))
 					return selectedItems;
-				return selectedItems.SkipWhile(x => x != clickedItem).Concat(selectedItems.TakeWhile(x => x != clickedItem)).ToList();
+				else
+					return selectedItems.SkipWhile(x => x != clickedItem).Concat(selectedItems.TakeWhile(x => x != clickedItem)).ToList();
 			}
 			internal set
 			{
@@ -1199,6 +1200,7 @@ namespace Files.App.Views.Layouts
 		{
 			if (sender is not SelectorItem selectorItem)
 				return;
+
 			clickedItem = GetItemFromElement(sender);
 			if (selectorItem.IsSelected && e.KeyModifiers == VirtualKeyModifiers.Control)
 			{

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -66,6 +66,7 @@ namespace Files.App.Views.Layouts
 
 		private bool shiftPressed;
 
+		private ListedItem? clickedItem = null;
 		private ListedItem? dragOverItem = null;
 		private ListedItem? hoveredItem = null;
 		private ListedItem? preRenamingItem = null;
@@ -216,14 +217,27 @@ namespace Files.App.Views.Layouts
 			}
 		}
 
+		private bool isSelectedItemsSorted = false;
 		private List<ListedItem>? selectedItems = [];
 		public List<ListedItem>? SelectedItems
 		{
-			get => selectedItems;
+			get {
+				if (!isSelectedItemsSorted)
+				{
+					var orderedItems = SortingHelper.OrderFileList(selectedItems, FolderSettings.DirectorySortOption, FolderSettings.DirectorySortDirection, FolderSettings.SortDirectoriesAlongsideFiles, FolderSettings.SortFilesFirst).ToList();
+					selectedItems = orderedItems;
+					isSelectedItemsSorted = true;
+				}
+				if (clickedItem is null || !selectedItems!.Contains(clickedItem))
+					return selectedItems;
+				return selectedItems.SkipWhile(x => x != clickedItem).Concat(selectedItems.TakeWhile(x => x != clickedItem)).ToList();
+			}
 			internal set
 			{
+				clickedItem = null;
 				if (value != selectedItems)
 				{
+					isSelectedItemsSorted = false;
 					selectedItems = value;
 
 					if (selectedItems?.Count == 0 || selectedItems?[0] is null)
@@ -971,7 +985,12 @@ namespace Files.App.Views.Layouts
 		{
 			try
 			{
-				var shellItemList = SafetyExtensions.IgnoreExceptions(() => e.Items.OfType<ListedItem>().Select(x => new VanaraWindowsShell.ShellItem(x.ItemPath)).ToArray());
+				var itemList = e.Items.OfType<ListedItem>().ToList();
+				var firstItem = itemList.FirstOrDefault();
+				var sortedItems = SortingHelper.OrderFileList(itemList, FolderSettings.DirectorySortOption, FolderSettings.DirectorySortDirection, FolderSettings.SortDirectoriesAlongsideFiles, FolderSettings.SortFilesFirst).ToList();
+				var orderedItems = sortedItems.SkipWhile(x => x != firstItem).Concat(sortedItems.TakeWhile(x => x != firstItem)).ToList();
+
+				var shellItemList = SafetyExtensions.IgnoreExceptions(() => orderedItems.Select(x => new VanaraWindowsShell.ShellItem(x.ItemPath)).ToArray());
 				if (shellItemList?[0].FileSystemPath is not null && !InstanceViewModel.IsPageTypeSearchResults)
 				{
 					var iddo = shellItemList[0].Parent.GetChildrenUIObjects<IDataObject>(HWND.NULL, shellItemList);
@@ -987,7 +1006,7 @@ namespace Files.App.Views.Layouts
 				else
 				{
 					// Only support IStorageItem capable paths
-					var storageItemList = e.Items.OfType<ListedItem>().Where(x => !(x.IsHiddenItem && x.IsLinkItem && x.IsRecycleBinItem && x.IsShortcut)).Select(x => VirtualStorageItem.FromListedItem(x));
+					var storageItemList = orderedItems.Where(x => !(x.IsHiddenItem && x.IsLinkItem && x.IsRecycleBinItem && x.IsShortcut)).Select(x => VirtualStorageItem.FromListedItem(x));
 					e.Data.SetStorageItems(storageItemList, false);
 				}
 			}
@@ -1176,11 +1195,11 @@ namespace Files.App.Views.Layouts
 			}
 		}
 
-		protected static void FileListItem_PointerPressed(object sender, PointerRoutedEventArgs e)
+		protected internal void FileListItem_PointerPressed(object sender, PointerRoutedEventArgs e)
 		{
 			if (sender is not SelectorItem selectorItem)
 				return;
-
+			clickedItem = GetItemFromElement(sender);
 			if (selectorItem.IsSelected && e.KeyModifiers == VirtualKeyModifiers.Control)
 			{
 				selectorItem.IsSelected = false;

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1202,15 +1202,21 @@ namespace Files.App.Views.Layouts
 			if (sender is not SelectorItem selectorItem)
 				return;
 
-			SelectedItem = GetItemFromElement(sender);
-			if (selectorItem.IsSelected && e.KeyModifiers == VirtualKeyModifiers.Control)
+			if (selectorItem.IsSelected)
 			{
-				selectorItem.IsSelected = false;
+				if (e.KeyModifiers == VirtualKeyModifiers.Control)
+				{
+					selectorItem.IsSelected = false;
 
-				// Prevent issues arising caused by the default handlers attempting to select the item that has just been deselected by ctrl + click
-				e.Handled = true;
+					// Prevent issues arising caused by the default handlers attempting to select the item that has just been deselected by ctrl + click
+					e.Handled = true;
+				}
+				else
+				{
+					SelectedItem = GetItemFromElement(sender);
+				}
 			}
-			else if (!selectorItem.IsSelected && e.GetCurrentPoint(selectorItem).Properties.IsLeftButtonPressed)
+			else if (e.GetCurrentPoint(selectorItem).Properties.IsLeftButtonPressed)
 			{
 				selectorItem.IsSelected = true;
 			}

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -66,7 +66,6 @@ namespace Files.App.Views.Layouts
 
 		private bool shiftPressed;
 
-		private ListedItem? clickedItem = null;
 		private ListedItem? dragOverItem = null;
 		private ListedItem? hoveredItem = null;
 		private ListedItem? preRenamingItem = null;
@@ -228,14 +227,13 @@ namespace Files.App.Views.Layouts
 					selectedItems = orderedItems;
 					isSelectedItemsSorted = true;
 				}
-				if (clickedItem is null || !selectedItems!.Contains(clickedItem))
+				if (SelectedItem is null || !selectedItems!.Contains(SelectedItem))
 					return selectedItems;
 				else
-					return selectedItems.SkipWhile(x => x != clickedItem).Concat(selectedItems.TakeWhile(x => x != clickedItem)).ToList();
+					return selectedItems.SkipWhile(x => x != SelectedItem).Concat(selectedItems.TakeWhile(x => x != SelectedItem)).ToList();
 			}
 			internal set
 			{
-				clickedItem = null;
 				if (value != selectedItems)
 				{
 					isSelectedItemsSorted = false;
@@ -276,7 +274,7 @@ namespace Files.App.Views.Layouts
 
 					NotifyPropertyChanged(nameof(SelectedItems));
 				}
-
+				
 				ParentShellPageInstance!.ToolbarViewModel.SelectedItems = value;
 			}
 		}
@@ -1201,7 +1199,7 @@ namespace Files.App.Views.Layouts
 			if (sender is not SelectorItem selectorItem)
 				return;
 
-			clickedItem = GetItemFromElement(sender);
+			SelectedItem = GetItemFromElement(sender);
 			if (selectorItem.IsSelected && e.KeyModifiers == VirtualKeyModifiers.Control)
 			{
 				selectorItem.IsSelected = false;

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1197,7 +1197,7 @@ namespace Files.App.Views.Layouts
 			}
 		}
 
-		protected void FileListItem_PointerPressed(object sender, PointerRoutedEventArgs e)
+		protected internal void FileListItem_PointerPressed(object sender, PointerRoutedEventArgs e)
 		{
 			if (sender is not SelectorItem selectorItem)
 				return;


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #8534 
- Closes #15308 

**Steps used to test these changes**

These changes make the behavior of opening or dragging and dropping multiple files consistent with Files Explorer.

1. Prepare 6 video files, named 1-6
2. Select them in any order
3. Click play all on tool bar or enter on keyboard
4. The 6 files open in the player in the same order as they appear in the file list
5. Set sorting to "by name ascending"
6. Select the 6 files in any order
7. Right-click on file 3, choose "Open" from the menu
8. The 6 files open in the player in the order: 3 -> 4 -> 5 -> 6 -> 1 -> 2
9. Select the 6 files in any order
10. Drag file 3 and drop on a Windows Media Player window
11. The 6 files open in the player in the order: 3 -> 4 -> 5 -> 6 -> 1 -> 2
