### PR TITLE
Fixed COMException in SidebarItem.ItemBorder_Drop

### DIFF
--- a/src/Files.App/UserControls/Sidebar/SidebarItem.cs
+++ b/src/Files.App/UserControls/Sidebar/SidebarItem.cs
@@ -433,11 +433,7 @@ namespace Files.App.UserControls.Sidebar
 		{
 			UpdatePointerState();
 			if (Owner is not null)
-			{
-				var deferral = e.GetDeferral();
 				await Owner.RaiseItemDropped(this, DetermineDropTargetPosition(e), e);
-				deferral.Complete();
-			}
 		}
 
 		private SidebarItemDropPosition DetermineDropTargetPosition(DragEventArgs args)

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -1243,18 +1243,20 @@ namespace Files.App.ViewModels.UserControls
 
 			args.RawEvent.Handled = true;
 
-			var storageItems = await Utils.Storage.FilesystemHelpers.GetDraggedStorageItems(args.DroppedItem);
+			// Comment out the code for dropping to Tags section as it is currently not supported.
 
-			if (!storageItems.Any())
-			{
-				args.RawEvent.AcceptedOperation = DataPackageOperation.None;
-			}
-			else
-			{
-				args.RawEvent.DragUIOverride.IsCaptionVisible = true;
-				args.RawEvent.DragUIOverride.Caption = string.Format("LinkToFolderCaptionText".GetLocalizedResource(), tagItem.Text);
-				args.RawEvent.AcceptedOperation = DataPackageOperation.Link;
-			}
+			//var storageItems = await Utils.Storage.FilesystemHelpers.GetDraggedStorageItems(args.DroppedItem);
+
+			//if (!storageItems.Any())
+			//{
+			args.RawEvent.AcceptedOperation = DataPackageOperation.None;
+			//}
+			//else
+			//{
+			//	args.RawEvent.DragUIOverride.IsCaptionVisible = true;
+			//	args.RawEvent.DragUIOverride.Caption = string.Format("LinkToFolderCaptionText".GetLocalizedResource(), tagItem.Text);
+			//	args.RawEvent.AcceptedOperation = DataPackageOperation.Link;
+			//}
 		}
 
 
@@ -1264,8 +1266,11 @@ namespace Files.App.ViewModels.UserControls
 				await HandleLocationItemDroppedAsync(locationItem, args);
 			else if (args.DropTarget is DriveItem driveItem)
 				await HandleDriveItemDroppedAsync(driveItem, args);
-			else if (args.DropTarget is FileTagItem fileTagItem)
-				await HandleTagItemDroppedAsync(fileTagItem, args);
+
+			// Comment out the code for dropping to Tags section as it is currently not supported.
+
+			//else if (args.DropTarget is FileTagItem fileTagItem)
+			//	await HandleTagItemDroppedAsync(fileTagItem, args);
 		}
 
 		private async Task HandleLocationItemDroppedAsync(LocationItem locationItem, ItemDroppedEventArgs args)
@@ -1293,6 +1298,7 @@ namespace Files.App.ViewModels.UserControls
 			return FilesystemHelpers.PerformOperationTypeAsync(args.RawEvent.AcceptedOperation, args.RawEvent.DataView, driveItem.Path, false, true);
 		}
 
+		// TODO: This method effectively does nothing. We need to implement the functionality for dropping to Tags section.
 		private async Task HandleTagItemDroppedAsync(FileTagItem fileTagItem, ItemDroppedEventArgs args)
 		{
 			var storageItems = await Utils.Storage.FilesystemHelpers.GetDraggedStorageItems(args.DroppedItem);


### PR DESCRIPTION
I believe the deferral is not necessary in drop operations in the first place.

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
https://sentry.io/organizations/files-org/issues/5834489987/?project=4507376940351488

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
