### PR TITLE
Feature: Improved behavior when dragging items from an unfocused Files window

### DIFF
--- a/src/Files.App.CsWin32/Windows.Win32.Extras.cs
+++ b/src/Files.App.CsWin32/Windows.Win32.Extras.cs
@@ -16,5 +16,51 @@ namespace Windows.Win32
 	{
 		[UnmanagedFunctionPointer(CallingConvention.Winapi)]
 		public delegate LRESULT WNDPROC(HWND hWnd, uint msg, WPARAM wParam, LPARAM lParam);
+
+		/// <summary>Contains information about the size and position of a window.</summary>
+		/// <remarks>
+		/// <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-windowpos">Learn more about this API from docs.microsoft.com</see>.</para>
+		/// </remarks>
+		public partial struct WINDOWPOS
+		{
+			/// <summary>
+			/// <para>Type: <b>HWND</b> A handle to the window.</para>
+			/// <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-windowpos#members">Read more on docs.microsoft.com</see>.</para>
+			/// </summary>
+			internal HWND hwnd;
+
+			/// <summary>
+			/// <para>Type: <b>HWND</b> The position of the window in Z order (front-to-back position). This member can be a handle to the window behind which this window is placed, or can be one of the special values listed with the <a href="https://docs.microsoft.com/windows/desktop/api/winuser/nf-winuser-setwindowpos">SetWindowPos</a> function.</para>
+			/// <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-windowpos#members">Read more on docs.microsoft.com</see>.</para>
+			/// </summary>
+			internal HWND hwndInsertAfter;
+
+			/// <summary>
+			/// <para>Type: <b>int</b> The position of the left edge of the window.</para>
+			/// <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-windowpos#members">Read more on docs.microsoft.com</see>.</para>
+			/// </summary>
+			internal int x;
+
+			/// <summary>
+			/// <para>Type: <b>int</b> The position of the top edge of the window.</para>
+			/// <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-windowpos#members">Read more on docs.microsoft.com</see>.</para>
+			/// </summary>
+			internal int y;
+
+			/// <summary>
+			/// <para>Type: <b>int</b> The window width, in pixels.</para>
+			/// <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-windowpos#members">Read more on docs.microsoft.com</see>.</para>
+			/// </summary>
+			internal int cx;
+
+			/// <summary>
+			/// <para>Type: <b>int</b> The window height, in pixels.</para>
+			/// <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-windowpos#members">Read more on docs.microsoft.com</see>.</para>
+			/// </summary>
+			internal int cy;
+
+			/// <summary>Type: <b>UINT</b></summary>
+			public SET_WINDOW_POS_FLAGS flags;
+		}
 	}
 }

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -157,8 +157,6 @@ namespace Files.App
 				}
 
 				await AppLifecycleHelper.InitializeAppComponentsAsync();
-
-				MainWindow.Instance.HookWindowMessageReceivedEvent();
 			}
 		}
 
@@ -198,9 +196,6 @@ namespace Files.App
 		/// </remarks>
 		private async void Window_Closed(object sender, WindowEventArgs args)
 		{
-			// Unhook events for the window
-			MainWindow.Instance.UnhookWindowMessageReceivedEvent();
-
 			// Save application state and stop any background activity
 			IUserSettingsService userSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
 			StatusCenterViewModel statusCenterViewModel = Ioc.Default.GetRequiredService<StatusCenterViewModel>();

--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -157,6 +157,8 @@ namespace Files.App
 				}
 
 				await AppLifecycleHelper.InitializeAppComponentsAsync();
+
+				MainWindow.Instance.HookWindowMessageReceivedEvent();
 			}
 		}
 
@@ -196,6 +198,9 @@ namespace Files.App
 		/// </remarks>
 		private async void Window_Closed(object sender, WindowEventArgs args)
 		{
+			// Unhook events for the window
+			MainWindow.Instance.UnhookWindowMessageReceivedEvent();
+
 			// Save application state and stop any background activity
 			IUserSettingsService userSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
 			StatusCenterViewModel statusCenterViewModel = Ioc.Default.GetRequiredService<StatusCenterViewModel>();

--- a/src/Files.App/Helpers/Win32/Win32Helper.WindowManagement.cs
+++ b/src/Files.App/Helpers/Win32/Win32Helper.WindowManagement.cs
@@ -4,8 +4,10 @@
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Windows.Win32;
 using Windows.Win32.UI.WindowsAndMessaging;
+using static Vanara.PInvoke.User32;
 
 namespace Files.App.Helpers
 {
@@ -57,6 +59,17 @@ namespace Files.App.Helpers
 				uiElement,
 				[cursor]
 			);
+		}
+
+		/// <summary>
+		/// Force window to stay at bottom of other upper windows.
+		/// </summary>
+		/// <param name="lParam">The lParam of the message.</param>
+		public static void ForceWindowPosition(nint lParam)
+		{
+			var windowPos = Marshal.PtrToStructure<WINDOWPOS>(lParam);
+			windowPos.flags |= SetWindowPosFlags.SWP_NOZORDER;
+			Marshal.StructureToPtr(windowPos, lParam, false);
 		}
 	}
 }

--- a/src/Files.App/Helpers/Win32/Win32Helper.WindowManagement.cs
+++ b/src/Files.App/Helpers/Win32/Win32Helper.WindowManagement.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using Windows.Win32;
 using Windows.Win32.UI.WindowsAndMessaging;
-using static Vanara.PInvoke.User32;
 
 namespace Files.App.Helpers
 {
@@ -68,7 +67,7 @@ namespace Files.App.Helpers
 		public static void ForceWindowPosition(nint lParam)
 		{
 			var windowPos = Marshal.PtrToStructure<WINDOWPOS>(lParam);
-			windowPos.flags |= SetWindowPosFlags.SWP_NOZORDER;
+			windowPos.flags |= SET_WINDOW_POS_FLAGS.SWP_NOZORDER;
 			Marshal.StructureToPtr(windowPos, lParam, false);
 		}
 	}

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -36,6 +36,8 @@ namespace Files.App
 			AppWindow.TitleBar.ButtonPressedBackgroundColor = Colors.Transparent;
 			AppWindow.TitleBar.ButtonHoverBackgroundColor = Colors.Transparent;
 			AppWindow.SetIcon(AppLifecycleHelper.AppIconPath);
+
+			WinUIEx.WindowManager.Get(this).WindowMessageReceived += WindowManager_WindowMessageReceived;
 		}
 
 		public void ShowSplashScreen()
@@ -349,16 +351,6 @@ namespace Files.App
 				return true;
 			}
 			return false;
-		}
-
-		public void HookWindowMessageReceivedEvent()
-		{
-			WinUIEx.WindowManager.Get(this).WindowMessageReceived += WindowManager_WindowMessageReceived;
-		}
-
-		public void UnhookWindowMessageReceivedEvent()
-		{
-			WinUIEx.WindowManager.Get(this).WindowMessageReceived -= WindowManager_WindowMessageReceived;
 		}
 
 		private const int WM_WINDOWPOSCHANGING = 0x0046;

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -351,11 +351,6 @@ namespace Files.App
 			return false;
 		}
 
-		public void BringToFrontEx()
-		{
-			Win32Helper.BringToForegroundEx(new(WindowHandle));
-		}
-
 		public void HookWindowMessageReceivedEvent()
 		{
 			WinUIEx.WindowManager.Get(this).WindowMessageReceived += WindowManager_WindowMessageReceived;

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -344,18 +344,18 @@ namespace Files.App
 			}
 		}
 
-        public bool SetCanWindowToFront(bool canWindowToFront)
-        {
-            lock (_canWindowToFrontLock)
-            {
-                if (CanWindowToFront != canWindowToFront)
-                {
-                    CanWindowToFront = canWindowToFront;
-                    return true;
-                }
-                return false;
-            }
-        }
+		public bool SetCanWindowToFront(bool canWindowToFront)
+		{
+			lock (_canWindowToFrontLock)
+			{
+				if (CanWindowToFront != canWindowToFront)
+				{
+					CanWindowToFront = canWindowToFront;
+					return true;
+				}
+				return false;
+			}
+		}
 
 		private const int WM_WINDOWPOSCHANGING = 0x0046;
 		private void WindowManager_WindowMessageReceived(object? sender, WinUIEx.Messaging.WindowMessageEventArgs e)

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ namespace Files.App
 
 		public nint WindowHandle { get; }
 		private bool CanWindowToFront { get; set; } = true;
+		private readonly object _canWindowToFrontLock = new();
 
 		public MainWindow()
 		{
@@ -343,15 +344,18 @@ namespace Files.App
 			}
 		}
 
-		public bool SetCanWindowToFront(bool canWindowToFront)
-		{
-			if (CanWindowToFront != canWindowToFront)
-			{
-				CanWindowToFront = canWindowToFront;
-				return true;
-			}
-			return false;
-		}
+        public bool SetCanWindowToFront(bool canWindowToFront)
+        {
+            lock (_canWindowToFrontLock)
+            {
+                if (CanWindowToFront != canWindowToFront)
+                {
+                    CanWindowToFront = canWindowToFront;
+                    return true;
+                }
+                return false;
+            }
+        }
 
 		private const int WM_WINDOWPOSCHANGING = 0x0046;
 		private void WindowManager_WindowMessageReceived(object? sender, WinUIEx.Messaging.WindowMessageEventArgs e)

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -36,8 +36,6 @@ namespace Files.App
 			AppWindow.TitleBar.ButtonPressedBackgroundColor = Colors.Transparent;
 			AppWindow.TitleBar.ButtonHoverBackgroundColor = Colors.Transparent;
 			AppWindow.SetIcon(AppLifecycleHelper.AppIconPath);
-
-			WinUIEx.WindowManager.Get(this).WindowMessageReceived += WindowManager_WindowMessageReceived;
 		}
 
 		public void ShowSplashScreen()
@@ -356,6 +354,16 @@ namespace Files.App
 		public void BringToFrontEx()
 		{
 			Win32Helper.BringToForegroundEx(new(WindowHandle));
+		}
+
+		public void HookWindowMessageReceivedEvent()
+		{
+			WinUIEx.WindowManager.Get(this).WindowMessageReceived += WindowManager_WindowMessageReceived;
+		}
+
+		public void UnhookWindowMessageReceivedEvent()
+		{
+			WinUIEx.WindowManager.Get(this).WindowMessageReceived -= WindowManager_WindowMessageReceived;
 		}
 
 		private const int WM_WINDOWPOSCHANGING = 0x0046;

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -356,13 +356,10 @@ namespace Files.App
 		private const int WM_WINDOWPOSCHANGING = 0x0046;
 		private void WindowManager_WindowMessageReceived(object? sender, WinUIEx.Messaging.WindowMessageEventArgs e)
 		{
-			if (!CanWindowToFront)
+			if ((!CanWindowToFront) && e.Message.MessageId == WM_WINDOWPOSCHANGING)
 			{
-				if (e.Message.MessageId == WM_WINDOWPOSCHANGING)
-				{
-					Win32Helper.ForceWindowPosition(e.Message.LParam);
-					e.Handled = true;
-				}
+				Win32Helper.ForceWindowPosition(e.Message.LParam);
+				e.Handled = true;
 			}
 		}
 	}

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1310,7 +1310,7 @@ namespace Files.App.Views.Layouts
 				// No need to bring the window to the front again
 				if (MainWindow.Instance.SetCanWindowToFront(true))
 				{
-					MainWindow.Instance.BringToFrontEx();
+					Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
 				}
 			}
 		}
@@ -1322,7 +1322,7 @@ namespace Files.App.Views.Layouts
 				// No need to bring the window to the front again
 				if (MainWindow.Instance.SetCanWindowToFront(true))
 				{
-					MainWindow.Instance.BringToFrontEx();
+					Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
 				}
 			}
 		}
@@ -1332,7 +1332,8 @@ namespace Files.App.Views.Layouts
 			if (!itemDragging)
 			{
 				MainWindow.Instance.SetCanWindowToFront(true);
-				MainWindow.Instance.BringToFrontEx();
+				// Bring the window to the front agin
+				Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
 			}
 
 			var rightClickedItem = GetItemFromElement(sender);

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1216,14 +1216,9 @@ namespace Files.App.Views.Layouts
 
 		protected internal void FileListItem_PointerPressed(object sender, PointerRoutedEventArgs e)
 		{
-			if (!itemDragging)
-			{
-				// No need to bring the window to the front again
-				if (MainWindow.Instance.SetCanWindowToFront(true))
-				{
-					Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
-				}
-			}
+			// Set can window to front and bring the window to the front if necessary
+			if ((!itemDragging) && MainWindow.Instance.SetCanWindowToFront(true))
+				Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
 
 			if (sender is not SelectorItem selectorItem)
 				return;
@@ -1250,6 +1245,7 @@ namespace Files.App.Views.Layouts
 
 		protected internal void FileListItem_PointerEntered(object sender, PointerRoutedEventArgs e)
 		{
+			// Set can window to front before the item is dragged
 			if (sender is SelectorItem selectorItem && selectorItem.IsSelected)
 				MainWindow.Instance.SetCanWindowToFront(false);
 
@@ -1299,9 +1295,9 @@ namespace Files.App.Views.Layouts
 
 		protected internal void FileListItem_PointerExited(object sender, PointerRoutedEventArgs e)
 		{
+			// Set can window to front
 			if (!itemDragging)
 				MainWindow.Instance.SetCanWindowToFront(true);
-				// No need to bring the window to the front
 
 			if (!UserSettingsService.FoldersSettingsService.SelectFilesOnHover)
 				return;
@@ -1312,38 +1308,23 @@ namespace Files.App.Views.Layouts
 
 		protected void FileListItem_Tapped(object sender, TappedRoutedEventArgs e)
 		{
-			if (!itemDragging)
-			{
-				// No need to bring the window to the front again
-				if (MainWindow.Instance.SetCanWindowToFront(true))
-				{
-					Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
-				}
-			}
+			// Set can window to front and bring the window to the front if necessary
+			if ((!itemDragging) && MainWindow.Instance.SetCanWindowToFront(true))
+				Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
 		}
 
 		protected void FileListItem_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
 		{
-			if (!itemDragging)
-			{
-				// No need to bring the window to the front again
-				if (MainWindow.Instance.SetCanWindowToFront(true))
-				{
-					Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
-				}
-			}
+			// Set can window to front and bring the window to the front if necessary
+			if ((!itemDragging) && MainWindow.Instance.SetCanWindowToFront(true))
+				Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
 		}
 
 		protected void FileListItem_RightTapped(object sender, RightTappedRoutedEventArgs e)
 		{
-			if (!itemDragging)
-			{
-				// No need to bring the window to the front again
-				if (MainWindow.Instance.SetCanWindowToFront(true))
-				{
-					Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
-				}
-			}
+			// Set can window to front and bring the window to the front if necessary
+			if ((!itemDragging) && MainWindow.Instance.SetCanWindowToFront(true))
+				Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
 
 			var rightClickedItem = GetItemFromElement(sender);
 

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1027,6 +1027,7 @@ namespace Files.App.Views.Layouts
 		{
 			itemDragging = false;
 			MainWindow.Instance.SetCanWindowToFront(true);
+			// No need to bring the window to the front
 		}
 
 		private void Item_DragLeave(object sender, DragEventArgs e)
@@ -1158,8 +1159,9 @@ namespace Files.App.Views.Layouts
 			RefreshContainer(args.ItemContainer, args.InRecycleQueue);
 			RefreshItem(args.ItemContainer, args.Item, args.InRecycleQueue, args);
 
-			MainWindow.Instance.SetCanWindowToFront(true);
 			itemDragging = false;
+			MainWindow.Instance.SetCanWindowToFront(true);
+			// No need to bring the window to the front
 		}
 
 		private void RefreshContainer(SelectorItem container, bool inRecycleQueue)
@@ -1215,7 +1217,13 @@ namespace Files.App.Views.Layouts
 		protected internal void FileListItem_PointerPressed(object sender, PointerRoutedEventArgs e)
 		{
 			if (!itemDragging)
-				MainWindow.Instance.SetCanWindowToFront(true);
+			{
+				// No need to bring the window to the front again
+				if (MainWindow.Instance.SetCanWindowToFront(true))
+				{
+					Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
+				}
+			}
 
 			if (sender is not SelectorItem selectorItem)
 				return;
@@ -1243,9 +1251,7 @@ namespace Files.App.Views.Layouts
 		protected internal void FileListItem_PointerEntered(object sender, PointerRoutedEventArgs e)
 		{
 			if (sender is SelectorItem selectorItem && selectorItem.IsSelected)
-			{
 				MainWindow.Instance.SetCanWindowToFront(false);
-			}
 
 			if (!UserSettingsService.FoldersSettingsService.SelectFilesOnHover)
 				return;
@@ -1295,6 +1301,7 @@ namespace Files.App.Views.Layouts
 		{
 			if (!itemDragging)
 				MainWindow.Instance.SetCanWindowToFront(true);
+				// No need to bring the window to the front
 
 			if (!UserSettingsService.FoldersSettingsService.SelectFilesOnHover)
 				return;
@@ -1331,9 +1338,11 @@ namespace Files.App.Views.Layouts
 		{
 			if (!itemDragging)
 			{
-				MainWindow.Instance.SetCanWindowToFront(true);
-				// Bring the window to the front agin
-				Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
+				// No need to bring the window to the front again
+				if (MainWindow.Instance.SetCanWindowToFront(true))
+				{
+					Win32Helper.BringToForegroundEx(new(MainWindow.Instance.WindowHandle));
+				}
 			}
 
 			var rightClickedItem = GetItemFromElement(sender);

--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml
@@ -183,6 +183,7 @@
 					CanDragItems="{x:Bind AllowItemDrag, Mode=OneWay}"
 					ContainerContentChanging="FileList_ContainerContentChanging"
 					DoubleTapped="FileList_DoubleTapped"
+					DragItemsCompleted="FileList_DragItemsCompleted"
 					DragItemsStarting="FileList_DragItemsStarting"
 					DragOver="ItemsLayout_DragOver"
 					Drop="ItemsLayout_Drop"

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml
@@ -229,6 +229,7 @@
 					CanDragItems="{x:Bind AllowItemDrag, Mode=OneWay}"
 					ContainerContentChanging="FileList_ContainerContentChanging"
 					DoubleTapped="FileList_DoubleTapped"
+					DragItemsCompleted="FileList_DragItemsCompleted"
 					DragItemsStarting="FileList_DragItemsStarting"
 					DragOver="ItemsLayout_DragOver"
 					Drop="ItemsLayout_Drop"

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml
@@ -787,6 +787,7 @@
 					ContainerContentChanging="FileList_ContainerContentChanging"
 					DoubleTapped="FileList_DoubleTapped"
 					DragEnter="ItemsLayout_DragEnter"
+					DragItemsCompleted="FileList_DragItemsCompleted"
 					DragItemsStarting="FileList_DragItemsStarting"
 					DragLeave="ItemsLayout_DragLeave"
 					DragOver="ItemsLayout_DragOver"


### PR DESCRIPTION
**Resolved / Related Issues**

- Added support for not focusing Files window when dragging a file/folder
- Closes #13255

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files and File Explorer.
2. Select files in Files.
3. Move File Explorer on the top, which is topper than Files. Make sure it doesn't cover Files so that you can drag files from Files.
4. Drag the selected files to the File Explorer. And you can find the Files won't move to the top when dragging files.
