### PR TITLE
Fix: Use working directory when running PowerShell scripts

### DIFF
--- a/src/Files.App/Actions/Content/Run/RunWithPowershellAction.cs
+++ b/src/Files.App/Actions/Content/Run/RunWithPowershellAction.cs
@@ -31,7 +31,11 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync(object? parameter = null)
 		{
-			return Win32Helper.RunPowershellCommandAsync($"& '{context.ShellPage?.SlimContentPage?.SelectedItem?.ItemPath}'", PowerShellExecutionOptions.None);
+			return Win32Helper.RunPowershellCommandAsync(
+				$"& '{context.ShellPage?.SlimContentPage?.SelectedItem?.ItemPath}'",
+				PowerShellExecutionOptions.None,
+				context.Folder?.ItemPath
+			);
 		}
 
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Files.App/Data/Factories/ShellContextFlyoutHelper.cs
+++ b/src/Files.App/Data/Factories/ShellContextFlyoutHelper.cs
@@ -199,6 +199,13 @@ namespace Files.App.Helpers
 						await Win32Helper.OpenFormatDriveDialog(drivePath);
 						break;
 
+					case "Windows.PowerShell.Run":
+						await contextMenu.InvokeItem(
+							menuId,
+							contextMenu.ItemsPath[0].EndsWith(".ps1") ? Path.GetDirectoryName(contextMenu.ItemsPath[0]) : null
+						);
+						break;
+
 					default:
 						await contextMenu.InvokeItem(menuId);
 						break;

--- a/src/Files.App/Helpers/Win32/Win32Helper.Storage.cs
+++ b/src/Files.App/Helpers/Win32/Win32Helper.Storage.cs
@@ -405,9 +405,9 @@ namespace Files.App.Helpers
 			}
 		}
 
-		public static async Task<bool> RunPowershellCommandAsync(string command, PowerShellExecutionOptions options)
+		public static async Task<bool> RunPowershellCommandAsync(string command, PowerShellExecutionOptions options, string? workingDirectory = null)
 		{
-			using Process process = CreatePowershellProcess(command, options);
+			using Process process = CreatePowershellProcess(command, options, workingDirectory);
 			using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(30 * 1000));
 
 			try
@@ -432,11 +432,11 @@ namespace Files.App.Helpers
 			}
 		}
 
-		public static bool RunPowershellCommand(string command, PowerShellExecutionOptions options)
+		public static bool RunPowershellCommand(string command, PowerShellExecutionOptions options, string? workingDirectory = null)
 		{
 			try
 			{
-				using Process process = CreatePowershellProcess(command, options);
+				using Process process = CreatePowershellProcess(command, options, workingDirectory);
 
 				process.Start();
 
@@ -867,7 +867,7 @@ namespace Files.App.Helpers
 			await RunPowershellCommandAsync(psCommand.Append("\"").ToString(), PowerShellExecutionOptions.Elevated | PowerShellExecutionOptions.Hidden);
 		}
 
-		private static Process CreatePowershellProcess(string command, PowerShellExecutionOptions options)
+		private static Process CreatePowershellProcess(string command, PowerShellExecutionOptions options, string? workingDirectory = null)
 		{
 			Process process = new();
 
@@ -883,6 +883,10 @@ namespace Files.App.Helpers
 				process.StartInfo.CreateNoWindow = true;
 				process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
 			}
+
+			if (workingDirectory is not null)
+				process.StartInfo.WorkingDirectory = workingDirectory;
+
 			process.StartInfo.Arguments = command;
 
 			return process;

--- a/src/Files.App/Utils/Shell/ContextMenu.cs
+++ b/src/Files.App/Utils/Shell/ContextMenu.cs
@@ -85,7 +85,7 @@ namespace Files.App.Utils.Shell
 			return false;
 		}
 
-		public async Task<bool> InvokeItem(int itemID)
+		public async Task<bool> InvokeItem(int itemID, string? workingDirectory = null)
 		{
 			if (itemID < 0)
 				return false;
@@ -100,6 +100,8 @@ namespace Files.App.Utils.Shell
 				};
 
 				pici.cbSize = (uint)Marshal.SizeOf(pici);
+				if (workingDirectory is not null)
+					pici.lpDirectoryW = workingDirectory;
 
 				await _owningThread.PostMethod(() => _cMenu.InvokeCommand(pici));
 				Win32Helper.BringToForeground(currentWindows);


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16811 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Create a PS script that reference the working directory
2. Run it both using the toolbar's button and the context menu command
