### PR TITLE
Feature: Added an option to disable the "Open in Windows Terminal" action

### DIFF
--- a/src/Files.App/Actions/Open/OpenTerminalAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalAction.cs
@@ -10,6 +10,8 @@ namespace Files.App.Actions
 	{
 		private readonly IContentPageContext context;
 
+		private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
+
 		public virtual string Label
 			=> Strings.OpenTerminal.GetLocalizedResource();
 
@@ -96,6 +98,9 @@ namespace Files.App.Actions
 
 		private bool GetIsExecutable()
 		{
+			if (UserSettingsService.GeneralSettingsService.ShowOpenTerminal is false)
+				return false;
+
 			if (context.PageType is ContentPageTypes.None or ContentPageTypes.Home or ContentPageTypes.RecycleBin or ContentPageTypes.ZipFolder or ContentPageTypes.ReleaseNotes or ContentPageTypes.Settings)
 				return false;
 

--- a/src/Files.App/Actions/Open/OpenTerminalFromHomeAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalFromHomeAction.cs
@@ -6,6 +6,7 @@ namespace Files.App.Actions
 	internal sealed partial class OpenTerminalFromHomeAction : OpenTerminalAction
 	{
 		private IHomePageContext HomePageContext { get; } = Ioc.Default.GetRequiredService<IHomePageContext>();
+		private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
 
 		public override string Label
 			=> Strings.OpenTerminal.GetLocalizedResource();
@@ -14,6 +15,7 @@ namespace Files.App.Actions
 			=> Strings.OpenTerminalDescription.GetLocalizedResource();
 
 		public override bool IsExecutable =>
+			UserSettingsService.GeneralSettingsService.ShowOpenTerminal &&
 			HomePageContext.IsAnyItemRightClicked &&
 			HomePageContext.RightClickedItem is not null &&
 			(HomePageContext.RightClickedItem is WidgetFileTagCardItem fileTagItem

--- a/src/Files.App/Actions/Open/OpenTerminalFromSidebarAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalFromSidebarAction.cs
@@ -6,6 +6,7 @@ namespace Files.App.Actions
 	internal sealed partial class OpenTerminalFromSidebarAction : OpenTerminalAction
 	{
 		private ISidebarContext SidebarContext { get; } = Ioc.Default.GetRequiredService<ISidebarContext>();
+		private IUserSettingsService UserSettingsService { get; } = Ioc.Default.GetRequiredService<IUserSettingsService>();
 
 		public override string Label
 			=> Strings.OpenTerminal.GetLocalizedResource();
@@ -14,6 +15,7 @@ namespace Files.App.Actions
 			=> Strings.OpenTerminalDescription.GetLocalizedResource();
 
 		public override bool IsExecutable =>
+			UserSettingsService.GeneralSettingsService.ShowOpenTerminal &&
 			SidebarContext.IsItemRightClicked &&
 			SidebarContext.RightClickedItem is not null &&
 			SidebarContext.RightClickedItem.MenuOptions.ShowShellItems &&

--- a/src/Files.App/Data/Contracts/IGeneralSettingsService.cs
+++ b/src/Files.App/Data/Contracts/IGeneralSettingsService.cs
@@ -211,6 +211,11 @@ namespace Files.App.Data.Contracts
 		bool ShowOpenInNewPane { get; set; }
 
 		/// <summary>
+		/// Gets or sets a value indicating whether or not to show the option to open folders in Windows Terminal.
+		/// </summary>
+		bool ShowOpenTerminal { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating whether or not to show the option to copy an items path.
 		/// </summary>
 		bool ShowCopyPath { get; set; }

--- a/src/Files.App/Services/Settings/GeneralSettingsService.cs
+++ b/src/Files.App/Services/Settings/GeneralSettingsService.cs
@@ -275,6 +275,12 @@ namespace Files.App.Services.Settings
 			set => Set(value);
 		}
 
+		public bool ShowOpenTerminal
+		{
+			get => Get(true);
+			set => Set(value);
+		}
+
 		public bool ShowCopyPath
 		{
 			get => Get(true);

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -4264,4 +4264,7 @@
   <data name="SeeMore" xml:space="preserve">
     <value>See more</value>
   </data>
+  <data name="ShowOpenTerminal" xml:space="preserve">
+    <value>Show option to open folders in Windows Terminal</value>
+  </data>
 </root>

--- a/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
@@ -521,6 +521,19 @@ namespace Files.App.ViewModels.Settings
 			}
 		}
 
+		public bool ShowOpenTerminal
+		{
+			get => UserSettingsService.GeneralSettingsService.ShowOpenTerminal;
+			set
+			{
+				if (value != UserSettingsService.GeneralSettingsService.ShowOpenTerminal)
+				{
+					UserSettingsService.GeneralSettingsService.ShowOpenTerminal = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		private string selectedShellPaneArrangementType;
 		public string SelectedShellPaneArrangementType
 		{

--- a/src/Files.App/Views/Settings/GeneralPage.xaml
+++ b/src/Files.App/Views/Settings/GeneralPage.xaml
@@ -261,6 +261,11 @@
 						<ToggleSwitch AutomationProperties.Name="{helpers:ResourceString Name=ShowOpenInNewPane}" IsOn="{x:Bind ViewModel.ShowOpenInNewPane, Mode=TwoWay}" />
 					</wctcontrols:SettingsCard>
 
+					<!--  Open in Windows Terminal  -->
+					<wctcontrols:SettingsCard Header="{helpers:ResourceString Name=ShowOpenTerminal}">
+						<ToggleSwitch AutomationProperties.Name="{helpers:ResourceString Name=ShowOpenTerminal}" IsOn="{x:Bind ViewModel.ShowOpenTerminal, Mode=TwoWay}" />
+					</wctcontrols:SettingsCard>
+
 					<!--  Copy path  -->
 					<wctcontrols:SettingsCard Header="{helpers:ResourceString Name=ShowCopyPath}">
 						<ToggleSwitch AutomationProperties.Name="{helpers:ResourceString Name=ShowCopyPath}" IsOn="{x:Bind ViewModel.ShowCopyPath, Mode=TwoWay}" />


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Closes #17246 

**Steps used to test these changes**

1. Opened Files
2. Navigated to the settings page
3. Clicked on the 'context menu options' expander and disabled the "Show option to open folders in Windows Terminal" toggle
4. Opened the context menu of folders in the sidebar, in the file browser, and in the homepage
5. Observed that the "Open in Windows Terminal" option is no longer present
