### PR TITLE
Fix: Fixed a bug where empty pages were stealing focus from the Properties window

### DIFF
--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1285,6 +1285,14 @@ namespace Files.App.Views.Layouts
 				ItemManipulationModel.SetSelectedItem(rightClickedItem);
 		}
 
+		protected void FileList_GettingFocus(UIElement sender, GettingFocusEventArgs args)
+		{
+			// Refuse to gain focus if the file list is empty.
+			// Otherwise, it keeps stealing focus from the Properties window (#13697)
+			if (ParentShellPageInstance is null || ParentShellPageInstance.ShellViewModel.FilesAndFolders.Count == 0)
+				args.TryCancel();
+		}
+
 		protected void InitializeDrag(UIElement container, ListedItem item)
 		{
 			if (item is null)

--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml
@@ -186,6 +186,7 @@
 					DragItemsStarting="FileList_DragItemsStarting"
 					DragOver="ItemsLayout_DragOver"
 					Drop="ItemsLayout_Drop"
+					GettingFocus="FileList_GettingFocus"
 					FocusVisualPrimaryThickness="0"
 					FocusVisualSecondaryThickness="0"
 					Holding="FileList_Holding"

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml
@@ -232,6 +232,7 @@
 					DragItemsStarting="FileList_DragItemsStarting"
 					DragOver="ItemsLayout_DragOver"
 					Drop="ItemsLayout_Drop"
+					GettingFocus="FileList_GettingFocus"
 					FocusVisualPrimaryThickness="0"
 					FocusVisualSecondaryThickness="0"
 					IsDoubleTapEnabled="True"

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml
@@ -791,6 +791,7 @@
 					DragLeave="ItemsLayout_DragLeave"
 					DragOver="ItemsLayout_DragOver"
 					Drop="ItemsLayout_Drop"
+					GettingFocus="FileList_GettingFocus"
 					FocusVisualPrimaryThickness="0"
 					FocusVisualSecondaryThickness="0"
 					IsDoubleTapEnabled="True"


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #13697

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open an empty folder
2. Right-click a folder in the sidebar and open the Properties window
3. Before: The Properties window opened but lost focus immediately, and clicking on it didn't bring it front
	After: The window gains focus normally
