### PR TITLE
Fix: Fixed issue where the extract button was sometimes not displayed in the toolbar

### DIFF
--- a/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
@@ -25,7 +25,7 @@ namespace Files.App.Actions
 
 		public override bool IsExecutable =>
 			(IsContextPageTypeAdaptedToCommand() &&
-			StorageArchiveService.CanDecompress(context.SelectedItems) ||
+			CanDecompressSelectedItems() ||
 			CanDecompressInsideArchive()) &&
 			UIHelpers.CanShowDialog;
 
@@ -125,11 +125,17 @@ namespace Files.App.Actions
 			return false;
 		}
 
+		protected virtual bool CanDecompressSelectedItems()
+		{
+			return StorageArchiveService.CanDecompress(context.SelectedItems);
+		}
+
 		protected virtual void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			switch (e.PropertyName)
 			{
 				case nameof(IContentPageContext.SelectedItems):
+				case nameof(IContentPageContext.Folder):
 					OnPropertyChanged(nameof(IsExecutable));
 					break;
 			}

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
@@ -31,7 +31,12 @@ namespace Files.App.Actions
 			if (context.ShellPage is null)
 				return;
 
-			BaseStorageFile archive = await StorageHelpers.ToStorageItem<BaseStorageFile>(context.SelectedItem?.ItemPath ?? string.Empty);
+			var archivePath = GetArchivePath();
+
+			if (string.IsNullOrEmpty(archivePath))
+				return;
+
+			BaseStorageFile archive = await StorageHelpers.ToStorageItem<BaseStorageFile>(archivePath);
 
 			if (archive?.Path is null)
 				return;
@@ -85,6 +90,22 @@ namespace Files.App.Actions
 				!context.HasSelection &&
 				context.Folder is not null &&
 				FileExtensionHelpers.IsZipFile(Path.GetExtension(context.Folder.ItemPath));
+		}
+
+		protected override bool CanDecompressSelectedItems()
+		{
+			return context.SelectedItems.Count == 1 && base.CanDecompressSelectedItems();
+		}
+
+		private string? GetArchivePath()
+		{
+			if (!string.IsNullOrEmpty(context.SelectedItem?.ItemPath))
+				return context.SelectedItem?.ItemPath;
+
+			if (context.PageType == ContentPageTypes.ZipFolder && !context.HasSelection)
+				return context.Folder?.ItemPath;
+
+			return null;
 		}
 	}
 }

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveToChildFolderAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchiveToChildFolderAction.cs
@@ -71,6 +71,7 @@ namespace Files.App.Actions
 			switch (e.PropertyName)
 			{
 				case nameof(IContentPageContext.SelectedItems):
+				case nameof(IContentPageContext.Folder):
 					{
 						if (IsContextPageTypeAdaptedToCommand())
 						{

--- a/src/Files.App/UserControls/Toolbar.xaml
+++ b/src/Files.App/UserControls/Toolbar.xaml
@@ -36,6 +36,7 @@
 				x:Key="NegatedBoolToVisibilityConverter"
 				FalseValue="Visible"
 				TrueValue="Collapsed" />
+			<wctconverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
 
 			<x:Boolean x:Key="True">True</x:Boolean>
 			<x:Boolean x:Key="False">False</x:Boolean>
@@ -302,29 +303,25 @@
 							<MenuFlyoutItem
 								x:Name="ExtractSingle"
 								Command="{x:Bind Commands.DecompressArchive, Mode=OneWay}"
-								IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
 								KeyboardAcceleratorTextOverride="{x:Bind Commands.DecompressArchive.HotKeyText, Mode=OneWay}"
 								Text="{x:Bind Commands.DecompressArchive.Label}"
-								Visibility="{x:Bind ViewModel.IsMultipleArchivesSelected, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
+								Visibility="{x:Bind Commands.DecompressArchive.IsExecutable, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
 							<MenuFlyoutItem
 								x:Name="ExtractHereSmart"
 								Command="{x:Bind Commands.DecompressArchiveHereSmart, Mode=OneWay}"
-								IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
 								KeyboardAcceleratorTextOverride="{x:Bind Commands.DecompressArchiveHereSmart.HotKeyText, Mode=OneWay}"
 								Text="{x:Bind Commands.DecompressArchiveHereSmart.Label}"
-								Visibility="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
+								Visibility="{x:Bind Commands.DecompressArchiveHereSmart.IsExecutable, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
 							<MenuFlyoutItem
 								x:Name="ExtractHere"
 								Command="{x:Bind Commands.DecompressArchiveHere, Mode=OneWay}"
-								IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
 								Text="{x:Bind Commands.DecompressArchiveHere.Label}"
-								Visibility="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
+								Visibility="{x:Bind Commands.DecompressArchiveHere.IsExecutable, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
 							<MenuFlyoutItem
 								x:Name="ExtractTo"
 								Command="{x:Bind Commands.DecompressArchiveToChildFolder, Mode=OneWay}"
-								IsEnabled="{x:Bind ViewModel.IsSelectionArchivesOnly, Mode=OneWay, FallbackValue=False}"
 								Text="{x:Bind Commands.DecompressArchiveToChildFolder.Label, Mode=OneWay}"
-								Visibility="{x:Bind ViewModel.IsArchiveOpened, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
+								Visibility="{x:Bind Commands.DecompressArchiveToChildFolder.IsExecutable, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
 						</MenuFlyout>
 					</AppBarButton.Flyout>
 

--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -75,14 +75,9 @@ namespace Files.App.ViewModels.UserControls
 
 		public SearchBoxViewModel SearchBoxViewModel => (SearchBoxViewModel)SearchBox;
 
-		public string ExtractToText => IsSelectionArchivesOnly ? SelectedItems.Count > 1 ? string.Format(Strings.ExtractToChildFolder.GetLocalizedResource(), $"*{Path.DirectorySeparatorChar}") : string.Format(Strings.ExtractToChildFolder.GetLocalizedResource() + "\\", Path.GetFileNameWithoutExtension(_SelectedItems.First().Name)) : Strings.ExtractToChildFolder.GetLocalizedResource();
-
 		public bool HasAdditionalAction => InstanceViewModel.IsPageTypeRecycleBin || IsPowerShellScript || CanExtract || IsImage || IsFont || IsInfFile;
 		public bool CanCopy => SelectedItems is not null && SelectedItems.Any();
-		public bool CanExtract => IsArchiveOpened ? (SelectedItems is null || !SelectedItems.Any()) : IsSelectionArchivesOnly;
-		public bool IsArchiveOpened => InstanceViewModel.IsPageTypeZipFolder;
-		public bool IsSelectionArchivesOnly => SelectedItems is not null && SelectedItems.Any() && SelectedItems.All(x => FileExtensionHelpers.IsZipFile(x.FileExtension)) && !InstanceViewModel.IsPageTypeRecycleBin;
-		public bool IsMultipleArchivesSelected => IsSelectionArchivesOnly && SelectedItems.Count > 1;
+		public bool CanExtract => Commands.DecompressArchive.CanExecute(null) || Commands.DecompressArchiveHere.CanExecute(null) || Commands.DecompressArchiveHereSmart.CanExecute(null) || Commands.DecompressArchiveToChildFolder.CanExecute(null);
 		public bool IsPowerShellScript => SelectedItems is not null && SelectedItems.Count == 1 && FileExtensionHelpers.IsPowerShellFile(SelectedItems.First().FileExtension) && !InstanceViewModel.IsPageTypeRecycleBin;
 		public bool IsImage => SelectedItems is not null && SelectedItems.Any() && SelectedItems.All(x => FileExtensionHelpers.IsImageFile(x.FileExtension)) && !InstanceViewModel.IsPageTypeRecycleBin;
 		public bool IsMultipleImageSelected => SelectedItems is not null && SelectedItems.Count > 1 && SelectedItems.All(x => FileExtensionHelpers.IsImageFile(x.FileExtension)) && !InstanceViewModel.IsPageTypeRecycleBin;
@@ -249,10 +244,6 @@ namespace Files.App.ViewModels.UserControls
 				{
 					OnPropertyChanged(nameof(CanCopy));
 					OnPropertyChanged(nameof(CanExtract));
-					OnPropertyChanged(nameof(ExtractToText));
-					OnPropertyChanged(nameof(IsArchiveOpened));
-					OnPropertyChanged(nameof(IsSelectionArchivesOnly));
-					OnPropertyChanged(nameof(IsMultipleArchivesSelected));
 					OnPropertyChanged(nameof(IsInfFile));
 					OnPropertyChanged(nameof(IsPowerShellScript));
 					OnPropertyChanged(nameof(IsImage));
@@ -280,6 +271,30 @@ namespace Files.App.ViewModels.UserControls
 			SearchBox.Escaped += SearchRegion_Escaped;
 			UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
 			UpdateService.PropertyChanged += UpdateService_OnPropertyChanged;
+
+			Commands.DecompressArchive.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName is nameof(Commands.DecompressArchive.IsExecutable))
+					OnPropertyChanged(nameof(CanExtract));
+			};
+
+			Commands.DecompressArchiveHere.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName is nameof(Commands.DecompressArchiveHere.IsExecutable))
+					OnPropertyChanged(nameof(CanExtract));
+			};
+
+			Commands.DecompressArchiveHereSmart.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName is nameof(Commands.DecompressArchiveHereSmart.IsExecutable))
+					OnPropertyChanged(nameof(CanExtract));
+			};
+
+			Commands.DecompressArchiveHereSmart.PropertyChanged += (s, e) =>
+			{
+				if (e.PropertyName is nameof(Commands.DecompressArchiveToChildFolder.IsExecutable))
+					OnPropertyChanged(nameof(CanExtract));
+			};
 
 			AppearanceSettingsService.PropertyChanged += (s, e) =>
 			{


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #15457

**Steps used to test these changes**

1. Set Files Dev as default application for .zip files
2. Opened .zip file via files explorer
3. .zip files gets opened in Files and the extract button is visible

I have also checked that the buttons are still displayed in the other cases

https://github.com/user-attachments/assets/41996f06-88af-43a4-a0a4-2ae747dd1900



