### PR TITLE
Feature: Removed expander from calculate folder size setting

### DIFF
--- a/src/Files.App/Views/Settings/FoldersPage.xaml
+++ b/src/Files.App/Views/Settings/FoldersPage.xaml
@@ -228,7 +228,6 @@
 					Style="{StaticResource RightAlignedToggleSwitchStyle}" />
 			</local:SettingsBlockControl>
 			<InfoBar
-				CornerRadius="0,0,2,2"
 				IsClosable="False"
 				IsIconVisible="True"
 				IsOpen="True"

--- a/src/Files.App/Views/Settings/FoldersPage.xaml
+++ b/src/Files.App/Views/Settings/FoldersPage.xaml
@@ -226,16 +226,14 @@
 					AutomationProperties.Name="{helpers:ResourceString Name=CalculateFolderSizes}"
 					IsOn="{x:Bind ViewModel.CalculateFolderSizes, Mode=TwoWay}"
 					Style="{StaticResource RightAlignedToggleSwitchStyle}" />
-				<local:SettingsBlockControl.ExpandableContent>
-					<InfoBar
-						CornerRadius="0,0,2,2"
-						IsClosable="False"
-						IsIconVisible="True"
-						IsOpen="True"
-						Message="{helpers:ResourceString Name=ShowFolderSizesWarning}"
-						Severity="Warning" />
-				</local:SettingsBlockControl.ExpandableContent>
 			</local:SettingsBlockControl>
+			<InfoBar
+				CornerRadius="0,0,2,2"
+				IsClosable="False"
+				IsIconVisible="True"
+				IsOpen="True"
+				Message="{helpers:ResourceString Name=ShowFolderSizesWarning}"
+				Severity="Warning" />
 		</StackPanel>
 	</Grid>
 </Page>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Closes #16349

**Steps used to test these changes**

1. Opened Files
2. Opened Settings and navigated to folders page
3. Confirmed that info bar is not in expander
