### PR TITLE
Code Quality: Simplified loading of logical drives and network locations in the Home widges

### DIFF
--- a/src/Files.App.CsWin32/ManualGuid.cs
+++ b/src/Files.App.CsWin32/ManualGuid.cs
@@ -41,6 +41,9 @@ namespace Windows.Win32
 
 		[GuidRVAGen.Guid("00021500-0000-0000-C000-000000000046")]
 		public static partial Guid* IID_IQueryInfo { get; }
+
+		[GuidRVAGen.Guid("000214F9-0000-0000-C000-000000000046")]
+		public static partial Guid* IID_IShellLinkW { get; }
 	}
 
 	public static unsafe partial class CLSID

--- a/src/Files.App.CsWin32/NativeMethods.txt
+++ b/src/Files.App.CsWin32/NativeMethods.txt
@@ -226,3 +226,6 @@ _SICHINTF
 RoGetAgileReference
 IQueryInfo
 QITIPF_FLAGS
+GetDiskFreeSpaceEx
+GetDriveType
+SLGP_FLAGS

--- a/src/Files.App.Storage/Storables/WindowsStorage/IWindowsFile.cs
+++ b/src/Files.App.Storage/Storables/WindowsStorage/IWindowsFile.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Storage
+{
+	public interface IWindowsFile : IWindowsStorable, IChildFile
+	{
+	}
+}

--- a/src/Files.App.Storage/Storables/WindowsStorage/IWindowsFolder.cs
+++ b/src/Files.App.Storage/Storables/WindowsStorage/IWindowsFolder.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Storage
+{
+	public interface IWindowsFolder : IWindowsStorable, IChildFolder
+	{
+	}
+}

--- a/src/Files.App.Storage/Storables/WindowsStorage/IWindowsStorable.cs
+++ b/src/Files.App.Storage/Storables/WindowsStorage/IWindowsStorable.cs
@@ -6,7 +6,7 @@ using Windows.Win32.UI.Shell;
 
 namespace Files.App.Storage
 {
-	public interface IWindowsStorable : IDisposable
+	public interface IWindowsStorable : IStorableChild, IEquatable<IWindowsStorable>, IDisposable
 	{
 		ComPtr<IShellItem> ThisPtr { get; }
 	}

--- a/src/Files.App.Storage/Storables/WindowsStorage/WindowsFile.cs
+++ b/src/Files.App.Storage/Storables/WindowsStorage/WindowsFile.cs
@@ -8,7 +8,7 @@ using Windows.Win32.UI.Shell;
 namespace Files.App.Storage
 {
 	[DebuggerDisplay("{" + nameof(ToString) + "()}")]
-	public sealed class WindowsFile : WindowsStorable, IChildFile
+	public sealed class WindowsFile : WindowsStorable, IWindowsFile
 	{
 		public WindowsFile(ComPtr<IShellItem> nativeObject)
 		{

--- a/src/Files.App.Storage/Storables/WindowsStorage/WindowsFolder.cs
+++ b/src/Files.App.Storage/Storables/WindowsStorage/WindowsFolder.cs
@@ -10,7 +10,7 @@ using Windows.Win32.UI.Shell;
 namespace Files.App.Storage
 {
 	[DebuggerDisplay("{" + nameof(ToString) + "()}")]
-	public sealed class WindowsFolder : WindowsStorable, IChildFolder
+	public sealed class WindowsFolder : WindowsStorable, IWindowsFolder
 	{
 		public WindowsFolder(ComPtr<IShellItem> nativeObject)
 		{

--- a/src/Files.App.Storage/Storables/WindowsStorage/WindowsStorable.cs
+++ b/src/Files.App.Storage/Storables/WindowsStorage/WindowsStorable.cs
@@ -8,7 +8,7 @@ using Windows.Win32.UI.Shell;
 
 namespace Files.App.Storage
 {
-	public abstract class WindowsStorable : IWindowsStorable, IStorableChild, IEquatable<IWindowsStorable>
+	public abstract class WindowsStorable : IWindowsStorable
 	{
 		public ComPtr<IShellItem> ThisPtr { get; protected set; }
 

--- a/src/Files.App.Storage/Storables/WindowsStorage/WindowsStorableHelpers.Shell.cs
+++ b/src/Files.App.Storage/Storables/WindowsStorage/WindowsStorableHelpers.Shell.cs
@@ -143,5 +143,19 @@ namespace Files.App.Storage
 
 			return HRESULT.S_OK;
 		}
+
+		public unsafe static HRESULT TryGetShellLink(this IWindowsStorable storable, out ComPtr<IShellLinkW> pShellLink)
+		{
+			pShellLink = default;
+
+			using ComPtr<IShellLinkW> pShellLinkW = default;
+			HRESULT hr = storable.ThisPtr.Get()->BindToHandler(null, BHID.BHID_SFUIObject, IID.IID_IShellLinkW, (void**)pShellLinkW.GetAddressOf());
+			if (hr.ThrowIfFailedOnDebug().Failed)
+				return hr;
+
+			pShellLink = pShellLinkW;
+
+			return HRESULT.S_OK;
+		}
 	}
 }

--- a/src/Files.App.Storage/Storables/WindowsStorage/WindowsStorableHelpers.Storage.cs
+++ b/src/Files.App.Storage/Storables/WindowsStorage/WindowsStorableHelpers.Storage.cs
@@ -3,6 +3,7 @@
 
 using Windows.Win32;
 using Windows.Win32.Foundation;
+using Windows.Win32.NetworkManagement.WNet;
 using Windows.Win32.Storage.FileSystem;
 using Windows.Win32.UI.Shell;
 
@@ -83,6 +84,38 @@ namespace Files.App.Storage
 			// NOTE: This calls an undocumented elevatable COM class, shell32.dll!CFormatEngine so this doesn't need to be elevated beforehand.
 			var result = PInvoke.SHFormatDrive(hWnd, driveLetterIndex, id, options);
 			return result is 0xFFFF;
+		}
+
+		public static bool TryGetDriveTotalSpace(this IWindowsStorable storable, out ulong totalSize)
+		{
+			ulong ulTotalSize = 0UL;
+			bool res = PInvoke.GetDiskFreeSpaceEx(storable.GetDisplayName(), null, &ulTotalSize, null);
+
+			totalSize = ulTotalSize;
+
+			return res;
+		}
+
+		public static bool TryGetDriveFreeSpace(this IWindowsStorable storable, out ulong freeSize)
+		{
+			ulong ulFreeSize = 0UL;
+			bool res = PInvoke.GetDiskFreeSpaceEx(storable.GetDisplayName(), null, null, &ulFreeSize);
+
+			freeSize = ulFreeSize;
+
+			return res;
+		}
+
+		public static bool TryGetDriveType(this IWindowsStorable storable, out uint driveType)
+		{
+			driveType = PInvoke.GetDriveType(storable.GetDisplayName());
+
+			return driveType is 0U; // DRIVE_UNKNOWN
+		}
+
+		public static bool TryDisconnectNetworkDrive(this IWindowsStorable storable)
+		{
+			return PInvoke.WNetCancelConnection2W(storable.GetDisplayName().TrimEnd('\\'), NET_CONNECT_FLAGS.CONNECT_UPDATE_PROFILE, true) is WIN32_ERROR.NO_ERROR;
 		}
 	}
 }

--- a/src/Files.App/Data/Items/WidgetDriveCardItem.cs
+++ b/src/Files.App/Data/Items/WidgetDriveCardItem.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.UI.Xaml.Media.Imaging;
-using Windows.Win32;
+using Windows.Win32.Foundation;
 using Windows.Win32.UI.Shell;
 
 namespace Files.App.Data.Items
@@ -45,8 +45,8 @@ namespace Files.App.Data.Items
 			if (string.IsNullOrEmpty(Path) || Item is not IWindowsStorable windowsStorable)
 				return;
 
-			windowsStorable.TryGetThumbnail((int)(Constants.ShellIconSizes.Large * App.AppModel.AppWindowDPI), SIIGBF.SIIGBF_ICONONLY, out var rawThumbnailData);
-			if (rawThumbnailData is null)
+			HRESULT hr = windowsStorable.TryGetThumbnail((int)(Constants.ShellIconSizes.Large * App.AppModel.AppWindowDPI), SIIGBF.SIIGBF_ICONONLY, out var rawThumbnailData);
+			if (hr.Failed || rawThumbnailData is null)
 				return;
 
 			Thumbnail = await rawThumbnailData.ToBitmapAsync();

--- a/src/Files.App/Data/Items/WidgetDriveCardItem.cs
+++ b/src/Files.App/Data/Items/WidgetDriveCardItem.cs
@@ -11,9 +11,7 @@ namespace Files.App.Data.Items
 	{
 		// Properties
 
-		public required IWindowsFolder Item { get; set; }
-
-		public required new string Path { get; set; }
+		public required new IWindowsFolder Item { get; set; }
 
 		public required string Text { get; set; }
 

--- a/src/Files.App/UserControls/Widgets/DrivesWidget.xaml
+++ b/src/Files.App/UserControls/Widgets/DrivesWidget.xaml
@@ -31,14 +31,14 @@
 						VerticalAlignment="Stretch"
 						HorizontalContentAlignment="Stretch"
 						VerticalContentAlignment="Stretch"
-						AutomationProperties.Name="{x:Bind Item.Text, Mode=OneWay}"
+						AutomationProperties.Name="{x:Bind Text, Mode=OneWay}"
 						Click="Button_Click"
 						CornerRadius="{StaticResource ControlCornerRadius}"
 						DataContext="{x:Bind}"
 						PointerPressed="Button_PointerPressed"
 						RightTapped="Button_RightTapped"
-						Tag="{x:Bind Item.Path}"
-						ToolTipService.ToolTip="{x:Bind Item.Text, Mode=OneWay}">
+						Tag="{x:Bind Path}"
+						ToolTipService.ToolTip="{x:Bind Text, Mode=OneWay}">
 						<Grid
 							Margin="8"
 							HorizontalAlignment="Stretch"
@@ -75,7 +75,7 @@
 								VerticalAlignment="Center"
 								FontSize="14"
 								FontWeight="Medium"
-								Text="{x:Bind Item.Text, Mode=OneWay}"
+								Text="{x:Bind Text, Mode=OneWay}"
 								TextTrimming="CharacterEllipsis"
 								TextWrapping="NoWrap" />
 
@@ -85,10 +85,10 @@
 								Grid.Column="1"
 								VerticalAlignment="Stretch"
 								VerticalContentAlignment="Stretch"
-								x:Load="{x:Bind Item.ShowDriveDetails, Mode=OneWay}"
+								x:Load="{x:Bind ShowDriveUsage, Mode=OneWay}"
 								AutomationProperties.AccessibilityView="Raw"
-								Maximum="{x:Bind Item.MaxSpace.GigaBytes, Mode=OneWay}"
-								Value="{x:Bind Item.SpaceUsed.GigaBytes, Mode=OneWay}" />
+								Maximum="{x:Bind TotalSize.GigaBytes, Mode=OneWay}"
+								Value="{x:Bind UsedSize.GigaBytes, Mode=OneWay}" />
 
 							<Button
 								x:Name="GoToStorageSense"
@@ -100,12 +100,12 @@
 								Padding="0"
 								HorizontalContentAlignment="Center"
 								VerticalContentAlignment="Center"
-								x:Load="{x:Bind Item.ShowStorageSense, Mode=OneWay}"
+								x:Load="{x:Bind ShowStorageSense, Mode=OneWay}"
 								AutomationProperties.Name="{helpers:ResourceString Name=OpenStorageSense}"
 								Background="Transparent"
 								BorderBrush="Transparent"
 								Click="GoToStorageSense_Click"
-								Tag="{x:Bind Item.Path}"
+								Tag="{x:Bind Path}"
 								ToolTipService.ToolTip="{helpers:ResourceString Name=OpenStorageSense}">
 								<FontIcon
 									HorizontalAlignment="Center"
@@ -121,13 +121,13 @@
 								Grid.ColumnSpan="2"
 								HorizontalAlignment="Stretch"
 								VerticalAlignment="Center"
-								x:Load="{x:Bind Item.ShowDriveDetails, Mode=OneWay}"
+								x:Load="{x:Bind ShowDriveUsage, Mode=OneWay}"
 								x:Phase="1"
 								FontSize="12"
-								Text="{x:Bind Item.SpaceText, Mode=OneWay}"
+								Text="{x:Bind UsageText, Mode=OneWay}"
 								TextTrimming="CharacterEllipsis"
 								TextWrapping="NoWrap"
-								ToolTipService.ToolTip="{x:Bind Item.SpaceText, Mode=OneWay}" />
+								ToolTipService.ToolTip="{x:Bind UsageText, Mode=OneWay}" />
 						</Grid>
 					</Button>
 				</DataTemplate>

--- a/src/Files.App/UserControls/Widgets/NetworkLocationsWidget.xaml
+++ b/src/Files.App/UserControls/Widgets/NetworkLocationsWidget.xaml
@@ -58,14 +58,14 @@
 						VerticalAlignment="Stretch"
 						HorizontalContentAlignment="Stretch"
 						VerticalContentAlignment="Stretch"
-						AutomationProperties.Name="{x:Bind Item.Text, Mode=OneWay}"
+						AutomationProperties.Name="{x:Bind Text, Mode=OneWay}"
 						Click="Button_Click"
 						CornerRadius="{StaticResource ControlCornerRadius}"
 						DataContext="{x:Bind}"
 						PointerPressed="Button_PointerPressed"
 						RightTapped="Button_RightTapped"
-						Tag="{x:Bind Item.Path}"
-						ToolTipService.ToolTip="{x:Bind Item.Text, Mode=OneWay}">
+						Tag="{x:Bind Path}"
+						ToolTipService.ToolTip="{x:Bind Text, Mode=OneWay}">
 						<Grid
 							Margin="8"
 							HorizontalAlignment="Stretch"
@@ -101,7 +101,7 @@
 								VerticalAlignment="Center"
 								FontSize="14"
 								FontWeight="Medium"
-								Text="{x:Bind Item.Text, Mode=OneWay}"
+								Text="{x:Bind Text, Mode=OneWay}"
 								TextTrimming="CharacterEllipsis"
 								TextWrapping="NoWrap" />
 
@@ -111,10 +111,10 @@
 								Grid.Column="1"
 								VerticalAlignment="Stretch"
 								VerticalContentAlignment="Stretch"
-								x:Load="{x:Bind Item.ShowDriveDetails, Mode=OneWay}"
+								x:Load="{x:Bind ShowDriveUsage, Mode=OneWay}"
 								AutomationProperties.AccessibilityView="Raw"
-								Maximum="{x:Bind Item.MaxSpace.GigaBytes, Mode=OneWay}"
-								Value="{x:Bind Item.SpaceUsed.GigaBytes, Mode=OneWay}" />
+								Maximum="{x:Bind TotalSize.GigaBytes, Mode=OneWay}"
+								Value="{x:Bind UsedSize.GigaBytes, Mode=OneWay}" />
 
 							<TextBlock
 								x:Name="DriveSpaceTextBlock"
@@ -122,13 +122,13 @@
 								Grid.Column="1"
 								HorizontalAlignment="Stretch"
 								VerticalAlignment="Center"
-								x:Load="{x:Bind Item.ShowDriveDetails, Mode=OneWay}"
+								x:Load="{x:Bind ShowDriveUsage, Mode=OneWay}"
 								x:Phase="1"
 								FontSize="12"
-								Text="{x:Bind Item.SpaceText, Mode=OneWay}"
+								Text="{x:Bind UsageText, Mode=OneWay}"
 								TextTrimming="CharacterEllipsis"
 								TextWrapping="NoWrap"
-								ToolTipService.ToolTip="{x:Bind Item.SpaceText, Mode=OneWay}" />
+								ToolTipService.ToolTip="{x:Bind UsageText, Mode=OneWay}" />
 						</Grid>
 					</Button>
 				</DataTemplate>


### PR DESCRIPTION
### Resolved / Related Issues

- Related: #4180
- Related: #15000
- Partially: #16447

### Steps used to test these changes

1. Open Files app
2. Test logical drives
    1. Click on one of them
    2. Right click on a drive
    3. See if the Eject option shows up for removal drives and CD ROM storage
    4. Try other menu flyout items
3. Test network locations
    1. Click on one of them
    2. Right click on one of them
    3. Try menu flyout items of them