### PR TITLE
Fix: Fixed issue where the icon for "developer tools" didn't display properly on Windows 10

### DIFF
--- a/src/Files.App/Dialogs/SettingsDialog.xaml
+++ b/src/Files.App/Dialogs/SettingsDialog.xaml
@@ -138,7 +138,7 @@
 					Content="{helpers:ResourceString Name=DevTools}"
 					Tag="DevToolsPage">
 					<NavigationViewItem.Icon>
-						<FontIcon Foreground="{ThemeResource App.Theme.IconBaseBrush}" Glyph="&#xE794;" />
+						<FontIcon Foreground="{ThemeResource App.Theme.IconBaseBrush}" Glyph="&#xEC7A;" />
 					</NavigationViewItem.Icon>
 				</NavigationViewItem>
 				<NavigationViewItem


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Closes #16949 

**Steps used to test these changes**

1. Opened Files
2. Checked that the glyph `&#xEC7A;` exists in both the **Segoe MDL2 Assets** and **Segoe Fluent Icons** fonts.

---

This changes the developer tools icon in the settings sidebar from sparkles to a wrench and screwdriver - not only to use the intended icon named "Developer Tools" in the Segoe font, but also to fix an issue where the sparkles icon is not available in the Windows 10 Segoe font (Segoe MDL2 Assets)

![image](https://github.com/user-attachments/assets/12168ef3-020b-40d7-9ce2-85c91e827a71)
