### PR TITLE
Fix: Fixed thumbails not loading in MTP devices

### DIFF
--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -1215,7 +1215,8 @@ namespace Files.App.ViewModels
 								Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
 
 								// For MTP devices load thumbnail using Storage API (#15084)
-								wasThumbnailLoaded |= await LoadThumbnailAsync(item, matchingStorageFile, cts.Token);
+								if (!wasThumbnailLoaded)
+									await LoadThumbnailAsync(item, matchingStorageFile, cts.Token);
 
 								SetFileTag(item);
 								wasSyncStatusLoaded = true;
@@ -1288,7 +1289,8 @@ namespace Files.App.ViewModels
 								Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
 
 								// For MTP devices load thumbnail using Storage API (#15084)
-								wasThumbnailLoaded |= await LoadThumbnailAsync(item, matchingStorageFolder, cts.Token);
+								if (!wasThumbnailLoaded)
+									await LoadThumbnailAsync(item, matchingStorageFolder, cts.Token);
 
 								SetFileTag(item);
 								wasSyncStatusLoaded = true;


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15084

Added back some code removed in #14423 which is necessary for loading thumbails in MTP.

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Verify that icons are loaded in MTP devices
2. Verify that loading on normal drives is not impacted
