### PR TITLE
Fix: Fixed OutOfMemoryException in the preview pane

### DIFF
--- a/src/Files.App/UserControls/FilePreviews/MediaPreview.xaml.cs
+++ b/src/Files.App/UserControls/FilePreviews/MediaPreview.xaml.cs
@@ -1,10 +1,7 @@
-using CommunityToolkit.Mvvm.DependencyInjection;
 using Files.App.ViewModels.Previews;
-using Files.App.Services.Settings;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
-using System;
 using Windows.Media.Playback;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
@@ -20,6 +17,7 @@ namespace Files.App.UserControls.FilePreviews
 			ViewModel = model;
 			InitializeComponent();
 			PlayerContext.Loaded += PlayerContext_Loaded;
+			Unloaded += MediaPreview_Unloaded;
 		}
 
 		public MediaPreviewViewModel ViewModel { get; set; }
@@ -30,6 +28,16 @@ namespace Files.App.UserControls.FilePreviews
 			PlayerContext.MediaPlayer.VolumeChanged += MediaPlayer_VolumeChanged;
 			ViewModel.TogglePlaybackRequested += TogglePlaybackRequestInvoked;
 		}
+
+		private void MediaPreview_Unloaded(object sender, RoutedEventArgs e)
+		{
+			// The MediaPlayerElement isn't properly disposed by Windows so we set the source to null
+			// to avoid issues the next time the control is used.
+			PlayerContext.Source = null;
+
+			PlayerContext.Loaded -= PlayerContext_Loaded;
+			Unloaded -= MediaPreview_Unloaded;		
+	}
 
 		private void MediaPlayer_VolumeChanged(MediaPlayer sender, object args)
 		{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #14791

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed the media player source is cleared when unloading media player
