### PR TITLE
Code Quality: Continued working on Shelf Pane

### DIFF
--- a/src/Files.App/Actions/FileSystem/Transfer/BaseTransferItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/Transfer/BaseTransferItemAction.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Files Community
 // Licensed under the MIT License.
 
-using Microsoft.Extensions.Logging;
-using System.Collections.Concurrent;
-using System.IO;
 using Windows.ApplicationModel.DataTransfer;
-using Windows.Storage;
 
 namespace Files.App.Actions
 {
@@ -24,103 +20,7 @@ namespace Files.App.Actions
 
 		public async Task ExecuteTransferAsync(DataPackageOperation type = DataPackageOperation.Copy)
 		{
-			if (ContentPageContext.ShellPage?.SlimContentPage is null ||
-				ContentPageContext.ShellPage.SlimContentPage.IsItemSelected is false)
-				return;
-
-			// Reset cut mode
-			ContentPageContext.ShellPage.SlimContentPage.ItemManipulationModel.RefreshItemsOpacity();
-
-			ConcurrentBag<IStorageItem> items = [];
-			var itemsCount = ContentPageContext.SelectedItems.Count;
-			var statusCenterItem = itemsCount > 50 ? StatusCenterHelper.AddCard_Prepare() : null;
-			var dataPackage = new DataPackage() { RequestedOperation = type };
-
-			try
-			{
-				// Update the status to in-progress
-				if (statusCenterItem is not null)
-				{
-					statusCenterItem.Progress.EnumerationCompleted = true;
-					statusCenterItem.Progress.ItemsCount = items.Count;
-					statusCenterItem.Progress.ReportStatus(FileSystemStatusCode.InProgress);
-				}
-
-				await ContentPageContext.SelectedItems.ToList().ParallelForEachAsync(async listedItem =>
-				{
-					// Update the status to increase processed count by one
-					if (statusCenterItem is not null)
-					{
-						statusCenterItem.Progress.AddProcessedItemsCount(1);
-						statusCenterItem.Progress.Report();
-					}
-
-					if (listedItem is FtpItem ftpItem)
-					{
-						// Don't dim selected items here since FTP doesn't support cut
-						if (ftpItem.PrimaryItemAttribute is StorageItemTypes.File or StorageItemTypes.Folder)
-							items.Add(await ftpItem.ToStorageItem());
-					}
-					else
-					{
-						if (type is DataPackageOperation.Move)
-						{
-							// Dim opacities accordingly
-							await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
-							{
-								listedItem.Opacity = Constants.UI.DimItemOpacity;
-							});
-						}
-
-						FilesystemResult? result =
-							listedItem.PrimaryItemAttribute == StorageItemTypes.File || listedItem is ZipItem
-								? await ContentPageContext.ShellPage.ShellViewModel.GetFileFromPathAsync(listedItem.ItemPath).OnSuccess(t => items.Add(t))
-								: await ContentPageContext.ShellPage.ShellViewModel.GetFolderFromPathAsync(listedItem.ItemPath).OnSuccess(t => items.Add(t));
-
-						if (!result)
-							throw new IOException($"Failed to process {listedItem.ItemPath} in cutting/copying to the clipboard.", (int)result.ErrorCode);
-					}
-				},
-				10,
-				statusCenterItem?.CancellationToken ?? default);
-
-				var standardObjectsOnly = items.All(x => x is StorageFile or StorageFolder or SystemStorageFile or SystemStorageFolder);
-				if (standardObjectsOnly)
-					items = new ConcurrentBag<IStorageItem>(await items.ToStandardStorageItemsAsync());
-
-				if (items.IsEmpty)
-					return;
-
-				dataPackage.Properties.PackageFamilyName = Windows.ApplicationModel.Package.Current.Id.FamilyName;
-				dataPackage.SetStorageItems(items, false);
-
-				Clipboard.SetContent(dataPackage);
-			}
-			catch (Exception ex)
-			{
-				dataPackage = default;
-
-				if (ex is not IOException)
-					App.Logger.LogWarning(ex, "Failed to process cutting/copying due to an unknown error.");
-
-				if ((FileSystemStatusCode)ex.HResult is FileSystemStatusCode.Unauthorized)
-				{
-					string[] filePaths = ContentPageContext.SelectedItems.Select(x => x.ItemPath).ToArray();
-					await FileOperationsHelpers.SetClipboard(filePaths, type);
-
-					return;
-				}
-
-				// Reset cut mode
-				ContentPageContext.ShellPage.SlimContentPage.ItemManipulationModel.RefreshItemsOpacity();
-
-				return;
-			}
-			finally
-			{
-				if (statusCenterItem is not null)
-					StatusCenterViewModel.RemoveItem(statusCenterItem);
-			}
+			await TransferHelpers.ExecuteTransferAsync(ContentPageContext, StatusCenterViewModel, type);
 		}
 
 		private void ContentPageContext_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Files.App/Actions/Shelf/CopyItemFromShelfAction.cs
+++ b/src/Files.App/Actions/Shelf/CopyItemFromShelfAction.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Windows.ApplicationModel.DataTransfer;
+
+namespace Files.App.Actions
+{
+	[GeneratedRichCommand]
+	internal sealed partial class CopyItemFromShelfAction : ObservableObject, IAction
+	{
+		private readonly IShelfContext shelfContext;
+		private readonly IContentPageContext contentPageContext;
+		private readonly StatusCenterViewModel statusCenterViewModel;
+
+		public string Label
+			=> Strings.Copy.GetLocalizedResource();
+
+		public string Description
+			=> Strings.CopyItemDescription.GetLocalizedFormatResource(shelfContext.SelectedItems.Count);
+
+		public ActionCategory Category
+			=> ActionCategory.FileSystem;
+
+		public RichGlyph Glyph
+			=> new(themedIconStyle: "App.ThemedIcons.Copy");
+
+		public bool IsExecutable
+			=> shelfContext.HasSelection && contentPageContext.ShellPage?.ShellViewModel is not null;
+
+		public bool IsAccessibleGlobally
+			=> false;
+
+		public CopyItemFromShelfAction()
+		{
+			shelfContext = Ioc.Default.GetRequiredService<IShelfContext>();
+			contentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
+			statusCenterViewModel = Ioc.Default.GetRequiredService<StatusCenterViewModel>();
+
+			shelfContext.PropertyChanged += ShelfContext_PropertyChanged;
+		}
+
+		public async Task ExecuteAsync(object? parameter = null)
+		{
+			if (contentPageContext.ShellPage?.ShellViewModel is not { } shellViewModel)
+				return;
+
+			var items = shelfContext.SelectedItems.Select(x => x.Inner).ToArray();
+			await TransferHelpers.ExecuteTransferAsync(items, shellViewModel, statusCenterViewModel, DataPackageOperation.Copy);
+		}
+
+		private void ShelfContext_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName is nameof(IShelfContext.HasSelection))
+				OnPropertyChanged(nameof(IsExecutable));
+		}
+	}
+}

--- a/src/Files.App/Actions/Shelf/CutItemFromShelfAction.cs
+++ b/src/Files.App/Actions/Shelf/CutItemFromShelfAction.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Windows.ApplicationModel.DataTransfer;
+
+namespace Files.App.Actions
+{
+	[GeneratedRichCommand]
+	internal sealed partial class CutItemFromShelfAction : ObservableObject, IAction
+	{
+		private readonly IShelfContext shelfContext;
+		private readonly IContentPageContext contentPageContext;
+		private readonly StatusCenterViewModel statusCenterViewModel;
+
+		public string Label
+			=> Strings.Cut.GetLocalizedResource();
+
+		public string Description
+			=> Strings.CutItemDescription.GetLocalizedFormatResource(shelfContext.SelectedItems.Count);
+
+		public ActionCategory Category
+			=> ActionCategory.FileSystem;
+
+		public RichGlyph Glyph
+			=> new(themedIconStyle: "App.ThemedIcons.Cut");
+
+		public bool IsExecutable
+			=> shelfContext.HasSelection && contentPageContext.ShellPage?.ShellViewModel is not null;
+
+		public bool IsAccessibleGlobally
+			=> false;
+
+		public CutItemFromShelfAction()
+		{
+			shelfContext = Ioc.Default.GetRequiredService<IShelfContext>();
+			contentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
+			statusCenterViewModel = Ioc.Default.GetRequiredService<StatusCenterViewModel>();
+
+			shelfContext.PropertyChanged += ShelfContext_PropertyChanged;
+		}
+
+		public async Task ExecuteAsync(object? parameter = null)
+		{
+			if (contentPageContext.ShellPage?.ShellViewModel is not { } shellViewModel)
+				return;
+
+			var items = shelfContext.SelectedItems.Select(x => x.Inner).ToArray();
+			await TransferHelpers.ExecuteTransferAsync(items, shellViewModel, statusCenterViewModel, DataPackageOperation.Move);
+		}
+
+		private void ShelfContext_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName is nameof(IShelfContext.HasSelection))
+				OnPropertyChanged(nameof(IsExecutable));
+		}
+	}
+}

--- a/src/Files.App/Actions/Shelf/DeleteItemFromShelfAction.cs
+++ b/src/Files.App/Actions/Shelf/DeleteItemFromShelfAction.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Actions
+{
+	[GeneratedRichCommand]
+	internal sealed partial class DeleteItemFromShelfAction : ObservableObject, IAction
+	{
+		private readonly IShelfContext shelfContext;
+		private readonly IContentPageContext contentPageContext;
+		private readonly IFoldersSettingsService foldersSettingsService;
+
+		public string Label
+			=> Strings.Delete.GetLocalizedResource();
+
+		public string Description
+			=> Strings.DeleteItemDescription.GetLocalizedFormatResource(shelfContext.SelectedItems.Count);
+
+		public ActionCategory Category
+			=> ActionCategory.FileSystem;
+
+		public RichGlyph Glyph
+			=> new(themedIconStyle: "App.ThemedIcons.Delete");
+
+		public bool IsExecutable
+			=> shelfContext.HasSelection && contentPageContext.ShellPage is not null;
+
+		public bool IsAccessibleGlobally
+			=> false;
+
+		public DeleteItemFromShelfAction()
+		{
+			shelfContext = Ioc.Default.GetRequiredService<IShelfContext>();
+			contentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
+			foldersSettingsService = Ioc.Default.GetRequiredService<IFoldersSettingsService>();
+
+			shelfContext.PropertyChanged += ShelfContext_PropertyChanged;
+		}
+
+		public async Task ExecuteAsync(object? parameter = null)
+		{
+			if (contentPageContext.ShellPage is not { } shellPage)
+				return;
+
+			var itemsToDelete = shelfContext.SelectedItems.Select(x => StorageHelpers.FromPathAndType(x.Inner.Id, x.Inner switch
+			{
+				IFile => FilesystemItemType.File,
+				IFolder => FilesystemItemType.Directory,
+				_ => throw new ArgumentOutOfRangeException(nameof(parameter))
+			}));
+
+			await shellPage.FilesystemHelpers.DeleteItemsAsync(itemsToDelete, foldersSettingsService.DeleteConfirmationPolicy, false, true);
+			await shellPage.ShellViewModel.ApplyFilesAndFoldersChangesAsync();
+		}
+
+		private void ShelfContext_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName is nameof(IShelfContext.HasSelection))
+				OnPropertyChanged(nameof(IsExecutable));
+		}
+	}
+}

--- a/src/Files.App/Actions/Show/ToggleShelfPaneAction.cs
+++ b/src/Files.App/Actions/Show/ToggleShelfPaneAction.cs
@@ -20,14 +20,6 @@ namespace Files.App.Actions
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Shelf");
 
-		// TODO Remove IsAccessibleGlobally when shelf feature is ready
-		public bool IsAccessibleGlobally
-			=> AppLifecycleHelper.AppEnvironment is AppEnvironment.Dev;
-
-		// TODO Remove IsExecutable when shelf feature is ready
-		public bool IsExecutable
-			=> AppLifecycleHelper.AppEnvironment is AppEnvironment.Dev;
-
 		public bool IsOn
 			=> generalSettingsService.ShowShelfPane;
 

--- a/src/Files.App/Actions/Show/ToggleShelfPaneAction.cs
+++ b/src/Files.App/Actions/Show/ToggleShelfPaneAction.cs
@@ -20,6 +20,14 @@ namespace Files.App.Actions
 		public RichGlyph Glyph
 			=> new(themedIconStyle: "App.ThemedIcons.Shelf");
 
+		// TODO Remove IsAccessibleGlobally when shelf feature is ready
+		public bool IsAccessibleGlobally
+			=> AppLifecycleHelper.AppEnvironment is AppEnvironment.Dev;
+
+		// TODO Remove IsExecutable when shelf feature is ready
+		public bool IsExecutable
+			=> AppLifecycleHelper.AppEnvironment is AppEnvironment.Dev;
+
 		public bool IsOn
 			=> generalSettingsService.ShowShelfPane;
 

--- a/src/Files.App/Data/Contexts/Shelf/IShelfContext.cs
+++ b/src/Files.App/Data/Contexts/Shelf/IShelfContext.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Data.Contexts
+{
+	/// <summary>
+	/// Represents context for <see cref="UserControls.ShelfPane"/>.
+	/// </summary>
+	public interface IShelfContext : INotifyPropertyChanged
+	{
+		/// <summary>
+		/// Gets the currently selected items in the shelf.
+		/// </summary>
+		IReadOnlyList<ShelfItem> SelectedItems { get; }
+
+		/// <summary>
+		/// Gets whether any item is selected in the shelf.
+		/// </summary>
+		bool HasSelection { get; }
+	}
+}

--- a/src/Files.App/Data/Contexts/Shelf/ShelfContext.cs
+++ b/src/Files.App/Data/Contexts/Shelf/ShelfContext.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Data.Contexts
+{
+	/// <inheritdoc cref="IShelfContext"/>
+	internal sealed partial class ShelfContext : ObservableObject, IShelfContext
+	{
+		private static readonly IReadOnlyList<ShelfItem> emptySelection = [];
+
+		private IReadOnlyList<ShelfItem> _SelectedItems = emptySelection;
+		public IReadOnlyList<ShelfItem> SelectedItems => _SelectedItems;
+
+		public bool HasSelection => _SelectedItems.Count > 0;
+
+		public ShelfContext()
+		{
+			ShelfViewModel.SelectedItemsChanged += ShelfViewModel_SelectedItemsChanged;
+		}
+
+		private void ShelfViewModel_SelectedItemsChanged(object? sender, IReadOnlyList<ShelfItem> e)
+		{
+			if (SetProperty(ref _SelectedItems, e ?? emptySelection, nameof(SelectedItems)))
+				OnPropertyChanged(nameof(HasSelection));
+		}
+	}
+}

--- a/src/Files.App/Data/Items/ShelfItem.cs
+++ b/src/Files.App/Data/Items/ShelfItem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Files.Shared.Utils;
+using System.Windows.Documents;
 
 namespace Files.App.Data.Items
 {
@@ -32,6 +33,20 @@ namespace Files.App.Data.Items
 		public async Task InitAsync(CancellationToken cancellationToken = default)
 		{
 			Icon = await _imageService.GetIconAsync(Inner, cancellationToken);
+		}
+
+		[RelayCommand]
+		public async Task ViewInFolderAsync(CancellationToken cancellationToken)
+		{
+			var context = Ioc.Default.GetRequiredService<IContentPageContext>();
+			if (context.ShellPage is not { } shellPage)
+				return;
+
+			var parent = await Inner.GetParentAsync(cancellationToken);
+			if (parent is null)
+				return;
+
+			await NavigationHelpers.OpenPath(parent.Id, shellPage);
 		}
 
 		[RelayCommand]

--- a/src/Files.App/Data/Items/ShelfItem.cs
+++ b/src/Files.App/Data/Items/ShelfItem.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Files.Shared.Utils;
-using System.Windows.Documents;
 
 namespace Files.App.Data.Items
 {

--- a/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
+++ b/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
@@ -230,6 +230,7 @@ namespace Files.App.Helpers
 					.AddSingleton<IMultitaskingContext, MultitaskingContext>()
 					.AddSingleton<ITagsContext, TagsContext>()
 					.AddSingleton<ISidebarContext, SidebarContext>()
+					.AddSingleton<IShelfContext, ShelfContext>()
 					// Services
 					.AddSingleton<IWindowsRecentItemsService, WindowsRecentItemsService>()
 					.AddSingleton<IWindowsIniService, WindowsIniService>()

--- a/src/Files.App/Helpers/TransferHelpers.cs
+++ b/src/Files.App/Helpers/TransferHelpers.cs
@@ -1,0 +1,170 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+
+namespace Files.App.Helpers
+{
+	public static class TransferHelpers
+	{
+		public static async Task ExecuteTransferAsync(IReadOnlyList<IStorable> itemsToTransfer, ShellViewModel shellViewModel, StatusCenterViewModel statusViewModel, DataPackageOperation type = DataPackageOperation.Copy)
+		{
+			ConcurrentBag<IStorageItem> items = [];
+			var itemsCount = itemsToTransfer.Count;
+			var statusCenterItem = itemsCount > 50 ? StatusCenterHelper.AddCard_Prepare() : null;
+			var dataPackage = new DataPackage() { RequestedOperation = type };
+
+			try
+			{
+				// Update the status to in-progress
+				if (statusCenterItem is not null)
+				{
+					statusCenterItem.Progress.EnumerationCompleted = true;
+					statusCenterItem.Progress.ItemsCount = items.Count;
+					statusCenterItem.Progress.ReportStatus(FileSystemStatusCode.InProgress);
+				}
+
+				await itemsToTransfer.ParallelForEachAsync(async storable =>
+				{
+					// Update the status to increase processed count by one
+					if (statusCenterItem is not null)
+					{
+						statusCenterItem.Progress.AddProcessedItemsCount(1);
+						statusCenterItem.Progress.Report();
+					}
+
+					var result = storable switch
+					{
+						IFile => await shellViewModel.GetFileFromPathAsync(storable.Id).OnSuccess(x => items.Add(x)),
+						IFolder => await shellViewModel.GetFolderFromPathAsync(storable.Id).OnSuccess(x => items.Add(x)),
+					};
+
+					if (!result)
+						throw new SystemIO.IOException($"Failed to process {storable.Id} in cutting/copying to the clipboard.", (int)result.ErrorCode);
+				}, 10, statusCenterItem?.CancellationToken ?? CancellationToken.None);
+
+				var standardObjectsOnly = items.All(x => x is StorageFile or StorageFolder or SystemStorageFile or SystemStorageFolder);
+				if (standardObjectsOnly)
+					items = new(await items.ToStandardStorageItemsAsync());
+
+				if (items.IsEmpty)
+					return;
+
+				dataPackage.Properties.PackageFamilyName = Windows.ApplicationModel.Package.Current.Id.FamilyName;
+				dataPackage.SetStorageItems(items, false);
+
+				Clipboard.SetContent(dataPackage);
+			}
+			catch (Exception ex)
+			{
+				if (ex is not SystemIO.IOException)
+					App.Logger.LogWarning(ex, "Failed to process cutting/copying due to an unknown error.");
+
+				if ((FileSystemStatusCode)ex.HResult is FileSystemStatusCode.Unauthorized)
+				{
+					var filePaths = itemsToTransfer.Select(x => x.Id).ToArray();
+					await FileOperationsHelpers.SetClipboard(filePaths, type);
+				}
+			}
+			finally
+			{
+				if (statusCenterItem is not null)
+					statusViewModel.RemoveItem(statusCenterItem);
+			}
+		}
+
+		public static async Task ExecuteTransferAsync(IContentPageContext context, StatusCenterViewModel statusViewModel, DataPackageOperation type = DataPackageOperation.Copy)
+		{
+			if (context.ShellPage?.SlimContentPage is null ||
+				context.ShellPage.SlimContentPage.IsItemSelected is false)
+				return;
+
+			// Reset cut mode
+			context.ShellPage.SlimContentPage.ItemManipulationModel.RefreshItemsOpacity();
+
+			ConcurrentBag<IStorageItem> items = [];
+			var itemsCount = context.SelectedItems.Count;
+			var statusCenterItem = itemsCount > 50 ? StatusCenterHelper.AddCard_Prepare() : null;
+			var dataPackage = new DataPackage() { RequestedOperation = type };
+
+			try
+			{
+				// Update the status to in-progress
+				if (statusCenterItem is not null)
+				{
+					statusCenterItem.Progress.EnumerationCompleted = true;
+					statusCenterItem.Progress.ItemsCount = items.Count;
+					statusCenterItem.Progress.ReportStatus(FileSystemStatusCode.InProgress);
+				}
+
+				await context.SelectedItems.ToList().ParallelForEachAsync(async listedItem =>
+				{
+					// Update the status to increase processed count by one
+					if (statusCenterItem is not null)
+					{
+						statusCenterItem.Progress.AddProcessedItemsCount(1);
+						statusCenterItem.Progress.Report();
+					}
+
+					if (listedItem is FtpItem ftpItem)
+					{
+						// Don't dim selected items here since FTP doesn't support cut
+						if (ftpItem.PrimaryItemAttribute is StorageItemTypes.File or StorageItemTypes.Folder)
+							items.Add(await ftpItem.ToStorageItem());
+					}
+					else
+					{
+						if (type is DataPackageOperation.Move)
+						{
+							// Dim opacities accordingly
+							await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
+							{
+								listedItem.Opacity = Constants.UI.DimItemOpacity;
+							});
+						}
+
+						var result = listedItem.PrimaryItemAttribute == StorageItemTypes.File || listedItem is ZipItem
+								? await context.ShellPage.ShellViewModel.GetFileFromPathAsync(listedItem.ItemPath).OnSuccess(t => items.Add(t))
+								: await context.ShellPage.ShellViewModel.GetFolderFromPathAsync(listedItem.ItemPath).OnSuccess(t => items.Add(t));
+
+						if (!result)
+							throw new SystemIO.IOException($"Failed to process {listedItem.ItemPath} in cutting/copying to the clipboard.", (int)result.ErrorCode);
+					}
+				}, 10, statusCenterItem?.CancellationToken ?? CancellationToken.None);
+
+				var standardObjectsOnly = items.All(x => x is StorageFile or StorageFolder or SystemStorageFile or SystemStorageFolder);
+				if (standardObjectsOnly)
+					items = new(await items.ToStandardStorageItemsAsync());
+
+				if (items.IsEmpty)
+					return;
+
+				dataPackage.Properties.PackageFamilyName = Windows.ApplicationModel.Package.Current.Id.FamilyName;
+				dataPackage.SetStorageItems(items, false);
+
+				Clipboard.SetContent(dataPackage);
+			}
+			catch (Exception ex)
+			{
+				if (ex is not SystemIO.IOException)
+					App.Logger.LogWarning(ex, "Failed to process cutting/copying due to an unknown error.");
+
+				if ((FileSystemStatusCode)ex.HResult is FileSystemStatusCode.Unauthorized)
+				{
+					var filePaths = context.SelectedItems.Select(x => x.ItemPath).ToArray();
+					await FileOperationsHelpers.SetClipboard(filePaths, type);
+
+					return;
+				}
+
+				// Reset cut mode
+				context.ShellPage.SlimContentPage.ItemManipulationModel.RefreshItemsOpacity();
+			}
+			finally
+			{
+				if (statusCenterItem is not null)
+					statusViewModel.RemoveItem(statusCenterItem);
+			}
+		}
+	}
+}

--- a/src/Files.App/Helpers/TransferHelpers.cs
+++ b/src/Files.App/Helpers/TransferHelpers.cs
@@ -37,6 +37,7 @@ namespace Files.App.Helpers
 					{
 						IFile => await shellViewModel.GetFileFromPathAsync(storable.Id).OnSuccess(x => items.Add(x)),
 						IFolder => await shellViewModel.GetFolderFromPathAsync(storable.Id).OnSuccess(x => items.Add(x)),
+						_ => throw new ArgumentOutOfRangeException(nameof(storable)),
 					};
 
 					if (!result)

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -4261,6 +4261,9 @@
   <data name="ClearItems" xml:space="preserve">
     <value>Clear items</value>
   </data>
+  <data name="BatchAction" xml:space="preserve">
+    <value>Batch action</value>
+  </data>
   <data name="RemoveFromShelf" xml:space="preserve">
     <value>Remove from shelf</value>
   </data>

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml
@@ -3,6 +3,7 @@
 	x:Class="Files.App.UserControls.ShelfPane"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:controls="using:Files.App.Controls"
 	xmlns:converters="using:Files.App.Converters"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:data="using:Files.App.Data.Items"
@@ -152,6 +153,19 @@
 			<Border Height="1" Background="{ThemeResource DividerStrokeColorDefaultBrush}" />
 
 			<!--  Bottom Actions  -->
+			<StackPanel
+				HorizontalAlignment="Center"
+				Orientation="Horizontal"
+				Spacing="12">
+				<Button
+					Padding="8"
+					Background="Transparent"
+					BorderThickness="0"
+					Command="{x:Bind BulkDeleteCommand, Mode=OneWay}">
+					<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Delete}" />
+				</Button>
+			</StackPanel>
+
 			<HyperlinkButton
 				HorizontalAlignment="Center"
 				VerticalAlignment="Center"

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml
@@ -164,6 +164,20 @@
 					Command="{x:Bind BulkDeleteCommand, Mode=OneWay}">
 					<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Delete}" />
 				</Button>
+				<Button
+					Padding="8"
+					Background="Transparent"
+					BorderThickness="0"
+					Command="{x:Bind BulkCopyCommand, Mode=OneWay}">
+					<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Copy}" />
+				</Button>
+				<Button
+					Padding="8"
+					Background="Transparent"
+					BorderThickness="0"
+					Command="{x:Bind BulkCutCommand, Mode=OneWay}">
+					<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Cut}" />
+				</Button>
 			</StackPanel>
 
 			<HyperlinkButton

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml
@@ -97,11 +97,18 @@
 
 		</StackPanel>
 
+		<Grid
+			Grid.Row="1"
+			Background="Transparent"
+			Tapped="Pane_Tapped" />
+
 		<!--  Items List  -->
 		<ListView
 			x:Name="ShelfItemsList"
 			Grid.Row="1"
+			Margin="0,0,0,8"
 			Padding="8,4,8,4"
+			VerticalAlignment="Top"
 			CanDragItems="True"
 			DragItemsStarting="ListView_DragItemsStarting"
 			GotFocus="ShelfItemsList_GotFocus"
@@ -110,6 +117,7 @@
 			RightTapped="ShelfItemsList_RightTapped"
 			ScrollViewer.VerticalScrollBarVisibility="Auto"
 			ScrollViewer.VerticalScrollMode="Auto"
+			SelectionChanged="ShelfItemsList_SelectionChanged"
 			SelectionMode="Extended">
 			<ListView.ItemTemplate>
 				<DataTemplate x:DataType="data:ShelfItem">
@@ -141,7 +149,6 @@
 			</ListView.ItemContainerStyle>
 		</ListView>
 
-
 		<!--  Shelf Footer  -->
 		<StackPanel
 			Grid.Row="2"
@@ -152,39 +159,60 @@
 			<!--  (Divider)  -->
 			<Border Height="1" Background="{ThemeResource DividerStrokeColorDefaultBrush}" />
 
-			<!--  Bottom Actions  -->
-			<StackPanel
-				HorizontalAlignment="Center"
-				Orientation="Horizontal"
-				Spacing="12">
-				<Button
-					Padding="8"
-					Background="Transparent"
-					BorderThickness="0"
-					Command="{x:Bind BulkDeleteCommand, Mode=OneWay}">
-					<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Delete}" />
-				</Button>
-				<Button
-					Padding="8"
-					Background="Transparent"
-					BorderThickness="0"
-					Command="{x:Bind BulkCopyCommand, Mode=OneWay}">
-					<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Copy}" />
-				</Button>
-				<Button
-					Padding="8"
-					Background="Transparent"
-					BorderThickness="0"
-					Command="{x:Bind BulkCutCommand, Mode=OneWay}">
-					<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Cut}" />
-				</Button>
-			</StackPanel>
+			<StackPanel x:Name="ActionsPanel" Spacing="4">
+				<StackPanel.Transitions>
+					<TransitionCollection>
+						<ReorderThemeTransition />
+					</TransitionCollection>
+				</StackPanel.Transitions>
 
-			<HyperlinkButton
-				HorizontalAlignment="Center"
-				VerticalAlignment="Center"
-				Command="{x:Bind ClearCommand, Mode=OneWay}"
-				Content="{helpers:ResourceString Name=ClearItems}" />
+				<!--  Clear action  -->
+				<HyperlinkButton
+					HorizontalAlignment="Center"
+					VerticalAlignment="Center"
+					Command="{x:Bind ClearCommand, Mode=OneWay}"
+					Content="{helpers:ResourceString Name=ClearItems}" />
+
+				<!--  Batch actions  -->
+				<HyperlinkButton
+					x:Name="BatchActionsButton"
+					HorizontalAlignment="Center"
+					VerticalAlignment="Center"
+					Background="Transparent"
+					BorderThickness="0"
+					Click="HyperlinkBatch_Click"
+					Content="Batch action"
+					Visibility="Collapsed">
+					<HyperlinkButton.ContextFlyout>
+						<MenuFlyout x:Name="BatchFlyout" Placement="Top">
+							<MenuFlyoutItem
+								Command="{x:Bind BulkCopyCommand, Mode=OneWay}"
+								CommandParameter="{x:Bind ShelfItemsList.SelectedItems, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=Copy}">
+								<MenuFlyoutItem.Icon>
+									<FontIcon Glyph="&#xE8C8;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+							<MenuFlyoutItem
+								Command="{x:Bind BulkCutCommand, Mode=OneWay}"
+								CommandParameter="{x:Bind ShelfItemsList.SelectedItems, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=Cut}">
+								<MenuFlyoutItem.Icon>
+									<FontIcon Glyph="&#xE8C6;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+							<MenuFlyoutItem
+								Command="{x:Bind BulkDeleteCommand, Mode=OneWay}"
+								CommandParameter="{x:Bind ShelfItemsList.SelectedItems, Mode=OneWay}"
+								Text="{helpers:ResourceString Name=Delete}">
+								<MenuFlyoutItem.Icon>
+									<FontIcon Glyph="&#xE74D;" />
+								</MenuFlyoutItem.Icon>
+							</MenuFlyoutItem>
+						</MenuFlyout>
+					</HyperlinkButton.ContextFlyout>
+				</HyperlinkButton>
+			</StackPanel>
 		</StackPanel>
 	</Grid>
 </UserControl>

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml
@@ -8,6 +8,7 @@
 	xmlns:data="using:Files.App.Data.Items"
 	xmlns:helpers="using:Files.App.Helpers"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uc="using:Files.App.UserControls"
 	mc:Ignorable="d">
 
 	<UserControl.Resources>
@@ -184,21 +185,18 @@
 					Visibility="Collapsed">
 					<HyperlinkButton.ContextFlyout>
 						<MenuFlyout x:Name="BatchFlyout" Placement="Top">
-							<MenuFlyoutItem Command="{x:Bind Commands.CopyItemFromShelf}" Text="{helpers:ResourceString Name=Copy}">
-								<MenuFlyoutItem.Icon>
-									<FontIcon Glyph="&#xE8C8;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutItem Command="{x:Bind Commands.CutItemFromShelf}" Text="{helpers:ResourceString Name=Cut}">
-								<MenuFlyoutItem.Icon>
-									<FontIcon Glyph="&#xE8C6;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
-							<MenuFlyoutItem Command="{x:Bind Commands.DeleteItemFromShelf}" Text="{helpers:ResourceString Name=Delete}">
-								<MenuFlyoutItem.Icon>
-									<FontIcon Glyph="&#xE74D;" />
-								</MenuFlyoutItem.Icon>
-							</MenuFlyoutItem>
+							<uc:MenuFlyoutItemWithThemedIcon
+								Command="{x:Bind Commands.CopyItemFromShelf}"
+								Text="{helpers:ResourceString Name=Copy}"
+								ThemedIconStyle="{x:Bind Commands.CopyItemFromShelf.ThemedIconStyle}" />
+							<uc:MenuFlyoutItemWithThemedIcon
+								Command="{x:Bind Commands.CutItemFromShelf}"
+								Text="{helpers:ResourceString Name=Cut}"
+								ThemedIconStyle="{x:Bind Commands.CutItemFromShelf.ThemedIconStyle}" />
+							<uc:MenuFlyoutItemWithThemedIcon
+								Command="{x:Bind Commands.DeleteItemFromShelf}"
+								Text="{helpers:ResourceString Name=Delete}"
+								ThemedIconStyle="{x:Bind Commands.DeleteItemFromShelf.ThemedIconStyle}" />
 						</MenuFlyout>
 					</HyperlinkButton.ContextFlyout>
 				</HyperlinkButton>

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml
@@ -181,7 +181,7 @@
 					Background="Transparent"
 					BorderThickness="0"
 					Click="HyperlinkBatch_Click"
-					Content="Batch action"
+					Content="{helpers:ResourceString Name=BatchAction}"
 					Visibility="Collapsed">
 					<HyperlinkButton.ContextFlyout>
 						<MenuFlyout x:Name="BatchFlyout" Placement="Top">

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml
@@ -3,7 +3,6 @@
 	x:Class="Files.App.UserControls.ShelfPane"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:controls="using:Files.App.Controls"
 	xmlns:converters="using:Files.App.Converters"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:data="using:Files.App.Data.Items"
@@ -185,26 +184,17 @@
 					Visibility="Collapsed">
 					<HyperlinkButton.ContextFlyout>
 						<MenuFlyout x:Name="BatchFlyout" Placement="Top">
-							<MenuFlyoutItem
-								Command="{x:Bind BulkCopyCommand, Mode=OneWay}"
-								CommandParameter="{x:Bind ShelfItemsList.SelectedItems, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=Copy}">
+							<MenuFlyoutItem Command="{x:Bind Commands.CopyItemFromShelf}" Text="{helpers:ResourceString Name=Copy}">
 								<MenuFlyoutItem.Icon>
 									<FontIcon Glyph="&#xE8C8;" />
 								</MenuFlyoutItem.Icon>
 							</MenuFlyoutItem>
-							<MenuFlyoutItem
-								Command="{x:Bind BulkCutCommand, Mode=OneWay}"
-								CommandParameter="{x:Bind ShelfItemsList.SelectedItems, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=Cut}">
+							<MenuFlyoutItem Command="{x:Bind Commands.CutItemFromShelf}" Text="{helpers:ResourceString Name=Cut}">
 								<MenuFlyoutItem.Icon>
 									<FontIcon Glyph="&#xE8C6;" />
 								</MenuFlyoutItem.Icon>
 							</MenuFlyoutItem>
-							<MenuFlyoutItem
-								Command="{x:Bind BulkDeleteCommand, Mode=OneWay}"
-								CommandParameter="{x:Bind ShelfItemsList.SelectedItems, Mode=OneWay}"
-								Text="{helpers:ResourceString Name=Delete}">
+							<MenuFlyoutItem Command="{x:Bind Commands.DeleteItemFromShelf}" Text="{helpers:ResourceString Name=Delete}">
 								<MenuFlyoutItem.Icon>
 									<FontIcon Glyph="&#xE74D;" />
 								</MenuFlyoutItem.Icon>

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
@@ -95,11 +95,17 @@ namespace Files.App.UserControls
 
 			var menuFlyout = new MenuFlyout();
 
-			menuFlyout.Items.Add (new MenuFlyoutItem
+			menuFlyout.Items.Add(new MenuFlyoutItem
+			{
+				Text = Strings.BaseLayoutItemContextFlyoutOpenParentFolder_Text.GetLocalizedResource(),
+				Icon = new FontIcon() { Glyph = "\uE838" },
+				Command = item.ViewInFolderCommand
+			});
+			menuFlyout.Items.Add(new MenuFlyoutItem
 			{
 				Text = Strings.RemoveFromShelf.GetLocalizedResource(),
 				Icon = new FontIcon { Glyph = "\uE738" },
-				Command = new RelayCommand(item.Remove)
+				Command = item.RemoveCommand
 			});
 
 			menuFlyout.ShowAt(widgetCardItem);

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
@@ -142,6 +142,22 @@ namespace Files.App.UserControls
 		public static readonly DependencyProperty BulkDeleteCommandProperty =
 			DependencyProperty.Register(nameof(BulkDeleteCommand), typeof(ICommand), typeof(ShelfPane), new PropertyMetadata(null));
 
+		public ICommand? BulkCopyCommand
+		{
+			get => (ICommand?)GetValue(BulkCopyCommandProperty);
+			set => SetValue(BulkCopyCommandProperty, value);
+		}
+		public static readonly DependencyProperty BulkCopyCommandProperty =
+			DependencyProperty.Register(nameof(BulkCopyCommand), typeof(ICommand), typeof(ShelfPane), new PropertyMetadata(null));
+
+		public ICommand? BulkCutCommand
+		{
+			get => (ICommand?)GetValue(BulkCutCommandProperty);
+			set => SetValue(BulkCutCommandProperty, value);
+		}
+		public static readonly DependencyProperty BulkCutCommandProperty =
+			DependencyProperty.Register(nameof(BulkCutCommand), typeof(ICommand), typeof(ShelfPane), new PropertyMetadata(null));
+
 		public ICommand? ItemFocusedCommand
 		{
 			get => (ICommand?)GetValue(ItemFocusedCommandProperty);

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
@@ -7,8 +7,10 @@ using System.Windows.Input;
 using Vanara.PInvoke;
 using Vanara.Windows.Shell;
 using Windows.ApplicationModel.DataTransfer;
+using Microsoft.UI.Xaml.Input;
 using WinRT;
 using DragEventArgs = Microsoft.UI.Xaml.DragEventArgs;
+using Visibility = Microsoft.UI.Xaml.Visibility;
 
 namespace Files.App.UserControls
 {
@@ -88,13 +90,10 @@ namespace Files.App.UserControls
 
 		private void ShelfItemsList_RightTapped(object sender, Microsoft.UI.Xaml.Input.RightTappedRoutedEventArgs e)
 		{
-			if (e.OriginalSource is not Microsoft.UI.Xaml.FrameworkElement widgetCardItem ||
-				widgetCardItem.DataContext is not ShelfItem item ||
-				item.Path is null)
+			if (e.OriginalSource is not Microsoft.UI.Xaml.FrameworkElement { DataContext: ShelfItem item } widgetCardItem || item.Path is null)
 				return;
 
 			var menuFlyout = new MenuFlyout();
-
 			menuFlyout.Items.Add(new MenuFlyoutItem
 			{
 				Text = Strings.BaseLayoutItemContextFlyoutOpenParentFolder_Text.GetLocalizedResource(),
@@ -114,8 +113,25 @@ namespace Files.App.UserControls
 
 		private void ShelfItemsList_GotFocus(object sender, RoutedEventArgs e)
 		{
-			if (ItemFocusedCommand is not null)
-				ItemFocusedCommand.Execute(null);
+			ItemFocusedCommand?.Execute(null);
+		}
+
+		private void HyperlinkBatch_Click(object sender, RoutedEventArgs e)
+		{
+			if (sender is not FrameworkElement element)
+				return;
+
+			BatchFlyout.ShowAt(element);
+		}
+
+		private void ShelfItemsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			BatchActionsButton.Visibility = ShelfItemsList.SelectedItems.IsEmpty() ? Visibility.Collapsed : Visibility.Visible;
+		}
+
+		private void Pane_Tapped(object sender, TappedRoutedEventArgs e)
+		{
+			ShelfItemsList.SelectedItems.Clear();
 		}
 
 		public ObservableCollection<ShelfItem>? ItemsSource

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
@@ -96,13 +96,47 @@ namespace Files.App.UserControls
 			if (e.OriginalSource is not Microsoft.UI.Xaml.FrameworkElement { DataContext: ShelfItem item } widgetCardItem || item.Path is null)
 				return;
 
-			var menuFlyout = new MenuFlyout();
-			menuFlyout.Items.Add(new MenuFlyoutItem
+			// If the right-clicked item isn't already part of the selection, select just it
+			if (!ShelfItemsList.SelectedItems.Contains(item))
+				ShelfItemsList.SelectedItem = item;
+
+			var menuFlyout = new MenuFlyout
 			{
-				Text = Strings.BaseLayoutItemContextFlyoutOpenParentFolder_Text.GetLocalizedResource(),
-				Icon = new FontIcon() { Glyph = "\uE838" },
-				Command = item.ViewInFolderCommand
+				Placement = Microsoft.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.Bottom
+			};
+
+			// Batch actions (operate on the current shelf selection via IShelfContext)
+			menuFlyout.Items.Add(new MenuFlyoutItemWithThemedIcon
+			{
+				Text = Commands.CopyItemFromShelf.Label,
+				Command = Commands.CopyItemFromShelf,
+				ThemedIconStyle = Commands.CopyItemFromShelf.ThemedIconStyle
 			});
+			menuFlyout.Items.Add(new MenuFlyoutItemWithThemedIcon
+			{
+				Text = Commands.CutItemFromShelf.Label,
+				Command = Commands.CutItemFromShelf,
+				ThemedIconStyle = Commands.CutItemFromShelf.ThemedIconStyle
+			});
+			menuFlyout.Items.Add(new MenuFlyoutItemWithThemedIcon
+			{
+				Text = Commands.DeleteItemFromShelf.Label,
+				Command = Commands.DeleteItemFromShelf,
+				ThemedIconStyle = Commands.DeleteItemFromShelf.ThemedIconStyle
+			});
+
+			menuFlyout.Items.Add(new MenuFlyoutSeparator());
+
+			// Per-item actions
+			if (ShelfItemsList.SelectedItems.Count is 1)
+			{
+				menuFlyout.Items.Add(new MenuFlyoutItem
+				{
+					Text = Strings.BaseLayoutItemContextFlyoutOpenParentFolder_Text.GetLocalizedResource(),
+					Icon = new FontIcon() { Glyph = "\uE838" },
+					Command = item.ViewInFolderCommand
+				});
+			}
 			menuFlyout.Items.Add(new MenuFlyoutItem
 			{
 				Text = Strings.RemoveFromShelf.GetLocalizedResource(),

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
@@ -16,9 +16,12 @@ namespace Files.App.UserControls
 {
 	public sealed partial class ShelfPane : UserControl
 	{
+		public ICommandManager Commands { get; } = Ioc.Default.GetRequiredService<ICommandManager>();
+
 		public ShelfPane()
 		{
 			InitializeComponent();
+			Unloaded += ShelfPane_Unloaded;
 		}
 
 		private void Shelf_DragOver(object sender, DragEventArgs e)
@@ -126,12 +129,20 @@ namespace Files.App.UserControls
 
 		private void ShelfItemsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			BatchActionsButton.Visibility = ShelfItemsList.SelectedItems.IsEmpty() ? Visibility.Collapsed : Visibility.Visible;
+			var selected = ShelfItemsList.SelectedItems.OfType<ShelfItem>().ToArray();
+			BatchActionsButton.Visibility = selected.Length is 0 ? Visibility.Collapsed : Visibility.Visible;
+			ShelfViewModel.RaiseSelectedItemsChanged(selected);
 		}
 
 		private void Pane_Tapped(object sender, TappedRoutedEventArgs e)
 		{
 			ShelfItemsList.SelectedItems.Clear();
+		}
+
+		private void ShelfPane_Unloaded(object sender, RoutedEventArgs e)
+		{
+			// Drop the shelf context's selection so actions don't operate on stale items
+			ShelfViewModel.RaiseSelectedItemsChanged([]);
 		}
 
 		public ObservableCollection<ShelfItem>? ItemsSource
@@ -149,30 +160,6 @@ namespace Files.App.UserControls
 		}
 		public static readonly DependencyProperty ClearCommandProperty =
 			DependencyProperty.Register(nameof(ClearCommand), typeof(ICommand), typeof(ShelfPane), new PropertyMetadata(null));
-
-		public ICommand? BulkDeleteCommand
-		{
-			get => (ICommand?)GetValue(BulkDeleteCommandProperty);
-			set => SetValue(BulkDeleteCommandProperty, value);
-		}
-		public static readonly DependencyProperty BulkDeleteCommandProperty =
-			DependencyProperty.Register(nameof(BulkDeleteCommand), typeof(ICommand), typeof(ShelfPane), new PropertyMetadata(null));
-
-		public ICommand? BulkCopyCommand
-		{
-			get => (ICommand?)GetValue(BulkCopyCommandProperty);
-			set => SetValue(BulkCopyCommandProperty, value);
-		}
-		public static readonly DependencyProperty BulkCopyCommandProperty =
-			DependencyProperty.Register(nameof(BulkCopyCommand), typeof(ICommand), typeof(ShelfPane), new PropertyMetadata(null));
-
-		public ICommand? BulkCutCommand
-		{
-			get => (ICommand?)GetValue(BulkCutCommandProperty);
-			set => SetValue(BulkCutCommandProperty, value);
-		}
-		public static readonly DependencyProperty BulkCutCommandProperty =
-			DependencyProperty.Register(nameof(BulkCutCommand), typeof(ICommand), typeof(ShelfPane), new PropertyMetadata(null));
 
 		public ICommand? ItemFocusedCommand
 		{

--- a/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
+++ b/src/Files.App/UserControls/Pane/ShelfPane.xaml.cs
@@ -95,7 +95,7 @@ namespace Files.App.UserControls
 
 			var menuFlyout = new MenuFlyout();
 
-			menuFlyout.Items.Add(new MenuFlyoutItem
+			menuFlyout.Items.Add (new MenuFlyoutItem
 			{
 				Text = Strings.RemoveFromShelf.GetLocalizedResource(),
 				Icon = new FontIcon { Glyph = "\uE738" },
@@ -128,6 +128,14 @@ namespace Files.App.UserControls
 		public static readonly DependencyProperty ClearCommandProperty =
 			DependencyProperty.Register(nameof(ClearCommand), typeof(ICommand), typeof(ShelfPane), new PropertyMetadata(null));
 
+		public ICommand? BulkDeleteCommand
+		{
+			get => (ICommand?)GetValue(BulkDeleteCommandProperty);
+			set => SetValue(BulkDeleteCommandProperty, value);
+		}
+		public static readonly DependencyProperty BulkDeleteCommandProperty =
+			DependencyProperty.Register(nameof(BulkDeleteCommand), typeof(ICommand), typeof(ShelfPane), new PropertyMetadata(null));
+
 		public ICommand? ItemFocusedCommand
 		{
 			get => (ICommand?)GetValue(ItemFocusedCommandProperty);
@@ -135,6 +143,5 @@ namespace Files.App.UserControls
 		}
 		public static readonly DependencyProperty ItemFocusedCommandProperty =
 			DependencyProperty.Register(nameof(ItemFocusedCommand), typeof(ICommand), typeof(ShelfPane), new PropertyMetadata(null));
-
 	}
 }

--- a/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
+++ b/src/Files.App/ViewModels/Layouts/BaseLayoutViewModel.cs
@@ -251,7 +251,9 @@ namespace Files.App.ViewModels.Layouts
 							new MenuFlyoutItem() { Text = string.Format(Strings.CopyToFolderCaptionText.GetLocalizedResource(), folderName), Command = new AsyncRelayCommand(async ct =>
 								await _associatedInstance.FilesystemHelpers.PerformOperationTypeAsync(DataPackageOperation.Copy, e.DataView, _associatedInstance.ShellViewModel.WorkingDirectory, false, true)) },
 							new MenuFlyoutItem() { Text = string.Format(Strings.MoveToFolderCaptionText.GetLocalizedResource(), folderName), Command = new AsyncRelayCommand(async ct =>
-								await _associatedInstance.FilesystemHelpers.PerformOperationTypeAsync(DataPackageOperation.Move, e.DataView, _associatedInstance.ShellViewModel.WorkingDirectory, false, true)) }
+								await _associatedInstance.FilesystemHelpers.PerformOperationTypeAsync(DataPackageOperation.Move, e.DataView, _associatedInstance.ShellViewModel.WorkingDirectory, false, true)) },
+							new MenuFlyoutItem() { Text = string.Format(Strings.LinkToFolderCaptionText.GetLocalizedResource(), folderName), Command = new AsyncRelayCommand(async ct =>
+								await _associatedInstance.FilesystemHelpers.PerformOperationTypeAsync(DataPackageOperation.Link, e.DataView, _associatedInstance.ShellViewModel.WorkingDirectory, false, true)) }
 						}
 					};
 

--- a/src/Files.App/ViewModels/UserControls/ShelfViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/ShelfViewModel.cs
@@ -40,16 +40,17 @@ namespace Files.App.ViewModels.UserControls
 		}
 
 		[RelayCommand]
-		private async Task BulkDeleteAsync()
+		private async Task BulkDeleteAsync(IEnumerable? enumerable, CancellationToken cancellationToken)
 		{
-			if (Items.IsEmpty())
+			var items = enumerable?.Cast<ShelfItem>().ToArray();
+			if (items.IsEmpty())
 				return;
 
 			var context = Ioc.Default.GetRequiredService<IContentPageContext>();
 			if (context.ShellPage is not { } shellPage)
 				return;
 
-			var itemsToDelete = Items.Select(x => StorageHelpers.FromPathAndType(x.Inner.Id, x.Inner switch
+			var itemsToDelete = items.Select(x => StorageHelpers.FromPathAndType(x.Inner.Id, x.Inner switch
 			{
 				IFile => FilesystemItemType.File,
 				IFolder => FilesystemItemType.Directory,
@@ -62,9 +63,10 @@ namespace Files.App.ViewModels.UserControls
 		}
 
 		[RelayCommand]
-		private async Task BulkCopyAsync()
+		private async Task BulkCopyAsync(IEnumerable? enumerable, CancellationToken cancellationToken)
 		{
-			if (Items.IsEmpty())
+			var items = enumerable?.Cast<ShelfItem>().ToArray();
+			if (items.IsEmpty())
 				return;
 
 			var context = Ioc.Default.GetRequiredService<IContentPageContext>();
@@ -73,14 +75,15 @@ namespace Files.App.ViewModels.UserControls
 			if (context.ShellPage?.ShellViewModel is not { } shellViewModel)
 				return;
 
-			var itemsToCopy = Items.Select(x => x.Inner).ToArray();
+			var itemsToCopy = items.Select(x => x.Inner).ToArray();
 			await TransferHelpers.ExecuteTransferAsync(itemsToCopy, shellViewModel, statusViewModel, DataPackageOperation.Copy);
 		}
 
 		[RelayCommand]
-		private async Task BulkCutAsync()
+		private async Task BulkCutAsync(IEnumerable? enumerable, CancellationToken cancellationToken)
 		{
-			if (Items.IsEmpty())
+			var items = enumerable?.Cast<ShelfItem>().ToArray();
+			if (items.IsEmpty())
 				return;
 
 			var context = Ioc.Default.GetRequiredService<IContentPageContext>();
@@ -89,7 +92,7 @@ namespace Files.App.ViewModels.UserControls
 			if (context.ShellPage?.ShellViewModel is not { } shellViewModel)
 				return;
 
-			var itemsToCut = Items.Select(x => x.Inner).ToArray();
+			var itemsToCut = items.Select(x => x.Inner).ToArray();
 			await TransferHelpers.ExecuteTransferAsync(itemsToCut, shellViewModel, statusViewModel, DataPackageOperation.Move);
 		}
 

--- a/src/Files.App/ViewModels/UserControls/ShelfViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/ShelfViewModel.cs
@@ -149,9 +149,6 @@ namespace Files.App.ViewModels.UserControls
 
 		private async void Watcher_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (sender is not IFolderWatcher)
-				return;
-
 			switch (e.Action)
 			{
 				case NotifyCollectionChangedAction.Remove when e.OldItems is not null:

--- a/src/Files.App/ViewModels/UserControls/ShelfViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/ShelfViewModel.cs
@@ -33,54 +33,76 @@ namespace Files.App.ViewModels.UserControls
 			Items.Clear();
 		}
 
+		[RelayCommand]
+		private async Task BulkDeleteAsync()
+		{
+			if (Items.IsEmpty())
+				return;
+
+			var context = Ioc.Default.GetRequiredService<IContentPageContext>();
+			if (context.ShellPage is not { } shellPage)
+				return;
+
+			var itemsToDelete = Items.Select(x => StorageHelpers.FromPathAndType(x.Inner.Id, x.Inner switch
+			{
+				IFile => FilesystemItemType.File,
+				IFolder => FilesystemItemType.Directory,
+				_ => throw new ArgumentOutOfRangeException(nameof(ShelfViewModel))
+			}));
+
+			var settings = Ioc.Default.GetRequiredService<IFoldersSettingsService>();
+			await shellPage.FilesystemHelpers.DeleteItemsAsync(itemsToDelete, settings.DeleteConfirmationPolicy, false, true);
+			await shellPage.ShellViewModel.ApplyFilesAndFoldersChangesAsync();
+		}
+
 		private async void Items_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
 		{
 			switch (e.Action)
 			{
 				case NotifyCollectionChangedAction.Add when e.NewItems is not null:
+				{
+					if (e.NewItems[0] is not ShelfItem shelfItem)
+						return;
+
+					var parentPath = SystemIO.Path.GetDirectoryName(shelfItem.Inner.Id) ?? string.Empty;
+					if (_watchers.TryGetValue(parentPath, out var reference))
 					{
-						if (e.NewItems[0] is not ShelfItem shelfItem)
-							return;
-
-						var parentPath = SystemIO.Path.GetDirectoryName(shelfItem.Inner.Id) ?? string.Empty;
-						if (_watchers.TryGetValue(parentPath, out var reference))
-						{
-							// Only increase the reference count if the watcher already exists
-							reference.Item2++;
-							return;
-						}
-
-						if (await shelfItem.Inner.GetParentAsync() is not IMutableFolder mutableFolder)
-							return;
-
-						// Register new watcher
-						var watcher = await mutableFolder.GetFolderWatcherAsync();
-						watcher.CollectionChanged += Watcher_CollectionChanged;
-
-						_watchers.Add(parentPath, (watcher, 1));
-						break;
+						// Only increase the reference count if the watcher already exists
+						reference.Item2 += 1;
+						return;
 					}
+					
+					if (await shelfItem.Inner.GetParentAsync() is not IMutableFolder mutableFolder)
+						return;
+
+					// Register new watcher
+					var watcher = await mutableFolder.GetFolderWatcherAsync();
+					watcher.CollectionChanged += Watcher_CollectionChanged;
+
+					_watchers.Add(parentPath, (watcher, 1));
+					break;
+				}
 
 				case NotifyCollectionChangedAction.Remove when e.OldItems is not null:
+				{
+					if (e.OldItems[0] is not ShelfItem shelfItem)
+						return;
+
+					var parentPath = SystemIO.Path.GetDirectoryName(shelfItem.Inner.Id) ?? string.Empty;
+					if (!_watchers.TryGetValue(parentPath, out var reference))
+						return;
+
+					// Decrease the reference count and remove the watcher if no references are present
+					reference.Item2 -= 1;
+					if (reference.Item2 < 1)
 					{
-						if (e.OldItems[0] is not ShelfItem shelfItem)
-							return;
-
-						var parentPath = SystemIO.Path.GetDirectoryName(shelfItem.Inner.Id) ?? string.Empty;
-						if (!_watchers.TryGetValue(parentPath, out var reference))
-							return;
-
-						// Decrease the reference count and remove the watcher if no references are present
-						reference.Item2--;
-						if (reference.Item2 < 1)
-						{
-							reference.Item1.CollectionChanged -= Watcher_CollectionChanged;
-							reference.Item1.Dispose();
-							_watchers.Remove(parentPath);
-						}
-
-						break;
+						reference.Item1.CollectionChanged -= Watcher_CollectionChanged;
+						reference.Item1.Dispose();
+						_watchers.Remove(parentPath);
 					}
+
+					break;
+				}
 			}
 		}
 
@@ -92,16 +114,16 @@ namespace Files.App.ViewModels.UserControls
 			switch (e.Action)
 			{
 				case NotifyCollectionChangedAction.Remove when e.OldItems is not null:
-					{
-						// Remove the matching item notified from the watcher
-						var item = e.OldItems.Cast<IStorable>().ElementAt(0);
-						var itemToRemove = Items.FirstOrDefault(x => x.Inner.Id == item.Id);
-						if (itemToRemove is null)
-							return;
+				{
+					// Remove the matching item notified from the watcher
+					var item = e.OldItems.Cast<IStorable>().ElementAt(0);
+					var itemToRemove = Items.FirstOrDefault(x => x.Inner.Id == item.Id);
+					if (itemToRemove is null)
+						return;
 
-						await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => Items.Remove(itemToRemove));
-						break;
-					}
+					await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() => Items.Remove(itemToRemove));
+					break;
+				}
 			}
 		}
 	}

--- a/src/Files.App/ViewModels/UserControls/ShelfViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/ShelfViewModel.cs
@@ -3,7 +3,6 @@
 
 using Files.Shared.Utils;
 using System.Collections.Specialized;
-using Windows.ApplicationModel.DataTransfer;
 
 namespace Files.App.ViewModels.UserControls
 {
@@ -16,6 +15,8 @@ namespace Files.App.ViewModels.UserControls
 	public sealed partial class ShelfViewModel : ObservableObject, IAsyncInitialize
 	{
 		private readonly Dictionary<string, WatcherReference> _watchers;
+
+		public static event EventHandler<IReadOnlyList<ShelfItem>>? SelectedItemsChanged;
 
 		public ObservableCollection<ShelfItem> Items { get; }
 
@@ -39,62 +40,8 @@ namespace Files.App.ViewModels.UserControls
 			Items.Clear();
 		}
 
-		[RelayCommand]
-		private async Task BulkDeleteAsync(IEnumerable? enumerable, CancellationToken cancellationToken)
-		{
-			var items = enumerable?.Cast<ShelfItem>().ToArray();
-			if (items.IsEmpty())
-				return;
-
-			var context = Ioc.Default.GetRequiredService<IContentPageContext>();
-			if (context.ShellPage is not { } shellPage)
-				return;
-
-			var itemsToDelete = items.Select(x => StorageHelpers.FromPathAndType(x.Inner.Id, x.Inner switch
-			{
-				IFile => FilesystemItemType.File,
-				IFolder => FilesystemItemType.Directory,
-				_ => throw new ArgumentOutOfRangeException(nameof(ShelfViewModel))
-			}));
-
-			var settings = Ioc.Default.GetRequiredService<IFoldersSettingsService>();
-			await shellPage.FilesystemHelpers.DeleteItemsAsync(itemsToDelete, settings.DeleteConfirmationPolicy, false, true);
-			await shellPage.ShellViewModel.ApplyFilesAndFoldersChangesAsync();
-		}
-
-		[RelayCommand]
-		private async Task BulkCopyAsync(IEnumerable? enumerable, CancellationToken cancellationToken)
-		{
-			var items = enumerable?.Cast<ShelfItem>().ToArray();
-			if (items.IsEmpty())
-				return;
-
-			var context = Ioc.Default.GetRequiredService<IContentPageContext>();
-			var statusViewModel = Ioc.Default.GetRequiredService<StatusCenterViewModel>();
-
-			if (context.ShellPage?.ShellViewModel is not { } shellViewModel)
-				return;
-
-			var itemsToCopy = items.Select(x => x.Inner).ToArray();
-			await TransferHelpers.ExecuteTransferAsync(itemsToCopy, shellViewModel, statusViewModel, DataPackageOperation.Copy);
-		}
-
-		[RelayCommand]
-		private async Task BulkCutAsync(IEnumerable? enumerable, CancellationToken cancellationToken)
-		{
-			var items = enumerable?.Cast<ShelfItem>().ToArray();
-			if (items.IsEmpty())
-				return;
-
-			var context = Ioc.Default.GetRequiredService<IContentPageContext>();
-			var statusViewModel = Ioc.Default.GetRequiredService<StatusCenterViewModel>();
-
-			if (context.ShellPage?.ShellViewModel is not { } shellViewModel)
-				return;
-
-			var itemsToCut = items.Select(x => x.Inner).ToArray();
-			await TransferHelpers.ExecuteTransferAsync(itemsToCut, shellViewModel, statusViewModel, DataPackageOperation.Move);
-		}
+		internal static void RaiseSelectedItemsChanged(IReadOnlyList<ShelfItem> items)
+			=> SelectedItemsChanged?.Invoke(null, items);
 
 		private async void Items_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
 		{
@@ -112,7 +59,7 @@ namespace Files.App.ViewModels.UserControls
 						reference.ReferenceCount += 1;
 						return;
 					}
-					
+
 					if (await shelfItem.Inner.GetParentAsync() is not IMutableFolder mutableFolder)
 						return;
 

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -276,9 +276,6 @@
 						Grid.Column="3"
 						Margin="4,0,0,8"
 						x:Load="{x:Bind ViewModel.ShowShelfPane, Mode=OneWay}"
-						BulkCopyCommand="{x:Bind ViewModel.ShelfViewModel.BulkCopyCommand}"
-						BulkCutCommand="{x:Bind ViewModel.ShelfViewModel.BulkCutCommand}"
-						BulkDeleteCommand="{x:Bind ViewModel.ShelfViewModel.BulkDeleteCommand}"
 						ClearCommand="{x:Bind ViewModel.ShelfViewModel.ClearItemsCommand}"
 						ItemFocusedCommand="{x:Bind Commands.ClearSelection}"
 						ItemsSource="{x:Bind ViewModel.ShelfViewModel.Items}" />

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -276,6 +276,8 @@
 						Grid.Column="3"
 						Margin="4,0,0,8"
 						x:Load="{x:Bind ViewModel.ShowShelfPane, Mode=OneWay}"
+						BulkCopyCommand="{x:Bind ViewModel.ShelfViewModel.BulkCopyCommand}"
+						BulkCutCommand="{x:Bind ViewModel.ShelfViewModel.BulkCutCommand}"
 						BulkDeleteCommand="{x:Bind ViewModel.ShelfViewModel.BulkDeleteCommand}"
 						ClearCommand="{x:Bind ViewModel.ShelfViewModel.ClearItemsCommand}"
 						ItemFocusedCommand="{x:Bind Commands.ClearSelection}"

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -276,8 +276,9 @@
 						Grid.Column="3"
 						Margin="4,0,0,8"
 						x:Load="{x:Bind ViewModel.ShowShelfPane, Mode=OneWay}"
+						BulkDeleteCommand="{x:Bind ViewModel.ShelfViewModel.BulkDeleteCommand}"
 						ClearCommand="{x:Bind ViewModel.ShelfViewModel.ClearItemsCommand}"
-						ItemFocusedCommand="{x:Bind Commands.ClearSelection, Mode=OneWay}"
+						ItemFocusedCommand="{x:Bind Commands.ClearSelection}"
 						ItemsSource="{x:Bind ViewModel.ShelfViewModel.Items}" />
 				</Grid>
 			</controls:SidebarView.InnerContent>

--- a/src/Files.Shared/Extensions/LinqExtensions.cs
+++ b/src/Files.Shared/Extensions/LinqExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -23,7 +24,7 @@ namespace Files.Shared.Extensions
 		/// <typeparam name="T"></typeparam>
 		/// <param name="enumerable"></param>
 		/// <returns></returns>
-		public static bool IsEmpty<T>(this IEnumerable<T> enumerable)
+		public static bool IsEmpty<T>([NotNullWhen(false)] this IEnumerable<T>? enumerable)
 		{
 			return enumerable is null || !enumerable.Any();
 		}


### PR DESCRIPTION
**Resolved / Related Issues**

- For #12490

This PR introduces minor changes, unless additional changes are requested. The file watcher was implemented quite some time ago and already works properly, thanks to #16900 and #16728. This PR focuses solely on re-enabling this feature, but can be iterated upon to accommodate any undocumented missing features (if any? - not that I'm aware of)

- [ ] ~~Re-enabled the command for showing the Shelf pane in production~~
- [x] Add a "Create link" menu option when dropping an item from the shelf to a folder
- [x] Add a delete bulk action
- [x] Add a copy and cut bulk actions
- [x] Add "View in parent folder" menu option
- [x] Fixed Shelf's file watcher reference counter logic

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files
2. Confirmed the action shows up appropriately
3. Confirmed the menu and bulk actions work properly
4. Confirmed that deleting two (or more) files from the same folder using the bulk delete action properly removes them from the Shelf
