### PR TITLE
Fix: Fixed issue where the size wasn't displayed after creating a new archive

### DIFF
--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -2496,6 +2496,7 @@ namespace Files.App.ViewModels
 				else if (storageItem.IsOfType(StorageItemTypes.Folder))
 				{
 					var properties = await storageItem.AsBaseStorageFolder().GetBasicPropertiesAsync();
+					size = item.IsArchive ? (long)properties.Size : null;
 					modified = properties.DateModified;
 					created = properties.DateCreated;
 				}

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -2496,7 +2496,7 @@ namespace Files.App.ViewModels
 				else if (storageItem.IsOfType(StorageItemTypes.Folder))
 				{
 					var properties = await storageItem.AsBaseStorageFolder().GetBasicPropertiesAsync();
-					size = item.IsArchive ? (long)properties.Size : null;
+					size = (long)properties.Size;
 					modified = properties.DateModified;
 					created = properties.DateCreated;
 				}


### PR DESCRIPTION
**Resolved / Related Issues**

The problem is related to the fact that the archive, which is perceived as a folder, is not assigned a size in the `ShellViewModel.GetFileOrFolderUpdateInfoAsync()` method, unlike files, but we also do not want to assign a size to regular folders, for which this method is called, so for them the size should be left as null.
- Closes #11580

**Steps used to test these changes**

1. Create an archive using any available actions.
2. Make sure that the size is displayed correctly.
