### PR TITLE
Feature: Add support for right-click drag&drop menu

### DIFF
--- a/src/Files.App/Data/Factories/ShellContextFlyoutHelper.cs
+++ b/src/Files.App/Data/Factories/ShellContextFlyoutHelper.cs
@@ -9,10 +9,13 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System.IO;
+using Vanara.PInvoke;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.Win32;
 using Windows.Win32.UI.WindowsAndMessaging;
+using WinRT;
 
 namespace Files.App.Helpers
 {
@@ -415,6 +418,21 @@ namespace Files.App.Helpers
 					flyoutSubItem.Visibility = Visibility.Visible;
 				}
 			}
+		}
+
+		public static void InvokeRightButtonDropMenu(string folderPath, DataPackageView dataView, DataPackageOperation acceptedOperation)
+		{
+			using var sf = new Vanara.Windows.Shell.ShellItem(folderPath);
+			if (!sf.IsFolder)
+				return;
+
+			PInvoke.GetCursorPos(out var dropPoint);
+
+			var dataObjectProvider = dataView.As<Shell32.IDataObjectProvider>();
+			var iddo = dataObjectProvider.GetDataObject();
+			var dropTarget = sf.GetHandler<Ole32.IDropTarget>(Shell32.BHID.BHID_SFViewObject);
+			dropTarget.DragEnter(iddo, MouseButtonState.MK_RBUTTON, new() { X = dropPoint.X, Y = dropPoint.Y }, (Ole32.DROPEFFECT)acceptedOperation);
+			dropTarget.Drop(iddo, MouseButtonState.MK_RBUTTON, new() { X = dropPoint.X, Y = dropPoint.Y }, (Ole32.DROPEFFECT)acceptedOperation);
 		}
 	}
 }

--- a/src/Files.App/Helpers/AutomaticDragHelper.cs
+++ b/src/Files.App/Helpers/AutomaticDragHelper.cs
@@ -1,0 +1,344 @@
+﻿using Microsoft.UI.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation;
+using Windows.Win32;
+
+namespace Files.App.Helpers
+{
+	public class AutomaticDragHelper : DependencyObject
+	{
+		public static AutomaticDragHelper GetDragHelper(DependencyObject obj)
+		{
+			return (AutomaticDragHelper)obj.GetValue(DragHelperProperty);
+		}
+
+		public static void SetDragHelper(DependencyObject obj, AutomaticDragHelper value)
+		{
+			obj.SetValue(DragHelperProperty, value);
+		}
+
+		public static readonly DependencyProperty DragHelperProperty =
+			DependencyProperty.RegisterAttached("DragHelper", typeof(AutomaticDragHelper), typeof(AutomaticDragHelper), new PropertyMetadata(null, OnDragHelperChanged));
+
+		private static void OnDragHelperChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (e.OldValue is AutomaticDragHelper old)
+				old.StopDetectingDrag();
+		}
+
+		// The standard Windows mouse drag box size is defined by SM_CXDRAG and SM_CYDRAG.
+		// UIElement uses the standard box size with dimensions multiplied by this constant.
+		// This arrangement is in place as accidentally triggering a drag was deemed too easy while
+		// selecting several items with the mouse in quick succession.
+		private const double UIELEMENT_MOUSE_DRAG_THRESHOLD_MULTIPLIER = 2.0;
+		private readonly UIElement m_pOwnerNoRef;
+		private readonly bool m_shouldAddInputHandlers;
+		private bool m_isCheckingForMouseDrag;
+		private Point m_lastMouseRightButtonDownPosition;
+		private bool m_dragDropPointerPressedToken, m_dragDropPointerMovedToken, m_dragDropPointerReleasedToken, m_dragDropPointerCaptureLostToken, m_dragDropHoldingToken;
+		private PointerPoint m_spPointerPoint;
+		private Pointer m_spPointer;
+		private bool m_isHoldingCompleted, m_isRightButtonPressed;
+
+		public AutomaticDragHelper(UIElement pUIElement, bool shouldAddInputHandlers)
+		{
+			m_pOwnerNoRef = pUIElement;
+			m_shouldAddInputHandlers = shouldAddInputHandlers;
+		}
+
+		// Begin tracking the mouse cursor in order to fire a drag start if the pointer
+		// moves a certain distance away from m_lastMouseRightButtonDownPosition.
+		public void BeginCheckingForMouseDrag(Pointer pPointer)
+		{
+
+			bool captured = m_pOwnerNoRef.CapturePointer(pPointer);
+
+			m_isCheckingForMouseDrag = !!captured;
+		}
+
+		// Stop tracking the mouse cursor.
+		public void StopCheckingForMouseDrag(Pointer pPointer)
+		{
+			// Do not call ReleasePointerCapture() more times than we called CapturePointer()
+			if (m_isCheckingForMouseDrag)
+			{
+				m_isCheckingForMouseDrag = false;
+
+				m_pOwnerNoRef.ReleasePointerCapture(pPointer);
+			}
+		}
+
+		// Return true if we're tracking the mouse and newMousePosition is outside the drag
+		// rectangle centered at m_lastMouseRightButtonDownPosition (see IsOutsideDragRectangle).
+		bool ShouldStartMouseDrag(Point newMousePosition)
+		{
+			return m_isCheckingForMouseDrag && IsOutsideDragRectangle(newMousePosition, m_lastMouseRightButtonDownPosition);
+		}
+
+
+		// Returns true if testPoint is outside of the rectangle
+		// defined by the SM_CXDRAG and SM_CYDRAG system metrics and
+		// dragRectangleCenter.
+		bool IsOutsideDragRectangle(Point testPoint, Point dragRectangleCenter)
+		{
+
+			double dx = Math.Abs(testPoint.X - dragRectangleCenter.X);
+			double dy = Math.Abs(testPoint.Y - dragRectangleCenter.Y);
+
+			double maxDx = PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_CXDRAG);
+			double maxDy = PInvoke.GetSystemMetrics(Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX.SM_CYDRAG);
+
+			maxDx *= UIELEMENT_MOUSE_DRAG_THRESHOLD_MULTIPLIER;
+			maxDy *= UIELEMENT_MOUSE_DRAG_THRESHOLD_MULTIPLIER;
+
+			return (dx > maxDx || dy > maxDy);
+		}
+
+		public void StartDetectingDrag()
+		{
+			if (m_shouldAddInputHandlers && !m_dragDropPointerPressedToken)
+			{
+				m_pOwnerNoRef.PointerPressed += HandlePointerPressedEventArgs;
+				m_dragDropPointerPressedToken = true;
+			}
+		}
+
+		public void StopDetectingDrag()
+		{
+			if (m_dragDropPointerPressedToken)
+			{
+				m_pOwnerNoRef.PointerPressed -= HandlePointerPressedEventArgs;
+				// zero out the token;
+				m_dragDropPointerPressedToken = false;
+			}
+		}
+
+		public void RegisterDragPointerEvents()
+		{
+			if (m_shouldAddInputHandlers)
+			{
+				PointerEventHandler spDragDropPointerMovedHandler;
+				PointerEventHandler spDragDropPointerReleasedHandler;
+				PointerEventHandler spDragDropPointerCaptureLostHandler;
+
+				// Hookup pointer events so we can catch and handle it for drag and drop.
+				if (!m_dragDropPointerMovedToken)
+				{
+					m_pOwnerNoRef.PointerMoved += HandlePointerMovedEventArgs;
+					m_dragDropPointerMovedToken = true;
+				}
+
+				if (!m_dragDropPointerReleasedToken)
+				{
+					m_pOwnerNoRef.PointerReleased += HandlePointerReleasedEventArgs;
+					m_dragDropPointerReleasedToken = true;
+				}
+
+				if (!m_dragDropPointerCaptureLostToken)
+				{
+					m_pOwnerNoRef.PointerCaptureLost += HandlePointerCaptureLostEventArgs;
+					m_dragDropPointerCaptureLostToken = true;
+				}
+			}
+		}
+
+		public void HandlePointerPressedEventArgs(object sender, PointerRoutedEventArgs pArgs)
+		{
+			Pointer spPointer;
+			PointerDeviceType pointerDeviceType = PointerDeviceType.Touch;
+			PointerPoint spPointerPoint;
+
+			m_spPointerPoint = null;
+			m_spPointer = null;
+			//m_isHoldingCompleted = false;
+
+			spPointer = pArgs.Pointer;
+			pointerDeviceType = spPointer.PointerDeviceType;
+
+			spPointerPoint = pArgs.GetCurrentPoint(m_pOwnerNoRef);
+
+			// Check if this is a mouse button down.
+			if (pointerDeviceType == PointerDeviceType.Mouse || pointerDeviceType == PointerDeviceType.Pen)
+			{
+				// Mouse button down.
+				PointerPointProperties spPointerProperties;
+				bool isRightButtonPressed = false;
+
+				spPointerProperties = spPointerPoint.Properties;
+				isRightButtonPressed = spPointerProperties.IsRightButtonPressed;
+
+				// If the left mouse button was the one pressed...
+				if (!m_isRightButtonPressed && isRightButtonPressed)
+				{
+					m_isRightButtonPressed = true;
+					// Start listening for a mouse drag gesture
+					m_lastMouseRightButtonDownPosition = spPointerPoint.Position;
+					BeginCheckingForMouseDrag(spPointer);
+
+					RegisterDragPointerEvents();
+				}
+			}
+			/*else
+			{
+				m_spPointerPoint = spPointerPoint;
+				m_spPointer = spPointer;
+
+				if (m_shouldAddInputHandlers && !m_dragDropHoldingToken)
+				{
+					// Touch input occurs, subscribe to holding
+					m_pOwnerNoRef.Holding += HandleHoldingEventArgs;
+				}
+
+				RegisterDragPointerEvents();
+			}*/
+		}
+
+		public void HandlePointerMovedEventArgs(object sender, PointerRoutedEventArgs pArgs)
+		{
+			Pointer spPointer;
+			PointerDeviceType pointerDeviceType = PointerDeviceType.Touch;
+
+			spPointer = pArgs.Pointer;
+			pointerDeviceType = spPointer.PointerDeviceType;
+
+			// Our behavior is different between mouse and touch.
+			// It's up to us to detect mouse drag gestures - if we
+			// detect one here, start a drag drop.
+			if (pointerDeviceType == PointerDeviceType.Mouse || pointerDeviceType == PointerDeviceType.Pen)
+			{
+				PointerPoint spPointerPoint;
+				Point newMousePosition;
+
+				spPointerPoint = pArgs.GetCurrentPoint(m_pOwnerNoRef);
+
+				newMousePosition = spPointerPoint.Position;
+				if (ShouldStartMouseDrag(newMousePosition))
+				{
+					IAsyncOperation<DataPackageOperation> spAsyncOperation;
+					StopCheckingForMouseDrag(spPointer);
+
+					spAsyncOperation = m_pOwnerNoRef.StartDragAsync(spPointerPoint);
+				}
+			}
+		}
+
+
+		public void HandlePointerReleasedEventArgs(object sender, PointerRoutedEventArgs pArgs)
+		{
+			Pointer spPointer;
+			PointerDeviceType pointerDeviceType = PointerDeviceType.Touch;
+
+			spPointer = pArgs.Pointer;
+			pointerDeviceType = spPointer.PointerDeviceType;
+
+			// Check if this is a mouse button up
+			if (pointerDeviceType == PointerDeviceType.Mouse || pointerDeviceType == PointerDeviceType.Pen)
+			{
+				bool isRightButtonPressed = false;
+				PointerPoint spPointerPoint;
+				PointerPointProperties spPointerProperties;
+
+				spPointerPoint = pArgs.GetCurrentPoint(m_pOwnerNoRef);
+				spPointerProperties = spPointerPoint.Properties;
+				isRightButtonPressed = spPointerProperties.IsRightButtonPressed;
+
+				// if the mouse left button was the one released...
+				if (m_isRightButtonPressed && !isRightButtonPressed)
+				{
+					m_isRightButtonPressed = false;
+					UnregisterEvents();
+					// Terminate any mouse drag gesture tracking.
+					StopCheckingForMouseDrag(spPointer);
+				}
+			}
+			else
+			{
+				UnregisterEvents();
+			}
+		}
+
+		public void HandlePointerCaptureLostEventArgs(object sender, PointerRoutedEventArgs pArgs)
+		{
+			Pointer spPointer;
+			PointerDeviceType pointerDeviceType = PointerDeviceType.Touch;
+
+			spPointer = pArgs.Pointer;
+
+			pointerDeviceType = spPointer.PointerDeviceType;
+			if (pointerDeviceType == PointerDeviceType.Mouse || pointerDeviceType == PointerDeviceType.Pen)
+			{
+				// We're not necessarily going to get a PointerReleased on capture lost, so reset this flag here.
+				m_isRightButtonPressed = false;
+			}
+
+			UnregisterEvents();
+		}
+
+		public void UnregisterEvents()
+		{
+			// Unregister events handlers
+			if (m_dragDropPointerMovedToken)
+			{
+				m_pOwnerNoRef.PointerMoved -= HandlePointerMovedEventArgs;
+				m_dragDropPointerMovedToken = false;
+			}
+
+			if (m_dragDropPointerReleasedToken)
+			{
+				m_pOwnerNoRef.PointerReleased -= HandlePointerReleasedEventArgs;
+				m_dragDropPointerReleasedToken = false;
+			}
+
+			if (m_dragDropPointerCaptureLostToken)
+			{
+				m_pOwnerNoRef.PointerCaptureLost -= HandlePointerCaptureLostEventArgs;
+				m_dragDropPointerCaptureLostToken = false;
+			}
+
+			/*if (m_dragDropHoldingToken)
+			{
+				m_pOwnerNoRef.Holding -= HandleHoldingEventArgs;
+				m_dragDropHoldingToken = false;
+			}*/
+		}
+
+		/*public void HandleHoldingEventArgs(object sender, HoldingRoutedEventArgs pArgs)
+		{
+			PointerDeviceType pointerDeviceType = PointerDeviceType.Touch;
+
+			pointerDeviceType = pArgs.PointerDeviceType;
+
+			if (pointerDeviceType == PointerDeviceType.Touch)
+			{
+				HoldingState holdingState = HoldingState.Started;
+				holdingState = pArgs.HoldingState;
+
+				if (holdingState == HoldingState.Started)
+				{
+					m_isHoldingCompleted = true;
+				}
+			}
+		}*/
+
+		/*public void HandleDirectManipulationDraggingStarted()
+		{
+			// Release cross-slide viewport now
+			m_pOwnerNoRef.DirectManipulationCrossSlideContainerCompleted();
+			if (m_isHoldingCompleted)
+			{
+				m_pOwnerNoRef.OnTouchDragStarted(m_spPointerPoint, m_spPointer);
+			}
+
+			m_spPointerPoint = null;
+			m_spPointer = null;
+		}*/
+	}
+}

--- a/src/Files.App/Helpers/AutomaticDragHelper.cs
+++ b/src/Files.App/Helpers/AutomaticDragHelper.cs
@@ -13,6 +13,7 @@ using Windows.Win32;
 
 namespace Files.App.Helpers
 {
+	// https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/1.6.3/src/dxaml/xcp/dxaml/lib/AutomaticDragHelper.cpp
 	public class AutomaticDragHelper : DependencyObject
 	{
 		public static AutomaticDragHelper GetDragHelper(DependencyObject obj)
@@ -125,10 +126,6 @@ namespace Files.App.Helpers
 		{
 			if (m_shouldAddInputHandlers)
 			{
-				PointerEventHandler spDragDropPointerMovedHandler;
-				PointerEventHandler spDragDropPointerReleasedHandler;
-				PointerEventHandler spDragDropPointerCaptureLostHandler;
-
 				// Hookup pointer events so we can catch and handle it for drag and drop.
 				if (!m_dragDropPointerMovedToken)
 				{

--- a/src/Files.App/Helpers/AutomaticDragHelper.cs
+++ b/src/Files.App/Helpers/AutomaticDragHelper.cs
@@ -1,12 +1,6 @@
 ﻿using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
 using Windows.Win32;
@@ -16,6 +10,7 @@ namespace Files.App.Helpers
 	// https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/1.6.3/src/dxaml/xcp/dxaml/lib/AutomaticDragHelper.cpp
 	public class AutomaticDragHelper : DependencyObject
 	{
+		// Added attached dependency property to unregister event handlers
 		public static AutomaticDragHelper GetDragHelper(DependencyObject obj)
 		{
 			return (AutomaticDragHelper)obj.GetValue(DragHelperProperty);
@@ -44,10 +39,11 @@ namespace Files.App.Helpers
 		private readonly bool m_shouldAddInputHandlers;
 		private bool m_isCheckingForMouseDrag;
 		private Point m_lastMouseRightButtonDownPosition;
-		private bool m_dragDropPointerPressedToken, m_dragDropPointerMovedToken, m_dragDropPointerReleasedToken, m_dragDropPointerCaptureLostToken, m_dragDropHoldingToken;
-		private PointerPoint m_spPointerPoint;
-		private Pointer m_spPointer;
-		private bool m_isHoldingCompleted, m_isRightButtonPressed;
+		private bool m_dragDropPointerPressedToken, m_dragDropPointerMovedToken, m_dragDropPointerReleasedToken, m_dragDropPointerCaptureLostToken/*, m_dragDropHoldingToken*/;
+		//private PointerPoint m_spPointerPoint;
+		//private Pointer m_spPointer;
+		//private bool m_isHoldingCompleted;
+		private bool m_isRightButtonPressed;
 
 		public AutomaticDragHelper(UIElement pUIElement, bool shouldAddInputHandlers)
 		{
@@ -59,7 +55,6 @@ namespace Files.App.Helpers
 		// moves a certain distance away from m_lastMouseRightButtonDownPosition.
 		public void BeginCheckingForMouseDrag(Pointer pPointer)
 		{
-
 			bool captured = m_pOwnerNoRef.CapturePointer(pPointer);
 
 			m_isCheckingForMouseDrag = !!captured;
@@ -84,13 +79,11 @@ namespace Files.App.Helpers
 			return m_isCheckingForMouseDrag && IsOutsideDragRectangle(newMousePosition, m_lastMouseRightButtonDownPosition);
 		}
 
-
 		// Returns true if testPoint is outside of the rectangle
 		// defined by the SM_CXDRAG and SM_CYDRAG system metrics and
 		// dragRectangleCenter.
 		bool IsOutsideDragRectangle(Point testPoint, Point dragRectangleCenter)
 		{
-
 			double dx = Math.Abs(testPoint.X - dragRectangleCenter.X);
 			double dy = Math.Abs(testPoint.Y - dragRectangleCenter.Y);
 
@@ -153,8 +146,8 @@ namespace Files.App.Helpers
 			PointerDeviceType pointerDeviceType = PointerDeviceType.Touch;
 			PointerPoint spPointerPoint;
 
-			m_spPointerPoint = null;
-			m_spPointer = null;
+			//m_spPointerPoint = null;
+			//m_spPointer = null;
 			//m_isHoldingCompleted = false;
 
 			spPointer = pArgs.Pointer;
@@ -172,7 +165,7 @@ namespace Files.App.Helpers
 				spPointerProperties = spPointerPoint.Properties;
 				isRightButtonPressed = spPointerProperties.IsRightButtonPressed;
 
-				// If the left mouse button was the one pressed...
+				// If the right mouse button was the one pressed...
 				if (!m_isRightButtonPressed && isRightButtonPressed)
 				{
 					m_isRightButtonPressed = true;
@@ -227,7 +220,6 @@ namespace Files.App.Helpers
 			}
 		}
 
-
 		public void HandlePointerReleasedEventArgs(object sender, PointerRoutedEventArgs pArgs)
 		{
 			Pointer spPointer;
@@ -247,7 +239,7 @@ namespace Files.App.Helpers
 				spPointerProperties = spPointerPoint.Properties;
 				isRightButtonPressed = spPointerProperties.IsRightButtonPressed;
 
-				// if the mouse left button was the one released...
+				// if the mouse right button was the one released...
 				if (m_isRightButtonPressed && !isRightButtonPressed)
 				{
 					m_isRightButtonPressed = false;

--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -9,11 +9,11 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using Vanara.PInvoke;
-using Vanara.Windows.Shell;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.Storage.Streams;
+using WinRT;
 using FileAttributes = System.IO.FileAttributes;
 
 namespace Files.App.Utils.Storage
@@ -758,12 +758,14 @@ namespace Files.App.Utils.Storage
 			{
 				if (hasVirtualItems && packageView.Contains("FileContents"))
 				{
-					var descriptor = NativeClipboard.CurrentDataObject.GetData<Shell32.FILEGROUPDESCRIPTOR>("FileGroupDescriptorW");
+					var dataObjectProvider = packageView.As<Shell32.IDataObjectProvider>();
+					var iddo = dataObjectProvider.GetDataObject();
+					var descriptor = iddo.GetData<Shell32.FILEGROUPDESCRIPTOR>("FileGroupDescriptorW");
 					for (var ii = 0; ii < descriptor.cItems; ii++)
 					{
 						if (descriptor.fgd[ii].dwFileAttributes.HasFlag(FileFlagsAndAttributes.FILE_ATTRIBUTE_DIRECTORY))
 							itemsList.Add(new VirtualStorageFolder(descriptor.fgd[ii].cFileName).FromStorageItem());
-						else if (NativeClipboard.CurrentDataObject.GetData("FileContents", DVASPECT.DVASPECT_CONTENT, ii) is IStream stream)
+						else if (iddo.GetData("FileContents", DVASPECT.DVASPECT_CONTENT, ii) is IStream stream)
 						{
 							var streamContent = new ComStreamWrapper(stream);
 							itemsList.Add(new VirtualStorageFile(streamContent, descriptor.fgd[ii].cFileName).FromStorageItem());

--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -9,11 +9,11 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using Vanara.PInvoke;
+using Vanara.Windows.Shell;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.Storage.Streams;
-using WinRT;
 using FileAttributes = System.IO.FileAttributes;
 
 namespace Files.App.Utils.Storage
@@ -758,14 +758,12 @@ namespace Files.App.Utils.Storage
 			{
 				if (hasVirtualItems && packageView.Contains("FileContents"))
 				{
-					var dataObjectProvider = packageView.As<Shell32.IDataObjectProvider>();
-					var iddo = dataObjectProvider.GetDataObject();
-					var descriptor = iddo.GetData<Shell32.FILEGROUPDESCRIPTOR>("FileGroupDescriptorW");
+					var descriptor = NativeClipboard.CurrentDataObject.GetData<Shell32.FILEGROUPDESCRIPTOR>("FileGroupDescriptorW");
 					for (var ii = 0; ii < descriptor.cItems; ii++)
 					{
 						if (descriptor.fgd[ii].dwFileAttributes.HasFlag(FileFlagsAndAttributes.FILE_ATTRIBUTE_DIRECTORY))
 							itemsList.Add(new VirtualStorageFolder(descriptor.fgd[ii].cFileName).FromStorageItem());
-						else if (iddo.GetData("FileContents", DVASPECT.DVASPECT_CONTENT, ii) is IStream stream)
+						else if (NativeClipboard.CurrentDataObject.GetData("FileContents", DVASPECT.DVASPECT_CONTENT, ii) is IStream stream)
 						{
 							var streamContent = new ComStreamWrapper(stream);
 							itemsList.Add(new VirtualStorageFile(streamContent, descriptor.fgd[ii].cFileName).FromStorageItem());

--- a/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
+++ b/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
@@ -7,12 +7,10 @@ using Microsoft.UI.Xaml.Input;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows.Input;
-using Vanara.PInvoke;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.ApplicationModel.DataTransfer.DragDrop;
 using Windows.Storage;
 using Windows.System;
-using WinRT;
 
 namespace Files.App.ViewModels.Layouts
 {
@@ -191,13 +189,7 @@ namespace Files.App.ViewModels.Layouts
 				{
 					if ((bool)e.DataView.Properties.GetValueOrDefault("dragRightButton", false))
 					{
-						Windows.Win32.PInvoke.GetCursorPos(out var dropPoint);
-						using var sf = new Vanara.Windows.Shell.ShellFolder(_associatedInstance.ShellViewModel.WorkingDirectory);
-						var dataObjectProvider = e.DataView.As<Shell32.IDataObjectProvider>();
-						var iddo = dataObjectProvider.GetDataObject();
-						var dropTarget = sf.GetViewObject<Ole32.IDropTarget>(HWND.NULL);
-						dropTarget.DragEnter(iddo, Vanara.PInvoke.MouseButtonState.MK_RBUTTON, new() { X=dropPoint.X, Y=dropPoint.Y }, (Ole32.DROPEFFECT)e.AcceptedOperation);
-						dropTarget.Drop(iddo, Vanara.PInvoke.MouseButtonState.MK_RBUTTON, new() { X=dropPoint.X, Y=dropPoint.Y }, (Ole32.DROPEFFECT)e.AcceptedOperation);
+						SafetyExtensions.IgnoreExceptions(() => ShellContextFlyoutFactory.InvokeRightButtonDropMenu(_associatedInstance.ShellViewModel.WorkingDirectory, e.DataView, e.AcceptedOperation));
 					}
 					else
 					{

--- a/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
+++ b/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
@@ -7,10 +7,12 @@ using Microsoft.UI.Xaml.Input;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows.Input;
+using Vanara.PInvoke;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.ApplicationModel.DataTransfer.DragDrop;
 using Windows.Storage;
 using Windows.System;
+using WinRT;
 
 namespace Files.App.ViewModels.Layouts
 {
@@ -100,6 +102,10 @@ namespace Files.App.ViewModels.Layouts
 				return;
 			}
 
+			// Check if this is a right-button drag operation and store into the dataobject
+			if (e.Modifiers.HasFlag(DragDropModifiers.RightButton))
+				e.DataView.As<Shell32.IDataObjectProvider>().GetDataObject().SetData<bool>("dragRightButton", true);
+
 			if (FilesystemHelpers.HasDraggedStorageItems(e.DataView))
 			{
 				e.Handled = true;
@@ -187,7 +193,9 @@ namespace Files.App.ViewModels.Layouts
 
 				try
 				{
-					if ((bool)e.DataView.Properties.GetValueOrDefault("dragRightButton", false))
+					var isRightButtonDrag = e.DataView.As<Shell32.IDataObjectProvider>().GetDataObject().GetData<bool>("dragRightButton");
+
+					if (isRightButtonDrag)
 					{
 						SafetyExtensions.IgnoreExceptions(() => ShellContextFlyoutFactory.InvokeRightButtonDropMenu(_associatedInstance.ShellViewModel.WorkingDirectory, e.DataView, e.AcceptedOperation));
 					}

--- a/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
+++ b/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
@@ -193,7 +193,7 @@ namespace Files.App.ViewModels.Layouts
 
 				try
 				{
-					var isRightButtonDrag = e.DataView.As<Shell32.IDataObjectProvider>().GetDataObject().GetData<bool>("dragRightButton");
+					e.DataView.As<Shell32.IDataObjectProvider>().GetDataObject().TryGetData<bool>(User32.RegisterClipboardFormat("dragRightButton"), out var isRightButtonDrag);
 
 					if (isRightButtonDrag)
 					{

--- a/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
@@ -10,8 +10,11 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using System.IO;
 using System.Windows.Input;
+using Vanara.PInvoke;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.ApplicationModel.DataTransfer.DragDrop;
 using Windows.UI.Text;
+using WinRT;
 using FocusManager = Microsoft.UI.Xaml.Input.FocusManager;
 
 namespace Files.App.ViewModels.UserControls
@@ -353,6 +356,10 @@ namespace Files.App.ViewModels.UserControls
 					TimeSpan.FromMilliseconds(Constants.DragAndDrop.HoverToOpenTimespan), false);
 				}
 			}
+
+			// Check if this is a right-button drag operation and store into the dataobject
+			if (e.Modifiers.HasFlag(DragDropModifiers.RightButton))
+				e.DataView.As<Shell32.IDataObjectProvider>().GetDataObject().SetData<bool>("dragRightButton", true);
 
 			// In search page
 			if (!FilesystemHelpers.HasDraggedStorageItems(e.DataView) || string.IsNullOrEmpty(pathBoxItem.Path))

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -11,13 +11,11 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using System.Collections.Specialized;
 using System.IO;
 using System.Windows.Input;
-using Vanara.PInvoke;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.ApplicationModel.DataTransfer.DragDrop;
 using Windows.Storage;
 using Windows.System;
 using Windows.UI.Core;
-using WinRT;
 
 namespace Files.App.ViewModels.UserControls
 {
@@ -1255,13 +1253,7 @@ namespace Files.App.ViewModels.UserControls
 				}
 				else if ((bool)args.DroppedItem.Properties.GetValueOrDefault("dragRightButton", false))
 				{
-					Windows.Win32.PInvoke.GetCursorPos(out var dropPoint);
-					using var sf = new Vanara.Windows.Shell.ShellFolder(locationItem.Path);
-					var dataObjectProvider = args.DroppedItem.As<Shell32.IDataObjectProvider>();
-					var iddo = dataObjectProvider.GetDataObject();
-					var dropTarget = sf.GetViewObject<Ole32.IDropTarget>(HWND.NULL);
-					dropTarget.DragEnter(iddo, Vanara.PInvoke.MouseButtonState.MK_RBUTTON, new() { X=dropPoint.X, Y=dropPoint.Y }, (Ole32.DROPEFFECT)args.RawEvent.AcceptedOperation);
-					dropTarget.Drop(iddo, Vanara.PInvoke.MouseButtonState.MK_RBUTTON, new() { X=dropPoint.X, Y=dropPoint.Y }, (Ole32.DROPEFFECT)args.RawEvent.AcceptedOperation);
+					SafetyExtensions.IgnoreExceptions(() => ShellContextFlyoutFactory.InvokeRightButtonDropMenu(locationItem.Path, args.DroppedItem, args.RawEvent.AcceptedOperation));
 				}
 				else
 				{
@@ -1274,13 +1266,7 @@ namespace Files.App.ViewModels.UserControls
 		{
 			if ((bool)args.DroppedItem.Properties.GetValueOrDefault("dragRightButton", false))
 			{
-				Windows.Win32.PInvoke.GetCursorPos(out var dropPoint);
-				using var sf = new Vanara.Windows.Shell.ShellFolder(driveItem.Path);
-				var dataObjectProvider = args.DroppedItem.As<Shell32.IDataObjectProvider>();
-				var iddo = dataObjectProvider.GetDataObject();
-				var dropTarget = sf.GetViewObject<Ole32.IDropTarget>(HWND.NULL);
-				dropTarget.DragEnter(iddo, Vanara.PInvoke.MouseButtonState.MK_RBUTTON, new() { X=dropPoint.X, Y=dropPoint.Y }, (Ole32.DROPEFFECT)args.RawEvent.AcceptedOperation);
-				dropTarget.Drop(iddo, Vanara.PInvoke.MouseButtonState.MK_RBUTTON, new() { X=dropPoint.X, Y=dropPoint.Y }, (Ole32.DROPEFFECT)args.RawEvent.AcceptedOperation);
+				SafetyExtensions.IgnoreExceptions(() => ShellContextFlyoutFactory.InvokeRightButtonDropMenu(driveItem.Path, args.DroppedItem, args.RawEvent.AcceptedOperation));
 				return Task.FromResult(ReturnResult.Success);
 			}
 			else

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -1263,7 +1263,7 @@ namespace Files.App.ViewModels.UserControls
 				}
 				else
 				{
-					var isRightButtonDrag = args.DroppedItem.As<Shell32.IDataObjectProvider>().GetDataObject().GetData<bool>("dragRightButton");
+					args.DroppedItem.As<Shell32.IDataObjectProvider>().GetDataObject().TryGetData<bool>(User32.RegisterClipboardFormat("dragRightButton"), out var isRightButtonDrag);
 
 					if (isRightButtonDrag)
 					{
@@ -1279,7 +1279,7 @@ namespace Files.App.ViewModels.UserControls
 
 		private Task<ReturnResult> HandleDriveItemDroppedAsync(DriveItem driveItem, ItemDroppedEventArgs args)
 		{
-			var isRightButtonDrag = args.DroppedItem.As<Shell32.IDataObjectProvider>().GetDataObject().GetData<bool>("dragRightButton");
+			args.DroppedItem.As<Shell32.IDataObjectProvider>().GetDataObject().TryGetData<bool>(User32.RegisterClipboardFormat("dragRightButton"), out var isRightButtonDrag);
 
 			if (isRightButtonDrag)
 			{

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -998,7 +998,6 @@ namespace Files.App.Views.Layouts
 
 			var selectedItems = SelectedItems?.ToList<object>() ?? new();
 			selectedItems.AddIfNotPresent(item);
-			args.Data.Properties["dragRightButton"] = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightButton).HasFlag(CoreVirtualKeyStates.Down);
 			args.Cancel = DragItemsStarting(ItemsControl, args.Data, selectedItems);
 		}
 
@@ -1060,6 +1059,10 @@ namespace Files.App.Views.Layouts
 				return;
 
 			DragOperationDeferral? deferral = null;
+
+			// Check if this is a right-button drag operation and store into the dataobject
+			if (e.Modifiers.HasFlag(DragDropModifiers.RightButton))
+				e.DataView.As<Shell32.IDataObjectProvider>().GetDataObject().SetData<bool>("dragRightButton", true);
 
 			try
 			{
@@ -1164,7 +1167,9 @@ namespace Files.App.Views.Layouts
 			var item = GetItemFromElement(sender);
 			if (item is not null)
 			{
-				if ((bool)e.DataView.Properties.GetValueOrDefault("dragRightButton", false))
+				var isRightButtonDrag = e.DataView.As<Shell32.IDataObjectProvider>().GetDataObject().GetData<bool>("dragRightButton");
+
+				if (isRightButtonDrag)
 				{
 					SafetyExtensions.IgnoreExceptions(() => ShellContextFlyoutFactory.InvokeRightButtonDropMenu(item.ItemPath, e.DataView, e.AcceptedOperation));
 				}

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1164,15 +1164,9 @@ namespace Files.App.Views.Layouts
 			var item = GetItemFromElement(sender);
 			if (item is not null)
 			{
-				if ((bool)e.DataView.Properties.GetValueOrDefault("dragRightButton", false) && item.IsFolder)
+				if ((bool)e.DataView.Properties.GetValueOrDefault("dragRightButton", false))
 				{
-					Windows.Win32.PInvoke.GetCursorPos(out var dropPoint);
-					using var sf = new Vanara.Windows.Shell.ShellFolder(item.ItemPath);
-					var dataObjectProvider = e.DataView.As<Shell32.IDataObjectProvider>();
-					var iddo = dataObjectProvider.GetDataObject();
-					var dropTarget = sf.GetViewObject<Ole32.IDropTarget>(HWND.NULL);
-					dropTarget.DragEnter(iddo, MouseButtonState.MK_RBUTTON, new() { X=dropPoint.X, Y=dropPoint.Y }, (Ole32.DROPEFFECT)e.AcceptedOperation);
-					dropTarget.Drop(iddo, MouseButtonState.MK_RBUTTON, new() { X=dropPoint.X, Y=dropPoint.Y }, (Ole32.DROPEFFECT)e.AcceptedOperation);
+					SafetyExtensions.IgnoreExceptions(() => ShellContextFlyoutFactory.InvokeRightButtonDropMenu(item.ItemPath, e.DataView, e.AcceptedOperation));
 				}
 				else
 				{

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1167,7 +1167,7 @@ namespace Files.App.Views.Layouts
 			var item = GetItemFromElement(sender);
 			if (item is not null)
 			{
-				var isRightButtonDrag = e.DataView.As<Shell32.IDataObjectProvider>().GetDataObject().GetData<bool>("dragRightButton");
+				e.DataView.As<Shell32.IDataObjectProvider>().GetDataObject().TryGetData<bool>(User32.RegisterClipboardFormat("dragRightButton"), out var isRightButtonDrag);
 
 				if (isRightButtonDrag)
 				{

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -419,7 +419,7 @@ namespace Files.App.Views.Shells
 
 		protected async void ShellPage_PathBoxItemDropped(object sender, PathBoxItemDroppedEventArgs e)
 		{
-			var isRightButtonDrag = e.Package.As<Shell32.IDataObjectProvider>().GetDataObject().GetData<bool>("dragRightButton");
+			e.Package.As<Shell32.IDataObjectProvider>().GetDataObject().TryGetData<bool>(User32.RegisterClipboardFormat("dragRightButton"), out var isRightButtonDrag);
 
 			if (isRightButtonDrag)
 			{

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -9,9 +9,11 @@ using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Navigation;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Vanara.PInvoke;
 using Windows.Foundation.Metadata;
 using Windows.System;
 using Windows.UI.Core;
+using WinRT;
 using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
 
 namespace Files.App.Views.Shells
@@ -417,7 +419,9 @@ namespace Files.App.Views.Shells
 
 		protected async void ShellPage_PathBoxItemDropped(object sender, PathBoxItemDroppedEventArgs e)
 		{
-			if ((bool)e.Package.Properties.GetValueOrDefault("dragRightButton", false))
+			var isRightButtonDrag = e.Package.As<Shell32.IDataObjectProvider>().GetDataObject().GetData<bool>("dragRightButton");
+
+			if (isRightButtonDrag)
 			{
 				SafetyExtensions.IgnoreExceptions(() => ShellContextFlyoutFactory.InvokeRightButtonDropMenu(e.Path, e.Package, e.AcceptedOperation));
 			}

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -9,11 +9,9 @@ using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Navigation;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Vanara.PInvoke;
 using Windows.Foundation.Metadata;
 using Windows.System;
 using Windows.UI.Core;
-using WinRT;
 using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
 
 namespace Files.App.Views.Shells
@@ -421,13 +419,7 @@ namespace Files.App.Views.Shells
 		{
 			if ((bool)e.Package.Properties.GetValueOrDefault("dragRightButton", false))
 			{
-				Windows.Win32.PInvoke.GetCursorPos(out var dropPoint);
-				using var sf = new Vanara.Windows.Shell.ShellFolder(e.Path);
-				var dataObjectProvider = e.Package.As<Shell32.IDataObjectProvider>();
-				var iddo = dataObjectProvider.GetDataObject();
-				var dropTarget = sf.GetViewObject<Ole32.IDropTarget>(HWND.NULL);
-				dropTarget.DragEnter(iddo, MouseButtonState.MK_RBUTTON, new() { X=dropPoint.X, Y=dropPoint.Y }, (Ole32.DROPEFFECT)e.AcceptedOperation);
-				dropTarget.Drop(iddo, MouseButtonState.MK_RBUTTON, new() { X=dropPoint.X, Y=dropPoint.Y }, (Ole32.DROPEFFECT)e.AcceptedOperation);
+				SafetyExtensions.IgnoreExceptions(() => ShellContextFlyoutFactory.InvokeRightButtonDropMenu(e.Path, e.Package, e.AcceptedOperation));
 			}
 			else
 			{


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #1396

Works but:
- uses the buit-in system context menu, not a custom Files UI
- does not work when dropping from Files to explorer :( maybe someone can help? 🙏

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Right-click drag inside Files or from explorer to Files and check drop memu
