### PR TITLE
Fix: Fixed context menu placement on the home page

### DIFF
--- a/src/Files.App/ViewModels/UserControls/Widgets/BaseWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/BaseWidgetViewModel.cs
@@ -65,7 +65,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 			// Create a new Flyout
 			var itemContextMenuFlyout = new CommandBarFlyout()
 			{
-				Placement = FlyoutPlacementMode.Full
+				Placement = FlyoutPlacementMode.Right
 			};
 
 			// Hook events


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16404

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Maximized the window
2. Right clicked an item on the home page (on the edge of the screen)
3. Confirmed the context menu was fully shown