### PR TITLE
Fix: Disabled text wrapping for the permissions list entries

### DIFF
--- a/src/Files.App/Views/Properties/SecurityPage.xaml
+++ b/src/Files.App/Views/Properties/SecurityPage.xaml
@@ -153,6 +153,7 @@
 									<TextBlock
 										Grid.Column="1"
 										Style="{StaticResource App.Theme.BodyTextBlockStyle}"
+										TextWrapping="NoWrap"
 										ToolTipService.ToolTip="{x:Bind Principal.FullNameHumanized}">
 										<Run Text="{x:Bind Principal.DisplayName}" />
 										<Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind Principal.FullNameHumanizedWithBrackes}" />


### PR DESCRIPTION
**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16836 

**Changes**
Disabled text wrapping of the `TextBlock`
Did not add a margin as suggested [here](https://github.com/files-community/Files/issues/16836#issuecomment-2675037028), since there is already a margin of 4 at the bottom of the `ListView` https://github.com/files-community/Files/blob/92e87fbfe48c16fe48d754e516bfccb68144c2f8/src/Files.App/Views/Properties/SecurityPage.xaml#L129

**Steps used to test these changes**

![image](https://github.com/user-attachments/assets/d1fc5482-5bbb-4196-8577-a8f5a4007642)

