### PR TITLE
GitHub: Make C++ headers actually detect as C++

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,5 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+*.h linguist-language=C++


### PR DESCRIPTION
Absolutely _miniscule_ change, but this makes the C++ header files in the Visual C++ projects detected as C++ rather than C as GitHub Linguist assumes.