### PR TITLE
Feature: Hide Cleanup and Format on Properties for Cloud Drives

### DIFF
--- a/.github/workflows/cd-store-preview.yml
+++ b/.github/workflows/cd-store-preview.yml
@@ -122,7 +122,7 @@ jobs:
         path: ${{ env.ARTIFACTS_STAGING_DIR }}
 
     - name: Publish the packages to Microsoft Store
-      uses: files-community/windows-store-action@1.0
+      uses: files-community/windows-store-action@1.1
       with:
         app-id: '9NSQD9PKV3SS'
         tenant-id: ${{ secrets.STORE_TENANT_ID }}

--- a/.github/workflows/cd-store-preview.yml
+++ b/.github/workflows/cd-store-preview.yml
@@ -122,7 +122,7 @@ jobs:
         path: ${{ env.ARTIFACTS_STAGING_DIR }}
 
     - name: Publish the packages to Microsoft Store
-      uses: isaacrlevin/windows-store-action@1.0
+      uses: files-community/windows-store-action@1.0
       with:
         app-id: '9NSQD9PKV3SS'
         tenant-id: ${{ secrets.STORE_TENANT_ID }}

--- a/.github/workflows/cd-store-preview.yml
+++ b/.github/workflows/cd-store-preview.yml
@@ -122,7 +122,7 @@ jobs:
         path: ${{ env.ARTIFACTS_STAGING_DIR }}
 
     - name: Publish the packages to Microsoft Store
-      uses: files-community/windows-store-action@1.1
+      uses: isaacrlevin/windows-store-action@1.0
       with:
         app-id: '9NSQD9PKV3SS'
         tenant-id: ${{ secrets.STORE_TENANT_ID }}

--- a/src/Files.App/ViewModels/Properties/BasePropertiesPage.cs
+++ b/src/Files.App/ViewModels/Properties/BasePropertiesPage.cs
@@ -39,8 +39,8 @@ namespace Files.App.ViewModels.Properties
 				var props = new DriveProperties(ViewModel, drive, AppInstance);
 				BaseProperties = props;
 
-				ViewModel.CleanupVisibility = props.Drive.Type != DriveType.Network;
-				ViewModel.FormatVisibility = !(props.Drive.Type == DriveType.Network || string.Equals(props.Drive.Path, $@"{Constants.UserEnvironmentPaths.SystemDrivePath}\", StringComparison.OrdinalIgnoreCase));
+				ViewModel.CleanupVisibility = props.Drive.Type != DriveType.Network && props.Drive.Type != DriveType.CloudDrive;
+				ViewModel.FormatVisibility = !(props.Drive.Type == DriveType.Network || props.Drive.Type == DriveType.CloudDrive || string.Equals(props.Drive.Path, $@"{Constants.UserEnvironmentPaths.SystemDrivePath}\", StringComparison.OrdinalIgnoreCase));
 				ViewModel.CleanupDriveCommand = new AsyncRelayCommand(() => StorageSenseHelper.OpenStorageSenseAsync(props.Drive.Path));
 				ViewModel.FormatDriveCommand = new RelayCommand(async () =>
 				{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

None, approved manually by Yair on Discord.

**Steps used to test these changes**

Opened the Properties window of the OneDrive (Personal) Cloud Drive and OneDrive (Business) Cloud Drive, neither showed "Cleanup your drive contents" and "Format drive" as expected.
