### PR TITLE
GitHub: Retry integration tests when failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,11 +236,16 @@ jobs:
       shell: pwsh
       run: Start-Process -FilePath "$env:WINAPPDRIVER_EXE86_PATH"
 
-    - name: Run interaction tests
-      run: |
-        dotnet test `
-          $env:AUTOMATED_TESTS_ASSEMBLY_DIR\**\Files.InteractionTests.dll `
-          --logger "trx;LogFileName=$env:AUTOMATED_TESTS_ASSEMBLY_DIR\testResults.trx"
+    # Integration tests became moody lately. Retry 3 times.
+    - uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 15
+        max_attempts: 3
+        shell: pwsh
+        command: |
+          dotnet test `
+            $env:AUTOMATED_TESTS_ASSEMBLY_DIR\**\Files.InteractionTests.dll `
+            --logger "trx;LogFileName=$env:AUTOMATED_TESTS_ASSEMBLY_DIR\testResults.trx"
 
     # - name: Generate markdown from the tests result
     #   shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
       shell: pwsh
       run: Start-Process -FilePath "$env:WINAPPDRIVER_EXE86_PATH"
 
-    # Integration tests became moody lately. Retry 3 times.
+    # Retry integration tests if first attempt fails```
     - name: Run interaction tests
       uses: nick-fields/retry@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
       shell: pwsh
       run: Start-Process -FilePath "$env:WINAPPDRIVER_EXE86_PATH"
 
-    # Retry integration tests if first attempt fails```
+    # Retry integration tests if first attempt fails
     - name: Run interaction tests
       uses: nick-fields/retry@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,7 @@ jobs:
     - name: Run interaction tests
       uses: nick-fields/retry@v3
       with:
+        timeout_minutes: 15
         max_attempts: 2
         shell: pwsh
         command: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,8 @@ jobs:
       run: Start-Process -FilePath "$env:WINAPPDRIVER_EXE86_PATH"
 
     # Integration tests became moody lately. Retry 3 times.
-    - uses: nick-fields/retry@v3
+    - name: Run interaction tests
+      uses: nick-fields/retry@v3
       with:
         max_attempts: 2
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,8 +239,7 @@ jobs:
     # Integration tests became moody lately. Retry 3 times.
     - uses: nick-fields/retry@v3
       with:
-        timeout_minutes: 15
-        max_attempts: 3
+        max_attempts: 2
         shell: pwsh
         command: |
           dotnet test `


### PR DESCRIPTION
### Resolved / Related Issues

- *Planned internally*

The integration tests became very moody and fail frequently. Let's make it run 3 times at maximum when failed.

### Steps used to test these changes

_None_