### PR TITLE
Feature: Automatically detect zip encoding

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
     <PackageVersion Include="TagLibSharp" Version="2.3.0" />
     <PackageVersion Include="Tulpep.ActiveDirectoryObjectPicker" Version="3.0.11" />
+    <PackageVersion Include="UTF.Unknown" Version="2.5.1" />
     <PackageVersion Include="WinUIEx" Version="2.5.1" />
     <PackageVersion Include="Vanara.Windows.Extensions" Version="4.0.1" />
     <PackageVersion Include="Vanara.Windows.Shell" Version="4.0.1" />

--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
@@ -43,6 +43,11 @@ namespace Files.App.Actions
 
 			var isArchiveEncrypted = await FilesystemTasks.Wrap(() => StorageArchiveService.IsEncryptedAsync(archive.Path));
 			var isArchiveEncodingUndetermined = await FilesystemTasks.Wrap(() => StorageArchiveService.IsEncodingUndeterminedAsync(archive.Path));
+			Encoding? detectedEncoding = null;
+			if (isArchiveEncodingUndetermined)
+			{
+				detectedEncoding = await FilesystemTasks.Wrap(() => StorageArchiveService.DetectEncodingAsync(archive.Path));
+			}
 			var password = string.Empty;
 			Encoding? encoding = null;
 
@@ -51,7 +56,8 @@ namespace Files.App.Actions
 			{
 				IsArchiveEncrypted = isArchiveEncrypted,
 				IsArchiveEncodingUndetermined = isArchiveEncodingUndetermined,
-				ShowPathSelection = true
+				ShowPathSelection = true,
+				DetectedEncoding = detectedEncoding,
 			};
 			decompressArchiveDialog.ViewModel = decompressArchiveViewModel;
 

--- a/src/Files.App/Data/Contracts/IStorageArchiveService.cs
+++ b/src/Files.App/Data/Contracts/IStorageArchiveService.cs
@@ -59,9 +59,16 @@ namespace Files.App.Data.Contracts
 		/// <summary>
 		/// Gets the value that indicates whether the archive file's encoding is undetermined.
 		/// </summary>
-		/// <param name="archiveFilePath">The archive file path to check if the item is encrypted.</param>
+		/// <param name="archiveFilePath">The archive file path to check if the encoding is undetermined.</param>
 		/// <returns>True if the archive file's encoding is undetermined; otherwise, false.</returns>
 		Task<bool> IsEncodingUndeterminedAsync(string archiveFilePath);
+
+		/// <summary>
+		/// Detect encoding for a zip file whose encoding is undetermined.
+		/// </summary>
+		/// <param name="archiveFilePath">The archive file path to detect encoding</param>
+		/// <returns>Null if the archive file doesn't need to detect encoding or its encoding can't be detected; otherwise, the encoding detected.</returns>
+		Task<Encoding?> DetectEncodingAsync(string archiveFilePath);
 
 		/// <summary>
 		/// Gets the <see cref="SevenZipExtractor"/> instance from the archive file path.

--- a/src/Files.App/Data/Items/EncodingItem.cs
+++ b/src/Files.App/Data/Items/EncodingItem.cs
@@ -22,7 +22,7 @@ namespace Files.App.Data.Items
         /// Initializes a new instance of the <see cref="EncodingItem"/> class.
         /// </summary>
         /// <param name="code">The code of the language.</param>
-        public EncodingItem(string code)
+        public EncodingItem(string? code)
         {
             if (string.IsNullOrEmpty(code))
             {
@@ -44,13 +44,33 @@ namespace Files.App.Data.Items
 
 		public static EncodingItem[] Defaults = new string?[] {
 			null,//System Default
-			"UTF-8",
-			"shift_jis",
-			"gb2312",
-			"big5",
-			"ks_c_5601-1987",
-			"Windows-1252",
-			"macintosh",
+            "UTF-8",
+			
+            //All possible Windows system encodings
+            //reference: https://en.wikipedia.org/wiki/Windows_code_page
+            //East Asian
+            "shift_jis",       //Japanese
+            "gb2312",          //Simplified Chinese
+            "big5",            //Traditional Chinese
+            "ks_c_5601-1987",  //Korean
+            
+            //Southeast Asian
+            "Windows-1258",    //Vietnamese
+            "Windows-874",     //Thai
+            
+            //Middle East
+            "Windows-1256",    //Arabic
+            "Windows-1255",    //Hebrew
+            "Windows-1254",    //Turkish
+            
+            //European
+            "Windows-1252",    //Western European
+            "Windows-1250",    //Central European
+            "Windows-1251",    //Cyrillic
+            "Windows-1253",    //Greek
+            "Windows-1257",    //Baltic
+            
+            "macintosh",
 		}
 			.Select(x => new EncodingItem(x))
 			.ToArray();

--- a/src/Files.App/Data/Items/EncodingItem.cs
+++ b/src/Files.App/Data/Items/EncodingItem.cs
@@ -36,6 +36,25 @@ namespace Files.App.Data.Items
             }
         }
 
-        public override string ToString() => Name;
+		public EncodingItem(Encoding encoding, string name)
+		{
+			Encoding = encoding;
+			Name = name;
+		}
+
+		public static EncodingItem[] Defaults = new string?[] {
+			null,//System Default
+			"UTF-8",
+			"shift_jis",
+			"gb2312",
+			"big5",
+			"ks_c_5601-1987",
+			"Windows-1252",
+			"macintosh",
+		}
+			.Select(x => new EncodingItem(x))
+			.ToArray();
+
+		public override string ToString() => Name;
     }
 }

--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -95,6 +95,7 @@
         <PackageReference Include="Microsoft.Graphics.Win2D" />
         <PackageReference Include="TagLibSharp" />
         <PackageReference Include="Tulpep.ActiveDirectoryObjectPicker" />
+        <PackageReference Include="UTF.Unknown" />
         <PackageReference Include="WinUIEx" />
         <PackageReference Include="Vanara.Windows.Extensions" />
         <PackageReference Include="Vanara.Windows.Shell" />

--- a/src/Files.App/Services/Storage/StorageArchiveService.cs
+++ b/src/Files.App/Services/Storage/StorageArchiveService.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using UtfUnknown;
-using Vanara.PInvoke;
 using Windows.Storage;
 using Windows.Win32;
 

--- a/src/Files.App/Services/Storage/StorageArchiveService.cs
+++ b/src/Files.App/Services/Storage/StorageArchiveService.cs
@@ -5,9 +5,7 @@ using Files.Shared.Helpers;
 using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
 using SevenZip;
-using System.Collections;
 using System.IO;
-using System.Linq;
 using System.Text;
 using UtfUnknown;
 using Windows.Storage;
@@ -92,7 +90,8 @@ namespace Files.App.Services
 		/// <inheritdoc/>
 		public Task<bool> DecompressAsync(string archiveFilePath, string destinationFolderPath, string password = "", Encoding? encoding = null)
 		{
-			if(encoding == null){
+			if (encoding == null)
+			{
 				return DecompressAsyncWithSevenZip(archiveFilePath, destinationFolderPath, password);
 			}
 			else
@@ -205,10 +204,10 @@ namespace Files.App.Services
 				string.IsNullOrEmpty(destinationFolderPath))
 				return false;
 			using var zipFile = new ZipFile(archiveFilePath, StringCodec.FromEncoding(encoding));
-			if(zipFile is null)
+			if (zipFile is null)
 				return false;
-			
-			if(!string.IsNullOrEmpty(password))
+
+			if (!string.IsNullOrEmpty(password))
 				zipFile.Password = password;
 
 			// Initialize a new in-progress status card
@@ -216,11 +215,11 @@ namespace Files.App.Services
 				archiveFilePath.CreateEnumerable(),
 				destinationFolderPath.CreateEnumerable(),
 				ReturnResult.InProgress);
-			
+
 			// Check if the decompress operation canceled
 			if (statusCard.CancellationToken.IsCancellationRequested)
 				return false;
-			
+
 			StatusCenterItemProgressModel fsProgress = new(
 				statusCard.ProgressEventSource,
 				enumerationCompleted: true,
@@ -324,7 +323,7 @@ namespace Files.App.Services
 			return isSuccess;
 		}
 
-		
+
 		/// <inheritdoc/>
 		public string GenerateArchiveNameFromItems(IReadOnlyList<ListedItem> items)
 		{
@@ -358,7 +357,7 @@ namespace Files.App.Services
 			{
 				using (ZipFile zipFile = new ZipFile(archiveFilePath))
 				{
-					return !zipFile.Cast<ZipEntry>().All(entry=>entry.IsUnicodeText);
+					return !zipFile.Cast<ZipEntry>().All(entry => entry.IsUnicodeText);
 				}
 			}
 			catch (Exception ex)
@@ -380,7 +379,7 @@ namespace Files.App.Services
 				using (ZipFile zipFile = new ZipFile(archiveFilePath, StringCodec.FromEncoding(cp437)))
 				{
 					var fileNameBytes = cp437.GetBytes(
-						String.Join("\n", 
+						String.Join("\n",
 							zipFile.Cast<ZipEntry>()
 								.Where(e => !e.IsUnicodeText)
 								.Select(e => e.Name)

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2099,6 +2099,9 @@
   <data name="Encoding" xml:space="preserve">
     <value>Encoding</value>
   </data>
+  <data name="EncodingDetected" xml:space="preserve">
+    <value> (detected)</value>
+  </data>
   <data name="ExtractToPath" xml:space="preserve">
     <value>Path</value>
   </data>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2100,7 +2100,7 @@
     <value>Encoding</value>
   </data>
   <data name="EncodingDetected" xml:space="preserve">
-    <value> (detected)</value>
+    <value>{0} (detected)</value>
   </data>
   <data name="ExtractToPath" xml:space="preserve">
     <value>Path</value>

--- a/src/Files.App/ViewModels/Dialogs/DecompressArchiveDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/DecompressArchiveDialogViewModel.cs
@@ -73,7 +73,7 @@ namespace Files.App.ViewModels.Dialogs
 				.Prepend(new EncodingItem(
 					detectedEncoding, 
 					string.Format(Strings.EncodingDetected.GetLocalizedResource(), detectedEncoding.EncodingName)
-				)
+				))
 				.ToArray();
 			}
 			else

--- a/src/Files.App/ViewModels/Dialogs/DecompressArchiveDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/DecompressArchiveDialogViewModel.cs
@@ -44,6 +44,16 @@ namespace Files.App.ViewModels.Dialogs
 			set => SetProperty(ref isArchiveEncodingUndetermined, value);
 		}
 
+		private Encoding? detectedEncoding;
+		public Encoding? DetectedEncoding
+		{
+			get => detectedEncoding;
+			set { 
+				SetProperty(ref detectedEncoding, value);
+				RefreshEncodingOptions();
+			}
+		}
+
 		private bool showPathSelection;
 		public bool ShowPathSelection
 		{
@@ -53,19 +63,27 @@ namespace Files.App.ViewModels.Dialogs
 
 		public DisposableArray? Password { get; private set; }
 
-		public EncodingItem[] EncodingOptions { get; set; } = new string?[] {
-			null,//System Default
-			"UTF-8",
-			"shift_jis",
-			"gb2312",
-			"big5",
-			"ks_c_5601-1987",
-			"Windows-1252",
-			"macintosh",
-		}
-			.Select(x=>new EncodingItem(x))
-			.ToArray();
+		public EncodingItem[] EncodingOptions { get; set; } = EncodingItem.Defaults;
 		public EncodingItem SelectedEncoding { get; set; }
+		void RefreshEncodingOptions()
+		{
+			if (detectedEncoding != null)
+			{
+				EncodingOptions = EncodingItem.Defaults
+				.Prepend(new EncodingItem(
+					detectedEncoding, 
+					detectedEncoding.EncodingName + Strings.EncodingDetected.GetLocalizedResource())
+				)
+				.ToArray();
+			}
+			else
+			{
+				EncodingOptions = EncodingItem.Defaults;
+			}
+			SelectedEncoding = EncodingOptions.FirstOrDefault();
+		}
+
+		
 
 		public IRelayCommand PrimaryButtonClickCommand { get; private set; }
 

--- a/src/Files.App/ViewModels/Dialogs/DecompressArchiveDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/DecompressArchiveDialogViewModel.cs
@@ -72,7 +72,7 @@ namespace Files.App.ViewModels.Dialogs
 				EncodingOptions = EncodingItem.Defaults
 				.Prepend(new EncodingItem(
 					detectedEncoding, 
-					detectedEncoding.EncodingName + Strings.EncodingDetected.GetLocalizedResource())
+					string.Format(Strings.EncodingDetected.GetLocalizedResource(), detectedEncoding.EncodingName)
 				)
 				.ToArray();
 			}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

After this PR, when decompressing zip file and the encoding of zip file is undetermined, Files will detect the encoding autometically. 

![image](https://github.com/user-attachments/assets/8cfc8ac9-617f-48c6-9908-08d0af816be9)

Before this PR, SharpZipLib decompressing (decompressing with specified encoding) blocks the UI. After this PR, it no longers blocks the UI and works like SevenZipSharp.

All possible Windows system encodings are added into the encoding list.

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- This PR is a part of #14937

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Download this zip file: 
[japanese-example.zip](https://github.com/user-attachments/files/19619832/japanese-example.zip)
2. In Files, right click this file, Extract -> Extract Files
3. Select "Japanese (Shift-JIS)" encoding
![image](https://github.com/user-attachments/assets/aa2c32e3-12a7-4bbb-83ed-0ca493190dad)
