### PR TITLE
Fix: Fixed InvalidOperationException in FileTagsContextMenu

### DIFF
--- a/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
+++ b/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
@@ -63,6 +63,7 @@ namespace Files.App.UserControls.Menus
 			// go through each tag and find the common one for all files
 			var commonFileTags = SelectedItems
 				.Select(x => x?.FileTags ?? Enumerable.Empty<string>())
+				.DefaultIfEmpty(Enumerable.Empty<string>())
 				.Aggregate((x, y) => x.Intersect(y))
 				.Select(x => Items.FirstOrDefault(y => x == ((TagViewModel)y.Tag)?.Uid));
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- https://files-org.sentry.io/issues/5811055100/events/59fdde21245e4ee6950305402b71bfc9/

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
