### PR TITLE
Fix: Ensure Home key moves cursor to start of filename during rename

### DIFF
--- a/src/Files.App/Views/Layouts/BaseGroupableLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseGroupableLayoutPage.cs
@@ -312,6 +312,11 @@ namespace Files.App.Views.Layouts
 					await CommitRenameAsync(textBox);
 					e.Handled = true;
 					break;
+				case VirtualKey.Home:
+					textBox.SelectionStart = 0;
+					textBox.SelectionLength = 0;
+					e.Handled = true;
+					break;
 				case VirtualKey.Up:
 					if (!isShiftPressed)
 						textBox.SelectionStart = 0;


### PR DESCRIPTION
This commit addresses the issue where pressing the Home key during file renaming in List View (and other views
inheriting from BaseGroupableLayoutPage) did not move the cursor to the absolute beginning of the filename if the
filename was longer than the visible TextBox. The fix ensures that textBox.SelectionStart is set to 0 and
textBox.SelectionLength is set to 0 when the Home key is pressed, providing behavior consistent with Windows
Explorer.

<!--
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. 2. Try not to make duplicates. Do a quick search before posting
3. 3. Add a clear title starting with "Feature:" or "Fix:"
4. -->
**Resolved / Related Issues**
Resolves #14253