### PR TITLE
Code Quality: Defer CurrentSelectedMode assignment in OmnibarMode_Loaded

### DIFF
--- a/src/Files.App.Controls/Omnibar/OmnibarMode.cs
+++ b/src/Files.App.Controls/Omnibar/OmnibarMode.cs
@@ -89,7 +89,12 @@ namespace Files.App.Controls
 		{
 			// Set this mode as the current mode if it is the default mode
 			if (IsDefault && _ownerRef is not null && _ownerRef.TryGetTarget(out var owner))
-				owner.CurrentSelectedMode = this;
+			{
+				DispatcherQueue.TryEnqueue(() =>
+				{
+					owner.CurrentSelectedMode = this;
+				});
+			}
 		}
 
 		public void SetOwner(Omnibar owner)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- For #16029

Hopefully fixes an issue from Sentry

> System.DivideByZeroException occurs within Omnibar.ChangeMode because a property of the OmnibarMode (e.g., a dimension or count) is zero, leading to an invalid division operation.

