### PR TITLE
GitHub: Made CI/CD workflow run names more concise

### DIFF
--- a/.github/workflows/cd-sideload-preview.yml
+++ b/.github/workflows/cd-sideload-preview.yml
@@ -11,13 +11,14 @@
 #  4. Sign the package
 #  5. Publish the package to Azure
 
-name: Files CD (Sideload Preview)
+name: Files CD
 
 on:
   workflow_dispatch:
 
 jobs:
   build:
+    name: Deploy (Sideload Preview)
     runs-on: windows-latest
     environment: Deployments
     strategy:

--- a/.github/workflows/cd-sideload-preview.yml
+++ b/.github/workflows/cd-sideload-preview.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        environment: [Sideload Preview]
         configuration: [Release]
         platform: [x64]
     env:

--- a/.github/workflows/cd-sideload-stable.yml
+++ b/.github/workflows/cd-sideload-stable.yml
@@ -18,12 +18,13 @@ on:
 
 jobs:
   build:
-    name: Deploy (Sideload Stable)
+    name: Deploy
     runs-on: windows-latest
     environment: Deployments
     strategy:
       fail-fast: false
       matrix:
+        environment: [Sideload Stable]
         configuration: [Release]
         platform: [x64]
     env:

--- a/.github/workflows/cd-sideload-stable.yml
+++ b/.github/workflows/cd-sideload-stable.yml
@@ -11,13 +11,14 @@
 #  4. Sign the package
 #  5. Publish the package to Azure
 
-name: Files CD (Sideload Stable)
+name: Files CD
 
 on:
   workflow_dispatch:
 
 jobs:
   build:
+    name: Deploy (Sideload Stable)
     runs-on: windows-latest
     environment: Deployments
     strategy:

--- a/.github/workflows/cd-store-preview.yml
+++ b/.github/workflows/cd-store-preview.yml
@@ -17,12 +17,13 @@ on:
 
 jobs:
   build:
-    name: Deploy (Store Preview)
+    name: Deploy
     runs-on: windows-latest
     environment: Deployments
     strategy:
       fail-fast: false
       matrix:
+        environment: [Store Preview]
         configuration: [Release]
         platform: [x64]
     env:

--- a/.github/workflows/cd-store-preview.yml
+++ b/.github/workflows/cd-store-preview.yml
@@ -10,13 +10,14 @@
 #  3. Generate a msixupload file
 #  4. Publish the msixupload to GitHub Actions
 
-name: Files CD (Store Preview)
+name: Files CD
 
 on:
   workflow_dispatch:
 
 jobs:
   build:
+    name: Deploy (Store Preview)
     runs-on: windows-latest
     environment: Deployments
     strategy:

--- a/.github/workflows/cd-store-stable.yml
+++ b/.github/workflows/cd-store-stable.yml
@@ -10,13 +10,14 @@
 #  3. Generate a msixupload file
 #  4. Publish the msixupload to GitHub Actions
 
-name: Files CD (Store Stable)
+name: Files CD
 
 on:
   workflow_dispatch:
 
 jobs:
   build:
+    name: Deploy (Store Stable)
     runs-on: windows-latest
     environment: Deployments
     strategy:

--- a/.github/workflows/cd-store-stable.yml
+++ b/.github/workflows/cd-store-stable.yml
@@ -17,12 +17,13 @@ on:
 
 jobs:
   build:
-    name: Deploy (Store Stable)
+    name: Deploy
     runs-on: windows-latest
     environment: Deployments
     strategy:
       fail-fast: false
       matrix:
+        environment: [Store Stable]
         configuration: [Release]
         platform: [x64]
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,9 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'assets/**'
-      - 'builds/**'
-      - 'docs/**'
       - '*.md'
   pull_request:
     paths-ignore:
-      - 'assets/**'
-      - 'builds/**'
-      - 'docs/**'
       - '*.md'
 
 run-name: ${{ github.event_name == 'pull_request' && 'Files PR Validation' || 'Files CI Validation' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ env:
 jobs:
 
   check-formatting:
-
+    name: Check formatting
     if: github.repository_owner == 'files-community'
 
     runs-on: windows-latest
@@ -82,7 +82,7 @@ jobs:
       run: exit 1
 
   build:
-
+    name: Build
     if: github.repository_owner == 'files-community'
 
     runs-on: windows-latest
@@ -180,7 +180,7 @@ jobs:
         path: ${{ env.ARTIFACTS_STAGING_DIR }}
 
   test:
-
+    name: Test
     if: github.repository_owner == 'files-community' && always()
 
     needs: [build]

--- a/.github/workflows/format-xaml.yml
+++ b/.github/workflows/format-xaml.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   format-xaml:
+    name: Format XAML
     if: github.event.issue.pull_request && github.event.comment.body == '/format'
     runs-on: windows-latest
     environment: Pull Requests


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

_Not worth opening another issue_

---

Makes the CI/CD workflow names a bit more concise.
- `build` is now `Build` to be consistent
- CD targets (Store Stable, Store Preview, etc.) are now part of the matrix
  ```
  Before: Files CD (Store Stable) / Deploy (Release, x64)
  After: Files CD / Deploy (Store Stable, Release, x64)
  ```
