### PR TITLE
Fix: Fixed issues with drag & drop to other applications

### DIFF
--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -22,6 +22,7 @@ using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Storage;
 using Windows.System;
+using WinRT;
 using static Files.App.Helpers.PathNormalization;
 using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
 using SortDirection = Files.App.Data.Enums.SortDirection;
@@ -999,13 +1000,8 @@ namespace Files.App.Views.Layouts
 				{
 					var iddo = shellItemList[0].Parent.GetChildrenUIObjects<IDataObject>(HWND.NULL, shellItemList);
 					shellItemList.ForEach(x => x.Dispose());
-
-					var format = System.Windows.Forms.DataFormats.GetFormat("Shell IDList Array");
-					if (iddo.TryGetData<byte[]>((uint)format.Id, out var data))
-					{
-						var mem = new MemoryStream(data).AsRandomAccessStream();
-						e.Data.SetData(format.Name, mem);
-					}
+					var dataObjectProvider = e.Data.As<Shell32.IDataObjectProvider>();
+					dataObjectProvider.SetDataObject(iddo);
 				}
 				else
 				{


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15564 
- Closes #16618 
- Related: #11735

This should help with drag&drop compatibility.
MPC, PowerDirector, XShell, Corel Photo-Paint, Phone Link, Visual Studio, WhatsApp, Unigram, Wordpad, Edge: OK
Notepad, Notepad++: not ok (OK when dropping outside text area)

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Drag & drop file from Files to MPC or PowerDirector 365
