### PR TITLE
Fix: Fixed NullReferenceException in PinnedFoldersManager.CreateLocationItemFromPathAsync

### DIFF
--- a/src/Files.App/Data/Models/PinnedFoldersManager.cs
+++ b/src/Files.App/Data/Models/PinnedFoldersManager.cs
@@ -93,12 +93,12 @@ namespace Files.App.Data.Models
 				ShowEmptyRecycleBin = string.Equals(path, Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase)
 			};
 			locationItem.IsDefaultLocation = false;
-			locationItem.Text = res.Result?.DisplayName ?? Path.GetFileName(path.TrimEnd('\\'));
+			locationItem.Text = res?.Result?.DisplayName ?? Path.GetFileName(path.TrimEnd('\\'));
 
 			if (res)
 			{
 				locationItem.IsInvalid = false;
-				if (res && res.Result is not null)
+				if (res.Result is not null)
 				{
 					var result = await FileThumbnailHelper.GetIconAsync(
 						res.Result.Path,
@@ -117,7 +117,7 @@ namespace Files.App.Data.Models
 			{
 				locationItem.Icon = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => UIHelpers.GetSidebarIconResource(Constants.ImageRes.Folder));
 				locationItem.IsInvalid = true;
-				Debug.WriteLine($"Pinned item was invalid {res.ErrorCode}, item: {path}");
+				Debug.WriteLine($"Pinned item was invalid {res?.ErrorCode}, item: {path}");
 			}
 
 			return locationItem;


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15946 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
