### PR TITLE
GitHub: Introduce GHA CD to Microsoft Store

### DIFF
--- a/.github/workflows/cd-store.yml
+++ b/.github/workflows/cd-store.yml
@@ -32,9 +32,9 @@ jobs:
       WORKING_DIR:                '${{ github.workspace }}' # D:\a\Files\Files\
       ARTIFACTS_STAGING_DIR:      '${{ github.workspace }}\artifacts'
       APPX_PACKAGE_DIR:           '${{ github.workspace }}\artifacts\AppxPackages'
-      PACKAGE_PROJECT_DIR:        '${{ github.workspace }}src\Files.App (Package)'
-      PACKAGE_PROJECT_PATH:       '${{ github.workspace }}src\Files.App (Package)\Files.Package.wapproj'
-      PACKAGE_MANIFEST_PATH:      '${{ github.workspace }}src\Files.App (Package)\Package.appxmanifest'
+      PACKAGE_PROJECT_DIR:        '${{ github.workspace }}\src\Files.App (Package)'
+      PACKAGE_PROJECT_PATH:       '${{ github.workspace }}\src\Files.App (Package)\Files.Package.wapproj'
+      PACKAGE_MANIFEST_PATH:      '${{ github.workspace }}\src\Files.App (Package)\Package.appxmanifest'
 
     steps:
     - name: Checkout the repository

--- a/.github/workflows/cd-store.yml
+++ b/.github/workflows/cd-store.yml
@@ -1,0 +1,106 @@
+# Copyright (c) 2024 Files Community
+# Licensed under the MIT License. See the LICENSE.
+
+# Abstract:
+#  Deploys Files (Store).
+#
+# Workflow:
+#  1. Configure manifest, logo and secrets
+#  2. Restore, build and package Files
+#  3. Generate a msixupload file
+#  4. Publish the msixuoload to GitHub Actions
+
+name: Files CD (Store)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    environment: Deployments
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Store]
+        platform: [x64]
+    env:
+      SOLUTION_NAME:              '${{ github.workspace }}\Files.sln'
+      CONFIGURATION:              '${{ matrix.configuration }}'
+      PLATFORM:                   '${{ matrix.platform }}'
+      APPX_BUNDLE_PLATFORMS:      'x64|arm64'
+      WORKING_DIR:                '${{ github.workspace }}' # D:\a\Files\Files\
+      ARTIFACTS_STAGING_DIR:      '${{ github.workspace }}\artifacts'
+      APPX_PACKAGE_DIR:           '${{ github.workspace }}\artifacts\AppxPackages'
+      PACKAGE_PROJECT_DIR:        '${{ github.workspace }}src\Files.App (Package)'
+      PACKAGE_PROJECT_PATH:       '${{ github.workspace }}src\Files.App (Package)\Files.Package.wapproj'
+      PACKAGE_MANIFEST_PATH:      '${{ github.workspace }}src\Files.App (Package)\Package.appxmanifest'
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v2
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Configure the package manifest, logo, and secrets
+      shell: pwsh
+      run: |
+        . './.github/scripts/Configure-AppxManifest.ps1' `
+          -Branch "$env:CONFIGURATION" `
+          -PackageManifestPath "$env:PACKAGE_MANIFEST_PATH" `
+          -Publisher "CN=53EC4384-7F5B-4CF6-8C23-513FFE9D1AB7" `
+          -WorkingDir "$env:WORKING_DIR" `
+          -SecretBingMapsKey "$env:SECRET_BINGMAPS_KEY" `
+          -SecretSentry "$env:SECRET_SENTRY" `
+          -SecretGitHubOAuthClientId "$env:SECRET_GITHUB_OAUTH_CLIENT_ID"
+      env:
+        SECRET_BINGMAPS_KEY: ${{ secrets.BING_MAPS_SECRET }}
+        SECRET_SENTRY: ${{ secrets.SENTRY_SECRET }}
+        SECRET_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+  
+    - name: Use Windows SDK Preview
+      shell: cmd
+      run: |
+        for /f %%a in ('dir /b /a:d %localappdata%\Microsoft\VisualStudio\17*') do echo UsePreviews=True>%localappdata%\Microsoft\VisualStudio\%%a\sdk.txt
+
+    - name: Restore NuGet
+      shell: pwsh
+      run: 'nuget restore $env:SOLUTION_NAME'
+
+    - name: Restore Files
+      shell: pwsh
+      run: |
+        msbuild $env:SOLUTION_NAME `
+        -t:Restore `
+        -p:Platform=$env:PLATFORM `
+        -p:Configuration=$env:CONFIGURATION `
+        -p:PublishReadyToRun=true
+
+    - name: Build & package Files
+      shell: pwsh
+      run: |
+        msbuild "$env:PACKAGE_PROJECT_PATH" `
+        -t:Build `
+        -t:_GenerateAppxPackage `
+        -p:Platform=$env:PLATFORM `
+        -p:Configuration=$env:CONFIGURATION `
+        -p:AppxBundlePlatforms=$env:APPX_BUNDLE_PLATFORMS `
+        -p:AppxPackageDir="$env:APPX_PACKAGE_DIR" `
+        -p:AppxBundle=Always `
+        -p:UapAppxPackageBuildMode=StoreUpload
+
+    - name: Remove empty files from the packages
+      shell: bash
+      run: find $ARTIFACTS_STAGING_DIR -empty -delete
+
+    - name: Upload the packages to GitHub Actions
+      uses: actions/upload-artifact@v4
+      with:
+        name: 'Appx Packages (${{ env.CONFIGURATION }}, ${{ env.PLATFORM }})'
+        path: ${{ env.ARTIFACTS_STAGING_DIR }}

--- a/.github/workflows/cd-store.yml
+++ b/.github/workflows/cd-store.yml
@@ -25,7 +25,7 @@ jobs:
         configuration: [Store]
         platform: [x64]
     env:
-      SOLUTION_NAME:              '${{ github.workspace }}\Files.sln'
+      SOLUTION_NAME:              'Files.sln'
       CONFIGURATION:              '${{ matrix.configuration }}'
       PLATFORM:                   '${{ matrix.platform }}'
       APPX_BUNDLE_PLATFORMS:      'x64|arm64'

--- a/.github/workflows/cd-store.yml
+++ b/.github/workflows/cd-store.yml
@@ -54,12 +54,13 @@ jobs:
         . './.github/scripts/Configure-AppxManifest.ps1' `
           -Branch "$env:CONFIGURATION" `
           -PackageManifestPath "$env:PACKAGE_MANIFEST_PATH" `
-          -Publisher "CN=53EC4384-7F5B-4CF6-8C23-513FFE9D1AB7" `
+          -Publisher "$env:STORE_PUBLISHER_SECRET" `
           -WorkingDir "$env:WORKING_DIR" `
           -SecretBingMapsKey "$env:SECRET_BINGMAPS_KEY" `
           -SecretSentry "$env:SECRET_SENTRY" `
           -SecretGitHubOAuthClientId "$env:SECRET_GITHUB_OAUTH_CLIENT_ID"
       env:
+        STORE_PUBLISHER_SECRET: ${{ secrets.STORE_PUBLISHER_SECRET }}
         SECRET_BINGMAPS_KEY: ${{ secrets.BING_MAPS_SECRET }}
         SECRET_SENTRY: ${{ secrets.SENTRY_SECRET }}
         SECRET_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}

--- a/.github/workflows/cd-store.yml
+++ b/.github/workflows/cd-store.yml
@@ -8,7 +8,7 @@
 #  1. Configure manifest, logo and secrets
 #  2. Restore, build and package Files
 #  3. Generate a msixupload file
-#  4. Publish the msixuoload to GitHub Actions
+#  4. Publish the msixupload to GitHub Actions
 
 name: Files CD (Store)
 


### PR DESCRIPTION
### Resolved / Related Issues

*Planned internally*

We have planned to move all CI/CD to GHA. However, the CD for Microsoft Store had a workflow that was incompatible with GHA and we haven't been able to migrate (StoreBroker ps module should work for us to upload a msix package).

This introduces a new workflow for the Store CD but doesn't contain steps to upload packages to Microsoft Store via StoreBroker yet. Hence, we still have to upload it manually.

### Steps used to test these changes

1. Merge this
2. Run the CD and check if the msixupload will be generated.