### PR TITLE
Code Quality: Fixed a number of focus related issues in Omnibar

### DIFF
--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -137,6 +137,8 @@ namespace Files.App.Controls
 				_textChangeReason = OmnibarTextChangeReason.UserInput;
 				_userInput = _textBox.Text;
 			}
+			else if (_textChangeReason is OmnibarTextChangeReason.ProgrammaticChange)
+				_textBox.SelectAll();
 
 			TextChanged?.Invoke(this, new(CurrentSelectedMode, _textChangeReason));
 

--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -118,16 +118,6 @@ namespace Files.App.Controls
 					previouslyFocusedElement?.Focus(FocusState.Programmatic);
 				}
 			}
-			else if (e.Key == VirtualKey.Tab && !InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down))
-			{
-				GlobalHelper.WriteDebugStringForOmnibar("The TextBox accepted the Tab key.");
-
-				// Focus on inactive content when pressing Tab instead of moving to the next control in the tab order
-				e.Handled = true;
-				IsFocused = false;
-				await Task.Delay(15);
-				CurrentSelectedMode?.ContentOnInactive?.Focus(FocusState.Keyboard);
-			}
 			else
 			{
 				_textChangeReason = OmnibarTextChangeReason.UserInput;

--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -15,6 +15,12 @@ namespace Files.App.Controls
 			// Popup width has to be set manually because it doesn't stretch with the parent
 			_textBoxSuggestionsContainerBorder.Width = ActualWidth;
 		}
+		
+		private void Omnibar_LostFocus(object sender, RoutedEventArgs e)
+		{
+			// Reset to the default mode when Omnibar loses focus
+			CurrentSelectedMode = Modes?.FirstOrDefault();
+		}
 
 		private void AutoSuggestBox_GettingFocus(UIElement sender, GettingFocusEventArgs args)
 		{

--- a/src/Files.App.Controls/Omnibar/Omnibar.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.cs
@@ -75,6 +75,7 @@ namespace Files.App.Controls
 			PopulateModes();
 
 			SizeChanged += Omnibar_SizeChanged;
+			LostFocus += Omnibar_LostFocus;
 			_textBox.GettingFocus += AutoSuggestBox_GettingFocus;
 			_textBox.GotFocus += AutoSuggestBox_GotFocus;
 			_textBox.LosingFocus += AutoSuggestBox_LosingFocus;

--- a/src/Files.App/UserControls/NavigationToolbar.xaml
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml
@@ -351,7 +351,7 @@
 			x:Load="{x:Bind ViewModel.EnableOmnibar, Mode=OneWay}"
 			CurrentSelectedModeName="{x:Bind ViewModel.OmnibarCurrentSelectedModeName, Mode=TwoWay}"
 			IsFocused="{x:Bind ViewModel.IsOmnibarFocused, Mode=TwoWay}"
-			LostFocus="Omnibar_LostFocus"
+			ModeChanged="Omnibar_ModeChanged"
 			PreviewKeyDown="Omnibar_PreviewKeyDown"
 			QuerySubmitted="Omnibar_QuerySubmitted"
 			TextChanged="Omnibar_TextChanged">

--- a/src/Files.App/UserControls/NavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml.cs
@@ -427,13 +427,11 @@ namespace Files.App.UserControls
 			e.Flyout.Items.Clear();
 		}
 
-		private void Omnibar_LostFocus(object sender, RoutedEventArgs e)
+		private void Omnibar_ModeChanged(object sender, OmnibarModeChangedEventArgs e)
 		{
+			// Reset the command palette text when switching modes
 			if (Omnibar.CurrentSelectedMode == OmnibarCommandPaletteMode)
-			{
-				Omnibar.CurrentSelectedMode = OmnibarPathMode;
 				ViewModel.OmnibarCommandPaletteModeText = string.Empty;
-			}
 		}
 
 		private void Omnibar_PreviewKeyDown(object sender, KeyRoutedEventArgs e)

--- a/src/Files.App/UserControls/NavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml.cs
@@ -12,6 +12,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.AI.Actions.Hosting;
 using Windows.System;
+using Windows.UI.Core;
 
 namespace Files.App.UserControls
 {
@@ -434,12 +435,23 @@ namespace Files.App.UserControls
 				ViewModel.OmnibarCommandPaletteModeText = string.Empty;
 		}
 
-		private void Omnibar_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+		private async void Omnibar_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
 		{
 			if (e.Key is VirtualKey.Escape)
 			{
 				Omnibar.IsFocused = false;
 				(MainPageViewModel.SelectedTabItem?.TabItemContent as Control)?.Focus(FocusState.Programmatic);
+			}
+			else if (e.Key is VirtualKey.Tab && Omnibar.IsFocused && !InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down))
+			{
+				var currentSelectedMode = Omnibar.CurrentSelectedMode;
+				Omnibar.IsFocused = false;
+				await Task.Delay(15);
+
+				if (currentSelectedMode == OmnibarPathMode)
+					BreadcrumbBar.Focus(FocusState.Keyboard);
+				else if (Omnibar.CurrentSelectedMode == OmnibarCommandPaletteMode)
+					OmnibarCommandPaletteMode.Focus(FocusState.Keyboard);
 			}
 		}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- For #16092
- Fixed "Entering text in Command mode, switching to Edit path mode, and then back to Command mode doesn't clear the original text"
- Fixed "Pressing tab in Command mode closes flyout but doesn't switch to the next control"
- Fixed "Switching to Path mode from Command mode isn't selecting the text"
- Moved the logic for resetting the selected mode on LostFocus from the app into the control

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

> Fixed Command Palette text when switching between modes

1. Entered text in Command mode
2. Switched to Edit path mode
3. Switched back to Command mode
4. Confirmed the text was correctly cleared

> Moved the logic for resetting the selected mode on LostFocus from the app into the control

1. Switched to Edit path mode
2. Removed focus by clicking the file area
3. Confirmed the Omnibar switched to Breadcrumb mode
4. Switched to Command mode and repeated steps 2 and 3

> Pressing tab in Command mode closes flyout but doesn't switch to the next control

1. Focused on path box
2. Pressed tab
3. Confirmed the breadcrumb bar is selected
4. Switched to Command mode
5. Confirmed pressing tab selects the mode button

> Switching to Path mode from Command mode isn't selecting the text

1. Switched to Command mode
2. Switched to Edit path mode
3. Confirmed the text was selected
