### PR TITLE
Fix: Fixed error dialog from appearing after updates

### DIFF
--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -6,7 +6,9 @@ using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
+using System.IO;
 using System.Runtime.InteropServices;
+using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Storage;
 using IO = System.IO;
@@ -63,7 +65,8 @@ namespace Files.App
 				case ILaunchActivatedEventArgs launchArgs:
 					if (launchArgs.Arguments is not null &&
 						(CommandLineParser.SplitArguments(launchArgs.Arguments, true)[0].EndsWith($"files-dev.exe", StringComparison.OrdinalIgnoreCase)
-						|| CommandLineParser.SplitArguments(launchArgs.Arguments, true)[0].EndsWith($"files-dev", StringComparison.OrdinalIgnoreCase)))
+						|| CommandLineParser.SplitArguments(launchArgs.Arguments, true)[0].EndsWith($"files-dev", StringComparison.OrdinalIgnoreCase)
+						|| CommandLineParser.SplitArguments(launchArgs.Arguments, true)[0].Equals(Path.Join(Package.Current.InstalledLocation.Path, "Files.App", "Files.exe"), StringComparison.OrdinalIgnoreCase)))
 					{
 						// WINUI3: When launching from commandline the argument is not ICommandLineActivatedEventArgs (#10370)
 						var ppm = CommandLineParser.ParseUntrustedCommands(launchArgs.Arguments);

--- a/src/Files.App/Utils/CommandLine/CommandLineParser.cs
+++ b/src/Files.App/Utils/CommandLine/CommandLineParser.cs
@@ -17,7 +17,7 @@ namespace Files.App.Utils.CommandLine
 		/// <returns>A collection of parsed command.</returns>
 		public static ParsedCommands ParseUntrustedCommands(string cmdLineString)
 		{
-			var parsedArgs = Parse(SplitArguments(cmdLineString, true));
+			var parsedArgs = Parse(SplitArguments(cmdLineString.TrimEnd(), true));
 
 			return ParseSplitArguments(parsedArgs);
 		}


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #16707

**explanation**
The LaunchArgs are evaluated [here](https://github.com/files-community/Files/blob/2382d8168350939dd59522287beadab09dce9bed/src/Files.App/MainWindow.xaml.cs#L65) when Files is started. Here an explicit check is made for files-dev.exe or files-dev. (Or, depending on the environment, for files-stable, ...)

After the update, however, files-dev.exe is not called from the %localappdata%\Microsoft\WindowsApps folder, but rather Files.exe is called directly from the C:\Program Files\WindowsApps\<AppDirectory>\ folder.
Example: “C:\Program Files\WindowsApps\FilesPreview_3.8.0.0_x64__cnsc1k9bd01st\Files.App\Files.exe”
Since there is also a space at the end of the LaunchArgs, the TrimEnd is required so that no additional empty tab is opened.

![image](https://github.com/user-attachments/assets/a0062afb-6704-4a86-9b66-87f91586347c)


**Steps used to test these changes**
For testing I built two Files versions locally and customized the Updater class to use the local msix packages. Code can be found [here](https://github.com/marcofranzen99/Files/commit/004beab59e447a69d34f153a45ac42d756a62bf1)

After the update, Files is now started and no additional tab is opened.
