### PR TITLE
Code Quality: Disable opening context menu on footer items

### DIFF
--- a/src/Files.App.Controls/Sidebar/SidebarView.xaml
+++ b/src/Files.App.Controls/Sidebar/SidebarView.xaml
@@ -48,7 +48,6 @@
 			HorizontalAlignment="Stretch"
 			VerticalAlignment="Stretch"
 			Canvas.ZIndex="10"
-			ContextRequested="PaneColumnGrid_ContextRequested"
 			XYFocusKeyboardNavigation="Enabled">
 			<Grid.RowDefinitions>
 				<RowDefinition Height="*" />
@@ -63,6 +62,7 @@
 				<ScrollViewer
 					x:Name="MenuItemHostScrollViewer"
 					Padding="0,8,0,0"
+					ContextRequested="MenuItemHostScrollViewer_ContextRequested"
 					HorizontalScrollMode="Disabled"
 					VerticalScrollBarVisibility="Auto"
 					XYFocusKeyboardNavigation="Enabled">

--- a/src/Files.App.Controls/Sidebar/SidebarView.xaml.cs
+++ b/src/Files.App.Controls/Sidebar/SidebarView.xaml.cs
@@ -228,7 +228,7 @@ namespace Files.App.Controls
 			e.Handled = true;
 		}
 
-		private void PaneColumnGrid_ContextRequested(UIElement sender, ContextRequestedEventArgs e)
+		private void MenuItemHostScrollViewer_ContextRequested(UIElement sender, ContextRequestedEventArgs e)
 		{
 			var newArgs = new ItemContextInvokedArgs(null, e.TryGetPosition(this, out var point) ? point : default);
 			ViewModel.HandleItemContextInvokedAsync(this, newArgs);


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

Addresses the issue that right clicking the settings item would open the menu to choose the sidebar items.
Preparation for #16969

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files and right clicked settings item -> no context menu
2. Right clicked on navigation items and empty space -> still opens context menu
