### PR TITLE
Code Quality: Fixed a GC hole in the network connection dialog

### DIFF
--- a/src/Files.App/Data/Contracts/ICommonDialogService.cs
+++ b/src/Files.App/Data/Contracts/ICommonDialogService.cs
@@ -43,6 +43,6 @@ namespace Files.App.Data.Contracts
 		/// <param name="remoteNetworkName">The name of the remote network.</param>
 		/// <param name="useMostRecentPath">The value indicating whether to enter the most recently used paths into the combination box.</param>
 		/// <returns>True if the 'OK' button was clicked; otherwise, false.</returns>
-		bool Open_NetworkConnectionDialog(nint hWind, bool hideRestoreConnectionCheckBox = false, bool persistConnectionAtLogon = false, bool readOnlyPath = false, string? remoteNetworkName = null, bool useMostRecentPath = false);
+		bool Open_NetworkConnectionDialog(nint hWnd, bool hideRestoreConnectionCheckBox = false, bool persistConnectionAtLogon = false, bool readOnlyPath = false, string? remoteNetworkName = null, bool useMostRecentPath = false);
 	}
 }


### PR DESCRIPTION
### Resolved / Related Issues

- Fixed GC hole
- Fixed an issue where it throws an exception even though the method returns NO_ERROR (0).

### Steps used to test these changes

1. Open the connection dialog
2. Close it