### PR TITLE
Fix: Resolved startup freeze issue caused by a heavily populated Recycle Bin

### DIFF
--- a/src/Files.App/Data/Items/LocationItem.cs
+++ b/src/Files.App/Data/Items/LocationItem.cs
@@ -128,7 +128,12 @@ namespace Files.App.Data.Items
 
 		public async void RefreshSpaceUsed(object? sender, FileSystemEventArgs e)
 		{
-			await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
+			await RefreshSpaceUsedAsync();
+		}
+
+		private Task RefreshSpaceUsedAsync()
+		{
+			return MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 			{
 				SpaceUsed = await Task.Run(() => StorageTrashBinService.GetSize());
 			});
@@ -155,7 +160,7 @@ namespace Files.App.Data.Items
 			StorageTrashBinService.Watcher.ItemAdded += RefreshSpaceUsed;
 			StorageTrashBinService.Watcher.ItemDeleted += RefreshSpaceUsed;
 
-			RefreshSpaceUsed(null, new(WatcherChangeTypes.Changed, "", null));
+			_ = RefreshSpaceUsedAsync();
 		}
 	}
 }

--- a/src/Files.App/Data/Items/LocationItem.cs
+++ b/src/Files.App/Data/Items/LocationItem.cs
@@ -128,9 +128,9 @@ namespace Files.App.Data.Items
 
 		public async void RefreshSpaceUsed(object? sender, FileSystemEventArgs e)
 		{
-			await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
+			await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
 			{
-				SpaceUsed = StorageTrashBinService.GetSize();
+				SpaceUsed = await Task.Run(() => StorageTrashBinService.GetSize());
 			});
 		}
 
@@ -152,10 +152,10 @@ namespace Files.App.Data.Items
 
 		public RecycleBinLocationItem()
 		{
-			SpaceUsed = StorageTrashBinService.GetSize();
-
 			StorageTrashBinService.Watcher.ItemAdded += RefreshSpaceUsed;
 			StorageTrashBinService.Watcher.ItemDeleted += RefreshSpaceUsed;
+
+			RefreshSpaceUsed(null, new(WatcherChangeTypes.Changed, "", null));
 		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #14108

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

- Unpin Recycle Bin from the sidebar
- Create 25,000 blank text files from cmd line
- Delete all of the files via File Explorer
- Go back to Files and delete a single file, verify that the app does NOT stop responding
- Pin Recycle Bin to the sidebar again and restart Files and verify that the app does NOT stop responding
