### PR TITLE
Feature: Naming a shortcut while creating it

### DIFF
--- a/src/Files.App/Dialogs/CreateShortcutDialog.xaml
+++ b/src/Files.App/Dialogs/CreateShortcutDialog.xaml
@@ -81,7 +81,6 @@
 				Grid.Row="4"
 				Grid.ColumnSpan="2"
 				HorizontalAlignment="Stretch"
-				IsEnabled="{x:Bind ViewModel.IsLocationValid, Mode=OneWay}"
 				Text="{x:Bind ViewModel.ShortcutName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
 				<TextBox.Resources>
 					<TeachingTip

--- a/src/Files.App/Dialogs/CreateShortcutDialog.xaml
+++ b/src/Files.App/Dialogs/CreateShortcutDialog.xaml
@@ -9,7 +9,7 @@
 	Title="{helpers:ResourceString Name=NewShortcutDialogTitle}"
 	DefaultButton="Primary"
 	HighContrastAdjustment="None"
-	IsPrimaryButtonEnabled="{x:Bind ViewModel.IsLocationValid, Mode=OneWay}"
+	IsPrimaryButtonEnabled="{x:Bind ViewModel.IsShortcutValid, Mode=OneWay}"
 	PrimaryButtonCommand="{x:Bind ViewModel.PrimaryButtonCommand}"
 	PrimaryButtonText="{helpers:ResourceString Name=Create}"
 	RequestedTheme="{x:Bind RootAppElement.RequestedTheme, Mode=OneWay}"
@@ -27,6 +27,8 @@
 				<ColumnDefinition Width="Auto" />
 			</Grid.ColumnDefinitions>
 			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
@@ -68,6 +70,27 @@
 				Command="{x:Bind ViewModel.SelectDestinationCommand}"
 				Content="{helpers:ResourceString Name=Browse}" />
 
+			<TextBlock
+				Grid.Row="3"
+				Grid.ColumnSpan="2"
+				Text="{helpers:ResourceString Name=EnterAnItemName}" />
+
+			<!--  Name Box  -->
+			<TextBox
+				x:Name="ShortcutName"
+				Grid.Row="4"
+				Grid.ColumnSpan="2"
+				HorizontalAlignment="Stretch"
+				IsEnabled="{x:Bind ViewModel.IsLocationValid, Mode=OneWay}"
+				Text="{x:Bind ViewModel.ShortcutName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+				<TextBox.Resources>
+					<TeachingTip
+						x:Name="InvalidNameWarning"
+						Title="{helpers:ResourceString Name=InvalidFilename/Text}"
+						IsOpen="{x:Bind ViewModel.ShowNameWarningTip, Mode=OneWay}"
+						PreferredPlacement="Bottom" />
+				</TextBox.Resources>
+			</TextBox>
 		</Grid>
 	</Border>
 </ContentDialog>

--- a/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/CreateShortcutDialogViewModel.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Input;
-using Windows.Storage.Pickers;
 using Files.Shared.Helpers;
 
 namespace Files.App.ViewModels.Dialogs
@@ -35,6 +34,20 @@ namespace Files.App.ViewModels.Dialogs
 
 		// Previous path of the destination item
 		private string _previousShortcutTargetPath;
+
+		private string _shortcutName;
+		public string ShortcutName
+		{
+			get => _shortcutName; 
+			set
+			{
+				if (SetProperty(ref _shortcutName, value))
+				{
+					OnPropertyChanged(nameof(ShowNameWarningTip));
+					OnPropertyChanged(nameof(IsShortcutValid));
+				}
+			}
+		}
 
 		// Destination of the shortcut chosen by the user (can be a path, a command or a URL)
 		private string _shortcutTarget;
@@ -167,6 +180,10 @@ namespace Files.App.ViewModels.Dialogs
 					Arguments = string.Empty;
 					_previousShortcutTargetPath = string.Empty;
 				}
+				finally
+				{
+					SetDefaultName();
+				}
 			}
 		}
 
@@ -178,11 +195,18 @@ namespace Files.App.ViewModels.Dialogs
 			set
 			{
 				if (SetProperty(ref _isLocationValid, value))
+				{ 
 					OnPropertyChanged(nameof(ShowWarningTip));
+					OnPropertyChanged(nameof(IsShortcutValid));
+				}
 			}
 		}
 
 		public bool ShowWarningTip => !string.IsNullOrEmpty(ShortcutTarget) && !_isLocationValid;
+
+		public bool ShowNameWarningTip => !string.IsNullOrEmpty(_shortcutTarget) && !FilesystemHelpers.IsValidForFilename(_shortcutName);
+
+		public bool IsShortcutValid => _isLocationValid && !ShowNameWarningTip && !string.IsNullOrEmpty(_shortcutTarget);
 
 		// Command invoked when the user clicks the 'Browse' button
 		public ICommand SelectDestinationCommand { get; private set; }
@@ -225,31 +249,9 @@ namespace Files.App.ViewModels.Dialogs
 
 		private async Task CreateShortcutAsync()
 		{
-			string? destinationName;
 			var extension = DestinationPathExists ? ".lnk" : ".url";
 
-			if (DestinationPathExists)
-			{
-				destinationName = Path.GetFileName(FullPath);
-
-				if(string.IsNullOrEmpty(FullPath))
-				{
-					
-					var destinationPath = FullPath.Replace('/', '\\');
-
-					if (destinationPath.EndsWith('\\'))
-						destinationPath = destinationPath.Substring(0, destinationPath.Length - 1);
-
-					destinationName = destinationPath.Substring(destinationPath.LastIndexOf('\\') + 1);
-				}
-			}
-			else
-			{
-				var uri = new Uri(FullPath);
-				destinationName = uri.Host;
-			}
-
-			var shortcutName = FilesystemHelpers.GetShortcutNamingPreference(destinationName);
+			var shortcutName = FilesystemHelpers.GetShortcutNamingPreference(_shortcutName);
 			ShortcutCompleteName = shortcutName + extension;
 			var filePath = Path.Combine(WorkingDirectory, ShortcutCompleteName);
 
@@ -261,6 +263,35 @@ namespace Files.App.ViewModels.Dialogs
 			}
 
 			ShortcutCreatedSuccessfully = await FileOperationsHelpers.CreateOrUpdateLinkAsync(filePath, FullPath, Arguments);
+		}
+
+		private void SetDefaultName()
+		{
+			if (DestinationPathExists)
+			{
+				var destinationName = Path.GetFileName(FullPath);
+				if (DestinationPathExists)
+				{
+					destinationName = Path.GetFileName(FullPath);
+
+					if (string.IsNullOrEmpty(FullPath))
+					{
+
+						var destinationPath = FullPath.Replace('/', '\\');
+
+						if (destinationPath.EndsWith('\\'))
+							destinationPath = destinationPath.Substring(0, destinationPath.Length - 1);
+
+						destinationName = destinationPath.Substring(destinationPath.LastIndexOf('\\') + 1);
+					}
+				}
+				ShortcutName = destinationName;
+			}
+			else
+			{
+				var uri = new Uri(FullPath);
+				ShortcutName = uri.Host;
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16387 

**Steps used to test these changes**
1. Click on `New`
2. Click on `Shortcut`
3. Try to break the modal

**Notes**
At the moment the `Name` is updated whenever the destination path changes.
> Or alternatively, we only auto fill the name if the field is empty.

I think this may not work as expected: 
let's say a user selects `SomePath/FileA`, then the name will be set to `File_A`. If now the destination is changed to `SomePath/File_B`, the name should not be updated according to above (because the field would not be empty).

![Screenshot 2024-11-21 214958](https://github.com/user-attachments/assets/f14e2266-2f10-4e2c-9b52-ef2138ccb675)
