### PR TITLE
Code Quality: Replaced DllImport calls with CsWin32 generations for DPI calculation operations

### DIFF
--- a/src/Files.App.CsWin32/NativeMethods.txt
+++ b/src/Files.App.CsWin32/NativeMethods.txt
@@ -97,7 +97,6 @@ SendMessage
 IsWindowVisible
 COPYDATASTRUCT
 WINDOW_LONG_PTR_INDEX
-GetDpiForWindow
 CallWindowProc
 MINMAXINFO
 SUBCLASSPROC

--- a/src/Files.App/Data/Models/AppModel.cs
+++ b/src/Files.App/Data/Models/AppModel.cs
@@ -131,7 +131,7 @@ namespace Files.App.Data.Models
 		/// Gets or sets a value indicating the AppWindow DPI.
 		/// </summary>
 		private float _AppWindowDPI = PInvoke.GetDpiForWindow((HWND)MainWindow.Instance.WindowHandle) / 96f;
-		public float AppWindowDPI // TODO: Update value if the DPI changes
+		public float AppWindowDPI
 		{
 			get => _AppWindowDPI;
 			set => SetProperty(ref _AppWindowDPI, value);

--- a/src/Files.App/Data/Models/AppModel.cs
+++ b/src/Files.App/Data/Models/AppModel.cs
@@ -4,6 +4,8 @@
 using Microsoft.UI.Xaml.Controls;
 using System.Runtime.InteropServices;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 
 namespace Files.App.Data.Models
 {
@@ -127,10 +129,9 @@ namespace Files.App.Data.Models
 
 		/// <summary>
 		/// Gets or sets a value indicating the AppWindow DPI.
-		/// TODO update value if the DPI changes
 		/// </summary>
-		private float _AppWindowDPI = Win32PInvoke.GetDpiForWindow(MainWindow.Instance.WindowHandle) / 96f;
-		public float AppWindowDPI
+		private float _AppWindowDPI = PInvoke.GetDpiForWindow((HWND)MainWindow.Instance.WindowHandle) / 96f;
+		public float AppWindowDPI // TODO: Update value if the DPI changes
 		{
 			get => _AppWindowDPI;
 			set => SetProperty(ref _AppWindowDPI, value);

--- a/src/Files.App/Helpers/Win32/Win32PInvoke.Methods.cs
+++ b/src/Files.App/Helpers/Win32/Win32PInvoke.Methods.cs
@@ -76,11 +76,6 @@ namespace Files.App.Helpers
 			IntPtr hEvent
 		);
 
-		[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-		public static extern int GetDpiForWindow(
-			IntPtr hwnd
-		);
-
 		[DllImport("ole32.dll")]
 		public static extern uint CoWaitForMultipleObjects(
 			uint dwFlags,


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Related #15000 

**Steps used to test these changes**

1. Opened the app
2. Tested components that reference the migrated `AppModel.AppWindowDPI` property

---

`GetDpiForWindow` is already being used in some places however the legacy method pointing to a `DllImport` call remains in the Win32 PInvoke helper.
This PR removes it from the helper and replaces the final reference to `Win32PInvoke.GetDpiForWindow()` with the appropriate method generated by CsWin32.
