### PR TITLE
Fix: Grouping by tags doesn't show all items

### DIFF
--- a/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
+++ b/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs
@@ -14,6 +14,8 @@ namespace Files.App.UserControls.Menus
 		private IFileTagsSettingsService FileTagsSettingsService { get; } =
 			Ioc.Default.GetService<IFileTagsSettingsService>();
 
+		public event EventHandler? TagsChanged;
+
 		public IEnumerable<ListedItem> SelectedItems { get; }
 
 		public FileTagsContextMenu(IEnumerable<ListedItem> selectedItems)
@@ -81,6 +83,7 @@ namespace Files.App.UserControls.Menus
 					selectedItem.FileTags = tagList;
 				}
 			}
+			TagsChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		private void AddFileTag(IEnumerable<ListedItem> selectedListedItems, TagViewModel added)
@@ -93,6 +96,7 @@ namespace Files.App.UserControls.Menus
 					selectedItem.FileTags = [.. existingTags, added.Uid];
 				}
 			}
+			TagsChanged?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -2675,52 +2675,52 @@ namespace Files.App.ViewModels
 	}
 
 	public sealed class PageTypeUpdatedEventArgs
-{
-	public bool IsTypeCloudDrive { get; set; }
-
-	public bool IsTypeRecycleBin { get; set; }
-
-	public bool IsTypeGitRepository { get; set; }
-
-	public bool IsTypeSearchResults { get; set; }
-}
-
-public sealed class WorkingDirectoryModifiedEventArgs : EventArgs
-{
-	public string? Path { get; set; }
-
-	public string? Name { get; set; }
-
-	public bool IsLibrary { get; set; }
-}
-
-public sealed class ItemLoadStatusChangedEventArgs : EventArgs
-{
-	public enum ItemLoadStatus
 	{
-		Starting,
-		InProgress,
-		Complete
+		public bool IsTypeCloudDrive { get; set; }
+
+		public bool IsTypeRecycleBin { get; set; }
+
+		public bool IsTypeGitRepository { get; set; }
+
+		public bool IsTypeSearchResults { get; set; }
 	}
 
-	public ItemLoadStatus Status { get; set; }
+	public sealed class WorkingDirectoryModifiedEventArgs : EventArgs
+	{
+		public string? Path { get; set; }
 
-	/// <summary>
-	/// This property may not be provided consistently if Status is not Complete
-	/// </summary>
-	public string? PreviousDirectory { get; set; }
+		public string? Name { get; set; }
 
-	/// <summary>
-	/// This property may not be provided consistently if Status is not Complete
-	/// </summary>
-	public string? Path { get; set; }
-}
+		public bool IsLibrary { get; set; }
+	}
 
-public enum GitProperties
-{
-	None,
-	Status,
-	Commit,
-	All,
-}
+	public sealed class ItemLoadStatusChangedEventArgs : EventArgs
+	{
+		public enum ItemLoadStatus
+		{
+			Starting,
+			InProgress,
+			Complete
+		}
+
+		public ItemLoadStatus Status { get; set; }
+
+		/// <summary>
+		/// This property may not be provided consistently if Status is not Complete
+		/// </summary>
+		public string? PreviousDirectory { get; set; }
+
+		/// <summary>
+		/// This property may not be provided consistently if Status is not Complete
+		/// </summary>
+		public string? Path { get; set; }
+	}
+
+	public enum GitProperties
+	{
+		None,
+		Status,
+		Commit,
+		All,
+	}
 }

--- a/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
@@ -485,7 +485,23 @@ namespace Files.App.ViewModels.UserControls
 
 			SelectedItem?.FileTagsUI?.ForEach(tag => Items.Add(new TagItem(tag)));
 
-			Items.Add(new FlyoutItem(new Files.App.UserControls.Menus.FileTagsContextMenu(new List<ListedItem>() { SelectedItem })));
+			var contextMenu = new Files.App.UserControls.Menus.FileTagsContextMenu(new List<ListedItem>() { SelectedItem });
+			contextMenu.Closed += HandleClosed;
+			contextMenu.TagsChanged += RequireTagGroupsUpdate;
+
+			Items.Add(new FlyoutItem(contextMenu));
+
+			async void RequireTagGroupsUpdate(object? sender, EventArgs e)
+			{
+				if (contentPageContext.ShellPage is not null)
+					await contentPageContext.ShellPage.ShellViewModel.UpdateGroupTagGroupsIfNeeded();
+			}
+
+			void HandleClosed(object? sender, object e)
+			{
+				contextMenu.TagsChanged -= RequireTagGroupsUpdate;
+				contextMenu.Closed -= HandleClosed;
+			}
 		}
 
 		private void SetDriveItem()

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -1267,6 +1267,7 @@ namespace Files.App.ViewModels.UserControls
 		{
 			var storageItems = await Utils.Storage.FilesystemHelpers.GetDraggedStorageItems(args.DroppedItem);
 			var dbInstance = FileTagsHelper.GetDbInstance();
+			var pathToTags = new Dictionary<string, string[]>();
 			foreach (var item in storageItems.Where(x => !string.IsNullOrEmpty(x.Path)))
 			{
 				var filesTags = FileTagsHelper.ReadFileTag(item.Path);
@@ -1276,7 +1277,14 @@ namespace Files.App.ViewModels.UserControls
 					var fileFRN = await FileTagsHelper.GetFileFRN(item.Item);
 					dbInstance.SetTags(item.Path, fileFRN, filesTags);
 					FileTagsHelper.WriteFileTag(item.Path, filesTags);
+					pathToTags[item.Path] = filesTags;
 				}
+			}
+
+			if (paneHolder.ActivePane is not null)
+			{
+				await paneHolder.ActivePane.ShellViewModel.UpdateItemsTags(pathToTags);
+				await paneHolder.ActivePane.ShellViewModel.UpdateGroupTagGroupsIfNeeded();
 			}
 		}
 

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -764,6 +764,21 @@ namespace Files.App.Views.Layouts
 				},
 				Flyout = fileTagsContextMenu
 			});
+
+			fileTagsContextMenu.TagsChanged += RequireTagGroupsUpdate;
+			fileTagsContextMenu.Closed += HandleClosed;
+
+			async void RequireTagGroupsUpdate(object? sender, EventArgs e)
+			{
+				if (ParentShellPageInstance is not null)
+					await ParentShellPageInstance.ShellViewModel.UpdateGroupTagGroupsIfNeeded();
+			}
+
+			void HandleClosed(object? sender, object e)
+			{
+				fileTagsContextMenu.TagsChanged -= RequireTagGroupsUpdate;
+				fileTagsContextMenu.Closed -= HandleClosed;
+			}
 		}
 
 		private async Task AddShellMenuItemsAsync(List<ContextMenuFlyoutItemViewModel> shellMenuItems, CommandBarFlyout contextMenuFlyout, bool shiftPressed)

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -938,7 +938,7 @@ namespace Files.App.Views.Layouts
 			VisualStateManager.GoToState((UserControl)sender, "Normal", true);
 		}
 
-		private void RemoveTagIcon_Tapped(object sender, TappedRoutedEventArgs e)
+		private async void RemoveTagIcon_Tapped(object sender, TappedRoutedEventArgs e)
 		{
 			var parent = (sender as FontIcon)?.Parent as StackPanel;
 			var tagName = (parent?.Children[TAG_TEXT_BLOCK] as TextBlock)?.Text;
@@ -953,6 +953,9 @@ namespace Files.App.Views.Layouts
 				item.FileTags = item.FileTags
 					.Except([tagId])
 					.ToArray();
+
+				if (ParentShellPageInstance is not null)
+					await ParentShellPageInstance.ShellViewModel.UpdateGroupTagGroupsIfNeeded();
 			}
 
 			e.Handled = true;


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #11579 

> [!NOTE]
> While working on this PR I found that [this class](https://github.com/files-community/Files/blob/main/src/Files.App/UserControls/Menus/FileTagsContextMenu.cs) is marked as `Obsolete`, is it something we did?

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open a folder with files inside.
2. Give them some tags
3. Group them by tags
4. All files should show up (even the untagged ones), but instead just some of them are.

https://github.com/user-attachments/assets/f47565e5-28b9-4898-bf14-3063d8fa90c7
