### PR TITLE
Feature: Add support for OX Drive integration

### DIFF
--- a/src/Files.App/Utils/Cloud/CloudProviders.cs
+++ b/src/Files.App/Utils/Cloud/CloudProviders.cs
@@ -49,6 +49,8 @@ namespace Files.App.Utils.Cloud
 
 		SyncDrive,
 
-		MagentaCloud
+		MagentaCloud,
+
+		OXDrive
 	}
 }

--- a/src/Files.App/Utils/Cloud/Detector/CloudDetector.cs
+++ b/src/Files.App/Utils/Cloud/Detector/CloudDetector.cs
@@ -33,6 +33,7 @@ namespace Files.App.Utils.Cloud
 			yield return new BoxCloudDetector();
 			yield return new GenericCloudDetector();
 			yield return new SynologyDriveCloudDetector();
+			yield return new OXDriveCloudDetector();
 		}
 	}
 }

--- a/src/Files.App/Utils/Cloud/Detector/OXDriveCloudDetector.cs
+++ b/src/Files.App/Utils/Cloud/Detector/OXDriveCloudDetector.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Files.App.Utils.Cloud;
+using Microsoft.Win32;
+using System.IO;
+using System.Text.Json;
+using Windows.Storage;
+using static Vanara.PInvoke.Gdi32;
+
+namespace Files.App.Utils.Cloud
+{
+	/// <summary>
+	/// Provides an utility for OX Drive Cloud detection.
+	/// </summary>
+	public sealed class OXDriveCloudDetector : AbstractCloudDetector
+	{
+		protected override async IAsyncEnumerable<ICloudProvider> GetProviders()
+		{
+			var syncFolder = await GetOXDriveSyncFolder();
+			if (!string.IsNullOrEmpty(syncFolder))
+			{
+				var iconFile = GetOXDriveIconFile();
+				yield return new CloudProvider(CloudProviders.OXDrive)
+				{
+					Name = "OX Drive",
+					SyncFolder = syncFolder,
+					IconData = iconFile?.IconData
+				};
+			}
+		}
+		public static async Task<string?> GetOXDriveSyncFolder()
+		{
+			var jsonPath = Path.Combine(UserDataPaths.GetDefault().LocalAppData, "Open-Xchange", "OXDrive", "userConfig.json");
+			if (!File.Exists(jsonPath))
+				return null; 
+
+			var configFile = await StorageFile.GetFileFromPathAsync(jsonPath);
+			using var jsonDoc = JsonDocument.Parse(await FileIO.ReadTextAsync(configFile));
+			var jsonElem = jsonDoc.RootElement;
+
+			string? syncFolderPath = null;
+
+			if (jsonElem.TryGetProperty("Accounts", out var accounts) && accounts.GetArrayLength() > 0)
+			{
+				var account = accounts[0];
+
+				if (account.TryGetProperty("MainFolderPath", out var folderPathElem))
+					syncFolderPath = folderPathElem.GetString();
+			}
+
+			return syncFolderPath;
+		}
+
+		private static IconFileInfo? GetOXDriveIconFile()
+		{
+			var installPath = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Open-Xchange\OXDrive", "InstallDir", null) as string;
+
+			// Fallback to default known path if not found in the registry.
+			if (string.IsNullOrEmpty(installPath))
+			{
+				var pfX86 = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+				if (string.IsNullOrEmpty(pfX86))
+					return null;
+
+				installPath = Path.Combine(pfX86, "Open-Xchange", "OXDrive");
+			}
+
+			var oxDriveFilePath = Path.Combine(installPath, "OXDrive.exe");
+			if (!File.Exists(oxDriveFilePath))
+			{
+				return null;
+			}
+
+			// Extract the icon from the OXDrive executable (though it is executable, it contains icons)
+			var icons = Win32Helper.ExtractSelectedIconsFromDLL(oxDriveFilePath, new List<int> { 0 }, 32);
+			return icons.FirstOrDefault();
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support for detecting OX Drive as a cloud provider in the Files app.

Closes #16000

### Changes:
- Introduced `OXDriveCloudDetector` for identifying OX Drive installations
- Extracts sync folder path from `userConfig.json` using `MainFolderPath`
- Loads OX Drive icon from the registry or fallback installation path (under Program Files(x86))
- Registered OX Drive in `CloudProviders` enum
- Integrated OX Drive detector into the cloud detection pipeline

Tested locally with OX Drive installed and verified detection.