### PR TITLE
Code Quality: Switch Storage Provider Status UI APIs to use MemberFunction

### DIFF
--- a/src/Files.App.CsWin32/IStorageProviderQuotaUI.cs
+++ b/src/Files.App.CsWin32/IStorageProviderQuotaUI.cs
@@ -16,13 +16,13 @@ namespace Windows.Win32.System.WinRT
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public HRESULT GetQuotaTotalInBytes(ulong* value)
 		{
-			return ((delegate* unmanaged[Stdcall]<IStorageProviderQuotaUI*, ulong*, HRESULT>)(lpVtbl[6]))((IStorageProviderQuotaUI*)Unsafe.AsPointer(ref this), value);
+			return (HRESULT)((delegate* unmanaged[MemberFunction]<IStorageProviderQuotaUI*, ulong*, int>)(lpVtbl[6]))((IStorageProviderQuotaUI*)Unsafe.AsPointer(ref this), value);
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public HRESULT GetQuotaUsedInBytes(ulong* value)
 		{
-			return ((delegate* unmanaged[Stdcall]<IStorageProviderQuotaUI*, ulong*, HRESULT>)(lpVtbl[8]))((IStorageProviderQuotaUI*)Unsafe.AsPointer(ref this), value);
+			return (HRESULT)((delegate* unmanaged[MemberFunction]<IStorageProviderQuotaUI*, ulong*, int>)(lpVtbl[8]))((IStorageProviderQuotaUI*)Unsafe.AsPointer(ref this), value);
 		}
 
 		public static ref readonly Guid Guid

--- a/src/Files.App.CsWin32/IStorageProviderStatusUI.cs
+++ b/src/Files.App.CsWin32/IStorageProviderStatusUI.cs
@@ -16,7 +16,7 @@ namespace Windows.Win32.System.WinRT
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public HRESULT GetQuotaUI(IStorageProviderQuotaUI** result)
 		{
-			return ((delegate* unmanaged[Stdcall]<IStorageProviderStatusUI*, IStorageProviderQuotaUI**, HRESULT>)lpVtbl[14])((IStorageProviderStatusUI*)Unsafe.AsPointer(ref this), result);
+			return (HRESULT)((delegate* unmanaged[MemberFunction]<IStorageProviderStatusUI*, IStorageProviderQuotaUI**, int>)lpVtbl[14])((IStorageProviderStatusUI*)Unsafe.AsPointer(ref this), result);
 		}
 
 		public static ref readonly Guid Guid

--- a/src/Files.App.CsWin32/IStorageProviderStatusUISource.cs
+++ b/src/Files.App.CsWin32/IStorageProviderStatusUISource.cs
@@ -16,7 +16,7 @@ namespace Windows.Win32.System.WinRT
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public HRESULT GetStatusUI(IStorageProviderStatusUI** result)
 		{
-			return ((delegate* unmanaged[Stdcall]<IStorageProviderStatusUISource*, IStorageProviderStatusUI**, HRESULT>)lpVtbl[6])((IStorageProviderStatusUISource*)Unsafe.AsPointer(ref this), result);
+			return (HRESULT)((delegate* unmanaged[MemberFunction]<IStorageProviderStatusUISource*, IStorageProviderStatusUI**, int>)lpVtbl[6])((IStorageProviderStatusUISource*)Unsafe.AsPointer(ref this), result);
 		}
 
 		public static ref readonly Guid Guid

--- a/src/Files.App.CsWin32/IStorageProviderStatusUISourceFactory.cs
+++ b/src/Files.App.CsWin32/IStorageProviderStatusUISourceFactory.cs
@@ -16,7 +16,7 @@ namespace Windows.Win32.System.WinRT
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public HRESULT GetStatusUISource(nint syncRootId, IStorageProviderStatusUISource** result)
 		{
-			return ((delegate* unmanaged[Stdcall]<IStorageProviderStatusUISourceFactory*, nint, IStorageProviderStatusUISource**, HRESULT>)lpVtbl[6])((IStorageProviderStatusUISourceFactory*)Unsafe.AsPointer(ref this), syncRootId, result);
+			return (HRESULT)((delegate* unmanaged[MemberFunction]<IStorageProviderStatusUISourceFactory*, nint, IStorageProviderStatusUISource**, int>)lpVtbl[6])((IStorageProviderStatusUISourceFactory*)Unsafe.AsPointer(ref this), syncRootId, result);
 		}
 
 		public static ref readonly Guid Guid


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

Switch the Storage Provider Status UI APIs from the `Stdcall` calling convention to `MemberFunction`, for correctness.

**Steps used to test these changes**

Tested the Properties window of OneDrive, works as expected.
