### PR TITLE
Fix: Fixed issue where toolbar button sometimes had the wrong icon state

### DIFF
--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
@@ -239,6 +239,11 @@ namespace Files.App.Controls
 
 		private void OnIsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
 		{
+			// Sometimes the variable _isOwnerEnabled is not set to true when the control is enabled
+			// Fixes a bug when certain icons (such as Delete and Copy) were not shown in color
+			// for image files even though the icon is enabled and clickable
+			_isOwnerEnabled = ownerControl?.IsEnabled ?? false;
+
 			UpdateVisualStates();
 		}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16715 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. Select an image file
3. Before the bugfix, some icons like Copy, Cut and Delete are shown as disabled even if they are enabled
4. With the bugfix all applicable icons show in color when selecting image files 
