### PR TITLE
Fix: Fixed crash that would occur when using an invalid background image

### DIFF
--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Navigation;
 using System.Windows.Input;
 using Windows.System;
-using Microsoft.UI.Xaml.Controls;
 
 namespace Files.App.ViewModels
 {
@@ -88,10 +88,27 @@ namespace Files.App.ViewModels
 		public float AppThemeBackgroundImageOpacity
 			=> AppearanceSettingsService.AppThemeBackgroundImageOpacity;
 
-		public ImageSource? AppThemeBackgroundImageSource =>
-			string.IsNullOrEmpty(AppearanceSettingsService.AppThemeBackgroundImageSource)
-				? null
-				: new BitmapImage(new Uri(AppearanceSettingsService.AppThemeBackgroundImageSource, UriKind.RelativeOrAbsolute));
+		public ImageSource? AppThemeBackgroundImageSource
+		{
+			get
+			{
+				if (string.IsNullOrWhiteSpace(AppearanceSettingsService.AppThemeBackgroundImageSource))
+					return null;
+
+				if (!Uri.TryCreate(AppearanceSettingsService.AppThemeBackgroundImageSource, UriKind.RelativeOrAbsolute, out Uri? validUri))
+					return null;
+
+				try
+				{
+					return new BitmapImage(validUri);
+				}
+				catch (Exception)
+				{
+					// Catch potential errors
+					return null;
+				}
+			}
+		}
 
 		public VerticalAlignment AppThemeBackgroundImageVerticalAlignment
 			=> AppearanceSettingsService.AppThemeBackgroundImageVerticalAlignment;
@@ -104,7 +121,7 @@ namespace Files.App.ViewModels
 			context.PageType is not ContentPageTypes.Home &&
 			context.PageType is not ContentPageTypes.ReleaseNotes &&
 			context.PageType is not ContentPageTypes.Settings;
-		
+
 		public bool ShowStatusBar =>
 			context.PageType is not ContentPageTypes.Home &&
 			context.PageType is not ContentPageTypes.ReleaseNotes &&


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17082

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Manually set `AppThemeBackgroundImageSource` to an invalid value (eg 'a')
2. Confirm Files starts correctly
