### PR TITLE
Code Quality: Improved display of plural strings in Status Center

### DIFF
--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3490,27 +3490,27 @@
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CompressComplete_Header" xml:space="preserve">
-    <value>Compressed {0} item(s) to "{1}"</value>
+    <value>Compressed {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CompressComplete_SubHeader" xml:space="preserve">
-    <value>Compressed {0} item(s) from "{1}" to "{2}"</value>
+    <value>Compressed {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CompressFailed_Header" xml:space="preserve">
-    <value>Error compressing {0} item(s) to "{1}"</value>
+    <value>Error compressing {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CompressFailed_SubHeader" xml:space="preserve">
-    <value>Failed to compress {0} item(s) from "{1}" to "{2}"</value>
+    <value>Failed to compress {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CompressInProgress_Header" xml:space="preserve">
-    <value>Compressing {0} item(s) to "{1}"</value>
+    <value>Compressing {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CompressInProgress_SubHeader" xml:space="preserve">
-    <value>Compressing {0} item(s) from "{1}" to "{2}"</value>
+    <value>Compressing {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_GitCloneCanceled_Header" xml:space="preserve">
@@ -3578,35 +3578,35 @@
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CopyCanceled_Header" xml:space="preserve">
-    <value>Canceled copying {0} item(s) to "{1}"</value>
+    <value>Canceled copying {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CopyCanceled_SubHeader" xml:space="preserve">
-    <value>Canceled copying {0} item(s) from "{1}" to "{2}"</value>
+    <value>Canceled copying {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CopyComplete_Header" xml:space="preserve">
-    <value>Copied {0} item(s) to "{1}"</value>
+    <value>Copied {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CopyComplete_SubHeader" xml:space="preserve">
-    <value>Copied {0} item(s) from "{1}" to "{2}"</value>
+    <value>Copied {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CopyFailed_Header" xml:space="preserve">
-    <value>Error copying {0} item(s) to "{1}"</value>
+    <value>Error copying {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CopyFailed_SubHeader" xml:space="preserve">
-    <value>Failed to copy {0} item(s) from "{1}" to "{2}"</value>
+    <value>Failed to copy {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CopyInProgress_Header" xml:space="preserve">
-    <value>Copying {0} item(s) to "{1}"</value>
+    <value>Copying {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CopyInProgress_SubHeader" xml:space="preserve">
-    <value>Copying {0} item(s) from "{1}" to "{2}"</value>
+    <value>Copying {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_DecompressCanceled_Header" xml:space="preserve">
@@ -3642,55 +3642,55 @@
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_DeleteCanceled_Header" xml:space="preserve">
-    <value>Canceled deleting {0} item(s) from "{1}"</value>
+    <value>Canceled deleting {0, plural, one {# item} other {# items}} from "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_DeleteComplete_Header" xml:space="preserve">
-    <value>Deleted {0} item(s) from "{1}"</value>
+    <value>Deleted {0, plural, one {# item} other {# items}} from "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_DeleteFailed_Header" xml:space="preserve">
-    <value>Error deleting {0} item(s) from "{1}"</value>
+    <value>Error deleting {0, plural, one {# item} other {# items}} from "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_DeleteFailed_SubHeader" xml:space="preserve">
-    <value>Failed to delete {0} item(s) from "{1}"</value>
+    <value>Failed to delete {0, plural, one {# item} other {# items}} from "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_DeleteInProgress_Header" xml:space="preserve">
-    <value>Deleting {0} item(s) from "{1}"</value>
+    <value>Deleting {0, plural, one {# item} other {# items}} from "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_MoveCanceled_Header" xml:space="preserve">
-    <value>Canceled moving {0} item(s) to "{1}"</value>
+    <value>Canceled moving {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_MoveCanceled_SubHeader" xml:space="preserve">
-    <value>Canceled moving {0} item(s) from "{1}" to "{2}"</value>
+    <value>Canceled moving {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_MoveComplete_Header" xml:space="preserve">
-    <value>Moved {0} item(s) to "{1}"</value>
+    <value>Moved {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_MoveComplete_SubHeader" xml:space="preserve">
-    <value>Moved {0} item(s) from "{1}" to "{2}"</value>
+    <value>Moved {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_MoveInProgress_Header" xml:space="preserve">
-    <value>Moving {0} item(s) to "{1}"</value>
+    <value>Moving {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_MoveInProgress_SubHeader" xml:space="preserve">
-    <value>Moving {0} item(s) from "{1}" to "{2}"</value>
+    <value>Moving {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_MoveFailed_Header" xml:space="preserve">
-    <value>Error moving {0} item(s) to "{1}"</value>
+    <value>Error moving {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_MoveFailed_SubHeader" xml:space="preserve">
-    <value>Failed to move {0} item(s) from "{1}" to "{2}"</value>
+    <value>Failed to move {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_EmptyRecycleBinCancel_Header" xml:space="preserve">

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3550,31 +3550,31 @@
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_InstallFontCanceled_SubHeader" xml:space="preserve">
-    <value>Canceled installing {0} font(s) from "{1}"</value>
+    <value>Canceled installing {0, plural, one {# font} other {# fonts}} from "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_InstallFontComplete_Header" xml:space="preserve">
-    <value>Installed {0} font(s)</value>
+    <value>Installed {0, plural, one {# font} other {# fonts}}</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_InstallFontComplete_SubHeader" xml:space="preserve">
-    <value>Installed {0} font(s) from "{1}"</value>
+    <value>Installed {0, plural, one {# font} other {# fonts}} from "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_InstallFontFailed_Header" xml:space="preserve">
-    <value>Error installing {0} font(s)</value>
+    <value>Error installing {0, plural, one {# font} other {# fonts}}</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_InstallFontFailed_SubHeader" xml:space="preserve">
-    <value>Failed to install {0} font(s) from "{1}"</value>
+    <value>Failed to install {0, plural, one {# font} other {# fonts}} from "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_InstallFontInProgress_Header" xml:space="preserve">
-    <value>Installing {0} font(s)</value>
+    <value>Installing {0, plural, one {# font} other {# fonts}}</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_InstallFontInProgress_SubHeader" xml:space="preserve">
-    <value>Installing {0} font(s) from "{1}"</value>
+    <value>Installing {0, plural, one {# font} other {# fonts}} from "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_CopyCanceled_Header" xml:space="preserve">

--- a/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
+++ b/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
@@ -640,218 +640,207 @@ namespace Files.App.Utils.StatusCenter
 				destinationDirName = destinationPath.Split('\\').Last();
 			}
 
-			string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty : card.HeaderStringResource.GetLocalizedResource();
-			string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty : card.SubHeaderStringResource.GetLocalizedResource();
-
 			// Update string resources
 			switch (card.Operation)
 			{
 				case FileOperationType.Copy:
 					{
-						if (headerString is not null)
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, destinationDirName);
+						card.Header = card.FileSystemOperationReturnResult switch
 						{
-							card.Header = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								ReturnResult.Success => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								_ => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-							};
-						}
-						if (subHeaderString is not null)
+							ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							ReturnResult.Success => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							_ => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+						};
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath, destinationPath);
+						card.SubHeader = card.FileSystemOperationReturnResult switch
 						{
-							card.SubHeader = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-							};
-						}
+							ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+						};
 						break;
 					}
 				case FileOperationType.Move:
 					{
-						if (headerString is not null)
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, destinationDirName);
+						card.Header = card.FileSystemOperationReturnResult switch
 						{
-							card.Header = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								ReturnResult.Success => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								_ => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-							};
-						}
-						if (subHeaderString is not null)
+							ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							ReturnResult.Success => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							_ => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+						};
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath, destinationPath);
+						card.SubHeader = card.FileSystemOperationReturnResult switch
 						{
-							card.SubHeader = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-							};
-						}
+							ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+						};
 						break;
 					}
 				case FileOperationType.Delete:
 					{
-						if (headerString is not null)
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourceDirName);
+						card.Header = card.FileSystemOperationReturnResult switch
 						{
-							card.Header = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount, sourceDirName),
-								ReturnResult.Success => string.Format(headerString, card.TotalItemsCount, sourceDirName),
-								ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount, sourceDirName),
-								ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount, sourceDirName),
-								_ => string.Format(headerString, card.TotalItemsCount, sourceDirName),
-							};
-						}
-						if (subHeaderString is not null)
+							ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount, sourceDirName),
+							ReturnResult.Success => string.Format(headerString, card.TotalItemsCount, sourceDirName),
+							ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount, sourceDirName),
+							ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount, sourceDirName),
+							_ => string.Format(headerString, card.TotalItemsCount, sourceDirName),
+						};
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath);
+						card.SubHeader = card.FileSystemOperationReturnResult switch
 						{
-							card.SubHeader = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-							};
-						}
+							ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+						};
 						break;
 					}
 				case FileOperationType.Recycle:
 					{
-						if (headerString is not null)
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourceDirName);
+						card.Header = card.FileSystemOperationReturnResult switch
 						{
-							card.Header = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount, sourceDirName),
-								ReturnResult.Success => string.Format(headerString, card.TotalItemsCount, sourceDirName),
-								ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount, sourceDirName),
-								ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount, sourceDirName),
-								_ => string.Format(headerString, card.TotalItemsCount, sourceDirName),
-							};
-						}
-						if (subHeaderString is not null)
+							ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount, sourceDirName),
+							ReturnResult.Success => string.Format(headerString, card.TotalItemsCount, sourceDirName),
+							ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount, sourceDirName),
+							ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount, sourceDirName),
+							_ => string.Format(headerString, card.TotalItemsCount, sourceDirName),
+						};
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath);
+						card.SubHeader = card.FileSystemOperationReturnResult switch
 						{
-							card.SubHeader = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-							};
-						}
+							ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+						};
 						break;
 					}
 				case FileOperationType.Extract:
 					{
-						if (headerString is not null)
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(sourceFileName, destinationDirName);
+						card.Header = card.FileSystemOperationReturnResult switch
 						{
-							card.Header = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(headerString, sourceFileName, destinationDirName),
-								ReturnResult.Success => string.Format(headerString, sourceFileName, destinationDirName),
-								ReturnResult.Failed => string.Format(headerString, sourceFileName, destinationDirName),
-								ReturnResult.InProgress => string.Format(headerString, sourceFileName, destinationDirName),
-								_ => string.Format(headerString, sourceFileName, destinationDirName),
-							};
-						}
-						if (subHeaderString is not null)
+							ReturnResult.Cancelled => string.Format(headerString, sourceFileName, destinationDirName),
+							ReturnResult.Success => string.Format(headerString, sourceFileName, destinationDirName),
+							ReturnResult.Failed => string.Format(headerString, sourceFileName, destinationDirName),
+							ReturnResult.InProgress => string.Format(headerString, sourceFileName, destinationDirName),
+							_ => string.Format(headerString, sourceFileName, destinationDirName),
+						};
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(sourceFileName, sourcePath, destinationPath);
+						card.SubHeader = card.FileSystemOperationReturnResult switch
 						{
-							card.SubHeader = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(subHeaderString, sourceFileName, sourcePath, destinationPath),
-								ReturnResult.Success => string.Format(subHeaderString, sourceFileName, sourcePath, destinationPath),
-								ReturnResult.Failed => string.Format(subHeaderString, sourceFileName, sourcePath, destinationPath),
-								ReturnResult.InProgress => string.Format(subHeaderString, sourceFileName, sourcePath, destinationPath),
-								_ => string.Format(subHeaderString, sourceFileName, sourcePath, destinationPath),
-							};
-						}
+							ReturnResult.Cancelled => string.Format(subHeaderString, sourceFileName, sourcePath, destinationPath),
+							ReturnResult.Success => string.Format(subHeaderString, sourceFileName, sourcePath, destinationPath),
+							ReturnResult.Failed => string.Format(subHeaderString, sourceFileName, sourcePath, destinationPath),
+							ReturnResult.InProgress => string.Format(subHeaderString, sourceFileName, sourcePath, destinationPath),
+							_ => string.Format(subHeaderString, sourceFileName, sourcePath, destinationPath),
+						};
 						break;
 					}
 				case FileOperationType.Compressed:
 					{
-						if (headerString is not null)
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, destinationDirName);
+						card.Header = card.FileSystemOperationReturnResult switch
 						{
-							card.Header = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								ReturnResult.Success => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-								_ => string.Format(headerString, card.TotalItemsCount, destinationDirName),
-							};
-						}
-						if (subHeaderString is not null)
+							ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							ReturnResult.Success => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+							_ => string.Format(headerString, card.TotalItemsCount, destinationDirName),
+						};
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath, destinationPath);
+						card.SubHeader = card.FileSystemOperationReturnResult switch
 						{
-							card.SubHeader = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-							};
-						}
+							ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+						};
 						break;
 					}
 				case FileOperationType.GitClone:
 					{
-						if (headerString is not null)
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(sourcePath, destinationDirName);
+						card.Header = card.FileSystemOperationReturnResult switch
 						{
-							card.Header = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(headerString, sourcePath, destinationDirName),
-								ReturnResult.Success => string.Format(headerString, sourcePath, destinationDirName),
-								ReturnResult.Failed => string.Format(headerString, sourcePath, destinationDirName),
-								ReturnResult.InProgress => string.Format(headerString, sourcePath, destinationDirName),
-								_ => string.Format(headerString, sourcePath, destinationDirName),
-							};
-						}
-						if (subHeaderString is not null)
+							ReturnResult.Cancelled => string.Format(headerString, sourcePath, destinationDirName),
+							ReturnResult.Success => string.Format(headerString, sourcePath, destinationDirName),
+							ReturnResult.Failed => string.Format(headerString, sourcePath, destinationDirName),
+							ReturnResult.InProgress => string.Format(headerString, sourcePath, destinationDirName),
+							_ => string.Format(headerString, sourcePath, destinationDirName),
+						};
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath, destinationPath);
+						card.SubHeader = card.FileSystemOperationReturnResult switch
 						{
-							card.SubHeader = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-								_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
-							};
-						}
+							ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+							_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath, destinationPath),
+						};
 						break;
 					}
 				case FileOperationType.InstallFont:
 					{
-						if (headerString is not null)
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount);
+						card.Header = card.FileSystemOperationReturnResult switch
 						{
-							card.Header = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount),
-								ReturnResult.Success => string.Format(headerString, card.TotalItemsCount),
-								ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount),
-								ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount),
-								_ => string.Format(headerString, card.TotalItemsCount),
-							};
-						}
-						if (subHeaderString is not null)
+							ReturnResult.Cancelled => string.Format(headerString, card.TotalItemsCount),
+							ReturnResult.Success => string.Format(headerString, card.TotalItemsCount),
+							ReturnResult.Failed => string.Format(headerString, card.TotalItemsCount),
+							ReturnResult.InProgress => string.Format(headerString, card.TotalItemsCount),
+							_ => string.Format(headerString, card.TotalItemsCount),
+						};
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath);
+						card.SubHeader = card.FileSystemOperationReturnResult switch
 						{
-							card.SubHeader = card.FileSystemOperationReturnResult switch
-							{
-								ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-								_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
-							};
-						}
+							ReturnResult.Cancelled => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							ReturnResult.Success => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							ReturnResult.Failed => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							ReturnResult.InProgress => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+							_ => string.Format(subHeaderString, card.TotalItemsCount, sourcePath),
+						};
 						break;
 					}
 			}


### PR DESCRIPTION
**Changes**

Update Status Center strings to include plural forms for `item(s)` and `font(s)`.
Use the `GetLocalizedFormatResource` instead of `GetLocalizedResource` and move the `headerString` and `subHeaderString` initialization to each corresponding case.
Also removed the redundant `if (headerString is not null)` checks, as the string cannot be null at that point.

**Resolved / Related Issues**

- Closes #17295

**Steps used to test these changes**

Tested the changed strings in file operations.

<img width="502" height="268" alt="image" src="https://github.com/user-attachments/assets/e5e0ce49-5076-4b02-bfae-bef328aa36b4" />

