### PR TITLE
Code Quality: Replace string literals with string constants

### DIFF
--- a/src/Files.App/Actions/Content/Archives/Compress/CompressIntoArchiveAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Compress/CompressIntoArchiveAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 	internal sealed partial class CompressIntoArchiveAction : BaseCompressArchiveAction
 	{
 		public override string Label
-			=> "CreateArchive".GetLocalizedResource();
+			=> Strings.CreateArchive.GetLocalizedResource();
 
 		public override string Description
-			=> "CompressIntoArchiveDescription".GetLocalizedResource();
+			=> Strings.CompressIntoArchiveDescription.GetLocalizedResource();
 
 		public CompressIntoArchiveAction()
 		{

--- a/src/Files.App/Actions/Content/Archives/Compress/CompressIntoSevenZipAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Compress/CompressIntoSevenZipAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CompressIntoSevenZipAction : BaseCompressArchiveAction
 	{
 		public override string Label
-			=> string.Format("CreateNamedArchive".GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.7z");
+			=> string.Format(Strings.CreateNamedArchive.GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.7z");
 
 		public override string Description
-			=> "CompressIntoSevenZipDescription".GetLocalizedResource();
+			=> Strings.CompressIntoSevenZipDescription.GetLocalizedResource();
 
 		public CompressIntoSevenZipAction()
 		{

--- a/src/Files.App/Actions/Content/Archives/Compress/CompressIntoZipAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Compress/CompressIntoZipAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CompressIntoZipAction : BaseCompressArchiveAction
 	{
 		public override string Label
-			=> string.Format("CreateNamedArchive".GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.zip");
+			=> string.Format(Strings.CreateNamedArchive.GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.zip");
 
 		public override string Description
-			=> "CompressIntoZipDescription".GetLocalizedResource();
+			=> Strings.CompressIntoZipDescription.GetLocalizedResource();
 
 		public CompressIntoZipAction()
 		{

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
@@ -14,10 +14,10 @@ namespace Files.App.Actions
 	internal sealed partial class DecompressArchive : BaseDecompressArchiveAction
 	{
 		public override string Label
-			=> "ExtractFiles".GetLocalizedResource();
+			=> Strings.ExtractFiles.GetLocalizedResource();
 
 		public override string Description
-			=> "DecompressArchiveDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveDescription.GetLocalizedResource();
 
 		public override HotKey HotKey
 			=> new(Keys.E, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHere.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHere.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class DecompressArchiveHere : BaseDecompressArchiveAction
 	{
 		public override string Label
-			=> "ExtractHere".GetLocalizedResource();
+			=> Strings.ExtractHere.GetLocalizedResource();
 
 		public override string Description
-			=> "DecompressArchiveHereDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveHereDescription.GetLocalizedResource();
 
 		public DecompressArchiveHere()
 		{

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHereSmart.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHereSmart.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class DecompressArchiveHereSmart : BaseDecompressArchiveAction
 	{
 		public override string Label
-			=> "ExtractHereSmart".GetLocalizedResource();
+			=> Strings.ExtractHereSmart.GetLocalizedResource();
 
 		public override string Description
-			=> "DecompressArchiveHereSmartDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveHereSmartDescription.GetLocalizedResource();
 
 		public override HotKey HotKey
 			=> new(Keys.E, KeyModifiers.CtrlShift);

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveToChildFolderAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveToChildFolderAction.cs
@@ -15,7 +15,7 @@ namespace Files.App.Actions
 			=> ComputeLabel();
 
 		public override string Description
-			=> "DecompressArchiveToChildFolderDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveToChildFolderDescription.GetLocalizedResource();
 
 		public DecompressArchiveToChildFolderAction()
 		{
@@ -86,11 +86,11 @@ namespace Files.App.Actions
 		private string ComputeLabel()
 		{
 			if (context.SelectedItems == null || context.SelectedItems.Count == 0)
-				return string.Format("BaseLayoutItemContextFlyoutExtractToChildFolder".GetLocalizedResource(), string.Empty);
+				return string.Format(Strings.BaseLayoutItemContextFlyoutExtractToChildFolder.GetLocalizedResource(), string.Empty);
 
 			return context.SelectedItems.Count > 1
-				? string.Format("BaseLayoutItemContextFlyoutExtractToChildFolder".GetLocalizedResource(), "*")
-				: string.Format("BaseLayoutItemContextFlyoutExtractToChildFolder".GetLocalizedResource(), SystemIO.Path.GetFileNameWithoutExtension(context.SelectedItems.First().Name));
+				? string.Format(Strings.BaseLayoutItemContextFlyoutExtractToChildFolder.GetLocalizedResource(), "*")
+				: string.Format(Strings.BaseLayoutItemContextFlyoutExtractToChildFolder.GetLocalizedResource(), SystemIO.Path.GetFileNameWithoutExtension(context.SelectedItems.First().Name));
 		}
 	}
 }

--- a/src/Files.App/Actions/Content/Background/BaseSetAsAction.cs
+++ b/src/Files.App/Actions/Content/Background/BaseSetAsAction.cs
@@ -34,9 +34,9 @@ namespace Files.App.Actions
 		{
 			var errorDialog = new ContentDialog()
 			{
-				Title = "FailedToSetBackground".GetLocalizedResource(),
+				Title = Strings.FailedToSetBackground.GetLocalizedResource(),
 				Content = message,
-				PrimaryButtonText = "OK".GetLocalizedResource(),
+				PrimaryButtonText = Strings.OK.GetLocalizedResource(),
 			};
 
 			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))

--- a/src/Files.App/Actions/Content/Background/SetAsAppBackgroundAction.cs
+++ b/src/Files.App/Actions/Content/Background/SetAsAppBackgroundAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 
 		public override string Label
-			=> "SetAsAppBackground".GetLocalizedResource();
+			=> Strings.SetAsAppBackground.GetLocalizedResource();
 
 		public override string Description
-			=> "SetAsAppBackgroundDescription".GetLocalizedResource();
+			=> Strings.SetAsAppBackgroundDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new("\uE91B");

--- a/src/Files.App/Actions/Content/Background/SetAsLockscreenBackgroundAction.cs
+++ b/src/Files.App/Actions/Content/Background/SetAsLockscreenBackgroundAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IWindowsWallpaperService WindowsWallpaperService = Ioc.Default.GetRequiredService<IWindowsWallpaperService>();
 
 		public override string Label
-			=> "SetAsLockscreen".GetLocalizedResource();
+			=> Strings.SetAsLockscreen.GetLocalizedResource();
 
 		public override string Description
-			=> "SetAsLockscreenBackgroundDescription".GetLocalizedResource();
+			=> Strings.SetAsLockscreenBackgroundDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new("\uEE3F");

--- a/src/Files.App/Actions/Content/Background/SetAsSlideshowBackgroundAction.cs
+++ b/src/Files.App/Actions/Content/Background/SetAsSlideshowBackgroundAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IWindowsWallpaperService WindowsWallpaperService = Ioc.Default.GetRequiredService<IWindowsWallpaperService>();
 
 		public override string Label
-			=> "SetAsSlideshow".GetLocalizedResource();
+			=> Strings.SetAsSlideshow.GetLocalizedResource();
 
 		public override string Description
-			=> "SetAsSlideshowBackgroundDescription".GetLocalizedResource();
+			=> Strings.SetAsSlideshowBackgroundDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new("\uE91B");

--- a/src/Files.App/Actions/Content/Background/SetAsWallpaperBackgroundAction.cs
+++ b/src/Files.App/Actions/Content/Background/SetAsWallpaperBackgroundAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 	internal sealed partial class SetAsWallpaperBackgroundAction : BaseSetAsAction
 	{
 		public override string Label
-			=> "SetAsBackground".GetLocalizedResource();
+			=> Strings.SetAsBackground.GetLocalizedResource();
 
 		public override string Description
-			=> "SetAsWallpaperBackgroundDescription".GetLocalizedResource();
+			=> Strings.SetAsWallpaperBackgroundDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new("\uE91B");

--- a/src/Files.App/Actions/Content/ImageManipulation/RotateLeftAction.cs
+++ b/src/Files.App/Actions/Content/ImageManipulation/RotateLeftAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 	internal sealed partial class RotateLeftAction : BaseRotateAction
 	{
 		public override string Label
-			=> "RotateLeft".GetLocalizedResource();
+			=> Strings.RotateLeft.GetLocalizedResource();
 
 		public override string Description
-			=> "RotateLeftDescription".GetLocalizedResource();
+			=> Strings.RotateLeftDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.ImageRotate.ACW");

--- a/src/Files.App/Actions/Content/ImageManipulation/RotateRightAction.cs
+++ b/src/Files.App/Actions/Content/ImageManipulation/RotateRightAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 	internal sealed partial class RotateRightAction : BaseRotateAction
 	{
 		public override string Label
-			=> "RotateRight".GetLocalizedResource();
+			=> Strings.RotateRight.GetLocalizedResource();
 
 		public override string Description
-			=> "RotateRightDescription".GetLocalizedResource();
+			=> Strings.RotateRightDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.ImageRotate.CW");

--- a/src/Files.App/Actions/Content/Install/InstallCertificateAction.cs
+++ b/src/Files.App/Actions/Content/Install/InstallCertificateAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Install".GetLocalizedResource();
+			=> Strings.Install.GetLocalizedResource();
 
 		public string Description
-			=> "InstallCertificateDescription".GetLocalizedResource();
+			=> Strings.InstallCertificateDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uEB95");

--- a/src/Files.App/Actions/Content/Install/InstallFontAction.cs
+++ b/src/Files.App/Actions/Content/Install/InstallFontAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Install".GetLocalizedResource();
+			=> Strings.Install.GetLocalizedResource();
 
 		public string Description
-			=> "InstallFontDescription".GetLocalizedResource();
+			=> Strings.InstallFontDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uE8D2");

--- a/src/Files.App/Actions/Content/Install/InstallInfDriverAction.cs
+++ b/src/Files.App/Actions/Content/Install/InstallInfDriverAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Install".GetLocalizedResource();
+			=> Strings.Install.GetLocalizedResource();
 		
 		public string Description
-			=> "InstallInfDriverDescription".GetLocalizedResource();
+			=> Strings.InstallInfDriverDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uE9F5");

--- a/src/Files.App/Actions/Content/PlayAllAction.cs
+++ b/src/Files.App/Actions/Content/PlayAllAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "PlayAll".GetLocalizedResource();
+			=> Strings.PlayAll.GetLocalizedResource();
 
 		public string Description
-			=> "PlayAllDescription".GetLocalizedResource();
+			=> Strings.PlayAllDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uE768");

--- a/src/Files.App/Actions/Content/PreviewPopup/LaunchPreviewPopupAction.cs
+++ b/src/Files.App/Actions/Content/PreviewPopup/LaunchPreviewPopupAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IPreviewPopupService previewPopupService;
 
 		public string Label
-			=> "LaunchPreviewPopup".GetLocalizedResource();
+			=> Strings.LaunchPreviewPopup.GetLocalizedResource();
 
 		public string Description
-			=> "LaunchPreviewPopupDescription".GetLocalizedResource();
+			=> Strings.LaunchPreviewPopupDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.Space);

--- a/src/Files.App/Actions/Content/RefreshItemsAction.cs
+++ b/src/Files.App/Actions/Content/RefreshItemsAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Refresh".GetLocalizedResource();
+			=> Strings.Refresh.GetLocalizedResource();
 
 		public string Description
-			=> "RefreshItemsDescription".GetLocalizedResource();
+			=> Strings.RefreshItemsDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uE72C");

--- a/src/Files.App/Actions/Content/Run/RunAsAdminAction.cs
+++ b/src/Files.App/Actions/Content/Run/RunAsAdminAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext ContentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		public override string Label
-			=> "RunAsAdministrator".GetLocalizedResource();
+			=> Strings.RunAsAdministrator.GetLocalizedResource();
 
 		public override string Description
-			=> "RunAsAdminDescription".GetLocalizedResource();
+			=> Strings.RunAsAdminDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new("\uE7EF");

--- a/src/Files.App/Actions/Content/Run/RunAsAnotherUserAction.cs
+++ b/src/Files.App/Actions/Content/Run/RunAsAnotherUserAction.cs
@@ -9,10 +9,10 @@ namespace Files.App.Actions
 	{
 		private readonly IContentPageContext ContentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
 		public override string Label
-			=> "BaseLayoutContextFlyoutRunAsAnotherUser/Text".GetLocalizedResource();
+			=> Strings.BaseLayoutContextFlyoutRunAsAnotherUser_Text.GetLocalizedResource();
 
 		public override string Description
-			=> "RunAsAnotherUserDescription".GetLocalizedResource();
+			=> Strings.RunAsAnotherUserDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new("\uE7EE");

--- a/src/Files.App/Actions/Content/Run/RunWithPowershellAction.cs
+++ b/src/Files.App/Actions/Content/Run/RunWithPowershellAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "RunWithPowerShell".GetLocalizedResource();
+			=> Strings.RunWithPowerShell.GetLocalizedResource();
 
 		public string Description
-			=> "RunWithPowershellDescription".GetLocalizedResource();
+			=> Strings.RunWithPowershellDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uE756");

--- a/src/Files.App/Actions/Content/Selection/ClearSelectionAction.cs
+++ b/src/Files.App/Actions/Content/Selection/ClearSelectionAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "ClearSelection".GetLocalizedResource();
+			=> Strings.ClearSelection.GetLocalizedResource();
 
 		public string Description
-			=> "ClearSelectionDescription".GetLocalizedResource();
+			=> Strings.ClearSelectionDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.SelectNone");

--- a/src/Files.App/Actions/Content/Selection/InvertSelectionAction.cs
+++ b/src/Files.App/Actions/Content/Selection/InvertSelectionAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "InvertSelection".GetLocalizedResource();
+			=> Strings.InvertSelection.GetLocalizedResource();
 
 		public string Description
-			=> "InvertSelectionDescription".GetLocalizedResource();
+			=> Strings.InvertSelectionDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.SelectInvert");

--- a/src/Files.App/Actions/Content/Selection/SelectAllAction.cs
+++ b/src/Files.App/Actions/Content/Selection/SelectAllAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "SelectAll".GetLocalizedResource();
+			=> Strings.SelectAll.GetLocalizedResource();
 
 		public string Description
-			=> "SelectAllDescription".GetLocalizedResource();
+			=> Strings.SelectAllDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.SelectAll");

--- a/src/Files.App/Actions/Content/Selection/ToggleSelectAction.cs
+++ b/src/Files.App/Actions/Content/Selection/ToggleSelectAction.cs
@@ -9,10 +9,10 @@ namespace Files.App.Actions
 	internal sealed class ToggleSelectAction : IAction
 	{
 		public string Label
-			=> "ToggleSelect".GetLocalizedResource();
+			=> Strings.ToggleSelect.GetLocalizedResource();
 
 		public string Description
-			=> "ToggleSelectDescription".GetLocalizedResource();
+			=> Strings.ToggleSelectDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.Space, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Content/Share/ShareItemAction.cs
+++ b/src/Files.App/Actions/Content/Share/ShareItemAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Share".GetLocalizedResource();
+			=> Strings.Share.GetLocalizedResource();
 
 		public string Description
-			=> "ShareItemDescription".GetLocalizedResource();
+			=> Strings.ShareItemDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Share");

--- a/src/Files.App/Actions/Content/Tags/OpenAllTaggedActions.cs
+++ b/src/Files.App/Actions/Content/Tags/OpenAllTaggedActions.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly ITagsContext _tagsContext;
 
 		public string Label
-			=> "OpenAllTaggedItems".GetLocalizedResource();
+			=> Strings.OpenAllTaggedItems.GetLocalizedResource();
 
 		public string Description
-			=> "OpenAllTaggedItemsDescription".GetLocalizedResource();
+			=> Strings.OpenAllTaggedItemsDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uE71D");

--- a/src/Files.App/Actions/Display/GroupAction.cs
+++ b/src/Files.App/Actions/Display/GroupAction.cs
@@ -9,10 +9,10 @@ namespace Files.App.Actions
 			=> GroupOption.None;
 
 		public override string Label
-			=> "None".GetLocalizedResource();
+			=> Strings.None.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByNoneDescription".GetLocalizedResource();
+			=> Strings.GroupByNoneDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByNameAction : GroupByAction
@@ -21,10 +21,10 @@ namespace Files.App.Actions
 			=> GroupOption.Name;
 
 		public override string Label
-			=> "Name".GetLocalizedResource();
+			=> Strings.Name.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByNameDescription".GetLocalizedResource();
+			=> Strings.GroupByNameDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByDateModifiedAction : GroupByAction
@@ -33,10 +33,10 @@ namespace Files.App.Actions
 			=> GroupOption.DateModified;
 
 		public override string Label
-			=> "DateModifiedLowerCase".GetLocalizedResource();
+			=> Strings.DateModifiedLowerCase.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateModifiedDescription".GetLocalizedResource();
+			=> Strings.GroupByDateModifiedDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByDateCreatedAction : GroupByAction
@@ -45,10 +45,10 @@ namespace Files.App.Actions
 			=> GroupOption.DateCreated;
 
 		public override string Label
-			=> "DateCreated".GetLocalizedResource();
+			=> Strings.DateCreated.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateCreatedDescription".GetLocalizedResource();
+			=> Strings.GroupByDateCreatedDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupBySizeAction : GroupByAction
@@ -57,10 +57,10 @@ namespace Files.App.Actions
 			=> GroupOption.Size;
 
 		public override string Label
-			=> "Size".GetLocalizedResource();
+			=> Strings.Size.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupBySizeDescription".GetLocalizedResource();
+			=> Strings.GroupBySizeDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByTypeAction : GroupByAction
@@ -69,10 +69,10 @@ namespace Files.App.Actions
 			=> GroupOption.FileType;
 
 		public override string Label
-			=> "Type".GetLocalizedResource();
+			=> Strings.Type.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByTypeDescription".GetLocalizedResource();
+			=> Strings.GroupByTypeDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupBySyncStatusAction : GroupByAction
@@ -81,10 +81,10 @@ namespace Files.App.Actions
 			=> GroupOption.SyncStatus;
 
 		public override string Label
-			=> "SyncStatus".GetLocalizedResource();
+			=> Strings.SyncStatus.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupBySyncStatusDescription".GetLocalizedResource();
+			=> Strings.GroupBySyncStatusDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.CloudDrive;
@@ -96,10 +96,10 @@ namespace Files.App.Actions
 			=> GroupOption.FileTag;
 
 		public override string Label
-			=> "FileTags".GetLocalizedResource();
+			=> Strings.FileTags.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByTagDescription".GetLocalizedResource();
+			=> Strings.GroupByTagDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByOriginalFolderAction : GroupByAction
@@ -108,10 +108,10 @@ namespace Files.App.Actions
 			=> GroupOption.OriginalFolder;
 
 		public override string Label
-			=> "OriginalFolder".GetLocalizedResource();
+			=> Strings.OriginalFolder.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByOriginalFolderDescription".GetLocalizedResource();
+			=> Strings.GroupByOriginalFolderDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.RecycleBin;
@@ -123,10 +123,10 @@ namespace Files.App.Actions
 			=> GroupOption.DateDeleted;
 
 		public override string Label
-			=> "DateDeleted".GetLocalizedResource();
+			=> Strings.DateDeleted.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateDeletedDescription".GetLocalizedResource();
+			=> Strings.GroupByDateDeletedDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.RecycleBin;
@@ -138,10 +138,10 @@ namespace Files.App.Actions
 			=> GroupOption.FolderPath;
 
 		public override string Label
-			=> "FolderPath".GetLocalizedResource();
+			=> Strings.FolderPath.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByFolderPathDescription".GetLocalizedResource();
+			=> Strings.GroupByFolderPathDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.Library or ContentPageTypes.SearchResults;
@@ -209,10 +209,10 @@ namespace Files.App.Actions
 			=> GroupByDateUnit.Year;
 
 		public override string Label
-			=> "Year".GetLocalizedResource();
+			=> Strings.Year.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateModifiedYearDescription".GetLocalizedResource();
+			=> Strings.GroupByDateModifiedYearDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByDateModifiedMonthAction : GroupByDateAction
@@ -224,10 +224,10 @@ namespace Files.App.Actions
 			=> GroupByDateUnit.Month;
 
 		public override string Label
-			=> "Month".GetLocalizedResource();
+			=> Strings.Month.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateModifiedMonthDescription".GetLocalizedResource();
+			=> Strings.GroupByDateModifiedMonthDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByDateModifiedDayAction : GroupByDateAction
@@ -239,10 +239,10 @@ namespace Files.App.Actions
 			=> GroupByDateUnit.Day;
 
 		public override string Label
-			=> "Day".GetLocalizedResource();
+			=> Strings.Day.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateModifiedDayDescription".GetLocalizedResource();
+			=> Strings.GroupByDateModifiedDayDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByDateCreatedYearAction : GroupByDateAction
@@ -254,10 +254,10 @@ namespace Files.App.Actions
 			=> GroupByDateUnit.Year;
 
 		public override string Label
-			=> "Year".GetLocalizedResource();
+			=> Strings.Year.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateCreatedYearDescription".GetLocalizedResource();
+			=> Strings.GroupByDateCreatedYearDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByDateCreatedMonthAction : GroupByDateAction
@@ -269,10 +269,10 @@ namespace Files.App.Actions
 			=> GroupByDateUnit.Month;
 
 		public override string Label
-			=> "Month".GetLocalizedResource();
+			=> Strings.Month.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateCreatedMonthDescription".GetLocalizedResource();
+			=> Strings.GroupByDateCreatedMonthDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByDateCreatedDayAction : GroupByDateAction
@@ -284,10 +284,10 @@ namespace Files.App.Actions
 			=> GroupByDateUnit.Day;
 
 		public override string Label
-			=> "Day".GetLocalizedResource();
+			=> Strings.Day.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateCreatedDayDescription".GetLocalizedResource();
+			=> Strings.GroupByDateCreatedDayDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class GroupByDateDeletedYearAction : GroupByDateAction
@@ -299,10 +299,10 @@ namespace Files.App.Actions
 			=> GroupByDateUnit.Year;
 
 		public override string Label
-			=> "Year".GetLocalizedResource();
+			=> Strings.Year.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateDeletedYearDescription".GetLocalizedResource();
+			=> Strings.GroupByDateDeletedYearDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.RecycleBin;
@@ -317,10 +317,10 @@ namespace Files.App.Actions
 			=> GroupByDateUnit.Month;
 
 		public override string Label
-			=> "Month".GetLocalizedResource();
+			=> Strings.Month.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateDeletedMonthDescription".GetLocalizedResource();
+			=> Strings.GroupByDateDeletedMonthDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.RecycleBin;
@@ -335,10 +335,10 @@ namespace Files.App.Actions
 			=> GroupByDateUnit.Day;
 
 		public override string Label
-			=> "Day".GetLocalizedResource();
+			=> Strings.Day.GetLocalizedResource();
 
 		public override string Description
-			=> "GroupByDateDeletedDayDescription".GetLocalizedResource();
+			=> Strings.GroupByDateDeletedDayDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.RecycleBin;
@@ -406,10 +406,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "Ascending".GetLocalizedResource();
+			=> Strings.Ascending.GetLocalizedResource();
 
 		public string Description
-			=> "GroupAscendingDescription".GetLocalizedResource();
+			=> Strings.GroupAscendingDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> context.GroupDirection is SortDirection.Ascending;
@@ -451,10 +451,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "Descending".GetLocalizedResource();
+			=> Strings.Descending.GetLocalizedResource();
 
 		public string Description
-			=> "GroupDescendingDescription".GetLocalizedResource();
+			=> Strings.GroupDescendingDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> context.GroupDirection is SortDirection.Descending;
@@ -496,10 +496,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "ToggleSortDirection".GetLocalizedResource();
+			=> Strings.ToggleSortDirection.GetLocalizedResource();
 
 		public string Description
-			=> "ToggleGroupDirectionDescription".GetLocalizedResource();
+			=> Strings.ToggleGroupDirectionDescription.GetLocalizedResource();
 
 		public ToggleGroupDirectionAction()
 		{
@@ -520,10 +520,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "Year".GetLocalizedResource();
+			=> Strings.Year.GetLocalizedResource();
 
 		public string Description
-			=> "GroupByYearDescription".GetLocalizedResource();
+			=> Strings.GroupByYearDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> context.GroupByDateUnit is GroupByDateUnit.Year;
@@ -565,10 +565,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "Month".GetLocalizedResource();
+			=> Strings.Month.GetLocalizedResource();
 
 		public string Description
-			=> "GroupByMonthDescription".GetLocalizedResource();
+			=> Strings.GroupByMonthDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> context.GroupByDateUnit is GroupByDateUnit.Month;
@@ -610,10 +610,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "ToggleGroupingUnit".GetLocalizedResource();
+			=> Strings.ToggleGroupingUnit.GetLocalizedResource();
 
 		public string Description
-			=> "ToggleGroupByDateUnitDescription".GetLocalizedResource();
+			=> Strings.ToggleGroupByDateUnitDescription.GetLocalizedResource();
 
 		public ToggleGroupByDateUnitAction()
 		{

--- a/src/Files.App/Actions/Display/SortAction.cs
+++ b/src/Files.App/Actions/Display/SortAction.cs
@@ -9,10 +9,10 @@ namespace Files.App.Actions
 			=> SortOption.Name;
 
 		public override string Label
-			=> "Name".GetLocalizedResource();
+			=> Strings.Name.GetLocalizedResource();
 
 		public override string Description
-			=> "SortByNameDescription".GetLocalizedResource();
+			=> Strings.SortByNameDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class SortByDateModifiedAction : SortByAction
@@ -21,10 +21,10 @@ namespace Files.App.Actions
 			=> SortOption.DateModified;
 
 		public override string Label
-			=> "DateModifiedLowerCase".GetLocalizedResource();
+			=> Strings.DateModifiedLowerCase.GetLocalizedResource();
 
 		public override string Description
-			=> "SortByDateModifiedDescription".GetLocalizedResource();
+			=> Strings.SortByDateModifiedDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class SortByDateCreatedAction : SortByAction
@@ -33,10 +33,10 @@ namespace Files.App.Actions
 			=> SortOption.DateCreated;
 
 		public override string Label
-			=> "DateCreated".GetLocalizedResource();
+			=> Strings.DateCreated.GetLocalizedResource();
 
 		public override string Description
-			=> "SortByDateCreatedDescription".GetLocalizedResource();
+			=> Strings.SortByDateCreatedDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class SortBySizeAction : SortByAction
@@ -45,10 +45,10 @@ namespace Files.App.Actions
 			=> SortOption.Size;
 
 		public override string Label
-			=> "Size".GetLocalizedResource();
+			=> Strings.Size.GetLocalizedResource();
 
 		public override string Description
-			=> "SortBySizeDescription".GetLocalizedResource();
+			=> Strings.SortBySizeDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class SortByTypeAction : SortByAction
@@ -57,10 +57,10 @@ namespace Files.App.Actions
 			=> SortOption.FileType;
 
 		public override string Label
-			=> "Type".GetLocalizedResource();
+			=> Strings.Type.GetLocalizedResource();
 
 		public override string Description
-			=> "SortByTypeDescription".GetLocalizedResource();
+			=> Strings.SortByTypeDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class SortBySyncStatusAction : SortByAction
@@ -69,10 +69,10 @@ namespace Files.App.Actions
 			=> SortOption.SyncStatus;
 
 		public override string Label
-			=> "SyncStatus".GetLocalizedResource();
+			=> Strings.SyncStatus.GetLocalizedResource();
 
 		public override string Description
-			=> "SortBySyncStatusDescription".GetLocalizedResource();
+			=> Strings.SortBySyncStatusDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.CloudDrive;
@@ -84,10 +84,10 @@ namespace Files.App.Actions
 			=> SortOption.FileTag;
 
 		public override string Label
-			=> "FileTags".GetLocalizedResource();
+			=> Strings.FileTags.GetLocalizedResource();
 
 		public override string Description
-			=> "SortByTagDescription".GetLocalizedResource();
+			=> Strings.SortByTagDescription.GetLocalizedResource();
 	}
 
 	internal sealed partial class SortByPathAction : SortByAction
@@ -96,10 +96,10 @@ namespace Files.App.Actions
 			=> SortOption.Path;
 
 		public override string Label
-			=> "Path".GetLocalizedResource();
+			=> Strings.Path.GetLocalizedResource();
 
 		public override string Description
-			=> "SortByPathDescription".GetLocalizedResource();
+			=> Strings.SortByPathDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.SearchResults;
@@ -111,10 +111,10 @@ namespace Files.App.Actions
 			=> SortOption.OriginalFolder;
 
 		public override string Label
-			=> "OriginalFolder".GetLocalizedResource();
+			=> Strings.OriginalFolder.GetLocalizedResource();
 
 		public override string Description
-			=> "SortByOriginalFolderDescription".GetLocalizedResource();
+			=> Strings.SortByOriginalFolderDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.RecycleBin;
@@ -126,10 +126,10 @@ namespace Files.App.Actions
 			=> SortOption.DateDeleted;
 
 		public override string Label
-			=> "DateDeleted".GetLocalizedResource();
+			=> Strings.DateDeleted.GetLocalizedResource();
 
 		public override string Description
-			=> "SortByDateDeletedDescription".GetLocalizedResource();
+			=> Strings.SortByDateDeletedDescription.GetLocalizedResource();
 
 		protected override bool GetIsExecutable(ContentPageTypes pageType)
 			=> pageType is ContentPageTypes.RecycleBin;
@@ -190,10 +190,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "Ascending".GetLocalizedResource();
+			=> Strings.Ascending.GetLocalizedResource();
 
 		public string Description
-			=> "SortAscendingDescription".GetLocalizedResource();
+			=> Strings.SortAscendingDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> context.SortDirection is SortDirection.Ascending;
@@ -225,10 +225,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "Descending".GetLocalizedResource();
+			=> Strings.Descending.GetLocalizedResource();
 
 		public string Description
-			=> "SortDescendingDescription".GetLocalizedResource();
+			=> Strings.SortDescendingDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> context.SortDirection is SortDirection.Descending;
@@ -260,10 +260,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "ToggleSortDirection".GetLocalizedResource();
+			=> Strings.ToggleSortDirection.GetLocalizedResource();
 
 		public string Description
-			=> "ToggleSortDirectionDescription".GetLocalizedResource();
+			=> Strings.ToggleSortDirectionDescription.GetLocalizedResource();
 
 		public ToggleSortDirectionAction()
 		{

--- a/src/Files.App/Actions/Display/SortFilesAndFoldersTogetherAction.cs
+++ b/src/Files.App/Actions/Display/SortFilesAndFoldersTogetherAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "SortFilesAndFoldersTogether".GetLocalizedResource();
+			=> Strings.SortFilesAndFoldersTogether.GetLocalizedResource();
 
 		public string Description
-			=> "SortFilesAndFoldersTogetherDescription".GetLocalizedResource();
+			=> Strings.SortFilesAndFoldersTogetherDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> context.SortDirectoriesAlongsideFiles;

--- a/src/Files.App/Actions/Display/SortFilesFirstAction.cs
+++ b/src/Files.App/Actions/Display/SortFilesFirstAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "SortFilesFirst".GetLocalizedResource();
+			=> Strings.SortFilesFirst.GetLocalizedResource();
 
 		public string Description
-			=> "SortFilesFirstDescription".GetLocalizedResource();
+			=> Strings.SortFilesFirstDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> context.SortFilesFirst && !context.SortDirectoriesAlongsideFiles;

--- a/src/Files.App/Actions/Display/SortFoldersFirstAction.cs
+++ b/src/Files.App/Actions/Display/SortFoldersFirstAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IDisplayPageContext context;
 
 		public string Label
-			=> "SortFoldersFirst".GetLocalizedResource();
+			=> Strings.SortFoldersFirst.GetLocalizedResource();
 
 		public string Description
-			=> "SortFoldersFirstDescription".GetLocalizedResource();
+			=> Strings.SortFoldersFirstDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> !context.SortFilesFirst && !context.SortDirectoriesAlongsideFiles;

--- a/src/Files.App/Actions/FileSystem/AddItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/AddItemAction.cs
@@ -12,10 +12,10 @@ namespace Files.App.Actions
 		private readonly AddItemDialogViewModel viewModel = new();
 
 		public string Label
-			=> "BaseLayoutContextFlyoutNew/Label".GetLocalizedResource();
+			=> Strings.BaseLayoutContextFlyoutNew_Label.GetLocalizedResource();
 
 		public string Description
-			=> "AddItemDescription".GetLocalizedResource();
+			=> Strings.AddItemDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.New.Item");

--- a/src/Files.App/Actions/FileSystem/CreateFolderAction.cs
+++ b/src/Files.App/Actions/FileSystem/CreateFolderAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Folder".GetLocalizedResource();
+			=> Strings.Folder.GetLocalizedResource();
 
 		public string Description
-			=> "CreateFolderDescription".GetLocalizedResource();
+			=> Strings.CreateFolderDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.N, KeyModifiers.CtrlShift);

--- a/src/Files.App/Actions/FileSystem/CreateFolderWithSelectionAction.cs
+++ b/src/Files.App/Actions/FileSystem/CreateFolderWithSelectionAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "CreateFolderWithSelection".GetLocalizedResource();
+			=> Strings.CreateFolderWithSelection.GetLocalizedResource();
 
 		public string Description
-			=> "CreateFolderWithSelectionDescription".GetLocalizedResource();
+			=> Strings.CreateFolderWithSelectionDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.New.Folder");

--- a/src/Files.App/Actions/FileSystem/CreateShortcutAction.cs
+++ b/src/Files.App/Actions/FileSystem/CreateShortcutAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "CreateShortcut".GetLocalizedResource();
+			=> Strings.CreateShortcut.GetLocalizedResource();
 
 		public string Description
-			=> "CreateShortcutDescription".GetLocalizedResource();
+			=> Strings.CreateShortcutDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.URL");

--- a/src/Files.App/Actions/FileSystem/CreateShortcutFromDialogAction.cs
+++ b/src/Files.App/Actions/FileSystem/CreateShortcutFromDialogAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Shortcut".GetLocalizedResource();
+			=> Strings.Shortcut.GetLocalizedResource();
 
 		public string Description
-			=> "CreateShortcutFromDialogDescription".GetLocalizedResource();
+			=> Strings.CreateShortcutFromDialogDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uE71B");

--- a/src/Files.App/Actions/FileSystem/DeleteItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/DeleteItemAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class DeleteItemAction : BaseDeleteAction, IAction
 	{
 		public string Label
-			=> "Delete".GetLocalizedResource();
+			=> Strings.Delete.GetLocalizedResource();
 
 		public string Description
-			=> "DeleteItemDescription".GetLocalizedResource();
+			=> Strings.DeleteItemDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new RichGlyph(themedIconStyle: "App.ThemedIcons.Delete");

--- a/src/Files.App/Actions/FileSystem/DeleteItemPermanentlyAction.cs
+++ b/src/Files.App/Actions/FileSystem/DeleteItemPermanentlyAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class DeleteItemPermanentlyAction : BaseDeleteAction, IAction
 	{
 		public string Label
-			=> "DeletePermanently".GetLocalizedResource();
+			=> Strings.DeletePermanently.GetLocalizedResource();
 
 		public string Description
-			=> "DeleteItemPermanentlyDescription".GetLocalizedResource();
+			=> Strings.DeleteItemPermanentlyDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.Delete, KeyModifiers.Shift);

--- a/src/Files.App/Actions/FileSystem/EmptyRecycleBinAction.cs
+++ b/src/Files.App/Actions/FileSystem/EmptyRecycleBinAction.cs
@@ -14,10 +14,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "EmptyRecycleBin".GetLocalizedResource();
+			=> Strings.EmptyRecycleBin.GetLocalizedResource();
 
 		public string Description
-			=> "EmptyRecycleBinDescription".GetLocalizedResource();
+			=> Strings.EmptyRecycleBinDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Delete");
@@ -36,13 +36,12 @@ namespace Files.App.Actions
 
 		public async Task ExecuteAsync(object? parameter = null)
 		{
-			// TODO: Use AppDialogService
 			var confirmationDialog = new ContentDialog()
 			{
-				Title = "ConfirmEmptyBinDialogTitle".GetLocalizedResource(),
-				Content = "ConfirmEmptyBinDialogContent".GetLocalizedResource(),
-				PrimaryButtonText = "Yes".GetLocalizedResource(),
-				SecondaryButtonText = "Cancel".GetLocalizedResource(),
+				Title = Strings.ConfirmEmptyBinDialogTitle.GetLocalizedResource(),
+				Content = Strings.ConfirmEmptyBinDialogContent.GetLocalizedResource(),
+				PrimaryButtonText = Strings.Yes.GetLocalizedResource(),
+				SecondaryButtonText = Strings.Cancel.GetLocalizedResource(),
 				DefaultButton = ContentDialogButton.Primary
 			};
 

--- a/src/Files.App/Actions/FileSystem/FlattenFolderAction.cs
+++ b/src/Files.App/Actions/FileSystem/FlattenFolderAction.cs
@@ -15,10 +15,10 @@ namespace Files.App.Actions
 		private readonly IGeneralSettingsService GeneralSettingsService = Ioc.Default.GetRequiredService<IGeneralSettingsService>();
 
 		public string Label
-			=> "FlattenFolder".GetLocalizedResource();
+			=> Strings.FlattenFolder.GetLocalizedResource();
 
 		public string Description
-			=> "FlattenFolderDescription".GetLocalizedResource();
+			=> Strings.FlattenFolderDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Folder");
@@ -46,10 +46,10 @@ namespace Files.App.Actions
 
 			var optionsDialog = new ContentDialog()
 			{
-				Title = "FlattenFolder".GetLocalizedResource(),
-				Content = "FlattenFolderDialogContent".GetLocalizedResource(),
-				PrimaryButtonText = "Flatten".GetLocalizedResource(),
-				SecondaryButtonText = "Cancel".GetLocalizedResource(),
+				Title = Strings.FlattenFolder.GetLocalizedResource(),
+				Content = Strings.FlattenFolderDialogContent.GetLocalizedResource(),
+				PrimaryButtonText = Strings.Flatten.GetLocalizedResource(),
+				SecondaryButtonText = Strings.Cancel.GetLocalizedResource(),
 				DefaultButton = ContentDialogButton.Primary
 			};
 

--- a/src/Files.App/Actions/FileSystem/OpenFileLocationAction.cs
+++ b/src/Files.App/Actions/FileSystem/OpenFileLocationAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "OpenFileLocation".GetLocalizedResource();
+			=> Strings.OpenFileLocation.GetLocalizedResource();
 
 		public string Description
-			=> "OpenFileLocationDescription".GetLocalizedResource();
+			=> Strings.OpenFileLocationDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(baseGlyph: "\uE8DA");
@@ -55,12 +55,12 @@ namespace Files.App.Actions
 			}
 			else if (destFolder == FileSystemStatusCode.NotFound)
 			{
-				await DialogDisplayHelper.ShowDialogAsync("FileNotFoundDialog/Title".GetLocalizedResource(), "FileNotFoundDialog/Text".GetLocalizedResource());
+				await DialogDisplayHelper.ShowDialogAsync(Strings.FileNotFoundDialog_Title.GetLocalizedResource(), Strings.FileNotFoundDialog_Text.GetLocalizedResource());
 			}
 			else
 			{
-				await DialogDisplayHelper.ShowDialogAsync("InvalidItemDialogTitle".GetLocalizedResource(),
-					string.Format("InvalidItemDialogContent".GetLocalizedResource(), Environment.NewLine, destFolder.ErrorCode.ToString()));
+				await DialogDisplayHelper.ShowDialogAsync(Strings.InvalidItemDialogTitle.GetLocalizedResource(),
+					string.Format(Strings.InvalidItemDialogContent.GetLocalizedResource(), Environment.NewLine, destFolder.ErrorCode.ToString()));
 			}
 		}
 

--- a/src/Files.App/Actions/FileSystem/OpenItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/OpenItemAction.cs
@@ -11,10 +11,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Open".GetLocalizedResource();
+			=> Strings.Open.GetLocalizedResource();
 
 		public string Description
-			=> "OpenItemDescription".GetLocalizedResource();
+			=> Strings.OpenItemDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.OpenFile");
@@ -55,10 +55,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "OpenWith".GetLocalizedResource();
+			=> Strings.OpenWith.GetLocalizedResource();
 
 		public string Description
-			=> "OpenItemWithApplicationPickerDescription".GetLocalizedResource();
+			=> Strings.OpenItemWithApplicationPickerDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.OpenWith");
@@ -96,10 +96,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "BaseLayoutItemContextFlyoutOpenParentFolder/Text".GetLocalizedResource();
+			=> Strings.BaseLayoutItemContextFlyoutOpenParentFolder_Text.GetLocalizedResource();
 
 		public string Description
-			=> "OpenParentFolderDescription".GetLocalizedResource();
+			=> Strings.OpenParentFolderDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(baseGlyph: "\uE197");

--- a/src/Files.App/Actions/FileSystem/PasteItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/PasteItemAction.cs
@@ -16,10 +16,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Paste".GetLocalizedResource();
+			=> Strings.Paste.GetLocalizedResource();
 
 		public string Description
-			=> "PasteItemDescription".GetLocalizedResource();
+			=> Strings.PasteItemDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Paste");

--- a/src/Files.App/Actions/FileSystem/PasteItemToSelectionAction.cs
+++ b/src/Files.App/Actions/FileSystem/PasteItemToSelectionAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Paste".GetLocalizedResource();
+			=> Strings.Paste.GetLocalizedResource();
 
 		public string Description
-			=> "PasteItemToSelectionDescription".GetLocalizedResource();
+			=> Strings.PasteItemToSelectionDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Paste");

--- a/src/Files.App/Actions/FileSystem/RenameAction.cs
+++ b/src/Files.App/Actions/FileSystem/RenameAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Rename".GetLocalizedResource();
+			=> Strings.Rename.GetLocalizedResource();
 
 		public string Description
-			=> "RenameDescription".GetLocalizedResource();
+			=> Strings.RenameDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.F2);

--- a/src/Files.App/Actions/FileSystem/RestoreAllRecycleBinAction.cs
+++ b/src/Files.App/Actions/FileSystem/RestoreAllRecycleBinAction.cs
@@ -11,10 +11,10 @@ namespace Files.App.Actions
 		private readonly IStorageTrashBinService StorageTrashBinService = Ioc.Default.GetRequiredService<IStorageTrashBinService>();
 
 		public string Label
-			=> "RestoreAllItems".GetLocalizedResource();
+			=> Strings.RestoreAllItems.GetLocalizedResource();
 
 		public string Description
-			=> "RestoreAllRecycleBinDescription".GetLocalizedResource();
+			=> Strings.RestoreAllRecycleBinDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.RestoreDeleted");
@@ -28,10 +28,10 @@ namespace Files.App.Actions
 			// TODO: Use AppDialogService
 			var confirmationDialog = new ContentDialog()
 			{
-				Title = "ConfirmRestoreBinDialogTitle".GetLocalizedResource(),
-				Content = "ConfirmRestoreBinDialogContent".GetLocalizedResource(),
-				PrimaryButtonText = "Yes".GetLocalizedResource(),
-				SecondaryButtonText = "Cancel".GetLocalizedResource(),
+				Title = Strings.ConfirmRestoreBinDialogTitle.GetLocalizedResource(),
+				Content = Strings.ConfirmRestoreBinDialogContent.GetLocalizedResource(),
+				PrimaryButtonText = Strings.Yes.GetLocalizedResource(),
+				SecondaryButtonText = Strings.Cancel.GetLocalizedResource(),
 				DefaultButton = ContentDialogButton.Primary
 			};
 
@@ -48,8 +48,8 @@ namespace Files.App.Actions
 			{
 				var errorDialog = new ContentDialog()
 				{
-					Title = "FailedToRestore".GetLocalizedResource(),
-					PrimaryButtonText = "OK".GetLocalizedResource(),
+					Title = Strings.FailedToRestore.GetLocalizedResource(),
+					PrimaryButtonText = Strings.OK.GetLocalizedResource(),
 				};
 
 				if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))

--- a/src/Files.App/Actions/FileSystem/RestoreRecycleBinAction.cs
+++ b/src/Files.App/Actions/FileSystem/RestoreRecycleBinAction.cs
@@ -12,10 +12,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Restore".GetLocalizedResource();
+			=> Strings.Restore.GetLocalizedResource();
 
 		public string Description
-			=> "RestoreRecycleBinDescription".GetLocalizedResource();
+			=> Strings.RestoreRecycleBinDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.RestoreDeleted");
@@ -36,10 +36,10 @@ namespace Files.App.Actions
 		{
 			var confirmationDialog = new ContentDialog()
 			{
-				Title = "ConfirmRestoreSelectionBinDialogTitle".GetLocalizedResource(),
-				Content = string.Format("ConfirmRestoreSelectionBinDialogContent".GetLocalizedResource(), context.SelectedItems.Count),
-				PrimaryButtonText = "Yes".GetLocalizedResource(),
-				SecondaryButtonText = "Cancel".GetLocalizedResource(),
+				Title = Strings.ConfirmRestoreSelectionBinDialogTitle.GetLocalizedResource(),
+				Content = string.Format(Strings.ConfirmRestoreSelectionBinDialogContent.GetLocalizedResource(), context.SelectedItems.Count),
+				PrimaryButtonText = Strings.Yes.GetLocalizedResource(),
+				SecondaryButtonText = Strings.Cancel.GetLocalizedResource(),
 				DefaultButton = ContentDialogButton.Primary
 			};
 

--- a/src/Files.App/Actions/FileSystem/Transfer/CopyItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/Transfer/CopyItemAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 	internal sealed partial class CopyItemAction : BaseTransferItemAction, IAction
 	{
 		public string Label
-			=> "Copy".GetLocalizedResource();
+			=> Strings.Copy.GetLocalizedResource();
 
 		public string Description
-			=> "CopyItemDescription".GetLocalizedResource();
+			=> Strings.CopyItemDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Copy");

--- a/src/Files.App/Actions/FileSystem/Transfer/CutItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/Transfer/CutItemAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 	internal sealed partial class CutItemAction : BaseTransferItemAction, IAction
 	{
 		public string Label
-			=> "Cut".GetLocalizedResource();
+			=> Strings.Cut.GetLocalizedResource();
 
 		public string Description
-			=> "CutItemDescription".GetLocalizedResource();
+			=> Strings.CutItemDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Cut");

--- a/src/Files.App/Actions/Git/GitFetchAction.cs
+++ b/src/Files.App/Actions/Git/GitFetchAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext _context;
 
 		public string Label
-			=> "GitFetch".GetLocalizedResource();
+			=> Strings.GitFetch.GetLocalizedResource();
 
 		public string Description
-			=> "GitFetchDescription".GetLocalizedResource();
+			=> Strings.GitFetchDescription.GetLocalizedResource();
 
 		public bool IsExecutable
 			=> _context.CanExecuteGitAction;

--- a/src/Files.App/Actions/Git/GitInitAction.cs
+++ b/src/Files.App/Actions/Git/GitInitAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext _context;
 
 		public string Label
-			=> "InitRepo".GetLocalizedResource();
+			=> Strings.InitRepo.GetLocalizedResource();
 
 		public string Description
-			=> "InitRepoDescription".GetLocalizedResource();
+			=> Strings.InitRepoDescription.GetLocalizedResource();
 
 		public bool IsExecutable => 
 			_context.Folder is not null &&

--- a/src/Files.App/Actions/Git/GitPullAction.cs
+++ b/src/Files.App/Actions/Git/GitPullAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext _context;
 
 		public string Label
-			=> "GitPull".GetLocalizedResource();
+			=> Strings.GitPull.GetLocalizedResource();
 
 		public string Description
-			=> "GitPullDescription".GetLocalizedResource();
+			=> Strings.GitPullDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uE74B");

--- a/src/Files.App/Actions/Git/GitPushAction.cs
+++ b/src/Files.App/Actions/Git/GitPushAction.cs
@@ -7,9 +7,9 @@ namespace Files.App.Actions
 	{
 		private readonly IContentPageContext _context;
 
-		public string Label { get; } = "Push".GetLocalizedResource();
+		public string Label { get; } = Strings.Push.GetLocalizedResource();
 
-		public string Description { get; } = "GitPushDescription".GetLocalizedResource();
+		public string Description { get; } = Strings.GitPushDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph { get; } = new("\uE74A");
 

--- a/src/Files.App/Actions/Git/GitSyncAction.cs
+++ b/src/Files.App/Actions/Git/GitSyncAction.cs
@@ -7,9 +7,9 @@ namespace Files.App.Actions
 	{
 		private readonly IContentPageContext _context;
 
-		public string Label { get; } = "GitSync".GetLocalizedResource();
+		public string Label { get; } = Strings.GitSync.GetLocalizedResource();
 
-		public string Description { get; } = "GitSyncDescription".GetLocalizedResource();
+		public string Description { get; } = Strings.GitSyncDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph { get; } = new("\uEDAB");
 

--- a/src/Files.App/Actions/Global/EditPathAction.cs
+++ b/src/Files.App/Actions/Global/EditPathAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "EditPath".GetLocalizedResource();
+			=> Strings.EditPath.GetLocalizedResource();
 
 		public string Description
-			=> "EditPathDescription".GetLocalizedResource();
+			=> Strings.EditPathDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.L, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Global/EnterCompactOverlayAction.cs
+++ b/src/Files.App/Actions/Global/EnterCompactOverlayAction.cs
@@ -11,7 +11,7 @@ namespace Files.App.Actions
 		private readonly IWindowContext windowContext;
 
 		public string Label
-			=> "EnterCompactOverlay".GetLocalizedResource();
+			=> Strings.EnterCompactOverlay.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.CompactOverlay");
@@ -20,7 +20,7 @@ namespace Files.App.Actions
 			=> new(Keys.Up, KeyModifiers.CtrlAlt);
 
 		public string Description
-			=> "EnterCompactOverlayDescription".GetLocalizedResource();
+			=> Strings.EnterCompactOverlayDescription.GetLocalizedResource();
 
 		public bool IsExecutable
 			=> !windowContext.IsCompactOverlay;

--- a/src/Files.App/Actions/Global/ExitCompactOverlayAction.cs
+++ b/src/Files.App/Actions/Global/ExitCompactOverlayAction.cs
@@ -10,7 +10,7 @@ namespace Files.App.Actions
 		private readonly IWindowContext windowContext;
 
 		public string Label
-			=> "ExitCompactOverlay".GetLocalizedResource();
+			=> Strings.ExitCompactOverlay.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.CompactOverlayExit");
@@ -19,7 +19,7 @@ namespace Files.App.Actions
 			=> new(Keys.Down, KeyModifiers.CtrlAlt);
 
 		public string Description
-			=> "ExitCompactOverlayDescription".GetLocalizedResource();
+			=> Strings.ExitCompactOverlayDescription.GetLocalizedResource();
 
 		public bool IsExecutable
 			=> windowContext.IsCompactOverlay;

--- a/src/Files.App/Actions/Global/OpenHelpAction.cs
+++ b/src/Files.App/Actions/Global/OpenHelpAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 	internal sealed class OpenHelpAction : IAction
 	{
 		public string Label
-			=> "Help".GetLocalizedResource();
+			=> Strings.Help.GetLocalizedResource();
 
 		public string Description
-			=> "OpenHelpDescription".GetLocalizedResource();
+			=> Strings.OpenHelpDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.F1);

--- a/src/Files.App/Actions/Global/RedoAction.cs
+++ b/src/Files.App/Actions/Global/RedoAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Redo".GetLocalizedResource();
+			=> Strings.Redo.GetLocalizedResource();
 
 		public string Description
-			=> "RedoDescription".GetLocalizedResource();
+			=> Strings.RedoDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.Y, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Global/SearchAction.cs
+++ b/src/Files.App/Actions/Global/SearchAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Search".GetLocalizedResource();
+			=> Strings.Search.GetLocalizedResource();
 
 		public string Description
-			=> "SearchDescription".GetLocalizedResource();
+			=> Strings.SearchDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.F, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Global/ToggleCompactOverlayAction.cs
+++ b/src/Files.App/Actions/Global/ToggleCompactOverlayAction.cs
@@ -11,13 +11,13 @@ namespace Files.App.Actions
 		private readonly IWindowContext windowContext;
 
 		public string Label
-			=> "ToggleCompactOverlay".GetLocalizedResource();
+			=> Strings.ToggleCompactOverlay.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.F12);
 
 		public string Description
-			=> "ToggleCompactOverlayDescription".GetLocalizedResource();
+			=> Strings.ToggleCompactOverlayDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> windowContext.IsCompactOverlay;

--- a/src/Files.App/Actions/Global/ToggleFullScreenAction.cs
+++ b/src/Files.App/Actions/Global/ToggleFullScreenAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 	internal sealed class ToggleFullScreenAction : IToggleAction
 	{
 		public string Label
-			=> "FullScreen".GetLocalizedResource();
+			=> Strings.FullScreen.GetLocalizedResource();
 
 		public string Description
-			=> "ToggleFullScreenDescription".GetLocalizedResource();
+			=> Strings.ToggleFullScreenDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.F11);

--- a/src/Files.App/Actions/Global/UndoAction.cs
+++ b/src/Files.App/Actions/Global/UndoAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Undo".GetLocalizedResource();
+			=> Strings.Undo.GetLocalizedResource();
 
 		public string Description
-			=> "UndoDescription".GetLocalizedResource();
+			=> Strings.UndoDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.Z, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Navigation/AddHorizontalPaneAction.cs
+++ b/src/Files.App/Actions/Navigation/AddHorizontalPaneAction.cs
@@ -9,10 +9,10 @@ namespace Files.App.Actions
 		private readonly IGeneralSettingsService GeneralSettingsService = Ioc.Default.GetRequiredService<IGeneralSettingsService>();
 
 		public string Label
-			=> "AddHorizontalPane".GetLocalizedResource();
+			=> Strings.AddHorizontalPane.GetLocalizedResource();
 
 		public string Description
-			=> "AddHorizontalPaneDescription".GetLocalizedResource();
+			=> Strings.AddHorizontalPaneDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.H, KeyModifiers.AltShift);

--- a/src/Files.App/Actions/Navigation/AddVerticalPaneAction.cs
+++ b/src/Files.App/Actions/Navigation/AddVerticalPaneAction.cs
@@ -9,10 +9,10 @@ namespace Files.App.Actions
 		private readonly IGeneralSettingsService GeneralSettingsService = Ioc.Default.GetRequiredService<IGeneralSettingsService>();
 
 		public string Label
-			=> "AddVerticalPane".GetLocalizedResource();
+			=> Strings.AddVerticalPane.GetLocalizedResource();
 
 		public string Description
-			=> "AddVerticalPaneDescription".GetLocalizedResource();
+			=> Strings.AddVerticalPaneDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.V, KeyModifiers.AltShift);

--- a/src/Files.App/Actions/Navigation/ArrangePanesHorizontallyAction.cs
+++ b/src/Files.App/Actions/Navigation/ArrangePanesHorizontallyAction.cs
@@ -9,10 +9,10 @@ namespace Files.App.Actions
 		private readonly IMultiPanesContext MultiPanesContext = Ioc.Default.GetRequiredService<IMultiPanesContext>();
 
 		public string Label
-			=> "ArrangePanesHorizontally".GetLocalizedResource();
+			=> Strings.ArrangePanesHorizontally.GetLocalizedResource();
 
 		public string Description
-			=> "ArrangePanesHorizontallyDescription".GetLocalizedResource();
+			=> Strings.ArrangePanesHorizontallyDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Panes.Vertical");

--- a/src/Files.App/Actions/Navigation/ArrangePanesVerticallyAction.cs
+++ b/src/Files.App/Actions/Navigation/ArrangePanesVerticallyAction.cs
@@ -9,10 +9,10 @@ namespace Files.App.Actions
 		private readonly IMultiPanesContext MultiPanesContext = Ioc.Default.GetRequiredService<IMultiPanesContext>();
 
 		public string Label
-			=> "ArrangePanesVertically".GetLocalizedResource();
+			=> Strings.ArrangePanesVertically.GetLocalizedResource();
 
 		public string Description
-			=> "ArrangePanesVerticallyDescription".GetLocalizedResource();
+			=> Strings.ArrangePanesVerticallyDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Panes.Horizontal");

--- a/src/Files.App/Actions/Navigation/CloseActivePaneAction.cs
+++ b/src/Files.App/Actions/Navigation/CloseActivePaneAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private IContentPageContext ContentPageContext { get; } = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		public string Label
-			=> "CloseActivePane".GetLocalizedResource();
+			=> Strings.CloseActivePane.GetLocalizedResource();
 
 		public string Description
-			=> "CloseActivePaneDescription".GetLocalizedResource();
+			=> Strings.CloseActivePaneDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.W, KeyModifiers.CtrlAlt);

--- a/src/Files.App/Actions/Navigation/CloseOtherTabsCurrentAction.cs
+++ b/src/Files.App/Actions/Navigation/CloseOtherTabsCurrentAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CloseOtherTabsCurrentAction : CloseTabBaseAction
 	{
 		public override string Label
-			=> "CloseOtherTabs".GetLocalizedResource();
+			=> Strings.CloseOtherTabs.GetLocalizedResource();
 
 		public override string Description
-			=> "CloseOtherTabsCurrentDescription".GetLocalizedResource();
+			=> Strings.CloseOtherTabsCurrentDescription.GetLocalizedResource();
 
 		public CloseOtherTabsCurrentAction()
 		{

--- a/src/Files.App/Actions/Navigation/CloseOtherTabsSelectedAction.cs
+++ b/src/Files.App/Actions/Navigation/CloseOtherTabsSelectedAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CloseOtherTabsSelectedAction : CloseTabBaseAction
 	{
 		public override string Label
-			=> "CloseOtherTabs".GetLocalizedResource();
+			=> Strings.CloseOtherTabs.GetLocalizedResource();
 
 		public override string Description
-			=> "CloseOtherTabsSelectedDescription".GetLocalizedResource();
+			=> Strings.CloseOtherTabsSelectedDescription.GetLocalizedResource();
 
 		public CloseOtherTabsSelectedAction()
 		{

--- a/src/Files.App/Actions/Navigation/CloseSelectedTabAction.cs
+++ b/src/Files.App/Actions/Navigation/CloseSelectedTabAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CloseSelectedTabAction : CloseTabBaseAction
 	{
 		public override string Label
-			=> "CloseTab".GetLocalizedResource();
+			=> Strings.CloseTab.GetLocalizedResource();
 
 		public override string Description
-			=> "CloseSelectedTabDescription".GetLocalizedResource();
+			=> Strings.CloseSelectedTabDescription.GetLocalizedResource();
 
 		public override HotKey HotKey
 			=> new(Keys.W, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Navigation/CloseTabsToTheLeftCurrentAction.cs
+++ b/src/Files.App/Actions/Navigation/CloseTabsToTheLeftCurrentAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CloseTabsToTheLeftCurrentAction : CloseTabBaseAction
 	{
 		public override string Label
-			=> "CloseTabsToTheLeft".GetLocalizedResource();
+			=> Strings.CloseTabsToTheLeft.GetLocalizedResource();
 
 		public override string Description
-			=> "CloseTabsToTheLeftCurrentDescription".GetLocalizedResource();
+			=> Strings.CloseTabsToTheLeftCurrentDescription.GetLocalizedResource();
 
 		public CloseTabsToTheLeftCurrentAction()
 		{

--- a/src/Files.App/Actions/Navigation/CloseTabsToTheLeftSelectedAction.cs
+++ b/src/Files.App/Actions/Navigation/CloseTabsToTheLeftSelectedAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CloseTabsToTheLeftSelectedAction : CloseTabBaseAction
 	{
 		public override string Label
-			=> "CloseTabsToTheLeft".GetLocalizedResource();
+			=> Strings.CloseTabsToTheLeft.GetLocalizedResource();
 
 		public override string Description
-			=> "CloseTabsToTheLeftSelectedDescription".GetLocalizedResource();
+			=> Strings.CloseTabsToTheLeftSelectedDescription.GetLocalizedResource();
 
 		public CloseTabsToTheLeftSelectedAction()
 		{

--- a/src/Files.App/Actions/Navigation/CloseTabsToTheRightCurrentAction.cs
+++ b/src/Files.App/Actions/Navigation/CloseTabsToTheRightCurrentAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CloseTabsToTheRightCurrentAction : CloseTabBaseAction
 	{
 		public override string Label
-			=> "CloseTabsToTheRight".GetLocalizedResource();
+			=> Strings.CloseTabsToTheRight.GetLocalizedResource();
 
 		public override string Description
-			=> "CloseTabsToTheRightCurrentDescription".GetLocalizedResource();
+			=> Strings.CloseTabsToTheRightCurrentDescription.GetLocalizedResource();
 
 		public CloseTabsToTheRightCurrentAction()
 		{

--- a/src/Files.App/Actions/Navigation/CloseTabsToTheRightSelectedAction.cs
+++ b/src/Files.App/Actions/Navigation/CloseTabsToTheRightSelectedAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CloseTabsToTheRightSelectedAction : CloseTabBaseAction
 	{
 		public override string Label
-			=> "CloseTabsToTheRight".GetLocalizedResource();
+			=> Strings.CloseTabsToTheRight.GetLocalizedResource();
 
 		public override string Description
-			=> "CloseTabsToTheRightSelectedDescription".GetLocalizedResource();
+			=> Strings.CloseTabsToTheRightSelectedDescription.GetLocalizedResource();
 
 		public CloseTabsToTheRightSelectedAction()
 		{

--- a/src/Files.App/Actions/Navigation/DuplicateCurrentTabAction.cs
+++ b/src/Files.App/Actions/Navigation/DuplicateCurrentTabAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IMultitaskingContext context;
 
 		public string Label
-			=> "DuplicateTab".GetLocalizedResource();
+			=> Strings.DuplicateTab.GetLocalizedResource();
 
 		public string Description
-			=> "DuplicateCurrentTabDescription".GetLocalizedResource();
+			=> Strings.DuplicateCurrentTabDescription.GetLocalizedResource();
 
 		public DuplicateCurrentTabAction()
 		{

--- a/src/Files.App/Actions/Navigation/DuplicateSelectedTabAction.cs
+++ b/src/Files.App/Actions/Navigation/DuplicateSelectedTabAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IMultitaskingContext context;
 
 		public string Label
-			=> "DuplicateTab".GetLocalizedResource();
+			=> Strings.DuplicateTab.GetLocalizedResource();
 
 		public string Description
-			=> "DuplicateSelectedTabDescription".GetLocalizedResource();
+			=> Strings.DuplicateSelectedTabDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.K, KeyModifiers.CtrlShift);

--- a/src/Files.App/Actions/Navigation/FocusOtherPane.cs
+++ b/src/Files.App/Actions/Navigation/FocusOtherPane.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "FocusOtherPane".GetLocalizedResource();
+			=> Strings.FocusOtherPane.GetLocalizedResource();
 
 		public string Description
-			=> "FocusOtherPaneDescription".GetLocalizedResource();
+			=> Strings.FocusOtherPaneDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.Right, KeyModifiers.CtrlShift);

--- a/src/Files.App/Actions/Navigation/NavigateBackAction.cs
+++ b/src/Files.App/Actions/Navigation/NavigateBackAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Back".GetLocalizedResource();
+			=> Strings.Back.GetLocalizedResource();
 
 		public string Description
-			=> "NavigateBackDescription".GetLocalizedResource();
+			=> Strings.NavigateBackDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.Left, KeyModifiers.Alt);

--- a/src/Files.App/Actions/Navigation/NavigateForwardAction.cs
+++ b/src/Files.App/Actions/Navigation/NavigateForwardAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Forward".GetLocalizedResource();
+			=> Strings.Forward.GetLocalizedResource();
 
 		public string Description
-			=> "NavigateForwardDescription".GetLocalizedResource();
+			=> Strings.NavigateForwardDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.Right, KeyModifiers.Alt);

--- a/src/Files.App/Actions/Navigation/NavigateHomeAction.cs
+++ b/src/Files.App/Actions/Navigation/NavigateHomeAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Home".GetLocalizedResource();
+			=> Strings.Home.GetLocalizedResource();
 
 		public string Description
-			=> "NavigateHomeDescription".GetLocalizedResource();
+			=> Strings.NavigateHomeDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uE80F");

--- a/src/Files.App/Actions/Navigation/NavigateUpAction.cs
+++ b/src/Files.App/Actions/Navigation/NavigateUpAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "Up".GetLocalizedResource();
+			=> Strings.Up.GetLocalizedResource();
 
 		public string Description
-			=> "NavigateUpDescription".GetLocalizedResource();
+			=> Strings.NavigateUpDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.Up, KeyModifiers.Alt);

--- a/src/Files.App/Actions/Navigation/NewTabAction.cs
+++ b/src/Files.App/Actions/Navigation/NewTabAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed class NewTabAction : IAction
 	{
 		public string Label
-			=> "NewTab".GetLocalizedResource();
+			=> Strings.NewTab.GetLocalizedResource();
 
 		public string Description
-			=> "NewTabDescription".GetLocalizedResource();
+			=> Strings.NewTabDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.T, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Navigation/NewWindowAction.cs
+++ b/src/Files.App/Actions/Navigation/NewWindowAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed class NewWindowAction : IAction
 	{
 		public string Label
-			=> "NewWindow".GetLocalizedResource();
+			=> Strings.NewWindow.GetLocalizedResource();
 
 		public string Description
-			=> "NewWindowDescription".GetLocalizedResource();
+			=> Strings.NewWindowDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.N, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Navigation/NextTabAction.cs
+++ b/src/Files.App/Actions/Navigation/NextTabAction.cs
@@ -11,10 +11,10 @@ namespace Files.App.Actions
 		private readonly IMultitaskingContext multitaskingContext;
 
 		public string Label
-			=> "NextTab".GetLocalizedResource();
+			=> Strings.NextTab.GetLocalizedResource();
 
 		public string Description
-			=> "NextTabDescription".GetLocalizedResource();
+			=> Strings.NextTabDescription.GetLocalizedResource();
 
 		public bool IsExecutable
 			=> multitaskingContext.TabCount > 1;

--- a/src/Files.App/Actions/Navigation/OpenInNewPane/BaseOpenInNewPaneAction.cs
+++ b/src/Files.App/Actions/Navigation/OpenInNewPane/BaseOpenInNewPaneAction.cs
@@ -11,10 +11,10 @@ namespace Files.App.Actions
 		protected ISidebarContext SidebarContext { get; } = Ioc.Default.GetRequiredService<ISidebarContext>();
 
 		public string Label
-			=> "OpenInNewPane".GetLocalizedResource();
+			=> Strings.OpenInNewPane.GetLocalizedResource();
 
 		public string Description
-			=> "OpenDirectoryInNewPaneDescription".GetLocalizedResource();
+			=> Strings.OpenDirectoryInNewPaneDescription.GetLocalizedResource();
 
 		public virtual bool IsExecutable =>
 			ContentPageContext.SelectedItem is not null &&

--- a/src/Files.App/Actions/Navigation/OpenInNewTab/BaseOpenInNewTabAction.cs
+++ b/src/Files.App/Actions/Navigation/OpenInNewTab/BaseOpenInNewTabAction.cs
@@ -11,10 +11,10 @@ namespace Files.App.Actions
 		protected ISidebarContext SidebarContext { get; } = Ioc.Default.GetRequiredService<ISidebarContext>();
 
 		public string Label
-			=> "OpenInNewTab".GetLocalizedResource();
+			=> Strings.OpenInNewTab.GetLocalizedResource();
 
 		public string Description
-			=> "OpenDirectoryInNewTabDescription".GetLocalizedResource();
+			=> Strings.OpenDirectoryInNewTabDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.OpenInTab");

--- a/src/Files.App/Actions/Navigation/OpenInNewWindow/BaseOpenInNewWindowAction.cs
+++ b/src/Files.App/Actions/Navigation/OpenInNewWindow/BaseOpenInNewWindowAction.cs
@@ -13,10 +13,10 @@ namespace Files.App.Actions
 		protected ISidebarContext SidebarContext { get; } = Ioc.Default.GetRequiredService<ISidebarContext>();
 
 		public string Label
-			=> "OpenInNewWindow".GetLocalizedResource();
+			=> Strings.OpenInNewWindow.GetLocalizedResource();
 
 		public string Description
-			=> "OpenInNewWindowDescription".GetLocalizedResource();
+			=> Strings.OpenInNewWindowDescription.GetLocalizedResource();
 
 		public virtual HotKey HotKey
 			=> new(Keys.Enter, KeyModifiers.CtrlAlt);

--- a/src/Files.App/Actions/Navigation/PreviousTabAction.cs
+++ b/src/Files.App/Actions/Navigation/PreviousTabAction.cs
@@ -11,10 +11,10 @@ namespace Files.App.Actions
 		private readonly IMultitaskingContext multitaskingContext;
 
 		public string Label
-			=> "PreviousTab".GetLocalizedResource();
+			=> Strings.PreviousTab.GetLocalizedResource();
 
 		public string Description
-			=> "PreviousTabDescription".GetLocalizedResource();
+			=> Strings.PreviousTabDescription.GetLocalizedResource();
 
 		public bool IsExecutable
 			=> multitaskingContext.TabCount > 1;

--- a/src/Files.App/Actions/Navigation/ReopenClosedTabAction.cs
+++ b/src/Files.App/Actions/Navigation/ReopenClosedTabAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IMultitaskingContext context;
 
 		public string Label
-			=> "ReopenClosedTab".GetLocalizedResource();
+			=> Strings.ReopenClosedTab.GetLocalizedResource();
 
 		public string Description
-			=> "ReopenClosedTabDescription".GetLocalizedResource();
+			=> Strings.ReopenClosedTabDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.T, KeyModifiers.CtrlShift);

--- a/src/Files.App/Actions/Open/EditInNotepadAction.cs
+++ b/src/Files.App/Actions/Open/EditInNotepadAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "EditInNotepad".GetLocalizedResource();
+			=> Strings.EditInNotepad.GetLocalizedResource();
 
 		public string Description
-			=> "EditInNotepadDescription".GetLocalizedResource();
+			=> Strings.EditInNotepadDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new("\uE70F");

--- a/src/Files.App/Actions/Open/OpenClassicPropertiesAction.cs
+++ b/src/Files.App/Actions/Open/OpenClassicPropertiesAction.cs
@@ -12,10 +12,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "OpenClassicProperties".GetLocalizedResource();
+			=> Strings.OpenClassicProperties.GetLocalizedResource();
 
 		public string Description
-			=> "OpenClassicPropertiesDescription".GetLocalizedResource();
+			=> Strings.OpenClassicPropertiesDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Properties");

--- a/src/Files.App/Actions/Open/OpenCommandPaletteAction.cs
+++ b/src/Files.App/Actions/Open/OpenCommandPaletteAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext _context;
 
 		public string Label
-			=> "CommandPalette".GetLocalizedResource();
+			=> Strings.CommandPalette.GetLocalizedResource();
 
 		public string Description
-			=> "OpenCommandPaletteDescription".GetLocalizedResource();
+			=> Strings.OpenCommandPaletteDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.P, KeyModifiers.CtrlShift);

--- a/src/Files.App/Actions/Open/OpenInVSCodeAction.cs
+++ b/src/Files.App/Actions/Open/OpenInVSCodeAction.cs
@@ -12,10 +12,10 @@ namespace Files.App.Actions
 		private readonly bool _isVSCodeInstalled;
 
 		public string Label
-			=> "OpenInVSCode".GetLocalizedResource();
+			=> Strings.OpenInVSCode.GetLocalizedResource();
 
 		public string Description
-			=> "OpenInVSCodeDescription".GetLocalizedResource();
+			=> Strings.OpenInVSCodeDescription.GetLocalizedResource();
 
 		public bool IsExecutable =>
 			_isVSCodeInstalled &&

--- a/src/Files.App/Actions/Open/OpenPropertiesAction.cs
+++ b/src/Files.App/Actions/Open/OpenPropertiesAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> "OpenProperties".GetLocalizedResource();
+			=> Strings.OpenProperties.GetLocalizedResource();
 
 		public string Description
-			=> "OpenPropertiesDescription".GetLocalizedResource();
+			=> Strings.OpenPropertiesDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Properties");

--- a/src/Files.App/Actions/Open/OpenRepoInVSCodeAction.cs
+++ b/src/Files.App/Actions/Open/OpenRepoInVSCodeAction.cs
@@ -12,10 +12,10 @@ namespace Files.App.Actions
 		private readonly bool _isVSCodeInstalled;
 
 		public string Label
-			=> "OpenRepoInVSCode".GetLocalizedResource();
+			=> Strings.OpenRepoInVSCode.GetLocalizedResource();
 
 		public string Description
-			=> "OpenRepoInVSCodeDescription".GetLocalizedResource();
+			=> Strings.OpenRepoInVSCodeDescription.GetLocalizedResource();
 
 		public bool IsExecutable =>
 			_isVSCodeInstalled &&

--- a/src/Files.App/Actions/Open/OpenSettingsAction.cs
+++ b/src/Files.App/Actions/Open/OpenSettingsAction.cs
@@ -12,10 +12,10 @@ namespace Files.App.Actions
 		private readonly SettingsDialogViewModel viewModel = new();
 
 		public string Label
-			=> "Settings".GetLocalizedResource();
+			=> Strings.Settings.GetLocalizedResource();
 
 		public string Description
-			=> "OpenSettingsDescription".GetLocalizedResource();
+			=> Strings.OpenSettingsDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.OemComma, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Open/OpenTerminalAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalAction.cs
@@ -11,10 +11,10 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public virtual string Label
-			=> "OpenTerminal".GetLocalizedResource();
+			=> Strings.OpenTerminal.GetLocalizedResource();
 
 		public virtual string Description
-			=> "OpenTerminalDescription".GetLocalizedResource();
+			=> Strings.OpenTerminalDescription.GetLocalizedResource();
 
 		public virtual HotKey HotKey
 			=> new(Keys.Oem3, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Open/OpenTerminalAsAdminAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalAsAdminAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class OpenTerminalAsAdminAction : OpenTerminalAction
 	{
 		public override string Label
-			=> "OpenTerminalAsAdmin".GetLocalizedResource();
+			=> Strings.OpenTerminalAsAdmin.GetLocalizedResource();
 
 		public override string Description
-			=> "OpenTerminalAsAdminDescription".GetLocalizedResource();
+			=> Strings.OpenTerminalAsAdminDescription.GetLocalizedResource();
 
 		public override HotKey HotKey
 			=> new(Keys.Oem3, KeyModifiers.CtrlShift);

--- a/src/Files.App/Actions/Open/OpenTerminalFromHomeAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalFromHomeAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private IHomePageContext HomePageContext { get; } = Ioc.Default.GetRequiredService<IHomePageContext>();
 
 		public override string Label
-			=> "OpenTerminal".GetLocalizedResource();
+			=> Strings.OpenTerminal.GetLocalizedResource();
 
 		public override string Description
-			=> "OpenTerminalDescription".GetLocalizedResource();
+			=> Strings.OpenTerminalDescription.GetLocalizedResource();
 
 		public override bool IsExecutable =>
 			HomePageContext.IsAnyItemRightClicked &&

--- a/src/Files.App/Actions/Open/OpenTerminalFromSidebarAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalFromSidebarAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private ISidebarContext SidebarContext { get; } = Ioc.Default.GetRequiredService<ISidebarContext>();
 
 		public override string Label
-			=> "OpenTerminal".GetLocalizedResource();
+			=> Strings.OpenTerminal.GetLocalizedResource();
 
 		public override string Description
-			=> "OpenTerminalDescription".GetLocalizedResource();
+			=> Strings.OpenTerminalDescription.GetLocalizedResource();
 
 		public override bool IsExecutable =>
 			SidebarContext.IsItemRightClicked &&

--- a/src/Files.App/Actions/Show/ToggleDotFilesSettingAction.cs
+++ b/src/Files.App/Actions/Show/ToggleDotFilesSettingAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IFoldersSettingsService FoldersSettingsService;
 
 		public string Label
-			=> "ShowDotFiles".GetLocalizedResource();
+			=> Strings.ShowDotFiles.GetLocalizedResource();
 
 		public string Description
-			=> "ToggleDotFilesSettingDescription".GetLocalizedResource();
+			=> Strings.ToggleDotFilesSettingDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> FoldersSettingsService.ShowDotFiles;

--- a/src/Files.App/Actions/Show/ToggleInfoPaneAction.cs
+++ b/src/Files.App/Actions/Show/ToggleInfoPaneAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly InfoPaneViewModel viewModel;
 
 		public string Label
-			=> "ToggleInfoPane".GetLocalizedResource();
+			=> Strings.ToggleInfoPane.GetLocalizedResource();
 
 		public string Description
-			=> "ToggleInfoPaneDescription".GetLocalizedResource();
+			=> Strings.ToggleInfoPaneDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.PanelRight");

--- a/src/Files.App/Actions/Show/ToggleShowFileExtensionsAction.cs
+++ b/src/Files.App/Actions/Show/ToggleShowFileExtensionsAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IFoldersSettingsService settings;
 
 		public string Label
-			=> "ShowFileExtensions".GetLocalizedResource();
+			=> Strings.ShowFileExtensions.GetLocalizedResource();
 
 		public string Description
-			=> "ToggleShowFileExtensionsDescription".GetLocalizedResource();
+			=> Strings.ToggleShowFileExtensionsDescription.GetLocalizedResource();
 
 		public bool IsOn
 			=> settings.ShowFileExtensions;

--- a/src/Files.App/Actions/Show/ToggleShowHiddenItemsAction.cs
+++ b/src/Files.App/Actions/Show/ToggleShowHiddenItemsAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IFoldersSettingsService settings;
 
 		public string Label
-			=> "ShowHiddenItems".GetLocalizedResource();
+			=> Strings.ShowHiddenItems.GetLocalizedResource();
 
 		public string Description
-			=> "ToggleShowHiddenItemsDescription".GetLocalizedResource();
+			=> Strings.ToggleShowHiddenItemsDescription.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.H, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Show/ToggleToolbarAction.cs
+++ b/src/Files.App/Actions/Show/ToggleToolbarAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private IAppearanceSettingsService AppearanceSettingsService { get; } = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 
 		public string Label
-			=> "ToggleToolbar".GetLocalizedResource();
+			=> Strings.ToggleToolbar.GetLocalizedResource();
 
 		public string Description
-			=> "ToggleToolbar".GetLocalizedResource();
+			=> Strings.ToggleToolbar.GetLocalizedResource();
 
 		public HotKey HotKey
 			=> new(Keys.B, KeyModifiers.CtrlShift);

--- a/src/Files.App/Actions/Sidebar/PinFolderToSidebarAction.cs
+++ b/src/Files.App/Actions/Sidebar/PinFolderToSidebarAction.cs
@@ -11,10 +11,10 @@ namespace Files.App.Actions
 		private readonly IQuickAccessService service;
 
 		public string Label
-			=> "PinFolderToSidebar".GetLocalizedResource();
+			=> Strings.PinFolderToSidebar.GetLocalizedResource();
 
 		public string Description
-			=> "PinFolderToSidebarDescription".GetLocalizedResource();
+			=> Strings.PinFolderToSidebarDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.FavoritePin");

--- a/src/Files.App/Actions/Sidebar/UnpinFolderToSidebarAction.cs
+++ b/src/Files.App/Actions/Sidebar/UnpinFolderToSidebarAction.cs
@@ -9,10 +9,10 @@ namespace Files.App.Actions
 		private readonly IQuickAccessService service;
 
 		public string Label
-			=> "UnpinFolderFromSidebar".GetLocalizedResource();
+			=> Strings.UnpinFolderFromSidebar.GetLocalizedResource();
 
 		public string Description
-			=> "UnpinFolderFromSidebarDescription".GetLocalizedResource();
+			=> Strings.UnpinFolderFromSidebarDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.FavoritePinRemove");

--- a/src/Files.App/Actions/Start/PinToStartAction.cs
+++ b/src/Files.App/Actions/Start/PinToStartAction.cs
@@ -12,10 +12,10 @@ namespace Files.App.Actions
 		public IContentPageContext context;
 
 		public string Label
-			=> "PinItemToStart/Text".GetLocalizedResource();
+			=> Strings.PinItemToStart_Text.GetLocalizedResource();
 
 		public string Description
-			=> "PinToStartDescription".GetLocalizedResource();
+			=> Strings.PinToStartDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.FavoritePin");

--- a/src/Files.App/Actions/Start/UnpinFromStartAction.cs
+++ b/src/Files.App/Actions/Start/UnpinFromStartAction.cs
@@ -12,10 +12,10 @@ namespace Files.App.Actions
 		public IContentPageContext context;
 
 		public string Label
-			=> "UnpinItemFromStart/Text".GetLocalizedResource();
+			=> Strings.UnpinItemFromStart_Text.GetLocalizedResource();
 
 		public string Description
-			=> "UnpinFromStartDescription".GetLocalizedResource();
+			=> Strings.UnpinFromStartDescription.GetLocalizedResource();
 
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.FavoritePinRemove");

--- a/src/Files.App/Data/Commands/HotKey/HotKey.cs
+++ b/src/Files.App/Data/Commands/HotKey/HotKey.cs
@@ -365,7 +365,7 @@ namespace Files.App.Data.Commands
 
 		private static string GetLocalizedNumPadKey(string key)
 		{
-			return "NumPadTypeName".GetLocalizedResource() + " " + key;
+			return Strings.NumPadTypeName.GetLocalizedResource() + " " + key;
 		}
 
 		private static string GetKeyCharacter(Forms.Keys key)

--- a/src/Files.App/Data/Factories/AppThemeResourcesFactory.cs
+++ b/src/Files.App/Data/Factories/AppThemeResourcesFactory.cs
@@ -10,102 +10,102 @@ namespace Files.App.Data.Factories
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#00000000", /* Transparent */
-				Name = "Default".GetLocalizedResource()
+				Name = Strings.Default.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#32FFB900", /* #FFB900 */
-				Name = "YellowGold".GetLocalizedResource()
+				Name = Strings.YellowGold.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#32F7630C", /* #F7630C */
-				Name = "OrangeBright".GetLocalizedResource()
+				Name = Strings.OrangeBright.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#32D13438", /* #D13438 */
-				Name = "BrickRed".GetLocalizedResource()
+				Name = Strings.BrickRed.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#32FF4343", /* #FF4343 */
-				Name = "ModRed".GetLocalizedResource()
+				Name = Strings.ModRed.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#32EA005E", /* #EA005E */
-				Name = "Red".GetLocalizedResource()
+				Name = Strings.Red.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#32EA005E", /* #EA005E */
-				Name = "RoseBright".GetLocalizedResource()
+				Name = Strings.RoseBright.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#320078D7", /* #0078D7 */
-				Name = "Blue".GetLocalizedResource()
+				Name = Strings.Blue.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#328764B8", /* #8764B8 */
-				Name = "IrisPastel".GetLocalizedResource()
+				Name = Strings.IrisPastel.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#32B146C2", /* #B146C2 */
-				Name = "VioletRedLight".GetLocalizedResource()
+				Name = Strings.VioletRedLight.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#320099BC", /* #0099BC */
-				Name = "CoolBlueBright".GetLocalizedResource()
+				Name = Strings.CoolBlueBright.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#3200B7C3", /* #00B7C3 */
-				Name = "Seafoam".GetLocalizedResource()
+				Name = Strings.Seafoam.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#3200B294", /* #00B294 */
-				Name = "MintLight".GetLocalizedResource()
+				Name = Strings.MintLight.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#327A7574", /* #7A7574 */
-				Name = "Gray".GetLocalizedResource()
+				Name = Strings.Gray.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#32107C10", /* #107C10 */
-				Name = "Green".GetLocalizedResource()
+				Name = Strings.Green.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#32767676", /* #767676 */
-				Name = "Overcast".GetLocalizedResource()
+				Name = Strings.Overcast.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#324C4A48", /* #4C4A48 */
-				Name = "Storm".GetLocalizedResource()
+				Name = Strings.Storm.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#3269797E", /* #69797E */
-				Name = "BlueGray".GetLocalizedResource()
+				Name = Strings.BlueGray.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#324A5459", /* #4A5459 */
-				Name = "GrayDark".GetLocalizedResource()
+				Name = Strings.GrayDark.GetLocalizedResource()
 			},
 			new AppThemeResourceItem
 			{
 				BackgroundColor = "#327E735F", /* #7E735F */
-				Name = "Camouflage".GetLocalizedResource()
+				Name = Strings.Camouflage.GetLocalizedResource()
 			}
 		];
 	}

--- a/src/Files.App/Data/Factories/PropertiesNavigationViewItemFactory.cs
+++ b/src/Files.App/Data/Factories/PropertiesNavigationViewItemFactory.cs
@@ -15,49 +15,49 @@ namespace Files.App.Data.Factories
 
 			var generalItem = new NavigationViewItemButtonStyleItem()
 			{
-				Name = "General".GetLocalizedResource(),
+				Name = Strings.General.GetLocalizedResource(),
 				ItemType = PropertiesNavigationViewItemType.General,
 				ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.Properties.General"],
 			};
 			var securityItem = new NavigationViewItemButtonStyleItem()
 			{
-				Name = "Security".GetLocalizedResource(),
+				Name = Strings.Security.GetLocalizedResource(),
 				ItemType = PropertiesNavigationViewItemType.Security,
 				ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.Properties.Security"],
 			};
 			var hashesItem = new NavigationViewItemButtonStyleItem()
 			{
-				Name = "Hashes".GetLocalizedResource(),
+				Name = Strings.Hashes.GetLocalizedResource(),
 				ItemType = PropertiesNavigationViewItemType.Hashes,
 				ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.Properties.Hashes"],
 			};
 			var shortcutItem = new NavigationViewItemButtonStyleItem()
 			{
-				Name = "Shortcut".GetLocalizedResource(),
+				Name = Strings.Shortcut.GetLocalizedResource(),
 				ItemType = PropertiesNavigationViewItemType.Shortcut,
 				ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.Properties.Shortcut"],
 			};
 			var libraryItem = new NavigationViewItemButtonStyleItem()
 			{
-				Name = "Library".GetLocalizedResource(),
+				Name = Strings.Library.GetLocalizedResource(),
 				ItemType = PropertiesNavigationViewItemType.Library,
 				ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.Properties.Library"],
 			};
 			var detailsItem = new NavigationViewItemButtonStyleItem()
 			{
-				Name = "Details".GetLocalizedResource(),
+				Name = Strings.Details.GetLocalizedResource(),
 				ItemType = PropertiesNavigationViewItemType.Details,
 				ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.Properties.Info"],
 			};
 			var customizationItem = new NavigationViewItemButtonStyleItem()
 			{
-				Name = "Customization".GetLocalizedResource(),
+				Name = Strings.Customization.GetLocalizedResource(),
 				ItemType = PropertiesNavigationViewItemType.Customization,
 				ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.Properties.CustomizeFolder"],
 			};
 			var compatibilityItem = new NavigationViewItemButtonStyleItem()
 			{
-				Name = "Compatibility".GetLocalizedResource(),
+				Name = Strings.Compatibility.GetLocalizedResource(),
 				ItemType = PropertiesNavigationViewItemType.Compatibility,
 				ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.Properties.Compatability"],
 			};

--- a/src/Files.App/Data/Factories/SecurityAdvancedAccessControlItemFactory.cs
+++ b/src/Files.App/Data/Factories/SecurityAdvancedAccessControlItemFactory.cs
@@ -28,109 +28,109 @@ namespace Files.App.Data.Factories
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.FullControl,
-						AccessMaskName = "SecurityFullControlLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityFullControlLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.Traverse,
-						AccessMaskName = "SecurityTraverseLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityTraverseLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.ExecuteFile,
-						AccessMaskName = "SecurityExecuteFileLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityExecuteFileLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.ListDirectory,
-						AccessMaskName = "SecurityListDirectoryLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityListDirectoryLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.ReadData,
-						AccessMaskName = "SecurityReadDataLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityReadDataLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.ReadAttributes,
-						AccessMaskName = "SecurityReadAttributesLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityReadAttributesLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.ReadExtendedAttributes,
-						AccessMaskName = "SecurityReadExtendedAttributesLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityReadExtendedAttributesLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.CreateFiles,
-						AccessMaskName = "SecurityCreateFilesLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityCreateFilesLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.CreateDirectories,
-						AccessMaskName = "SecurityCreateDirectoriesLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityCreateDirectoriesLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.WriteData,
-						AccessMaskName = "SecurityWriteDataLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityWriteDataLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.AppendData,
-						AccessMaskName = "SecurityAppendDataLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityAppendDataLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.WriteAttributes,
-						AccessMaskName = "SecurityWriteAttributesLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityWriteAttributesLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.WriteExtendedAttributes,
-						AccessMaskName = "SecurityWriteExtendedAttributesLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityWriteExtendedAttributesLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.DeleteSubdirectoriesAndFiles,
-						AccessMaskName = "SecurityDeleteSubdirectoriesAndFilesLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityDeleteSubdirectoriesAndFilesLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.Delete,
-						AccessMaskName = "Delete".GetLocalizedResource(),
+						AccessMaskName = Strings.Delete.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.ReadPermissions,
-						AccessMaskName = "SecurityReadPermissionsLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityReadPermissionsLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.ChangePermissions,
-						AccessMaskName = "SecurityChangePermissionsLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityChangePermissionsLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.TakeOwnership,
-						AccessMaskName = "SecurityTakeOwnershipLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityTakeOwnershipLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					}
 				];
@@ -160,42 +160,42 @@ namespace Files.App.Data.Factories
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.FullControl,
-						AccessMaskName = "SecurityFullControlLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityFullControlLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.Modify,
-						AccessMaskName = "Modify".GetLocalizedResource(),
+						AccessMaskName = Strings.Modify.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.ReadAndExecute,
-						AccessMaskName = "SecurityReadAndExecuteLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityReadAndExecuteLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.ListDirectory,
-						AccessMaskName = "SecurityListDirectoryLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityListDirectoryLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.Read,
-						AccessMaskName = "SecurityReadLabel/Text".GetLocalizedResource(),
+						AccessMaskName = Strings.SecurityReadLabel_Text.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current)
 					{
 						AccessMask = AccessMaskFlags.Write,
-						AccessMaskName = "Write".GetLocalizedResource(),
+						AccessMaskName = Strings.Write.GetLocalizedResource(),
 						IsEditable = !isInherited
 					},
 					new(current, false)
 					{
-						AccessMaskName = "SecuritySpecialLabel/Text".GetLocalizedResource()
+						AccessMaskName = Strings.SecuritySpecialLabel_Text.GetLocalizedResource()
 					}
 				];
 

--- a/src/Files.App/Data/Factories/ShellContextFlyoutHelper.cs
+++ b/src/Files.App/Data/Factories/ShellContextFlyoutHelper.cs
@@ -88,7 +88,7 @@ namespace Files.App.Helpers
 				{
 					var menuLayoutSubItem = new ContextMenuFlyoutItemViewModel()
 					{
-						Text = "ShowMoreOptions".GetLocalizedResource(),
+						Text = Strings.ShowMoreOptions.GetLocalizedResource(),
 						Glyph = "\xE712",
 					};
 					LoadMenuFlyoutItem(menuLayoutSubItem.Items, contextMenu, overflowItems, cancellationToken, showIcons);
@@ -328,7 +328,7 @@ namespace Files.App.Helpers
 					overflowItem.Visibility = overflowItems?.Any() ?? false ? Visibility.Visible : Visibility.Collapsed;
 					overflowSeparator.Visibility = overflowItems?.Any() ?? false ? Visibility.Visible : Visibility.Collapsed;
 
-					overflowItem.Label = "ShowMoreOptions".GetLocalizedResource();
+					overflowItem.Label = Strings.ShowMoreOptions.GetLocalizedResource();
 					overflowItem.IsEnabled = true;
 				}
 

--- a/src/Files.App/Data/Items/AccessControlEntry.cs
+++ b/src/Files.App/Data/Items/AccessControlEntry.cs
@@ -36,8 +36,8 @@ namespace Files.App.Data.Items
 		public string AccessControlTypeHumanized
 			=> AccessControlType switch
 			{
-				AccessControlEntryType.Allow => "Allow".GetLocalizedResource(),
-				_ => "Deny".GetLocalizedResource() // AccessControlType.Deny
+				AccessControlEntryType.Allow => Strings.Allow.GetLocalizedResource(),
+				_ => Strings.Deny.GetLocalizedResource() // AccessControlType.Deny
 			};
 
 		/// <summary>
@@ -60,22 +60,22 @@ namespace Files.App.Data.Items
 				var accessMaskStrings = new List<string>();
 
 				if (AccessMaskFlags == AccessMaskFlags.NULL)
-					accessMaskStrings.Add("None".GetLocalizedResource());
+					accessMaskStrings.Add(Strings.None.GetLocalizedResource());
 
 				if (FullControlAccess)
-					accessMaskStrings.Add("SecurityFullControlLabel/Text".GetLocalizedResource());
+					accessMaskStrings.Add(Strings.SecurityFullControlLabel_Text.GetLocalizedResource());
 				else if (ModifyAccess)
-					accessMaskStrings.Add("Modify".GetLocalizedResource());
+					accessMaskStrings.Add(Strings.Modify.GetLocalizedResource());
 				else if (ReadAndExecuteAccess)
-					accessMaskStrings.Add("SecurityReadAndExecuteLabel/Text".GetLocalizedResource());
+					accessMaskStrings.Add(Strings.SecurityReadAndExecuteLabel_Text.GetLocalizedResource());
 				else if (ReadAccess)
-					accessMaskStrings.Add("SecurityReadLabel/Text".GetLocalizedResource());
+					accessMaskStrings.Add(Strings.SecurityReadLabel_Text.GetLocalizedResource());
 
 				if (!FullControlAccess && !ModifyAccess && WriteAccess)
-					accessMaskStrings.Add("Write".GetLocalizedResource());
+					accessMaskStrings.Add(Strings.Write.GetLocalizedResource());
 
 				if (SpecialAccess)
-					accessMaskStrings.Add("SecuritySpecialLabel/Text".GetLocalizedResource());
+					accessMaskStrings.Add(Strings.SecuritySpecialLabel_Text.GetLocalizedResource());
 
 				return string.Join(", ", accessMaskStrings);
 			}
@@ -85,7 +85,7 @@ namespace Files.App.Data.Items
 		/// IsInheritedHumanized
 		/// </summary>
 		public string IsInheritedHumanized
-			=> IsInherited ? "Yes".GetLocalizedResource() : "No".GetLocalizedResource();
+			=> IsInherited ? Strings.Yes.GetLocalizedResource() : Strings.No.GetLocalizedResource();
 
 		/// <summary>
 		/// InheritanceFlagsHumanized
@@ -98,13 +98,13 @@ namespace Files.App.Data.Items
 
 				if (AccessControlEntryFlags == AccessControlEntryFlags.None ||
 					AccessControlEntryFlags == AccessControlEntryFlags.NoPropagateInherit)
-					inheritanceStrings.Add("SecurityAdvancedFlagsFolderLabel".GetLocalizedResource());
+					inheritanceStrings.Add(Strings.SecurityAdvancedFlagsFolderLabel.GetLocalizedResource());
 
 				if (AccessControlEntryFlags.HasFlag(AccessControlEntryFlags.ContainerInherit))
-					inheritanceStrings.Add("SecurityAdvancedFlagsSubfoldersLabel".GetLocalizedResource());
+					inheritanceStrings.Add(Strings.SecurityAdvancedFlagsSubfoldersLabel.GetLocalizedResource());
 
 				if (AccessControlEntryFlags.HasFlag(AccessControlEntryFlags.ObjectInherit))
-					inheritanceStrings.Add("SecurityAdvancedFlagsFilesLabel".GetLocalizedResource());
+					inheritanceStrings.Add(Strings.SecurityAdvancedFlagsFilesLabel.GetLocalizedResource());
 
 				// Capitalize the first letter
 				if (inheritanceStrings.Any())

--- a/src/Files.App/Data/Items/AppLanguageItem.cs
+++ b/src/Files.App/Data/Items/AppLanguageItem.cs
@@ -30,7 +30,7 @@ namespace Files.App.Data.Items
 			if (systemDefault || string.IsNullOrEmpty(code))
 			{
 				Code = new CultureInfo(code).Name;
-				Name = "SettingsPreferencesSystemDefaultLanguageOption".GetLocalizedResource();
+				Name = Strings.SettingsPreferencesSystemDefaultLanguageOption.GetLocalizedResource();
 			}
 			else
 			{

--- a/src/Files.App/Data/Items/DriveItem.cs
+++ b/src/Files.App/Data/Items/DriveItem.cs
@@ -219,7 +219,7 @@ namespace Files.App.Data.Items
 					}
 				};
 
-				ToolTipService.SetToolTip(itemDecorator, "Eject".GetLocalizedResource());
+				ToolTipService.SetToolTip(itemDecorator, Strings.Eject.GetLocalizedResource());
 
 				itemDecorator.Click += ItemDecorator_Click;
 
@@ -294,7 +294,7 @@ namespace Files.App.Data.Items
 				}
 				else
 				{
-					SpaceText = "Unknown".GetLocalizedResource();
+					SpaceText = Strings.Unknown.GetLocalizedResource();
 					MaxSpace = SpaceUsed = FreeSpace = ByteSize.FromBytes(0);
 				}
 
@@ -307,7 +307,7 @@ namespace Files.App.Data.Items
 			}
 			catch (Exception)
 			{
-				SpaceText = "Unknown".GetLocalizedResource();
+				SpaceText = Strings.Unknown.GetLocalizedResource();
 				MaxSpace = SpaceUsed = FreeSpace = ByteSize.FromBytes(0);
 				Filesystem = string.Empty;
 
@@ -351,7 +351,7 @@ namespace Files.App.Data.Items
 		private string GetSizeString()
 		{
 			return string.Format(
-				"DriveFreeSpaceAndCapacity".GetLocalizedResource(),
+				Strings.DriveFreeSpaceAndCapacity.GetLocalizedResource(),
 				FreeSpace.ToSizeString(),
 				MaxSpace.ToSizeString());
 		}

--- a/src/Files.App/Data/Models/ByteSize.cs
+++ b/src/Files.App/Data/Models/ByteSize.cs
@@ -9,13 +9,13 @@ namespace Files.App.Data.Models
 	{
 		private static readonly FrozenDictionary<string, string> units = new Dictionary<string, string>
 		{
-			[ByteSizeLib.ByteSize.BitSymbol] = "ByteSymbol".ToLocalized(),
-			[ByteSizeLib.ByteSize.ByteSymbol] = "ByteSymbol".ToLocalized(),
-			[ByteSizeLib.ByteSize.KibiByteSymbol] = "KiloByteSymbol".ToLocalized(),
-			[ByteSizeLib.ByteSize.MebiByteSymbol] = "MegaByteSymbol".ToLocalized(),
-			[ByteSizeLib.ByteSize.GibiByteSymbol] = "GigaByteSymbol".ToLocalized(),
-			[ByteSizeLib.ByteSize.TebiByteSymbol] = "TeraByteSymbol".ToLocalized(),
-			[ByteSizeLib.ByteSize.PebiByteSymbol] = "PetaByteSymbol".ToLocalized(),
+			[ByteSizeLib.ByteSize.BitSymbol] = Strings.ByteSymbol.ToLocalized(),
+			[ByteSizeLib.ByteSize.ByteSymbol] = Strings.ByteSymbol.ToLocalized(),
+			[ByteSizeLib.ByteSize.KibiByteSymbol] = Strings.KiloByteSymbol.ToLocalized(),
+			[ByteSizeLib.ByteSize.MebiByteSymbol] = Strings.MegaByteSymbol.ToLocalized(),
+			[ByteSizeLib.ByteSize.GibiByteSymbol] = Strings.GigaByteSymbol.ToLocalized(),
+			[ByteSizeLib.ByteSize.TebiByteSymbol] = Strings.TeraByteSymbol.ToLocalized(),
+			[ByteSizeLib.ByteSize.PebiByteSymbol] = Strings.PetaByteSymbol.ToLocalized(),
 		}.ToFrozenDictionary();
 
 		private readonly ByteSizeLib.ByteSize size;

--- a/src/Files.App/Data/Models/DirectoryPropertiesViewModel.cs
+++ b/src/Files.App/Data/Models/DirectoryPropertiesViewModel.cs
@@ -133,7 +133,7 @@ namespace Files.App.ViewModels.UserControls
 			var behind = head is not null ? head.BehindBy ?? 0 : 0;
 			var ahead = head is not null ? head.AheadBy ?? 0 : 0;
 
-			ExtendedStatusInfo = string.Format("GitSyncStatusExtendedInfo".GetLocalizedResource(), ahead, behind);
+			ExtendedStatusInfo = string.Format(Strings.GitSyncStatusExtendedInfo.GetLocalizedResource(), ahead, behind);
 			StatusInfo = $"{ahead} / {behind}";
 
 			OnPropertyChanged(nameof(ShowOpenInIDEButton));

--- a/src/Files.App/Data/Models/PinnedFoldersManager.cs
+++ b/src/Files.App/Data/Models/PinnedFoldersManager.cs
@@ -83,9 +83,9 @@ namespace Files.App.Data.Models
 				locationItem = LocationItem.Create<LocationItem>();
 
 				if (path.Equals(Constants.UserEnvironmentPaths.MyComputerPath, StringComparison.OrdinalIgnoreCase))
-					locationItem.Text = "ThisPC".GetLocalizedResource();
+					locationItem.Text = Strings.ThisPC.GetLocalizedResource();
 				else if (path.Equals(Constants.UserEnvironmentPaths.NetworkFolderPath, StringComparison.OrdinalIgnoreCase))
-					locationItem.Text = "Network".GetLocalizedResource();
+					locationItem.Text = Strings.Network.GetLocalizedResource();
 			}
 
 			locationItem.Path = path;

--- a/src/Files.App/Dialogs/CreateArchiveDialog.xaml.cs
+++ b/src/Files.App/Dialogs/CreateArchiveDialog.xaml.cs
@@ -199,28 +199,28 @@ namespace Files.App.Dialogs
 
 			public ImmutableList<CompressionLevelItem> CompressionLevels { get; } =
 			[
-				new CompressionLevelItem(ArchiveCompressionLevels.Ultra, "CompressionLevelUltra".GetLocalizedResource()),
-				new CompressionLevelItem(ArchiveCompressionLevels.High, "CompressionLevelHigh".GetLocalizedResource()),
-				new CompressionLevelItem(ArchiveCompressionLevels.Normal, "CompressionLevelNormal".GetLocalizedResource()),
-				new CompressionLevelItem(ArchiveCompressionLevels.Low, "CompressionLevelLow".GetLocalizedResource()),
-				new CompressionLevelItem(ArchiveCompressionLevels.Fast, "CompressionLevelFast".GetLocalizedResource()),
-				new CompressionLevelItem(ArchiveCompressionLevels.None, "CompressionLevelNone".GetLocalizedResource()),
+				new CompressionLevelItem(ArchiveCompressionLevels.Ultra, Strings.CompressionLevelUltra.GetLocalizedResource()),
+				new CompressionLevelItem(ArchiveCompressionLevels.High, Strings.CompressionLevelHigh.GetLocalizedResource()),
+				new CompressionLevelItem(ArchiveCompressionLevels.Normal, Strings.CompressionLevelNormal.GetLocalizedResource()),
+				new CompressionLevelItem(ArchiveCompressionLevels.Low, Strings.CompressionLevelLow.GetLocalizedResource()),
+				new CompressionLevelItem(ArchiveCompressionLevels.Fast, Strings.CompressionLevelFast.GetLocalizedResource()),
+				new CompressionLevelItem(ArchiveCompressionLevels.None, Strings.CompressionLevelNone.GetLocalizedResource()),
 			];
 
 			public ImmutableList<SplittingSizeItem> SplittingSizes { get; } =
 			[
-				new(ArchiveSplittingSizes.None, "Do not split".GetLocalizedResource()),
+				new(ArchiveSplittingSizes.None, Strings.Do_not_split.GetLocalizedResource()),
 				new(ArchiveSplittingSizes.Mo10, ToSizeText(10)),
 				new(ArchiveSplittingSizes.Mo100, ToSizeText(100)),
-				new(ArchiveSplittingSizes.Cd650, ToSizeText(650), "CD".GetLocalizedResource()),
-				new(ArchiveSplittingSizes.Cd700, ToSizeText(700), "CD".GetLocalizedResource()),
+				new(ArchiveSplittingSizes.Cd650, ToSizeText(650), Strings.CD.GetLocalizedResource()),
+				new(ArchiveSplittingSizes.Cd700, ToSizeText(700), Strings.CD.GetLocalizedResource()),
 				new(ArchiveSplittingSizes.Mo1024, ToSizeText(1024)),
 				new(ArchiveSplittingSizes.Mo2048, ToSizeText(2048)),
-				new(ArchiveSplittingSizes.Fat4092, ToSizeText(4092), "FAT".GetLocalizedResource()),
-				new(ArchiveSplittingSizes.Dvd4480, ToSizeText(4480), "DVD".GetLocalizedResource()),
+				new(ArchiveSplittingSizes.Fat4092, ToSizeText(4092), Strings.FAT.GetLocalizedResource()),
+				new(ArchiveSplittingSizes.Dvd4480, ToSizeText(4480), Strings.DVD.GetLocalizedResource()),
 				new(ArchiveSplittingSizes.Mo5120, ToSizeText(5120)),
-				new(ArchiveSplittingSizes.Dvd8128, ToSizeText(8128), "DVD".GetLocalizedResource()),
-				new(ArchiveSplittingSizes.Bd23040, ToSizeText(23040), "Bluray".GetLocalizedResource()),
+				new(ArchiveSplittingSizes.Dvd8128, ToSizeText(8128), Strings.DVD.GetLocalizedResource()),
+				new(ArchiveSplittingSizes.Bd23040, ToSizeText(23040), Strings.Bluray.GetLocalizedResource()),
 			];
 
 			public DialogViewModel()

--- a/src/Files.App/Dialogs/ReorderSidebarItemsDialog.xaml.cs
+++ b/src/Files.App/Dialogs/ReorderSidebarItemsDialog.xaml.cs
@@ -79,7 +79,7 @@ namespace Files.App.Dialogs
 			else
 			{
 				e.DragUIOverride.IsCaptionVisible = true;
-				e.DragUIOverride.Caption = "MoveItemsDialogPrimaryButtonText".GetLocalizedResource();
+				e.DragUIOverride.Caption = Strings.MoveItemsDialogPrimaryButtonText.GetLocalizedResource();
 				e.AcceptedOperation = DataPackageOperation.Move;
 			}
 		}

--- a/src/Files.App/Extensions/StringExtensions.cs
+++ b/src/Files.App/Extensions/StringExtensions.cs
@@ -60,13 +60,13 @@ namespace Files.App.Extensions
 
 		private static readonly Dictionary<string, string> abbreviations = new()
 		{
-			{ "KiB", "KiloByteSymbol".GetLocalizedResource() },
-			{ "MiB", "MegaByteSymbol".GetLocalizedResource() },
-			{ "GiB", "GigaByteSymbol".GetLocalizedResource() },
-			{ "TiB", "TeraByteSymbol".GetLocalizedResource() },
-			{ "PiB", "PetaByteSymbol".GetLocalizedResource() },
-			{ "B", "ByteSymbol".GetLocalizedResource() },
-			{ "b", "ByteSymbol".GetLocalizedResource() }
+			{ "KiB", Strings.KiloByteSymbol.GetLocalizedResource() },
+			{ "MiB", Strings.MegaByteSymbol.GetLocalizedResource() },
+			{ "GiB", Strings.GigaByteSymbol.GetLocalizedResource() },
+			{ "TiB", Strings.TeraByteSymbol.GetLocalizedResource() },
+			{ "PiB", Strings.PetaByteSymbol.GetLocalizedResource() },
+			{ "B", Strings.ByteSymbol.GetLocalizedResource() },
+			{ "b", Strings.ByteSymbol.GetLocalizedResource() }
 		};
 
 		public static string ConvertSizeAbbreviation(this string value)
@@ -87,7 +87,7 @@ namespace Files.App.Extensions
 
 		public static string ToLongSizeString(this long size) => ByteSize.FromBytes(size).ToLongSizeString();
 		public static string ToLongSizeString(this ulong size) => ByteSize.FromBytes(size).ToLongSizeString();
-		public static string ToLongSizeString(this ByteSize size) => $"{size.ToSizeString()} ({size.Bytes:#,##0} {"ItemSizeBytes".GetLocalizedResource()})";
+		public static string ToLongSizeString(this ByteSize size) => $"{size.ToSizeString()} ({size.Bytes:#,##0} {Strings.ItemSizeBytes.GetLocalizedResource()})";
 
 		//public static string GetLocalizedResource(this string s) => s.GetLocalized("Resources");
 

--- a/src/Files.App/Helpers/Application/AppToastNotificationHelper.cs
+++ b/src/Files.App/Helpers/Application/AppToastNotificationHelper.cs
@@ -13,10 +13,10 @@ namespace Files.App.Helpers.Application
 		public static void ShowUnhandledExceptionToast()
 		{
 			var toastContent = new AppNotificationBuilder()
-					.AddText("ExceptionNotificationHeader".GetLocalizedResource())
-					.AddText("ExceptionNotificationBody".GetLocalizedResource())
+					.AddText(Strings.ExceptionNotificationHeader.GetLocalizedResource())
+					.AddText(Strings.ExceptionNotificationBody.GetLocalizedResource())
 					.SetAppLogoOverride(new Uri("ms-appx:///Assets/error.png"))
-					.AddButton(new AppNotificationButton("ExceptionNotificationReportButton".GetLocalizedResource())
+					.AddButton(new AppNotificationButton(Strings.ExceptionNotificationReportButton.GetLocalizedResource())
 						.SetInvokeUri(new Uri(Constants.ExternalUrl.BugReportUrl)))
 					.BuildNotification();
 			AppNotificationManager.Default.Show(toastContent);
@@ -25,8 +25,8 @@ namespace Files.App.Helpers.Application
 		public static void ShowBackgroundRunningToast()
 		{
 			var toastContent = new AppNotificationBuilder()
-				.AddText("BackgroundRunningNotificationHeader".GetLocalizedResource())
-				.AddText("BackgroundRunningNotificationBody".GetLocalizedResource())
+				.AddText(Strings.BackgroundRunningNotificationHeader.GetLocalizedResource())
+				.AddText(Strings.BackgroundRunningNotificationBody.GetLocalizedResource())
 				.BuildNotification();
 			AppNotificationManager.Default.Show(toastContent);
 		}
@@ -34,8 +34,8 @@ namespace Files.App.Helpers.Application
 		public static void ShowDriveEjectToast()
 		{
 			var toastContent = new AppNotificationBuilder()
-				.AddText("EjectNotificationHeader".GetLocalizedResource())
-				.AddText("EjectNotificationBody".GetLocalizedResource())
+				.AddText(Strings.EjectNotificationHeader.GetLocalizedResource())
+				.AddText(Strings.EjectNotificationBody.GetLocalizedResource())
 				.SetAttributionText("SettingsAboutAppName".GetLocalizedResource())
 				.BuildNotification();
 			AppNotificationManager.Default.Show(toastContent);

--- a/src/Files.App/Helpers/BitmapHelper.cs
+++ b/src/Files.App/Helpers/BitmapHelper.cs
@@ -94,9 +94,9 @@ namespace Files.App.Helpers
 			{
 				var errorDialog = new ContentDialog()
 				{
-					Title = "FailedToRotateImage".GetLocalizedResource(),
+					Title = Strings.FailedToRotateImage.GetLocalizedResource(),
 					Content = ex.Message,
-					PrimaryButtonText = "OK".GetLocalizedResource(),
+					PrimaryButtonText = Strings.OK.GetLocalizedResource(),
 				};
 
 				if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))

--- a/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
+++ b/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
@@ -19,11 +19,11 @@ namespace Files.App.Helpers
 		{
 			DynamicDialog dialog = new DynamicDialog(new DynamicDialogViewModel()
 			{
-				TitleText = "PropertySaveErrorDialog/Title".GetLocalizedResource(),
-				SubtitleText = "PropertySaveErrorMessage/Text".GetLocalizedResource(), // We can use subtitle here as our content
-				PrimaryButtonText = "Retry".GetLocalizedResource(),
-				SecondaryButtonText = "PropertySaveErrorDialog/SecondaryButtonText".GetLocalizedResource(),
-				CloseButtonText = "Cancel".GetLocalizedResource(),
+				TitleText = Strings.PropertySaveErrorDialog_Title.GetLocalizedResource(),
+				SubtitleText = Strings.PropertySaveErrorMessage_Text.GetLocalizedResource(), // We can use subtitle here as our content
+				PrimaryButtonText = Strings.Retry.GetLocalizedResource(),
+				SecondaryButtonText = Strings.PropertySaveErrorDialog_SecondaryButtonText.GetLocalizedResource(),
+				CloseButtonText = Strings.Cancel.GetLocalizedResource(),
 				DynamicButtons = DynamicDialogButtons.Primary | DynamicDialogButtons.Secondary | DynamicDialogButtons.Cancel
 			});
 			return dialog;
@@ -33,9 +33,9 @@ namespace Files.App.Helpers
 		{
 			DynamicDialog dialog = new DynamicDialog(new DynamicDialogViewModel()
 			{
-				TitleText = "WelcomeDialog/Title".GetLocalizedResource(),
-				SubtitleText = "WelcomeDialogTextBlock/Text".GetLocalizedResource(), // We can use subtitle here as our content
-				PrimaryButtonText = "WelcomeDialog/PrimaryButtonText".GetLocalizedResource(),
+				TitleText = Strings.WelcomeDialog_Title.GetLocalizedResource(),
+				SubtitleText = Strings.WelcomeDialogTextBlock_Text.GetLocalizedResource(), // We can use subtitle here as our content
+				PrimaryButtonText = Strings.WelcomeDialog_PrimaryButtonText.GetLocalizedResource(),
 				PrimaryButtonAction = async (vm, e) => await Launcher.LaunchUriAsync(new Uri("ms-settings:privacy-broadfilesystemaccess")),
 				DynamicButtons = DynamicDialogButtons.Primary
 			});
@@ -46,10 +46,10 @@ namespace Files.App.Helpers
 		{
 			DynamicDialog dialog = new(new DynamicDialogViewModel
 			{
-				TitleText = "ShortcutCannotBeOpened".GetLocalizedResource(),
-				SubtitleText = string.Format("DeleteShortcutDescription".GetLocalizedResource(), targetPath),
-				PrimaryButtonText = "Delete".GetLocalizedResource(),
-				SecondaryButtonText = "No".GetLocalizedResource(),
+				TitleText = Strings.ShortcutCannotBeOpened.GetLocalizedResource(),
+				SubtitleText = string.Format(Strings.DeleteShortcutDescription.GetLocalizedResource(), targetPath),
+				PrimaryButtonText = Strings.Delete.GetLocalizedResource(),
+				SecondaryButtonText = Strings.No.GetLocalizedResource(),
 				DynamicButtons = DynamicDialogButtons.Primary | DynamicDialogButtons.Secondary
 			});
 			return dialog;
@@ -60,12 +60,12 @@ namespace Files.App.Helpers
 			DynamicDialog? dialog = null;
 			TextBox inputText = new()
 			{
-				PlaceholderText = "EnterAnItemName".GetLocalizedResource()
+				PlaceholderText = Strings.EnterAnItemName.GetLocalizedResource()
 			};
 
 			TeachingTip warning = new()
 			{
-				Title = "InvalidFilename/Text".GetLocalizedResource(),
+				Title = Strings.InvalidFilename_Text.GetLocalizedResource(),
 				PreferredPlacement = TeachingTipPlacementMode.Bottom,
 				DataContext = new CreateItemDialogViewModel(),
 			};
@@ -101,7 +101,7 @@ namespace Files.App.Helpers
 
 			dialog = new DynamicDialog(new DynamicDialogViewModel()
 			{
-				TitleText = string.Format("CreateNewItemTitle".GetLocalizedResource(), itemType),
+				TitleText = string.Format(Strings.CreateNewItemTitle.GetLocalizedResource(), itemType),
 				SubtitleText = null,
 				DisplayControl = new Grid()
 				{
@@ -115,8 +115,8 @@ namespace Files.App.Helpers
 				{
 					vm.HideDialog(); // Rename successful
 				},
-				PrimaryButtonText = "Create".GetLocalizedResource(),
-				CloseButtonText = "Cancel".GetLocalizedResource(),
+				PrimaryButtonText = Strings.Create.GetLocalizedResource(),
+				CloseButtonText = Strings.Cancel.GetLocalizedResource(),
 				DynamicButtonsEnabled = DynamicDialogButtons.Cancel,
 				DynamicButtons = DynamicDialogButtons.Primary | DynamicDialogButtons.Cancel
 			});
@@ -133,9 +133,9 @@ namespace Files.App.Helpers
 		{
 			DynamicDialog dialog = new DynamicDialog(new DynamicDialogViewModel()
 			{
-				TitleText = "FileInUseDialog/Title".GetLocalizedResource(),
-				SubtitleText = lockingProcess.IsEmpty() ? "FileInUseDialog/Text".GetLocalizedResource() :
-					string.Format("FileInUseByDialog/Text".GetLocalizedResource(), string.Join(", ", lockingProcess.Select(x => $"{x.AppName ?? x.Name} (PID: {x.Pid})"))),
+				TitleText = Strings.FileInUseDialog_Title.GetLocalizedResource(),
+				SubtitleText = lockingProcess.IsEmpty() ? Strings.FileInUseDialog_Text.GetLocalizedResource() :
+					string.Format(Strings.FileInUseByDialog_Text.GetLocalizedResource(), string.Join(", ", lockingProcess.Select(x => $"{x.AppName ?? x.Name} (PID: {x.Pid})"))),
 				PrimaryButtonText = "OK",
 				DynamicButtons = DynamicDialogButtons.Primary
 			});
@@ -149,17 +149,17 @@ namespace Files.App.Helpers
 
 			TextBox inputUsername = new()
 			{
-				PlaceholderText = "CredentialDialogUserName/PlaceholderText".GetLocalizedResource()
+				PlaceholderText = Strings.CredentialDialogUserName_PlaceholderText.GetLocalizedResource()
 			};
 
 			PasswordBox inputPassword = new()
 			{
-				PlaceholderText = "Password".GetLocalizedResource()
+				PlaceholderText = Strings.Password.GetLocalizedResource()
 			};
 
 			CheckBox saveCreds = new()
 			{
-				Content = "NetworkAuthenticationSaveCheckbox".GetLocalizedResource()
+				Content = Strings.NetworkAuthenticationSaveCheckbox.GetLocalizedResource()
 			};
 
 			inputUsername.TextChanged += (textBox, args) =>
@@ -188,10 +188,10 @@ namespace Files.App.Helpers
 
 			dialog = new DynamicDialog(new DynamicDialogViewModel()
 			{
-				TitleText = "NetworkAuthenticationDialogTitle".GetLocalizedResource(),
-				PrimaryButtonText = "OK".GetLocalizedResource(),
-				CloseButtonText = "Cancel".GetLocalizedResource(),
-				SubtitleText = string.Format("NetworkAuthenticationDialogMessage".GetLocalizedResource(), path.Substring(2)),
+				TitleText = Strings.NetworkAuthenticationDialogTitle.GetLocalizedResource(),
+				PrimaryButtonText = Strings.OK.GetLocalizedResource(),
+				CloseButtonText = Strings.Cancel.GetLocalizedResource(),
+				SubtitleText = string.Format(Strings.NetworkAuthenticationDialogMessage.GetLocalizedResource(), path.Substring(2)),
 				DisplayControl = new Grid()
 				{
 					MinWidth = 250d,
@@ -228,9 +228,9 @@ namespace Files.App.Helpers
 			{
 				ItemsSource = new string[]
 				{
-					string.Format("BringChanges".GetLocalizedResource(), checkoutBranchName),
-					string.Format("StashChanges".GetLocalizedResource(), headBranchName),
-					"DiscardChanges".GetLocalizedResource()
+					string.Format(Strings.BringChanges.GetLocalizedResource(), checkoutBranchName),
+					string.Format(Strings.StashChanges.GetLocalizedResource(), headBranchName),
+					Strings.DiscardChanges.GetLocalizedResource()
 				},
 				SelectionMode = ListViewSelectionMode.Single
 			};
@@ -243,10 +243,10 @@ namespace Files.App.Helpers
 
 			dialog = new DynamicDialog(new DynamicDialogViewModel()
 			{
-				TitleText = "SwitchBranch".GetLocalizedResource(),
-				PrimaryButtonText = "Switch".GetLocalizedResource(),
-				CloseButtonText = "Cancel".GetLocalizedResource(),
-				SubtitleText = "UncommittedChanges".GetLocalizedResource(),
+				TitleText = Strings.SwitchBranch.GetLocalizedResource(),
+				PrimaryButtonText = Strings.Switch.GetLocalizedResource(),
+				CloseButtonText = Strings.Cancel.GetLocalizedResource(),
+				SubtitleText = Strings.UncommittedChanges.GetLocalizedResource(),
 				DisplayControl = new Grid()
 				{
 					MinWidth = 250d,
@@ -271,8 +271,8 @@ namespace Files.App.Helpers
 			DynamicDialog dialog = new DynamicDialog(new DynamicDialogViewModel()
 			{
 				TitleText = "Error".GetLocalizedResource(),
-				SubtitleText = "CannotReachGitHubError".GetLocalizedResource(),
-				PrimaryButtonText = "Close".GetLocalizedResource(),
+				SubtitleText = Strings.CannotReachGitHubError.GetLocalizedResource(),
+				PrimaryButtonText = Strings.Close.GetLocalizedResource(),
 				DynamicButtons = DynamicDialogButtons.Primary
 			});
 			return dialog;
@@ -283,8 +283,8 @@ namespace Files.App.Helpers
 			return new DynamicDialog(new DynamicDialogViewModel()
 			{
 				TitleText = "Error".GetLocalizedResource(),
-				SubtitleText = "CannotInitializeGitRepo".GetLocalizedResource(),
-				PrimaryButtonText = "Close".GetLocalizedResource(),
+				SubtitleText = Strings.CannotInitializeGitRepo.GetLocalizedResource(),
+				PrimaryButtonText = Strings.Close.GetLocalizedResource(),
 				DynamicButtons = DynamicDialogButtons.Primary
 			});
 		}
@@ -294,10 +294,10 @@ namespace Files.App.Helpers
 			DynamicDialog dialog = null!;
 			dialog = new DynamicDialog(new DynamicDialogViewModel()
 			{
-				TitleText = "GitDeleteBranch".GetLocalizedResource(),
-				SubtitleText = string.Format("GitDeleteBranchSubtitle".GetLocalizedResource(), branchName),
-				PrimaryButtonText = "OK".GetLocalizedResource(),
-				CloseButtonText = "Cancel".GetLocalizedResource(),
+				TitleText = Strings.GitDeleteBranch.GetLocalizedResource(),
+				SubtitleText = string.Format(Strings.GitDeleteBranchSubtitle.GetLocalizedResource(), branchName),
+				PrimaryButtonText = Strings.OK.GetLocalizedResource(),
+				CloseButtonText = Strings.Cancel.GetLocalizedResource(),
 				AdditionalData = true,
 				CloseButtonAction = (vm, e) =>
 				{
@@ -314,10 +314,10 @@ namespace Files.App.Helpers
 			DynamicDialog dialog = null!;
 			dialog = new DynamicDialog(new DynamicDialogViewModel()
 			{
-				TitleText = "ItemRenameFailed".GetLocalizedResource(),
-				SubtitleText = string.Format("HigherPermissionsRequired".GetLocalizedResource(), path),
-				PrimaryButtonText = "OK".GetLocalizedResource(),
-				SecondaryButtonText = "EditPermissions".GetLocalizedResource(),
+				TitleText = Strings.ItemRenameFailed.GetLocalizedResource(),
+				SubtitleText = string.Format(Strings.HigherPermissionsRequired.GetLocalizedResource(), path),
+				PrimaryButtonText = Strings.OK.GetLocalizedResource(),
+				SecondaryButtonText = Strings.EditPermissions.GetLocalizedResource(),
 				SecondaryButtonAction = (vm, e) =>
 				{
 					var context = Ioc.Default.GetRequiredService<IContentPageContext>();

--- a/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
@@ -189,19 +189,19 @@ namespace Files.App.Helpers
 
 			if (string.IsNullOrEmpty(currentPath) || currentPath == "Home")
 			{
-				tabLocationHeader = "Home".GetLocalizedResource();
+				tabLocationHeader = Strings.Home.GetLocalizedResource();
 				iconSource.ImageSource = new BitmapImage(new Uri(Constants.FluentIconsPaths.HomeIcon));
 			}
 			else if (currentPath.Equals(Constants.UserEnvironmentPaths.DesktopPath, StringComparison.OrdinalIgnoreCase))
-				tabLocationHeader = "Desktop".GetLocalizedResource();
+				tabLocationHeader = Strings.Desktop.GetLocalizedResource();
 			else if (currentPath.Equals(Constants.UserEnvironmentPaths.DownloadsPath, StringComparison.OrdinalIgnoreCase))
-				tabLocationHeader = "Downloads".GetLocalizedResource();
+				tabLocationHeader = Strings.Downloads.GetLocalizedResource();
 			else if (currentPath.Equals(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
-				tabLocationHeader = "RecycleBin".GetLocalizedResource();
+				tabLocationHeader = Strings.RecycleBin.GetLocalizedResource();
 			else if (currentPath.Equals(Constants.UserEnvironmentPaths.MyComputerPath, StringComparison.OrdinalIgnoreCase))
-				tabLocationHeader = "ThisPC".GetLocalizedResource();
+				tabLocationHeader = Strings.ThisPC.GetLocalizedResource();
 			else if (currentPath.Equals(Constants.UserEnvironmentPaths.NetworkFolderPath, StringComparison.OrdinalIgnoreCase))
-				tabLocationHeader = "Network".GetLocalizedResource();
+				tabLocationHeader = Strings.Network.GetLocalizedResource();
 			else if (App.LibraryManager.TryGetLibrary(currentPath, out LibraryLocationItem library))
 			{
 				var libName = System.IO.Path.GetFileNameWithoutExtension(library.Path).GetLocalizedResource();
@@ -477,7 +477,7 @@ namespace Files.App.Helpers
 
 			if (opened.ErrorCode == FileSystemStatusCode.NotFound && !openSilent)
 			{
-				await DialogDisplayHelper.ShowDialogAsync("FileNotFoundDialog/Title".GetLocalizedResource(), "FileNotFoundDialog/Text".GetLocalizedResource());
+				await DialogDisplayHelper.ShowDialogAsync(Strings.FileNotFoundDialog_Title.GetLocalizedResource(), Strings.FileNotFoundDialog_Text.GetLocalizedResource());
 				associatedInstance.ToolbarViewModel.CanRefresh = false;
 				associatedInstance.ShellViewModel?.RefreshItems(previousDir);
 			}

--- a/src/Files.App/Helpers/ShareItemHelpers.cs
+++ b/src/Files.App/Helpers/ShareItemHelpers.cs
@@ -40,9 +40,9 @@ namespace Files.App.Helpers
 			{
 				var errorDialog = new ContentDialog()
 				{
-					Title = "FaildToShareItems".GetLocalizedResource(),
+					Title = Strings.FaildToShareItems.GetLocalizedResource(),
 					Content = ex.Message,
-					PrimaryButtonText = "OK".GetLocalizedResource(),
+					PrimaryButtonText = Strings.OK.GetLocalizedResource(),
 				};
 
 				if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
@@ -63,8 +63,8 @@ namespace Files.App.Helpers
 					{
 						if (shItem.IsLinkItem && !string.IsNullOrEmpty(shItem.TargetPath))
 						{
-							dataRequest.Data.Properties.Title = string.Format("ShareDialogTitle".GetLocalizedResource(), item.Name);
-							dataRequest.Data.Properties.Description = "ShareDialogSingleItemDescription".GetLocalizedResource();
+							dataRequest.Data.Properties.Title = string.Format(Strings.ShareDialogTitle.GetLocalizedResource(), item.Name);
+							dataRequest.Data.Properties.Description = Strings.ShareDialogSingleItemDescription.GetLocalizedResource();
 							dataRequest.Data.SetWebLink(new Uri(shItem.TargetPath));
 							dataRequestDeferral.Complete();
 
@@ -85,12 +85,12 @@ namespace Files.App.Helpers
 
 				if (items.Count == 1)
 				{
-					dataRequest.Data.Properties.Title = string.Format("ShareDialogTitle".GetLocalizedResource(), items.First().Name);
-					dataRequest.Data.Properties.Description = "ShareDialogSingleItemDescription".GetLocalizedResource();
+					dataRequest.Data.Properties.Title = string.Format(Strings.ShareDialogTitle.GetLocalizedResource(), items.First().Name);
+					dataRequest.Data.Properties.Description = Strings.ShareDialogSingleItemDescription.GetLocalizedResource();
 				}
 				else if (items.Count == 0)
 				{
-					dataRequest.FailWithDisplayText("ShareDialogFailMessage".GetLocalizedResource());
+					dataRequest.FailWithDisplayText(Strings.ShareDialogFailMessage.GetLocalizedResource());
 					dataRequestDeferral.Complete();
 
 					return;
@@ -98,10 +98,10 @@ namespace Files.App.Helpers
 				else
 				{
 					dataRequest.Data.Properties.Title = string.Format(
-						"ShareDialogTitleMultipleItems".GetLocalizedResource(),
+						Strings.ShareDialogTitleMultipleItems.GetLocalizedResource(),
 						items.Count,
 						"ItemsCount.Text".GetLocalizedResource());
-					dataRequest.Data.Properties.Description = "ShareDialogMultipleItemsDescription".GetLocalizedResource();
+					dataRequest.Data.Properties.Description = Strings.ShareDialogMultipleItemsDescription.GetLocalizedResource();
 				}
 
 				dataRequest.Data.SetStorageItems(items, false);

--- a/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
@@ -121,14 +121,14 @@ namespace Files.App.Helpers
 			switch (itemType)
 			{
 				case AddItemDialogItemType.Folder:
-					userInput = !string.IsNullOrWhiteSpace(userInput) ? userInput : "NewFolder".GetLocalizedResource();
+					userInput = !string.IsNullOrWhiteSpace(userInput) ? userInput : Strings.NewFolder.GetLocalizedResource();
 					created = await associatedInstance.FilesystemHelpers.CreateAsync(
 						StorageHelpers.FromPathAndType(PathNormalization.Combine(currentPath, userInput), FilesystemItemType.Directory),
 						true);
 					break;
 
 				case AddItemDialogItemType.File:
-					userInput = !string.IsNullOrWhiteSpace(userInput) ? userInput : itemInfo?.Name ?? "NewFile".GetLocalizedResource();
+					userInput = !string.IsNullOrWhiteSpace(userInput) ? userInput : itemInfo?.Name ?? Strings.NewFile.GetLocalizedResource();
 					created = await associatedInstance.FilesystemHelpers.CreateAsync(
 						StorageHelpers.FromPathAndType(PathNormalization.Combine(currentPath, userInput + itemInfo?.Extension), FilesystemItemType.File),
 						true);
@@ -145,8 +145,8 @@ namespace Files.App.Helpers
 			{
 				await DialogDisplayHelper.ShowDialogAsync
 				(
-					"AccessDenied".GetLocalizedResource(),
-					"AccessDeniedCreateDialog/Text".GetLocalizedResource()
+					Strings.AccessDenied.GetLocalizedResource(),
+					Strings.AccessDeniedCreateDialog_Text.GetLocalizedResource()
 				);
 			}
 
@@ -230,10 +230,10 @@ namespace Files.App.Helpers
 		{
 			var result = await DialogDisplayHelper.ShowDialogAsync
 			(
-				"CannotCreateShortcutDialogTitle".ToLocalized(),
-				"CannotCreateShortcutDialogMessage".ToLocalized(),
-				"Create".ToLocalized(),
-				"Cancel".ToLocalized()
+				Strings.CannotCreateShortcutDialogTitle.ToLocalized(),
+				Strings.CannotCreateShortcutDialogMessage.ToLocalized(),
+				Strings.Create.ToLocalized(),
+				Strings.Cancel.ToLocalized()
 			);
 			if (!result)
 				return false;

--- a/src/Files.App/Helpers/UI/UIHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIHelpers.cs
@@ -49,8 +49,8 @@ namespace Files.App.Helpers
 				Debug.WriteLine("Can't eject device");
 
 				await DialogDisplayHelper.ShowDialogAsync(
-					"EjectNotificationErrorDialogHeader".GetLocalizedResource(),
-					"EjectNotificationErrorDialogBody".GetLocalizedResource());
+					Strings.EjectNotificationErrorDialogHeader.GetLocalizedResource(),
+					Strings.EjectNotificationErrorDialogBody.GetLocalizedResource());
 			}
 		}
 

--- a/src/Files.App/Services/App/AppUpdateStoreService.cs
+++ b/src/Files.App/Services/App/AppUpdateStoreService.cs
@@ -159,10 +159,10 @@ namespace Files.App.Services
 			//TODO: Use IDialogService in future.
 			ContentDialog dialog = new()
 			{
-				Title = "ConsentDialogTitle".GetLocalizedResource(),
-				Content = "ConsentDialogContent".GetLocalizedResource(),
-				CloseButtonText = "Close".GetLocalizedResource(),
-				PrimaryButtonText = "ConsentDialogPrimaryButtonText".GetLocalizedResource()
+				Title = Strings.ConsentDialogTitle.GetLocalizedResource(),
+				Content = Strings.ConsentDialogContent.GetLocalizedResource(),
+				CloseButtonText = Strings.Close.GetLocalizedResource(),
+				PrimaryButtonText = Strings.ConsentDialogPrimaryButtonText.GetLocalizedResource()
 			};
 
 			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))

--- a/src/Files.App/Services/DateTimeFormatter/AbstractDateTimeFormatter.cs
+++ b/src/Files.App/Services/DateTimeFormatter/AbstractDateTimeFormatter.cs
@@ -27,24 +27,24 @@ namespace Files.App.Services.DateTimeFormatter
 			return 0 switch
 			{
 				_ when now.Date < time.Date
-					=> new Label("Future".GetLocalizedResource(), "\uED28", 1000000006),
+					=> new Label(Strings.Future.GetLocalizedResource(), "\uED28", 1000000006),
 				_ when now.Date == time.Date
-					=> new Label("Today".GetLocalizedResource(), "\uE8D1", 1000000005),
+					=> new Label(Strings.Today.GetLocalizedResource(), "\uE8D1", 1000000005),
 				_ when now.AddDays(-1).Date == time.Date
-					=> new Label("Yesterday".GetLocalizedResource(), "\uE8BF", 1000000004),
+					=> new Label(Strings.Yesterday.GetLocalizedResource(), "\uE8BF", 1000000004),
 
 				// Group by day
 				_ when unit == GroupByDateUnit.Day
 					=> new Label(ToString(time, "D"), "\uE8BF", time.Year * 10000 + time.Month * 100 + time.Day),
 
 				_ when diff.Days <= 7 && GetWeekOfYear(now) == GetWeekOfYear(time)
-					=> new Label("EarlierThisWeek".GetLocalizedResource(), "\uE8C0", 1000000003),
+					=> new Label(Strings.EarlierThisWeek.GetLocalizedResource(), "\uE8C0", 1000000003),
 				_ when diff.Days <= 14 && GetWeekOfYear(now.AddDays(-7)) == GetWeekOfYear(time)
-					=> new Label("LastWeek".GetLocalizedResource(), "\uE8C0", 1000000002),
+					=> new Label(Strings.LastWeek.GetLocalizedResource(), "\uE8C0", 1000000002),
 				_ when now.Year == time.Year && now.Month == time.Month
-					=> new Label("EarlierThisMonth".GetLocalizedResource(), "\uE787", 1000000001),
+					=> new Label(Strings.EarlierThisMonth.GetLocalizedResource(), "\uE787", 1000000001),
 				_ when now.AddMonths(-1).Year == time.Year && now.AddMonths(-1).Month == time.Month
-					=> new Label("LastMonth".GetLocalizedResource(), "\uE787", 1000000000),
+					=> new Label(Strings.LastMonth.GetLocalizedResource(), "\uE787", 1000000000),
 
 				// Group by month
 				_ when unit == GroupByDateUnit.Month
@@ -52,11 +52,11 @@ namespace Files.App.Services.DateTimeFormatter
 
 				// Group by year
 				_ when now.Year == time.Year
-					=> new Label("EarlierThisYear".GetLocalizedResource(), "\uEC92", 10000001),
+					=> new Label(Strings.EarlierThisYear.GetLocalizedResource(), "\uEC92", 10000001),
 				_ when now.AddYears(-1).Year == time.Year
-					=> new Label("LastYear".GetLocalizedResource(), "\uEC92", 10000000),
+					=> new Label(Strings.LastYear.GetLocalizedResource(), "\uEC92", 10000000),
 				_
-					=> new Label(string.Format("YearN".GetLocalizedResource(), time.Year), "\uEC92", time.Year),
+					=> new Label(string.Format(Strings.YearN.GetLocalizedResource(), time.Year), "\uEC92", time.Year),
 			};
 		}
 

--- a/src/Files.App/Services/DateTimeFormatter/ApplicationDateTimeFormatter.cs
+++ b/src/Files.App/Services/DateTimeFormatter/ApplicationDateTimeFormatter.cs
@@ -14,7 +14,7 @@ namespace Files.App.Services.DateTimeFormatter
 		/// Gets the name of the formatter.
 		/// </summary>
 		public override string Name
-			=> "Application".GetLocalizedResource();
+			=> Strings.Application.GetLocalizedResource();
 
 		/// <summary>
 		/// Converts the provided <see cref="DateTimeOffset"/> to a short label.
@@ -33,15 +33,15 @@ namespace Files.App.Services.DateTimeFormatter
 			return elapsed switch
 			{
 				{ TotalDays: >= 7 } => ToString(offset, "D"),
-				{ TotalDays: >= 2 } => string.Format("DaysAgo_Plural".GetLocalizedResource(), elapsed.Days),
-				{ TotalDays: >= 1 } => "DaysAgo_Singular".GetLocalizedResource(),
-				{ TotalHours: >= 2 } => string.Format("HoursAgo_Plural".GetLocalizedResource(), elapsed.Hours),
-				{ TotalHours: >= 1 } => "HoursAgo_Singular".GetLocalizedResource(),
-				{ TotalMinutes: >= 2 } => string.Format("MinutesAgo_Plural".GetLocalizedResource(), elapsed.Minutes),
-				{ TotalMinutes: >= 1 } => "MinutesAgo_Singular".GetLocalizedResource(),
-				{ TotalSeconds: >= 2 } => string.Format("SecondsAgo_Plural".GetLocalizedResource(), elapsed.Seconds),
-				{ TotalSeconds: >= 1 } => "SecondsAgo_Singular".GetLocalizedResource(),
-				{ TotalSeconds: >= 0 } => "Now".GetLocalizedResource(),
+				{ TotalDays: >= 2 } => string.Format(Strings.DaysAgo_Plural.GetLocalizedResource(), elapsed.Days),
+				{ TotalDays: >= 1 } => Strings.DaysAgo_Singular.GetLocalizedResource(),
+				{ TotalHours: >= 2 } => string.Format(Strings.HoursAgo_Plural.GetLocalizedResource(), elapsed.Hours),
+				{ TotalHours: >= 1 } => Strings.HoursAgo_Singular.GetLocalizedResource(),
+				{ TotalMinutes: >= 2 } => string.Format(Strings.MinutesAgo_Plural.GetLocalizedResource(), elapsed.Minutes),
+				{ TotalMinutes: >= 1 } => Strings.MinutesAgo_Singular.GetLocalizedResource(),
+				{ TotalSeconds: >= 2 } => string.Format(Strings.SecondsAgo_Plural.GetLocalizedResource(), elapsed.Seconds),
+				{ TotalSeconds: >= 1 } => Strings.SecondsAgo_Singular.GetLocalizedResource(),
+				{ TotalSeconds: >= 0 } => Strings.Now.GetLocalizedResource(),
 				_ => ToString(offset, "D"),
 			};
 		}

--- a/src/Files.App/Services/DateTimeFormatter/SystemDateTimeFormatter.cs
+++ b/src/Files.App/Services/DateTimeFormatter/SystemDateTimeFormatter.cs
@@ -9,7 +9,7 @@ namespace Files.App.Services.DateTimeFormatter
 	internal sealed class SystemDateTimeFormatter : AbstractDateTimeFormatter
 	{
 		public override string Name
-			=> "SystemTimeStyle".GetLocalizedResource();
+			=> Strings.SystemTimeStyle.GetLocalizedResource();
 
 		public override string ToShortLabel(DateTimeOffset offset)
 		{

--- a/src/Files.App/Services/DateTimeFormatter/UniversalDateTimeFormatter.cs
+++ b/src/Files.App/Services/DateTimeFormatter/UniversalDateTimeFormatter.cs
@@ -9,7 +9,7 @@ namespace Files.App.Services.DateTimeFormatter
 	internal sealed class UniversalDateTimeFormatter : AbstractDateTimeFormatter
 	{
 		public override string Name
-			=> "Universal".GetLocalizedResource();
+			=> Strings.Universal.GetLocalizedResource();
 
 		public override string ToShortLabel(DateTimeOffset offset)
 		{

--- a/src/Files.App/Services/Settings/FileTagsSettingsService.cs
+++ b/src/Files.App/Services/Settings/FileTagsSettingsService.cs
@@ -69,7 +69,7 @@ namespace Files.App.Services.Settings
 
 			if (!string.IsNullOrEmpty(uid) && tag is null)
 			{
-				tag = new TagViewModel("Unknown".GetLocalizedResource(), "#9ea3a1", uid);
+				tag = new TagViewModel(Strings.Unknown.GetLocalizedResource(), "#9ea3a1", uid);
 				FileTagList = FileTagList.Append(tag).ToList();
 			}
 

--- a/src/Files.App/Services/Storage/StorageNetworkService.cs
+++ b/src/Files.App/Services/Storage/StorageNetworkService.cs
@@ -43,7 +43,7 @@ namespace Files.App.Services
 			var networkItem = new DriveItem()
 			{
 				DeviceID = "network-folder",
-				Text = "Network".GetLocalizedResource(),
+				Text = Strings.Network.GetLocalizedResource(),
 				Path = Constants.UserEnvironmentPaths.NetworkFolderPath,
 				Type = DriveType.Network,
 				ItemType = NavigationControlItemType.Drive,
@@ -263,7 +263,7 @@ namespace Files.App.Services
 			}
 			else
 			{
-				await DialogDisplayHelper.ShowDialogAsync("NetworkFolderErrorDialogTitle".GetLocalizedResource(), res.ToString());
+				await DialogDisplayHelper.ShowDialogAsync(Strings.NetworkFolderErrorDialogTitle.GetLocalizedResource(), res.ToString());
 
 				return false;
 			}

--- a/src/Files.App/Services/Windows/WindowsJumpListService.cs
+++ b/src/Files.App/Services/Windows/WindowsJumpListService.cs
@@ -131,7 +131,7 @@ namespace Files.App.Services
 				string? displayName = null;
 
 				if (path.StartsWith("\\\\SHELL", StringComparison.OrdinalIgnoreCase))
-					displayName = "ThisPC".GetLocalizedResource();
+					displayName = Strings.ThisPC.GetLocalizedResource();
 
 				if (path.EndsWith('\\'))
 				{
@@ -153,11 +153,11 @@ namespace Files.App.Services
 					else if (path.Equals(Constants.UserEnvironmentPaths.DownloadsPath, StringComparison.OrdinalIgnoreCase))
 						displayName = "ms-resource:///Resources/Downloads";
 					else if (path.Equals(Constants.UserEnvironmentPaths.NetworkFolderPath, StringComparison.OrdinalIgnoreCase))
-						displayName = "Network".GetLocalizedResource();
+						displayName = Strings.Network.GetLocalizedResource();
 					else if (path.Equals(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
-						displayName = "RecycleBin".GetLocalizedResource();
+						displayName = Strings.RecycleBin.GetLocalizedResource();
 					else if (path.Equals(Constants.UserEnvironmentPaths.MyComputerPath, StringComparison.OrdinalIgnoreCase))
-						displayName = "ThisPC".GetLocalizedResource();
+						displayName = Strings.ThisPC.GetLocalizedResource();
 					else if (App.LibraryManager.TryGetLibrary(path, out LibraryLocationItem library))
 					{
 						var libName = Path.GetFileNameWithoutExtension(library.Path);

--- a/src/Files.App/UserControls/Sidebar/SidebarItem.cs
+++ b/src/Files.App/UserControls/Sidebar/SidebarItem.cs
@@ -22,7 +22,7 @@ namespace Files.App.UserControls.Sidebar
 		public bool CollapseEnabled => DisplayMode != SidebarDisplayMode.Compact;
 
 		// TODO: Do not use localized text for comparison. This is a workaround to avoid major refactoring for now, it should be done any time soon
-		public bool IsHomeItem => Item?.Text == "Home".GetLocalizedResource() && Owner?.MenuItemsSource is IList enumerable && enumerable.IndexOf(Item) == 0;
+		public bool IsHomeItem => Item?.Text == Strings.Home.GetLocalizedResource() && Owner?.MenuItemsSource is IList enumerable && enumerable.IndexOf(Item) == 0;
 
 		private bool hasChildSelection => selectedChildItem != null;
 		private bool isPointerOver = false;

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -163,7 +163,7 @@ namespace Files.App.UserControls.TabBar
 				HorizontalTabView.CanReorderTabs = WindowContext.CanDragAndDrop;
 
 				e.AcceptedOperation = DataPackageOperation.Move;
-				e.DragUIOverride.Caption = "TabStripDragAndDropUIOverrideCaption".GetLocalizedResource();
+				e.DragUIOverride.Caption = Strings.TabStripDragAndDropUIOverrideCaption.GetLocalizedResource();
 				e.DragUIOverride.IsCaptionVisible = true;
 				e.DragUIOverride.IsGlyphVisible = false;
 			}
@@ -333,7 +333,7 @@ namespace Files.App.UserControls.TabBar
 				e.Handled = true;
 				var deferral = e.GetDeferral();
 				e.DragUIOverride.IsCaptionVisible = true;
-				e.DragUIOverride.Caption = string.Format("OpenInNewTab".GetLocalizedResource());
+				e.DragUIOverride.Caption = string.Format(Strings.OpenInNewTab.GetLocalizedResource());
 				e.AcceptedOperation = DataPackageOperation.Link;
 				deferral.Complete();
 			}

--- a/src/Files.App/Utils/Cloud/CloudDriveSyncStatusUI.cs
+++ b/src/Files.App/Utils/Cloud/CloudDriveSyncStatusUI.cs
@@ -16,7 +16,7 @@ namespace Files.App.Utils.Cloud
 
 		public bool LoadSyncStatus { get; }
 
-		public string SyncStatusString { get; } = "CloudDriveSyncStatus_Unknown".GetLocalizedResource();
+		public string SyncStatusString { get; } = Strings.CloudDriveSyncStatus_Unknown.GetLocalizedResource();
 
 		public CloudDriveSyncStatusUI()
 		{

--- a/src/Files.App/Utils/FileTags/FileTagsHelper.cs
+++ b/src/Files.App/Utils/FileTags/FileTagsHelper.cs
@@ -42,8 +42,8 @@ namespace Files.App.Utils.FileTags
 				{
 					ContentDialog dialog = new()
 					{
-						Title = "ErrorApplyingTagTitle".GetLocalizedResource(),
-						Content = "ErrorApplyingTagContent".GetLocalizedResource(),
+						Title = Strings.ErrorApplyingTagTitle.GetLocalizedResource(),
+						Content = Strings.ErrorApplyingTagContent.GetLocalizedResource(),
 						PrimaryButtonText = "Ok".GetLocalizedResource()
 					};
 

--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -442,9 +442,9 @@ namespace Files.App.Utils.Git
 			{
 				var viewModel = new DynamicDialogViewModel()
 				{
-					TitleText = "GitError".GetLocalizedResource(),
-					SubtitleText = "PullTimeoutError".GetLocalizedResource(),
-					CloseButtonText = "Close".GetLocalizedResource(),
+					TitleText = Strings.GitError.GetLocalizedResource(),
+					SubtitleText = Strings.PullTimeoutError.GetLocalizedResource(),
+					CloseButtonText = Strings.Close.GetLocalizedResource(),
 					DynamicButtons = DynamicDialogButtons.Cancel
 				};
 				var dialog = new DynamicDialog(viewModel);
@@ -570,7 +570,7 @@ namespace Files.App.Utils.Git
 			var expiresIn = codeJsonContent.RootElement.GetProperty("expires_in").GetInt32();
 
 			var loginCTS = new CancellationTokenSource();
-			var viewModel = new GitHubLoginDialogViewModel(userCode, "ConnectGitHubDescription".GetLocalizedResource(), loginCTS);
+			var viewModel = new GitHubLoginDialogViewModel(userCode, Strings.ConnectGitHubDescription.GetLocalizedResource(), loginCTS);
 
 			var dialog = _dialogService.GetDialog(viewModel);
 			var loginDialogTask = dialog.TryShowAsync();
@@ -621,7 +621,7 @@ namespace Files.App.Utils.Git
 						GIT_RESOURCE_USERNAME,
 						token);
 
-					viewModel.Subtitle = "AuthorizationSucceded".GetLocalizedResource();
+					viewModel.Subtitle = Strings.AuthorizationSucceded.GetLocalizedResource();
 					viewModel.LoginConfirmed = true;
 				}
 				catch (Exception ex)
@@ -687,10 +687,10 @@ namespace Files.App.Utils.Git
 				{
 					changeKindHumanized = changeKind switch
 					{
-						ChangeKind.Added => "Added".GetLocalizedResource(),
-						ChangeKind.Deleted => "Deleted".GetLocalizedResource(),
-						ChangeKind.Modified => "Modified".GetLocalizedResource(),
-						ChangeKind.Untracked => "Untracked".GetLocalizedResource(),
+						ChangeKind.Added => Strings.Added.GetLocalizedResource(),
+						ChangeKind.Deleted => Strings.Deleted.GetLocalizedResource(),
+						ChangeKind.Modified => Strings.Modified.GetLocalizedResource(),
+						ChangeKind.Untracked => Strings.Untracked.GetLocalizedResource(),
 						_ => null,
 					};
 				}

--- a/src/Files.App/Utils/Library/LibraryManager.cs
+++ b/src/Files.App/Utils/Library/LibraryManager.cs
@@ -255,20 +255,20 @@ namespace Files.App.Utils.Library
 		{
 			if (string.IsNullOrWhiteSpace(name))
 			{
-				return (false, "ErrorInputEmpty".GetLocalizedResource());
+				return (false, Strings.ErrorInputEmpty.GetLocalizedResource());
 			}
 			if (FilesystemHelpers.ContainsRestrictedCharacters(name))
 			{
-				return (false, "ErrorNameInputRestrictedCharacters".GetLocalizedResource());
+				return (false, Strings.ErrorNameInputRestrictedCharacters.GetLocalizedResource());
 			}
 			if (FilesystemHelpers.ContainsRestrictedFileName(name))
 			{
-				return (false, "ErrorNameInputRestricted".GetLocalizedResource());
+				return (false, Strings.ErrorNameInputRestricted.GetLocalizedResource());
 			}
 			if (Libraries.Any((item) => string.Equals(name, item.Text, StringComparison.OrdinalIgnoreCase) ||
 				string.Equals(name, Path.GetFileNameWithoutExtension(item.Path), StringComparison.OrdinalIgnoreCase)))
 			{
-				return (false, "CreateLibraryErrorAlreadyExists".GetLocalizedResource());
+				return (false, Strings.CreateLibraryErrorAlreadyExists.GetLocalizedResource());
 			}
 			return (true, string.Empty);
 		}
@@ -277,10 +277,10 @@ namespace Files.App.Utils.Library
 		{
 			var dialog = new DynamicDialog(new DynamicDialogViewModel
 			{
-				TitleText = "DialogRestoreLibrariesTitleText".GetLocalizedResource(),
-				SubtitleText = "DialogRestoreLibrariesSubtitleText".GetLocalizedResource(),
-				PrimaryButtonText = "Restore".GetLocalizedResource(),
-				CloseButtonText = "Cancel".GetLocalizedResource(),
+				TitleText = Strings.DialogRestoreLibrariesTitleText.GetLocalizedResource(),
+				SubtitleText = Strings.DialogRestoreLibrariesSubtitleText.GetLocalizedResource(),
+				PrimaryButtonText = Strings.Restore.GetLocalizedResource(),
+				CloseButtonText = Strings.Cancel.GetLocalizedResource(),
 				PrimaryButtonAction = async (vm, e) =>
 				{
 					await ContextMenu.InvokeVerb("restorelibraries", ShellLibraryItem.LibrariesPath);
@@ -303,7 +303,7 @@ namespace Files.App.Utils.Library
 		{
 			var inputText = new TextBox
 			{
-				PlaceholderText = "FolderWidgetCreateNewLibraryInputPlaceholderText".GetLocalizedResource()
+				PlaceholderText = Strings.FolderWidgetCreateNewLibraryInputPlaceholderText.GetLocalizedResource()
 			};
 			var tipText = new TextBlock
 			{
@@ -328,10 +328,10 @@ namespace Files.App.Utils.Library
 						}
 					}
 				},
-				TitleText = "FolderWidgetCreateNewLibraryDialogTitleText".GetLocalizedResource(),
-				SubtitleText = "SideBarCreateNewLibrary/Text".GetLocalizedResource(),
-				PrimaryButtonText = "Create".GetLocalizedResource(),
-				CloseButtonText = "Cancel".GetLocalizedResource(),
+				TitleText = Strings.FolderWidgetCreateNewLibraryDialogTitleText.GetLocalizedResource(),
+				SubtitleText = Strings.SideBarCreateNewLibrary_Text.GetLocalizedResource(),
+				PrimaryButtonText = Strings.Create.GetLocalizedResource(),
+				CloseButtonText = Strings.Cancel.GetLocalizedResource(),
 				PrimaryButtonAction = async (vm, e) =>
 				{
 					var (result, reason) = App.LibraryManager.CanCreateLibrary(inputText.Text);

--- a/src/Files.App/Utils/Shell/ShellHelpers.cs
+++ b/src/Files.App/Utils/Shell/ShellHelpers.cs
@@ -28,10 +28,10 @@ namespace Files.App.Utils.Shell
 		{
 			return shPath switch
 			{
-				"Home" => "Home".GetLocalizedResource(),
-				Constants.UserEnvironmentPaths.RecycleBinPath => "RecycleBin".GetLocalizedResource(),
-				Constants.UserEnvironmentPaths.NetworkFolderPath => "Network".GetLocalizedResource(),
-				Constants.UserEnvironmentPaths.MyComputerPath => "ThisPC".GetLocalizedResource(),
+				"Home" => Strings.Home.GetLocalizedResource(),
+				Constants.UserEnvironmentPaths.RecycleBinPath => Strings.RecycleBin.GetLocalizedResource(),
+				Constants.UserEnvironmentPaths.NetworkFolderPath => Strings.Network.GetLocalizedResource(),
+				Constants.UserEnvironmentPaths.MyComputerPath => Strings.ThisPC.GetLocalizedResource(),
 				_ => shPath
 			};
 		}

--- a/src/Files.App/Utils/StatusCenter/StatusCenterItem.cs
+++ b/src/Files.App/Utils/StatusCenter/StatusCenterItem.cs
@@ -199,7 +199,7 @@ namespace Files.App.Utils.StatusCenter
 			AnimatedIconState = "NormalOff";
 			SpeedGraphValues = [];
 			CancelCommand = new RelayCommand(ExecuteCancelCommand);
-			Message = "ProcessingItems".GetLocalizedResource();
+			Message = Strings.ProcessingItems.GetLocalizedResource();
 			Source = source;
 			Destination = destination;
 
@@ -296,7 +296,7 @@ namespace Files.App.Utils.StatusCenter
 					{
 						Message =
 							$"{string.Format(
-								"StatusCenter_ProcessedItems_Header".GetLocalizedResource(),
+								Strings.StatusCenter_ProcessedItems_Header.GetLocalizedResource(),
 								value.ProcessedItemsCount,
 								value.ItemsCount)}";
 					}
@@ -304,7 +304,7 @@ namespace Files.App.Utils.StatusCenter
 					{
 						Message =
 							$"{string.Format(
-								"StatusCenter_ProcessedSize_Header".GetLocalizedResource(),
+								Strings.StatusCenter_ProcessedSize_Header.GetLocalizedResource(),
 								value.ProcessedSize.ToSizeString(),
 								value.TotalSize.ToSizeString())}";
 					}
@@ -393,7 +393,7 @@ namespace Files.App.Utils.StatusCenter
 				IsCancelable = false;
 				IsExpanded = false;
 				IsSpeedAndProgressAvailable = false;
-				Header = $"{"Canceling".GetLocalizedResource()} - {Header}";
+				Header = $"{Strings.Canceling.GetLocalizedResource()} - {Header}";
 			}
 		}
 	}

--- a/src/Files.App/Utils/Storage/Collection/GroupedCollection.cs
+++ b/src/Files.App/Utils/Storage/Collection/GroupedCollection.cs
@@ -43,8 +43,8 @@ namespace Files.App.Utils.Storage
 			{
 				Model.CountText = string.Format(
 					Count > 1
-						? "GroupItemsCount_Plural".GetLocalizedResource()
-						: "GroupItemsCount_Singular".GetLocalizedResource(),
+						? Strings.GroupItemsCount_Plural.GetLocalizedResource()
+						: Strings.GroupItemsCount_Singular.GetLocalizedResource(),
 					Count);
 			}
 		}

--- a/src/Files.App/Utils/Storage/Collection/GroupingHelper.cs
+++ b/src/Files.App/Utils/Storage/Collection/GroupingHelper.cs
@@ -92,7 +92,7 @@ namespace Files.App.Utils.Storage
 				{
 					ListedItem first = x.FirstOrDefault();
 					x.Model.ShowCountTextBelow = true;
-					x.Model.Text = first.FileTagsUI?.FirstOrDefault()?.Name ?? "Untagged".GetLocalizedResource();
+					x.Model.Text = first.FileTagsUI?.FirstOrDefault()?.Name ?? Strings.Untagged.GetLocalizedResource();
 					//x.Model.Icon = first.FileTagsUI?.FirstOrDefault()?.Color;
 				}, null),
 
@@ -141,7 +141,7 @@ namespace Files.App.Utils.Storage
 				lastSizeStr = sizeGp.sizeText;
 			}
 
-			return ("0", "ItemSizeText_Tiny".GetLocalizedResource(), $"{"0 B".ConvertSizeAbbreviation()} - {lastSizeStr}", 0);
+			return ("0", Strings.ItemSizeText_Tiny.GetLocalizedResource(), $"{"0 B".ConvertSizeAbbreviation()} - {lastSizeStr}", 0);
 		}
 
 		public static string GetGroupSizeKey(long size)
@@ -159,11 +159,11 @@ namespace Files.App.Utils.Storage
 
 		private static readonly (long size, string text, string sizeText)[] sizeGroups =
 		[
-			(5000000000, "ItemSizeText_Huge".GetLocalizedResource(), "5 GiB".ConvertSizeAbbreviation()),
-			(1000000000, "ItemSizeText_VeryLarge".GetLocalizedResource(), "1 GiB".ConvertSizeAbbreviation()),
-			(128000000, "ItemSizeText_Large".GetLocalizedResource(), "128 MiB".ConvertSizeAbbreviation()),
-			(1000000, "ItemSizeText_Medium".GetLocalizedResource(), "1 MiB".ConvertSizeAbbreviation()),
-			(16000, "ItemSizeText_Small".GetLocalizedResource(), "16 KiB".ConvertSizeAbbreviation()),
+			(5000000000, Strings.ItemSizeText_Huge.GetLocalizedResource(), "5 GiB".ConvertSizeAbbreviation()),
+			(1000000000, Strings.ItemSizeText_VeryLarge.GetLocalizedResource(), "1 GiB".ConvertSizeAbbreviation()),
+			(128000000, Strings.ItemSizeText_Large.GetLocalizedResource(), "128 MiB".ConvertSizeAbbreviation()),
+			(1000000, Strings.ItemSizeText_Medium.GetLocalizedResource(), "1 MiB".ConvertSizeAbbreviation()),
+			(16000, Strings.ItemSizeText_Small.GetLocalizedResource(), "16 KiB".ConvertSizeAbbreviation()),
 		];
 
 		private static string GetFolderName(string path)

--- a/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
+++ b/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
@@ -15,7 +15,7 @@ namespace Files.App.Utils.Storage
 		private static readonly ISizeProvider folderSizeProvider = Ioc.Default.GetService<ISizeProvider>();
 		private static readonly IStorageCacheService fileListCache = Ioc.Default.GetRequiredService<IStorageCacheService>();
 
-		private static readonly string folderTypeTextLocalized = "Folder".GetLocalizedResource();
+		private static readonly string folderTypeTextLocalized = Strings.Folder.GetLocalizedResource();
 
 		public static async Task<List<ListedItem>> ListEntries(
 			string path,
@@ -112,7 +112,7 @@ namespace Files.App.Utils.Storage
 
 		public static ListedItem GetAlternateStream((string Name, long Size) ads, ListedItem main)
 		{
-			string itemType = "File".GetLocalizedResource();
+			string itemType = Strings.File.GetLocalizedResource();
 			string itemFileExtension = null;
 
 			if (ads.Name.Contains('.'))
@@ -250,7 +250,7 @@ namespace Files.App.Utils.Storage
 
 			long itemSizeBytes = findData.GetSize();
 			var itemSize = itemSizeBytes.ToSizeString();
-			string itemType = "File".GetLocalizedResource();
+			string itemType = Strings.File.GetLocalizedResource();
 			string itemFileExtension = null;
 
 			if (findData.cFileName.Contains('.'))
@@ -289,7 +289,7 @@ namespace Files.App.Utils.Storage
 						ItemDateModifiedReal = itemModifiedDate,
 						ItemDateAccessedReal = itemLastAccessDate,
 						ItemDateCreatedReal = itemCreatedDate,
-						ItemType = "Shortcut".GetLocalizedResource(),
+						ItemType = Strings.Shortcut.GetLocalizedResource(),
 						ItemPath = itemPath,
 						FileSize = itemSize,
 						FileSizeBytes = itemSizeBytes,
@@ -311,7 +311,7 @@ namespace Files.App.Utils.Storage
 						ItemDateModifiedReal = itemModifiedDate,
 						ItemDateAccessedReal = itemLastAccessDate,
 						ItemDateCreatedReal = itemCreatedDate,
-						ItemType = "Shortcut".GetLocalizedResource(),
+						ItemType = Strings.Shortcut.GetLocalizedResource(),
 						ItemPath = itemPath,
 						FileSize = itemSize,
 						FileSizeBytes = itemSizeBytes,
@@ -342,7 +342,7 @@ namespace Files.App.Utils.Storage
 						ItemDateModifiedReal = itemModifiedDate,
 						ItemDateAccessedReal = itemLastAccessDate,
 						ItemDateCreatedReal = itemCreatedDate,
-						ItemType = isUrl ? "ShortcutWebLinkFileType".GetLocalizedResource() : "Shortcut".GetLocalizedResource(),
+						ItemType = isUrl ? Strings.ShortcutWebLinkFileType.GetLocalizedResource() : Strings.Shortcut.GetLocalizedResource(),
 						ItemPath = itemPath,
 						FileSize = itemSize,
 						FileSizeBytes = itemSizeBytes,
@@ -368,7 +368,7 @@ namespace Files.App.Utils.Storage
 						ItemDateModifiedReal = itemModifiedDate,
 						ItemDateAccessedReal = itemLastAccessDate,
 						ItemDateCreatedReal = itemCreatedDate,
-						ItemType = isUrl ? "ShortcutWebLinkFileType".GetLocalizedResource() : "Shortcut".GetLocalizedResource(),
+						ItemType = isUrl ? Strings.ShortcutWebLinkFileType.GetLocalizedResource() : Strings.Shortcut.GetLocalizedResource(),
 						ItemPath = itemPath,
 						FileSize = itemSize,
 						FileSizeBytes = itemSizeBytes,

--- a/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
@@ -42,10 +42,10 @@ namespace Files.App.Utils.Storage
 				return false;
 
 			var ejectButton = await DialogDisplayHelper.ShowDialogAsync(
-				"InsertDiscDialog/Title".GetLocalizedResource(),
-				string.Format("InsertDiscDialog/Text".GetLocalizedResource(), matchingDrive.Path),
-				"InsertDiscDialog/OpenDriveButton".GetLocalizedResource(),
-				"Close".GetLocalizedResource());
+				Strings.InsertDiscDialog_Title.GetLocalizedResource(),
+				string.Format(Strings.InsertDiscDialog_Text.GetLocalizedResource(), matchingDrive.Path),
+				Strings.InsertDiscDialog_OpenDriveButton.GetLocalizedResource(),
+				Strings.Close.GetLocalizedResource());
 			if (ejectButton)
 				EjectDeviceAsync(matchingDrive.Path);
 			return true;

--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -117,7 +117,7 @@ namespace Files.App.Utils.Storage
 			propertiesWindow.SystemBackdrop = new AppSystemBackdrop(true);
 
 			var appWindow = propertiesWindow.AppWindow;
-			appWindow.Title = "Properties".GetLocalizedResource();
+			appWindow.Title = Strings.Properties.GetLocalizedResource();
 			appWindow.TitleBar.ExtendsContentIntoTitleBar = true;
 			appWindow.TitleBar.ButtonBackgroundColor = Colors.Transparent;
 			appWindow.TitleBar.ButtonInactiveBackgroundColor = Colors.Transparent;

--- a/src/Files.App/Utils/Storage/Helpers/StorageFileExtensions.cs
+++ b/src/Files.App/Utils/Storage/Helpers/StorageFileExtensions.cs
@@ -139,7 +139,7 @@ namespace Files.App.Utils.Storage
 			foreach (var item in pathBoxItems)
 			{
 				if (item.Path == "Home")
-					item.Title = "Home".GetLocalizedResource();
+					item.Title = Strings.Home.GetLocalizedResource();
 				else
 				{
 					BaseStorageFolder folder = await FilesystemTasks.Wrap(() => DangerousGetFolderFromPathAsync(item.Path));
@@ -287,15 +287,15 @@ namespace Files.App.Utils.Storage
 			if (component.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.Ordinal))
 			{
 				// Handle the recycle bin: use the localized folder name
-				title = "RecycleBin".GetLocalizedResource();
+				title = Strings.RecycleBin.GetLocalizedResource();
 			}
 			else if (component.StartsWith(Constants.UserEnvironmentPaths.MyComputerPath, StringComparison.Ordinal))
 			{
-				title = "ThisPC".GetLocalizedResource();
+				title = Strings.ThisPC.GetLocalizedResource();
 			}
 			else if (component.StartsWith(Constants.UserEnvironmentPaths.NetworkFolderPath, StringComparison.Ordinal))
 			{
-				title = "Network".GetLocalizedResource();
+				title = Strings.Network.GetLocalizedResource();
 			}
 			else if (component.EndsWith(':'))
 			{
@@ -303,7 +303,7 @@ namespace Files.App.Utils.Storage
 
 				var drives = drivesViewModel.Drives.Cast<DriveItem>();
 				var drive = drives.FirstOrDefault(y => y.ItemType is NavigationControlItemType.Drive && y.Path.Contains(component, StringComparison.OrdinalIgnoreCase));
-				title = drive is not null ? drive.Text : string.Format("DriveWithLetter".GetLocalizedResource(), component);
+				title = drive is not null ? drive.Text : string.Format(Strings.DriveWithLetter.GetLocalizedResource(), component);
 			}
 			else
 			{

--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -70,8 +70,8 @@ namespace Files.App.Utils.Storage
 			if (!IsValidForFilename(source.Name))
 			{
 				await DialogDisplayHelper.ShowDialogAsync(
-					"ErrorDialogThisActionCannotBeDone".GetLocalizedResource(),
-					"ErrorDialogNameNotAllowed".GetLocalizedResource());
+					Strings.ErrorDialogThisActionCannotBeDone.GetLocalizedResource(),
+					Strings.ErrorDialogNameNotAllowed.GetLocalizedResource());
 				return (ReturnResult.Failed, null);
 			}
 
@@ -547,8 +547,8 @@ namespace Files.App.Utils.Storage
 			if (!IsValidForFilename(newName))
 			{
 				await DialogDisplayHelper.ShowDialogAsync(
-					"ErrorDialogThisActionCannotBeDone".GetLocalizedResource(),
-					"ErrorDialogNameNotAllowed".GetLocalizedResource());
+					Strings.ErrorDialogThisActionCannotBeDone.GetLocalizedResource(),
+					Strings.ErrorDialogNameNotAllowed.GetLocalizedResource());
 				return ReturnResult.Failed;
 			}
 
@@ -569,7 +569,7 @@ namespace Files.App.Utils.Storage
 						UserSettingsService.FoldersSettingsService.ShowFileExtensionWarning
 					)
 					{
-						var yesSelected = await DialogDisplayHelper.ShowDialogAsync("Rename".GetLocalizedResource(), "RenameFileDialog/Text".GetLocalizedResource(), "Yes".GetLocalizedResource(), "No".GetLocalizedResource());
+						var yesSelected = await DialogDisplayHelper.ShowDialogAsync(Strings.Rename.GetLocalizedResource(), Strings.RenameFileDialog_Text.GetLocalizedResource(), Strings.Yes.GetLocalizedResource(), Strings.No.GetLocalizedResource());
 						if (yesSelected)
 						{
 							history = await filesystemOperations.RenameAsync(source, newName, collision, progress, cancellationToken);
@@ -877,7 +877,7 @@ namespace Files.App.Utils.Storage
 			var value = Registry.GetValue(keyName, "ShortcutNameTemplate", null);
 
 			if (value is null)
-				return string.Format("ShortcutCreateNewSuffix".GetLocalizedResource(), itemName) + ".lnk";
+				return string.Format(Strings.ShortcutCreateNewSuffix.GetLocalizedResource(), itemName) + ".lnk";
 			else
 			{
 				// Trim the quotes and the "%s" from the string

--- a/src/Files.App/Utils/Storage/Operations/FilesystemOperations.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemOperations.cs
@@ -126,8 +126,8 @@ namespace Files.App.Utils.Storage
 
 				// Do not paste files and folders inside the recycle bin
 				await DialogDisplayHelper.ShowDialogAsync(
-					"ErrorDialogThisActionCannotBeDone".GetLocalizedResource(),
-					"ErrorDialogUnsupportedOperation".GetLocalizedResource());
+					Strings.ErrorDialogThisActionCannotBeDone.GetLocalizedResource(),
+					Strings.ErrorDialogUnsupportedOperation.GetLocalizedResource());
 
 				return null;
 			}
@@ -144,10 +144,10 @@ namespace Files.App.Utils.Storage
 
 					ContentDialog dialog = new()
 					{
-						Title = "ErrorDialogThisActionCannotBeDone".GetLocalizedResource(),
-						Content = $"{"ErrorDialogTheDestinationFolder".GetLocalizedResource()} ({destinationName}) {"ErrorDialogIsASubfolder".GetLocalizedResource()} ({sourceName})",
+						Title = Strings.ErrorDialogThisActionCannotBeDone.GetLocalizedResource(),
+						Content = $"{Strings.ErrorDialogTheDestinationFolder.GetLocalizedResource()} ({destinationName}) {Strings.ErrorDialogIsASubfolder.GetLocalizedResource()} ({sourceName})",
 						//PrimaryButtonText = "Skip".GetLocalizedResource(),
-						CloseButtonText = "Cancel".GetLocalizedResource()
+						CloseButtonText = Strings.Cancel.GetLocalizedResource()
 					};
 
 					if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
@@ -327,8 +327,8 @@ namespace Files.App.Utils.Storage
 
 				// Do not paste files and folders inside the recycle bin
 				await DialogDisplayHelper.ShowDialogAsync(
-					"ErrorDialogThisActionCannotBeDone".GetLocalizedResource(),
-					"ErrorDialogUnsupportedOperation".GetLocalizedResource());
+					Strings.ErrorDialogThisActionCannotBeDone.GetLocalizedResource(),
+					Strings.ErrorDialogUnsupportedOperation.GetLocalizedResource());
 
 				return null;
 			}
@@ -346,10 +346,10 @@ namespace Files.App.Utils.Storage
 
 					ContentDialog dialog = new()
 					{
-						Title = "ErrorDialogThisActionCannotBeDone".GetLocalizedResource(),
-						Content = $"{"ErrorDialogTheDestinationFolder".GetLocalizedResource()} ({destinationName}) {"ErrorDialogIsASubfolder".GetLocalizedResource()} ({sourceName})",
+						Title = Strings.ErrorDialogThisActionCannotBeDone.GetLocalizedResource(),
+						Content = $"{Strings.ErrorDialogTheDestinationFolder.GetLocalizedResource()} ({destinationName}) {Strings.ErrorDialogIsASubfolder.GetLocalizedResource()} ({sourceName})",
 						//PrimaryButtonText = "Skip".GetLocalizedResource(),
-						CloseButtonText = "Cancel".GetLocalizedResource()
+						CloseButtonText = Strings.Cancel.GetLocalizedResource()
 					};
 
 					if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
@@ -389,7 +389,7 @@ namespace Files.App.Utils.Storage
 								// Moving folders using Storage API can result in data loss, copy instead
 								//var fsResultMove = await FilesystemTasks.Wrap(() => MoveDirectoryAsync((BaseStorageFolder)fsSourceFolder, (BaseStorageFolder)fsDestinationFolder, fsSourceFolder.Result.Name, collision.Convert(), true));
 
-								if (await DialogDisplayHelper.ShowDialogAsync("ErrorDialogThisActionCannotBeDone".GetLocalizedResource(), "ErrorDialogUnsupportedMoveOperation".GetLocalizedResource(), "OK", "Cancel".GetLocalizedResource()))
+								if (await DialogDisplayHelper.ShowDialogAsync(Strings.ErrorDialogThisActionCannotBeDone.GetLocalizedResource(), Strings.ErrorDialogUnsupportedMoveOperation.GetLocalizedResource(), "OK", Strings.Cancel.GetLocalizedResource()))
 									fsResultMove = await FilesystemTasks.Wrap(() => CloneDirectoryAsync((BaseStorageFolder)fsSourceFolder, (BaseStorageFolder)fsDestinationFolder, fsSourceFolder.Result.Name, collision.Convert()));
 							}
 
@@ -636,11 +636,11 @@ namespace Files.App.Utils.Storage
 				}
 				else if (renamed == FileSystemStatusCode.NotAFile || renamed == FileSystemStatusCode.NotAFolder)
 				{
-					await DialogDisplayHelper.ShowDialogAsync("RenameError/NameInvalid/Title".GetLocalizedResource(), "RenameError/NameInvalid/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.RenameError_NameInvalid_Title.GetLocalizedResource(), Strings.RenameError_NameInvalid_Text.GetLocalizedResource());
 				}
 				else if (renamed == FileSystemStatusCode.NameTooLong)
 				{
-					await DialogDisplayHelper.ShowDialogAsync("RenameError/TooLong/Title".GetLocalizedResource(), "RenameError/TooLong/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.RenameError_TooLong_Title.GetLocalizedResource(), Strings.RenameError_TooLong_Text.GetLocalizedResource());
 				}
 				else if (renamed == FileSystemStatusCode.InUse)
 				{
@@ -649,17 +649,17 @@ namespace Files.App.Utils.Storage
 				}
 				else if (renamed == FileSystemStatusCode.NotFound)
 				{
-					await DialogDisplayHelper.ShowDialogAsync("RenameError/ItemDeleted/Title".GetLocalizedResource(), "RenameError/ItemDeleted/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.RenameError_ItemDeleted_Title.GetLocalizedResource(), Strings.RenameError_ItemDeleted_Text.GetLocalizedResource());
 				}
 				else if (renamed == FileSystemStatusCode.AlreadyExists)
 				{
 					var ItemAlreadyExistsDialog = new ContentDialog()
 					{
-						Title = "ItemAlreadyExistsDialogTitle".GetLocalizedResource(),
-						Content = "ItemAlreadyExistsDialogContent".GetLocalizedResource(),
-						PrimaryButtonText = "GenerateNewName".GetLocalizedResource(),
-						SecondaryButtonText = "ItemAlreadyExistsDialogSecondaryButtonText".GetLocalizedResource(),
-						CloseButtonText = "Cancel".GetLocalizedResource()
+						Title = Strings.ItemAlreadyExistsDialogTitle.GetLocalizedResource(),
+						Content = Strings.ItemAlreadyExistsDialogContent.GetLocalizedResource(),
+						PrimaryButtonText = Strings.GenerateNewName.GetLocalizedResource(),
+						SecondaryButtonText = Strings.ItemAlreadyExistsDialogSecondaryButtonText.GetLocalizedResource(),
+						CloseButtonText = Strings.Cancel.GetLocalizedResource()
 					};
 
 					ContentDialogResult result = await ItemAlreadyExistsDialog.TryShowAsync();
@@ -749,7 +749,7 @@ namespace Files.App.Utils.Storage
 						// Moving folders using Storage API can result in data loss, copy instead
 						//fsResult = await FilesystemTasks.Wrap(() => MoveDirectoryAsync(sourceFolder.Result, destinationFolder.Result, Path.GetFileName(destination), CreationCollisionOption.FailIfExists, true));
 
-						if (await DialogDisplayHelper.ShowDialogAsync("ErrorDialogThisActionCannotBeDone".GetLocalizedResource(), "ErrorDialogUnsupportedMoveOperation".GetLocalizedResource(), "OK", "Cancel".GetLocalizedResource()))
+						if (await DialogDisplayHelper.ShowDialogAsync(Strings.ErrorDialogThisActionCannotBeDone.GetLocalizedResource(), Strings.ErrorDialogUnsupportedMoveOperation.GetLocalizedResource(), "OK", Strings.Cancel.GetLocalizedResource()))
 							fsResult = await FilesystemTasks.Wrap(() => CloneDirectoryAsync(sourceFolder.Result, destinationFolder.Result, Path.GetFileName(destination), CreationCollisionOption.FailIfExists));
 
 						// TODO: we could use here FilesystemHelpers with registerHistory false?
@@ -792,15 +792,15 @@ namespace Files.App.Utils.Storage
 			{
 				if (((FileSystemStatusCode)fsResult).HasFlag(FileSystemStatusCode.Unauthorized))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("AccessDenied".GetLocalizedResource(), "AccessDeniedDeleteDialog/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.AccessDenied.GetLocalizedResource(), Strings.AccessDeniedDeleteDialog_Text.GetLocalizedResource());
 				}
 				else if (((FileSystemStatusCode)fsResult).HasFlag(FileSystemStatusCode.NotFound))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("FileNotFoundDialog/Title".GetLocalizedResource(), "FileNotFoundDialog/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.FileNotFoundDialog_Title.GetLocalizedResource(), Strings.FileNotFoundDialog_Text.GetLocalizedResource());
 				}
 				else if (((FileSystemStatusCode)fsResult).HasFlag(FileSystemStatusCode.AlreadyExists))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("ItemAlreadyExistsDialogTitle".GetLocalizedResource(), "ItemAlreadyExistsDialogContent".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.ItemAlreadyExistsDialogTitle.GetLocalizedResource(), Strings.ItemAlreadyExistsDialogContent.GetLocalizedResource());
 				}
 			}
 

--- a/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
+++ b/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
@@ -149,18 +149,18 @@ namespace Files.App.Utils.Storage
 				}
 				else if (copyResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.NotFound))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("FileNotFoundDialog/Title".GetLocalizedResource(), "FileNotFoundDialog/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.FileNotFoundDialog_Title.GetLocalizedResource(), Strings.FileNotFoundDialog_Text.GetLocalizedResource());
 				}
 				else if (copyResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.AlreadyExists))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("ItemAlreadyExistsDialogTitle".GetLocalizedResource(), "ItemAlreadyExistsDialogContent".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.ItemAlreadyExistsDialogTitle.GetLocalizedResource(), Strings.ItemAlreadyExistsDialogContent.GetLocalizedResource());
 				}
 				else if (copyResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.PropertyLoss))
 				{
 					var failedSources = copyResult.Items.Where(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.PropertyLoss);
 					var filePath = failedSources.Select(x => x.Source);
 
-					switch (await GetFileListDialog(filePath, "FilePropertiesCannotBeCopied".GetLocalizedResource(), "CopyFileWithoutProperties".GetLocalizedResource(), "OK".GetLocalizedResource(), "Cancel".GetLocalizedResource()))
+					switch (await GetFileListDialog(filePath, Strings.FilePropertiesCannotBeCopied.GetLocalizedResource(), Strings.CopyFileWithoutProperties.GetLocalizedResource(), Strings.OK.GetLocalizedResource(), Strings.Cancel.GetLocalizedResource()))
 					{
 						case DialogResult.Primary:
 							var copyZip = sourceNoSkip.Zip(destinationNoSkip, (src, dest) => new { src, dest }).Zip(collisionsNoSkip, (z1, coll) => new { z1.src, z1.dest, coll });
@@ -284,11 +284,11 @@ namespace Files.App.Utils.Storage
 				}
 				else if (createResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.NotFound))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("FileNotFoundDialog/Title".GetLocalizedResource(), "FileNotFoundDialog/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.FileNotFoundDialog_Title.GetLocalizedResource(), Strings.FileNotFoundDialog_Text.GetLocalizedResource());
 				}
 				else if (createResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.AlreadyExists))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("ItemAlreadyExistsDialogTitle".GetLocalizedResource(), "ItemAlreadyExistsDialogContent".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.ItemAlreadyExistsDialogTitle.GetLocalizedResource(), Strings.ItemAlreadyExistsDialogContent.GetLocalizedResource());
 				}
 
 				fsProgress.ReportStatus(CopyEngineResult.Convert(createResult.Items.FirstOrDefault(x => !x.Succeeded)?.HResult));
@@ -430,7 +430,7 @@ namespace Files.App.Utils.Storage
 				}
 				else if (deleteResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.NotFound))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("FileNotFoundDialog/Title".GetLocalizedResource(), "FileNotFoundDialog/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.FileNotFoundDialog_Title.GetLocalizedResource(), Strings.FileNotFoundDialog_Text.GetLocalizedResource());
 				}
 				else if (deleteResult.Items.All(x => x.HResult == -1) && permanently) // ADS
 				{
@@ -542,7 +542,7 @@ namespace Files.App.Utils.Storage
 					var destName = subtree.dest.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).Last();
 					var srcName = subtree.src.Path.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries).Last();
 
-					await DialogDisplayHelper.ShowDialogAsync("ErrorDialogThisActionCannotBeDone".GetLocalizedResource(), $"{"ErrorDialogTheDestinationFolder".GetLocalizedResource()} ({destName}) {"ErrorDialogIsASubfolder".GetLocalizedResource()} ({srcName})");
+					await DialogDisplayHelper.ShowDialogAsync(Strings.ErrorDialogThisActionCannotBeDone.GetLocalizedResource(), $"{Strings.ErrorDialogTheDestinationFolder.GetLocalizedResource()} ({destName}) {Strings.ErrorDialogIsASubfolder.GetLocalizedResource()} ({srcName})");
 				}
 				else if (moveResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.InUse))
 				{
@@ -576,17 +576,17 @@ namespace Files.App.Utils.Storage
 				}
 				else if (moveResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.NotFound))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("FileNotFoundDialog/Title".GetLocalizedResource(), "FileNotFoundDialog/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.FileNotFoundDialog_Title.GetLocalizedResource(), Strings.FileNotFoundDialog_Text.GetLocalizedResource());
 				}
 				else if (moveResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.AlreadyExists))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("ItemAlreadyExistsDialogTitle".GetLocalizedResource(), "ItemAlreadyExistsDialogContent".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.ItemAlreadyExistsDialogTitle.GetLocalizedResource(), Strings.ItemAlreadyExistsDialogContent.GetLocalizedResource());
 				}
 				else if (moveResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.PropertyLoss))
 				{
 					var failedSources = moveResult.Items.Where(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.PropertyLoss);
 					var filePath = failedSources.Select(x => x.Source);
-					switch (await GetFileListDialog(filePath, "FilePropertiesCannotBeMoved".GetLocalizedResource(), "MoveFileWithoutProperties".GetLocalizedResource(), "OK".GetLocalizedResource(), "Cancel".GetLocalizedResource()))
+					switch (await GetFileListDialog(filePath, Strings.FilePropertiesCannotBeMoved.GetLocalizedResource(), Strings.MoveFileWithoutProperties.GetLocalizedResource(), Strings.OK.GetLocalizedResource(), Strings.Cancel.GetLocalizedResource()))
 					{
 						case DialogResult.Primary:
 							var copyZip = sourceNoSkip.Zip(destinationNoSkip, (src, dest) => new { src, dest }).Zip(collisionsNoSkip, (z1, coll) => new { z1.src, z1.dest, coll });
@@ -691,11 +691,11 @@ namespace Files.App.Utils.Storage
 				}
 				else if (renameResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.NotFound))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("RenameError/ItemDeleted/Title".GetLocalizedResource(), "RenameError/ItemDeleted/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.RenameError_ItemDeleted_Title.GetLocalizedResource(), Strings.RenameError_ItemDeleted_Text.GetLocalizedResource());
 				}
 				else if (renameResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.AlreadyExists))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("ItemAlreadyExistsDialogTitle".GetLocalizedResource(), "ItemAlreadyExistsDialogContent".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.ItemAlreadyExistsDialogTitle.GetLocalizedResource(), Strings.ItemAlreadyExistsDialogContent.GetLocalizedResource());
 				}
 				// ADS
 				else if (renameResult.Items.All(x => x.HResult == -1))
@@ -807,11 +807,11 @@ namespace Files.App.Utils.Storage
 				}
 				else if (moveResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.NotFound))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("FileNotFoundDialog/Title".GetLocalizedResource(), "FileNotFoundDialog/Text".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.FileNotFoundDialog_Title.GetLocalizedResource(), Strings.FileNotFoundDialog_Text.GetLocalizedResource());
 				}
 				else if (moveResult.Items.Any(x => CopyEngineResult.Convert(x.HResult) == FileSystemStatusCode.AlreadyExists))
 				{
-					await DialogDisplayHelper.ShowDialogAsync("ItemAlreadyExistsDialogTitle".GetLocalizedResource(), "ItemAlreadyExistsDialogContent".GetLocalizedResource());
+					await DialogDisplayHelper.ShowDialogAsync(Strings.ItemAlreadyExistsDialogTitle.GetLocalizedResource(), Strings.ItemAlreadyExistsDialogContent.GetLocalizedResource());
 				}
 
 				fsProgress.ReportStatus(CopyEngineResult.Convert(moveResult.Items.FirstOrDefault(x => !x.Succeeded)?.HResult));
@@ -833,12 +833,12 @@ namespace Files.App.Utils.Storage
 
 		private Task<DialogResult> GetFileInUseDialog(IEnumerable<string> source, IEnumerable<Win32Process> lockingProcess = null)
 		{
-			var titleText = "FileInUseDialog/Title".GetLocalizedResource();
+			var titleText = Strings.FileInUseDialog_Title.GetLocalizedResource();
 			var subtitleText = lockingProcess.IsEmpty()
-				? "FileInUseDialog/Text".GetLocalizedResource()
-				: string.Format("FileInUseByDialog/Text".GetLocalizedResource(), string.Join(", ", lockingProcess.Select(x => $"{x.AppName ?? x.Name} (PID: {x.Pid})")));
+				? Strings.FileInUseDialog_Text.GetLocalizedResource()
+				: string.Format(Strings.FileInUseByDialog_Text.GetLocalizedResource(), string.Join(", ", lockingProcess.Select(x => $"{x.AppName ?? x.Name} (PID: {x.Pid})")));
 
-			return GetFileListDialog(source, titleText, subtitleText, "Retry".GetLocalizedResource(), "Cancel".GetLocalizedResource());
+			return GetFileListDialog(source, titleText, subtitleText, Strings.Retry.GetLocalizedResource(), Strings.Cancel.GetLocalizedResource());
 		}
 
 		private async Task<DialogResult> GetFileListDialog(IEnumerable<string> source, string titleText, string descriptionText = null, string primaryButtonText = null, string secondaryButtonText = null)

--- a/src/Files.App/Utils/Storage/StorageItems/FtpStorageFile.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/FtpStorageFile.cs
@@ -28,7 +28,7 @@ namespace Files.App.Utils.Storage
 		{
 			get
 			{
-				var itemType = "File".GetLocalizedResource();
+				var itemType = Strings.File.GetLocalizedResource();
 				if (Name.Contains('.', StringComparison.Ordinal))
 				{
 					itemType = IO.Path.GetExtension(Name).Trim('.') + " " + itemType;

--- a/src/Files.App/Utils/Storage/StorageItems/FtpStorageFolder.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/FtpStorageFolder.cs
@@ -19,7 +19,7 @@ namespace Files.App.Utils.Storage
 		public override string Path { get; }
 		public override string Name { get; }
 		public override string DisplayName => Name;
-		public override string DisplayType => "Folder".GetLocalizedResource();
+		public override string DisplayType => Strings.Folder.GetLocalizedResource();
 		public string FtpPath { get; }
 		public override string FolderRelativeId => $"0\\{Name}";
 

--- a/src/Files.App/Utils/Storage/StorageItems/NativeStorageFile.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/NativeStorageFile.cs
@@ -34,7 +34,7 @@ namespace Files.App.Utils.Storage
 		{
 			get
 			{
-				var itemType = "File".GetLocalizedResource();
+				var itemType = Strings.File.GetLocalizedResource();
 
 				if (Name.Contains('.', StringComparison.Ordinal))
 					itemType = IO.Path.GetExtension(Name).Trim('.') + " " + itemType;

--- a/src/Files.App/Utils/Storage/StorageItems/VirtualStorageFile.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/VirtualStorageFile.cs
@@ -24,7 +24,7 @@ namespace Files.App.Utils.Storage
 		{
 			get
 			{
-				var itemType = "File".GetLocalizedResource();
+				var itemType = Strings.File.GetLocalizedResource();
 				if (Name.Contains('.', StringComparison.Ordinal))
 				{
 					itemType = IO.Path.GetExtension(Name).Trim('.') + " " + itemType;

--- a/src/Files.App/Utils/Storage/StorageItems/VirtualStorageFolder.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/VirtualStorageFolder.cs
@@ -14,7 +14,7 @@ namespace Files.App.Utils.Storage
 		public override string Path { get; }
 		public override string Name { get; }
 		public override string DisplayName => Name;
-		public override string DisplayType => "Folder".GetLocalizedResource();
+		public override string DisplayType => Strings.Folder.GetLocalizedResource();
 		public override string FolderRelativeId => $"0\\{Name}";
 
 		public override DateTimeOffset DateCreated { get; }

--- a/src/Files.App/Utils/Storage/StorageItems/ZipStorageFile.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/ZipStorageFile.cs
@@ -30,7 +30,7 @@ namespace Files.App.Utils.Storage
 		{
 			get
 			{
-				var itemType = "File".GetLocalizedResource();
+				var itemType = Strings.File.GetLocalizedResource();
 				if (Name.Contains('.', StringComparison.Ordinal))
 				{
 					itemType = FileType.Trim('.') + " " + itemType;

--- a/src/Files.App/Utils/Storage/StorageItems/ZipStorageFolder.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/ZipStorageFolder.cs
@@ -24,7 +24,7 @@ namespace Files.App.Utils.Storage
 		public override string Path { get; }
 		public override string Name { get; }
 		public override string DisplayName => Name;
-		public override string DisplayType => "Folder".GetLocalizedResource();
+		public override string DisplayType => Strings.Folder.GetLocalizedResource();
 		public override string FolderRelativeId => $"0\\{Name}";
 
 		public override DateTimeOffset DateCreated { get; }

--- a/src/Files.App/Utils/Taskbar/SystemTrayIcon.cs
+++ b/src/Files.App/Utils/Taskbar/SystemTrayIcon.cs
@@ -237,10 +237,10 @@ namespace Files.App.Utils.Taskbar
 			DestroyMenuSafeHandle hMenu = PInvoke.CreatePopupMenu_SafeHandle();
 
 			// Generate the classic context menu
-			PInvoke.AppendMenu(hMenu, MENU_ITEM_FLAGS.MF_BYCOMMAND, WM_FILES_CONTEXTMENU_DOCSLINK, "Documentation".GetLocalizedResource());
+			PInvoke.AppendMenu(hMenu, MENU_ITEM_FLAGS.MF_BYCOMMAND, WM_FILES_CONTEXTMENU_DOCSLINK, Strings.Documentation.GetLocalizedResource());
 			PInvoke.AppendMenu(hMenu, MENU_ITEM_FLAGS.MF_SEPARATOR, 0u, string.Empty);
 			//PInvoke.AppendMenu(hMenu, MENU_ITEM_FLAGS.MF_BYCOMMAND, WM_FILES_CONTEXTMENU_RESTART, "Restart".GetLocalizedResource());
-			PInvoke.AppendMenu(hMenu, MENU_ITEM_FLAGS.MF_BYCOMMAND, WM_FILES_CONTEXTMENU_QUIT, "Quit".GetLocalizedResource());
+			PInvoke.AppendMenu(hMenu, MENU_ITEM_FLAGS.MF_BYCOMMAND, WM_FILES_CONTEXTMENU_QUIT, Strings.Quit.GetLocalizedResource());
 			PInvoke.SetForegroundWindow(_IconWindow.WindowHandle);
 
 			TRACK_POPUP_MENU_FLAGS tRACK_POPUP_MENU_FLAGS =

--- a/src/Files.App/ViewModels/Dialogs/AddItemDialog/AddItemDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/AddItemDialog/AddItemDialogViewModel.cs
@@ -33,8 +33,8 @@ namespace Files.App.ViewModels.Dialogs.AddItemDialog
 
 			AddItemsList.Add(new()
 			{
-				Header = "Folder".ToLocalized(),
-				SubHeader = "AddDialogListFolderSubHeader".ToLocalized(),
+				Header = Strings.Folder.ToLocalized(),
+				SubHeader = Strings.AddDialogListFolderSubHeader.ToLocalized(),
 				Glyph = "\xE838",
 				IsItemEnabled = true,
 				ItemResult = new()
@@ -45,8 +45,8 @@ namespace Files.App.ViewModels.Dialogs.AddItemDialog
 
 			AddItemsList.Add(new()
 			{
-				Header = "File".ToLocalized(),
-				SubHeader = "AddDialogListFileSubHeader".ToLocalized(),
+				Header = Strings.File.ToLocalized(),
+				SubHeader = Strings.AddDialogListFileSubHeader.ToLocalized(),
 				Glyph = "\xE8A5",
 				IsItemEnabled = true,
 				ItemResult = new()
@@ -58,8 +58,8 @@ namespace Files.App.ViewModels.Dialogs.AddItemDialog
 
 			AddItemsList.Add(new()
 			{
-				Header = "Shortcut".ToLocalized(),
-				SubHeader = "AddDialogListShortcutSubHeader".ToLocalized(),
+				Header = Strings.Shortcut.ToLocalized(),
+				SubHeader = Strings.AddDialogListShortcutSubHeader.ToLocalized(),
 				Glyph = "\uE71B",
 				IsItemEnabled = true,
 				ItemResult = new()

--- a/src/Files.App/ViewModels/Dialogs/FileSystemDialog/FileSystemDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/FileSystemDialog/FileSystemDialogViewModel.cs
@@ -149,14 +149,14 @@ namespace Files.App.ViewModels.Dialogs.FileSystemDialog
 
 			if (dialogMode.ConflictsExist)
 			{
-				titleText = "ConflictingItemsDialogTitle".GetLocalizedFormatResource(totalCount);
+				titleText = Strings.ConflictingItemsDialogTitle.GetLocalizedFormatResource(totalCount);
 
 				descriptionText = nonConflictingItems.Count > 0
-					? "ConflictingItemsDialogSubtitleConflictsNonConflicts".GetLocalizedFormatResource(conflictingItems.Count, nonConflictingItems.Count)
-					: "ConflictingItemsDialogSubtitleConflicts".GetLocalizedFormatResource(conflictingItems.Count);
+					? Strings.ConflictingItemsDialogSubtitleConflictsNonConflicts.GetLocalizedFormatResource(conflictingItems.Count, nonConflictingItems.Count)
+					: Strings.ConflictingItemsDialogSubtitleConflicts.GetLocalizedFormatResource(conflictingItems.Count);
 
-				primaryButtonText = "ConflictingItemsDialogPrimaryButtonText".ToLocalized();
-				secondaryButtonText = "Cancel".ToLocalized();
+				primaryButtonText = Strings.ConflictingItemsDialogPrimaryButtonText.ToLocalized();
+				secondaryButtonText = Strings.Cancel.ToLocalized();
 			}
 			else
 			{
@@ -164,33 +164,33 @@ namespace Files.App.ViewModels.Dialogs.FileSystemDialog
 				{
 					case FilesystemOperationType.Copy:
 						{
-							titleText = "CopyItemsDialogTitle".GetLocalizedFormatResource(totalCount);
+							titleText = Strings.CopyItemsDialogTitle.GetLocalizedFormatResource(totalCount);
 
-							descriptionText = "CopyItemsDialogSubtitle".GetLocalizedFormatResource(totalCount);
-							primaryButtonText = "Copy".ToLocalized();
-							secondaryButtonText = "Cancel".ToLocalized();
+							descriptionText = Strings.CopyItemsDialogSubtitle.GetLocalizedFormatResource(totalCount);
+							primaryButtonText = Strings.Copy.ToLocalized();
+							secondaryButtonText = Strings.Cancel.ToLocalized();
 
 							break;
 						}
 
 					case FilesystemOperationType.Move:
 						{
-							titleText = "MoveItemsDialogTitle".GetLocalizedFormatResource(totalCount);
+							titleText = Strings.MoveItemsDialogTitle.GetLocalizedFormatResource(totalCount);
 
-							descriptionText = "MoveItemsDialogSubtitle".GetLocalizedFormatResource(totalCount);
-							primaryButtonText = "MoveItemsDialogPrimaryButtonText".ToLocalized();
-							secondaryButtonText = "Cancel".ToLocalized();
+							descriptionText = Strings.MoveItemsDialogSubtitle.GetLocalizedFormatResource(totalCount);
+							primaryButtonText = Strings.MoveItemsDialogPrimaryButtonText.ToLocalized();
+							secondaryButtonText = Strings.Cancel.ToLocalized();
 
 							break;
 						}
 
 					case FilesystemOperationType.Delete:
 						{
-							titleText = "DeleteItemsDialogTitle".GetLocalizedFormatResource(totalCount);
+							titleText = Strings.DeleteItemsDialogTitle.GetLocalizedFormatResource(totalCount);
 
-							descriptionText = "DeleteItemsDialogSubtitle".GetLocalizedFormatResource(totalCount);
-							primaryButtonText = "Delete".ToLocalized();
-							secondaryButtonText = "Cancel".ToLocalized();
+							descriptionText = Strings.DeleteItemsDialogSubtitle.GetLocalizedFormatResource(totalCount);
+							primaryButtonText = Strings.Delete.ToLocalized();
+							secondaryButtonText = Strings.Cancel.ToLocalized();
 
 							isInDeleteMode = true;
 

--- a/src/Files.App/ViewModels/Dialogs/ReorderSidebarItemsDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/ReorderSidebarItemsDialogViewModel.cs
@@ -9,7 +9,7 @@ namespace Files.App.ViewModels.Dialogs
 	{
 		private readonly IQuickAccessService quickAccessService = Ioc.Default.GetRequiredService<IQuickAccessService>();
 
-		public string HeaderText = "ReorderSidebarItemsDialogText".GetLocalizedResource();
+		public string HeaderText = Strings.ReorderSidebarItemsDialogText.GetLocalizedResource();
 		public ICommand PrimaryButtonCommand { get; private set; }
 
 		public ObservableCollection<LocationItem> SidebarPinnedFolderItems = new(App.QuickAccessManager.Model._PinnedFolderItems

--- a/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
+++ b/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
@@ -125,23 +125,23 @@ namespace Files.App.ViewModels.Layouts
 						e.DragUIOverride.IsCaptionVisible = true;
 						if (pwd.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.Ordinal))
 						{
-							e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), folderName);
+							e.DragUIOverride.Caption = string.Format(Strings.MoveToFolderCaptionText.GetLocalizedResource(), folderName);
 							// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 							e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 						}
 						else if (e.Modifiers.HasFlag(DragDropModifiers.Alt) || e.Modifiers.HasFlag(DragDropModifiers.Control | DragDropModifiers.Shift))
 						{
-							e.DragUIOverride.Caption = string.Format("LinkToFolderCaptionText".GetLocalizedResource(), folderName);
+							e.DragUIOverride.Caption = string.Format(Strings.LinkToFolderCaptionText.GetLocalizedResource(), folderName);
 							e.AcceptedOperation = DataPackageOperation.Link;
 						}
 						else if (e.Modifiers.HasFlag(DragDropModifiers.Control))
 						{
-							e.DragUIOverride.Caption = string.Format("CopyToFolderCaptionText".GetLocalizedResource(), folderName);
+							e.DragUIOverride.Caption = string.Format(Strings.CopyToFolderCaptionText.GetLocalizedResource(), folderName);
 							e.AcceptedOperation = DataPackageOperation.Copy;
 						}
 						else if (e.Modifiers.HasFlag(DragDropModifiers.Shift))
 						{
-							e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), folderName);
+							e.DragUIOverride.Caption = string.Format(Strings.MoveToFolderCaptionText.GetLocalizedResource(), folderName);
 							// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 							e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 						}
@@ -150,18 +150,18 @@ namespace Files.App.ViewModels.Layouts
 							x.Item is ZipStorageFolder) ||
 							ZipStorageFolder.IsZipPath(pwd))
 						{
-							e.DragUIOverride.Caption = string.Format("CopyToFolderCaptionText".GetLocalizedResource(), folderName);
+							e.DragUIOverride.Caption = string.Format(Strings.CopyToFolderCaptionText.GetLocalizedResource(), folderName);
 							e.AcceptedOperation = DataPackageOperation.Copy;
 						}
 						else if (draggedItems.AreItemsInSameDrive(_associatedInstance.ShellViewModel.WorkingDirectory))
 						{
-							e.DragUIOverride.Caption = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), folderName);
+							e.DragUIOverride.Caption = string.Format(Strings.MoveToFolderCaptionText.GetLocalizedResource(), folderName);
 							// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 							e.AcceptedOperation = DataPackageOperation.Move | DataPackageOperation.Copy;
 						}
 						else
 						{
-							e.DragUIOverride.Caption = string.Format("CopyToFolderCaptionText".GetLocalizedResource(), folderName);
+							e.DragUIOverride.Caption = string.Format(Strings.CopyToFolderCaptionText.GetLocalizedResource(), folderName);
 							e.AcceptedOperation = DataPackageOperation.Copy;
 						}
 

--- a/src/Files.App/ViewModels/Properties/BasePropertiesPage.cs
+++ b/src/Files.App/ViewModels/Properties/BasePropertiesPage.cs
@@ -86,7 +86,7 @@ namespace Files.App.ViewModels.Properties
 
 				string[] extensions =
 				[
-					"BitmapFiles".GetLocalizedResource(), "*.bmp",
+					Strings.BitmapFiles.GetLocalizedResource(), "*.bmp",
 					"JPEG", "*.jpg;*.jpeg",
 					"PNG", "*.png",
 				];

--- a/src/Files.App/ViewModels/Properties/CompatibilityViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/CompatibilityViewModel.cs
@@ -85,26 +85,26 @@ namespace Files.App.ViewModels.Properties
 
 			CompatibilityOptions = WindowsCompatibilityService.GetCompatibilityOptionsForPath(ItemPath);
 
-			CompatibilityModes.Add(WindowsCompatModeKind.None, "None".GetLocalizedResource());
+			CompatibilityModes.Add(WindowsCompatModeKind.None, Strings.None.GetLocalizedResource());
 			CompatibilityModes.Add(WindowsCompatModeKind.WindowsVista, "Windows Vista");
 			CompatibilityModes.Add(WindowsCompatModeKind.WindowsVistaSP1, "Windows Vista (Service Pack 1)");
 			CompatibilityModes.Add(WindowsCompatModeKind.WindowsVistaSP2, "Windows Vista (Service Pack 2)");
 			CompatibilityModes.Add(WindowsCompatModeKind.Windows7, "Windows 7");
 			CompatibilityModes.Add(WindowsCompatModeKind.Windows8, "Windows 8");
 
-			ReducedColorModes.Add(WindowsCompatReducedColorModeKind.None, "CompatibilityNoReducedColor".GetLocalizedResource());
-			ReducedColorModes.Add(WindowsCompatReducedColorModeKind.Color8Bit, "CompatibilityReducedColorModeColor8bit".GetLocalizedResource());
-			ReducedColorModes.Add(WindowsCompatReducedColorModeKind.Color16Bit, "CompatibilityReducedColorModeColor16bit".GetLocalizedResource());
+			ReducedColorModes.Add(WindowsCompatReducedColorModeKind.None, Strings.CompatibilityNoReducedColor.GetLocalizedResource());
+			ReducedColorModes.Add(WindowsCompatReducedColorModeKind.Color8Bit, Strings.CompatibilityReducedColorModeColor8bit.GetLocalizedResource());
+			ReducedColorModes.Add(WindowsCompatReducedColorModeKind.Color16Bit, Strings.CompatibilityReducedColorModeColor16bit.GetLocalizedResource());
 
-			HighDpiOptions.Add(WindowsCompatDPIOptionKind.None, "CompatibilityDoNotAdjustDPI".GetLocalizedResource());
-			HighDpiOptions.Add(WindowsCompatDPIOptionKind.UseDPIOnLogin, "CompatibilityOnWindowsLogin".GetLocalizedResource());
-			HighDpiOptions.Add(WindowsCompatDPIOptionKind.UseDPIOnProgramStart, "CompatibilityOnProgramStart".GetLocalizedResource());
+			HighDpiOptions.Add(WindowsCompatDPIOptionKind.None, Strings.CompatibilityDoNotAdjustDPI.GetLocalizedResource());
+			HighDpiOptions.Add(WindowsCompatDPIOptionKind.UseDPIOnLogin, Strings.CompatibilityOnWindowsLogin.GetLocalizedResource());
+			HighDpiOptions.Add(WindowsCompatDPIOptionKind.UseDPIOnProgramStart, Strings.CompatibilityOnProgramStart.GetLocalizedResource());
 
-			HighDpiOverrides.Add(WindowsCompatDpiOverrideKind.None, "CompatibilityDoNotOverrideDPI".GetLocalizedResource());
-			HighDpiOverrides.Add(WindowsCompatDpiOverrideKind.Advanced, "Advanced".GetLocalizedResource());
-			HighDpiOverrides.Add(WindowsCompatDpiOverrideKind.Application, "Application".GetLocalizedResource());
-			HighDpiOverrides.Add(WindowsCompatDpiOverrideKind.System, "System".GetLocalizedResource());
-			HighDpiOverrides.Add(WindowsCompatDpiOverrideKind.SystemAdvanced, "CompatibilitySystemEnhanced".GetLocalizedResource());
+			HighDpiOverrides.Add(WindowsCompatDpiOverrideKind.None, Strings.CompatibilityDoNotOverrideDPI.GetLocalizedResource());
+			HighDpiOverrides.Add(WindowsCompatDpiOverrideKind.Advanced, Strings.Advanced.GetLocalizedResource());
+			HighDpiOverrides.Add(WindowsCompatDpiOverrideKind.Application, Strings.Application.GetLocalizedResource());
+			HighDpiOverrides.Add(WindowsCompatDpiOverrideKind.System, Strings.System.GetLocalizedResource());
+			HighDpiOverrides.Add(WindowsCompatDpiOverrideKind.SystemAdvanced, Strings.CompatibilitySystemEnhanced.GetLocalizedResource());
 
 			RunTroubleshooterCommand = new AsyncRelayCommand(ExecuteRunTroubleshooterCommand);
 		}

--- a/src/Files.App/ViewModels/Properties/HashesViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/HashesViewModel.cs
@@ -71,7 +71,7 @@ namespace Files.App.ViewModels.Properties
 			// Don't calculate hashes for online files
 			if (_item.SyncStatusUI.SyncStatus is CloudDriveSyncStatus.FileOnline or CloudDriveSyncStatus.FolderOnline)
 			{
-				hashInfoItem.HashValue = "CalculationOnlineFileHashError".GetLocalizedResource();
+				hashInfoItem.HashValue = Strings.CalculationOnlineFileHashError.GetLocalizedResource();
 				return;
 			}
 
@@ -106,11 +106,11 @@ namespace Files.App.ViewModels.Properties
 					catch (IOException)
 					{
 						// File is currently open
-						hashInfoItem.HashValue = "CalculationErrorFileIsOpen".GetLocalizedResource();
+						hashInfoItem.HashValue = Strings.CalculationErrorFileIsOpen.GetLocalizedResource();
 					}
 					catch (Exception)
 					{
-						hashInfoItem.HashValue = "CalculationError".GetLocalizedResource();
+						hashInfoItem.HashValue = Strings.CalculationError.GetLocalizedResource();
 					}
 					finally
 					{

--- a/src/Files.App/ViewModels/Properties/Items/BaseProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/BaseProperties.cs
@@ -122,8 +122,8 @@ namespace Files.App.ViewModels.Properties
 		public void SetItemsCountString()
 		{
 			ViewModel.FilesAndFoldersCountString = ViewModel.LocationsCount > 0
-				? "PropertiesFilesAndFoldersAndLocationsCount".GetLocalizedFormatResource(ViewModel.FilesCount, ViewModel.FoldersCount, ViewModel.LocationsCount)
-				: "PropertiesFilesAndFoldersCountString".GetLocalizedFormatResource(ViewModel.FilesCount, ViewModel.FoldersCount);
+				? Strings.PropertiesFilesAndFoldersAndLocationsCount.GetLocalizedFormatResource(ViewModel.FilesCount, ViewModel.FoldersCount, ViewModel.LocationsCount)
+				: Strings.PropertiesFilesAndFoldersCountString.GetLocalizedFormatResource(ViewModel.FilesCount, ViewModel.FoldersCount);
 		}
 	}
 }

--- a/src/Files.App/ViewModels/Properties/Items/CombinedFileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/CombinedFileProperties.cs
@@ -64,8 +64,8 @@ namespace Files.App.ViewModels.Properties
 					else if (props.Where(x => x.Property == prop.Property).Any(x => !Equals(x.Value, prop.Value)))
 					{
 						// Has multiple values
-						prop.Value = prop.IsReadOnly ? "MultipleValues".GetLocalizedResource() : null;
-						prop.PlaceholderText = "MultipleValues".GetLocalizedResource();
+						prop.Value = prop.IsReadOnly ? Strings.MultipleValues.GetLocalizedResource() : null;
+						prop.PlaceholderText = Strings.MultipleValues.GetLocalizedResource();
 					}
 				}
 			}

--- a/src/Files.App/ViewModels/Properties/Items/CombinedProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/CombinedProperties.cs
@@ -41,18 +41,18 @@ namespace Files.App.ViewModels.Properties
 
 				if (List.All(x => x.ItemType.Equals(List.First().ItemType)))
 				{
-					ViewModel.ItemType = string.Format("PropertiesDriveItemTypesEquals".GetLocalizedResource(), List.First().ItemType);
+					ViewModel.ItemType = string.Format(Strings.PropertiesDriveItemTypesEquals.GetLocalizedResource(), List.First().ItemType);
 				}
 				else
 				{
-					ViewModel.ItemType = "PropertiesDriveItemTypeDifferent".GetLocalizedResource();
+					ViewModel.ItemType = Strings.PropertiesDriveItemTypeDifferent.GetLocalizedResource();
 				}
 
 				var itemsPath = List.Select(Item => (Item as RecycleBinItem)?.ItemOriginalFolder ??
 					(Path.IsPathRooted(Item.ItemPath) ? Path.GetDirectoryName(Item.ItemPath) : Item.ItemPath));
 
 				if (itemsPath.Distinct().Count() == 1)
-					ViewModel.ItemLocation = string.Format("PropertiesCombinedItemLocation".GetLocalizedResource(), itemsPath.First());
+					ViewModel.ItemLocation = string.Format(Strings.PropertiesCombinedItemLocation.GetLocalizedResource(), itemsPath.First());
 			}
 		}
 

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -58,8 +58,8 @@ namespace Files.App.ViewModels.Properties
 				FileExtensionHelpers.IsExecutableFile(shortcutItem.TargetPath) ||
 				FileExtensionHelpers.IsMsiFile(shortcutItem.TargetPath);
 
-			ViewModel.ShortcutItemType = isApplication ? "Application".GetLocalizedResource() :
-				Item.IsLinkItem ? "PropertiesShortcutTypeLink".GetLocalizedResource() : "File".GetLocalizedResource();
+			ViewModel.ShortcutItemType = isApplication ? Strings.Application.GetLocalizedResource() :
+				Item.IsLinkItem ? Strings.PropertiesShortcutTypeLink.GetLocalizedResource() : Strings.File.GetLocalizedResource();
 			ViewModel.ShortcutItemPath = shortcutItem.TargetPath;
 			ViewModel.IsShortcutItemPathReadOnly = shortcutItem.IsSymLink;
 			ViewModel.ShortcutItemWorkingDir = shortcutItem.WorkingDirectory;

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -51,7 +51,7 @@ namespace Files.App.ViewModels.Properties
 				if (Item.IsShortcut)
 				{
 					var shortcutItem = (ShortcutItem)Item;
-					ViewModel.ShortcutItemType = "Folder".GetLocalizedResource();
+					ViewModel.ShortcutItemType = Strings.Folder.GetLocalizedResource();
 					ViewModel.ShortcutItemPath = shortcutItem.TargetPath;
 					ViewModel.IsShortcutItemPathReadOnly = false;
 					ViewModel.ShortcutItemWorkingDir = shortcutItem.WorkingDirectory;

--- a/src/Files.App/ViewModels/Properties/Items/LibraryProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/LibraryProperties.cs
@@ -101,7 +101,7 @@ namespace Files.App.ViewModels.Properties
 			}
 			else
 			{
-				ViewModel.FilesAndFoldersCountString = "LibraryNoLocations/Text".GetLocalizedResource();
+				ViewModel.FilesAndFoldersCountString = Strings.LibraryNoLocations_Text.GetLocalizedResource();
 			}
 		}
 

--- a/src/Files.App/ViewModels/Properties/SecurityAdvancedViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/SecurityAdvancedViewModel.cs
@@ -180,14 +180,14 @@ namespace Files.App.ViewModels.Properties
 				if (error is WIN32_ERROR.ERROR_ACCESS_DENIED)
 				{
 					ErrorMessage = 
-						"SecurityRequireReadPermissions".GetLocalizedResource() +
+						Strings.SecurityRequireReadPermissions.GetLocalizedResource() +
 						"\r\n\r\n" +
-						"SecuritySuggestToTakeOwnership".GetLocalizedResource();
+						Strings.SecuritySuggestToTakeOwnership.GetLocalizedResource();
 				}
 				else
 				{
 					ErrorMessage =
-						"SecurityUnableToDisplayPermissions".GetLocalizedResource() +
+						Strings.SecurityUnableToDisplayPermissions.GetLocalizedResource() +
 						"\r\n\r\n" +
 						error.ToString();
 				}

--- a/src/Files.App/ViewModels/Properties/SecurityViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/SecurityViewModel.cs
@@ -36,8 +36,8 @@ namespace Files.App.ViewModels.Properties
 
 		public string SelectedItemHeaderText =>
 			SelectedAccessControlEntry is null
-				? "Permissions".GetLocalizedResource()
-				: string.Format("SecurityPermissionsHeaderText".GetLocalizedResource(), SelectedAccessControlEntry?.Principal.DisplayName);
+				? Strings.Permissions.GetLocalizedResource()
+				: string.Format(Strings.SecurityPermissionsHeaderText.GetLocalizedResource(), SelectedAccessControlEntry?.Principal.DisplayName);
 
 		private AccessControlList _AccessControlList;
 		public AccessControlList AccessControlList
@@ -98,8 +98,8 @@ namespace Files.App.ViewModels.Properties
 			{
 				DisplayElements = false;
 				ErrorMessage = error is WIN32_ERROR.ERROR_ACCESS_DENIED
-					? "SecurityRequireReadPermissions".GetLocalizedResource() + "\r\n" + "SecurityClickAdvancedPermissions".GetLocalizedResource()
-					: "SecurityUnableToDisplayPermissions".GetLocalizedResource();
+					? Strings.SecurityRequireReadPermissions.GetLocalizedResource() + "\r\n" + Strings.SecurityClickAdvancedPermissions.GetLocalizedResource()
+					: Strings.SecurityUnableToDisplayPermissions.GetLocalizedResource();
 			}
 			else
 			{

--- a/src/Files.App/ViewModels/Settings/AboutViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AboutViewModel.cs
@@ -24,7 +24,7 @@ namespace Files.App.ViewModels.Settings
 		// Properties
 
 		public string Version
-			=> string.Format($"{"SettingsAboutVersionTitle".GetLocalizedResource()} {AppVersion.Major}.{AppVersion.Minor}.{AppVersion.Build}.{AppVersion.Revision}");
+			=> string.Format($"{Strings.SettingsAboutVersionTitle.GetLocalizedResource()} {AppVersion.Major}.{AppVersion.Minor}.{AppVersion.Build}.{AppVersion.Revision}");
 
 		public string AppName
 			=> Package.Current.DisplayName;

--- a/src/Files.App/ViewModels/Settings/AdvancedViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AdvancedViewModel.cs
@@ -160,7 +160,7 @@ namespace Files.App.ViewModels.Settings
 
 		private async Task ImportSettingsAsync()
 		{
-			string[] extensions = ["ZipFileCapitalized".GetLocalizedResource(), "*.zip"];
+			string[] extensions = [Strings.ZipFileCapitalized.GetLocalizedResource(), "*.zip"];
 			bool result = CommonDialogService.Open_FileOpenDialog(MainWindow.Instance.WindowHandle, false, extensions, Environment.SpecialFolder.Desktop, out var filePath);
 			if (!result)
 				return;
@@ -200,13 +200,13 @@ namespace Files.App.ViewModels.Settings
 			{
 				App.Logger.LogWarning(ex, "Error importing settings");
 				UIHelpers.CloseAllDialogs();
-				await DialogDisplayHelper.ShowDialogAsync("SettingsImportErrorTitle".GetLocalizedResource(), "SettingsImportErrorDescription".GetLocalizedResource());
+				await DialogDisplayHelper.ShowDialogAsync(Strings.SettingsImportErrorTitle.GetLocalizedResource(), Strings.SettingsImportErrorDescription.GetLocalizedResource());
 			}
 		}
 
 		private async Task ExportSettingsAsync()
 		{
-			string[] extensions = ["ZipFileCapitalized".GetLocalizedResource(), "*.zip" ];
+			string[] extensions = [Strings.ZipFileCapitalized.GetLocalizedResource(), "*.zip" ];
 			bool result = CommonDialogService.Open_FileSaveDialog(MainWindow.Instance.WindowHandle, false, extensions, Environment.SpecialFolder.Desktop, out var filePath);
 			if (!result)
 				return;

--- a/src/Files.App/ViewModels/Settings/AppearanceViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AppearanceViewModel.cs
@@ -37,16 +37,16 @@ namespace Files.App.ViewModels.Settings
 
 			Themes =
 			[
-				"Default".GetLocalizedResource(),
-				"LightTheme".GetLocalizedResource(),
-				"DarkTheme".GetLocalizedResource()
+				Strings.Default.GetLocalizedResource(),
+				Strings.LightTheme.GetLocalizedResource(),
+				Strings.DarkTheme.GetLocalizedResource()
 			];
 
-			BackdropMaterialTypes.Add(BackdropMaterialType.Solid, "None".GetLocalizedResource());
-			BackdropMaterialTypes.Add(BackdropMaterialType.Acrylic, "Acrylic".GetLocalizedResource());
-			BackdropMaterialTypes.Add(BackdropMaterialType.ThinAcrylic, "ThinAcrylic".GetLocalizedResource());
-			BackdropMaterialTypes.Add(BackdropMaterialType.Mica, "Mica".GetLocalizedResource());
-			BackdropMaterialTypes.Add(BackdropMaterialType.MicaAlt, "MicaAlt".GetLocalizedResource());
+			BackdropMaterialTypes.Add(BackdropMaterialType.Solid, Strings.None.GetLocalizedResource());
+			BackdropMaterialTypes.Add(BackdropMaterialType.Acrylic, Strings.Acrylic.GetLocalizedResource());
+			BackdropMaterialTypes.Add(BackdropMaterialType.ThinAcrylic, Strings.ThinAcrylic.GetLocalizedResource());
+			BackdropMaterialTypes.Add(BackdropMaterialType.Mica, Strings.Mica.GetLocalizedResource());
+			BackdropMaterialTypes.Add(BackdropMaterialType.MicaAlt, Strings.MicaAlt.GetLocalizedResource());
 
 			selectedBackdropMaterial = BackdropMaterialTypes[UserSettingsService.AppearanceSettingsService.AppThemeBackdropMaterial];
 
@@ -54,24 +54,24 @@ namespace Files.App.ViewModels.Settings
 
 
 			// Background image fit options
-			ImageStretchTypes.Add(Stretch.None, "None".GetLocalizedResource());
-			ImageStretchTypes.Add(Stretch.Fill, "Fill".GetLocalizedResource());
-			ImageStretchTypes.Add(Stretch.Uniform, "Uniform".GetLocalizedResource());
-			ImageStretchTypes.Add(Stretch.UniformToFill, "UniformToFill".GetLocalizedResource());
+			ImageStretchTypes.Add(Stretch.None, Strings.None.GetLocalizedResource());
+			ImageStretchTypes.Add(Stretch.Fill, Strings.Fill.GetLocalizedResource());
+			ImageStretchTypes.Add(Stretch.Uniform, Strings.Uniform.GetLocalizedResource());
+			ImageStretchTypes.Add(Stretch.UniformToFill, Strings.UniformToFill.GetLocalizedResource());
 			SelectedImageStretchType = ImageStretchTypes[UserSettingsService.AppearanceSettingsService.AppThemeBackgroundImageFit];
 
 			// Background image allignment options
 
 			// VerticalAlignment
-			ImageVerticalAlignmentTypes.Add(VerticalAlignment.Top, "Top".GetLocalizedResource());
-			ImageVerticalAlignmentTypes.Add(VerticalAlignment.Center, "Center".GetLocalizedResource());
-			ImageVerticalAlignmentTypes.Add(VerticalAlignment.Bottom, "Bottom".GetLocalizedResource());
+			ImageVerticalAlignmentTypes.Add(VerticalAlignment.Top, Strings.Top.GetLocalizedResource());
+			ImageVerticalAlignmentTypes.Add(VerticalAlignment.Center, Strings.Center.GetLocalizedResource());
+			ImageVerticalAlignmentTypes.Add(VerticalAlignment.Bottom, Strings.Bottom.GetLocalizedResource());
 			SelectedImageVerticalAlignmentType = ImageVerticalAlignmentTypes[UserSettingsService.AppearanceSettingsService.AppThemeBackgroundImageVerticalAlignment];
 
 			// HorizontalAlignment
-			ImageHorizontalAlignmentTypes.Add(HorizontalAlignment.Left, "Left".GetLocalizedResource());
-			ImageHorizontalAlignmentTypes.Add(HorizontalAlignment.Center, "Center".GetLocalizedResource());
-			ImageHorizontalAlignmentTypes.Add(HorizontalAlignment.Right, "Right".GetLocalizedResource());
+			ImageHorizontalAlignmentTypes.Add(HorizontalAlignment.Left, Strings.Left.GetLocalizedResource());
+			ImageHorizontalAlignmentTypes.Add(HorizontalAlignment.Center, Strings.Center.GetLocalizedResource());
+			ImageHorizontalAlignmentTypes.Add(HorizontalAlignment.Right, Strings.Right.GetLocalizedResource());
 			SelectedImageHorizontalAlignmentType = ImageHorizontalAlignmentTypes[UserSettingsService.AppearanceSettingsService.AppThemeBackgroundImageHorizontalAlignment];
 
 			UpdateSelectedResource();
@@ -87,7 +87,7 @@ namespace Files.App.ViewModels.Settings
 		{
 			string[] extensions =
 			[
-				"BitmapFiles".GetLocalizedResource(), "*.bmp;*.dib",
+				Strings.BitmapFiles.GetLocalizedResource(), "*.bmp;*.dib",
 				"JPEG", "*.jpg;*.jpeg;*.jpe;*.jfif",
 				"GIF", "*.gif",
 				"TIFF", "*.tif;*.tiff",
@@ -120,13 +120,13 @@ namespace Files.App.ViewModels.Settings
 			if (!AppThemeResources.Any(p => p.BackgroundColor == themeBackgroundColor))
 			{
 				// Remove current value before adding a new one
-				if (AppThemeResources.Last().Name == "Custom".GetLocalizedResource())
+				if (AppThemeResources.Last().Name == Strings.Custom.GetLocalizedResource())
 					AppThemeResources.Remove(AppThemeResources.Last());
 
 				var appThemeBackgroundColor = new AppThemeResourceItem
 				{
 					BackgroundColor = themeBackgroundColor,
-					Name = "Custom".GetLocalizedResource(),
+					Name = Strings.Custom.GetLocalizedResource(),
 				};
 
 				AppThemeResources.Add(appThemeBackgroundColor);

--- a/src/Files.App/ViewModels/Settings/DevToolsViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/DevToolsViewModel.cs
@@ -25,8 +25,8 @@ namespace Files.App.ViewModels.Settings
 		public DevToolsViewModel()
 		{
 			// Open in IDE options
-			OpenInIDEOptions.Add(OpenInIDEOption.GitRepos, "GitRepos".GetLocalizedResource());
-			OpenInIDEOptions.Add(OpenInIDEOption.AllLocations, "AllLocations".GetLocalizedResource());
+			OpenInIDEOptions.Add(OpenInIDEOption.GitRepos, Strings.GitRepos.GetLocalizedResource());
+			OpenInIDEOptions.Add(OpenInIDEOption.AllLocations, Strings.AllLocations.GetLocalizedResource());
 			SelectedOpenInIDEOption = OpenInIDEOptions[DevToolsSettingsService.OpenInIDEOption];
 
 			IsLogoutEnabled = GitHelpers.GetSavedCredentials() != string.Empty;

--- a/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
@@ -107,8 +107,8 @@ namespace Files.App.ViewModels.Settings
 			PagesOnStartupList.CollectionChanged += PagesOnStartupList_CollectionChanged;
 
 			// ShellPaneArrangement
-			ShellPaneArrangementTypes.Add(ShellPaneArrangement.Horizontal, "Horizontal".GetLocalizedResource());
-			ShellPaneArrangementTypes.Add(ShellPaneArrangement.Vertical, "Vertical".GetLocalizedResource());
+			ShellPaneArrangementTypes.Add(ShellPaneArrangement.Horizontal, Strings.Horizontal.GetLocalizedResource());
+			ShellPaneArrangementTypes.Add(ShellPaneArrangement.Vertical, Strings.Vertical.GetLocalizedResource());
 			SelectedShellPaneArrangementType = ShellPaneArrangementTypes[UserSettingsService.GeneralSettingsService.ShellPaneArrangementOption];
 
 			InitStartupSettingsRecentFoldersFlyout();
@@ -146,14 +146,14 @@ namespace Files.App.ViewModels.Settings
 
 		private void InitStartupSettingsRecentFoldersFlyout()
 		{
-			var recentsItem = new MenuFlyoutSubItemViewModel("JumpListRecentGroupHeader".GetLocalizedResource());
-			recentsItem.Items.Add(new MenuFlyoutItemViewModel("Home".GetLocalizedResource())
+			var recentsItem = new MenuFlyoutSubItemViewModel(Strings.JumpListRecentGroupHeader.GetLocalizedResource());
+			recentsItem.Items.Add(new MenuFlyoutItemViewModel(Strings.Home.GetLocalizedResource())
 			{
 				Command = AddPageCommand,
 				CommandParameter = "Home",
-				Tooltip = "Home".GetLocalizedResource()
+				Tooltip = Strings.Home.GetLocalizedResource()
 			});
-			recentsItem.Items.Add(new MenuFlyoutItemViewModel("Browse".GetLocalizedResource()) { Command = AddPageCommand });
+			recentsItem.Items.Add(new MenuFlyoutItemViewModel(Strings.Browse.GetLocalizedResource()) { Command = AddPageCommand });
 		}
 
 		private void PagesOnStartupList_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -359,7 +359,7 @@ namespace Files.App.ViewModels.Settings
 		}
 
 		public string DateFormatSample
-			=> string.Format("DateFormatSample".GetLocalizedResource(), DateFormats[SelectedDateTimeFormatIndex].Sample1, DateFormats[SelectedDateTimeFormatIndex].Sample2);
+			=> string.Format(Strings.DateFormatSample.GetLocalizedResource(), DateFormats[SelectedDateTimeFormatIndex].Sample1, DateFormats[SelectedDateTimeFormatIndex].Sample2);
 
 		private DispatcherQueue dispatcherQueue;
 

--- a/src/Files.App/ViewModels/UserControls/Previews/ArchivePreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/ArchivePreviewViewModel.cs
@@ -51,7 +51,7 @@ namespace Files.App.ViewModels.Previews
 
 			folderCount = (int)zipFile.FilesCount - fileCount;
 
-			string propertyItemCount = "DetailsArchiveItems".GetLocalizedFormatResource(zipFile.FilesCount, fileCount, folderCount);
+			string propertyItemCount = Strings.DetailsArchiveItems.GetLocalizedFormatResource(zipFile.FilesCount, fileCount, folderCount);
 			details.Add(GetFileProperty("PropertyItemCount", propertyItemCount));
 			details.Add(GetFileProperty("PropertyUncompressedSize", totalSize.ToLongSizeString()));
 

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -403,25 +403,25 @@ namespace Files.App.ViewModels.UserControls
 			{
 				switch (section.Text)
 				{
-					case var text when text == "Pinned".GetLocalizedResource():
+					case var text when text == Strings.Pinned.GetLocalizedResource():
 						UserSettingsService.GeneralSettingsService.IsPinnedSectionExpanded = section.IsExpanded;
 						break;
-					case var text when text == "SidebarLibraries".GetLocalizedResource():
+					case var text when text == Strings.SidebarLibraries.GetLocalizedResource():
 						UserSettingsService.GeneralSettingsService.IsLibrarySectionExpanded = section.IsExpanded;
 						break;
-					case var text when text == "Drives".GetLocalizedResource():
+					case var text when text == Strings.Drives.GetLocalizedResource():
 						UserSettingsService.GeneralSettingsService.IsDriveSectionExpanded = section.IsExpanded;
 						break;
-					case var text when text == "SidebarCloudDrives".GetLocalizedResource():
+					case var text when text == Strings.SidebarCloudDrives.GetLocalizedResource():
 						UserSettingsService.GeneralSettingsService.IsCloudDriveSectionExpanded = section.IsExpanded;
 						break;
-					case var text when text == "Network".GetLocalizedResource():
+					case var text when text == Strings.Network.GetLocalizedResource():
 						UserSettingsService.GeneralSettingsService.IsNetworkSectionExpanded = section.IsExpanded;
 						break;
-					case var text when text == "WSL".GetLocalizedResource():
+					case var text when text == Strings.WSL.GetLocalizedResource():
 						UserSettingsService.GeneralSettingsService.IsWslSectionExpanded = section.IsExpanded;
 						break;
-					case var text when text == "FileTags".GetLocalizedResource():
+					case var text when text == Strings.FileTags.GetLocalizedResource():
 						UserSettingsService.GeneralSettingsService.IsFileTagsSectionExpanded = section.IsExpanded;
 						break;
 				}
@@ -449,7 +449,7 @@ namespace Files.App.ViewModels.UserControls
 			{
 				case SectionType.Home:
 					{
-						section = BuildSection("Home".GetLocalizedResource(), sectionType, new ContextMenuOptions { IsLocationItem = true }, true);
+						section = BuildSection(Strings.Home.GetLocalizedResource(), sectionType, new ContextMenuOptions { IsLocationItem = true }, true);
 						section.Path = "Home";
 						section.Icon = new BitmapImage(new Uri(Constants.FluentIconsPaths.HomeIcon));
 						section.IsHeader = true;
@@ -464,7 +464,7 @@ namespace Files.App.ViewModels.UserControls
 							break;
 						}
 
-						section = BuildSection("Pinned".GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
+						section = BuildSection(Strings.Pinned.GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
 						icon = new BitmapImage(new Uri(Constants.FluentIconsPaths.StarIcon));
 						section.IsHeader = true;
 						section.IsExpanded = UserSettingsService.GeneralSettingsService.IsPinnedSectionExpanded;
@@ -478,7 +478,7 @@ namespace Files.App.ViewModels.UserControls
 						{
 							break;
 						}
-						section = BuildSection("SidebarLibraries".GetLocalizedResource(), sectionType, new ContextMenuOptions { IsLibrariesHeader = true, ShowHideSection = true }, false);
+						section = BuildSection(Strings.SidebarLibraries.GetLocalizedResource(), sectionType, new ContextMenuOptions { IsLibrariesHeader = true, ShowHideSection = true }, false);
 						iconIdex = Constants.ImageRes.Libraries;
 						section.IsHeader = true;
 						section.IsExpanded = UserSettingsService.GeneralSettingsService.IsLibrarySectionExpanded;
@@ -492,7 +492,7 @@ namespace Files.App.ViewModels.UserControls
 						{
 							break;
 						}
-						section = BuildSection("Drives".GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
+						section = BuildSection(Strings.Drives.GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
 						iconIdex = Constants.ImageRes.ThisPC;
 						section.IsHeader = true;
 						section.IsExpanded = UserSettingsService.GeneralSettingsService.IsDriveSectionExpanded;
@@ -506,7 +506,7 @@ namespace Files.App.ViewModels.UserControls
 						{
 							break;
 						}
-						section = BuildSection("SidebarCloudDrives".GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
+						section = BuildSection(Strings.SidebarCloudDrives.GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
 						icon = new BitmapImage(new Uri(Constants.FluentIconsPaths.CloudDriveIcon));
 						section.IsHeader = true;
 						section.IsExpanded = UserSettingsService.GeneralSettingsService.IsCloudDriveSectionExpanded;
@@ -520,7 +520,7 @@ namespace Files.App.ViewModels.UserControls
 						{
 							break;
 						}
-						section = BuildSection("Network".GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
+						section = BuildSection(Strings.Network.GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
 						iconIdex = Constants.ImageRes.Network;
 						section.IsHeader = true;
 						section.IsExpanded = UserSettingsService.GeneralSettingsService.IsNetworkSectionExpanded;
@@ -534,7 +534,7 @@ namespace Files.App.ViewModels.UserControls
 						{
 							break;
 						}
-						section = BuildSection("WSL".GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
+						section = BuildSection(Strings.WSL.GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
 						icon = new BitmapImage(new Uri(Constants.WslIconsPaths.GenericIcon));
 						section.IsHeader = true;
 						section.IsExpanded = UserSettingsService.GeneralSettingsService.IsWslSectionExpanded;
@@ -548,7 +548,7 @@ namespace Files.App.ViewModels.UserControls
 						{
 							break;
 						}
-						section = BuildSection("FileTags".GetLocalizedResource(), sectionType, new ContextMenuOptions { IsTagsHeader = true, ShowHideSection = true }, false);
+						section = BuildSection(Strings.FileTags.GetLocalizedResource(), sectionType, new ContextMenuOptions { IsTagsHeader = true, ShowHideSection = true }, false);
 						icon = new BitmapImage(new Uri(Constants.FluentIconsPaths.FileTagsIcon));
 						section.IsHeader = true;
 						section.IsExpanded = UserSettingsService.GeneralSettingsService.IsFileTagsSectionExpanded;
@@ -896,7 +896,7 @@ namespace Files.App.ViewModels.UserControls
 						ItemPath = locationItem.Path,
 						ItemNameRaw = locationItem.Text,
 						PrimaryItemAttribute = StorageItemTypes.Folder,
-						ItemType = "Folder".GetLocalizedResource(),
+						ItemType = Strings.Folder.GetLocalizedResource(),
 					};
 
 					if (!string.Equals(locationItem.Path, Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
@@ -973,7 +973,7 @@ namespace Files.App.ViewModels.UserControls
 				}.Build(),
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "PinFolderToSidebar".GetLocalizedResource(),
+					Text = Strings.PinFolderToSidebar.GetLocalizedResource(),
 					ThemedIconModel = new ThemedIconModel()
 					{
 						ThemedIconStyle = "App.ThemedIcons.FavoritePin",
@@ -983,7 +983,7 @@ namespace Files.App.ViewModels.UserControls
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "UnpinFolderFromSidebar".GetLocalizedResource(),
+					Text = Strings.UnpinFolderFromSidebar.GetLocalizedResource(),
 					ThemedIconModel = new ThemedIconModel()
 					{
 						ThemedIconStyle = "App.ThemedIcons.FavoritePinRemove",
@@ -993,27 +993,27 @@ namespace Files.App.ViewModels.UserControls
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "ReorderSidebarItemsDialogText".GetLocalizedResource(),
+					Text = Strings.ReorderSidebarItemsDialogText.GetLocalizedResource(),
 					Glyph = "\uE8D8",
 					Command = ReorderItemsCommand,
 					ShowItem = isPinnedItem || item.Section is SectionType.Pinned
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = string.Format("SideBarHideSectionFromSideBar/Text".GetLocalizedResource(), rightClickedItem.Text),
+					Text = string.Format(Strings.SideBarHideSectionFromSideBar_Text.GetLocalizedResource(), rightClickedItem.Text),
 					Glyph = "\uE77A",
 					Command = HideSectionCommand,
 					ShowItem = options.ShowHideSection
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "Eject".GetLocalizedResource(),
+					Text = Strings.Eject.GetLocalizedResource(),
 					Command = EjectDeviceCommand,
 					ShowItem = options.ShowEjectDevice
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "Properties".GetLocalizedResource(),
+					Text = Strings.Properties.GetLocalizedResource(),
 					ThemedIconModel = new ThemedIconModel()
 					{
 						ThemedIconStyle = "App.ThemedIcons.Properties",
@@ -1040,7 +1040,7 @@ namespace Files.App.ViewModels.UserControls
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "Loading".GetLocalizedResource(),
+					Text = Strings.Loading.GetLocalizedResource(),
 					Glyph = "\xE712",
 					Items = [],
 					ID = "ItemOverflow",
@@ -1050,7 +1050,7 @@ namespace Files.App.ViewModels.UserControls
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{
-					Text = "ManageTags".GetLocalizedResource(),
+					Text = Strings.ManageTags.GetLocalizedResource(),
 					Glyph = "\uE8EC",
 					Command = Commands.OpenSettings,
 					CommandParameter = new SettingsNavigationParams() { PageKind = SettingsPageKind.TagsPage },
@@ -1091,7 +1091,7 @@ namespace Files.App.ViewModels.UserControls
 					}
 					else
 					{
-						var captionText = "PinFolderToSidebar".GetLocalizedResource();
+						var captionText = Strings.PinFolderToSidebar.GetLocalizedResource();
 						CompleteDragEventArgs(rawEvent, captionText, DataPackageOperation.Move);
 					}
 				}
@@ -1111,41 +1111,41 @@ namespace Files.App.ViewModels.UserControls
 					DataPackageOperation operationType;
 					if (locationItem.Path.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.Ordinal))
 					{
-						captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
+						captionText = string.Format(Strings.MoveToFolderCaptionText.GetLocalizedResource(), locationItem.Text);
 						// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 						operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else if (rawEvent.Modifiers.HasFlag(DragDropModifiers.Alt) || rawEvent.Modifiers.HasFlag(DragDropModifiers.Control | DragDropModifiers.Shift))
 					{
-						captionText = string.Format("LinkToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
+						captionText = string.Format(Strings.LinkToFolderCaptionText.GetLocalizedResource(), locationItem.Text);
 						operationType = DataPackageOperation.Link;
 					}
 					else if (rawEvent.Modifiers.HasFlag(DragDropModifiers.Control))
 					{
-						captionText = string.Format("CopyToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
+						captionText = string.Format(Strings.CopyToFolderCaptionText.GetLocalizedResource(), locationItem.Text);
 						operationType = DataPackageOperation.Copy;
 					}
 					else if (rawEvent.Modifiers.HasFlag(DragDropModifiers.Shift))
 					{
-						captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
+						captionText = string.Format(Strings.MoveToFolderCaptionText.GetLocalizedResource(), locationItem.Text);
 						// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 						operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else if (storageItems.Any(x => x.Item is ZipStorageFile || x.Item is ZipStorageFolder)
 						|| ZipStorageFolder.IsZipPath(locationItem.Path))
 					{
-						captionText = string.Format("CopyToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
+						captionText = string.Format(Strings.CopyToFolderCaptionText.GetLocalizedResource(), locationItem.Text);
 						operationType = DataPackageOperation.Copy;
 					}
 					else if (locationItem.IsDefaultLocation || storageItems.AreItemsInSameDrive(locationItem.Path))
 					{
-						captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
+						captionText = string.Format(Strings.MoveToFolderCaptionText.GetLocalizedResource(), locationItem.Text);
 						// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 						operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 					}
 					else
 					{
-						captionText = string.Format("CopyToFolderCaptionText".GetLocalizedResource(), locationItem.Text);
+						captionText = string.Format(Strings.CopyToFolderCaptionText.GetLocalizedResource(), locationItem.Text);
 						operationType = DataPackageOperation.Copy;
 					}
 					CompleteDragEventArgs(rawEvent, captionText, operationType);
@@ -1163,7 +1163,7 @@ namespace Files.App.ViewModels.UserControls
 			var storageItems = await Utils.Storage.FilesystemHelpers.GetDraggedStorageItems(args.DroppedItem);
 			var hasStorageItems = storageItems.Any();
 
-			if ("Unknown".GetLocalizedResource().Equals(driveItem.SpaceText, StringComparison.OrdinalIgnoreCase) ||
+			if (Strings.Unknown.GetLocalizedResource().Equals(driveItem.SpaceText, StringComparison.OrdinalIgnoreCase) ||
 				(hasStorageItems && storageItems.AreItemsAlreadyInFolder(driveItem.Path)))
 			{
 				args.RawEvent.AcceptedOperation = DataPackageOperation.None;
@@ -1178,29 +1178,29 @@ namespace Files.App.ViewModels.UserControls
 				DataPackageOperation operationType;
 				if (args.RawEvent.Modifiers.HasFlag(DragDropModifiers.Alt) || args.RawEvent.Modifiers.HasFlag(DragDropModifiers.Control | DragDropModifiers.Shift))
 				{
-					captionText = string.Format("LinkToFolderCaptionText".GetLocalizedResource(), driveItem.Text);
+					captionText = string.Format(Strings.LinkToFolderCaptionText.GetLocalizedResource(), driveItem.Text);
 					operationType = DataPackageOperation.Link;
 				}
 				else if (args.RawEvent.Modifiers.HasFlag(DragDropModifiers.Control))
 				{
-					captionText = string.Format("CopyToFolderCaptionText".GetLocalizedResource(), driveItem.Text);
+					captionText = string.Format(Strings.CopyToFolderCaptionText.GetLocalizedResource(), driveItem.Text);
 					operationType = DataPackageOperation.Copy;
 				}
 				else if (args.RawEvent.Modifiers.HasFlag(DragDropModifiers.Shift))
 				{
-					captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), driveItem.Text);
+					captionText = string.Format(Strings.MoveToFolderCaptionText.GetLocalizedResource(), driveItem.Text);
 					// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 					operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 				}
 				else if (storageItems.AreItemsInSameDrive(driveItem.Path))
 				{
-					captionText = string.Format("MoveToFolderCaptionText".GetLocalizedResource(), driveItem.Text);
+					captionText = string.Format(Strings.MoveToFolderCaptionText.GetLocalizedResource(), driveItem.Text);
 					// Some applications such as Edge can't raise the drop event by the Move flag (#14008), so we set the Copy flag as well.
 					operationType = DataPackageOperation.Move | DataPackageOperation.Copy;
 				}
 				else
 				{
-					captionText = string.Format("CopyToFolderCaptionText".GetLocalizedResource(), driveItem.Text);
+					captionText = string.Format(Strings.CopyToFolderCaptionText.GetLocalizedResource(), driveItem.Text);
 					operationType = DataPackageOperation.Copy;
 				}
 				CompleteDragEventArgs(args.RawEvent, captionText, operationType);
@@ -1223,7 +1223,7 @@ namespace Files.App.ViewModels.UserControls
 			else
 			{
 				args.RawEvent.DragUIOverride.IsCaptionVisible = true;
-				args.RawEvent.DragUIOverride.Caption = string.Format("LinkToFolderCaptionText".GetLocalizedResource(), tagItem.Text);
+				args.RawEvent.DragUIOverride.Caption = string.Format(Strings.LinkToFolderCaptionText.GetLocalizedResource(), tagItem.Text);
 				args.RawEvent.AcceptedOperation = DataPackageOperation.Link;
 			}
 		}

--- a/src/Files.App/ViewModels/UserControls/Widgets/FileTagsWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/FileTagsWidgetViewModel.cs
@@ -19,8 +19,8 @@ namespace Files.App.ViewModels.UserControls.Widgets
 		public ObservableCollection<WidgetFileTagsContainerItem> Containers { get; } = [];
 
 		public string WidgetName => nameof(FileTagsWidget);
-		public string WidgetHeader => "FileTags".GetLocalizedResource();
-		public string AutomationProperties => "FileTags".GetLocalizedResource();
+		public string WidgetHeader => Strings.FileTags.GetLocalizedResource();
+		public string AutomationProperties => Strings.FileTags.GetLocalizedResource();
 		public bool IsWidgetSettingEnabled => UserSettingsService.GeneralSettingsService.ShowFileTagsWidget;
 		public bool ShowMenuFlyout => false;
 		public MenuFlyoutItem? MenuFlyoutItem => null;
@@ -108,14 +108,14 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				}.Build(),
 				new()
 				{
-					Text = "OpenWith".GetLocalizedResource(),
+					Text = Strings.OpenWith.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.OpenWith" },
 					Tag = "OpenWithPlaceholder",
 					ShowItem = !isFolder
 				},
 				new()
 				{
-					Text = "OpenFileLocation".GetLocalizedResource(),
+					Text = Strings.OpenFileLocation.GetLocalizedResource(),
 					Glyph = "\uED25",
 					Command = OpenFileLocationCommand,
 					CommandParameter = item,
@@ -123,7 +123,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				},
 				new()
 				{
-					Text = "PinFolderToSidebar".GetLocalizedResource(),
+					Text = Strings.PinFolderToSidebar.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.FavoritePin" },
 					Command = PinToSidebarCommand,
 					CommandParameter = item,
@@ -131,7 +131,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				},
 				new()
 				{
-					Text = "UnpinFolderFromSidebar".GetLocalizedResource(),
+					Text = Strings.UnpinFolderFromSidebar.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.FavoritePinRemove" },
 					Command = UnpinFromSidebarCommand,
 					CommandParameter = item,
@@ -139,13 +139,13 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				},
 				new()
 				{
-					Text = "SendTo".GetLocalizedResource(),
+					Text = Strings.SendTo.GetLocalizedResource(),
 					Tag = "SendToPlaceholder",
 					ShowItem = UserSettingsService.GeneralSettingsService.ShowSendToMenu
 				},
 				new()
 				{
-					Text = "Properties".GetLocalizedResource(),
+					Text = Strings.Properties.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.Properties" },
 					Command = OpenPropertiesCommand,
 					CommandParameter = item,
@@ -164,7 +164,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				},
 				new()
 				{
-					Text = "Loading".GetLocalizedResource(),
+					Text = Strings.Loading.GetLocalizedResource(),
 					Glyph = "\xE712",
 					Items = [],
 					ID = "ItemOverflow",
@@ -193,7 +193,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 					ItemPath = (item.Item as WidgetFileTagCardItem)?.Path ?? string.Empty,
 					ItemNameRaw = (item.Item as WidgetFileTagCardItem)?.Name ?? string.Empty,
 					PrimaryItemAttribute = StorageItemTypes.Folder,
-					ItemType = "Folder".GetLocalizedResource(),
+					ItemType = Strings.Folder.GetLocalizedResource(),
 				};
 
 				FilePropertiesHelpers.OpenPropertiesWindow(listedItem, ContentPageContext.ShellPage!);

--- a/src/Files.App/ViewModels/UserControls/Widgets/NetworkLocationsWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/NetworkLocationsWidgetViewModel.cs
@@ -20,14 +20,14 @@ namespace Files.App.ViewModels.UserControls.Widgets
 		public ObservableCollection<WidgetDriveCardItem> Items { get; } = [];
 
 		public string WidgetName => nameof(NetworkLocationsWidget);
-		public string AutomationProperties => "NetworkLocations".GetLocalizedResource();
-		public string WidgetHeader => "NetworkLocations".GetLocalizedResource();
+		public string AutomationProperties => Strings.NetworkLocations.GetLocalizedResource();
+		public string WidgetHeader => Strings.NetworkLocations.GetLocalizedResource();
 		public bool IsWidgetSettingEnabled => UserSettingsService.GeneralSettingsService.ShowNetworkLocationsWidget;
 		public bool ShowMenuFlyout => true;
 		public MenuFlyoutItem? MenuFlyoutItem => new()
 		{
 			Icon = new FontIcon() { Glyph = "\uE710" },
-			Text = "DrivesWidgetOptionsFlyoutMapNetDriveMenuItem/Text".GetLocalizedResource(),
+			Text = Strings.DrivesWidgetOptionsFlyoutMapNetDriveMenuItem_Text.GetLocalizedResource(),
 			Command = MapNetworkDriveCommand
 		};
 

--- a/src/Files.App/ViewModels/UserControls/Widgets/QuickAccessWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/QuickAccessWidgetViewModel.cs
@@ -22,8 +22,8 @@ namespace Files.App.ViewModels.UserControls.Widgets
 		public ObservableCollection<WidgetFolderCardItem> Items { get; } = [];
 
 		public string WidgetName => nameof(QuickAccessWidget);
-		public string AutomationProperties => "QuickAccess".GetLocalizedResource();
-		public string WidgetHeader => "QuickAccess".GetLocalizedResource();
+		public string AutomationProperties => Strings.QuickAccess.GetLocalizedResource();
+		public string WidgetHeader => Strings.QuickAccess.GetLocalizedResource();
 		public bool IsWidgetSettingEnabled => UserSettingsService.GeneralSettingsService.ShowQuickAccessWidget;
 		public bool ShowMenuFlyout => false;
 		public MenuFlyoutItem? MenuFlyoutItem => null;
@@ -74,7 +74,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				}.Build(),
 				new()
 				{
-					Text = "PinFolderToSidebar".GetLocalizedResource(),
+					Text = Strings.PinFolderToSidebar.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.FavoritePin" },
 					Command = PinToSidebarCommand,
 					CommandParameter = item,
@@ -82,7 +82,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				},
 				new()
 				{
-					Text = "UnpinFolderFromSidebar".GetLocalizedResource(),
+					Text = Strings.UnpinFolderFromSidebar.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.FavoritePinRemove" },
 					Command = UnpinFromSidebarCommand,
 					CommandParameter = item,
@@ -90,13 +90,13 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				},
 				new()
 				{
-					Text = "SendTo".GetLocalizedResource(),
+					Text = Strings.SendTo.GetLocalizedResource(),
 					Tag = "SendToPlaceholder",
 					ShowItem = UserSettingsService.GeneralSettingsService.ShowSendToMenu
 				},
 				new()
 				{
-					Text = "Properties".GetLocalizedResource(),
+					Text = Strings.Properties.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.Properties" },
 					Command = OpenPropertiesCommand,
 					CommandParameter = item
@@ -114,7 +114,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				},
 				new()
 				{
-					Text = "Loading".GetLocalizedResource(),
+					Text = Strings.Loading.GetLocalizedResource(),
 					Glyph = "\xE712",
 					Items = [],
 					ID = "ItemOverflow",
@@ -277,7 +277,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 					ItemPath = item.Item.Path,
 					ItemNameRaw = item.Item.Text,
 					PrimaryItemAttribute = StorageItemTypes.Folder,
-					ItemType = "Folder".GetLocalizedResource(),
+					ItemType = Strings.Folder.GetLocalizedResource(),
 				};
 
 				if (!string.Equals(item.Item.Path, Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))

--- a/src/Files.App/ViewModels/UserControls/Widgets/RecentFilesWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/RecentFilesWidgetViewModel.cs
@@ -25,8 +25,8 @@ namespace Files.App.ViewModels.UserControls.Widgets
 		public ObservableCollection<RecentItem> Items { get; } = [];
 
 		public string WidgetName => nameof(RecentFilesWidget);
-		public string AutomationProperties => "RecentFiles".GetLocalizedResource();
-		public string WidgetHeader => "RecentFiles".GetLocalizedResource();
+		public string AutomationProperties => Strings.RecentFiles.GetLocalizedResource();
+		public string WidgetHeader => Strings.RecentFiles.GetLocalizedResource();
 		public bool IsWidgetSettingEnabled => UserSettingsService.GeneralSettingsService.ShowRecentFilesWidget;
 		public bool ShowMenuFlyout => false;
 		public MenuFlyoutItem? MenuFlyoutItem => null;
@@ -78,39 +78,39 @@ namespace Files.App.ViewModels.UserControls.Widgets
 			{
 				new()
 				{
-					Text = "OpenWith".GetLocalizedResource(),
+					Text = Strings.OpenWith.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.OpenWith" },
 					Tag = "OpenWithPlaceholder",
 				},
 				new()
 				{
-					Text = "RecentItemRemove/Text".GetLocalizedResource(),
+					Text = Strings.RecentItemRemove_Text.GetLocalizedResource(),
 					Glyph = "\uE738",
 					Command = RemoveRecentItemCommand,
 					CommandParameter = item
 				},
 				new()
 				{
-					Text = "RecentItemClearAll/Text".GetLocalizedResource(),
+					Text = Strings.RecentItemClearAll_Text.GetLocalizedResource(),
 					Glyph = "\uE74D",
 					Command = ClearAllItemsCommand
 				},
 				new()
 				{
-					Text = "OpenFileLocation".GetLocalizedResource(),
+					Text = Strings.OpenFileLocation.GetLocalizedResource(),
 					Glyph = "\uED25",
 					Command = OpenFileLocationCommand,
 					CommandParameter = item
 				},
 				new()
 				{
-					Text = "SendTo".GetLocalizedResource(),
+					Text = Strings.SendTo.GetLocalizedResource(),
 					Tag = "SendToPlaceholder",
 					ShowItem = UserSettingsService.GeneralSettingsService.ShowSendToMenu
 				},
 				new()
 				{
-					Text = "Properties".GetLocalizedResource(),
+					Text = Strings.Properties.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.Properties" },
 					Command = OpenPropertiesCommand,
 					CommandParameter = item
@@ -122,7 +122,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				},
 				new()
 				{
-					Text = "Loading".GetLocalizedResource(),
+					Text = Strings.Loading.GetLocalizedResource(),
 					Glyph = "\xE712",
 					Items = [],
 					ID = "ItemOverflow",
@@ -332,8 +332,8 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				{
 					ContentDialog dialog = new()
 					{
-						Title = "CannotAccessPropertiesTitle".GetLocalizedResource(),
-						Content = "CannotAccessPropertiesContent".GetLocalizedResource(),
+						Title = Strings.CannotAccessPropertiesTitle.GetLocalizedResource(),
+						Content = Strings.CannotAccessPropertiesContent.GetLocalizedResource(),
 						PrimaryButtonText = "Ok".GetLocalizedResource()
 					};
 

--- a/src/Files.App/Views/HomePage.xaml.cs
+++ b/src/Files.App/Views/HomePage.xaml.cs
@@ -57,7 +57,7 @@ namespace Files.App.Views
 
 			string componentLabel =
 				parameters?.NavPathParam == "Home"
-					? "Home".GetLocalizedResource()
+					? Strings.Home.GetLocalizedResource()
 					: parameters?.NavPathParam
 				?? string.Empty;
 

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -63,10 +63,10 @@ namespace Files.App.Views
 		{
 			var promptForReviewDialog = new ContentDialog
 			{
-				Title = "ReviewFiles".ToLocalized(),
-				Content = "ReviewFilesContent".ToLocalized(),
-				PrimaryButtonText = "Yes".ToLocalized(),
-				SecondaryButtonText = "No".ToLocalized()
+				Title = Strings.ReviewFiles.ToLocalized(),
+				Content = Strings.ReviewFilesContent.ToLocalized(),
+				PrimaryButtonText = Strings.Yes.ToLocalized(),
+				SecondaryButtonText = Strings.No.ToLocalized()
 			};
 
 			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
@@ -94,10 +94,10 @@ namespace Files.App.Views
 		{
 			var runningAsAdminPrompt = new ContentDialog
 			{
-				Title = "FilesRunningAsAdmin".ToLocalized(),
-				Content = "FilesRunningAsAdminContent".ToLocalized(),
+				Title = Strings.FilesRunningAsAdmin.ToLocalized(),
+				Content = Strings.FilesRunningAsAdminContent.ToLocalized(),
 				PrimaryButtonText = "Ok".ToLocalized(),
-				SecondaryButtonText = "DontShowAgain".ToLocalized()
+				SecondaryButtonText = Strings.DontShowAgain.ToLocalized()
 			};
 
 			var result = await SetContentDialogRoot(runningAsAdminPrompt).TryShowAsync();

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -233,7 +233,7 @@ namespace Files.App.Views.Shells
 			if (ContentPage is null)
 				return;
 
-			var directoryItemCountLocalization = "Items".GetLocalizedFormatResource(ShellViewModel.FilesAndFolders.Count);
+			var directoryItemCountLocalization = Strings.Items.GetLocalizedFormatResource(ShellViewModel.FilesAndFolders.Count);
 
 			BranchItem? headBranch = headBranch = InstanceViewModel.IsGitRepository
 					? await GitHelpers.GetRepositoryHead(InstanceViewModel.GitRepositoryPath)
@@ -759,7 +759,7 @@ namespace Files.App.Views.Shells
 		protected void SelectSidebarItemFromPath(Type incomingSourcePageType = null)
 		{
 			if (incomingSourcePageType == typeof(HomePage) && incomingSourcePageType is not null)
-				ToolbarViewModel.PathControlDisplayText = "Home".GetLocalizedResource();
+				ToolbarViewModel.PathControlDisplayText = Strings.Home.GetLocalizedResource();
 		}
 
 		protected void SetLoadingIndicatorForTabs(bool isLoading)

--- a/src/Files.App/Views/Shells/ModernShellPage.xaml.cs
+++ b/src/Files.App/Views/Shells/ModernShellPage.xaml.cs
@@ -45,7 +45,7 @@ namespace Files.App.Views.Shells
 			ShellViewModel.OnSelectionRequestedEvent += FilesystemViewModel_OnSelectionRequestedEvent;
 			ShellViewModel.GitDirectoryUpdated += FilesystemViewModel_GitDirectoryUpdated;
 
-			ToolbarViewModel.PathControlDisplayText = "Home".GetLocalizedResource();
+			ToolbarViewModel.PathControlDisplayText = Strings.Home.GetLocalizedResource();
 			ToolbarViewModel.RefreshWidgetsRequested += ModernShellPage_RefreshWidgetsRequested;
 
 			_navigationInteractionTracker = new NavigationInteractionTracker(this, BackIcon, ForwardIcon);


### PR DESCRIPTION
Feature/Code Quality: Replace string literals with string constants in Files App

This pull request addresses the improvement of code quality in the Files App by replacing string literals with string constants. This change enhances maintainability, reduces the likelihood of typos, and improves overall code readability.

Changes Made

- Replaced string literals with corresponding string constants throughout the Files App codebase.

Ensured all affected strings are now referenced using constants instead of hard-coded values.

Testing Steps

- Open Files App
- Navigated through various sections of the app to ensure all strings are displayed correctly
- Performed actions that trigger string-dependent functionality (e.g., error messages, tooltips)
- Update language via settings and repeat step 2 and 3
- Verified that no visual or functional regressions occurred due to the changes
- Checked for any compile-time errors or warnings related to string usage

Additional Notes

- This change does not alter any functionality but improves code maintainability.
- All string constants are now centralized, making future updates and localization efforts easier.
- Code reviewers should pay special attention to ensure no string literals were missed during this refactoring.
