### PR TITLE
Fix: Fixed issue with displaying properties for tagged items

### DIFF
--- a/src/Files.App/Utils/Storage/Search/FolderSearch.cs
+++ b/src/Files.App/Utils/Storage/Search/FolderSearch.cs
@@ -345,10 +345,14 @@ namespace Files.App.Utils.Storage
 			ListedItem listedItem = null;
 			var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
 			var isFolder = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory;
+			Win32PInvoke.FileTimeToSystemTime(ref findData.ftLastWriteTime, out Win32PInvoke.SYSTEMTIME systemModifiedTimeOutput);
+			Win32PInvoke.FileTimeToSystemTime(ref findData.ftCreationTime, out Win32PInvoke.SYSTEMTIME systemCreatedTimeOutput);
+
 			if (!isFolder)
 			{
 				string itemFileExtension = null;
 				string itemType = null;
+				long fileSize = Win32FindDataExtensions.GetSize(findData);
 				if (findData.cFileName.Contains('.', StringComparison.Ordinal))
 				{
 					itemFileExtension = Path.GetExtension(itemPath);
@@ -360,11 +364,15 @@ namespace Files.App.Utils.Storage
 					PrimaryItemAttribute = StorageItemTypes.File,
 					ItemNameRaw = findData.cFileName,
 					ItemPath = itemPath,
+					ItemDateModifiedReal = systemModifiedTimeOutput.ToDateTime(),
+					ItemDateCreatedReal = systemCreatedTimeOutput.ToDateTime(),
 					IsHiddenItem = isHidden,
 					LoadFileIcon = false,
 					FileExtension = itemFileExtension,
 					ItemType = itemType,
-					Opacity = isHidden ? Constants.UI.DimItemOpacity : 1
+					Opacity = isHidden ? Constants.UI.DimItemOpacity : 1,
+					FileSize = fileSize.ToSizeString(),
+					FileSizeBytes = fileSize,
 				};
 			}
 			else
@@ -376,6 +384,8 @@ namespace Files.App.Utils.Storage
 						PrimaryItemAttribute = StorageItemTypes.Folder,
 						ItemNameRaw = findData.cFileName,
 						ItemPath = itemPath,
+						ItemDateModifiedReal = systemModifiedTimeOutput.ToDateTime(),
+						ItemDateCreatedReal = systemCreatedTimeOutput.ToDateTime(),
 						IsHiddenItem = isHidden,
 						LoadFileIcon = false,
 						Opacity = isHidden ? Constants.UI.DimItemOpacity : 1


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #13185 

I know the related issue is not approved, but this bug was annoying me

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Activate the Tag Widgets in the settings.
2. Assign a tag to an element.
3. Go to the homepage.
4. Click on the name of the tag assigned to this element.
5. Navigate to the properties of the element.
