### PR TITLE
Code Quality: Force PreserveSig to all COM methods generated by CsWin32

### DIFF
--- a/src/Files.App.CsWin32/NativeMethods.json
+++ b/src/Files.App.CsWin32/NativeMethods.json
@@ -4,7 +4,7 @@
 	"public": true,
 	"comInterop": {
 		"preserveSigMethods": [
-			"IEnumShellItems.Next"
+			"*"
 		]
 	}
 }


### PR DESCRIPTION
This prevents from triggering COMException inside of .NET marshal and helps me to check HRESULT