### PR TITLE
Code Quality: Retarget BladeView to ContentControl

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,13 +21,13 @@
     <PackageVersion Include="FluentFTP" Version="52.0.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.30.0" />
     <PackageVersion Include="MessageFormat" Version="7.1.2" />
-    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0" />
-    <PackageVersion Include="Sentry" Version="5.1.0" />
+    <PackageVersion Include="Sentry" Version="5.1.1" />
     <PackageVersion Include="SevenZipSharp" Version="1.0.2" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.10" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.250205002" />
@@ -35,8 +35,8 @@
     <PackageVersion Include="TagLibSharp" Version="2.3.0" />
     <PackageVersion Include="Tulpep.ActiveDirectoryObjectPicker" Version="3.0.11" />
     <PackageVersion Include="WinUIEx" Version="2.5.1" />
-    <PackageVersion Include="Vanara.Windows.Extensions" Version="4.0.4" />
-    <PackageVersion Include="Vanara.Windows.Shell" Version="4.0.4" />
+    <PackageVersion Include="Vanara.Windows.Extensions" Version="4.0.5" />
+    <PackageVersion Include="Vanara.Windows.Shell" Version="4.0.5" />
     <PackageVersion Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Management.Infrastructure.Runtime.Win" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
@@ -45,13 +45,13 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.1" />
-    <PackageVersion Include="System.IO.Hashing" Version="9.0.1" />
-    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.2" />
+    <PackageVersion Include="System.IO.Hashing" Version="9.0.2" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.2" />
     <PackageVersion Include="Appium.WebDriver" Version="4.4.5" />
     <PackageVersion Include="Axe.Windows" Version="2.4.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.7.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.8.2" />
   </ItemGroup>
 </Project>

--- a/src/Files.App.Controls/BladeView/BladeItem.Properties.cs
+++ b/src/Files.App.Controls/BladeView/BladeItem.Properties.cs
@@ -17,19 +17,14 @@ namespace Files.App.Controls
 	public partial class BladeItem
 	{
 		/// <summary>
-		/// Identifies the <see cref="TitleBarVisibility"/> dependency property.
-		/// </summary>
-		public static readonly DependencyProperty TitleBarVisibilityProperty = DependencyProperty.Register(nameof(TitleBarVisibility), typeof(Visibility), typeof(BladeItem), new PropertyMetadata(default(Visibility)));
-
-		/// <summary>
-		/// Identifies the <see cref="TitleBarBackground"/> dependency property.
-		/// </summary>
-		public static readonly DependencyProperty TitleBarBackgroundProperty = DependencyProperty.Register(nameof(TitleBarBackground), typeof(Brush), typeof(BladeItem), new PropertyMetadata(default(Brush)));
-
-		/// <summary>
 		/// Identifies the <see cref="CloseButtonBackground"/> dependency property.
 		/// </summary>
 		public static readonly DependencyProperty CloseButtonBackgroundProperty = DependencyProperty.Register(nameof(CloseButtonBackground), typeof(Brush), typeof(BladeItem), new PropertyMetadata(default(Brush)));
+
+		/// <summary>
+		/// Identifies the <see cref="CloseButtonVisibility"/> dependency property.
+		/// </summary>
+		public static readonly DependencyProperty CloseButtonVisibilityProperty = DependencyProperty.Register(nameof(CloseButtonVisibility), typeof(Visibility), typeof(BladeItem), new PropertyMetadata(default(Visibility)));
 
 		/// <summary>
 		/// Identifies the <see cref="IsOpen"/> dependency property.
@@ -53,21 +48,12 @@ namespace Files.App.Controls
 		}
 
 		/// <summary>
-		/// Gets or sets the visibility of the title bar for this blade
+		/// Gets or sets the visibility of the close button
 		/// </summary>
-		public Visibility TitleBarVisibility
+		public Visibility CloseButtonVisibility
 		{
-			get { return (Visibility)GetValue(TitleBarVisibilityProperty); }
-			set { SetValue(TitleBarVisibilityProperty, value); }
-		}
-
-		/// <summary>
-		/// Gets or sets the background color of the title bar
-		/// </summary>
-		public Brush TitleBarBackground
-		{
-			get { return (Brush)GetValue(TitleBarBackgroundProperty); }
-			set { SetValue(TitleBarBackgroundProperty, value); }
+			get { return (Visibility)GetValue(CloseButtonVisibilityProperty); }
+			set { SetValue(CloseButtonVisibilityProperty, value); }
 		}
 
 		/// <summary>

--- a/src/Files.App.Controls/BladeView/BladeItem.cs
+++ b/src/Files.App.Controls/BladeView/BladeItem.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using CommunityToolkit.WinUI;
 using Microsoft.UI.Xaml.Automation.Peers;
-using Microsoft.UI.Xaml.Automation;
 
 namespace Files.App.Controls
 {
@@ -11,24 +9,15 @@ namespace Files.App.Controls
 	/// The Blade is used as a child in the BladeView
 	/// </summary>
 	[TemplatePart(Name = "CloseButton", Type = typeof(Button))]
-	[TemplatePart(Name = "EnlargeButton", Type = typeof(Button))]
-	public partial class BladeItem : Expander
+	public partial class BladeItem : ContentControl
 	{
 		private Button _closeButton;
-		private Button _enlargeButton;
-		private double _normalModeWidth;
-		private bool _loaded = false;
-
 		/// <summary>
 		/// Initializes a new instance of the <see cref="BladeItem"/> class.
 		/// </summary>
 		public BladeItem()
 		{
 			DefaultStyleKey = typeof(BladeItem);
-
-			SizeChanged += OnSizeChanged;
-			Expanding += OnExpanding;
-			Collapsed += OnCollapsed;
 		}
 
 		/// <summary>
@@ -36,10 +25,9 @@ namespace Files.App.Controls
 		/// </summary>
 		protected override void OnApplyTemplate()
 		{
-			_loaded = true;
+			base.OnApplyTemplate();
 
 			_closeButton = GetTemplateChild("CloseButton") as Button;
-			_enlargeButton = GetTemplateChild("EnlargeButton") as Button;
 
 			if (_closeButton == null)
 			{
@@ -48,43 +36,7 @@ namespace Files.App.Controls
 
 			_closeButton.Click -= CloseButton_Click;
 			_closeButton.Click += CloseButton_Click;
-
-			if (_enlargeButton == null)
-			{
-				return;
-			}
-
-			_enlargeButton.Click -= EnlargeButton_Click;
-			_enlargeButton.Click += EnlargeButton_Click;
 		}
-
-		/// <inheritdoc/>
-		private void OnExpanding(Expander sender, ExpanderExpandingEventArgs args)
-		{
-			if (_loaded)
-			{
-				Width = _normalModeWidth;
-				VisualStateManager.GoToState(this, "Expanded", true);
-				if (_enlargeButton != null)
-				{
-					AutomationProperties.SetName(_enlargeButton, "Expand Blade Item");
-				}
-			}
-		}
-
-		/// <inheritdoc/>
-		private void OnCollapsed(Expander sender, ExpanderCollapsedEventArgs args)
-		{
-			if (_loaded)
-			{
-				Width = double.NaN;
-				if (_enlargeButton != null)
-				{
-					AutomationProperties.SetName(_enlargeButton, "Collapse Blade Item");
-				}
-			}
-		}
-
 		/// <summary>
 		/// Creates AutomationPeer (<see cref="UIElement.OnCreateAutomationPeer"/>)
 		/// </summary>
@@ -94,22 +46,9 @@ namespace Files.App.Controls
 			return new BladeItemAutomationPeer(this);
 		}
 
-		private void OnSizeChanged(object sender, SizeChangedEventArgs sizeChangedEventArgs)
-		{
-			if (IsExpanded)
-			{
-				_normalModeWidth = Width;
-			}
-		}
-
 		private void CloseButton_Click(object sender, RoutedEventArgs e)
 		{
 			IsOpen = false;
-		}
-
-		private void EnlargeButton_Click(object sender, RoutedEventArgs e)
-		{
-			IsExpanded = !IsExpanded;
 		}
 	}
 }

--- a/src/Files.App.Controls/BladeView/BladeItemAutomationPeer.cs
+++ b/src/Files.App.Controls/BladeView/BladeItemAutomationPeer.cs
@@ -75,12 +75,6 @@ namespace Files.App.Controls
 				return name;
 			}
 
-			name = this.OwnerBladeItem.Header?.ToString();
-			if (!string.IsNullOrEmpty(name))
-			{
-				return name;
-			}
-
 			TextBlock textBlock = this.OwnerBladeItem.FindDescendant<TextBlock>();
 			if (textBlock != null)
 			{

--- a/src/Files.App.Controls/BladeView/BladeView.Properties.cs
+++ b/src/Files.App.Controls/BladeView/BladeView.Properties.cs
@@ -27,11 +27,6 @@ namespace Files.App.Controls
 		public static readonly DependencyProperty BladeModeProperty = DependencyProperty.RegisterAttached(nameof(BladeMode), typeof(BladeMode), typeof(BladeView), new PropertyMetadata(BladeMode.Normal, OnBladeModeChanged));
 
 		/// <summary>
-		///  Identifies the <see cref="AutoCollapseCountThreshold"/> attached property.
-		/// </summary>
-		public static readonly DependencyProperty AutoCollapseCountThresholdProperty = DependencyProperty.RegisterAttached(nameof(AutoCollapseCountThreshold), typeof(int), typeof(BladeView), new PropertyMetadata(int.MaxValue, OnOpenBladesChanged));
-
-		/// <summary>
 		/// Gets or sets a collection of visible blades
 		/// </summary>
 		public IList<BladeItem> ActiveBlades
@@ -47,24 +42,6 @@ namespace Files.App.Controls
 		{
 			get { return (BladeMode)GetValue(BladeModeProperty); }
 			set { SetValue(BladeModeProperty, value); }
-		}
-
-		/// <summary>
-		/// Gets or sets a value indicating what the overflow amount should be to start auto collapsing blade items
-		/// </summary>
-		/// <example>
-		/// For example we put AutoCollapseCountThreshold = 2
-		/// This means that each time a blade is added to the bladeview collection,
-		/// we will validate the amount of added blades that have a title bar visible.
-		/// If this number get's bigger than AutoCollapseCountThreshold, we will collapse all blades but the last one
-		/// </example>
-		/// <remarks>
-		/// We don't touch blade items that have no title bar
-		/// </remarks>
-		public int AutoCollapseCountThreshold
-		{
-			get { return (int)GetValue(AutoCollapseCountThresholdProperty); }
-			set { SetValue(AutoCollapseCountThresholdProperty, value); }
 		}
 
 		private static void OnBladeModeChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)

--- a/src/Files.App.Controls/BladeView/BladeView.cs
+++ b/src/Files.App.Controls/BladeView/BladeView.cs
@@ -105,19 +105,6 @@ namespace Files.App.Controls
 					}
 				}
 			}
-
-			// For now we skip this feature when blade mode is set to fullscreen
-			if (AutoCollapseCountThreshold > 0 && BladeMode != BladeMode.Fullscreen && ActiveBlades.Any())
-			{
-				var openBlades = ActiveBlades.Where(item => item.TitleBarVisibility == Visibility.Visible).ToList();
-				if (openBlades.Count > AutoCollapseCountThreshold)
-				{
-					for (int i = 0; i < openBlades.Count - 1; i++)
-					{
-						openBlades[i].IsExpanded = false;
-					}
-				}
-			}
 		}
 
 		private BladeItem GetBladeItem(object item)
@@ -161,12 +148,6 @@ namespace Files.App.Controls
 
 			BladeClosed?.Invoke(this, blade);
 			ActiveBlades.Remove(blade);
-
-			var lastBlade = ActiveBlades.LastOrDefault();
-			if (lastBlade != null && lastBlade.TitleBarVisibility == Visibility.Visible)
-			{
-				lastBlade.IsExpanded = true;
-			}
 		}
 
 		private ScrollViewer GetScrollViewer()

--- a/src/Files.App.Controls/BladeView/BladeView.xaml
+++ b/src/Files.App.Controls/BladeView/BladeView.xaml
@@ -88,7 +88,6 @@
 		<Setter Property="CloseButtonForeground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
 		<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
 		<Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
-		<Setter Property="TitleBarBackground" Value="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" />
 		<Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
 		<Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
 		<Setter Property="TabNavigation" Value="Local" />
@@ -102,18 +101,7 @@
 		<Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
 		<Setter Property="BorderThickness" Value="1" />
 		<Setter Property="IsTabStop" Value="False" />
-		<Setter Property="IsExpanded" Value="True" />
 		<Setter Property="Width" Value="320" />
-		<Setter Property="HeaderTemplate">
-			<Setter.Value>
-				<DataTemplate>
-					<TextBlock
-						Margin="12,7,0,9"
-						VerticalAlignment="Center"
-						Text="{Binding}" />
-				</DataTemplate>
-			</Setter.Value>
-		</Setter>
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="controls:BladeItem">
@@ -121,70 +109,24 @@
 						Width="{TemplateBinding Width}"
 						BorderBrush="{TemplateBinding BorderBrush}"
 						BorderThickness="{TemplateBinding BorderThickness}">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto" />
-							<RowDefinition Height="*" />
-						</Grid.RowDefinitions>
-
-						<Grid
-							Height="32"
-							Background="{TemplateBinding TitleBarBackground}"
-							Visibility="{TemplateBinding TitleBarVisibility}">
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition Width="*" />
-								<ColumnDefinition Width="Auto" />
-								<ColumnDefinition Width="Auto" />
-							</Grid.ColumnDefinitions>
-
-							<ContentPresenter
-								x:Name="TitleBar"
-								Content="{TemplateBinding Header}"
-								ContentTemplate="{TemplateBinding HeaderTemplate}" />
-							<Button
-								Name="EnlargeButton"
-								Grid.Column="1"
-								HorizontalAlignment="Right"
-								VerticalAlignment="Stretch"
-								Background="{TemplateBinding CloseButtonBackground}"
-								BorderThickness="1"
-								Content="&#xE73F;"
-								FontFamily="Segoe MDL2 Assets"
-								FontSize="14"
-								Foreground="{TemplateBinding CloseButtonForeground}"
-								Style="{StaticResource ButtonRevealStyle}"
-								TabIndex="0" />
-							<Button
-								Name="CloseButton"
-								Grid.Column="2"
-								HorizontalAlignment="Right"
-								VerticalAlignment="Stretch"
-								Background="{TemplateBinding CloseButtonBackground}"
-								BorderThickness="1"
-								Content="&#xE711;"
-								FontFamily="Segoe MDL2 Assets"
-								FontSize="14"
-								Foreground="{TemplateBinding CloseButtonForeground}"
-								Style="{StaticResource ButtonRevealStyle}"
-								TabIndex="0" />
-						</Grid>
-
 						<ContentPresenter
 							x:Name="ContentPresenter"
-							Grid.Row="1"
 							VerticalAlignment="Stretch"
-							Background="{TemplateBinding Background}"
-							Visibility="{TemplateBinding IsOpen}" />
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="ExpandedStates">
-								<VisualState x:Name="Expanded" />
-								<VisualState x:Name="Collapsed">
-									<VisualState.Setters>
-										<Setter Target="ContentPresenter.Visibility" Value="Collapsed" />
-										<Setter Target="EnlargeButton.Content" Value="&#xE740;" />
-									</VisualState.Setters>
-								</VisualState>
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
+							Background="{TemplateBinding Background}" />
+
+						<Button
+							Name="CloseButton"
+							HorizontalAlignment="Right"
+							VerticalAlignment="Top"
+							Background="{TemplateBinding CloseButtonBackground}"
+							BorderThickness="1"
+							Content="&#xE711;"
+							FontFamily="Segoe MDL2 Assets"
+							FontSize="14"
+							Foreground="{TemplateBinding CloseButtonForeground}"
+							Style="{StaticResource ButtonRevealStyle}"
+							Visibility="{TemplateBinding CloseButtonVisibility}"
+							TabIndex="0" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>

--- a/src/Files.App/Views/Layouts/ColumnsLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/ColumnsLayoutPage.xaml
@@ -21,7 +21,7 @@
 	<local:BaseLayoutPage.Resources>
 		<Style TargetType="controls:BladeItem">
 			<Setter Property="Background" Value="Transparent" />
-			<Setter Property="TitleBarVisibility" Value="Collapsed" />
+			<Setter Property="CloseButtonVisibility" Value="Collapsed" />
 			<Setter Property="BorderThickness" Value="0,0,1,0" />
 			<Setter Property="BorderBrush" Value="{ThemeResource DividerStrokeColorDefaultBrush}" />
 			<Setter Property="Width" Value="300" />


### PR DESCRIPTION
`Expander` is buggy and its `OnApplyTemplate` is not usable. Retarget it to `ContentControl` and remove the unused titlebar and expand (enlarge) features.

Resolves the missing styles and crashing issue.