### PR TITLE
Fix: Fixed keyboard navigation in the address path bar

### DIFF
--- a/src/Files.App/UserControls/AddressToolbar.xaml
+++ b/src/Files.App/UserControls/AddressToolbar.xaml
@@ -428,6 +428,7 @@
 				BorderBrush="{ThemeResource ControlElevationBorderBrush}"
 				BorderThickness="1"
 				CornerRadius="{StaticResource ControlCornerRadius}"
+				GettingFocus="ClickablePath_GettingFocus"
 				PointerPressed="ManualPathEntryItem_Click"
 				Visibility="{x:Bind converters:MultiBooleanConverter.OrNotConvertToVisibility(ShowSearchBox, ViewModel.IsSearchBoxVisible), Mode=OneWay}">
 				<Grid.ColumnDefinitions>

--- a/src/Files.App/UserControls/AddressToolbar.xaml.cs
+++ b/src/Files.App/UserControls/AddressToolbar.xaml.cs
@@ -73,10 +73,18 @@ namespace Files.App.UserControls
 			ViewModel.IsEditModeEnabled = true;
 		}
 
-		private void VisiblePath_KeyDown(object _, KeyRoutedEventArgs e)
+		private async void VisiblePath_KeyDown(object _, KeyRoutedEventArgs e)
 		{
 			if (e.Key is VirtualKey.Escape)
 				ViewModel.IsEditModeEnabled = false;
+
+			if (e.Key is VirtualKey.Tab)
+			{
+				ViewModel.IsEditModeEnabled = false;
+				// Delay to ensure clickable path is ready to be focused
+				await Task.Delay(10);
+				ClickablePath.Focus(FocusState.Keyboard);
+			}
 		}
 		private void VisiblePath_LostFocus(object _, RoutedEventArgs e)
 		{
@@ -215,6 +223,16 @@ namespace Files.App.UserControls
 				// Navigate forward
 				shellPage.Forward_Click();
 			}
+		}
+
+		private void ClickablePath_GettingFocus(UIElement sender, GettingFocusEventArgs args)
+		{
+			if (args.InputDevice != FocusInputDeviceKind.Keyboard)
+				return;
+
+			var previousControl = args.OldFocusedElement as FrameworkElement;
+			if (previousControl?.Name == "HomeButton" || previousControl?.Name == "Refresh")
+				ViewModel.IsEditModeEnabled = true;
 		}
 	}
 }

--- a/src/Files.App/UserControls/AddressToolbar.xaml.cs
+++ b/src/Files.App/UserControls/AddressToolbar.xaml.cs
@@ -231,7 +231,7 @@ namespace Files.App.UserControls
 				return;
 
 			var previousControl = args.OldFocusedElement as FrameworkElement;
-			if (previousControl?.Name == "HomeButton" || previousControl?.Name == "Refresh")
+			if (previousControl?.Name == nameof(HomeButton) || previousControl?.Name == nameof(Refresh))
 				ViewModel.IsEditModeEnabled = true;
 		}
 	}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #7077

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Pressing the Tab key when the Refresh button (or Home button) is focused will switch the focus to the breadcrumb bar and enable edit mode.
2. Pressing the Tab key again will turn off edit mode and allow navigation within the breadcrumb bar.