### PR TITLE
Feature: Refresh Details Layout Columns after changing setting

### DIFF
--- a/src/Files.App/Helpers/Layout/LayoutPreferencesItem.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesItem.cs
@@ -16,6 +16,8 @@ namespace Files.App.Helpers
 
 		public ColumnsViewModel ColumnsViewModel { get; set; }
 
+		public bool IsDefault { get; set; } = true;
+
 		public bool SortDirectoriesAlongsideFiles { get; set; }
 		public bool SortFilesFirst { get; set; }
 		public bool IsAdaptiveLayoutOverridden { get; set; }

--- a/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
+++ b/src/Files.App/Helpers/Layout/LayoutPreferencesManager.cs
@@ -583,6 +583,7 @@ namespace Files.App.Helpers
 			if (string.IsNullOrEmpty(path))
 				return false;
 
+			preferencesItem.IsDefault = false;
 			return SafetyExtensions.IgnoreExceptions(() =>
 			{
 				var dbInstance = GetDatabaseManagerInstance();

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -206,6 +206,32 @@ namespace Files.App.Views.Layouts
 				// Restore correct scroll position
 				ContentScroller?.ChangeView(null, previousOffset, null);
 			}
+			else
+			{
+				var settings = sender as ILayoutSettingsService;
+				if (settings is not null && 
+					(settings.SyncFolderPreferencesAcrossDirectories || (FolderSettings?.LayoutPreferencesItem.IsDefault ?? false)))
+				{
+					switch (e.PropertyName)
+					{
+						case nameof(ILayoutSettingsService.ShowFileTagColumn):
+							ColumnsViewModel.TagColumn.UserCollapsed = !settings.ShowFileTagColumn;
+							break;
+						case nameof(ILayoutSettingsService.ShowSizeColumn):
+							ColumnsViewModel.SizeColumn.UserCollapsed = !settings.ShowSizeColumn;
+							break;
+						case nameof(ILayoutSettingsService.ShowTypeColumn):
+							ColumnsViewModel.ItemTypeColumn.UserCollapsed = !settings.ShowTypeColumn;
+							break;
+						case nameof(ILayoutSettingsService.ShowDateCreatedColumn):
+							ColumnsViewModel.DateCreatedColumn.UserCollapsed = !settings.ShowDateCreatedColumn;
+							break;
+						case nameof(ILayoutSettingsService.ShowDateColumn):
+							ColumnsViewModel.DateModifiedColumn.UserCollapsed = !settings.ShowDateColumn;
+							break;
+					}
+				}
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #13747 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open some tabs (2 or 3 should be enough), each using `Details View`
2. Navigate between folders to build up a back stack
3. Open `Settings/Layout/Details View/Columns`
4. Enable `Sync layout ...`
5. Toggle some columns
6. Check if the layout has been updated in each tab
7. Navigate back/forward to ensure the new layout is being applied
8. Repeat `3 -> 6` as many times as you want
9. Check that the layout is updated even if `Sync layout ...` is disabled but current tab is using the default layout