### PR TITLE
Feature: Display storage information for phones and tablets

### DIFF
--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Storage;
+using Windows.Storage.Provider;
 using Windows.Storage.Streams;
 using ByteSize = ByteSizeLib.ByteSize;
 
@@ -278,7 +279,37 @@ namespace Files.App.Data.Items
 		{
 			try
 			{
-				var properties = await Root.Properties.RetrievePropertiesAsync(["System.FreeSpace", "System.Capacity", "System.Volume.FileSystem"])
+
+				// Double check version
+				//IDictionary<string, object>? properties = null;
+				//bool propsAssigned = false;
+				//if (string.IsNullOrEmpty(Root.Path) && Path.StartsWith(@"\\?\", StringComparison.Ordinal))
+				//{
+				//	var systemFolder = ;
+				//	if (systemFolder != null)
+				//	{
+				//		properties = await systemFolder.Properties.RetrievePropertiesAsync(["System.FreeSpace", "System.Capacity", "System.Volume.FileSystem"])
+				//			.AsTask().WithTimeoutAsync(TimeSpan.FromSeconds(5));
+				//		propsAssigned = properties is not null;
+				//	}
+				//}
+
+				//if (!propsAssigned)
+				//{
+				//	properties = await Root.Properties.RetrievePropertiesAsync(["System.FreeSpace", "System.Capacity", "System.Volume.FileSystem"])
+				//		.AsTask().WithTimeoutAsync(TimeSpan.FromSeconds(5));
+				//}
+				//----------------------------------------------
+
+				var propertiesSource = Root;
+				if (string.IsNullOrEmpty(Root.Path) &&
+					Path.StartsWith(@"\\?\", StringComparison.Ordinal) &&
+					(await Root.GetFoldersAsync())[0] is StorageFolder systemFolder)
+				{
+					propertiesSource = systemFolder;
+				}
+
+				var properties = await propertiesSource.Properties.RetrievePropertiesAsync(["System.FreeSpace", "System.Capacity", "System.Volume.FileSystem"])
 					.AsTask().WithTimeoutAsync(TimeSpan.FromSeconds(5));
 
 				if (properties is not null && properties["System.Capacity"] is not null && properties["System.FreeSpace"] is not null)


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #6872 

**Notes**
I proposed two possible working solutions (one commented out):
- the first one performs a double check
- the second goes with only one check (which should be enough in most cases)

Tell me which one do you find more appropriate

**Screenshots**
![Screenshot 2025-01-09 215554](https://github.com/user-attachments/assets/dbe84f4a-240e-4fe3-a020-b124e4daac3d)
![Screenshot 2025-01-09 215559](https://github.com/user-attachments/assets/851465f5-773b-4bc0-bb71-60c2b9f387ee)

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open `Files` Home
2. Enable `Drives` widget
3. Connect a phone/tablet
4. Check that storage is shown
5. *IMPORTANT*: if you have the opportunity, test this feature using a phone with an SD card (may be source of bugs) 