### PR TITLE
Fix: Fixed errors that occurred with shortcut items in git repositories

### DIFF
--- a/src/Files.App/Actions/FileSystem/OpenFileLocationAction.cs
+++ b/src/Files.App/Actions/FileSystem/OpenFileLocationAction.cs
@@ -35,7 +35,7 @@ namespace Files.App.Actions
 			if (context.ShellPage?.ShellViewModel is null)
 				return;
 
-			var item = context.SelectedItem as ShortcutItem;
+			var item = context.SelectedItem as IShortcutItem;
 
 			if (string.IsNullOrWhiteSpace(item?.TargetPath))
 				return;

--- a/src/Files.App/Actions/Navigation/OpenInNewTab/BaseOpenInNewTabAction.cs
+++ b/src/Files.App/Actions/Navigation/OpenInNewTab/BaseOpenInNewTabAction.cs
@@ -42,7 +42,7 @@ namespace Files.App.Actions
 				{
 					await NavigationHelpers.AddNewTabByPathAsync(
 						typeof(ShellPanesPage),
-						(listedItem as ShortcutItem)?.TargetPath ?? listedItem.ItemPath,
+						(listedItem as IShortcutItem)?.TargetPath ?? listedItem.ItemPath,
 						false);
 				},
 				Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);

--- a/src/Files.App/Actions/Navigation/OpenInNewWindow/BaseOpenInNewWindowAction.cs
+++ b/src/Files.App/Actions/Navigation/OpenInNewWindow/BaseOpenInNewWindowAction.cs
@@ -48,7 +48,7 @@ namespace Files.App.Actions
 
 			foreach (ListedItem listedItem in items)
 			{
-				var selectedItemPath = (listedItem as ShortcutItem)?.TargetPath ?? listedItem.ItemPath;
+				var selectedItemPath = (listedItem as IShortcutItem)?.TargetPath ?? listedItem.ItemPath;
 				var folderUri = new Uri($"files-dev:?folder={@selectedItemPath}");
 
 				await Launcher.LaunchUriAsync(folderUri);

--- a/src/Files.App/Actions/Start/PinToStartAction.cs
+++ b/src/Files.App/Actions/Start/PinToStartAction.cs
@@ -39,7 +39,7 @@ namespace Files.App.Actions
 						IStorable storable = listedItem.IsFolder switch
 						{
 							true => await StorageService.GetFolderAsync(listedItem.ItemPath),
-							_ => await StorageService.GetFileAsync((listedItem as ShortcutItem)?.TargetPath ?? listedItem.ItemPath)
+							_ => await StorageService.GetFileAsync((listedItem as IShortcutItem)?.TargetPath ?? listedItem.ItemPath)
 						};
 						await StartMenuService.PinAsync(storable, listedItem.Name);
 					});

--- a/src/Files.App/Actions/Start/UnpinFromStartAction.cs
+++ b/src/Files.App/Actions/Start/UnpinFromStartAction.cs
@@ -36,7 +36,7 @@ namespace Files.App.Actions
 						IStorable storable = listedItem.IsFolder switch
 						{
 							true => await StorageService.GetFolderAsync(listedItem.ItemPath),
-							_ => await StorageService.GetFileAsync((listedItem as ShortcutItem)?.TargetPath ?? listedItem.ItemPath)
+							_ => await StorageService.GetFileAsync((listedItem as IShortcutItem)?.TargetPath ?? listedItem.ItemPath)
 						};
 						await StartMenuService.UnpinAsync(storable);
 					});

--- a/src/Files.App/Data/Items/IListedItem.cs
+++ b/src/Files.App/Data/Items/IListedItem.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Files.App.ViewModels.Properties;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Windows.Storage;
+
+namespace Files.App.Utils
+{
+	public interface IListedItem
+	{
+		GitItem AsGitItem { get; }
+		RecycleBinItem AsRecycleBinItem { get; }
+		bool ContainsFilesOrFolders { get; set; }
+		string ContextualProperty { get; set; }
+		BitmapImage CustomIcon { get; set; }
+		Uri CustomIconSource { get; set; }
+		ObservableCollection<FileProperty> FileDetails { get; set; }
+		string FileExtension { get; set; }
+		ulong? FileFRN { get; set; }
+		BitmapImage FileImage { get; set; }
+		string FileSize { get; set; }
+		long FileSizeBytes { get; set; }
+		string FileSizeDisplay { get; }
+		string[] FileTags { get; set; }
+		IList<TagViewModel>? FileTagsUI { get; }
+		string FileVersion { get; set; }
+		string FolderRelativeId { get; set; }
+		bool HasTags { get; set; }
+		BitmapImage IconOverlay { get; set; }
+		string ImageDimensions { get; set; }
+		bool IsAlternateStream { get; }
+		bool IsArchive { get; }
+		bool IsDriveRoot { get; }
+		bool IsElevationRequired { get; set; }
+		bool IsExecutable { get; }
+		bool IsFolder { get; }
+		bool IsFtpItem { get; }
+		bool IsGitItem { get; }
+		bool IsHiddenItem { get; set; }
+		bool IsItemPinnedToStart { get; }
+		bool IsLibrary { get; }
+		bool IsLinkItem { get; }
+		bool IsPinned { get; }
+		bool IsRecycleBinItem { get; }
+		bool IsScriptFile { get; }
+		bool IsShortcut { get; }
+		string ItemDateAccessed { get; }
+		DateTimeOffset ItemDateAccessedReal { get; set; }
+		string ItemDateCreated { get; }
+		DateTimeOffset ItemDateCreatedReal { get; set; }
+		string ItemDateModified { get; }
+		DateTimeOffset ItemDateModifiedReal { get; set; }
+		BaseStorageFile ItemFile { get; set; }
+		string ItemNameRaw { get; set; }
+		string ItemPath { get; set; }
+		ObservableCollection<FileProperty> ItemProperties { get; set; }
+		bool ItemPropertiesInitialized { get; set; }
+		string ItemTooltipText { get; }
+		string ItemType { get; set; }
+		string Key { get; set; }
+		bool LoadCustomIcon { get; set; }
+		bool LoadFileIcon { get; set; }
+		ByteSizeLib.ByteSize MaxSpace { get; set; }
+		string MediaDuration { get; set; }
+		string Name { get; }
+		bool NeedsPlaceholderGlyph { get; set; }
+		double Opacity { get; set; }
+		StorageItemTypes PrimaryItemAttribute { get; set; }
+		BitmapImage ShieldIcon { get; set; }
+		bool ShowDriveStorageDetails { get; set; }
+		ByteSizeLib.ByteSize SpaceUsed { get; set; }
+		string SyncStatusString { get; }
+		CloudDriveSyncStatusUI SyncStatusUI { get; set; }
+
+		string ToString();
+		void UpdateContainsFilesFolders();
+	}
+}

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -16,7 +16,7 @@ using ByteSize = ByteSizeLib.ByteSize;
 
 namespace Files.App.Utils
 {
-	public partial class ListedItem : ObservableObject, IGroupableItem
+	public partial class ListedItem : ObservableObject, IGroupableItem, IListedItem
 	{
 		protected static IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
 
@@ -187,7 +187,7 @@ namespace Files.App.Utils
 			}
 		}
 
-		public bool IsItemPinnedToStart => StartMenuService.IsPinned((this as ShortcutItem)?.TargetPath ?? ItemPath);
+		public bool IsItemPinnedToStart => StartMenuService.IsPinned((this as IShortcutItem)?.TargetPath ?? ItemPath);
 
 		private BitmapImage iconOverlay;
 		public BitmapImage IconOverlay
@@ -352,7 +352,7 @@ namespace Files.App.Utils
 			set => SetProperty(ref spaceUsed, value);
 
 		}
-		
+
 		private string imageDimensions;
 		public string ImageDimensions
 		{
@@ -427,7 +427,7 @@ namespace Files.App.Utils
 		public bool IsRecycleBinItem => this is RecycleBinItem;
 		public bool IsShortcut => this is IShortcutItem;
 		public bool IsLibrary => this is LibraryItem;
-		public bool IsLinkItem => IsShortcut && ((ShortcutItem)this).IsUrl;
+		public bool IsLinkItem => IsShortcut && ((IShortcutItem)this).IsUrl;
 		public bool IsFtpItem => this is FtpItem;
 		public bool IsArchive => this is ZipItem;
 		public bool IsAlternateStream => this is AlternateStreamItem;
@@ -788,7 +788,7 @@ namespace Files.App.Utils
 		public bool IsSymLink { get; set; }
 		public override bool IsExecutable => FileExtensionHelpers.IsExecutableFile(TargetPath, true);
 	}
-	public interface IGitItem
+	public interface IGitItem : IListedItem
 	{
 		public bool StatusPropertiesInitialized { get; set; }
 		public bool CommitPropertiesInitialized { get; set; }
@@ -815,7 +815,7 @@ namespace Files.App.Utils
 			set;
 		}
 	}
-	public interface IShortcutItem
+	public interface IShortcutItem : IListedItem
 	{
 		public string TargetPath { get; set; }
 		public string Name { get; }

--- a/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
@@ -314,7 +314,7 @@ namespace Files.App.Helpers
 			if (associatedInstance is null || listedItem is null)
 				return;
 
-			associatedInstance.PaneHolder?.OpenSecondaryPane((listedItem as ShortcutItem)?.TargetPath ?? listedItem.ItemPath);
+			associatedInstance.PaneHolder?.OpenSecondaryPane((listedItem as IShortcutItem)?.TargetPath ?? listedItem.ItemPath);
 		}
 
 		public static Task LaunchNewWindowAsync()

--- a/src/Files.App/Helpers/ShareItemHelpers.cs
+++ b/src/Files.App/Helpers/ShareItemHelpers.cs
@@ -59,7 +59,7 @@ namespace Files.App.Helpers
 
 				foreach (ListedItem item in itemsToShare)
 				{
-					if (item is ShortcutItem shItem)
+					if (item is IShortcutItem shItem)
 					{
 						if (shItem.IsLinkItem && !string.IsNullOrEmpty(shItem.TargetPath))
 						{

--- a/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
+++ b/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
@@ -65,7 +65,7 @@ namespace Files.App.ViewModels.Layouts
 				_associatedInstance.SlimContentPage.IsMiddleClickToScrollEnabled = true;
 
 				if (Item.IsShortcut)
-					await NavigationHelpers.OpenPathInNewTab(((e.OriginalSource as FrameworkElement)?.DataContext as ShortcutItem)?.TargetPath ?? Item.ItemPath);
+					await NavigationHelpers.OpenPathInNewTab(((e.OriginalSource as FrameworkElement)?.DataContext as IShortcutItem)?.TargetPath ?? Item.ItemPath);
 				else
 					await NavigationHelpers.OpenPathInNewTab(Item.ItemPath);
 			}

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -52,7 +52,7 @@ namespace Files.App.ViewModels.Properties
 			if (!Item.IsShortcut)
 				return;
 
-			var shortcutItem = (ShortcutItem)Item;
+			var shortcutItem = (IShortcutItem)Item;
 
 			var isApplication =
 				FileExtensionHelpers.IsExecutableFile(shortcutItem.TargetPath) ||
@@ -78,7 +78,6 @@ namespace Files.App.ViewModels.Properties
 			{
 				if (Item.IsLinkItem)
 				{
-					var tmpItem = (ShortcutItem)Item;
 					await Win32Helper.InvokeWin32ComponentAsync(ViewModel.ShortcutItemPath, AppInstance, ViewModel.ShortcutItemArguments, ViewModel.RunAsAdmin, ViewModel.ShortcutItemWorkingDir);
 				}
 				else
@@ -125,14 +124,14 @@ namespace Files.App.ViewModels.Properties
 			{
 				ViewModel.ItemCreatedTimestampReal = Item.ItemDateCreatedReal;
 				ViewModel.ItemAccessedTimestampReal = Item.ItemDateAccessedReal;
-				if (Item.IsLinkItem || string.IsNullOrWhiteSpace(((ShortcutItem)Item).TargetPath))
+				if (Item.IsLinkItem || string.IsNullOrWhiteSpace(((IShortcutItem)Item).TargetPath))
 				{
 					// Can't show any other property
 					return;
 				}
 			}
 
-			string filePath = (Item as ShortcutItem)?.TargetPath ?? Item.ItemPath;
+			string filePath = (Item as IShortcutItem)?.TargetPath ?? Item.ItemPath;
 			BaseStorageFile file = await AppInstance.ShellViewModel.GetFileFromPathAsync(filePath);
 
 			// Couldn't access the file and can't load any other properties

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -48,9 +48,8 @@ namespace Files.App.ViewModels.Properties
 				ViewModel.LoadFileIcon = Item.LoadFileIcon;
 				ViewModel.ContainsFilesOrFolders = Item.ContainsFilesOrFolders;
 
-				if (Item.IsShortcut)
+				if (Item.IsShortcut && Item is IShortcutItem shortcutItem)
 				{
-					var shortcutItem = (ShortcutItem)Item;
 					ViewModel.ShortcutItemType = Strings.Folder.GetLocalizedResource();
 					ViewModel.ShortcutItemPath = shortcutItem.TargetPath;
 					ViewModel.IsShortcutItemPathReadOnly = false;
@@ -104,14 +103,14 @@ namespace Files.App.ViewModels.Properties
 
 				ViewModel.ItemCreatedTimestampReal = Item.ItemDateCreatedReal;
 				ViewModel.ItemAccessedTimestampReal = Item.ItemDateAccessedReal;
-				if (Item.IsLinkItem || string.IsNullOrWhiteSpace(((ShortcutItem)Item).TargetPath))
+				if (Item.IsLinkItem || string.IsNullOrWhiteSpace(((IShortcutItem)Item).TargetPath))
 				{
 					// Can't show any other property
 					return;
 				}
 			}
 
-			string folderPath = (Item as ShortcutItem)?.TargetPath ?? Item.ItemPath;
+			string folderPath = (Item as IShortcutItem)?.TargetPath ?? Item.ItemPath;
 			BaseStorageFolder storageFolder = await AppInstance.ShellViewModel.GetFolderFromPathAsync(folderPath);
 
 			if (storageFolder is not null)
@@ -222,12 +221,12 @@ namespace Files.App.ViewModels.Properties
 				case nameof(ViewModel.ShortcutItemWorkingDir):
 				case nameof(ViewModel.ShowWindowCommand):
 				case nameof(ViewModel.ShortcutItemArguments):
-					var tmpItem = (ShortcutItem)Item;
+					var shortcutItem = (IShortcutItem)Item;
 
 					if (string.IsNullOrWhiteSpace(ViewModel.ShortcutItemPath))
 						return;
 
-					await FileOperationsHelpers.CreateOrUpdateLinkAsync(Item.ItemPath, ViewModel.ShortcutItemPath, ViewModel.ShortcutItemArguments, ViewModel.ShortcutItemWorkingDir, tmpItem.RunAsAdmin, ViewModel.ShowWindowCommand);
+					await FileOperationsHelpers.CreateOrUpdateLinkAsync(Item.ItemPath, ViewModel.ShortcutItemPath, ViewModel.ShortcutItemArguments, ViewModel.ShortcutItemWorkingDir, shortcutItem.RunAsAdmin, ViewModel.ShowWindowCommand);
 					break;
 			}
 		}

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -1357,7 +1357,7 @@ namespace Files.App.ViewModels
 			if (item.SyncStatusUI.LoadSyncStatus)
 				return false;
 
-			return WindowsSecurityService.IsElevationRequired(item.IsShortcut ? ((ShortcutItem)item).TargetPath : item.ItemPath);
+			return WindowsSecurityService.IsElevationRequired(item.IsShortcut ? ((IShortcutItem)item).TargetPath : item.ItemPath);
 		}
 
 		public async Task LoadGitPropertiesAsync(IGitItem gitItem)

--- a/src/Files.App/ViewModels/UserControls/Previews/ShortcutPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/ShortcutPreviewViewModel.cs
@@ -11,7 +11,7 @@ namespace Files.App.ViewModels.Previews
 
 		public async override Task<List<FileProperty>> LoadPreviewAndDetailsAsync()
 		{
-			var item = Item as ShortcutItem;
+			var item = Item as IShortcutItem;
 			var details = new List<FileProperty>
 			{
 				GetFileProperty("PropertyParsingPath", item.ItemPath),

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1170,7 +1170,7 @@ namespace Files.App.Views.Layouts
 
 				var item = GetItemFromElement(sender);
 				if (item is not null)
-					await ParentShellPageInstance!.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, (item as ShortcutItem)?.TargetPath ?? item.ItemPath, false, true, item.IsExecutable, item.IsScriptFile);
+					await ParentShellPageInstance!.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, (item as IShortcutItem)?.TargetPath ?? item.ItemPath, false, true, item.IsExecutable, item.IsScriptFile);
 			}
 			finally
 			{

--- a/src/Files.App/Views/Properties/ShortcutPage.xaml.cs
+++ b/src/Files.App/Views/Properties/ShortcutPage.xaml.cs
@@ -19,7 +19,7 @@ namespace Files.App.Views.Properties
 				FileProperties properties => properties.Item,
 				FolderProperties properties => properties.Item,
 				_ => null
-			} as ShortcutItem;
+			} as IShortcutItem;
 
 			if (shortcutItem is null)
 				return true;


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #17008 

**Description**
The problem was that GitShortcutItem cannot be cast to ShortcutItem because GitShortcutItem only inherits from GitItem and IShortcutItem. It cannot additionally inherit from ShortcutItem, since a class in C# cannot have multiple base classes.

Simply casting to IShortcutItem everywhere did not work, as the IShortcutItem interface would lack properties of the ListedItem (such as ItemPath).

That's why I decided to create an interface IListedItem. IShortcutItem & IGitItem now both inherit from this interface.

Problems only occurred with shortcut items that are part of a git repository. Not all of them led to a crash, some only displayed error messages or led to incorrect behavior. Here is a list of affected actions:
- Selecting a shortcut item
- Selecting a shortcut item with preview pane open
- Open Properties Window for a shortcut item
- Save modified properties of a shortcut via properties window
- Open in new tab
- Open in new pane
- Open in new Window
- Pin To Start
- Unpin From Start
- Share Item

**Steps used to test these changes**
1. tested if the actions listed above work correctly
