### PR TITLE
Code Quality: Introduced ComPtr.As() to QI easily

### DIFF
--- a/src/Files.App.CsWin32/Windows.Win32.ComHeapPtr.cs
+++ b/src/Files.App.CsWin32/Windows.Win32.ComHeapPtr.cs
@@ -16,7 +16,7 @@ namespace Windows.Win32
 		private T* _ptr;
 
 		public bool IsNull
-			=> _ptr == default;
+			=> _ptr == null;
 
 		public ComHeapPtr(T* ptr)
 		{

--- a/src/Files.App.CsWin32/Windows.Win32.ComPtr.cs
+++ b/src/Files.App.CsWin32/Windows.Win32.ComPtr.cs
@@ -41,11 +41,9 @@ namespace Windows.Win32
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public readonly ComPtr<U> As<U>(Guid riid) where U : unmanaged
 		{
-			void* newRawPtr;
-			ComPtr<U> newPtr = default;
-			((IUnknown*)_ptr)->QueryInterface(&riid, &newRawPtr);
-			newPtr._ptr = (U*)newRawPtr;
-			return newPtr;
+			ComPtr<U> pNewPtr = default;
+			((IUnknown*)_ptr)->QueryInterface(&riid, (void**)pNewPtr.GetAddressOf());
+			return pNewPtr;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Files.App.CsWin32/Windows.Win32.ComPtr.cs
+++ b/src/Files.App.CsWin32/Windows.Win32.ComPtr.cs
@@ -16,7 +16,7 @@ namespace Windows.Win32
 		private T* _ptr;
 
 		public bool IsNull
-			=> _ptr == default;
+			=> _ptr == null;
 
 		public ComPtr(T* ptr)
 		{
@@ -36,6 +36,16 @@ namespace Windows.Win32
 		public readonly T** GetAddressOf()
 		{
 			return (T**)Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public readonly ComPtr<U> As<U>(Guid riid) where U : unmanaged
+		{
+			void* newRawPtr;
+			ComPtr<U> newPtr = default;
+			((IUnknown*)_ptr)->QueryInterface(&riid, &newRawPtr);
+			newPtr._ptr = (U*)newRawPtr;
+			return newPtr;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
### Resolved / Related Issues

- Related #16071
- Related #15000

> [!NOTE]
> While I settled on this method to QI for now, we may want to use IDynamicInterfaceCastable, which is Hez let me know, after .NET 9 (stack allocation for classes) becomes GA. I need more exploration but this enables us to utilize `is` and `as` with QI called implicitly.

### Steps used to test these changes

_None_
