### PR TITLE
Feature: Added support for opening breadcrumb items using the `space` and `enter` keys

### DIFF
--- a/src/Files.App/UserControls/PathBreadcrumb.xaml
+++ b/src/Files.App/UserControls/PathBreadcrumb.xaml
@@ -136,7 +136,7 @@
 		IsItemClickEnabled="True"
 		ItemTemplateSelector="{StaticResource PathBreadcrumbItemSelector}"
 		ItemsSource="{x:Bind ViewModel.PathComponents, Mode=OneWay}"
-		KeyDown="PathBoxItem_KeyDown"
+		PreviewKeyDown="PathBoxItem_PreviewKeyDown"
 		ScrollViewer.HorizontalScrollBarVisibility="Hidden"
 		ScrollViewer.HorizontalScrollMode="Enabled"
 		ScrollViewer.VerticalScrollBarVisibility="Disabled"

--- a/src/Files.App/UserControls/PathBreadcrumb.xaml.cs
+++ b/src/Files.App/UserControls/PathBreadcrumb.xaml.cs
@@ -55,9 +55,9 @@ namespace Files.App.UserControls
 			ViewModel.PathBoxItem_PointerPressed(sender, e);
 		}
 
-		private void PathBoxItem_KeyDown(object sender, KeyRoutedEventArgs e)
+		private void PathBoxItem_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
 		{
-			ViewModel.PathBoxItem_KeyDown(sender, e);
+			ViewModel.PathBoxItem_PreviewKeyDown(sender, e);
 		}
 	}
 }

--- a/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
@@ -525,13 +525,24 @@ namespace Files.App.ViewModels.UserControls
 			});
 		}
 
-		public void PathBoxItem_KeyDown(object sender, KeyRoutedEventArgs e)
+		public void PathBoxItem_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
 		{
 			if (e.Key == Windows.System.VirtualKey.Down)
 			{
 				var item = e.OriginalSource as ListViewItem;
 				var button = item?.FindDescendant<Button>();
 				button?.Flyout.ShowAt(button);
+				e.Handled = true;
+			} else if (e.Key == Windows.System.VirtualKey.Space || e.Key == Windows.System.VirtualKey.Enter)
+			{
+				var item = e.OriginalSource as ListViewItem;
+				var path = (item?.Content as PathBoxItem)?.Path;
+				if (path == null || path == PathControlDisplayText)
+					return;
+				ToolbarPathItemInvoked?.Invoke(this, new PathNavigationEventArgs()
+				{
+					ItemPath = path
+				});
 				e.Handled = true;
 			}
 		}

--- a/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
@@ -527,13 +527,13 @@ namespace Files.App.ViewModels.UserControls
 
 		public void PathBoxItem_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
 		{
-			if (e.Key == Windows.System.VirtualKey.Down)
+			if (e.Key is Windows.System.VirtualKey.Down)
 			{
 				var item = e.OriginalSource as ListViewItem;
 				var button = item?.FindDescendant<Button>();
 				button?.Flyout.ShowAt(button);
 				e.Handled = true;
-			} else if (e.Key == Windows.System.VirtualKey.Space || e.Key == Windows.System.VirtualKey.Enter)
+			} else if (e.Key is Windows.System.VirtualKey.Space or Windows.System.VirtualKey.Enter)
 			{
 				var item = e.OriginalSource as ListViewItem;
 				var path = (item?.Content as PathBoxItem)?.Path;

--- a/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/AddressToolbarViewModel.cs
@@ -527,23 +527,30 @@ namespace Files.App.ViewModels.UserControls
 
 		public void PathBoxItem_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
 		{
-			if (e.Key is Windows.System.VirtualKey.Down)
+			switch (e.Key)
 			{
-				var item = e.OriginalSource as ListViewItem;
-				var button = item?.FindDescendant<Button>();
-				button?.Flyout.ShowAt(button);
-				e.Handled = true;
-			} else if (e.Key is Windows.System.VirtualKey.Space or Windows.System.VirtualKey.Enter)
-			{
-				var item = e.OriginalSource as ListViewItem;
-				var path = (item?.Content as PathBoxItem)?.Path;
-				if (path == null || path == PathControlDisplayText)
-					return;
-				ToolbarPathItemInvoked?.Invoke(this, new PathNavigationEventArgs()
+				case Windows.System.VirtualKey.Down:
 				{
-					ItemPath = path
-				});
-				e.Handled = true;
+					var item = e.OriginalSource as ListViewItem;
+					var button = item?.FindDescendant<Button>();
+					button?.Flyout.ShowAt(button);
+					e.Handled = true;
+					break;
+				}
+				case Windows.System.VirtualKey.Space: 
+				case Windows.System.VirtualKey.Enter:
+				{
+					var item = e.OriginalSource as ListViewItem;
+					var path = (item?.Content as PathBoxItem)?.Path;
+					if (path == PathControlDisplayText)
+						return;
+					ToolbarPathItemInvoked?.Invoke(this, new PathNavigationEventArgs()
+					{
+						ItemPath = path
+					});
+					e.Handled = true;
+					break;
+				}
 			}
 		}
 

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -235,19 +235,18 @@ namespace Files.App.Views
 				default:
 					var currentModifiers = HotKeyHelpers.GetCurrentKeyModifiers();
 					HotKey hotKey = new((Keys)e.Key, currentModifiers);
-					var source = (DependencyObject)e.OriginalSource;
+					var source = e.OriginalSource as DependencyObject;
 
 					// A textbox takes precedence over certain hotkeys.
-					if (source.FindAscendantOrSelf<TextBox>() is not null)
+					if (source?.FindAscendantOrSelf<TextBox>() is not null)
 						break;
 
 					// Execute command for hotkey
 					var command = Commands[hotKey];
 
-					if (command.Code is CommandCodes.OpenItem && source.FindAscendantOrSelf<PathBreadcrumb>() is not null)
-					{
+					if (command.Code is CommandCodes.OpenItem && source?.FindAscendantOrSelf<PathBreadcrumb>() is not null)
 						break;
-					}
+					
 
 					if (command.Code is not CommandCodes.None && keyReleased)
 					{

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -235,13 +235,20 @@ namespace Files.App.Views
 				default:
 					var currentModifiers = HotKeyHelpers.GetCurrentKeyModifiers();
 					HotKey hotKey = new((Keys)e.Key, currentModifiers);
+					var source = (DependencyObject)e.OriginalSource;
 
 					// A textbox takes precedence over certain hotkeys.
-					if (e.OriginalSource is DependencyObject source && source.FindAscendantOrSelf<TextBox>() is not null)
+					if (source.FindAscendantOrSelf<TextBox>() is not null)
 						break;
 
 					// Execute command for hotkey
 					var command = Commands[hotKey];
+
+					if (command.Code is CommandCodes.OpenItem && source.FindAscendantOrSelf<PathBreadcrumb>() is not null)
+					{
+						break;
+					}
+
 					if (command.Code is not CommandCodes.None && keyReleased)
 					{
 						keyReleased = false;


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #16113

**Steps used to test these changes**

1. Select an item in the address bar breadcrumb via keyboard
2. Press `Space` or `Enter`
3. It goes to the corresponding path
