### PR TITLE
Fix: Fixed issue where toolbar button sometimes had the wrong icon state

### DIFF
--- a/src/Files.App/Actions/Content/ImageManipulation/BaseRotateAction.cs
+++ b/src/Files.App/Actions/Content/ImageManipulation/BaseRotateAction.cs
@@ -22,6 +22,7 @@ namespace Files.App.Actions
 
 		public bool IsExecutable =>
 			context.ShellPage is not null &&
+			context.ShellPage.SlimContentPage is not null &&
 			context.PageType != ContentPageTypes.RecycleBin &&
 			context.PageType != ContentPageTypes.ZipFolder &&
 			context.PageType != ContentPageTypes.ReleaseNotes &&
@@ -48,14 +49,8 @@ namespace Files.App.Actions
 
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			switch (e.PropertyName)
-			{
-				case nameof(IContentPageContext.SelectedItems):
-					{
-						OnPropertyChanged(nameof(IsExecutable));
-						break;
-					}
-			}
+			if (e.PropertyName is nameof(IContentPageContext.SelectedItems))
+				OnPropertyChanged(nameof(IsExecutable));
 		}
 	}
 }

--- a/src/Files.App/UserControls/Toolbar.xaml
+++ b/src/Files.App/UserControls/Toolbar.xaml
@@ -287,13 +287,13 @@
 					x:Name="ExtractButton"
 					Width="Auto"
 					MinWidth="40"
-					x:Load="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
 					AccessKey="Z"
 					AccessKeyInvoked="AppBarButton_AccessKeyInvoked"
 					IsEnabled="{x:Bind ViewModel.CanExtract, Mode=OneWay, FallbackValue=False}"
 					Label="{helpers:ResourceString Name=Extract}"
 					LabelPosition="Default"
-					Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}">
+					Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
+					Visibility="{x:Bind ViewModel.CanExtract, Mode=OneWay}">
 
 					<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Zip}" />
 
@@ -331,12 +331,12 @@
 					x:Name="RunWithPowerShellButton"
 					Width="Auto"
 					MinWidth="40"
-					x:Load="{x:Bind Commands.RunWithPowershell.IsExecutable, Mode=OneWay}"
 					AutomationProperties.Name="RunWithPowerShell"
 					Command="{x:Bind Commands.RunWithPowershell}"
 					Label="{x:Bind Commands.RunWithPowershell.Label}"
 					LabelPosition="Default"
-					ToolTipService.ToolTip="{x:Bind Commands.RunWithPowershell.LabelWithHotKey, Mode=OneWay}">
+					ToolTipService.ToolTip="{x:Bind Commands.RunWithPowershell.LabelWithHotKey, Mode=OneWay}"
+					Visibility="{x:Bind Commands.RunWithPowershell.IsExecutable, Mode=OneWay}">
 					<AppBarButton.Icon>
 						<FontIcon Foreground="{ThemeResource App.Theme.IconBaseBrush}" Glyph="{x:Bind Commands.RunWithPowershell.Glyph.BaseGlyph}" />
 					</AppBarButton.Icon>
@@ -347,12 +347,12 @@
 					x:Name="EditInNotepadButton"
 					Width="Auto"
 					MinWidth="40"
-					x:Load="{x:Bind Commands.EditInNotepad.IsExecutable, Mode=OneWay}"
 					AutomationProperties.Name="EditInNotepad"
 					Command="{x:Bind Commands.EditInNotepad}"
 					Label="{x:Bind Commands.EditInNotepad.Label}"
 					LabelPosition="Default"
-					ToolTipService.ToolTip="{x:Bind Commands.EditInNotepad.LabelWithHotKey, Mode=OneWay}">
+					ToolTipService.ToolTip="{x:Bind Commands.EditInNotepad.LabelWithHotKey, Mode=OneWay}"
+					Visibility="{x:Bind Commands.EditInNotepad.IsExecutable, Mode=OneWay}">
 					<AppBarButton.Icon>
 						<FontIcon Foreground="{ThemeResource App.Theme.IconBaseBrush}" Glyph="{x:Bind Commands.EditInNotepad.Glyph.BaseGlyph}" />
 					</AppBarButton.Icon>
@@ -363,11 +363,11 @@
 					x:Name="SetAsBackgroundButton"
 					Width="Auto"
 					MinWidth="40"
-					x:Load="{x:Bind Commands.SetAsWallpaperBackground.IsExecutable, Mode=OneWay}"
 					Label="{helpers:ResourceString Name=SetAsBackgroundFlyout}"
 					LabelPosition="Default"
 					Style="{StaticResource ToolBarAppBarButtonFlyoutStyle}"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsBackgroundFlyout}">
+					ToolTipService.ToolTip="{helpers:ResourceString Name=SetAsBackgroundFlyout}"
+					Visibility="{x:Bind Commands.SetAsWallpaperBackground.IsExecutable, Mode=OneWay}">
 
 					<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.SetWallpaper.16}" />
 
@@ -410,21 +410,21 @@
 					x:Name="SetAsSlideshowButton"
 					Width="Auto"
 					MinWidth="40"
-					x:Load="{x:Bind Commands.SetAsSlideshowBackground.IsExecutable, Mode=OneWay}"
 					Command="{x:Bind Commands.SetAsSlideshowBackground}"
 					Icon="{x:Bind Commands.SetAsSlideshowBackground.FontIcon}"
 					Label="{x:Bind Commands.SetAsSlideshowBackground.Label}"
 					LabelPosition="Default"
-					ToolTipService.ToolTip="{x:Bind Commands.SetAsSlideshowBackground.LabelWithHotKey, Mode=OneWay}" />
+					ToolTipService.ToolTip="{x:Bind Commands.SetAsSlideshowBackground.LabelWithHotKey, Mode=OneWay}"
+					Visibility="{x:Bind Commands.SetAsSlideshowBackground.IsExecutable, Mode=OneWay}" />
 
 				<!--  Install Inf  -->
 				<AppBarButton
 					x:Name="InstallInfButton"
-					x:Load="{x:Bind Commands.InstallInfDriver.IsExecutable, Mode=OneWay, FallbackValue=False}"
 					Command="{x:Bind Commands.InstallInfDriver, Mode=OneWay}"
 					Label="{x:Bind Commands.InstallInfDriver.Label}"
 					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
+					ToolTipService.ToolTip="{helpers:ResourceString Name=Install}"
+					Visibility="{x:Bind Commands.InstallInfDriver.IsExecutable, Mode=OneWay}">
 					<AppBarButton.Icon>
 						<FontIcon Foreground="{ThemeResource App.Theme.IconBaseBrush}" Glyph="{x:Bind Commands.InstallInfDriver.Glyph.BaseGlyph}" />
 					</AppBarButton.Icon>
@@ -433,44 +433,44 @@
 				<!--  Rotate Image Left  -->
 				<AppBarButton
 					x:Name="RotateImageLeftButton"
-					x:Load="{x:Bind ViewModel.IsImage, Mode=OneWay, FallbackValue=False}"
 					Command="{x:Bind Commands.RotateLeft, Mode=OneWay}"
 					Label="{x:Bind Commands.RotateLeft.Label}"
 					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=RotateLeft}">
+					ToolTipService.ToolTip="{helpers:ResourceString Name=RotateLeft}"
+					Visibility="{x:Bind Commands.RotateLeft.IsExecutable, Mode=OneWay}">
 					<controls:ThemedIcon Style="{x:Bind Commands.RotateLeft.ThemedIconStyle}" />
 				</AppBarButton>
 
 				<!--  Rotate Image Right  -->
 				<AppBarButton
 					x:Name="RotateImageRightButton"
-					x:Load="{x:Bind ViewModel.IsImage, Mode=OneWay, FallbackValue=False}"
 					Command="{x:Bind Commands.RotateRight, Mode=OneWay}"
 					Label="{x:Bind Commands.RotateRight.Label}"
 					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=RotateRight}">
+					ToolTipService.ToolTip="{helpers:ResourceString Name=RotateRight}"
+					Visibility="{x:Bind Commands.RotateRight.IsExecutable, Mode=OneWay}">
 					<controls:ThemedIcon Style="{x:Bind Commands.RotateRight.ThemedIconStyle}" />
 				</AppBarButton>
 
 				<!--  Install Font  -->
 				<AppBarButton
 					x:Name="InstallFontButton"
-					x:Load="{x:Bind Commands.InstallFont.IsExecutable, Mode=OneWay, FallbackValue=False}"
 					Command="{x:Bind Commands.InstallFont, Mode=OneWay}"
 					Label="{x:Bind Commands.InstallFont.Label}"
 					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
+					ToolTipService.ToolTip="{helpers:ResourceString Name=Install}"
+					Visibility="{x:Bind Commands.InstallFont.IsExecutable, Mode=OneWay}">
 					<controls:ThemedIcon Style="{x:Bind Commands.InstallFont.ThemedIconStyle}" />
 				</AppBarButton>
 
 				<!--  Install Certificate  -->
 				<AppBarButton
 					x:Name="InstallCertificateButton"
-					x:Load="{x:Bind Commands.InstallCertificate.IsExecutable, Mode=OneWay, FallbackValue=False}"
 					Command="{x:Bind Commands.InstallCertificate, Mode=OneWay}"
 					Label="{x:Bind Commands.InstallCertificate.Label}"
 					LabelPosition="Default"
-					ToolTipService.ToolTip="{helpers:ResourceString Name=Install}">
+					ToolTipService.ToolTip="{helpers:ResourceString Name=Install}"
+					Visibility="{x:Bind Commands.InstallCertificate.IsExecutable, Mode=OneWay}">
 					<AppBarButton.Icon>
 						<FontIcon Foreground="{ThemeResource App.Theme.IconBaseBrush}" Glyph="{x:Bind Commands.InstallCertificate.Glyph.BaseGlyph, Mode=OneTime}" />
 					</AppBarButton.Icon>
@@ -479,12 +479,12 @@
 				<!--  Play All Media  -->
 				<AppBarButton
 					x:Name="PlayAllMediaButton"
-					x:Load="{x:Bind Commands.PlayAll.IsExecutable, Mode=OneWay, FallbackValue=False}"
 					Command="{x:Bind Commands.PlayAll, Mode=OneWay}"
 					KeyboardAcceleratorTextOverride="{x:Bind Commands.PlayAll.HotKeyText, Mode=OneWay}"
 					Label="{x:Bind Commands.PlayAll.Label}"
 					LabelPosition="Default"
-					ToolTipService.ToolTip="{x:Bind Commands.PlayAll.LabelWithHotKey, Mode=OneWay}">
+					ToolTipService.ToolTip="{x:Bind Commands.PlayAll.LabelWithHotKey, Mode=OneWay}"
+					Visibility="{x:Bind Commands.PlayAll.IsExecutable, Mode=OneWay}">
 					<AppBarButton.Icon>
 						<FontIcon Foreground="{ThemeResource App.Theme.IconBaseBrush}" Glyph="{x:Bind Commands.PlayAll.Glyph.BaseGlyph}" />
 					</AppBarButton.Icon>

--- a/src/Files.App/UserControls/Toolbar.xaml
+++ b/src/Files.App/UserControls/Toolbar.xaml
@@ -72,7 +72,8 @@
 			Grid.Column="0"
 			HorizontalAlignment="Left"
 			x:Load="{x:Bind ViewModel.InstanceViewModel.IsPageTypeNotHome, Mode=OneWay}"
-			DefaultLabelPosition="Right">
+			DefaultLabelPosition="Right"
+			IsDynamicOverflowEnabled="{x:Bind ViewModel.IsDynamicOverflowEnabled, Mode=OneWay}">
 			<CommandBar.PrimaryCommands>
 
 				<!--  New Item  -->

--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -139,6 +139,9 @@ namespace Files.App.ViewModels.UserControls
 		private bool _IsCommandPaletteOpen;
 		public bool IsCommandPaletteOpen { get => _IsCommandPaletteOpen; set => SetProperty(ref _IsCommandPaletteOpen, value); }
 
+		private bool _IsDynamicOverflowEnabled;
+		public bool IsDynamicOverflowEnabled { get => _IsDynamicOverflowEnabled; set => SetProperty(ref _IsDynamicOverflowEnabled, value); }
+		
 		private bool _IsUpdating;
 		public bool IsUpdating { get => _IsUpdating; set => SetProperty(ref _IsUpdating, value); }
 
@@ -257,6 +260,10 @@ namespace Files.App.ViewModels.UserControls
 				{
 					OnPropertyChanged(nameof(CanExtract));
 					OnPropertyChanged(nameof(HasAdditionalAction));
+
+					// Workaround to ensure the overflow button is only displayed when there are overflow items
+					IsDynamicOverflowEnabled = false;
+					IsDynamicOverflowEnabled = true;
 				}
 			}
 		}

--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using CommunityToolkit.WinUI;
+using Files.App.Actions;
 using Files.Shared.Helpers;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
@@ -75,14 +76,26 @@ namespace Files.App.ViewModels.UserControls
 
 		public SearchBoxViewModel SearchBoxViewModel => (SearchBoxViewModel)SearchBox;
 
-		public bool HasAdditionalAction => InstanceViewModel.IsPageTypeRecycleBin || IsPowerShellScript || CanExtract || IsImage || IsFont || IsInfFile;
-		public bool CanCopy => SelectedItems is not null && SelectedItems.Any();
+		public bool HasAdditionalAction =>
+			InstanceViewModel.IsPageTypeRecycleBin ||
+			Commands.RunWithPowershell.IsExecutable ||
+			CanExtract ||
+			Commands.DecompressArchive.IsExecutable ||
+			Commands.DecompressArchiveHere.IsExecutable ||
+			Commands.DecompressArchiveHereSmart.IsExecutable ||
+			Commands.DecompressArchiveToChildFolder.IsExecutable ||
+			Commands.EditInNotepad.IsExecutable ||
+			Commands.RotateLeft.IsExecutable ||
+			Commands.RotateRight.IsExecutable ||
+			Commands.SetAsAppBackground.IsExecutable ||
+			Commands.SetAsWallpaperBackground.IsExecutable ||
+			Commands.SetAsLockscreenBackground.IsExecutable ||
+			Commands.SetAsSlideshowBackground.IsExecutable ||
+			Commands.InstallFont.IsExecutable ||
+			Commands.InstallInfDriver.IsExecutable ||
+			Commands.InstallCertificate.IsExecutable;
+
 		public bool CanExtract => Commands.DecompressArchive.CanExecute(null) || Commands.DecompressArchiveHere.CanExecute(null) || Commands.DecompressArchiveHereSmart.CanExecute(null) || Commands.DecompressArchiveToChildFolder.CanExecute(null);
-		public bool IsPowerShellScript => SelectedItems is not null && SelectedItems.Count == 1 && FileExtensionHelpers.IsPowerShellFile(SelectedItems.First().FileExtension) && !InstanceViewModel.IsPageTypeRecycleBin;
-		public bool IsImage => SelectedItems is not null && SelectedItems.Any() && SelectedItems.All(x => FileExtensionHelpers.IsImageFile(x.FileExtension)) && !InstanceViewModel.IsPageTypeRecycleBin;
-		public bool IsMultipleImageSelected => SelectedItems is not null && SelectedItems.Count > 1 && SelectedItems.All(x => FileExtensionHelpers.IsImageFile(x.FileExtension)) && !InstanceViewModel.IsPageTypeRecycleBin;
-		public bool IsInfFile => SelectedItems is not null && SelectedItems.Count == 1 && FileExtensionHelpers.IsInfFile(SelectedItems.First().FileExtension) && !InstanceViewModel.IsPageTypeRecycleBin;
-		public bool IsFont => SelectedItems is not null && SelectedItems.Any() && SelectedItems.All(x => FileExtensionHelpers.IsFontFile(x.FileExtension)) && !InstanceViewModel.IsPageTypeRecycleBin;
 
 		public bool IsCardsLayout => _InstanceViewModel.FolderSettings.LayoutMode is FolderLayoutModes.CardsView;
 		public bool IsColumnLayout => _InstanceViewModel.FolderSettings.LayoutMode is FolderLayoutModes.ColumnView;
@@ -242,13 +255,7 @@ namespace Files.App.ViewModels.UserControls
 			{
 				if (SetProperty(ref _SelectedItems, value))
 				{
-					OnPropertyChanged(nameof(CanCopy));
 					OnPropertyChanged(nameof(CanExtract));
-					OnPropertyChanged(nameof(IsInfFile));
-					OnPropertyChanged(nameof(IsPowerShellScript));
-					OnPropertyChanged(nameof(IsImage));
-					OnPropertyChanged(nameof(IsMultipleImageSelected));
-					OnPropertyChanged(nameof(IsFont));
 					OnPropertyChanged(nameof(HasAdditionalAction));
 				}
 			}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16715 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed toolbar buttons have the correct icon state

**Comments**

The issue only occurs for files with additional actions in the toolbar. I discovered that changing from `x:Load` to `Visibility` resolves the issue. However, this introduces a different issue where the overflow button sometimes displays when there were no overflow items. Toggling `IsDynamicOverflowEnabled` seems to workaround this issue.