### PR TITLE
GitHub: Updated license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Files Community
+Copyright (c) 2018 - present Files Community
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Files.App.SaveDialog/Files.App.SaveDialog.Win32.vcxproj
+++ b/src/Files.App.SaveDialog/Files.App.SaveDialog.Win32.vcxproj
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (c) Files Community. Licensed under the MIT License.  -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|arm64">

--- a/src/Files.App.Server/Files.App.Server.csproj
+++ b/src/Files.App.Server/Files.App.Server.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<!--  Copyright (c) Files Community. Licensed under the MIT License.  -->
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>

--- a/src/Files.Core.SourceGenerator/Extensions/StringBuilderExtensions.cs
+++ b/src/Files.Core.SourceGenerator/Extensions/StringBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Files.Core.SourceGenerator.Extensions
 		/// <returns>The <see cref="StringBuilder"/> instance with the appended license header.</returns>
 		internal static StringBuilder AppendLicenceHeader(this StringBuilder sb)
 		{
-			return sb.AppendLine($"// Copyright (c) {DateTime.Now.Year} Files Community")
+			return sb.AppendLine($"// Copyright (c) Files Community")
 				.AppendLine("// Licensed under the MIT License.");
 		}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

Fixes some small issues with:
- license header missing in some projects
- source generator was not updated
- removed "2025" from license file in favour of "2018-present"
