### PR TITLE
Code Quality: Added a static method to the PCWSTR struct that allows constructing from a string

### DIFF
--- a/src/Files.App.CsWin32/Extras.cs
+++ b/src/Files.App.CsWin32/Extras.cs
@@ -44,6 +44,20 @@ namespace Windows.Win32
 		public const int PixelFormat32bppARGB = 2498570;
 	}
 
+	namespace Foundation
+	{
+		public partial struct PCWSTR
+		{
+			public static unsafe PCWSTR FromString(string value)
+			{
+				fixed (char* p = value)
+				{
+					return new PCWSTR(p);
+				}
+			}
+		}
+	}
+
 	namespace Extras
 	{
 		[GeneratedComInterface, Guid("EACDD04C-117E-4E17-88F4-D1B12B0E3D89"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Related #15000 

**Steps used to test these changes**

1. Built the app
> This only introduces a new API that can be used in future PRs to make migrating from DllImport calls to CsWin32 generations easier, and does not have any effect over the app as it is.

---

This method makes it easier to pass in a `PCWSTR` struct to a P/Invoke method that might previously require a string input.
A lot of methods generated by CsWin32 that require unsafe will prefer a `PCWSTR` passed as an argument over a literal `System.String` however this method allows using a string value (via fixing the `string` in memory as a `char*`) for simplicity and so that code isn't reused.

e.g.:
```cs
unsafe void Example()
{
	HANDLE file = PInvoke.CreateFile(lpFileName: PCWSTR.FromString("example") ...);
}
```