### PR TITLE
Fix: Fixed an issue where shortcuts couldn't be created for commands

### DIFF
--- a/src/Files.App/Dialogs/CreateShortcutDialog.xaml
+++ b/src/Files.App/Dialogs/CreateShortcutDialog.xaml
@@ -51,7 +51,7 @@
 				Grid.Column="0"
 				HorizontalAlignment="Stretch"
 				PlaceholderText="{x:Bind ViewModel.DestinationPlaceholder, Mode=OneWay}"
-				Text="{x:Bind ViewModel.DestinationItemPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+				Text="{x:Bind ViewModel.ShortcutTarget, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
 				<TextBox.Resources>
 					<TeachingTip
 						x:Name="InvalidPathWarning"

--- a/src/Files.App/Dialogs/CreateShortcutDialog.xaml
+++ b/src/Files.App/Dialogs/CreateShortcutDialog.xaml
@@ -46,7 +46,7 @@
 
 			<!--  Path Box  -->
 			<TextBox
-				x:Name="DestinationItemPath"
+				x:Name="ShortcutTarget"
 				Grid.Row="2"
 				Grid.Column="0"
 				HorizontalAlignment="Stretch"

--- a/src/Files.App/Dialogs/CreateShortcutDialog.xaml.cs
+++ b/src/Files.App/Dialogs/CreateShortcutDialog.xaml.cs
@@ -27,7 +27,7 @@ namespace Files.App.Dialogs
 
 			InvalidPathWarning.SetBinding(TeachingTip.TargetProperty, new Binding()
 			{
-				Source = DestinationItemPath
+				Source = ShortcutTarget
 			});
 		}
 

--- a/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
@@ -198,12 +198,12 @@ namespace Files.App.Helpers
 			if (result != DialogResult.Primary || viewModel.ShortcutCreatedSuccessfully)
 				return;
 
-			await HandleShortcutCannotBeCreated(viewModel.ShortcutCompleteName, viewModel.ShortcutTarget);
+			await HandleShortcutCannotBeCreated(viewModel.ShortcutCompleteName, viewModel.FullPath, viewModel.Arguments);
 
 			await associatedInstance.RefreshIfNoWatcherExistsAsync();
 		}
 
-		public static async Task<bool> HandleShortcutCannotBeCreated(string shortcutName, string destinationPath)
+		public static async Task<bool> HandleShortcutCannotBeCreated(string shortcutName, string destinationPath, string arguments = "")
 		{
 			var result = await DialogDisplayHelper.ShowDialogAsync
 			(
@@ -217,7 +217,7 @@ namespace Files.App.Helpers
 
 			var shortcutPath = Path.Combine(Constants.UserEnvironmentPaths.DesktopPath, shortcutName);
 
-			return await FileOperationsHelpers.CreateOrUpdateLinkAsync(shortcutPath, destinationPath);
+			return await FileOperationsHelpers.CreateOrUpdateLinkAsync(shortcutPath, destinationPath, arguments);
 		}
 
 		/// <summary>

--- a/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
@@ -198,7 +198,7 @@ namespace Files.App.Helpers
 			if (result != DialogResult.Primary || viewModel.ShortcutCreatedSuccessfully)
 				return;
 
-			await HandleShortcutCannotBeCreated(viewModel.ShortcutCompleteName, viewModel.DestinationItemPath);
+			await HandleShortcutCannotBeCreated(viewModel.ShortcutCompleteName, viewModel.ShortcutTarget);
 
 			await associatedInstance.RefreshIfNoWatcherExistsAsync();
 		}

--- a/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
@@ -92,8 +92,7 @@ namespace Files.App.ViewModels.Dialogs
 						// If the quoted part is a valid filename, try to find it in the PATH
 						if (quoted == Path.GetFileName(quoted)
 							&& quoted.IndexOfAny(Path.GetInvalidFileNameChars()) == -1
-							&& PathHelpers.TryGetFullPath(quoted, out var fullPath)
-							)
+							&& PathHelpers.TryGetFullPath(quoted, out var fullPath))
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
@@ -112,12 +111,6 @@ namespace Files.App.ViewModels.Dialogs
 					}
 					else
 					{
-						if (trimmed == _previousShortcutTargetPath)
-						{
-							Arguments = trimmed.Split(' ')[1..].Aggregate(Arguments, (current, arg) => current + arg + " ");
-							return;
-						}
-
 						// Try to parse the whole text as path
 						if (Path.Exists(trimmed)
 						    && Path.IsPathFullyQualified(trimmed)
@@ -132,10 +125,16 @@ namespace Files.App.ViewModels.Dialogs
 						}
 
 						var filename = trimmed.Split(' ')[0];
+
+						if (filename == _previousShortcutTargetPath)
+						{
+							Arguments = trimmed.Split(' ')[1..].Aggregate(Arguments, (current, arg) => current + arg + " ");
+							return;
+						}
+
 						if (filename == Path.GetFileName(filename)
 							&& filename.IndexOfAny(Path.GetInvalidFileNameChars()) == -1
-							&& PathHelpers.TryGetFullPath(filename, out var fullPath)
-							)
+							&& PathHelpers.TryGetFullPath(filename, out var fullPath))
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;

--- a/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
@@ -57,7 +57,9 @@ namespace Files.App.ViewModels.Dialogs
 						}
 						var quoted = trimmed[1..endQuoteIndex];
 
-						if (Path.Exists(quoted) && quoted != Path.GetPathRoot(quoted))
+						if (Path.Exists(quoted) 
+						    && Path.IsPathFullyQualified(quoted)
+						    && quoted != Path.GetPathRoot(quoted))
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
@@ -87,7 +89,9 @@ namespace Files.App.ViewModels.Dialogs
 					else
 					{
 						// Try to parse the whole text as path
-						if (Path.Exists(trimmed) && trimmed != Path.GetPathRoot(trimmed))
+						if (Path.Exists(trimmed)
+						    && Path.IsPathFullyQualified(trimmed)
+							&& trimmed != Path.GetPathRoot(trimmed))
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;

--- a/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
@@ -128,7 +128,7 @@ namespace Files.App.ViewModels.Dialogs
 
 						if (filename == _previousShortcutTargetPath)
 						{
-							Arguments = trimmed.Split(' ')[1..].Aggregate(Arguments, (current, arg) => current + arg + " ");
+							Arguments = trimmed.Split(' ')[1..].Aggregate(string.Empty, (current, arg) => current + arg + " ");
 							return;
 						}
 
@@ -139,7 +139,7 @@ namespace Files.App.ViewModels.Dialogs
 							DestinationPathExists = true;
 							IsLocationValid = true;
 							FullPath = fullPath;
-							Arguments = trimmed.Split(' ')[1..].Aggregate(Arguments, (current, arg) => current + arg + " ");
+							Arguments = trimmed.Split(' ')[1..].Aggregate(string.Empty, (current, arg) => current + arg + " ");
 							_previousShortcutTargetPath = filename;
 							return;
 						}

--- a/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
@@ -111,10 +111,30 @@ namespace Files.App.ViewModels.Dialogs
 					}
 					else
 					{
+						var filePath = trimmed.Split(' ')[0];
+
+						if (filePath == _previousShortcutTargetPath)
+						{
+							Arguments = !Directory.Exists(FullPath) ? trimmed.Split(' ')[1..].Aggregate(string.Empty, (current, arg) => current + arg + " ") : string.Empty;
+							return;
+						}
+
+						if (Path.Exists(filePath)
+						    && Path.IsPathFullyQualified(filePath)
+						    && filePath != Path.GetPathRoot(filePath))
+						{
+							DestinationPathExists = true;
+							IsLocationValid = true;
+							FullPath = Path.GetFullPath(filePath);
+							Arguments = !Directory.Exists(FullPath) ? trimmed.Split(' ')[1..].Aggregate(string.Empty, (current, arg) => current + arg + " ") : string.Empty;
+							_previousShortcutTargetPath = filePath;
+							return;
+						}
+
 						// Try to parse the whole text as path
 						if (Path.Exists(trimmed)
 						    && Path.IsPathFullyQualified(trimmed)
-							&& trimmed != Path.GetPathRoot(trimmed))
+						    && trimmed != Path.GetPathRoot(trimmed))
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
@@ -124,23 +144,15 @@ namespace Files.App.ViewModels.Dialogs
 							return;
 						}
 
-						var filename = trimmed.Split(' ')[0];
-
-						if (filename == _previousShortcutTargetPath)
-						{
-							Arguments = trimmed.Split(' ')[1..].Aggregate(string.Empty, (current, arg) => current + arg + " ");
-							return;
-						}
-
-						if (filename == Path.GetFileName(filename)
-							&& filename.IndexOfAny(Path.GetInvalidFileNameChars()) == -1
-							&& PathHelpers.TryGetFullPath(filename, out var fullPath))
+						if (filePath == Path.GetFileName(filePath)
+							&& filePath.IndexOfAny(Path.GetInvalidFileNameChars()) == -1
+							&& PathHelpers.TryGetFullPath(filePath, out var fullPath))
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
 							FullPath = fullPath;
 							Arguments = trimmed.Split(' ')[1..].Aggregate(string.Empty, (current, arg) => current + arg + " ");
-							_previousShortcutTargetPath = filename;
+							_previousShortcutTargetPath = filePath;
 							return;
 						}
 

--- a/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
@@ -77,9 +77,7 @@ namespace Files.App.ViewModels.Dialogs
 							return;
 						}
 
-						if (Path.Exists(quoted) 
-						    && Path.IsPathFullyQualified(quoted)
-						    && quoted != Path.GetPathRoot(quoted))
+						if (IsValidAbsolutePath(quoted))
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
@@ -119,9 +117,7 @@ namespace Files.App.ViewModels.Dialogs
 							return;
 						}
 
-						if (Path.Exists(filePath)
-						    && Path.IsPathFullyQualified(filePath)
-						    && filePath != Path.GetPathRoot(filePath))
+						if (IsValidAbsolutePath(filePath))
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
@@ -132,9 +128,7 @@ namespace Files.App.ViewModels.Dialogs
 						}
 
 						// Try to parse the whole text as path
-						if (Path.Exists(trimmed)
-						    && Path.IsPathFullyQualified(trimmed)
-						    && trimmed != Path.GetPathRoot(trimmed))
+						if (IsValidAbsolutePath(trimmed))
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
@@ -203,6 +197,11 @@ namespace Files.App.ViewModels.Dialogs
 
 			SelectDestinationCommand = new AsyncRelayCommand(SelectDestination);
 			PrimaryButtonCommand = new AsyncRelayCommand(CreateShortcutAsync);
+		}
+
+		private bool IsValidAbsolutePath(string path)
+		{
+			return Path.Exists(path) && Path.IsPathFullyQualified(path) && path != Path.GetPathRoot(path);
 		}
 
 		private Task SelectDestination()

--- a/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
@@ -65,12 +65,14 @@ namespace Files.App.ViewModels.Dialogs
 					}
 
 					var uri = new Uri(DestinationItemPath);
+					DestinationPathExists = false;
 					IsLocationValid = uri.IsWellFormedOriginalString();
 					_isLocationInPath = false;
 					_fullPath = DestinationItemPath;
 				}
 				catch (Exception)
 				{
+					DestinationPathExists = false;
 					IsLocationValid = false;
 					_isLocationInPath = false;
 				}

--- a/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
@@ -28,10 +28,10 @@ namespace Files.App.ViewModels.Dialogs
 		public string ShortcutCompleteName { get; private set; } = string.Empty;
 
 		// Full path of the destination item
-		private string _fullPath;
+		public string FullPath { get; private set; }
 
 		// Arguments to be passed to the destination item if it's an executable
-		private string _arguments;
+		public string Arguments { get; private set; }
 
 		// Previous path of the destination item
 		private string _previousShortcutTargetPath;
@@ -73,7 +73,7 @@ namespace Files.App.ViewModels.Dialogs
 
 						if (quoted == _previousShortcutTargetPath)
 						{
-							_arguments = !Directory.Exists(_fullPath) ? trimmed[(endQuoteIndex + 1)..] : string.Empty;
+							Arguments = !Directory.Exists(FullPath) ? trimmed[(endQuoteIndex + 1)..] : string.Empty;
 							return;
 						}
 
@@ -83,8 +83,8 @@ namespace Files.App.ViewModels.Dialogs
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
-							_fullPath = Path.GetFullPath(quoted);
-							_arguments = !Directory.Exists(_fullPath) ? trimmed[(endQuoteIndex + 1)..] : string.Empty;
+							FullPath = Path.GetFullPath(quoted);
+							Arguments = !Directory.Exists(FullPath) ? trimmed[(endQuoteIndex + 1)..] : string.Empty;
 							_previousShortcutTargetPath = quoted;
 							return;
 						}
@@ -92,12 +92,13 @@ namespace Files.App.ViewModels.Dialogs
 						// If the quoted part is a valid filename, try to find it in the PATH
 						if (quoted == Path.GetFileName(quoted)
 							&& quoted.IndexOfAny(Path.GetInvalidFileNameChars()) == -1
-							&& PathHelpers.TryGetFullPath(quoted, out _fullPath)
+							&& PathHelpers.TryGetFullPath(quoted, out var fullPath)
 							)
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
-							_arguments = trimmed[(endQuoteIndex + 1)..];
+							FullPath = fullPath;
+							Arguments = trimmed[(endQuoteIndex + 1)..];
 							_previousShortcutTargetPath = quoted;
 							return;
 						}
@@ -105,15 +106,15 @@ namespace Files.App.ViewModels.Dialogs
 						var uri = new Uri(quoted);
 						DestinationPathExists = false;
 						IsLocationValid = uri.IsWellFormedOriginalString();
-						_fullPath = quoted;
-						_arguments = string.Empty;
+						FullPath = quoted;
+						Arguments = string.Empty;
 						_previousShortcutTargetPath = string.Empty;
 					}
 					else
 					{
 						if (trimmed == _previousShortcutTargetPath)
 						{
-							_arguments = trimmed.Split(' ')[1..].Aggregate(_arguments, (current, arg) => current + arg + " ");
+							Arguments = trimmed.Split(' ')[1..].Aggregate(Arguments, (current, arg) => current + arg + " ");
 							return;
 						}
 
@@ -124,8 +125,8 @@ namespace Files.App.ViewModels.Dialogs
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
-							_fullPath = Path.GetFullPath(trimmed);
-							_arguments = string.Empty;
+							FullPath = Path.GetFullPath(trimmed);
+							Arguments = string.Empty;
 							_previousShortcutTargetPath = string.Empty;
 							return;
 						}
@@ -133,12 +134,13 @@ namespace Files.App.ViewModels.Dialogs
 						var filename = trimmed.Split(' ')[0];
 						if (filename == Path.GetFileName(filename)
 							&& filename.IndexOfAny(Path.GetInvalidFileNameChars()) == -1
-							&& PathHelpers.TryGetFullPath(filename, out _fullPath)
+							&& PathHelpers.TryGetFullPath(filename, out var fullPath)
 							)
 						{
 							DestinationPathExists = true;
 							IsLocationValid = true;
-							_arguments = trimmed.Split(' ')[1..].Aggregate(_arguments, (current, arg) => current + arg + " ");
+							FullPath = fullPath;
+							Arguments = trimmed.Split(' ')[1..].Aggregate(Arguments, (current, arg) => current + arg + " ");
 							_previousShortcutTargetPath = filename;
 							return;
 						}
@@ -146,8 +148,8 @@ namespace Files.App.ViewModels.Dialogs
 						var uri = new Uri(trimmed);
 						DestinationPathExists = false;
 						IsLocationValid = uri.IsWellFormedOriginalString();
-						_fullPath = trimmed;
-						_arguments = string.Empty;
+						FullPath = trimmed;
+						Arguments = string.Empty;
 						_previousShortcutTargetPath = string.Empty;
 					}
 
@@ -156,8 +158,8 @@ namespace Files.App.ViewModels.Dialogs
 				{
 					DestinationPathExists = false;
 					IsLocationValid = false;
-					_fullPath = string.Empty;
-					_arguments = string.Empty;
+					FullPath = string.Empty;
+					Arguments = string.Empty;
 					_previousShortcutTargetPath = string.Empty;
 				}
 			}
@@ -218,12 +220,12 @@ namespace Files.App.ViewModels.Dialogs
 
 			if (DestinationPathExists)
 			{
-				destinationName = Path.GetFileName(_fullPath);
+				destinationName = Path.GetFileName(FullPath);
 
-				if(string.IsNullOrEmpty(_fullPath))
+				if(string.IsNullOrEmpty(FullPath))
 				{
 					
-					var destinationPath = _fullPath.Replace('/', '\\');
+					var destinationPath = FullPath.Replace('/', '\\');
 
 					if (destinationPath.EndsWith('\\'))
 						destinationPath = destinationPath.Substring(0, destinationPath.Length - 1);
@@ -233,7 +235,7 @@ namespace Files.App.ViewModels.Dialogs
 			}
 			else
 			{
-				var uri = new Uri(_fullPath);
+				var uri = new Uri(FullPath);
 				destinationName = uri.Host;
 			}
 
@@ -248,7 +250,7 @@ namespace Files.App.ViewModels.Dialogs
 				filePath = Path.Combine(WorkingDirectory, ShortcutCompleteName);
 			}
 
-			ShortcutCreatedSuccessfully = await FileOperationsHelpers.CreateOrUpdateLinkAsync(filePath, _fullPath, _arguments);
+			ShortcutCreatedSuccessfully = await FileOperationsHelpers.CreateOrUpdateLinkAsync(filePath, FullPath, Arguments);
 		}
 	}
 }

--- a/src/Files.Shared/Helpers/PathHelpers.cs
+++ b/src/Files.Shared/Helpers/PathHelpers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See the LICENSE.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 
 namespace Files.Shared.Helpers
@@ -62,6 +63,40 @@ namespace Files.Shared.Helpers
 			}
 
 			return false;
+		}
+
+		public static bool TryGetFullPath(string exeName, out string fullPath)
+		{
+			try
+			{
+				var p = new Process();
+				p.StartInfo = new ProcessStartInfo
+				{
+					UseShellExecute = false,
+					CreateNoWindow = true,
+					FileName = "where.exe",
+					Arguments = exeName,
+					RedirectStandardOutput = true
+				};
+				p.Start();
+				var output = p.StandardOutput.ReadToEnd();
+				p.WaitForExit();
+
+				if (p.ExitCode != 0)
+				{
+					fullPath = string.Empty;
+					return false;
+				}
+
+				fullPath = output[..output.IndexOf(Environment.NewLine, StringComparison.Ordinal)];
+				return true;
+			}
+			catch (Exception)
+			{
+				fullPath = string.Empty;
+				return false;
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #15928

**Steps used to test these changes**

1. Right click in a folder
2. Click New -> Shortcut in the context menu
3. Type "cmd /?" in the textbox
4. Before: You got a prompt saying "Invalid location"
	After: Shortcut successfully created
5. (After) Open the shortcut and see the cmd help text

**-- Update --**
These modifications make the behavior of creating shortcuts more consistent with File Explorer.

These modifications can be tested by creating the following shortcuts, all of which are supported by File Explorer but not supported by Files before:
1. `cmd`
2. `cmd.exe`
3. `cmd /?`
4. `  cmd`
5. `"C:\Windows\System32\cmd.exe" /?`
6. `C:\Windows\System32\cmd.exe /?`
7. `"C:\Program Files\PowerShell\7\pwsh.exe" -c cmd /?`
8. `"https://www.google.com"`

Also fixed the issue 4 mentioned below, which is caused by Path.Exists considering Files' startup path as relative path.