### PR TITLE
Code Quality: Update localization to use centralized Strings class 4

### DIFF
--- a/src/Files.App/Actions/Content/Archives/Compress/CompressIntoArchiveAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Compress/CompressIntoArchiveAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 	internal sealed partial class CompressIntoArchiveAction : BaseCompressArchiveAction
 	{
 		public override string Label
-			=> "CreateArchive".GetLocalizedResource();
+			=> Strings.CreateArchive.GetLocalizedResource();
 
 		public override string Description
-			=> "CompressIntoArchiveDescription".GetLocalizedResource();
+			=> Strings.CompressIntoArchiveDescription.GetLocalizedResource();
 
 		public CompressIntoArchiveAction()
 		{

--- a/src/Files.App/Actions/Content/Archives/Compress/CompressIntoSevenZipAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Compress/CompressIntoSevenZipAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CompressIntoSevenZipAction : BaseCompressArchiveAction
 	{
 		public override string Label
-			=> string.Format("CreateNamedArchive".GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.7z");
+			=> string.Format(Strings.CreateNamedArchive.GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.7z");
 
 		public override string Description
-			=> "CompressIntoSevenZipDescription".GetLocalizedResource();
+			=> Strings.CompressIntoSevenZipDescription.GetLocalizedResource();
 
 		public CompressIntoSevenZipAction()
 		{

--- a/src/Files.App/Actions/Content/Archives/Compress/CompressIntoZipAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Compress/CompressIntoZipAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CompressIntoZipAction : BaseCompressArchiveAction
 	{
 		public override string Label
-			=> string.Format("CreateNamedArchive".GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.zip");
+			=> string.Format(Strings.CreateNamedArchive.GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.zip");
 
 		public override string Description
-			=> "CompressIntoZipDescription".GetLocalizedResource();
+			=> Strings.CompressIntoZipDescription.GetLocalizedResource();
 
 		public CompressIntoZipAction()
 		{

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
@@ -14,10 +14,10 @@ namespace Files.App.Actions
 	internal sealed partial class DecompressArchive : BaseDecompressArchiveAction
 	{
 		public override string Label
-			=> "ExtractFiles".GetLocalizedResource();
+			=> Strings.ExtractFiles.GetLocalizedResource();
 
 		public override string Description
-			=> "DecompressArchiveDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveDescription.GetLocalizedResource();
 
 		public override HotKey HotKey
 			=> new(Keys.E, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHere.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHere.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class DecompressArchiveHere : BaseDecompressArchiveAction
 	{
 		public override string Label
-			=> "ExtractHere".GetLocalizedResource();
+			=> Strings.ExtractHere.GetLocalizedResource();
 
 		public override string Description
-			=> "DecompressArchiveHereDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveHereDescription.GetLocalizedResource();
 
 		public DecompressArchiveHere()
 		{

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHereSmart.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHereSmart.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class DecompressArchiveHereSmart : BaseDecompressArchiveAction
 	{
 		public override string Label
-			=> "ExtractHereSmart".GetLocalizedResource();
+			=> Strings.ExtractHereSmart.GetLocalizedResource();
 
 		public override string Description
-			=> "DecompressArchiveHereSmartDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveHereSmartDescription.GetLocalizedResource();
 
 		public override HotKey HotKey
 			=> new(Keys.E, KeyModifiers.CtrlShift);

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveToChildFolderAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveToChildFolderAction.cs
@@ -15,7 +15,7 @@ namespace Files.App.Actions
 			=> ComputeLabel();
 
 		public override string Description
-			=> "DecompressArchiveToChildFolderDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveToChildFolderDescription.GetLocalizedResource();
 
 		public DecompressArchiveToChildFolderAction()
 		{
@@ -86,11 +86,11 @@ namespace Files.App.Actions
 		private string ComputeLabel()
 		{
 			if (context.SelectedItems == null || context.SelectedItems.Count == 0)
-				return string.Format("BaseLayoutItemContextFlyoutExtractToChildFolder".GetLocalizedResource(), string.Empty);
+				return string.Format(Strings.BaseLayoutItemContextFlyoutExtractToChildFolder.GetLocalizedResource(), string.Empty);
 
 			return context.SelectedItems.Count > 1
-				? string.Format("BaseLayoutItemContextFlyoutExtractToChildFolder".GetLocalizedResource(), "*")
-				: string.Format("BaseLayoutItemContextFlyoutExtractToChildFolder".GetLocalizedResource(), SystemIO.Path.GetFileNameWithoutExtension(context.SelectedItems.First().Name));
+				? string.Format(Strings.BaseLayoutItemContextFlyoutExtractToChildFolder.GetLocalizedResource(), "*")
+				: string.Format(Strings.BaseLayoutItemContextFlyoutExtractToChildFolder.GetLocalizedResource(), SystemIO.Path.GetFileNameWithoutExtension(context.SelectedItems.First().Name));
 		}
 	}
 }


### PR DESCRIPTION
## Code Quality: Refactor Localization Strings in Archive Compression and Decompression Actions

This pull request aims to improve code quality and maintainability in the Files App by centralizing localization strings for archive compression and decompression actions. The changes replace direct string literals with references to a new `Strings` class, enhancing consistency and streamlining future updates and localization efforts.

Closes #16718 

### Changes Made

- Created a new `Strings` class to centralize localization strings for archive-related actions.
- Refactored localization strings in the following actions:
    - `CompressIntoArchiveAction`
    - `CompressIntoSevenZipAction`
    - `CompressIntoZipAction`
    - `DecompressArchive`
    - `DecompressArchiveHere`
    - `DecompressArchiveHereSmart`
    - `DecompressArchiveToChildFolderAction`
- Updated the `ComputeLabel` method in `DecompressArchiveToChildFolderAction` for consistent localization.
- Replaced string literals with corresponding string constants throughout the affected classes.


### Benefits

- Improved maintainability: All archive-related strings are now managed in one place.
- Enhanced consistency across the application.
- Reduced likelihood of typos and errors in localization.
- Improved code readability.
- Streamlined future updates and localization efforts for archive-related actions.


### Testing Steps

1. Open Files App.
2. Locate or create archive files (zip, 7z, etc.) for testing.
3. Right-click on files/folders and check the compression options (Compress, Compress to ZIP, Compress to 7z).
4. Right-click on archive files and verify all decompression options (Extract, Extract Here, Extract to [ArchiveName]).
5. Perform compression and decompression actions to ensure functionality and correct string display.
6. Change the application language in settings and repeat steps 3-5 to verify localization.
7. Check for any visual inconsistencies or errors in the displayed strings.
8. Verify that the `ComputeLabel` method in `DecompressArchiveToChildFolderAction` works correctly for different archive types.

### Additional Notes

- This change does not alter any functionality but improves code maintainability for archive-related actions.
- Code reviewers should ensure all string literals in the affected classes have been replaced with references to the new `Strings` class.
- Special attention should be given to the `ComputeLabel` method in `DecompressArchiveToChildFolderAction` to ensure it handles different archive types correctly.
- Verify that the changes do not introduce any regression in existing archive compression and decompression functionality.