### PR TITLE
Fix: Fixed a crash when Windows Event Log service was not running

### DIFF
--- a/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
+++ b/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
@@ -147,6 +147,9 @@ namespace Files.App.Helpers
 			return Host.CreateDefaultBuilder()
 				.UseEnvironment(AppLifecycleHelper.AppEnvironment.ToString())
 				.ConfigureLogging(builder => builder
+					.ClearProviders()
+					.AddConsole()
+					.AddDebug()
 					.AddProvider(new FileLoggerProvider(Path.Combine(ApplicationData.Current.LocalFolder.Path, "debug.log")))
 					.AddProvider(new SentryLoggerProvider())
 					.SetMinimumLevel(LogLevel.Information))

--- a/src/Files.App/Services/App/AppUpdateSideloadService.cs
+++ b/src/Files.App/Services/App/AppUpdateSideloadService.cs
@@ -140,8 +140,7 @@ namespace Files.App.Services
 			}
 			catch (Exception e)
 			{
-				// It seems that the logger may throw an exception, so we need to ignore it. (#15688)
-				SafetyExtensions.IgnoreExceptions(() => Logger?.LogError(e, e.Message));
+				Logger?.LogError(e, e.Message);
 			}
 		}
 


### PR DESCRIPTION

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15688

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Disable Windows Event Log service in Service applet.
2. Launch Files.
3. Now the app starts without crashing.