### PR TITLE
Code Quality: Ignored `Files.App.Launcher.exe.sha256`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 Files.App.OpenDialog*.dll
 Files.App.SaveDialog*.dll
 Files.App.Launcher.exe
+Files.App.Launcher.exe.sha256
 
 # User-specific files
 *.rsuser
@@ -408,4 +409,3 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 .idea/
-src/Files.App/Assets/FilesOpenDialog/Files.App.Launcher.exe.sha256


### PR DESCRIPTION
Correctly ignores the `Files.App.Launcher.exe.sha256` file that was not correctly ignored previously.