### PR TITLE
Fix: Fixed issue where a drive with letter matching partially uninstalled Google Drive was not being recognized

### DIFF
--- a/src/Files.App/Services/Storage/StorageDevicesService.cs
+++ b/src/Files.App/Services/Storage/StorageDevicesService.cs
@@ -23,7 +23,8 @@ namespace Files.App.Services
 			foreach (var drive in list)
 			{
 				var driveLabel = DriveHelpers.GetExtendedDriveLabel(drive);
-				// We don't want cloud drives to appear in a plain "Drives" section.
+				// Cloud Drive Filter If (CDFI)
+				// We don't want cloud drives to appear in the plain "Drives" sections.
 				if (driveLabel.Equals("Google Drive") || drive.Name.Equals(pCloudDrivePath))
 					continue;
 
@@ -31,13 +32,13 @@ namespace Files.App.Services
 				if (res.ErrorCode is FileSystemStatusCode.Unauthorized)
 				{
 					App.Logger.LogWarning($"{res.ErrorCode}: Attempting to add the device, {drive.Name},"
-					                      + " failed at the StorageFolder initialization step. This device will be ignored.");
+						+ " failed at the StorageFolder initialization step. This device will be ignored.");
 					continue;
 				}
 				else if (!res)
 				{
 					App.Logger.LogWarning($"{res.ErrorCode}: Attempting to add the device, {drive.Name},"
-					                      + " failed at the StorageFolder initialization step. This device will be ignored.");
+						+ " failed at the StorageFolder initialization step. This device will be ignored.");
 					continue;
 				}
 

--- a/src/Files.App/Services/Storage/StorageDevicesService.cs
+++ b/src/Files.App/Services/Storage/StorageDevicesService.cs
@@ -24,15 +24,17 @@ namespace Files.App.Services
 			var sw = Stopwatch.StartNew();
 			var googleDrivePath = GoogleDriveCloudDetector.GetRegistryBasePath();
 			sw.Stop();
-			Debug.WriteLine($"In RemovableDrivesService: Time elapsed for registry check: {sw.Elapsed}");
+			Debug.WriteLine($"In RemovableDrivesService: Time elapsed for Google Drive registry check: {sw.Elapsed}");
 			var googleDrivePathWithMyDrive = googleDrivePath ?? string.Empty;
 			var gdPathIsValid = GoogleDriveCloudDetector.AddMyDriveToPathAndValidate(ref googleDrivePathWithMyDrive);
 			App.AppModel.GoogleDrivePath = gdPathIsValid ? googleDrivePathWithMyDrive : string.Empty;
 
 			foreach (var drive in list)
 			{
+				var driveLabel = DriveHelpers.GetExtendedDriveLabel(drive);
+				Debug.WriteLine($"In RemovableDrivesService: Drive {drive.Name} has ExtendedDriveLabel `{driveLabel}`");
 				// We don't want cloud drives to appear in a plain "Drives" section.
-				if ((gdPathIsValid && drive.Name.Equals(googleDrivePath)) || drive.Name.Equals(pCloudDrivePath))
+				if (driveLabel.Equals("Google Drive") || drive.Name.Equals(pCloudDrivePath))
 					continue;
 
 				var res = await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(drive.Name).AsTask());

--- a/src/Files.App/Services/Storage/StorageDevicesService.cs
+++ b/src/Files.App/Services/Storage/StorageDevicesService.cs
@@ -20,19 +20,9 @@ namespace Files.App.Services
 		{
 			var list = DriveInfo.GetDrives();
 			var pCloudDrivePath = App.AppModel.PCloudDrivePath;
-
-			var sw = Stopwatch.StartNew();
-			var googleDrivePath = GoogleDriveCloudDetector.GetRegistryBasePath();
-			sw.Stop();
-			Debug.WriteLine($"In RemovableDrivesService: Time elapsed for Google Drive registry check: {sw.Elapsed}");
-			var googleDrivePathWithMyDrive = googleDrivePath ?? string.Empty;
-			var gdPathIsValid = GoogleDriveCloudDetector.AddMyDriveToPathAndValidate(ref googleDrivePathWithMyDrive);
-			App.AppModel.GoogleDrivePath = gdPathIsValid ? googleDrivePathWithMyDrive : string.Empty;
-
 			foreach (var drive in list)
 			{
 				var driveLabel = DriveHelpers.GetExtendedDriveLabel(drive);
-				Debug.WriteLine($"In RemovableDrivesService: Drive {drive.Name} has ExtendedDriveLabel `{driveLabel}`");
 				// We don't want cloud drives to appear in a plain "Drives" section.
 				if (driveLabel.Equals("Google Drive") || drive.Name.Equals(pCloudDrivePath))
 					continue;

--- a/src/Files.App/Utils/Cloud/Detector/GoogleDriveCloudDetector.cs
+++ b/src/Files.App/Utils/Cloud/Detector/GoogleDriveCloudDetector.cs
@@ -171,6 +171,11 @@ namespace Files.App.Utils.Cloud
 			return googleDriveRegValueJson;
 		}
 
+		/// <summary>
+        /// Get the base file system path for Google Drive from the Registry.
+        /// For advanced "Google Drive for desktop" settings reference, see:
+        /// https://support.google.com/a/answer/7644837
+		/// </summary>
 		public static string? GetRegistryBasePath()
 		{
 			var googleDriveRegValJson = GetGoogleDriveRegValJson();

--- a/src/Files.App/Utils/Cloud/Detector/GoogleDriveCloudDetector.cs
+++ b/src/Files.App/Utils/Cloud/Detector/GoogleDriveCloudDetector.cs
@@ -108,7 +108,7 @@ namespace Files.App.Utils.Cloud
 			await Inspect(database, "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY 1", "root_preferences db, all tables");
 
 			var registryPath = App.AppModel.GoogleDrivePath;
-			if (!AddMyDriveToPathAndValidate(ref registryPath))
+			if (registryPath.Equals(string.Empty))
 				yield break;
 			yield return new CloudProvider(CloudProviders.GoogleDrive)
 			{
@@ -258,7 +258,7 @@ namespace Files.App.Utils.Cloud
 			return await FilesystemTasks.Wrap(() => StorageFile.GetFileFromPathAsync(iconPath).AsTask());
 		}
 
-		private static bool AddMyDriveToPathAndValidate(ref string path)
+		public static bool AddMyDriveToPathAndValidate(ref string path)
 		{ 
 			// If `path` contains a shortcut named "My Drive", store its target in `shellFolderBaseFirst`.
 			// This happens when "My Drive syncing options" is set to "Mirror files".


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

## Related Issues

* #16149

## Background

* We don't want Google Drive (or any cloud drive) to appear in the plain "Drives" sections.
* Most of the logic that populates the plain "Drives" sections is in `Files.App.Services.StorageDevicesService.GetDrivesAsync()`.
* In this method, there is a `foreach` over the drives returned from a basic `DriveInfo.GetDrives()` call (where each iterated drive is stored in the temporary variable `drive`).
* At the top of this `foreach` there is an `if` that skips the current iteration if the `drive` is Google Drive or pCloud.
  * (I'll refer to this `if` as the "Cloud Drive Filter If" -- CDFI)
* Previously, the CDFI compared `drive.Name` to the file system paths of Google Drive and pCloud.
* To allow this comparison for Google Drive, I got Google Drive's system path from the Registry.
* I got the root filepath (normally `G:\`) and then the CDFI skipped any drive with that path, under the assumption that this was Google Drive and therefore a cloud drive. 
* In hindsight, this logic was not the best. It is possible, as issue #16149 shows, that a user might have Google Drive listed in their Registry under `G:\`, but a different, non-cloud drive actually assigned to `G:\`, which we *would* want to appear under the plain "Drives" sections.
* The current PR hopefully fixes this issue.

## Solution Approach

* Instead of comparing the root Google Drive filepath to `drive.Name` in the CDFI, use `File.App.Utils.Storage.DriveHelpers.GetExtendedDriveLabel` to get the `DriveInfo.VolumeLabel` of the `drive`, and compare that to the string "Google Drive". 
* This approach is better because it filters by an attribute of the `drive` that only a Google Drive `drive` would have, and it does not rely on the Registry, which can contain misleading Google Drive artifacts if Google Drive is in a "partially uninstalled" state on the user's system.

## Summary of Changes

* `StorageDevicesService`: Remove logic that (1) gets the Google Drive path with a Registry query, (2) times the Registry query, and (3) saves the Google Drive path to `App.AppModel.GoogleDrivePath`, because the Google Drive path is no longer needed in `StorageDevicesService`, it was only used in the CDFI.
* `StorageDevicesService`: Get the drive label and use it in the CDFI, as described in Solution Approach.
* `StorageDevicesService`: Edit/add some comments.
* `GoogleDriveCloudDetector`: Add logic that (1) gets the Google Drive path with a Registry query, (2) times the Registry query (moved back here from `StorageDevicesService`).
* `GoogleDriveCloudDetector`: Change a variable name and edit/add some comments.

## Test Plans

* Regression tests
  * Test [RT1](https://drive.google.com/file/d/1_2gY0xn_6yotS-fUR7g_da1QSsoH9pAH/view?usp=sharing)
    * Setup
      * Set Google Drive preferences to Syncing Mirror, StreamLoc DriveLetter
    * Checks
      * Check RT1-C1: Does Google Drive appear under plain "Drives" in sidebar or home?
        * Expected: No
        * Actual: No
      * Check RT1-C2: Does Google Drive appear exactly once under "Cloud Drives"?
        * Expected: Yes
        * Actual: Yes
      * Check RT1-C3: Does clicking on Google Drive open "My Drive" directly?
        * Expected: Yes
        * Actual: Yes
      * Check RT1-C4: Does clicking on Google Drive open the correct file system path for the settings configuration?
        * Expected: Yes
        * Actual: Yes
  * Test [RT2](https://drive.google.com/file/d/1aluTKManVASX8pExAPcuiLX0B1dFW46e/view?usp=sharing)
    * Setup
      * Set Google Drive preferences to Syncing Mirror, StreamLoc Folder
    * Checks
      * Check RT2-C1: Does Google Drive appear under plain "Drives" in sidebar or home?
        * Expected: No
        * Actual: No
      * Check RT2-C2: Does Google Drive appear exactly once under "Cloud Drives"?
        * Expected: Yes
        * Actual: Yes
      * Check RT2-C3: Does clicking on Google Drive open "My Drive" directly?
        * Expected: Yes
        * Actual: Yes
      * Check RT2-C4: Does clicking on Google Drive open the correct file system path for the settings configuration?
        * Expected: Yes
        * Actual: Yes
  * Test [RT3](https://drive.google.com/file/d/1gAJJtFjB6CKRp71E18G6y0tlpH5vmqPd/view?usp=sharing)
    * Setup
      * Set Google Drive preferences to Syncing Stream, StreamLoc Folder
    * Checks
      * Check RT3-C1: Does Google Drive appear under plain "Drives" in sidebar or home?
        * Expected: No
        * Actual: No
      * Check RT3-C2: Does Google Drive appear exactly once under "Cloud Drives"?
        * Expected: Yes
        * Actual: Yes
      * Check RT3-C3: Does clicking on Google Drive open "My Drive" directly?
        * Expected: Yes
        * Actual: Yes
      * Check RT3-C4: Does clicking on Google Drive open the correct file system path for the settings configuration?
        * Expected: Yes
        * Actual: Yes
  * Test [RT4](https://drive.google.com/file/d/1XfP4CdjHw7CvI-XcfHBINQj6ujr1TYmN/view?usp=sharing)
    * Setup
      * Set Google Drive preferences to Syncing Stream, StreamLoc DriveLetter
    * Checks
      * Check RT4-C1: Does Google Drive appear under plain "Drives" in sidebar or home?
        * Expected: No
        * Actual: No
      * Check RT4-C2: Does Google Drive appear exactly once under "Cloud Drives"?
        * Expected: Yes
        * Actual: Yes
      * Check RT4-C3: Does clicking on Google Drive open "My Drive" directly?
        * Expected: Yes
        * Actual: Yes
      * Check RT4-C4: Does clicking on Google Drive open the correct file system path for the settings configuration?
        * Expected: Yes
        * Actual: Yes
* Bugfix tests
  * Test BFT1
    * Summary
      * Confirm that a Google Drive `drive` has "Google Drive" as its drive label (and is therefore skipped by the CDFI)
    * Setup
      * Set Google Drive preferences to "Syncing set to Stream, Stream Location set to Drive Letter" with drive letter G.
      * Run Files with debugger.
      * Track the `driveLabel` local variable for each iteration of the `foreach` in `StorageDevicesService.GetDrivesAsync`.
    * Checks   
      * Check BFT1-C1: Does `driveLabel` for the `drive` whose `Name` is "G:\" equal "Google Drive"?
        * Expected: Yes
        * Actual:
  * Test BFT2
    * Summary
      * Confirm that a non-Google Drive `drive` that has "G:\" as its path (which is what KremmenUK's dashcam drive was) does not have "Google Drive" as its drive label (and is therefore *not* skipped by the CDFI)
    * Setup 1
      * Switch to main branch.
      * Set Google Drive preferences to "Syncing set to Stream, Stream Location set to Drive Letter" with drive letter G.
      * Stop Google Drive process.
      * Plug in a flash drive and set its drive letter to G.
      * Run Files with debugger.
      * Track what `GoogleDriveCloudDetector.GetRegistryBasePath` finds in the registry.
      * Track the `driveLabel` local variable for each iteration of the `foreach` in `StorageDevicesService.GetDrivesAsync`.
    * Checks 1 (these should show that the changes made to my machine's configuration in Setup 1 reproduce KremmenUK's issue)
      * Check BFT2-C1: Do we see "G" as the mount point?
        * Expected: Yes
        * Actual:
      * Check BFT2-C2: Does the `driveLabel` for the `drive` whose `Name` is "G:\" equal "Google Drive"?
        * Expected: No
        * Actual:
      * Check BFT2-C3: Does the flash drive on drive letter G appear in the plain "Drives" sections in the app?
        * Expected: No
        * Actual:
    * Setup 2
      * Switch to BugGoogleDriveNotRecognized branch.
    * Checks 2 (these should show that the changes made to the Files code in this PR branch solve KremmenUK's issue)
      * Check BFT2-C4: Does the flash drive on drive letter G appear in the plain "Drives" sections in the app?
        * Expected: Yes
        * Actual:

