### PR TITLE
Fix: Fixed an issue where tags would sometimes display with the wrong color

### DIFF
--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.Properties.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.Properties.cs
@@ -32,7 +32,7 @@ namespace Files.App.Controls
 		protected virtual void OnColorPropertyChanged(Brush oldValue, Brush newValue)
 		{
 			OnIconTypeChanged();
-			UpdateColor(newValue);
+			OnIconColorChanged(newValue);
 		}
 
 		protected virtual void OnIconTypePropertyChanged(ThemedIconTypes oldValue, ThemedIconTypes newValue)

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.Properties.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.Properties.cs
@@ -32,6 +32,7 @@ namespace Files.App.Controls
 		protected virtual void OnColorPropertyChanged(Brush oldValue, Brush newValue)
 		{
 			OnIconTypeChanged();
+			UpdateColor(newValue);
 		}
 
 		protected virtual void OnIconTypePropertyChanged(ThemedIconTypes oldValue, ThemedIconTypes newValue)

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.Properties.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.Properties.cs
@@ -32,7 +32,7 @@ namespace Files.App.Controls
 		protected virtual void OnColorPropertyChanged(Brush oldValue, Brush newValue)
 		{
 			OnIconTypeChanged();
-			OnIconColorChanged(newValue);
+			OnIconColorChanged();
 		}
 
 		protected virtual void OnIconTypePropertyChanged(ThemedIconTypes oldValue, ThemedIconTypes newValue)

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
@@ -240,5 +240,14 @@ namespace Files.App.Controls
 		{
 			UpdateVisualStates();
 		}
+
+		private void UpdateColor(Brush newColor)
+		{
+			if (GetTemplateChild(OutlineIconPath) is Path outlinePath)
+				outlinePath.Fill = newColor;
+
+			if (GetTemplateChild(FilledIconPath) is Path fillPath)
+				fillPath.Fill = newColor;
+		}
 	}
 }

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
@@ -241,13 +241,13 @@ namespace Files.App.Controls
 			UpdateVisualStates();
 		}
 
-		private void OnIconColorChanged(Brush newColor)
+		private void OnIconColorChanged()
 		{
 			if (GetTemplateChild(OutlineIconPath) is Path outlinePath)
-				outlinePath.Fill = newColor;
+				outlinePath.Fill = (Brush)this.GetValue(ColorProperty);
 
 			if (GetTemplateChild(FilledIconPath) is Path fillPath)
-				fillPath.Fill = newColor;
+				fillPath.Fill = (Brush)this.GetValue(ColorProperty);
 		}
 	}
 }

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
@@ -241,7 +241,7 @@ namespace Files.App.Controls
 			UpdateVisualStates();
 		}
 
-		private void UpdateColor(Brush newColor)
+		private void OnIconColorChanged(Brush newColor)
 		{
 			if (GetTemplateChild(OutlineIconPath) is Path outlinePath)
 				outlinePath.Fill = newColor;

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.xaml
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.xaml
@@ -150,8 +150,8 @@
 								</VisualState>
 								<VisualState x:Name="Custom">
 									<VisualState.Setters>
-										<Setter Target="PART_OutlinePath.Fill" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Color}" />
-										<Setter Target="PART_FilledPath.Fill" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Color}" />
+										<Setter Target="PART_OutlinePath.Fill" Value="{Binding Color, Mode=OneTime}" />
+										<Setter Target="PART_FilledPath.Fill" Value="{Binding Color, Mode=OneTime}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Toggle">

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.xaml
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.xaml
@@ -150,8 +150,8 @@
 								</VisualState>
 								<VisualState x:Name="Custom">
 									<VisualState.Setters>
-										<Setter Target="PART_OutlinePath.Fill" Value="{Binding Color, Mode=OneTime}" />
-										<Setter Target="PART_FilledPath.Fill" Value="{Binding Color, Mode=OneTime}" />
+										<Setter Target="PART_OutlinePath.Fill" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Color}" />
+										<Setter Target="PART_FilledPath.Fill" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Color}" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Toggle">


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16548 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open a folder containing some tagged items
2. Change sort order
3. Then, check that tag icons in the following controls are using the appropiate color : `Settings/Tags`, `Sidebar>Tags`, `Home>Tags Widget`, `Preview Pane`, `Right click context menu`

**Notes**
I changed the bindings (I think we may remove that `VisualState` - our `DependencyProperty` doesn't seem to be bindable).
I don't know if this is the appropriate way to address the issue