### PR TITLE
Code Quality: Fixed a number of focus related issues in Omnibar

### DIFF
--- a/src/Files.App.Controls/Files.App.Controls.csproj
+++ b/src/Files.App.Controls/Files.App.Controls.csproj
@@ -10,7 +10,6 @@
         <Platforms>x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <DefineConstants>$(DefineConstants);OMNIBAR_DEBUG</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -106,14 +106,6 @@ namespace Files.App.Controls
 					previouslyFocusedElement?.Focus(FocusState.Programmatic);
 				}
 			}
-			else if (e.Key == VirtualKey.Tab && !InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down))
-			{
-				// Focus on inactive content when pressing Tab instead of moving to the next control in the tab order
-				e.Handled = true;
-				IsFocused = false;
-				await Task.Delay(15);
-				CurrentSelectedMode?.ContentOnInactive?.Focus(FocusState.Keyboard);
-			}
 			else
 			{
 				_textChangeReason = OmnibarTextChangeReason.UserInput;

--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -15,6 +15,12 @@ namespace Files.App.Controls
 			// Popup width has to be set manually because it doesn't stretch with the parent
 			_textBoxSuggestionsContainerBorder.Width = ActualWidth;
 		}
+		
+		private void Omnibar_LostFocus(object sender, RoutedEventArgs e)
+		{
+			// Reset to the default mode when Omnibar loses focus
+			CurrentSelectedMode = Modes?.FirstOrDefault();
+		}
 
 		private void AutoSuggestBox_GettingFocus(UIElement sender, GettingFocusEventArgs args)
 		{

--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -21,8 +21,6 @@ namespace Files.App.Controls
 			if (args.OldFocusedElement is null)
 				return;
 
-			GlobalHelper.WriteDebugStringForOmnibar("The TextBox is getting the focus.");
-
 			_previouslyFocusedElement = new(args.OldFocusedElement as UIElement);
 		}
 
@@ -38,8 +36,6 @@ namespace Files.App.Controls
 
 		private void AutoSuggestBox_GotFocus(object sender, RoutedEventArgs e)
 		{
-			GlobalHelper.WriteDebugStringForOmnibar("The TextBox got the focus.");
-
 			IsFocused = true;
 			_textBox.SelectAll();
 		}
@@ -50,8 +46,6 @@ namespace Files.App.Controls
 			if (_textBox.ContextFlyout.IsOpen)
 				return;
 
-			GlobalHelper.WriteDebugStringForOmnibar("The TextBox lost the focus.");
-
 			IsFocused = false;
 		}
 
@@ -61,15 +55,11 @@ namespace Files.App.Controls
 			{
 				e.Handled = true;
 
-				GlobalHelper.WriteDebugStringForOmnibar("The TextBox accepted the Enter key.");
-
 				SubmitQuery(_textBoxSuggestionsPopup.IsOpen && _textBoxSuggestionsListView.SelectedIndex is not -1 ? _textBoxSuggestionsListView.SelectedItem : null);
 			}
 			else if ((e.Key == VirtualKey.Up || e.Key == VirtualKey.Down) && _textBoxSuggestionsPopup.IsOpen)
 			{
 				e.Handled = true;
-
-				GlobalHelper.WriteDebugStringForOmnibar("The TextBox accepted the Up/Down key while the suggestions pop-up is open.");
 
 				var currentIndex = _textBoxSuggestionsListView.SelectedIndex;
 				var nextIndex = currentIndex;
@@ -99,8 +89,6 @@ namespace Files.App.Controls
 			{
 				e.Handled = true;
 
-				GlobalHelper.WriteDebugStringForOmnibar("The TextBox accepted the Esc key.");
-
 				if (_textBoxSuggestionsPopup.IsOpen)
 				{
 					RevertTextToUserInput();
@@ -114,8 +102,6 @@ namespace Files.App.Controls
 			}
 			else if (e.Key == VirtualKey.Tab && !InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down))
 			{
-				GlobalHelper.WriteDebugStringForOmnibar("The TextBox accepted the Tab key.");
-
 				// Focus on inactive content when pressing Tab instead of moving to the next control in the tab order
 				e.Handled = true;
 				IsFocused = false;
@@ -150,7 +136,6 @@ namespace Files.App.Controls
 
 		private void AutoSuggestBoxSuggestionsPopup_GettingFocus(UIElement sender, GettingFocusEventArgs args)
 		{
-			// The suggestions popup is never wanted to be focused when it come to open.
 			args.TryCancel();
 		}
 

--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -125,6 +125,8 @@ namespace Files.App.Controls
 				_textChangeReason = OmnibarTextChangeReason.UserInput;
 				_userInput = _textBox.Text;
 			}
+			else if (_textChangeReason is OmnibarTextChangeReason.ProgrammaticChange)
+				_textBox.SelectAll();
 
 			TextChanged?.Invoke(this, new(CurrentSelectedMode, _textChangeReason));
 

--- a/src/Files.App.Controls/Omnibar/Omnibar.Properties.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Properties.cs
@@ -27,11 +27,6 @@ namespace Files.App.Controls
 			if (e.NewValue is not OmnibarMode newMode)
 				return;
 
-			if (e.OldValue is OmnibarMode oldMode)
-				GlobalHelper.WriteDebugStringForOmnibar($"The mode change from {oldMode} to {newMode} has been requested.");
-			else
-				GlobalHelper.WriteDebugStringForOmnibar($"The mode change to {newMode} has been requested.");
-
 			ChangeMode(e.OldValue as OmnibarMode, newMode);
 			CurrentSelectedModeName = newMode.Name;
 		}
@@ -55,8 +50,6 @@ namespace Files.App.Controls
 		{
 			if (CurrentSelectedMode is null || _textBox is null)
 				return;
-
-			GlobalHelper.WriteDebugStringForOmnibar($"{nameof(IsFocused)} has been changed to {IsFocused}");
 
 			if (newValue)
 			{

--- a/src/Files.App.Controls/Omnibar/Omnibar.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.cs
@@ -51,8 +51,6 @@ namespace Files.App.Controls
 
 			Modes = [];
 			AutoSuggestBoxPadding = new(0, 0, 0, 0);
-
-			GlobalHelper.WriteDebugStringForOmnibar("Omnibar has been initialized.");
 		}
 
 		// Methods
@@ -88,8 +86,6 @@ namespace Files.App.Controls
 
 			// Set the default width
 			_textBoxSuggestionsContainerBorder.Width = ActualWidth;
-
-			GlobalHelper.WriteDebugStringForOmnibar("The template and the events have been initialized.");
 		}
 
 		public void PopulateModes()
@@ -199,8 +195,6 @@ namespace Files.App.Controls
 				mode.Transitions.Clear();
 				mode.UpdateLayout();
 			}
-
-			GlobalHelper.WriteDebugStringForOmnibar($"Successfully changed Mode from {oldMode} to {newMode}");
 		}
 
 		internal protected void FocusTextBox()
@@ -216,15 +210,10 @@ namespace Files.App.Controls
 			if (wantToOpen && (!IsFocused || CurrentSelectedMode?.ItemsSource is null || (CurrentSelectedMode?.ItemsSource is IList collection && collection.Count is 0)))
 			{
 				_textBoxSuggestionsPopup.IsOpen = false;
-
-				GlobalHelper.WriteDebugStringForOmnibar("The suggestions pop-up closed.");
-
 				return false;
 			}
 
 			_textBoxSuggestionsPopup.IsOpen = wantToOpen;
-
-			GlobalHelper.WriteDebugStringForOmnibar("The suggestions pop-up is open.");
 
 			return false;
 		}

--- a/src/Files.App.Controls/Omnibar/Omnibar.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.cs
@@ -73,6 +73,7 @@ namespace Files.App.Controls
 			PopulateModes();
 
 			SizeChanged += Omnibar_SizeChanged;
+			LostFocus += Omnibar_LostFocus;
 			_textBox.GettingFocus += AutoSuggestBox_GettingFocus;
 			_textBox.GotFocus += AutoSuggestBox_GotFocus;
 			_textBox.LosingFocus += AutoSuggestBox_LosingFocus;

--- a/src/Files.App.Controls/Omnibar/OmnibarMode.Events.cs
+++ b/src/Files.App.Controls/Omnibar/OmnibarMode.Events.cs
@@ -12,8 +12,6 @@ namespace Files.App.Controls
 			if (_ownerRef is null || _ownerRef.TryGetTarget(out var owner) is false || owner.CurrentSelectedMode == this)
 				return;
 
-			GlobalHelper.WriteDebugStringForOmnibar($"The mouse pointer has entered the UI area of this Mode ({this})");
-
 			VisualStateManager.GoToState(this, "PointerOver", true);
 		}
 
@@ -22,8 +20,6 @@ namespace Files.App.Controls
 			if (_ownerRef is null || _ownerRef.TryGetTarget(out var owner) is false || owner.CurrentSelectedMode == this)
 				return;
 
-			GlobalHelper.WriteDebugStringForOmnibar($"The mouse pointer has been pressed on the UI area of this Mode ({this})");
-
 			VisualStateManager.GoToState(this, "PointerPressed", true);
 		}
 
@@ -31,8 +27,6 @@ namespace Files.App.Controls
 		{
 			if (_ownerRef is null || _ownerRef.TryGetTarget(out var owner) is false || owner.CurrentSelectedMode == this)
 				return;
-
-			GlobalHelper.WriteDebugStringForOmnibar($"The mouse pointer has been unpressed from the UI area of this Mode ({this})");
 
 			VisualStateManager.GoToState(this, "PointerOver", true);
 
@@ -44,8 +38,6 @@ namespace Files.App.Controls
 
 		private void ModeButton_PointerExited(object sender, PointerRoutedEventArgs e)
 		{
-			GlobalHelper.WriteDebugStringForOmnibar($"The mouse pointer has moved away from the UI area of this Mode ({this})");
-
 			VisualStateManager.GoToState(this, "PointerNormal", true);
 		}
 	}

--- a/src/Files.App.Controls/Omnibar/OmnibarMode.cs
+++ b/src/Files.App.Controls/Omnibar/OmnibarMode.cs
@@ -23,8 +23,6 @@ namespace Files.App.Controls
 		public OmnibarMode()
 		{
 			DefaultStyleKey = typeof(OmnibarMode);
-
-			GlobalHelper.WriteDebugStringForOmnibar($"Omnibar Mode ({this}) has been initialized.");
 		}
 
 		// Methods
@@ -41,8 +39,6 @@ namespace Files.App.Controls
 			_modeButton.PointerPressed += ModeButton_PointerPressed;
 			_modeButton.PointerReleased += ModeButton_PointerReleased;
 			_modeButton.PointerExited += ModeButton_PointerExited;
-
-			GlobalHelper.WriteDebugStringForOmnibar($"The template and the events of the Omnibar Mode ({this}) have been initialized.");
 		}
 
 		protected override void OnKeyUp(KeyRoutedEventArgs args)
@@ -92,7 +88,7 @@ namespace Files.App.Controls
 
 		public override string ToString()
 		{
-			return Name ?? string.Empty;
+			return ModeName ?? string.Empty;
 		}
 	}
 }

--- a/src/Files.App.Controls/Util.cs
+++ b/src/Files.App.Controls/Util.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Files.App.Controls
 {
-	public static class GlobalHelper
+	public static class Util
 	{
 		/// <summary>
 		/// Sets cursor when hovering on a specific element.
@@ -21,12 +21,6 @@ namespace Files.App.Controls
 				uiElement,
 				[cursor]
 			);
-		}
-
-		[Conditional("OMNIBAR_DEBUG")]
-		public static void WriteDebugStringForOmnibar(string? message)
-		{
-			Debug.WriteLine($"OMNIBAR DEBUG: [{message}]");
 		}
 	}
 }

--- a/src/Files.App/UserControls/NavigationToolbar.xaml
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml
@@ -351,7 +351,7 @@
 			x:Load="{x:Bind ViewModel.EnableOmnibar, Mode=OneWay}"
 			CurrentSelectedModeName="{x:Bind ViewModel.OmnibarCurrentSelectedModeName, Mode=TwoWay}"
 			IsFocused="{x:Bind ViewModel.IsOmnibarFocused, Mode=TwoWay}"
-			LostFocus="Omnibar_LostFocus"
+			ModeChanged="Omnibar_ModeChanged"
 			PreviewKeyDown="Omnibar_PreviewKeyDown"
 			QuerySubmitted="Omnibar_QuerySubmitted"
 			TextChanged="Omnibar_TextChanged">

--- a/src/Files.App/UserControls/NavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml.cs
@@ -427,13 +427,11 @@ namespace Files.App.UserControls
 			e.Flyout.Items.Clear();
 		}
 
-		private void Omnibar_LostFocus(object sender, RoutedEventArgs e)
+		private void Omnibar_ModeChanged(object sender, OmnibarModeChangedEventArgs e)
 		{
+			// Reset the command palette text when switching modes
 			if (Omnibar.CurrentSelectedMode == OmnibarCommandPaletteMode)
-			{
-				Omnibar.CurrentSelectedMode = OmnibarPathMode;
 				ViewModel.OmnibarCommandPaletteModeText = string.Empty;
-			}
 		}
 
 		private void Omnibar_PreviewKeyDown(object sender, KeyRoutedEventArgs e)

--- a/src/Files.App/UserControls/NavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml.cs
@@ -12,6 +12,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.AI.Actions.Hosting;
 using Windows.System;
+using Windows.UI.Core;
 
 namespace Files.App.UserControls
 {
@@ -434,12 +435,23 @@ namespace Files.App.UserControls
 				ViewModel.OmnibarCommandPaletteModeText = string.Empty;
 		}
 
-		private void Omnibar_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+		private async void Omnibar_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
 		{
 			if (e.Key is VirtualKey.Escape)
 			{
 				Omnibar.IsFocused = false;
 				(MainPageViewModel.SelectedTabItem?.TabItemContent as Control)?.Focus(FocusState.Programmatic);
+			}
+			else if (e.Key is VirtualKey.Tab && Omnibar.IsFocused && !InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down))
+			{
+				var currentSelectedMode = Omnibar.CurrentSelectedMode;
+				Omnibar.IsFocused = false;
+				await Task.Delay(15);
+
+				if (currentSelectedMode == OmnibarPathMode)
+					BreadcrumbBar.Focus(FocusState.Keyboard);
+				else if (Omnibar.CurrentSelectedMode == OmnibarCommandPaletteMode)
+					OmnibarCommandPaletteMode.Focus(FocusState.Keyboard);
 			}
 		}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- For #16092
- Fixed "Entering text in Command mode, switching to Edit path mode, and then back to Command mode doesn't clear the original text"
- Fixed "Pressing tab in Command mode closes flyout but doesn't switch to the next control"
- Fixed "Switching to Path mode from Command mode isn't selecting the text"
- Moved the logic for resetting the selected mode on LostFocus from the app into the control

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

> Fixed Command Palette text when switching between modes

1. Entered text in Command mode
2. Switched to Edit path mode
3. Switched back to Command mode
4. Confirmed the text was correctly cleared

> Moved the logic for resetting the selected mode on LostFocus from the app into the control

1. Switched to Edit path mode
2. Removed focus by clicking the file area
3. Confirmed the Omnibar switched to Breadcrumb mode
4. Switched to Command mode and repeated steps 2 and 3

> Pressing tab in Command mode closes flyout but doesn't switch to the next control

1. Focused on path box
2. Pressed tab
3. Confirmed the breadcrumb bar is selected
4. Switched to Command mode
5. Confirmed pressing tab selects the mode button

> Switching to Path mode from Command mode isn't selecting the text

1. Switched to Command mode
2. Switched to Edit path mode
3. Confirmed the text was selected
