### PR TITLE
Fix: Fixed performance issue with SMB shares

### DIFF
--- a/src/Files.App/Services/Storage/StorageNetworkService.cs
+++ b/src/Files.App/Services/Storage/StorageNetworkService.cs
@@ -208,6 +208,25 @@ namespace Files.App.Services
 
 			unsafe
 			{
+
+   				if (!path.StartsWith(@"\\", StringComparison.Ordinal))
+				{
+					//  Special handling for network drives
+	 				//  This part will change path from "y:\Download" to "\\192.168.0.1\nfs\Download"
+					[DllImport("mpr.dll", CharSet = CharSet.Auto)]
+					static extern int WNetGetConnection(string lpLocalName, StringBuilder lpRemoteName, ref int lpnLength);
+					
+					StringBuilder remoteName = new StringBuilder(300);
+					int length = remoteName.Capacity;
+					string lpLocalName = path.Substring(0, 2);
+
+					int ret = WNetGetConnection(lpLocalName, remoteName, ref length);
+
+					if ( ret == 0 )
+						path = path.Replace(lpLocalName, remoteName.ToString());
+
+				}
+	
 				fixed (char* lpcPath = path)
 					netRes.lpRemoteName = new PWSTR(lpcPath);
 			}

--- a/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
@@ -93,10 +93,9 @@ namespace Files.App.Utils.Storage
 			}
 			// Network share
 			else if (
-						(  devicePath.StartsWith(@"\\", StringComparison.Ordinal) &&
+						  (  devicePath.StartsWith(@"\\", StringComparison.Ordinal) ||
+							 GetDriveType(new SystemIO.DriveInfo(devicePath)) is DriveType.Network  ) &&
 						  !devicePath.StartsWith(@"\\SHELL\", StringComparison.Ordinal)
-						) ||
-						GetDriveType(new SystemIO.DriveInfo(devicePath)) is DriveType.Network
 					)
 			{
 				int lastSepIndex = rootPath.LastIndexOf(@"\", StringComparison.Ordinal);

--- a/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
@@ -92,8 +92,12 @@ namespace Files.App.Utils.Storage
 				}
 			}
 			// Network share
-			else if (devicePath.StartsWith(@"\\", StringComparison.Ordinal) &&
-				!devicePath.StartsWith(@"\\SHELL\", StringComparison.Ordinal))
+			else if (
+						(  devicePath.StartsWith(@"\\", StringComparison.Ordinal) &&
+						  !devicePath.StartsWith(@"\\SHELL\", StringComparison.Ordinal)
+						) ||
+						GetDriveType(new SystemIO.DriveInfo(devicePath)) is DriveType.Network
+					)
 			{
 				int lastSepIndex = rootPath.LastIndexOf(@"\", StringComparison.Ordinal);
 				rootPath = lastSepIndex > 1 ? rootPath.Substring(0, lastSepIndex) : rootPath; // Remove share name

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -1633,12 +1633,18 @@ namespace Files.App.ViewModels
 				!isMtp &&
 				!isShellFolder &&
 				!isWslDistro;
+	
+			// Special handling for network drives
+			bool isNetdisk = false;
+			if (!isNetwork)
+				isNetdisk = (new DriveInfo(path).DriveType == System.IO.DriveType.Network);
+ 			
 			bool isFtp = FtpHelpers.IsFtpPath(path);
 			bool enumFromStorageFolder = isBoxFolder || isFtp;
 
 			BaseStorageFolder? rootFolder = null;
 
-			if (isNetwork)
+			if (isNetwork || isNetdisk)
 			{
 				var auth = await NetworkService.AuthenticateNetworkShare(path);
 				if (!auth)

--- a/src/Files.Shared/Helpers/PathHelpers.cs
+++ b/src/Files.Shared/Helpers/PathHelpers.cs
@@ -22,7 +22,11 @@ namespace Files.Shared.Helpers
 			string fileName;
 			string rootPath = Path.GetPathRoot(path) ?? string.Empty;
 
-			if (rootPath == path && path.StartsWith(@"\\"))
+			if (rootPath == path && 
+					( path.StartsWith(@"\\") ||
+					  (new DriveInfo(path).DriveType == System.IO.DriveType.Network)
+					)
+			   )
 			{
 				// Network Share path
 				fileName = path.Substring(path.LastIndexOf(@"\", StringComparison.Ordinal) + 1);


### PR DESCRIPTION
**Resolved / Related Issues**

Related to #12704
I'm not pro in c_sh,
This is only a temporary solution.
Because my work relies heavily on various mapped network drives,
Till now, this patch work for me.



**Steps used to test these changes**

1） Enter an smb that has been mapped as a network drive like "Y:\Download"
2）enter the directory containing a large number of large compressed files and wait for them to be lod.
3)  Observe whether the loading speed is the same with "\\192.168.0.1\nfs\Download"



ps:
The root cause may be the reading of the zip file，
Although it has not been tested, this is just a guess. Will huge files on slow devices have similar phenomena?
I also think that the compressed file recognition problem I mentioned in #12704 may aggravate this phenomenon.
Additionally, I would suggest that the file system type detection could be more unified into one function, rather than being everywhere.