### PR TITLE
Code Quality: Update localization to use centralized Strings class 5

### DIFF
--- a/src/Files.App/Actions/Content/Archives/Compress/CompressIntoArchiveAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Compress/CompressIntoArchiveAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 	internal sealed partial class CompressIntoArchiveAction : BaseCompressArchiveAction
 	{
 		public override string Label
-			=> "CreateArchive".GetLocalizedResource();
+			=> Strings.CreateArchive.GetLocalizedResource();
 
 		public override string Description
-			=> "CompressIntoArchiveDescription".GetLocalizedResource();
+			=> Strings.CompressIntoArchiveDescription.GetLocalizedResource();
 
 		public CompressIntoArchiveAction()
 		{

--- a/src/Files.App/Actions/Content/Archives/Compress/CompressIntoSevenZipAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Compress/CompressIntoSevenZipAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CompressIntoSevenZipAction : BaseCompressArchiveAction
 	{
 		public override string Label
-			=> string.Format("CreateNamedArchive".GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.7z");
+			=> string.Format(Strings.CreateNamedArchive.GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.7z");
 
 		public override string Description
-			=> "CompressIntoSevenZipDescription".GetLocalizedResource();
+			=> Strings.CompressIntoSevenZipDescription.GetLocalizedResource();
 
 		public CompressIntoSevenZipAction()
 		{

--- a/src/Files.App/Actions/Content/Archives/Compress/CompressIntoZipAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Compress/CompressIntoZipAction.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class CompressIntoZipAction : BaseCompressArchiveAction
 	{
 		public override string Label
-			=> string.Format("CreateNamedArchive".GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.zip");
+			=> string.Format(Strings.CreateNamedArchive.GetLocalizedResource(), $"{StorageArchiveService.GenerateArchiveNameFromItems(context.SelectedItems)}.zip");
 
 		public override string Description
-			=> "CompressIntoZipDescription".GetLocalizedResource();
+			=> Strings.CompressIntoZipDescription.GetLocalizedResource();
 
 		public CompressIntoZipAction()
 		{

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
@@ -14,10 +14,10 @@ namespace Files.App.Actions
 	internal sealed partial class DecompressArchive : BaseDecompressArchiveAction
 	{
 		public override string Label
-			=> "ExtractFiles".GetLocalizedResource();
+			=> Strings.ExtractFiles.GetLocalizedResource();
 
 		public override string Description
-			=> "DecompressArchiveDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveDescription.GetLocalizedResource();
 
 		public override HotKey HotKey
 			=> new(Keys.E, KeyModifiers.Ctrl);

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHere.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHere.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class DecompressArchiveHere : BaseDecompressArchiveAction
 	{
 		public override string Label
-			=> "ExtractHere".GetLocalizedResource();
+			=> Strings.ExtractHere.GetLocalizedResource();
 
 		public override string Description
-			=> "DecompressArchiveHereDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveHereDescription.GetLocalizedResource();
 
 		public DecompressArchiveHere()
 		{

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHereSmart.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveHereSmart.cs
@@ -6,10 +6,10 @@ namespace Files.App.Actions
 	internal sealed partial class DecompressArchiveHereSmart : BaseDecompressArchiveAction
 	{
 		public override string Label
-			=> "ExtractHereSmart".GetLocalizedResource();
+			=> Strings.ExtractHereSmart.GetLocalizedResource();
 
 		public override string Description
-			=> "DecompressArchiveHereSmartDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveHereSmartDescription.GetLocalizedResource();
 
 		public override HotKey HotKey
 			=> new(Keys.E, KeyModifiers.CtrlShift);

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveToChildFolderAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveToChildFolderAction.cs
@@ -15,7 +15,7 @@ namespace Files.App.Actions
 			=> ComputeLabel();
 
 		public override string Description
-			=> "DecompressArchiveToChildFolderDescription".GetLocalizedResource();
+			=> Strings.DecompressArchiveToChildFolderDescription.GetLocalizedResource();
 
 		public DecompressArchiveToChildFolderAction()
 		{
@@ -86,11 +86,11 @@ namespace Files.App.Actions
 		private string ComputeLabel()
 		{
 			if (context.SelectedItems == null || context.SelectedItems.Count == 0)
-				return string.Format("BaseLayoutItemContextFlyoutExtractToChildFolder".GetLocalizedResource(), string.Empty);
+				return string.Format(Strings.BaseLayoutItemContextFlyoutExtractToChildFolder.GetLocalizedResource(), string.Empty);
 
 			return context.SelectedItems.Count > 1
-				? string.Format("BaseLayoutItemContextFlyoutExtractToChildFolder".GetLocalizedResource(), "*")
-				: string.Format("BaseLayoutItemContextFlyoutExtractToChildFolder".GetLocalizedResource(), SystemIO.Path.GetFileNameWithoutExtension(context.SelectedItems.First().Name));
+				? string.Format(Strings.BaseLayoutItemContextFlyoutExtractToChildFolder.GetLocalizedResource(), "*")
+				: string.Format(Strings.BaseLayoutItemContextFlyoutExtractToChildFolder.GetLocalizedResource(), SystemIO.Path.GetFileNameWithoutExtension(context.SelectedItems.First().Name));
 		}
 	}
 }

--- a/src/Files.App/Actions/Content/Background/BaseSetAsAction.cs
+++ b/src/Files.App/Actions/Content/Background/BaseSetAsAction.cs
@@ -34,9 +34,9 @@ namespace Files.App.Actions
 		{
 			var errorDialog = new ContentDialog()
 			{
-				Title = "FailedToSetBackground".GetLocalizedResource(),
+				Title = Strings.FailedToSetBackground.GetLocalizedResource(),
 				Content = message,
-				PrimaryButtonText = "OK".GetLocalizedResource(),
+				PrimaryButtonText = Strings.OK.GetLocalizedResource(),
 			};
 
 			if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))

--- a/src/Files.App/Actions/Content/Background/SetAsAppBackgroundAction.cs
+++ b/src/Files.App/Actions/Content/Background/SetAsAppBackgroundAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 		private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 
 		public override string Label
-			=> "SetAsAppBackground".GetLocalizedResource();
+			=> Strings.SetAsAppBackground.GetLocalizedResource();
 
 		public override string Description
-			=> "SetAsAppBackgroundDescription".GetLocalizedResource();
+			=> Strings.SetAsAppBackgroundDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new("\uE91B");

--- a/src/Files.App/Actions/Content/Background/SetAsLockscreenBackgroundAction.cs
+++ b/src/Files.App/Actions/Content/Background/SetAsLockscreenBackgroundAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IWindowsWallpaperService WindowsWallpaperService = Ioc.Default.GetRequiredService<IWindowsWallpaperService>();
 
 		public override string Label
-			=> "SetAsLockscreen".GetLocalizedResource();
+			=> Strings.SetAsLockscreen.GetLocalizedResource();
 
 		public override string Description
-			=> "SetAsLockscreenBackgroundDescription".GetLocalizedResource();
+			=> Strings.SetAsLockscreenBackgroundDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new("\uEE3F");

--- a/src/Files.App/Actions/Content/Background/SetAsSlideshowBackgroundAction.cs
+++ b/src/Files.App/Actions/Content/Background/SetAsSlideshowBackgroundAction.cs
@@ -10,10 +10,10 @@ namespace Files.App.Actions
 		private readonly IWindowsWallpaperService WindowsWallpaperService = Ioc.Default.GetRequiredService<IWindowsWallpaperService>();
 
 		public override string Label
-			=> "SetAsSlideshow".GetLocalizedResource();
+			=> Strings.SetAsSlideshow.GetLocalizedResource();
 
 		public override string Description
-			=> "SetAsSlideshowBackgroundDescription".GetLocalizedResource();
+			=> Strings.SetAsSlideshowBackgroundDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new("\uE91B");

--- a/src/Files.App/Actions/Content/Background/SetAsWallpaperBackgroundAction.cs
+++ b/src/Files.App/Actions/Content/Background/SetAsWallpaperBackgroundAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 	internal sealed partial class SetAsWallpaperBackgroundAction : BaseSetAsAction
 	{
 		public override string Label
-			=> "SetAsBackground".GetLocalizedResource();
+			=> Strings.SetAsBackground.GetLocalizedResource();
 
 		public override string Description
-			=> "SetAsWallpaperBackgroundDescription".GetLocalizedResource();
+			=> Strings.SetAsWallpaperBackgroundDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new("\uE91B");

--- a/src/Files.App/Actions/Content/ImageManipulation/RotateLeftAction.cs
+++ b/src/Files.App/Actions/Content/ImageManipulation/RotateLeftAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 	internal sealed partial class RotateLeftAction : BaseRotateAction
 	{
 		public override string Label
-			=> "RotateLeft".GetLocalizedResource();
+			=> Strings.RotateLeft.GetLocalizedResource();
 
 		public override string Description
-			=> "RotateLeftDescription".GetLocalizedResource();
+			=> Strings.RotateLeftDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.ImageRotate.ACW");

--- a/src/Files.App/Actions/Content/ImageManipulation/RotateRightAction.cs
+++ b/src/Files.App/Actions/Content/ImageManipulation/RotateRightAction.cs
@@ -8,10 +8,10 @@ namespace Files.App.Actions
 	internal sealed partial class RotateRightAction : BaseRotateAction
 	{
 		public override string Label
-			=> "RotateRight".GetLocalizedResource();
+			=> Strings.RotateRight.GetLocalizedResource();
 
 		public override string Description
-			=> "RotateRightDescription".GetLocalizedResource();
+			=> Strings.RotateRightDescription.GetLocalizedResource();
 
 		public override RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.ImageRotate.CW");


### PR DESCRIPTION
This pull request refactors localization strings in several action classes within the `Files.App.Actions` namespace, replacing hardcoded string literals with references to a centralized `Strings` class. The changes improve maintainability and enhance localization support across the application.

#16718 

## Changes Made

- Created a centralized `Strings` class for managing localization strings.
- Refactored localization strings in the following action classes:
  - `SetAsAppBackgroundAction`
  - `SetAsLockscreenBackgroundAction`
  - `SetAsSlideshowBackgroundAction`
  - `SetAsWallpaperBackgroundAction`
  - `RotateLeftAction`
  - `RotateRightAction`
- Updated error messages, labels, and descriptions to use the new `Strings` class.

## Benefits

- Improved maintainability: All localization strings are now managed in one place.
- Enhanced consistency across the application.
- Simplified future updates and localization efforts.
- Reduced risk of typos and errors in localized strings.

## Testing Steps

1. Open the Files App.
2. Navigate to image files and test the following actions:
   - Set as app background
   - Set as lock screen background
   - Set as slideshow background
   - Set as wallpaper background
   - Rotate left
   - Rotate right
3. Verify that all labels, descriptions, and error messages are displayed correctly.
4. Change the application language in settings and repeat steps 2-3 to ensure proper localization.
5. Check for any visual inconsistencies or errors in the displayed strings.

## Additional Notes

- This change does not alter any functionality but improves code maintainability for the affected action classes.
- Code reviewers should ensure all string literals in the mentioned classes have been replaced with references to the new `Strings` class.
- Verify that the changes do not introduce any regression in existing image-related actions.
