### PR TITLE
GitHub: Format C# as well when format command invoked

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Format XAML
+name: Format XAML/C#
 on:
   issue_comment:
     types: [created]
@@ -6,7 +6,7 @@ on:
 jobs:
   format-xaml:
     if: github.event.issue.pull_request && github.event.comment.body == '/format'
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     environment: Pull Requests
     defaults:
       run:
@@ -84,6 +84,11 @@ jobs:
           xstyler -l None -r -d src/Files.App
           xstyler -l None -r -d src/Files.App.Controls
           xstyler -l None -r -d tests/Files.App.UITests
+
+      - name: Format C# files
+        if: env.CAN_RUN == 1
+        run: |
+          dotnet format --fix-analyzers --fix-style
 
       - name: Commit formatted files
         if: env.CAN_RUN == 1


### PR DESCRIPTION
### Resolved / Related Issues

Formatting C# files can be done via 'dotnet format' but I fear that we may include irrelevant code quality  fixes if we don't run this every time we merge any commit to 'main'.
I'd like to ask your opinion @yair100 

### Steps used to test these changes

1. Merge this
2. Run the '/format' command in a PR.