### PR TITLE
Feature: Displayed all extensions that can be used as a folder icon in open dialog

### DIFF
--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -4236,4 +4236,8 @@
     <value>Status center progress ping</value>
     <comment>Screen reader name for the status center progress ring</comment>
   </data>
+  <data name="IconFile" xml:space="preserve">
+    <value>Icon files</value>
+    <comment>This is the friendly name for a variety of different icon files.</comment>
+  </data>
 </root>

--- a/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
+++ b/src/Files.App/ViewModels/Properties/CustomizationViewModel.cs
@@ -95,6 +95,7 @@ namespace Files.App.ViewModels.Properties
 
 			string[] extensions =
 			[
+				Strings.IconFile.GetLocalizedResource(), "*.dll; *.exe; *.ico; *.icl",
 				Strings.ApplicationExtension.GetLocalizedResource(), "*.dll",
 				Strings.Application.GetLocalizedResource(), "*.exe",
 				Strings.IcoFileCapitalized.GetLocalizedResource(), "*.ico",


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Closes #17156 

**Steps used to test these changes**

1. Opened Files
2. Navigated to the properties window of a folder
3. Opened the customise folder icon dialogue
4. Tried selecting all the different options