### PR TITLE
Feature: Introduced Omnibar 1

### DIFF
--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -16,7 +16,7 @@ namespace Files.App.Controls
 
 		private void AutoSuggestBox_GotFocus(object sender, RoutedEventArgs e)
 		{
-			_isFocused = true;
+			IsFocused = true;
 
 			VisualStateManager.GoToState(CurrentSelectedMode, "Focused", true);
 			VisualStateManager.GoToState(_textBox, "InputAreaVisible", true);
@@ -30,7 +30,7 @@ namespace Files.App.Controls
 			if (_textBox.ContextFlyout.IsOpen)
 				return;
 
-			_isFocused = false;
+			IsFocused = false;
 
 			if (CurrentSelectedMode?.ContentOnInactive is not null)
 			{
@@ -92,7 +92,8 @@ namespace Files.App.Controls
 
 		private void AutoSuggestBox_TextChanged(object sender, TextChangedEventArgs e)
 		{
-			CurrentSelectedMode!.Text = _textBox.Text;
+			if (string.Compare(_textBox.Text, CurrentSelectedMode!.Text, StringComparison.OrdinalIgnoreCase) is not 0)
+				CurrentSelectedMode!.Text = _textBox.Text;
 
 			// UpdateSuggestionListView();
 

--- a/src/Files.App.Controls/Omnibar/Omnibar.Properties.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Properties.cs
@@ -14,6 +14,22 @@ namespace Files.App.Controls
 		public partial OmnibarMode? CurrentSelectedMode { get; set; }
 
 		[GeneratedDependencyProperty]
+		public partial string? CurrentSelectedModeName { get; set; }
+
+		[GeneratedDependencyProperty]
 		public partial Thickness AutoSuggestBoxPadding { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial bool IsFocused { get; set; }
+
+		partial void OnCurrentSelectedModeChanged(OmnibarMode? newValue)
+		{
+			CurrentSelectedModeName = newValue?.ModeName;
+		}
+
+		partial void OnIsFocusedChanged(bool newValue)
+		{
+			//_textBox?.Focus(newValue ? FocusState.Programmatic : FocusState.Unfocused);
+		}
 	}
 }

--- a/src/Files.App.Controls/Omnibar/Omnibar.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.cs
@@ -188,7 +188,7 @@ namespace Files.App.Controls
 
 		public bool TryToggleIsSuggestionsPopupOpen(bool wantToOpen)
 		{
-			if (wantToOpen && (!IsFocused || CurrentSelectedMode?.SuggestionItemsSource is null))
+			if (wantToOpen && (!IsFocused || CurrentSelectedMode?.SuggestionItemsSource is null || (CurrentSelectedMode?.SuggestionItemsSource is IList collection && collection.Count is 0)))
 				return false;
 
 			_textBoxSuggestionsPopup.IsOpen = wantToOpen;

--- a/src/Files.App.Controls/Omnibar/Omnibar.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.cs
@@ -28,7 +28,6 @@ namespace Files.App.Controls
 		private Border _textBoxSuggestionsContainerBorder = null!;
 		private ListView _textBoxSuggestionsListView = null!;
 
-		private bool _isFocused;
 		private string _userInput = string.Empty;
 		private OmnibarTextChangeReason _textChangeReason = OmnibarTextChangeReason.None;
 
@@ -148,7 +147,7 @@ namespace Files.App.Controls
 			CurrentSelectedMode = modeToExpand;
 
 			_textChangeReason = OmnibarTextChangeReason.ProgrammaticChange;
-			_textBox.Text = CurrentSelectedMode.Text ?? string.Empty;
+			ChangeTextBoxText(CurrentSelectedMode.Text ?? string.Empty);
 
 			// Move cursor of the TextBox to the tail
 			_textBox.Select(_textBox.Text.Length, 0);
@@ -156,7 +155,7 @@ namespace Files.App.Controls
 			VisualStateManager.GoToState(CurrentSelectedMode, "Focused", true);
 			CurrentSelectedMode.OnChangingCurrentMode(true);
 
-			if (_isFocused)
+			if (IsFocused)
 			{
 				VisualStateManager.GoToState(CurrentSelectedMode, "Focused", true);
 				VisualStateManager.GoToState(_textBox, "InputAreaVisible", true);
@@ -174,7 +173,7 @@ namespace Files.App.Controls
 			if (shouldFocus)
 				_textBox.Focus(FocusState.Keyboard);
 
-			TryToggleIsSuggestionsPopupOpen(_isFocused && CurrentSelectedMode?.SuggestionItemsSource is not null);
+			TryToggleIsSuggestionsPopupOpen(IsFocused && CurrentSelectedMode?.SuggestionItemsSource is not null);
 
 			// Remove the reposition transition from the all modes
 			if (useTransition)
@@ -189,7 +188,7 @@ namespace Files.App.Controls
 
 		public bool TryToggleIsSuggestionsPopupOpen(bool wantToOpen)
 		{
-			if (wantToOpen && (!_isFocused || CurrentSelectedMode?.SuggestionItemsSource is null))
+			if (wantToOpen && (!IsFocused || CurrentSelectedMode?.SuggestionItemsSource is null))
 				return false;
 
 			_textBoxSuggestionsPopup.IsOpen = wantToOpen;
@@ -205,10 +204,15 @@ namespace Files.App.Controls
 			if (CurrentSelectedMode.UpdateTextOnSelect)
 			{
 				_textChangeReason = OmnibarTextChangeReason.SuggestionChosen;
-				_textBox.Text = GetObjectText(obj);
+				ChangeTextBoxText(GetObjectText(obj));
 			}
 
 			SuggestionChosen?.Invoke(this, new(CurrentSelectedMode, obj));
+		}
+
+		internal protected void ChangeTextBoxText(string text)
+		{
+			_textBox.Text = text;
 
 			// Move the cursor to the end of the TextBox
 			_textBox?.Select(_textBox.Text.Length, 0);
@@ -233,7 +237,7 @@ namespace Files.App.Controls
 			return obj is string text
 				? text
 				: obj is IOmnibarTextMemberPathProvider textMemberPathProvider
-					? textMemberPathProvider.GetTextMemberPath(CurrentSelectedMode.DisplayMemberPath ?? string.Empty)
+					? textMemberPathProvider.GetTextMemberPath(CurrentSelectedMode.TextMemberPath ?? string.Empty)
 					: obj.ToString() ?? string.Empty;
 		}
 
@@ -245,10 +249,7 @@ namespace Files.App.Controls
 			_textBoxSuggestionsListView.SelectedIndex = -1;
 			_textChangeReason = OmnibarTextChangeReason.ProgrammaticChange;
 
-			_textBox.Text = _userInput ?? "";
-
-			// Move the cursor to the end of the TextBox
-			_textBox?.Select(_textBox.Text.Length, 0);
+			ChangeTextBoxText(_userInput ?? "");
 		}
 	}
 }

--- a/src/Files.App.Controls/Omnibar/Omnibar.xaml
+++ b/src/Files.App.Controls/Omnibar/Omnibar.xaml
@@ -133,7 +133,6 @@
 						Height="{TemplateBinding Height}"
 						HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 						Background="{TemplateBinding Background}"
-						CornerRadius="{TemplateBinding CornerRadius}"
 						TabFocusNavigation="Local">
 						<!--  Mode Button  -->
 						<Border

--- a/src/Files.App.Controls/Omnibar/OmnibarMode.Properties.cs
+++ b/src/Files.App.Controls/Omnibar/OmnibarMode.Properties.cs
@@ -35,9 +35,20 @@ namespace Files.App.Controls
 		public partial DataTemplate? SuggestionItemTemplate { get; set; }
 
 		[GeneratedDependencyProperty]
-		public partial string? DisplayMemberPath { get; set; }
+		/// <remark>
+		/// Implement <see cref="IOmnibarTextMemberPathProvider"/> in <see cref="SuggestionItemsSource"/> to get the text member path from the suggestion item correctly.
+		/// </remark>
+		public partial string? TextMemberPath { get; set; }
 
 		[GeneratedDependencyProperty(DefaultValue = true)]
 		public partial bool UpdateTextOnSelect { get; set; }
+
+		partial void OnTextChanged(string? newValue)
+		{
+			if (_ownerRef is null || _ownerRef.TryGetTarget(out var owner) is false)
+				return;
+
+			owner.ChangeTextBoxText(newValue ?? string.Empty);
+		}
 	}
 }

--- a/src/Files.App/Data/Items/NavigationBarSuggestionItem.cs
+++ b/src/Files.App/Data/Items/NavigationBarSuggestionItem.cs
@@ -3,6 +3,7 @@
 
 namespace Files.App.Data.Items
 {
+	[Obsolete("Remove once Omnibar goes out of experimental.")]
 	public sealed partial class NavigationBarSuggestionItem : ObservableObject
 	{
 		private string? _Text;

--- a/src/Files.App/Data/Models/BreadcrumbBarItemModel.cs
+++ b/src/Files.App/Data/Models/BreadcrumbBarItemModel.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Data.Models
+{
+	internal record BreadcrumbBarItemModel(string Text);
+}

--- a/src/Files.App/Data/Models/OmnibarPathModeSuggestionModel.cs
+++ b/src/Files.App/Data/Models/OmnibarPathModeSuggestionModel.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Files.App.Controls;
+
+namespace Files.App.Data.Models
+{
+	internal record OmnibarPathModeSuggestionModel(string Path, string DisplayName) : IOmnibarTextMemberPathProvider
+	{
+		public string GetTextMemberPath(string textMemberPath)
+		{
+			return textMemberPath switch
+			{
+				nameof(Path) => Path,
+				nameof(DisplayName) => DisplayName,
+				_ => string.Empty
+			};
+		}
+	}
+}

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -4202,9 +4202,6 @@
   <data name="EmptyShelfText" xml:space="preserve">
     <value>Drag files or folders here to interact with them across different tabs</value>
   </data>
-  <data name="CommandPalette" xml:space="preserve">
-    <value>Command palette</value>
-  </data>
   <data name="OmnibarPathModeTextPlaceholder" xml:space="preserve">
     <value>Enter a path to navigate to...</value>
   </data>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -4202,4 +4202,7 @@
   <data name="EmptyShelfText" xml:space="preserve">
     <value>Drag files or folders here to interact with them across different tabs</value>
   </data>
+  <data name="OmnibarPathModeTextPlaceholder" xml:space="preserve">
+    <value>Enter a path to navigate to...</value>
+  </data>
 </root>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -4202,7 +4202,16 @@
   <data name="EmptyShelfText" xml:space="preserve">
     <value>Drag files or folders here to interact with them across different tabs</value>
   </data>
+  <data name="CommandPalette" xml:space="preserve">
+    <value>Command palette</value>
+  </data>
   <data name="OmnibarPathModeTextPlaceholder" xml:space="preserve">
     <value>Enter a path to navigate to...</value>
+  </data>
+  <data name="OmnibarCommandPaletteModeTextPlaceholder" xml:space="preserve">
+    <value>Find features and commands...</value>
+  </data>
+  <data name="OmnibarSearchModeTextPlaceholder" xml:space="preserve">
+    <value>Search for files and folders...</value>
   </data>
 </root>

--- a/src/Files.App/UserControls/NavigationToolbar.xaml
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml
@@ -9,6 +9,8 @@
 	xmlns:converters="using:Files.App.Converters"
 	xmlns:converters1="using:CommunityToolkit.WinUI.Converters"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:dataitems="using:Files.App.Data.Items"
+	xmlns:datamodels="using:Files.App.Data.Models"
 	xmlns:helpers="using:Files.App.Helpers"
 	xmlns:items="using:Files.App.Data.Items"
 	xmlns:keyboard="using:Files.App.UserControls.KeyboardShortcut"
@@ -211,6 +213,7 @@
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="*" />
 				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
 			</Grid.ColumnDefinitions>
 			<!--  Path Box  -->
 			<AutoSuggestBox
@@ -314,24 +317,11 @@
 				LostFocus="SearchRegion_LostFocus"
 				SearchBoxViewModel="{x:Bind ViewModel.SearchBoxViewModel, Mode=OneWay}"
 				Visibility="{x:Bind converters:MultiBooleanConverter.OrConvertToVisibility(ShowSearchBox, ViewModel.IsSearchBoxVisible), Mode=OneWay}" />
-		</Grid>
-
-		<!--  Omnibar  -->
-		<controls:Omnibar
-			x:Name="Omnibar"
-			Grid.Column="1"
-			x:Load="{x:Bind ViewModel.EnableOmnibar, Mode=OneWay}" />
-
-		<!--  Right Side Action Buttons  -->
-		<StackPanel
-			Grid.Column="2"
-			Margin="0,0,4,0"
-			Orientation="Horizontal"
-			Spacing="4">
 
 			<!--  Mini Search Button  -->
 			<Button
 				x:Name="ShowSearchButton"
+				Grid.Column="2"
 				AccessKey="I"
 				AccessKeyInvoked="Button_AccessKeyInvoked"
 				AutomationProperties.Name="{x:Bind Commands.Search.Label, Mode=OneWay}"
@@ -342,6 +332,111 @@
 				Visibility="Collapsed">
 				<FontIcon FontSize="14" Glyph="{x:Bind ViewModel.SearchButtonGlyph, Mode=OneWay}" />
 			</Button>
+
+		</Grid>
+
+		<!--  Omnibar  -->
+		<controls:Omnibar
+			x:Name="Omnibar"
+			Grid.Column="1"
+			x:Load="{x:Bind ViewModel.EnableOmnibar, Mode=OneWay}"
+			CurrentSelectedModeName="{x:Bind ViewModel.OmnibarCurrentSelectedModeName, Mode=TwoWay}"
+			IsFocused="{x:Bind ViewModel.IsOmnibarFocused, Mode=TwoWay}"
+			QuerySubmitted="Omnibar_QuerySubmitted"
+			SuggestionChosen="Omnibar_SuggestionChosen"
+			TextChanged="Omnibar_TextChanged">
+
+			<controls:OmnibarMode
+				IconOnActive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Path}, IsFilled=True}"
+				IconOnInactive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Path}, IconType=Outline}"
+				IsDefault="True"
+				ModeName="Path"
+				PlaceholderText="{helpers:ResourceString Name=OmnibarPathModeTextPlaceholder}"
+				SuggestionItemsSource="{x:Bind ViewModel.PathModeSuggestionItems, Mode=OneWay}"
+				Text="{x:Bind ViewModel.OmnibarPathModeText, Mode=TwoWay}"
+				TextMemberPath="Path">
+				<controls:OmnibarMode.ContentOnInactive>
+					<controls:BreadcrumbBar
+						x:Name="BreadcrumbBar"
+						ItemClicked="BreadcrumbBar_ItemClicked"
+						ItemDropDownFlyoutClosed="BreadcrumbBar_ItemDropDownFlyoutClosed"
+						ItemDropDownFlyoutOpening="BreadcrumbBar_ItemDropDownFlyoutOpening"
+						ItemsSource="{x:Bind ViewModel.PathComponents, Mode=OneWay}">
+						<controls:BreadcrumbBar.RootItem>
+							<Image
+								Width="16"
+								Height="16"
+								Source="/Assets/FluentIcons/Home.png" />
+						</controls:BreadcrumbBar.RootItem>
+						<controls:BreadcrumbBar.ItemTemplate>
+							<DataTemplate x:DataType="dataitems:PathBoxItem">
+								<controls:BreadcrumbBarItem Content="{x:Bind Title, Mode=OneWay}" />
+							</DataTemplate>
+						</controls:BreadcrumbBar.ItemTemplate>
+					</controls:BreadcrumbBar>
+				</controls:OmnibarMode.ContentOnInactive>
+				<controls:OmnibarMode.SuggestionItemTemplate>
+					<DataTemplate x:DataType="datamodels:OmnibarPathModeSuggestionModel">
+						<TextBlock Text="{x:Bind DisplayName, Mode=OneWay}" />
+					</DataTemplate>
+				</controls:OmnibarMode.SuggestionItemTemplate>
+			</controls:OmnibarMode>
+
+			<controls:OmnibarMode
+				IconOnActive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Commands}, IsFilled=True}"
+				IconOnInactive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Commands}, IconType=Outline}"
+				ModeName="Palette"
+				PlaceholderText="Enter a palette command...">
+				<!--<controls:OmnibarMode.SuggestionItemTemplate>
+					<DataTemplate x:DataType="data:OmnibarPaletteSuggestionItem">
+						<Grid Height="48" ColumnSpacing="12">
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
+							<controls:ThemedIcon
+								Width="20"
+								Height="20"
+								VerticalAlignment="Center"
+								Style="{StaticResource App.ThemedIcons.Actions.Copying}" />
+							<StackPanel Grid.Column="1" VerticalAlignment="Center">
+								<TextBlock
+									Style="{StaticResource BodyStrongTextBlockStyle}"
+									Text="{x:Bind Title}"
+									TextTrimming="CharacterEllipsis"
+									TextWrapping="NoWrap" />
+								<TextBlock
+									Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+									Style="{StaticResource CaptionTextBlockStyle}"
+									Text="{x:Bind Description}"
+									TextTrimming="CharacterEllipsis"
+									TextWrapping="NoWrap" />
+							</StackPanel>
+							<StackPanel Grid.Column="2" VerticalAlignment="Center">
+								<TextBlock
+									Text="{x:Bind HotKeys}"
+									TextTrimming="CharacterEllipsis"
+									TextWrapping="NoWrap" />
+							</StackPanel>
+						</Grid>
+					</DataTemplate>
+				</controls:OmnibarMode.SuggestionItemTemplate>-->
+			</controls:OmnibarMode>
+
+			<controls:OmnibarMode
+				IconOnActive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Search}, IsFilled=True}"
+				IconOnInactive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Search}, IconType=Outline}"
+				ModeName="Search"
+				PlaceholderText="Enter a search query..." />
+
+		</controls:Omnibar>
+
+		<!--  Right Side Action Buttons  -->
+		<StackPanel
+			Grid.Column="2"
+			Orientation="Horizontal"
+			Spacing="4">
 
 			<!--  Shelf Pane  -->
 			<ToggleButton

--- a/src/Files.App/UserControls/NavigationToolbar.xaml
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml
@@ -112,7 +112,6 @@
 				AutomationProperties.FullDescription="{x:Bind Commands.NavigateBack.Description, Mode=OneWay}"
 				AutomationProperties.Name="{x:Bind Commands.NavigateBack.Label, Mode=OneWay}"
 				Command="{x:Bind Commands.NavigateBack, Mode=OneWay}"
-				IsEnabled="{x:Bind Commands.NavigateBack.IsExecutable, Mode=OneWay}"
 				Style="{StaticResource AddressToolbarButtonStyle}"
 				ToolTipService.ToolTip="{x:Bind Commands.NavigateBack.LabelWithHotKey, Mode=OneWay}">
 				<FontIcon FontSize="14" Glyph="{x:Bind Commands.NavigateBack.Glyph.BaseGlyph, Mode=OneTime}" />
@@ -142,7 +141,6 @@
 				AutomationProperties.FullDescription="{x:Bind Commands.NavigateForward.Description, Mode=OneWay}"
 				AutomationProperties.Name="{x:Bind Commands.NavigateForward.Label, Mode=OneWay}"
 				Command="{x:Bind Commands.NavigateForward, Mode=OneWay}"
-				IsEnabled="{x:Bind Commands.NavigateForward.IsExecutable, Mode=OneWay}"
 				Style="{StaticResource AddressToolbarButtonStyle}"
 				ToolTipService.ToolTip="{x:Bind Commands.NavigateForward.LabelWithHotKey, Mode=OneWay}">
 				<FontIcon FontSize="14" Glyph="{x:Bind Commands.NavigateForward.Glyph.BaseGlyph, Mode=OneTime}" />
@@ -172,7 +170,6 @@
 				AutomationProperties.FullDescription="{x:Bind Commands.NavigateUp.Description, Mode=OneWay}"
 				AutomationProperties.Name="{x:Bind Commands.NavigateUp.Label, Mode=OneWay}"
 				Command="{x:Bind Commands.NavigateUp, Mode=OneWay}"
-				IsEnabled="{x:Bind Commands.NavigateUp.IsExecutable, Mode=OneWay}"
 				Style="{StaticResource AddressToolbarButtonStyle}"
 				ToolTipService.ToolTip="{x:Bind Commands.NavigateUp.LabelWithHotKey, Mode=OneWay}">
 				<FontIcon FontSize="14" Glyph="{x:Bind Commands.NavigateUp.Glyph.BaseGlyph, Mode=OneTime}" />
@@ -184,7 +181,6 @@
 				AccessKeyInvoked="Button_AccessKeyInvoked"
 				AutomationProperties.Name="{x:Bind Commands.RefreshItems.Label, Mode=OneWay}"
 				Command="{x:Bind Commands.RefreshItems, Mode=OneWay}"
-				IsEnabled="{x:Bind Commands.RefreshItems.IsExecutable, Mode=OneWay}"
 				Style="{StaticResource AddressToolbarButtonStyle}"
 				ToolTipService.ToolTip="{x:Bind Commands.RefreshItems.LabelWithHotKey, Mode=OneWay}">
 				<FontIcon FontSize="14" Glyph="{x:Bind Commands.RefreshItems.Glyph.BaseGlyph, Mode=OneTime}" />
@@ -197,7 +193,6 @@
 				AccessKeyInvoked="Button_AccessKeyInvoked"
 				AutomationProperties.Name="{x:Bind Commands.NavigateHome.Label, Mode=OneWay}"
 				Command="{x:Bind Commands.NavigateHome, Mode=OneWay}"
-				IsEnabled="{x:Bind Commands.NavigateHome.IsExecutable, Mode=OneWay}"
 				Style="{StaticResource AddressToolbarButtonStyle}"
 				ToolTipService.ToolTip="{x:Bind Commands.NavigateHome.LabelWithHotKey, Mode=OneWay}">
 				<FontIcon FontSize="14" Glyph="{x:Bind Commands.NavigateHome.Glyph.BaseGlyph, Mode=OneTime}" />
@@ -350,10 +345,10 @@
 				IconOnActive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Path}, IsFilled=True}"
 				IconOnInactive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Path}, IconType=Outline}"
 				IsDefault="True"
-				ModeName="Path"
+				ModeName="{helpers:ResourceString Name=Path}"
 				PlaceholderText="{helpers:ResourceString Name=OmnibarPathModeTextPlaceholder}"
 				SuggestionItemsSource="{x:Bind ViewModel.PathModeSuggestionItems, Mode=OneWay}"
-				Text="{x:Bind ViewModel.OmnibarPathModeText, Mode=TwoWay}"
+				Text="{x:Bind ViewModel.PathText, Mode=TwoWay}"
 				TextMemberPath="Path">
 				<controls:OmnibarMode.ContentOnInactive>
 					<controls:BreadcrumbBar
@@ -385,8 +380,8 @@
 			<controls:OmnibarMode
 				IconOnActive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Commands}, IsFilled=True}"
 				IconOnInactive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Commands}, IconType=Outline}"
-				ModeName="Palette"
-				PlaceholderText="Enter a palette command...">
+				ModeName="{helpers:ResourceString Name=CommandPalette}"
+				PlaceholderText="{helpers:ResourceString Name=OmnibarCommandPaletteModeTextPlaceholder}">
 				<!--<controls:OmnibarMode.SuggestionItemTemplate>
 					<DataTemplate x:DataType="data:OmnibarPaletteSuggestionItem">
 						<Grid Height="48" ColumnSpacing="12">
@@ -427,8 +422,8 @@
 			<controls:OmnibarMode
 				IconOnActive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Search}, IsFilled=True}"
 				IconOnInactive="{controls:ThemedIconMarkup Style={StaticResource App.ThemedIcons.Omnibar.Search}, IconType=Outline}"
-				ModeName="Search"
-				PlaceholderText="Enter a search query..." />
+				ModeName="{helpers:ResourceString Name=Search}"
+				PlaceholderText="{helpers:ResourceString Name=OmnibarSearchModeTextPlaceholder}" />
 
 		</controls:Omnibar>
 

--- a/src/Files.App/UserControls/NavigationToolbar.xaml
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml
@@ -435,6 +435,7 @@
 		<!--  Right Side Action Buttons  -->
 		<StackPanel
 			Grid.Column="2"
+			Margin="0,0,4,0"
 			Orientation="Horizontal"
 			Spacing="4">
 

--- a/src/Files.App/UserControls/NavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using CommunityToolkit.WinUI;
+using Files.App.Controls;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -9,9 +10,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
-using System.Windows.Input;
 using Windows.System;
-using FocusManager = Microsoft.UI.Xaml.Input.FocusManager;
 
 namespace Files.App.UserControls
 {
@@ -41,18 +40,14 @@ namespace Files.App.UserControls
 		[GeneratedDependencyProperty]
 		public partial NavigationToolbarViewModel ViewModel { get; set; }
 
-		// Commands
-
-		private readonly ICommand historyItemClickedCommand;
-
 		// Constructor
 
 		public NavigationToolbar()
 		{
 			InitializeComponent();
-
-			historyItemClickedCommand = new RelayCommand<ToolbarHistoryItemModel?>(HistoryItemClicked);
 		}
+
+		// Methods
 
 		private void NavToolbar_Loading(FrameworkElement _, object e)
 		{
@@ -104,7 +99,7 @@ namespace Files.App.UserControls
 			if (App.AppModel.IsMainWindowClosed)
 				return;
 
-			var element = FocusManager.GetFocusedElement(MainWindow.Instance.Content.XamlRoot);
+			var element = Microsoft.UI.Xaml.Input.FocusManager.GetFocusedElement(MainWindow.Instance.Content.XamlRoot);
 			if (element is FlyoutBase or AppBarButton or Popup)
 				return;
 
@@ -195,9 +190,9 @@ namespace Files.App.UserControls
 
 				var flyoutItem = new MenuFlyoutItem
 				{
-					Icon = new FontIcon { Glyph = "\uE8B7" }, // Use font icon as placeholder
+					Icon = new FontIcon() { Glyph = "\uE8B7" }, // Placeholder icon
 					Text = fileName,
-					Command = historyItemClickedCommand,
+					Command = new RelayCommand<ToolbarHistoryItemModel?>(HistoryItemClicked),
 					CommandParameter = new ToolbarHistoryItemModel(item, isBackMode)
 				};
 
@@ -205,47 +200,47 @@ namespace Files.App.UserControls
 
 				// Start loading the thumbnail in the background
 				_ = LoadFlyoutItemIconAsync(flyoutItem, args.NavPathParam);
-			}
-		}
 
-		private async Task LoadFlyoutItemIconAsync(MenuFlyoutItem flyoutItem, string path)
-		{
-			var imageSource = await NavigationHelpers.GetIconForPathAsync(path);
-
-			if (imageSource is not null)
-				flyoutItem.Icon = new ImageIcon { Source = imageSource };
-		}
-
-		private void HistoryItemClicked(ToolbarHistoryItemModel? itemModel)
-		{
-			if (itemModel is null)
-				return;
-
-			var shellPage = Ioc.Default.GetRequiredService<IContentPageContext>().ShellPage;
-			if (shellPage is null)
-				return;
-
-			if (itemModel.IsBackMode)
-			{
-				// Remove all entries after the target entry in the BackwardStack
-				while (shellPage.BackwardStack.Last() != itemModel.PageStackEntry)
+				async Task LoadFlyoutItemIconAsync(MenuFlyoutItem flyoutItem, string path)
 				{
-					shellPage.BackwardStack.RemoveAt(shellPage.BackwardStack.Count - 1);
+					var imageSource = await NavigationHelpers.GetIconForPathAsync(path);
+
+					if (imageSource is not null)
+						flyoutItem.Icon = new ImageIcon() { Source = imageSource };
 				}
 
-				// Navigate back
-				shellPage.Back_Click();
-			}
-			else
-			{
-				// Remove all entries before the target entry in the ForwardStack
-				while (shellPage.ForwardStack.First() != itemModel.PageStackEntry)
+				void HistoryItemClicked(ToolbarHistoryItemModel? itemModel)
 				{
-					shellPage.ForwardStack.RemoveAt(0);
-				}
+					if (itemModel is null)
+						return;
 
-				// Navigate forward
-				shellPage.Forward_Click();
+					var shellPage = Ioc.Default.GetRequiredService<IContentPageContext>().ShellPage;
+					if (shellPage is null)
+						return;
+
+					if (itemModel.IsBackMode)
+					{
+						// Remove all entries after the target entry in the BackwardStack
+						while (shellPage.BackwardStack.Last() != itemModel.PageStackEntry)
+						{
+							shellPage.BackwardStack.RemoveAt(shellPage.BackwardStack.Count - 1);
+						}
+
+						// Navigate back
+						shellPage.Back_Click();
+					}
+					else
+					{
+						// Remove all entries before the target entry in the ForwardStack
+						while (shellPage.ForwardStack.First() != itemModel.PageStackEntry)
+						{
+							shellPage.ForwardStack.RemoveAt(0);
+						}
+
+						// Navigate forward
+						shellPage.Forward_Click();
+					}
+				}
 			}
 		}
 
@@ -257,6 +252,63 @@ namespace Files.App.UserControls
 			var previousControl = args.OldFocusedElement as FrameworkElement;
 			if (previousControl?.Name == nameof(HomeButton) || previousControl?.Name == nameof(Refresh))
 				ViewModel.IsEditModeEnabled = true;
+		}
+
+		private async void Omnibar_QuerySubmitted(Omnibar sender, OmnibarQuerySubmittedEventArgs args)
+		{
+			await ViewModel.HandleItemNavigationAsync(args.Text);
+		}
+
+		private async void Omnibar_SuggestionChosen(Omnibar sender, OmnibarSuggestionChosenEventArgs args)
+		{
+			if (args.SelectedItem is OmnibarPathModeSuggestionModel item &&
+				!string.IsNullOrEmpty(item.Path))
+				await ViewModel.HandleItemNavigationAsync(item.Path);
+		}
+
+		private async void Omnibar_TextChanged(Omnibar sender, OmnibarTextChangedEventArgs args)
+		{
+			await ViewModel.PopulateOmnibarSuggestionsForPathMode();
+		}
+
+		private async void BreadcrumbBar_ItemClicked(Controls.BreadcrumbBar sender, Controls.BreadcrumbBarItemClickedEventArgs args)
+		{
+			if (args.IsRootItem)
+			{
+				await ViewModel.HandleItemNavigationAsync("Home");
+				return;
+			}
+
+			await ViewModel.HandleFolderNavigationAsync(ViewModel.PathComponents[args.Index].Path);
+		}
+
+		private async void BreadcrumbBar_ItemDropDownFlyoutOpening(object sender, BreadcrumbBarItemDropDownFlyoutEventArgs e)
+		{
+			if (e.IsRootItem)
+			{
+				// TODO: Populate a different flyout for the root item
+				e.Flyout.Items.Add(new MenuFlyoutHeaderItem() { Text = "Quick access" });
+				e.Flyout.Items.Add(new MenuFlyoutItem() { Text = "Desktop" });
+				e.Flyout.Items.Add(new MenuFlyoutItem() { Text = "Download" });
+				e.Flyout.Items.Add(new MenuFlyoutItem() { Text = "Documents" });
+				e.Flyout.Items.Add(new MenuFlyoutItem() { Text = "Pictures" });
+				e.Flyout.Items.Add(new MenuFlyoutItem() { Text = "Music" });
+				e.Flyout.Items.Add(new MenuFlyoutItem() { Text = "Videos" });
+				e.Flyout.Items.Add(new MenuFlyoutItem() { Text = "Recycle bin" });
+				e.Flyout.Items.Add(new MenuFlyoutHeaderItem() { Text = "Drives" });
+				e.Flyout.Items.Add(new MenuFlyoutItem() { Text = "Local Disk (C:)" });
+				e.Flyout.Items.Add(new MenuFlyoutItem() { Text = "Local Disk (D:)" });
+
+				return;
+			}
+
+			await ViewModel.SetPathBoxDropDownFlyoutAsync(e.Flyout, ViewModel.PathComponents[e.Index]);
+		}
+
+		private void BreadcrumbBar_ItemDropDownFlyoutClosed(object sender, BreadcrumbBarItemDropDownFlyoutEventArgs e)
+		{
+			// Clear the flyout items to save memory
+			e.Flyout.Items.Clear();
 		}
 	}
 }

--- a/src/Files.App/UserControls/PathBreadcrumb.xaml.cs
+++ b/src/Files.App/UserControls/PathBreadcrumb.xaml.cs
@@ -50,7 +50,15 @@ namespace Files.App.UserControls
 
 		private async void PathBoxItem_Tapped(object sender, TappedRoutedEventArgs e)
 		{
-			await ViewModel.PathBoxItem_Tapped(sender, e);
+			if (sender is not TextBlock textBlock ||
+				textBlock.DataContext is not PathBoxItem item ||
+				item.Path is not { } path)
+				return;
+
+			// TODO: Implement middle click retrieving.
+			await ViewModel.HandleFolderNavigationAsync(path);
+
+			e.Handled = true;
 		}
 
 		private void PathBoxItem_PointerPressed(object sender, PointerRoutedEventArgs e)

--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -3,6 +3,7 @@
 
 using CommunityToolkit.WinUI;
 using Files.App.Actions;
+using Files.App.Controls;
 using Files.Shared.Helpers;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -22,6 +23,10 @@ namespace Files.App.ViewModels.UserControls
 
 		private const int MaxSuggestionsCount = 10;
 
+		public const string OmnibarPathModeName = "Path";
+		public const string OmnibarPaletteModeName = "Palette";
+		public const string OmnibarSearchModeName = "Search";
+
 		// Dependency injections
 
 		private readonly IUserSettingsService UserSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
@@ -30,6 +35,7 @@ namespace Files.App.ViewModels.UserControls
 		private readonly DrivesViewModel drivesViewModel = Ioc.Default.GetRequiredService<DrivesViewModel>();
 		private readonly IUpdateService UpdateService = Ioc.Default.GetRequiredService<IUpdateService>();
 		private readonly ICommandManager Commands = Ioc.Default.GetRequiredService<ICommandManager>();
+		private readonly IContentPageContext ContentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		// Fields
 
@@ -62,6 +68,8 @@ namespace Files.App.ViewModels.UserControls
 		public ObservableCollection<PathBoxItem> PathComponents { get; } = [];
 
 		public ObservableCollection<NavigationBarSuggestionItem> NavigationBarSuggestions { get; } = [];
+
+		internal ObservableCollection<OmnibarPathModeSuggestionModel> PathModeSuggestionItems { get; } = [];
 
 		public bool IsSingleItemOverride { get; set; }
 
@@ -199,15 +207,54 @@ namespace Files.App.ViewModels.UserControls
 		}
 
 		private string? _PathText;
+		[Obsolete("Remove once Omnibar goes out of experimental.")]
 		public string? PathText
 		{
 			get => _PathText;
 			set
 			{
-				_PathText = value;
-				OnPropertyChanged(nameof(PathText));
+				if (SetProperty(ref _PathText, value))
+					OnPropertyChanged(nameof(OmnibarPathModeText));
 			}
 		}
+
+		private bool _IsOmnibarFocused;
+		public  bool IsOmnibarFocused
+		{
+			get => _IsOmnibarFocused;
+			set
+			{
+				if (SetProperty(ref _IsOmnibarFocused, value))
+				{
+					if (value)
+					{
+						switch(OmnibarCurrentSelectedModeName)
+						{
+							case OmnibarPathModeName:
+								OmnibarPathModeText =
+									string.IsNullOrEmpty(ContentPageContext.ShellPage?.ShellViewModel?.WorkingDirectory)
+										? Constants.UserEnvironmentPaths.HomePath
+										: ContentPageContext.ShellPage.ShellViewModel.WorkingDirectory;
+								_ = PopulateOmnibarSuggestionsForPathMode();
+								break;
+							case OmnibarPaletteModeName:
+								break;
+							case OmnibarSearchModeName:
+								break;
+							default:
+								throw new ArgumentOutOfRangeException("");
+						}
+
+					}
+				}
+			}
+		}
+
+		private string _OmnibarCurrentSelectedModeName;
+		public string OmnibarCurrentSelectedModeName { get => _OmnibarCurrentSelectedModeName; set => SetProperty(ref _OmnibarCurrentSelectedModeName, value); }
+
+		private string _OmnibarPathModeText;
+		public string OmnibarPathModeText { get => _OmnibarPathModeText; set => SetProperty(ref _OmnibarPathModeText, value); }
 
 		private CurrentInstanceViewModel _InstanceViewModel;
 		public CurrentInstanceViewModel InstanceViewModel
@@ -226,6 +273,7 @@ namespace Files.App.ViewModels.UserControls
 			}
 		}
 
+		[Obsolete("Remove once Omnibar goes out of experimental.")]
 		public bool IsEditModeEnabled
 		{
 			get => ManualEntryBoxLoaded;
@@ -548,28 +596,124 @@ namespace Files.App.ViewModels.UserControls
 			_pointerRoutedEventArgs = ptrPt.Properties.IsMiddleButtonPressed ? e : null;
 		}
 
-		public async Task PathBoxItem_Tapped(object sender, TappedRoutedEventArgs e)
+		public async Task HandleFolderNavigationAsync(string path, bool openNewTab = false)
 		{
-			var itemTappedPath = ((sender as TextBlock)?.DataContext as PathBoxItem)?.Path;
-			if (itemTappedPath is null)
-				return;
-
-			if (_pointerRoutedEventArgs is not null)
+			openNewTab |= _pointerRoutedEventArgs is not null;
+			if (openNewTab)
 			{
-				await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
-				{
-					await NavigationHelpers.AddNewTabByPathAsync(typeof(ShellPanesPage), itemTappedPath, true);
-				}, DispatcherQueuePriority.Low);
-				e.Handled = true;
+				await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(
+					async () =>
+					{
+						await NavigationHelpers.AddNewTabByPathAsync(typeof(ShellPanesPage), path, true);
+					},
+					DispatcherQueuePriority.Low);
+
 				_pointerRoutedEventArgs = null;
 
 				return;
 			}
 
-			ToolbarPathItemInvoked?.Invoke(this, new PathNavigationEventArgs()
+			ToolbarPathItemInvoked?.Invoke(this, new() { ItemPath = path });
+		}
+
+		public async Task HandleItemNavigationAsync(string path)
+		{
+			if (ContentPageContext.ShellPage is null || PathComponents.LastOrDefault()?.Path is not { } currentPath)
+				return;
+
+			var isFtp = FtpHelpers.IsFtpPath(path);
+			var normalizedInput = NormalizePathInput(path, isFtp);
+			if (currentPath.Equals(normalizedInput, StringComparison.OrdinalIgnoreCase) ||
+				string.IsNullOrWhiteSpace(normalizedInput))
+				return;
+
+			if (normalizedInput.Equals(ContentPageContext.ShellPage.ShellViewModel.WorkingDirectory) &&
+				ContentPageContext.ShellPage.CurrentPageType != typeof(HomePage))
+				return;
+
+			if (normalizedInput.Equals("Home", StringComparison.OrdinalIgnoreCase) ||
+				normalizedInput.Equals(Strings.Home.GetLocalizedResource(), StringComparison.OrdinalIgnoreCase))
 			{
-				ItemPath = itemTappedPath
-			});
+				SavePathToHistory("Home");
+				ContentPageContext.ShellPage.NavigateHome();
+			}
+			else if (normalizedInput.Equals("ReleaseNotes", StringComparison.OrdinalIgnoreCase) ||
+				normalizedInput.Equals(Strings.ReleaseNotes.GetLocalizedResource(), StringComparison.OrdinalIgnoreCase))
+			{
+				SavePathToHistory("ReleaseNotes");
+				ContentPageContext.ShellPage.NavigateToReleaseNotes();
+			}
+			else if (normalizedInput.Equals("Settings", StringComparison.OrdinalIgnoreCase) ||
+				normalizedInput.Equals(Strings.Settings.GetLocalizedResource(), StringComparison.OrdinalIgnoreCase))
+			{
+				//SavePathToHistory("Settings");
+				//ContentPageContext.ShellPage.NavigateToSettings();
+			}
+			else
+			{
+				normalizedInput = StorageFileExtensions.GetResolvedPath(normalizedInput, isFtp);
+				if (currentPath.Equals(normalizedInput, StringComparison.OrdinalIgnoreCase))
+					return;
+
+				var item = await FilesystemTasks.Wrap(() => DriveHelpers.GetRootFromPathAsync(normalizedInput));
+
+				var resFolder = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFolderWithPathFromPathAsync(normalizedInput, item));
+				if (resFolder || FolderHelpers.CheckFolderAccessWithWin32(normalizedInput))
+				{
+					var matchingDrive = drivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(x => PathNormalization.NormalizePath(normalizedInput).StartsWith(PathNormalization.NormalizePath(x.Path), StringComparison.Ordinal));
+					if (matchingDrive is not null && matchingDrive.Type == Data.Items.DriveType.CDRom && matchingDrive.MaxSpace == ByteSizeLib.ByteSize.FromBytes(0))
+					{
+						bool ejectButton = await DialogDisplayHelper.ShowDialogAsync(Strings.InsertDiscDialog_Title.GetLocalizedResource(), string.Format(Strings.InsertDiscDialog_Text.GetLocalizedResource(), matchingDrive.Path), Strings.InsertDiscDialog_OpenDriveButton.GetLocalizedResource(), Strings.Close.GetLocalizedResource());
+						if (ejectButton)
+							DriveHelpers.EjectDeviceAsync(matchingDrive.Path);
+						return;
+					}
+
+					var pathToNavigate = resFolder.Result?.Path ?? normalizedInput;
+					SavePathToHistory(pathToNavigate);
+					ContentPageContext.ShellPage.NavigateToPath(pathToNavigate);
+				}
+				else if (isFtp)
+				{
+					SavePathToHistory(normalizedInput);
+					ContentPageContext.ShellPage.NavigateToPath(normalizedInput);
+				}
+				else // Not a folder or inaccessible
+				{
+					var resFile = await FilesystemTasks.Wrap(() => StorageFileExtensions.DangerousGetFileWithPathFromPathAsync(normalizedInput, item));
+					if (resFile)
+					{
+						var pathToInvoke = resFile.Result.Path;
+						await Win32Helper.InvokeWin32ComponentAsync(pathToInvoke, ContentPageContext.ShellPage);
+					}
+					else // Not a file or not accessible
+					{
+						var workingDir =
+							string.IsNullOrEmpty(ContentPageContext.ShellPage.ShellViewModel.WorkingDirectory) ||
+							ContentPageContext.ShellPage.CurrentPageType == typeof(HomePage)
+								? Constants.UserEnvironmentPaths.HomePath
+								: ContentPageContext.ShellPage.ShellViewModel.WorkingDirectory;
+
+						if (await LaunchApplicationFromPath(OmnibarPathModeText, workingDir))
+							return;
+
+						try
+						{
+							if (!await Windows.System.Launcher.LaunchUriAsync(new Uri(OmnibarPathModeText)))
+								await DialogDisplayHelper.ShowDialogAsync(Strings.InvalidItemDialogTitle.GetLocalizedResource(),
+									string.Format(Strings.InvalidItemDialogContent.GetLocalizedResource(), Environment.NewLine, resFolder.ErrorCode.ToString()));
+						}
+						catch (Exception ex) when (ex is UriFormatException || ex is ArgumentException)
+						{
+							await DialogDisplayHelper.ShowDialogAsync(Strings.InvalidItemDialogTitle.GetLocalizedResource(),
+								string.Format(Strings.InvalidItemDialogContent.GetLocalizedResource(), Environment.NewLine, resFolder.ErrorCode.ToString()));
+						}
+					}
+				}
+			}
+
+			PathControlDisplayText = ContentPageContext.ShellPage.ShellViewModel.WorkingDirectory;
+			IsOmnibarFocused = false;
 		}
 
 		public void PathBoxItem_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
@@ -677,12 +821,12 @@ namespace Files.App.ViewModels.UserControls
 		private void SearchRegion_Escaped(object? sender, ISearchBoxViewModel _SearchBox)
 			=> CloseSearchBox(true);
 
-		public async Task SetPathBoxDropDownFlyoutAsync(MenuFlyout flyout, PathBoxItem pathItem, IShellPage shellPage)
+		public async Task SetPathBoxDropDownFlyoutAsync(MenuFlyout flyout, PathBoxItem pathItem)
 		{
 			var nextPathItemTitle = PathComponents[PathComponents.IndexOf(pathItem) + 1].Title;
 			IList<StorageFolderWithPath>? childFolders = null;
 
-			StorageFolderWithPath folder = await shellPage.ShellViewModel.GetFolderWithPathFromPathAsync(pathItem.Path);
+			StorageFolderWithPath folder = await ContentPageContext.ShellPage.ShellViewModel.GetFolderWithPathFromPathAsync(pathItem.Path);
 			if (folder is not null)
 				childFolders = (await FilesystemTasks.Wrap(() => folder.GetFoldersWithPathAsync(string.Empty))).Result;
 
@@ -723,7 +867,7 @@ namespace Files.App.ViewModels.UserControls
 					flyoutItem.Click += (sender, args) =>
 					{
 						// Navigate to the directory
-						shellPage.NavigateToPath(childFolder.Path);
+						ContentPageContext.ShellPage.NavigateToPath(childFolder.Path);
 					};
 				}
 
@@ -755,6 +899,7 @@ namespace Files.App.ViewModels.UserControls
 			return currentInput;
 		}
 
+		[Obsolete("Remove once Omnibar goes out of experimental.")]
 		public async Task CheckPathInputAsync(string currentInput, string currentSelectedPath, IShellPage shellPage)
 		{
 			if (currentInput.StartsWith('>'))
@@ -885,6 +1030,107 @@ namespace Files.App.ViewModels.UserControls
 			);
 		}
 
+		public async Task PopulateOmnibarSuggestionsForPathMode()
+		{
+			var result = await SafetyExtensions.IgnoreExceptions(async () =>
+			{
+				List<OmnibarPathModeSuggestionModel>? newSuggestions = [];
+				var pathText = OmnibarPathModeText;
+
+				// If the current input is special, populate navigation history instead.
+				if (string.IsNullOrWhiteSpace(pathText) ||
+					pathText is "Home" or "ReleaseNotes" or "Settings")
+				{
+					// Load previously entered path
+					if (UserSettingsService.GeneralSettingsService.PathHistoryList is { } pathHistoryList)
+					{
+						newSuggestions.AddRange(pathHistoryList.Select(x => new OmnibarPathModeSuggestionModel(x, x)));
+					}
+				}
+				else
+				{
+					var isFtp = FtpHelpers.IsFtpPath(pathText);
+					pathText = NormalizePathInput(pathText, isFtp);
+					var expandedPath = StorageFileExtensions.GetResolvedPath(pathText, isFtp);
+					var folderPath = PathNormalization.GetParentDir(expandedPath) ?? expandedPath;
+					StorageFolderWithPath folder = await ContentPageContext.ShellPage.ShellViewModel.GetFolderWithPathFromPathAsync(folderPath);
+					if (folder is null)
+						return false;
+
+					var currPath = await folder.GetFoldersWithPathAsync(Path.GetFileName(expandedPath), MaxSuggestionsCount);
+					if (currPath.Count >= MaxSuggestionsCount)
+					{
+						newSuggestions.AddRange(currPath.Select(x => new OmnibarPathModeSuggestionModel(x.Path, x.Item.DisplayName)));
+					}
+					else if (currPath.Any())
+					{
+						var subPath = await currPath.First().GetFoldersWithPathAsync((uint)(MaxSuggestionsCount - currPath.Count));
+						newSuggestions.AddRange(currPath.Select(x => new OmnibarPathModeSuggestionModel(x.Path, x.Item.DisplayName)));
+						newSuggestions.AddRange(subPath.Select(x => new OmnibarPathModeSuggestionModel(x.Path, PathNormalization.Combine(currPath.First().Item.DisplayName, x.Item.DisplayName))));
+					}
+				}
+
+				// If there are no suggestions, show "No suggestions"
+				if (newSuggestions.Count is 0)
+				{
+					AddNoResultsItem();
+				}
+
+				// Check whether at least one item is in common between the old and the new suggestions
+				// since the suggestions popup becoming empty causes flickering
+				if (!PathModeSuggestionItems.IntersectBy(newSuggestions, x => x.DisplayName).Any())
+				{
+					// No items in common, update the list in-place
+					for (int index = 0; index < newSuggestions.Count; index++)
+					{
+						if (index < PathModeSuggestionItems.Count)
+						{
+							PathModeSuggestionItems[index] = newSuggestions[index];
+						}
+						else
+						{
+							PathModeSuggestionItems.Add(newSuggestions[index]);
+						}
+					}
+
+					while (PathModeSuggestionItems.Count > newSuggestions.Count)
+						PathModeSuggestionItems.RemoveAt(PathModeSuggestionItems.Count - 1);
+				}
+				else
+				{
+					// At least an element in common, show animation
+					foreach (var s in PathModeSuggestionItems.ExceptBy(newSuggestions, x => x.DisplayName).ToList())
+						PathModeSuggestionItems.Remove(s);
+
+					for (int index = 0; index < newSuggestions.Count; index++)
+					{
+						if (PathModeSuggestionItems.Count > index && PathModeSuggestionItems[index].DisplayName == newSuggestions[index].DisplayName)
+						{
+							PathModeSuggestionItems[index] = newSuggestions[index];
+						}
+						else
+							PathModeSuggestionItems.Insert(index, newSuggestions[index]);
+					}
+				}
+
+				return true;
+			});
+
+			if (!result)
+			{
+				AddNoResultsItem();
+			}
+
+			void AddNoResultsItem()
+			{
+				PathModeSuggestionItems.Clear();
+				PathModeSuggestionItems.Add(new(
+					ContentPageContext.ShellPage.ShellViewModel.WorkingDirectory,
+					Strings.NavigationToolbarVisiblePathNoResults.GetLocalizedResource()));
+			}
+		}
+
+		[Obsolete("Remove once Omnibar goes out of experimental.")]
 		public async Task SetAddressBarSuggestionsAsync(AutoSuggestBox sender, IShellPage shellpage)
 		{
 			if (sender.Text is not null && shellpage.ShellViewModel is not null)

--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -859,7 +859,7 @@ namespace Files.App.ViewModels.UserControls
 				{
 					Icon = new FontIcon { Glyph = "\uE8B7" }, // Use font icon as placeholder
 					Text = childFolder.Item.Name,
-					FontSize = 12,
+					FontSize = 12
 				};
 
 				if (workingPath != childFolder.Path)

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -422,7 +422,7 @@ namespace Files.App.Views.Shells
 
 		protected async void ShellPage_ToolbarPathItemLoaded(object sender, ToolbarPathItemLoadedEventArgs e)
 		{
-			await ToolbarViewModel.SetPathBoxDropDownFlyoutAsync(e.OpenedFlyout, e.Item, this);
+			await ToolbarViewModel.SetPathBoxDropDownFlyoutAsync(e.OpenedFlyout, e.Item);
 		}
 
 		protected async void ShellPage_ToolbarFlyoutOpening(object sender, ToolbarFlyoutOpeningEventArgs e)
@@ -430,7 +430,7 @@ namespace Files.App.Views.Shells
 			var pathBoxItem = ((Button)e.OpeningFlyout.Target).DataContext as PathBoxItem;
 
 			if (pathBoxItem is not null)
-				await ToolbarViewModel.SetPathBoxDropDownFlyoutAsync(e.OpeningFlyout, pathBoxItem, this);
+				await ToolbarViewModel.SetPathBoxDropDownFlyoutAsync(e.OpeningFlyout, pathBoxItem);
 		}
 
 		protected async void NavigationToolbar_QuerySubmitted(object sender, ToolbarQuerySubmittedEventArgs e)
@@ -442,9 +442,10 @@ namespace Files.App.Views.Shells
 		{
 			ToolbarViewModel.ManualEntryBoxLoaded = true;
 			ToolbarViewModel.ClickablePathLoaded = false;
-			ToolbarViewModel.PathText = string.IsNullOrEmpty(ShellViewModel?.WorkingDirectory)
+			ToolbarViewModel.OmnibarPathModeText = string.IsNullOrEmpty(ShellViewModel?.WorkingDirectory)
 				? Constants.UserEnvironmentPaths.HomePath
 				: ShellViewModel.WorkingDirectory;
+			ToolbarViewModel.PathText = ToolbarViewModel.OmnibarPathModeText;
 		}
 
 		protected async void DrivesManager_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -442,10 +442,9 @@ namespace Files.App.Views.Shells
 		{
 			ToolbarViewModel.ManualEntryBoxLoaded = true;
 			ToolbarViewModel.ClickablePathLoaded = false;
-			ToolbarViewModel.OmnibarPathModeText = string.IsNullOrEmpty(ShellViewModel?.WorkingDirectory)
+			ToolbarViewModel.PathText = string.IsNullOrEmpty(ShellViewModel?.WorkingDirectory)
 				? Constants.UserEnvironmentPaths.HomePath
 				: ShellViewModel.WorkingDirectory;
-			ToolbarViewModel.PathText = ToolbarViewModel.OmnibarPathModeText;
 		}
 
 		protected async void DrivesManager_PropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Resolved / Related Issues

Introduced Omnibar and added support for the Path mode.

- #16029

### Steps used to test these changes

1. Open Files app
2. Enable Omnibar from Settings > Advanced
3. Test the breadcrumb bar
    1. Click on a breadcrumb item
    2. Click on a breadcrumb item's chevron
    3. Click on a flyout item of a breadcrumb item's chevron
    4. Click on the root item (Home)
    5. Click on a flyout item of the root item's chevron
4. Test the Omnibar's textbox
    1. Enter test and see the suggestions being updated
    2. Submit the entered text by tappping Enter key to see the navigation
5. Test the Omnibar's focus

![image](https://github.com/user-attachments/assets/d4e28c07-cfe4-4660-addd-da9e944048a9)

![image](https://github.com/user-attachments/assets/e7c177b8-bad9-4fe3-9eea-fbc0d7b5f977)

