### PR TITLE
Fix: Fixed InvalidOperationException in ShellViewModel.FolderSizeProvider_SizeChanged

### DIFF
--- a/src/Files.App/Services/SizeProvider/CachedSizeProvider.cs
+++ b/src/Files.App/Services/SizeProvider/CachedSizeProvider.cs
@@ -37,6 +37,7 @@ namespace Files.App.Services.SizeProvider
 				RaiseSizeChanged(path, 0, SizeChangedValueState.None);
 			}
 
+			var stopwatch = Stopwatch.StartNew();
 			ulong size = await Calculate(path);
 
 			sizes[path] = size;
@@ -81,8 +82,10 @@ namespace Files.App.Services.SizeProvider
 							await Task.Yield();
 							sizes[localPath] = localSize;
 						}
-						if (level is 0)
+						if (level is 0 && stopwatch.ElapsedMilliseconds > 500)
 						{
+							// Limit updates to every 0.5 seconds to prevent crashes due to frequent updates
+							stopwatch.Restart();
 							RaiseSizeChanged(path, size, SizeChangedValueState.Intermediate);
 						}
 

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -603,7 +603,7 @@ namespace Files.App.ViewModels
 			try
 			{
 				var matchingItem = filesAndFolders.ToList().FirstOrDefault(x => x.ItemPath == e.Path);
-				if (matchingItem is not null)
+				if (matchingItem is not null && (e.ValueState is not SizeChangedValueState.Intermediate || (long)e.NewSize > matchingItem.FileSizeBytes))
 				{
 					await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 					{


### PR DESCRIPTION
This could have occurred when folder size calculation is on and a folder containing many items is displayed

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
https://files-org.sentry.io/issues/5834287744/?project=4507376940351488

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
