### PR TITLE
Code Quality: Implemented Breadcrumb

### DIFF
--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBar.Properties.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBar.Properties.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using CommunityToolkit.WinUI;
+
+namespace Files.App.Controls
+{
+	public partial class BreadcrumbBar : Control
+	{
+		[GeneratedDependencyProperty]
+		public partial FrameworkElement? RootItem { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial object? ItemsSource { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial object? ItemTemplate { get; set; }
+	}
+}

--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBar.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBar.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml.Automation;
+using Windows.Foundation;
+
+namespace Files.App.Controls
+{
+	public partial class BreadcrumbBar : Control
+	{
+		// Constants
+
+		private const string TemplatePartName_RootBreadcrumbBarItem = "PART_RootBreadcrumbBarItem";
+		private const string TemplatePartName_EllipsisBreadcrumbBarItem = "PART_EllipsisBreadcrumbBarItem";
+		private const string TemplatePartName_MainItemsRepeater = "PART_MainItemsRepeater";
+
+		// Fields
+
+		private readonly BreadcrumbBarLayout _itemsRepeaterLayout;
+
+		private BreadcrumbBarItem? _rootBreadcrumbBarItem;
+		private BreadcrumbBarItem? _ellipsisBreadcrumbBarItem;
+		private BreadcrumbBarItem? _lastBreadcrumbBarItem;
+		private ItemsRepeater? _itemsRepeater;
+
+		private bool _isEllipsisRendered;
+
+		// Properties
+
+		public int IndexAfterEllipsis
+			=> _itemsRepeaterLayout.IndexAfterEllipsis;
+
+		// Events
+
+		public event TypedEventHandler<BreadcrumbBar, BreadcrumbBarItemClickedEventArgs>? ItemClicked;
+		public event EventHandler<BreadcrumbBarItemDropDownFlyoutEventArgs>? ItemDropDownFlyoutOpening;
+		public event EventHandler<BreadcrumbBarItemDropDownFlyoutEventArgs>? ItemDropDownFlyoutClosed;
+
+		// Constructor
+
+		public BreadcrumbBar()
+		{
+			DefaultStyleKey = typeof(BreadcrumbBar);
+
+			_itemsRepeaterLayout = new(this, 2d);
+		}
+
+		// Methods
+
+		protected override void OnApplyTemplate()
+		{
+			base.OnApplyTemplate();
+
+			_rootBreadcrumbBarItem = GetTemplateChild(TemplatePartName_RootBreadcrumbBarItem) as BreadcrumbBarItem
+				?? throw new MissingFieldException($"Could not find {TemplatePartName_RootBreadcrumbBarItem} in the given {nameof(BreadcrumbBar)}'s style.");
+			_ellipsisBreadcrumbBarItem = GetTemplateChild(TemplatePartName_EllipsisBreadcrumbBarItem) as BreadcrumbBarItem
+				?? throw new MissingFieldException($"Could not find {TemplatePartName_EllipsisBreadcrumbBarItem} in the given {nameof(BreadcrumbBar)}'s style.");
+			_itemsRepeater = GetTemplateChild(TemplatePartName_MainItemsRepeater) as ItemsRepeater
+				?? throw new MissingFieldException($"Could not find {TemplatePartName_MainItemsRepeater} in the given {nameof(BreadcrumbBar)}'s style.");
+
+			_rootBreadcrumbBarItem.SetOwner(this);
+			_ellipsisBreadcrumbBarItem.SetOwner(this);
+			_itemsRepeater.Layout = _itemsRepeaterLayout;
+
+			_itemsRepeater.ElementPrepared += ItemsRepeater_ElementPrepared;
+			_itemsRepeater.ItemsSourceView.CollectionChanged += ItemsSourceView_CollectionChanged;
+		}
+
+		internal protected virtual void RaiseItemClickedEvent(BreadcrumbBarItem item)
+		{
+			var index = _itemsRepeater?.GetElementIndex(item) ?? throw new ArgumentNullException($"{_itemsRepeater} is null.");
+			var eventArgs = new BreadcrumbBarItemClickedEventArgs(item, index, item == _rootBreadcrumbBarItem);
+			ItemClicked?.Invoke(this, eventArgs);
+		}
+
+		internal protected virtual void RaiseItemDropDownFlyoutOpening(BreadcrumbBarItem item, MenuFlyout flyout)
+		{
+			var index = _itemsRepeater?.GetElementIndex(item) ?? throw new ArgumentNullException($"{_itemsRepeater} is null.");
+			ItemDropDownFlyoutOpening?.Invoke(this, new(flyout, item, index, item == _rootBreadcrumbBarItem));
+		}
+
+		internal protected virtual void RaiseItemDropDownFlyoutClosed(BreadcrumbBarItem item, MenuFlyout flyout)
+		{
+			var index = _itemsRepeater?.GetElementIndex(item) ?? throw new ArgumentNullException($"{_itemsRepeater} is null.");
+			ItemDropDownFlyoutClosed?.Invoke(this, new(flyout, item, index, item == _rootBreadcrumbBarItem));
+		}
+
+		internal protected virtual void OnLayoutUpdated()
+		{
+			if (_itemsRepeater is null)
+				return;
+
+			_isEllipsisRendered = _itemsRepeaterLayout.EllipsisIsRendered;
+			if (_ellipsisBreadcrumbBarItem is not null)
+				_ellipsisBreadcrumbBarItem.Visibility = _isEllipsisRendered ? Visibility.Visible : Visibility.Collapsed;
+
+			for (int accessibilityIndex = 0, collectionIndex = _itemsRepeaterLayout.IndexAfterEllipsis;
+				accessibilityIndex < _itemsRepeaterLayout.VisibleItemsCount;
+				accessibilityIndex++, collectionIndex++)
+			{
+				if (_itemsRepeater.TryGetElement(collectionIndex) is { } element)
+				{
+					element.SetValue(AutomationProperties.PositionInSetProperty, accessibilityIndex);
+					element.SetValue(AutomationProperties.SizeOfSetProperty, _itemsRepeaterLayout.VisibleItemsCount);
+				}
+			}
+		}
+
+		internal bool TryGetElement(int index, out BreadcrumbBarItem? item)
+		{
+			item = null;
+
+			if (_itemsRepeater is null)
+				return false;
+
+			item = _itemsRepeater.TryGetElement(index) as BreadcrumbBarItem;
+
+			return item is not null;
+		}
+
+		// Event methods
+
+		private void ItemsRepeater_ElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
+		{
+			if (args.Element is not BreadcrumbBarItem item || _itemsRepeater is null)
+				return;
+
+			if (args.Index == _itemsRepeater.ItemsSourceView.Count - 1)
+			{
+				_lastBreadcrumbBarItem = item;
+				_lastBreadcrumbBarItem.IsLastItem = true;
+			}
+
+			item.SetOwner(this);
+		}
+
+		private void ItemsSourceView_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			if (_lastBreadcrumbBarItem is not null)
+				_lastBreadcrumbBarItem.IsLastItem = false;
+
+			if (e.NewItems is not null &&
+				e.NewItems.Count > 0 &&
+				e.NewItems[e.NewItems.Count - 1] is BreadcrumbBarItem item)
+			{
+				_lastBreadcrumbBarItem = item;
+				item.IsLastItem = true;
+			}
+		}
+	}
+}

--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBar.xaml
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBar.xaml
@@ -1,0 +1,303 @@
+<!--  Copyright (c) Files Community. Licensed under the MIT License.  -->
+<ResourceDictionary
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
+	xmlns:local="using:Files.App.Controls">
+
+	<x:Double x:Key="BreadcrumbBarHeight">32</x:Double>
+	<x:Double x:Key="BreadcrumbBarMinWidth">120</x:Double>
+	<x:Double x:Key="BreadcrumbBarEllipsisFontSize">16</x:Double>
+
+	<Thickness x:Key="BreadcrumbBarChevronPadding">4,0</Thickness>
+	<Thickness x:Key="BreadcrumbBarItemPadding">8,0</Thickness>
+	<Thickness x:Key="BreadcrumbBarRootItemPadding">16,0,8,0</Thickness>
+
+	<CornerRadius x:Key="BreadcrumbBarItemCornerRadius">2,2,2,2</CornerRadius>
+	<CornerRadius x:Key="BreadcrumbBarChevronCornerRaduis">2,2,2,2</CornerRadius>
+	<CornerRadius x:Key="BreadcrumbBarRootItemCornerRadius">16,2,2,16</CornerRadius>
+
+	<Style BasedOn="{StaticResource DefaultBreadcrumbBarStyle}" TargetType="local:BreadcrumbBar" />
+	<Style BasedOn="{StaticResource DefaultBreadcrumbBarItemStyle}" TargetType="local:BreadcrumbBarItem" />
+
+	<Style x:Key="DefaultBreadcrumbBarStyle" TargetType="local:BreadcrumbBar">
+		<Setter Property="MinWidth" Value="{StaticResource BreadcrumbBarMinWidth}" />
+		<Setter Property="AutomationProperties.LandmarkType" Value="Navigation" />
+		<Setter Property="IsTabStop" Value="False" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="local:BreadcrumbBar">
+					<Grid
+						MinWidth="{TemplateBinding MinWidth}"
+						ColumnSpacing="2"
+						TabFocusNavigation="Once"
+						XYFocusKeyboardNavigation="Enabled">
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="Auto" />
+							<ColumnDefinition Width="Auto" />
+							<ColumnDefinition Width="*" />
+						</Grid.ColumnDefinitions>
+
+						<local:BreadcrumbBarItem
+							x:Name="PART_RootBreadcrumbBarItem"
+							Grid.Column="0"
+							Padding="{StaticResource BreadcrumbBarRootItemPadding}"
+							AutomationProperties.AccessibilityView="Content"
+							CornerRadius="{StaticResource BreadcrumbBarRootItemCornerRadius}">
+							<ContentPresenter Content="{Binding RootItem, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+						</local:BreadcrumbBarItem>
+
+						<local:BreadcrumbBarItem
+							x:Name="PART_EllipsisBreadcrumbBarItem"
+							Grid.Column="1"
+							AutomationProperties.AccessibilityView="Content"
+							IsEllipsis="True"
+							Visibility="Collapsed">
+							<FontIcon FontSize="{StaticResource BreadcrumbBarEllipsisFontSize}" Glyph="&#xE712;" />
+						</local:BreadcrumbBarItem>
+
+						<ItemsRepeater
+							x:Name="PART_MainItemsRepeater"
+							Grid.Column="2"
+							ItemTemplate="{Binding ItemTemplate, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+							ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="DefaultBreadcrumbBarItemStyle" TargetType="local:BreadcrumbBarItem">
+
+		<Setter Property="Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}" />
+		<Setter Property="Foreground" Value="{ThemeResource BreadcrumbBarForegroundBrush}" />
+		<Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}" />
+		<Setter Property="CornerRadius" Value="{StaticResource BreadcrumbBarItemCornerRadius}" />
+
+		<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+		<Setter Property="FontSize" Value="{ThemeResource BreadcrumbBarItemThemeFontSize}" />
+		<Setter Property="FontWeight" Value="{ThemeResource BreadcrumbBarItemFontWeight}" />
+
+		<Setter Property="Padding" Value="{ThemeResource BreadcrumbBarItemPadding}" />
+		<Setter Property="Height" Value="{ThemeResource BreadcrumbBarHeight}" />
+
+		<Setter Property="HorizontalAlignment" Value="Stretch" />
+		<Setter Property="HorizontalContentAlignment" Value="Center" />
+		<Setter Property="VerticalAlignment" Value="Stretch" />
+		<Setter Property="VerticalContentAlignment" Value="Center" />
+
+		<Setter Property="FocusVisualMargin" Value="1" />
+		<Setter Property="IsTabStop" Value="False" />
+		<Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="local:BreadcrumbBarItem">
+					<Grid
+						x:Name="PART_LayoutRoot"
+						ColumnSpacing="2"
+						TabFocusNavigation="Once"
+						XYFocusKeyboardNavigation="Enabled">
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition x:Name="PART_ContentColumn" Width="Auto" />
+							<ColumnDefinition x:Name="PART_ChevronColumn" Width="Auto" />
+						</Grid.ColumnDefinitions>
+
+						<!--  Clickable Area  -->
+						<Button
+							x:Name="PART_ItemContentButton"
+							Padding="{TemplateBinding Padding}"
+							VerticalAlignment="Stretch"
+							AutomationProperties.AccessibilityView="Raw"
+							Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							BorderThickness="{TemplateBinding BorderThickness}"
+							Control.IsTemplateFocusTarget="True"
+							CornerRadius="{TemplateBinding CornerRadius}"
+							UseSystemFocusVisuals="True">
+							<FlyoutBase.AttachedFlyout>
+								<MenuFlyout
+									x:Name="PART_ItemEllipsisDropDownMenuFlyout"
+									Placement="Bottom"
+									ScrollViewer.VerticalScrollBarVisibility="Auto"
+									ScrollViewer.VerticalScrollMode="Auto">
+									<MenuFlyout.MenuFlyoutPresenterStyle>
+										<Style TargetType="MenuFlyoutPresenter">
+											<Setter Property="MaxHeight" Value="400" />
+											<!--  Workaround for https://github.com/files-community/Files/issues/13078  -->
+											<Setter Target="HighContrastAdjustment" Value="None" />
+										</Style>
+									</MenuFlyout.MenuFlyoutPresenterStyle>
+								</MenuFlyout>
+							</FlyoutBase.AttachedFlyout>
+
+							<ContentPresenter
+								x:Name="PART_ItemContentPresenter"
+								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+								AutomationProperties.AccessibilityView="Raw"
+								Content="{TemplateBinding Content}"
+								ContentTemplate="{TemplateBinding ContentTemplate}"
+								ContentTransitions="{TemplateBinding ContentTransitions}"
+								FontFamily="{TemplateBinding FontFamily}"
+								FontSize="{TemplateBinding FontSize}"
+								FontWeight="{TemplateBinding FontWeight}"
+								Foreground="{ThemeResource BreadcrumbBarForegroundBrush}"
+								TextLineBounds="Tight" />
+
+						</Button>
+
+						<!--  Chevron  -->
+						<Button
+							x:Name="PART_ItemChevronButton"
+							Grid.Column="1"
+							Padding="{StaticResource BreadcrumbBarChevronPadding}"
+							VerticalAlignment="Stretch"
+							AutomationProperties.AccessibilityView="Content"
+							Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							BorderThickness="{TemplateBinding BorderThickness}"
+							CornerRadius="{StaticResource BreadcrumbBarChevronCornerRaduis}"
+							Style="{StaticResource BreadcrumbBarItemChevronButtonStyle}"
+							UseSystemFocusVisuals="True">
+							<FlyoutBase.AttachedFlyout>
+								<MenuFlyout
+									x:Name="PART_ItemChevronDropDownMenuFlyout"
+									Placement="BottomEdgeAlignedLeft"
+									ScrollViewer.VerticalScrollBarVisibility="Auto"
+									ScrollViewer.VerticalScrollMode="Auto">
+									<MenuFlyout.MenuFlyoutPresenterStyle>
+										<Style TargetType="MenuFlyoutPresenter">
+											<Setter Property="MaxHeight" Value="400" />
+											<!--  Workaround for https://github.com/files-community/Files/issues/13078  -->
+											<Setter Target="HighContrastAdjustment" Value="None" />
+										</Style>
+									</MenuFlyout.MenuFlyoutPresenterStyle>
+								</MenuFlyout>
+							</FlyoutBase.AttachedFlyout>
+
+							<AnimatedIcon
+								x:Name="PART_ItemChevronIcon"
+								Width="{StaticResource BreadcrumbBarChevronFontSize}"
+								Height="{StaticResource BreadcrumbBarChevronFontSize}"
+								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+								AnimatedIcon.State="NormalOff"
+								AutomationProperties.AccessibilityView="Raw"
+								Foreground="{ThemeResource BreadcrumbBarForegroundBrush}"
+								MirroredWhenRightToLeft="True"
+								RenderTransformOrigin="0.5, 0.5">
+								<AnimatedIcon.FallbackIconSource>
+									<FontIconSource
+										FontSize="{StaticResource BreadcrumbBarChevronFontSize}"
+										Glyph="&#xE76C;"
+										IsTextScaleFactorEnabled="False" />
+								</AnimatedIcon.FallbackIconSource>
+								<animatedvisuals:AnimatedChevronRightDownSmallVisualSource />
+							</AnimatedIcon>
+
+						</Button>
+
+						<VisualStateManager.VisualStateGroups>
+
+							<VisualStateGroup x:Name="ChevronVisibilityStates">
+								<VisualState x:Name="ChevronVisible" />
+								<VisualState x:Name="ChevronCollapsed">
+									<VisualState.Setters>
+										<Setter Target="PART_ItemChevronButton.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="ChevronStates">
+								<VisualState x:Name="ChevronNormalOff" />
+								<VisualState x:Name="ChevronNormalOn">
+									<VisualState.Setters>
+										<Setter Target="PART_ItemChevronIcon.(AnimatedIcon.State)" Value="NormalOn" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+
+						</VisualStateManager.VisualStateGroups>
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style
+		x:Key="BreadcrumbBarItemChevronButtonStyle"
+		BasedOn="{StaticResource DefaultButtonStyle}"
+		TargetType="Button">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Button">
+					<ContentPresenter
+						x:Name="ContentPresenter"
+						Padding="{TemplateBinding Padding}"
+						HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+						VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+						AutomationProperties.AccessibilityView="Raw"
+						Background="{TemplateBinding Background}"
+						BackgroundSizing="{TemplateBinding BackgroundSizing}"
+						BorderBrush="{TemplateBinding BorderBrush}"
+						BorderThickness="{TemplateBinding BorderThickness}"
+						Content="{TemplateBinding Content}"
+						ContentTemplate="{TemplateBinding ContentTemplate}"
+						ContentTransitions="{TemplateBinding ContentTransitions}"
+						CornerRadius="{TemplateBinding CornerRadius}"
+						Foreground="{TemplateBinding Foreground}">
+						<ContentPresenter.BackgroundTransition>
+							<BrushTransition Duration="0:0:0.083" />
+						</ContentPresenter.BackgroundTransition>
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="PointerOver">
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPointerOver}" />
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushPointerOver}" />
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForegroundPointerOver}" />
+										</ObjectAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPressed}" />
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushPressed}" />
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForegroundPressed}" />
+										</ObjectAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundDisabled}" />
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBorderBrushDisabled}" />
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonForegroundDisabled}" />
+										</ObjectAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+					</ContentPresenter>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+</ResourceDictionary>

--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.Events.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.Events.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Controls
+{
+	public partial class BreadcrumbBarItem
+	{
+		private void ItemContentButton_Click(object sender, RoutedEventArgs e)
+		{
+			OnItemClicked();
+		}
+
+		private void ItemChevronButton_Click(object sender, RoutedEventArgs e)
+		{
+			FlyoutBase.ShowAttachedFlyout(_itemChevronButton);
+		}
+
+		private void ChevronDropDownMenuFlyout_Opening(object? sender, object e)
+		{
+			if (_ownerRef is null ||
+				_ownerRef.TryGetTarget(out var breadcrumbBar) is false ||
+				sender is not MenuFlyout flyout)
+				return;
+
+			breadcrumbBar.RaiseItemDropDownFlyoutOpening(this, flyout);
+		}
+
+		private void ChevronDropDownMenuFlyout_Opened(object? sender, object e)
+		{
+			VisualStateManager.GoToState(this, "ChevronNormalOn", true);
+		}
+
+		private void ChevronDropDownMenuFlyout_Closed(object? sender, object e)
+		{
+			if (_ownerRef is null ||
+				_ownerRef.TryGetTarget(out var breadcrumbBar) is false ||
+				sender is not MenuFlyout flyout)
+				return;
+
+			breadcrumbBar.RaiseItemDropDownFlyoutClosed(this, flyout);
+
+			VisualStateManager.GoToState(this, "ChevronNormalOff", true);
+			VisualStateManager.GoToState(this, "PointerNormal", true);
+		}
+	}
+}

--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.Properties.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.Properties.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using CommunityToolkit.WinUI;
+
+namespace Files.App.Controls
+{
+	public partial class BreadcrumbBarItem
+	{
+		[GeneratedDependencyProperty]
+		public partial bool IsEllipsis { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial bool IsLastItem { get; set; }
+
+		partial void OnIsEllipsisChanged(bool newValue)
+		{
+			VisualStateManager.GoToState(this, newValue ? "ChevronCollapsed" : "ChevronVisible", true);
+		}
+
+		partial void OnIsLastItemChanged(bool newValue)
+		{
+			VisualStateManager.GoToState(this, newValue ? "ChevronCollapsed" : "ChevronVisible", true);
+		}
+	}
+}

--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Controls
+{
+	public partial class BreadcrumbBarItem : ContentControl
+	{
+		// Constants
+
+		private const string TemplatePartName_ItemContentButton = "PART_ItemContentButton";
+		private const string TemplatePartName_ItemChevronButton = "PART_ItemChevronButton";
+		private const string TemplatePartName_ItemEllipsisDropDownMenuFlyout = "PART_ItemEllipsisDropDownMenuFlyout";
+		private const string TemplatePartName_ItemChevronDropDownMenuFlyout = "PART_ItemChevronDropDownMenuFlyout";
+
+		// Fields
+
+		private WeakReference<BreadcrumbBar>? _ownerRef;
+
+		private Button _itemContentButton = null!;
+		private Button _itemChevronButton = null!;
+		private MenuFlyout _itemEllipsisDropDownMenuFlyout = null!;
+		private MenuFlyout _itemChevronDropDownMenuFlyout = null!;
+
+		// Constructor
+
+		public BreadcrumbBarItem()
+		{
+			DefaultStyleKey = typeof(BreadcrumbBarItem);
+		}
+
+		// Methods
+
+		protected override void OnApplyTemplate()
+		{
+			base.OnApplyTemplate();
+
+			_itemContentButton = GetTemplateChild(TemplatePartName_ItemContentButton) as Button
+				?? throw new MissingFieldException($"Could not find {TemplatePartName_ItemContentButton} in the given {nameof(BreadcrumbBarItem)}'s style.");
+			_itemChevronButton = GetTemplateChild(TemplatePartName_ItemChevronButton) as Button
+				?? throw new MissingFieldException($"Could not find {TemplatePartName_ItemChevronButton} in the given {nameof(BreadcrumbBarItem)}'s style.");
+			_itemEllipsisDropDownMenuFlyout = GetTemplateChild(TemplatePartName_ItemEllipsisDropDownMenuFlyout) as MenuFlyout
+				?? throw new MissingFieldException($"Could not find {TemplatePartName_ItemEllipsisDropDownMenuFlyout} in the given {nameof(BreadcrumbBarItem)}'s style.");
+			_itemChevronDropDownMenuFlyout = GetTemplateChild(TemplatePartName_ItemChevronDropDownMenuFlyout) as MenuFlyout
+				?? throw new MissingFieldException($"Could not find {TemplatePartName_ItemChevronDropDownMenuFlyout} in the given {nameof(BreadcrumbBarItem)}'s style.");
+
+			if (IsEllipsis || IsLastItem)
+				VisualStateManager.GoToState(this, "ChevronCollapsed", true);
+
+			_itemContentButton.Click += ItemContentButton_Click;
+			_itemChevronButton.Click += ItemChevronButton_Click;
+			_itemChevronDropDownMenuFlyout.Opening += ChevronDropDownMenuFlyout_Opening;
+			_itemChevronDropDownMenuFlyout.Opened += ChevronDropDownMenuFlyout_Opened;
+			_itemChevronDropDownMenuFlyout.Closed += ChevronDropDownMenuFlyout_Closed;
+		}
+
+		public void OnItemClicked()
+		{
+			if (_ownerRef is not null &&
+				_ownerRef.TryGetTarget(out var breadcrumbBar))
+			{
+				if (IsEllipsis)
+				{
+					// Clear items in the ellipsis flyout
+					_itemEllipsisDropDownMenuFlyout.Items.Clear();
+
+					// Populate items in the ellipsis flyout
+					for (int index = 0; index < breadcrumbBar.IndexAfterEllipsis; index++)
+					{
+						if (breadcrumbBar.TryGetElement(index, out var item) && item?.Content is string text)
+						{
+							_itemEllipsisDropDownMenuFlyout.Items.Add(new MenuFlyoutItem() { Text = text });
+						}
+					}
+
+					// Open the ellipsis flyout
+					FlyoutBase.ShowAttachedFlyout(_itemContentButton);
+				}
+				else
+				{
+					// Fire a click event
+					breadcrumbBar.RaiseItemClickedEvent(this);
+				}
+			}
+		}
+
+		public void SetOwner(BreadcrumbBar breadcrumbBar)
+		{
+			_ownerRef = new(breadcrumbBar);
+		}
+	}
+}

--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItemAutomationPeer.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItemAutomationPeer.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
+
+namespace Files.App.Controls
+{
+	public partial class BreadcrumbBarItemAutomationPeer : FrameworkElementAutomationPeer, IInvokeProvider
+	{
+		/// <summary>
+		/// Initializes a new instance of the BreadcrumbBarItemAutomationPeer class.
+		/// </summary>
+		/// <param name="owner"></param>
+		public BreadcrumbBarItemAutomationPeer(BreadcrumbBarItem owner) : base(owner)
+		{
+		}
+
+		// IAutomationPeerOverrides
+		protected override string GetLocalizedControlTypeCore()
+		{
+			return "breadcrumb bar item";
+		}
+
+		protected override object GetPatternCore(PatternInterface patternInterface)
+		{
+			if (patternInterface is PatternInterface.Invoke)
+				return this;
+
+			return base.GetPatternCore(patternInterface);
+		}
+
+		protected override string GetClassNameCore()
+		{
+			return nameof(BreadcrumbBarItem);
+		}
+
+		protected override AutomationControlType GetAutomationControlTypeCore()
+		{
+			return AutomationControlType.Button;
+		}
+
+		/// <summary>
+		/// Sends a request to invoke the item associated with the automation peer.
+		/// </summary>
+		public void Invoke()
+		{
+			if (Owner is not BreadcrumbBarItem item)
+				return;
+
+			item.OnItemClicked();
+		}
+	}
+}

--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItemEventArgs.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItemEventArgs.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Controls
+{
+	public record class BreadcrumbBarItemClickedEventArgs(BreadcrumbBarItem Item, int Index, bool IsRootItem = false);
+
+	public record class BreadcrumbBarItemDropDownFlyoutEventArgs(MenuFlyout Flyout, BreadcrumbBarItem? Item = null, int Index = -1, bool IsRootItem = false);
+}

--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarLayout.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarLayout.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Windows.Foundation;
+
+namespace Files.App.Controls
+{
+	/// <summary>
+	/// Handles layout of <see cref="BreadcrumbBar"/>, collapsing items into an ellipsis button when necessary.
+	/// </summary>
+	public partial class BreadcrumbBarLayout : NonVirtualizingLayout
+	{
+		// Fields
+
+		private readonly WeakReference<BreadcrumbBar>? _ownerRef;
+		private readonly double _spacing = 0d;
+
+		private Size _availableSize;
+		private BreadcrumbBarItem? _ellipsisButton = null;
+
+		// Properties
+
+		public bool EllipsisIsRendered { get; private set; }
+		public int IndexAfterEllipsis { get; private set; }
+		public int VisibleItemsCount { get; private set; }
+
+		public BreadcrumbBarLayout(BreadcrumbBar breadcrumb, double spacing)
+		{
+			_ownerRef = new(breadcrumb);
+			_spacing = spacing;
+		}
+
+		protected override Size MeasureOverride(NonVirtualizingLayoutContext context, Size availableSize)
+		{
+			var accumulatedSize = new Size(0, 0);
+			_availableSize = availableSize;
+
+			// Go through all items and measure them
+			foreach (var item in context.Children)
+			{
+				if (item is BreadcrumbBarItem breadcrumbItem)
+				{
+					breadcrumbItem.Measure(availableSize);
+					accumulatedSize.Width += breadcrumbItem.DesiredSize.Width;
+					accumulatedSize.Height = Math.Max(accumulatedSize.Height, breadcrumbItem.DesiredSize.Height);
+				}
+			}
+
+			// Get a reference to the ellipsis item
+			if (context.Children.Count > 0)
+				_ellipsisButton ??= context.Children[0] as BreadcrumbBarItem;
+
+			// Sets the ellipsis item's visibility based on whether the items are overflowing
+			EllipsisIsRendered = accumulatedSize.Width > availableSize.Width;
+
+			return accumulatedSize;
+		}
+
+		protected override Size ArrangeOverride(NonVirtualizingLayoutContext context, Size finalSize)
+		{
+			double accumulatedWidths = 0d;
+
+			IndexAfterEllipsis = GetFirstIndexToRender(context);
+			VisibleItemsCount = 0;
+
+			// Go through all items and arrange them
+			for (int index = 0; index < context.Children.Count; index++)
+			{
+				if (context.Children[index] is BreadcrumbBarItem breadcrumbItem)
+				{
+					if (index < IndexAfterEllipsis)
+					{
+						// Collapse
+						breadcrumbItem.Arrange(new Rect(0, 0, 0, 0));
+					}
+					else
+					{
+						// Arrange normally
+						breadcrumbItem.Arrange(new Rect(accumulatedWidths, 0, breadcrumbItem.DesiredSize.Width, breadcrumbItem.DesiredSize.Height));
+
+						accumulatedWidths += breadcrumbItem.DesiredSize.Width;
+						accumulatedWidths += _spacing;
+
+						VisibleItemsCount++;
+					}
+				}
+			}
+
+			if (_ownerRef?.TryGetTarget(out var breadcrumbBar) ?? false)
+				breadcrumbBar.OnLayoutUpdated();
+
+			return finalSize;
+		}
+
+		private int GetFirstIndexToRender(NonVirtualizingLayoutContext context)
+		{
+			var itemCount = context.Children.Count;
+			var accumulatedWidth = _spacing;
+
+			// Go through all items from the end
+			for (int index = itemCount - 1; index >= 0; index--)
+			{
+				var newAccumulatedWidth = accumulatedWidth + context.Children[index].DesiredSize.Width;
+				if (newAccumulatedWidth >= _availableSize.Width)
+					return index + 1;
+
+				accumulatedWidth = newAccumulatedWidth;
+			}
+
+			return 0;
+		}
+	}
+}

--- a/src/Files.App.Controls/Themes/Generic.xaml
+++ b/src/Files.App.Controls/Themes/Generic.xaml
@@ -55,7 +55,7 @@
 		<!--#endregion-->
 
 		<!--#region SidebarView-->
-    <ResourceDictionary Source="ms-appx:///Files.App.Controls/Sidebar/SidebarStyles.xaml" />
+		<ResourceDictionary Source="ms-appx:///Files.App.Controls/Sidebar/SidebarStyles.xaml" />
 		<!--#endregion-->
 
 		<!--#region Omnibar-->
@@ -65,6 +65,10 @@
 
 		<!--#region SamplePanel-->
 		<ResourceDictionary Source="ms-appx:///Files.App.Controls/SamplePanel/SamplePanel.xaml" />
+		<!--#endregion-->
+
+		<!--#region Breadcrumb-->
+		<ResourceDictionary Source="ms-appx:///Files.App.Controls/BreadcrumbBar/BreadcrumbBar.xaml" />
 		<!--#endregion-->
 
 	</ResourceDictionary.MergedDictionaries>

--- a/tests/Files.App.UITests/Data/DummyItem2.cs
+++ b/tests/Files.App.UITests/Data/DummyItem2.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+
+namespace Files.App.UITests.Data
+{
+	internal record DummyItem2(string Text, ObservableCollection<DummyItem2>? Children = null);
+}

--- a/tests/Files.App.UITests/MainWindow.xaml
+++ b/tests/Files.App.UITests/MainWindow.xaml
@@ -82,7 +82,7 @@
 			SelectionChanged="NavigationView_SelectionChanged">
 
 			<NavigationView.MenuItems>
-				<NavigationViewItem Content="Controls">
+				<NavigationViewItem Content="Controls" IsExpanded="True">
 					<NavigationViewItem.Icon>
 						<FontIcon Glyph="&#xE73A;" />
 					</NavigationViewItem.Icon>
@@ -92,6 +92,7 @@
 						<NavigationViewItem Content="SidebarView" Tag="SidebarViewPage" />
 						<NavigationViewItem Content="StorageRing/StorageBar" Tag="StorageControlsPage" />
 						<NavigationViewItem Content="Omnibar" Tag="OmnibarPage" />
+						<NavigationViewItem Content="BreadcrumbBar" Tag="BreadcrumbBarPage" />
 					</NavigationViewItem.MenuItems>
 				</NavigationViewItem>
 			</NavigationView.MenuItems>

--- a/tests/Files.App.UITests/MainWindow.xaml.cs
+++ b/tests/Files.App.UITests/MainWindow.xaml.cs
@@ -50,6 +50,7 @@ namespace Files.App.UITests
 					nameof(StorageControlsPage) => typeof(StorageControlsPage),
 					nameof(SidebarViewPage) => typeof(SidebarViewPage),
 					nameof(OmnibarPage) => typeof(OmnibarPage),
+					nameof(BreadcrumbBarPage) => typeof(BreadcrumbBarPage),
 					_ => throw new InvalidOperationException("There's no applicable page associated with the given key."),
 				});
 

--- a/tests/Files.App.UITests/Views/BreadcrumbBarPage.xaml
+++ b/tests/Files.App.UITests/Views/BreadcrumbBarPage.xaml
@@ -1,0 +1,81 @@
+<!--  Copyright (c) Files Community. Licensed under the MIT License.  -->
+<Page
+	x:Class="Files.App.UITests.Views.BreadcrumbBarPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:controls="using:Files.App.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:data="using:Files.App.UITests.Data"
+	xmlns:local="using:Files.App.UITests.Views"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<StackPanel Spacing="24">
+
+		<controls:SamplePanel Header="Default usage">
+			<controls:SamplePanel.MainContent>
+				<Grid
+					Height="36"
+					MinWidth="120"
+					Padding="2"
+					HorizontalAlignment="Stretch"
+					VerticalAlignment="Center"
+					Background="{ThemeResource ControlFillColorDefaultBrush}"
+					BorderBrush="{ThemeResource CircleElevationBorderBrush}"
+					CornerRadius="18">
+					<controls:BreadcrumbBar
+						x:Name="BreadcrumbBar1"
+						FlowDirection="{x:Bind BreadcrumbBar1FlowDirection, Mode=OneWay}"
+						ItemClicked="BreadcrumbBar1_ItemClicked"
+						ItemDropDownFlyoutClosed="BreadcrumbBar1_ItemDropDownFlyoutClosed"
+						ItemDropDownFlyoutOpening="BreadcrumbBar1_ItemDropDownFlyoutOpening"
+						ItemsSource="{x:Bind DummyItems, Mode=OneWay}">
+						<controls:BreadcrumbBar.RootItem>
+							<Image
+								Width="16"
+								Height="16"
+								Source="/Data/DummyIcon1.png" />
+						</controls:BreadcrumbBar.RootItem>
+						<controls:BreadcrumbBar.ItemTemplate>
+							<DataTemplate x:DataType="data:DummyItem2">
+								<controls:BreadcrumbBarItem Content="{x:Bind Text}">
+									<!--<controls:BreadcrumbBarItem.ContentTemplate>
+										<DataTemplate>
+											<TextBlock Text="{Binding Text}" TextLineBounds="Tight" />
+										</DataTemplate>
+									</controls:BreadcrumbBarItem.ContentTemplate>-->
+								</controls:BreadcrumbBarItem>
+							</DataTemplate>
+						</controls:BreadcrumbBar.ItemTemplate>
+					</controls:BreadcrumbBar>
+				</Grid>
+			</controls:SamplePanel.MainContent>
+			<controls:SamplePanel.SideContent>
+				<StackPanel Spacing="12">
+					<Grid HorizontalAlignment="Stretch" ColumnSpacing="8">
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="*" />
+						</Grid.ColumnDefinitions>
+						<TextBox
+							Grid.Column="0"
+							Header="Clicked item name:"
+							IsReadOnly="True"
+							Text="{x:Bind ClickedItemName, Mode=OneWay}" />
+						<TextBox
+							Grid.Column="1"
+							Header="Clicked item index:"
+							IsReadOnly="True"
+							Text="{x:Bind ClickedItemIndex, Mode=OneWay}" />
+					</Grid>
+					<ToggleSwitch
+						Header="RTL flow direction:"
+						IsOn="{x:Bind IsRTLEnabled, Mode=TwoWay}"
+						OffContent="Disabled"
+						OnContent="Enabled" />
+				</StackPanel>
+			</controls:SamplePanel.SideContent>
+		</controls:SamplePanel>
+
+	</StackPanel>
+</Page>

--- a/tests/Files.App.UITests/Views/BreadcrumbBarPage.xaml.cs
+++ b/tests/Files.App.UITests/Views/BreadcrumbBarPage.xaml.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using CommunityToolkit.WinUI;
+using Files.App.Controls;
+using Files.App.UITests.Data;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System.Collections.ObjectModel;
+
+namespace Files.App.UITests.Views
+{
+	public sealed partial class BreadcrumbBarPage : Page
+	{
+		private readonly ObservableCollection<DummyItem2> DummyItems;
+
+		[GeneratedDependencyProperty]
+		private partial string? ClickedItemName { get; set; }
+
+		[GeneratedDependencyProperty]
+		private partial string? ClickedItemIndex { get; set; }
+
+		[GeneratedDependencyProperty]
+		private partial bool IsRTLEnabled { get; set; }
+
+		[GeneratedDependencyProperty]
+		private partial FlowDirection BreadcrumbBar1FlowDirection { get; set; }
+
+		public BreadcrumbBarPage()
+		{
+			InitializeComponent();
+
+			DummyItems =
+			[
+				new("Local Disk (C:)"),
+				new("Users"),
+				new("me"),
+				new("OneDrive"),
+				new("Desktop"),
+				new("Folder1"),
+				new("Folder2"),
+			];
+		}
+
+		private void BreadcrumbBar1_ItemClicked(Controls.BreadcrumbBar sender, Controls.BreadcrumbBarItemClickedEventArgs args)
+		{
+			if (args.IsRootItem)
+			{
+				ClickedItemName = "Home";
+				ClickedItemIndex = "Root";
+			}
+			else
+			{
+				ClickedItemName = DummyItems[args.Index].Text;
+				ClickedItemIndex = $"{args.Index}";
+			}
+		}
+
+		private void BreadcrumbBar1_ItemDropDownFlyoutOpening(object sender, BreadcrumbBarItemDropDownFlyoutEventArgs e)
+		{
+			e.Flyout.Items.Add(new MenuFlyoutItem { Icon = new FontIcon() { Glyph = "\uE8B7" }, Text = "Item 1" });
+			e.Flyout.Items.Add(new MenuFlyoutItem { Icon = new FontIcon() { Glyph = "\uE8B7" }, Text = "Item 2" });
+			e.Flyout.Items.Add(new MenuFlyoutItem { Icon = new FontIcon() { Glyph = "\uE8B7" }, Text = "Item 3" });
+		}
+
+		private void BreadcrumbBar1_ItemDropDownFlyoutClosed(object sender, BreadcrumbBarItemDropDownFlyoutEventArgs e)
+		{
+			e.Flyout.Items.Clear();
+		}
+
+		partial void OnIsRTLEnabledChanged(bool newValue)
+		{
+			BreadcrumbBar1FlowDirection = IsRTLEnabled ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+		}
+	}
+}


### PR DESCRIPTION
### Resolved / Related Issues

- #16029

### Steps used to test these changes

1. Open Files UI tests app
2. Go to Breadcrumb page
3. Check the ellipsis behavior
4. Check the flyout behavior
5. Check the button click behavior
6. Check the behavior when the window size changed
7. Check the tabbing behavior (It only should XY navigation within the BreadcrumbBar)

Full:
![image](https://github.com/user-attachments/assets/082bad36-3604-4ee0-96b4-c47180675f46)
With ellipsis:
![image](https://github.com/user-attachments/assets/21a7f312-9ad2-4c3f-be49-46a98919eb97)
Item chevron flyout:
![image](https://github.com/user-attachments/assets/984216d3-5736-431d-90c1-fd876a35a1f0)
