### PR TITLE
Feature: Added support for Magenta & Sync cloud drive

### DIFF
--- a/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
+++ b/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
@@ -91,6 +91,7 @@ namespace Files.App.Utils.Cloud
 						"ProtonDrive" => CloudProviders.ProtonDrive,
 						"kDrive" => CloudProviders.kDrive,
 						"Lucid" => CloudProviders.LucidLink,
+						"SyncCom" => CloudProviders.SyncDrive,
 						_ => null,
 					};
 
@@ -98,9 +99,7 @@ namespace Files.App.Utils.Cloud
 						continue;
 
 					var nextCloudValue = (string?)namespaceSubKey?.GetValue(string.Empty);
-					var ownCloudValue = (string?)clsidSubKey?.GetValue(string.Empty);
-					var kDriveValue = (string?)clsidSubKey?.GetValue(string.Empty);
-					var lucidLinkValue = (string?)clsidSubKey?.GetValue(string.Empty);
+					var clsidDefaultValue = (string?)clsidSubKey?.GetValue(string.Empty);
 
 					using var defaultIconKey = clsidSubKey?.OpenSubKey(@"DefaultIcon");
 					var iconPath = (string?)defaultIconKey?.GetValue(string.Empty);
@@ -115,10 +114,11 @@ namespace Files.App.Utils.Cloud
 							CloudProviders.AppleCloudDrive => $"iCloud Drive",
 							CloudProviders.AppleCloudPhotos => $"iCloud Photos",
 							CloudProviders.AdobeCreativeCloud => $"Creative Cloud Files",
-							CloudProviders.ownCloud => !string.IsNullOrEmpty(ownCloudValue) ? ownCloudValue : "ownCloud",
+							CloudProviders.ownCloud => !string.IsNullOrEmpty(clsidDefaultValue) ? clsidDefaultValue : "ownCloud",
 							CloudProviders.ProtonDrive => $"Proton Drive",
-							CloudProviders.kDrive => !string.IsNullOrEmpty(kDriveValue) ? kDriveValue : "kDrive",
-							CloudProviders.LucidLink => !string.IsNullOrEmpty(lucidLinkValue) ? lucidLinkValue : "lucidLink",
+							CloudProviders.kDrive => !string.IsNullOrEmpty(clsidDefaultValue) ? clsidDefaultValue : "kDrive",
+							CloudProviders.LucidLink => !string.IsNullOrEmpty(clsidDefaultValue) ? clsidDefaultValue : "lucidLink",
+							CloudProviders.SyncDrive => !string.IsNullOrEmpty(clsidDefaultValue) ? clsidDefaultValue : "Sync",
 							_ => null
 						},
 						SyncFolder = syncedFolder,
@@ -349,6 +349,8 @@ namespace Files.App.Utils.Cloud
 				return "ownCloud";
 			if (driveIdentifier.StartsWith("ProtonDrive"))
 				return "ProtonDrive";
+			if (driveIdentifier.StartsWith("SyncCom"))
+				return "SyncCom";
 
 			// Nextcloud specific
 			var appNameFromNamespace = (string?)namespaceSubKey?.GetValue("ApplicationName");

--- a/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
+++ b/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
@@ -92,6 +92,7 @@ namespace Files.App.Utils.Cloud
 						"kDrive" => CloudProviders.kDrive,
 						"Lucid" => CloudProviders.LucidLink,
 						"SyncCom" => CloudProviders.SyncDrive,
+						"MagentaCLOUD" => CloudProviders.MagentaCloud,
 						_ => null,
 					};
 
@@ -119,6 +120,7 @@ namespace Files.App.Utils.Cloud
 							CloudProviders.kDrive => !string.IsNullOrEmpty(clsidDefaultValue) ? clsidDefaultValue : "kDrive",
 							CloudProviders.LucidLink => !string.IsNullOrEmpty(clsidDefaultValue) ? clsidDefaultValue : "lucidLink",
 							CloudProviders.SyncDrive => !string.IsNullOrEmpty(clsidDefaultValue) ? clsidDefaultValue : "Sync",
+							CloudProviders.MagentaCloud => !string.IsNullOrEmpty(clsidDefaultValue) ? clsidDefaultValue : "MagentaCLOUD",
 							_ => null
 						},
 						SyncFolder = syncedFolder,

--- a/src/Files.App/Utils/Cloud/CloudProviders.cs
+++ b/src/Files.App/Utils/Cloud/CloudProviders.cs
@@ -45,6 +45,8 @@ namespace Files.App.Utils.Cloud
 
 		LucidLink,
 
-		kDrive
+		kDrive,
+
+		SyncDrive
 	}
 }

--- a/src/Files.App/Utils/Cloud/CloudProviders.cs
+++ b/src/Files.App/Utils/Cloud/CloudProviders.cs
@@ -47,6 +47,8 @@ namespace Files.App.Utils.Cloud
 
 		kDrive,
 
-		SyncDrive
+		SyncDrive,
+
+		MagentaCloud
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #15999 
- Closes #16935 

**Steps used to test these changes**

1. Installed the cloud drives and made sure they are displayed in Files

There is no icon displayed for the Sync drive, but that is an error on their side because the program does not set the icon path in the registry
![image](https://github.com/user-attachments/assets/431a719a-c3f4-4169-a8bf-24ba66e12783)


Sync:
![image](https://github.com/user-attachments/assets/f27ce936-a300-4d7b-8417-32f8753e594a)

Magenta:
![image](https://github.com/user-attachments/assets/f3dbf1cc-4318-4f81-84ba-b946d3121717)



