### PR TITLE
Fix: Fixed an issue when navigating the sidebar with the tab key

### DIFF
--- a/src/Files.App/UserControls/Sidebar/SidebarItem.cs
+++ b/src/Files.App/UserControls/Sidebar/SidebarItem.cs
@@ -75,7 +75,7 @@ namespace Files.App.UserControls.Sidebar
 				border.DragOver += ItemBorder_DragOver;
 				border.Drop += ItemBorder_Drop;
 				border.AllowDrop = true;
-				border.IsTabStop = true;
+				border.IsTabStop = false;
 			}
 
 			if (GetTemplateChild("ChildrenPresenter") is ItemsRepeater repeater)


### PR DESCRIPTION
**Resolved / Related Issues**

> **Note:** The solution to the issue was a simple change: setting the `IsTabStop` attribute to `False`. This was necessary as we were excluding focus from each selected element.

- Closes #16145 

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files
2. Press "Tab" (You can see focused element)
3. Use the 'Down' and 'Up' arrow keys (you won't be able to see the focused element, but it will change. When you press 'Tab' again, you will see the border on the element where the focus is. If you try to move to the next element, it will change, but without a visible border)."
