### PR TITLE
Feature: Added an action to collapse/expand the sidebar

### DIFF
--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -3,9 +3,9 @@
 
 namespace Files.App.Actions
 {
-	internal sealed class ToggleSidebarAction : IToggleAction
+	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
 	{
-		private IAppearanceSettingsService AppearanceSettingsService { get; } = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
+		// private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 
 		public string Label
 			=> "ToggleSidebar".GetLocalizedResource();
@@ -26,8 +26,9 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync(object? parameter = null)
 		{
-			AppearanceSettingsService.IsSidebarOpen = !IsOn;
-
+			// AppearanceSettingsService.IsSidebarOpen = !IsOn;
+			Files.App.ViewModels.UserControls.IsSidebarOpen.set(!IsOn);
+			// Let's try this with as few abstractions as possible.
 			return Task.CompletedTask;
 		}
 

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -30,7 +30,7 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync(object? parameter = null)
 		{
-			SidebarViewModel.SidebarDisplayMode = IsOn
+			SidebarViewModel.SidebarDisplayMode = !IsOn
 				? SidebarDisplayMode.Expanded
 				: SidebarDisplayMode.Compact;
 			return Task.CompletedTask;

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -5,8 +5,7 @@ namespace Files.App.Actions
 {
 	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
 	{
-		private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
-		private readonly ISidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<ISidebarViewModel>();
+		private readonly ISidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<SidebarViewModel>();
 
 		public string Label
 			=> "ToggleSidebar".GetLocalizedResource();
@@ -17,24 +16,27 @@ namespace Files.App.Actions
 		public HotKey HotKey
 			=> new(Keys.S, KeyModifiers.CtrlAlt);
 
-		public bool IsOn
-			=> AppearanceSettingsService.IsSidebarOpen;
+		public bool IsOn =>
+			SidebarViewModel.SidebarDisplayMode is SidebarDisplayMode.Expanded
+				? true
+				: false;
 
 		public ToggleSidebarAction()
 		{
-			AppearanceSettingsService.PropertyChanged += ViewModel_PropertyChanged;
+			SidebarViewModel.PropertyChanged += ViewModel_PropertyChanged;
 		}
 
 		public Task ExecuteAsync(object? parameter = null)
 		{
-			AppearanceSettingsService.IsSidebarOpen = !IsOn;
-			SidebarViewModel.UpdateTabControlMargin();
+			SidebarViewModel.SidebarDisplayMode = IsOn
+				? SidebarDisplayMode.Expanded
+				: SidebarDisplayMode.Compact;
 			return Task.CompletedTask;
 		}
 
 		private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName is nameof(AppearanceSettingsService.IsSidebarOpen))
+			if (e.PropertyName is nameof(SidebarViewModel.SidebarDisplayMode))
 				OnPropertyChanged(nameof(IsOn));
 		}
 	}

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
-using Files.App.UserControls.Sidebar;
-
 namespace Files.App.Actions
 {
-	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
+	internal sealed class ToggleSidebarAction : IToggleAction
 	{
-		private readonly SidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<SidebarViewModel>();
+		private IAppearanceSettingsService AppearanceSettingsService { get; } = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 
 		public string Label
 			=> "ToggleSidebar".GetLocalizedResource();
@@ -18,27 +16,24 @@ namespace Files.App.Actions
 		public HotKey HotKey
 			=> new(Keys.S, KeyModifiers.CtrlAlt);
 
-		public bool IsOn =>
-			SidebarViewModel.SidebarDisplayMode is SidebarDisplayMode.Expanded
-				? true
-				: false;
+		public bool IsOn
+			=> AppearanceSettingsService.IsSidebarOpen;
 
 		public ToggleSidebarAction()
 		{
-			SidebarViewModel.PropertyChanged += ViewModel_PropertyChanged;
+			AppearanceSettingsService.PropertyChanged += ViewModel_PropertyChanged;
 		}
 
 		public Task ExecuteAsync(object? parameter = null)
 		{
-			SidebarViewModel.SidebarDisplayMode = !IsOn
-				? SidebarDisplayMode.Expanded
-				: SidebarDisplayMode.Compact;
+			AppearanceSettingsService.IsSidebarOpen = !IsOn;
+
 			return Task.CompletedTask;
 		}
 
 		private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName is nameof(SidebarViewModel.SidebarDisplayMode))
+			if (e.PropertyName is nameof(AppearanceSettingsService.IsSidebarOpen))
 				OnPropertyChanged(nameof(IsOn));
 		}
 	}

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -3,9 +3,9 @@
 
 namespace Files.App.Actions
 {
-	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
+	internal sealed class ToggleSidebarAction : IToggleAction
 	{
-		// private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
+		private IAppearanceSettingsService AppearanceSettingsService { get; } = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 
 		public string Label
 			=> "ToggleSidebar".GetLocalizedResource();
@@ -26,9 +26,8 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync(object? parameter = null)
 		{
-			// AppearanceSettingsService.IsSidebarOpen = !IsOn;
-			Files.App.ViewModels.UserControls.IsSidebarOpen.set(!IsOn);
-			// Let's try this with as few abstractions as possible.
+			AppearanceSettingsService.IsSidebarOpen = !IsOn;
+
 			return Task.CompletedTask;
 		}
 

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2024 Files Community
 // Licensed under the MIT License. See the LICENSE.
 
+using Files.App.UserControls.Sidebar;
+
 namespace Files.App.Actions
 {
 	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -5,7 +5,7 @@ namespace Files.App.Actions
 {
 	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
 	{
-		private readonly ISidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<SidebarViewModel>();
+		private readonly SidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<SidebarViewModel>();
 
 		public string Label
 			=> "ToggleSidebar".GetLocalizedResource();

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -6,7 +6,7 @@ namespace Files.App.Actions
 	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
 	{
 		private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
-		private readonly SidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<SidebarViewModel>();
+		private readonly ISidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<SidebarViewModel>();
 
 		public string Label
 			=> "ToggleSidebar".GetLocalizedResource();

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -3,7 +3,7 @@
 
 namespace Files.App.Actions
 {
-	internal sealed class ToggleSidebarAction : IToggleAction
+	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
 	{
 		private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -6,6 +6,7 @@ namespace Files.App.Actions
 	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
 	{
 		private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
+		private readonly SidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<SidebarViewModel>();
 
 		public string Label
 			=> "ToggleSidebar".GetLocalizedResource();
@@ -27,7 +28,7 @@ namespace Files.App.Actions
 		public Task ExecuteAsync(object? parameter = null)
 		{
 			AppearanceSettingsService.IsSidebarOpen = !IsOn;
-
+			SidebarViewModel.UpdateTabControlMargin();
 			return Task.CompletedTask;
 		}
 

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2024 Files Community
+// Licensed under the MIT License. See the LICENSE.
+
+namespace Files.App.Actions
+{
+	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
+	{
+		private IAppearanceSettingsService AppearanceSettingsService { get; } = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
+
+		public string Label
+			=> "ToggleSidebar".GetLocalizedResource();
+
+		public string Description
+			=> "ToggleSidebar".GetLocalizedResource();
+
+		public HotKey HotKey
+			=> new(Keys.S, KeyModifiers.CtrlAlt);
+
+		public bool IsOn
+			=> AppearanceSettingsService.IsSidebarOpen;
+
+		public ToggleSidebarAction()
+		{
+			AppearanceSettingsService.PropertyChanged += ViewModel_PropertyChanged;
+		}
+
+		public Task ExecuteAsync(object? parameter = null)
+		{
+			AppearanceSettingsService.IsSidebarOpen = !IsOn;
+
+			return Task.CompletedTask;
+		}
+
+		private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName is nameof(AppearanceSettingsService.IsSidebarOpen))
+				OnPropertyChanged(nameof(IsOn));
+		}
+	}
+}

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -3,7 +3,7 @@
 
 namespace Files.App.Actions
 {
-	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
+	internal sealed class ToggleSidebarAction : IToggleAction
 	{
 		private IAppearanceSettingsService AppearanceSettingsService { get; } = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -11,7 +11,7 @@ namespace Files.App.Actions
 			=> "ToggleSidebar".GetLocalizedResource();
 
 		public string Description
-			=> "ToggleSidebar".GetLocalizedResource();
+			=> "ToggleSidebarDescription".GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.S, KeyModifiers.CtrlAlt);

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -6,7 +6,7 @@ namespace Files.App.Actions
 	internal sealed class ToggleSidebarAction : ObservableObject, IToggleAction
 	{
 		private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
-		private readonly ISidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<SidebarViewModel>();
+		private readonly ISidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<ISidebarViewModel>();
 
 		public string Label
 			=> "ToggleSidebar".GetLocalizedResource();

--- a/src/Files.App/Actions/Show/ToggleSidebarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleSidebarAction.cs
@@ -5,7 +5,7 @@ namespace Files.App.Actions
 {
 	internal sealed class ToggleSidebarAction : IToggleAction
 	{
-		private IAppearanceSettingsService AppearanceSettingsService { get; } = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
+		private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 
 		public string Label
 			=> "ToggleSidebar".GetLocalizedResource();

--- a/src/Files.App/Data/Commands/Manager/CommandCodes.cs
+++ b/src/Files.App/Data/Commands/Manager/CommandCodes.cs
@@ -26,6 +26,7 @@ namespace Files.App.Data.Commands
 		ToggleDetailsPane,
 		ToggleInfoPane,
 		ToggleToolbar,
+		ToggleSidebar,
 
 		// File System
 		CopyItem,

--- a/src/Files.App/Data/Commands/Manager/CommandManager.cs
+++ b/src/Files.App/Data/Commands/Manager/CommandManager.cs
@@ -57,6 +57,7 @@ namespace Files.App.Data.Commands
 		public IRichCommand ToggleDetailsPane => commands[CommandCodes.ToggleDetailsPane];
 		public IRichCommand ToggleInfoPane => commands[CommandCodes.ToggleInfoPane];
 		public IRichCommand ToggleToolbar => commands[CommandCodes.ToggleToolbar];
+		public IRichCommand ToggleSidebar => commands[CommandCodes.ToggleSidebar];
 		public IRichCommand SelectAll => commands[CommandCodes.SelectAll];
 		public IRichCommand InvertSelection => commands[CommandCodes.InvertSelection];
 		public IRichCommand ClearSelection => commands[CommandCodes.ClearSelection];
@@ -253,6 +254,7 @@ namespace Files.App.Data.Commands
 			[CommandCodes.ToggleDetailsPane] = new ToggleDetailsPaneAction(),
 			[CommandCodes.ToggleInfoPane] = new ToggleInfoPaneAction(),
 			[CommandCodes.ToggleToolbar] = new ToggleToolbarAction(),
+			[CommandCodes.ToggleSidebar] = new ToggleSidebarAction(),
 			[CommandCodes.SelectAll] = new SelectAllAction(),
 			[CommandCodes.InvertSelection] = new InvertSelectionAction(),
 			[CommandCodes.ClearSelection] = new ClearSelectionAction(),

--- a/src/Files.App/Data/Commands/Manager/ICommandManager.cs
+++ b/src/Files.App/Data/Commands/Manager/ICommandManager.cs
@@ -31,6 +31,7 @@ namespace Files.App.Data.Commands
 		IRichCommand ToggleDetailsPane { get; }
 		IRichCommand ToggleInfoPane { get; }
 		IRichCommand ToggleToolbar { get; }
+		IRichCommand ToggleSidebar { get; }
 
 		IRichCommand CopyItem { get; }
 		IRichCommand CopyItemPath { get; }

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -1091,6 +1091,9 @@
   <data name="ToggleToolbar" xml:space="preserve">
     <value>Toggle the Toolbar</value>
   </data>
+  <data name="ToggleSidebar" xml:space="preserve">
+    <value>Toggle the Sidebar</value>
+  </data>
   <data name="DetailsPanePreviewNotAvaliableText" xml:space="preserve">
     <value>No preview available</value>
   </data>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -1091,9 +1091,6 @@
   <data name="ToggleToolbar" xml:space="preserve">
     <value>Toggle the Toolbar</value>
   </data>
-  <data name="ToggleSidebar" xml:space="preserve">
-    <value>Toggle the Sidebar</value>
-  </data>
   <data name="DetailsPanePreviewNotAvaliableText" xml:space="preserve">
     <value>No preview available</value>
   </data>


### PR DESCRIPTION
Added a `ToggleSidebar` action, imitating 4af2d59 as a template.  

**Resolved / Related Issues**  

- Closes #16005  

**Steps used to test these changes**  

1. Launch Files.  
2. Take visual note of the sidebar, its size, presentation and border.  
3. Press `[Ctrl]+[Alt]+[S]` as the default keybinding for ToggleSidebar.  
4. Observe the sidebar and note if it has either collapsed or expanded.  
5. Repeat the keyboard input as in №3.  
6. Observe the sidebar and note if the opposite of №4 occured.  
7. Finally, repeat the input from №3 a third time to confirm that the toggle state machine survives a full loop onwards.  
8. Additionally, you may try to unbind the ToggleSidebar action and rebind it to another keyboard input to repeat the test with a non-default input.  
9. Could also test calling from the command palette (`[Ctrl]+[Shift]+[P]`).

---

Not quite seeing how I could test this myself yet. Assuming that having imitated an equivalent commit closely should make this a relatively straightforward contribution nevertheless.  

As for the callback contents, it seemed like there's three ways of doing this — through:
- Ad-hoc proxy to `SidebarResizer_DoubleTapped`. Was my initial plan.
  - <https://github.com/files-community/Files/blob/39df64d692a83f01eb69dab96dc261a3d0bc9976/src/Files.App/UserControls/Sidebar/SidebarView.xaml.cs#L193>
- `SidebarDisplayMode.Expanded`/`SidebarDisplayMode.Compact`. Seemed abstracted away.
  - <https://github.com/files-community/Files/blob/39df64d692a83f01eb69dab96dc261a3d0bc9976/src/Files.App/UserControls/Sidebar/SidebarDisplayMode.cs#L9>
- `AppearanceSettingsService.IsSidebarOpen`. Gone with this one.
  - <https://github.com/files-community/Files/blob/39df64d692a83f01eb69dab96dc261a3d0bc9976/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs#L125>

Used the latter for this PR to closely match the reference commit.
