### PR TITLE
Fix: Fixed issue where the "What's new" dialog sometimes used the wrong theme

### DIFF
--- a/src/Files.App/Dialogs/ReleaseNotesDialog.xaml.cs
+++ b/src/Files.App/Dialogs/ReleaseNotesDialog.xaml.cs
@@ -68,6 +68,7 @@ namespace Files.App.Dialogs
 
 		private async void BlogPostWebView_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
 		{
+			BlogPostWebView.CoreWebView2.Profile.PreferredColorScheme = (CoreWebView2PreferredColorScheme)RootAppElement.RequestedTheme;
 			BlogPostWebView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
 			BlogPostWebView.CoreWebView2.Settings.AreDevToolsEnabled = false;
 			BlogPostWebView.CoreWebView2.Settings.AreBrowserAcceleratorKeysEnabled = false;


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #16889

**Steps used to test these changes**
Changed theme within the app several times and opened the What's new dialog to check if the correct theme is used
![image](https://github.com/user-attachments/assets/629c70c1-9c0d-4fbe-b481-74eace4e166e)
