### PR TITLE
Fix: Fixed issue where the Recycle Bin was sometimes unpinned

### DIFF
--- a/src/Files.App/Services/Windows/WindowsQuickAccessService.cs
+++ b/src/Files.App/Services/Windows/WindowsQuickAccessService.cs
@@ -26,7 +26,12 @@ namespace Files.App.Services
 		private async Task PinToSidebarAsync(string[] folderPaths, bool doUpdateQuickAccessWidget)
 		{
 			foreach (string folderPath in folderPaths)
-				await ContextMenu.InvokeVerb("pintohome", [folderPath]);
+			{
+				// make sure that the item has not yet been pinned
+				// the verb 'pintohome' is for both adding and removing
+				if (!IsItemPinned(folderPath))
+					await ContextMenu.InvokeVerb("pintohome", folderPath);
+			}
 
 			await App.QuickAccessManager.Model.LoadAsync();
 			if (doUpdateQuickAccessWidget)

--- a/src/Files.App/Utils/Global/QuickAccessManager.cs
+++ b/src/Files.App/Utils/Global/QuickAccessManager.cs
@@ -42,11 +42,10 @@ namespace Files.App.Utils
 		public async Task InitializeAsync()
 		{
 			PinnedItemsModified += Model.LoadAsync;
+			await Model.LoadAsync();
 
 			if (!Model.PinnedFolders.Contains(Constants.UserEnvironmentPaths.RecycleBinPath) && AppLifecycleHelper.IsFirstRun)
 				await QuickAccessService.PinToSidebarAsync(Constants.UserEnvironmentPaths.RecycleBinPath);
-
-			await Model.LoadAsync();
 		}
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #16676

**Steps used to test these changes**

1. Uninstalled Files Dev
2. Pinned `Shell:RecycleBinFolder` via File Explorer
3. Installed Files Dev (Launched with Visual Studio)
4. Checked that `Shell:RecycleBinFolder` is still pinned

Additionally i have checked that `Shell:RecycleBinFolder` gets pinned at the first start of Files and that pinning/unpinning of folders via the context menu still works