### PR TITLE
Code Quality: Don't wait canceled git fetch

### DIFF
--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -238,16 +238,17 @@ namespace Files.App.Views.Shells
 					? headBranch.Name
 					: string.Empty;
 
+				var isGitFetchCanceled = false;
 				if (!_gitFetch.IsCompleted)
 				{
 					_gitFetchToken.Cancel();
-					await _gitFetch;
-					_gitFetchToken.TryReset();
+					_gitFetchToken = new CancellationTokenSource();
+					isGitFetchCanceled = true;
 				}
-				if (InstanceViewModel.IsGitRepository && !GitHelpers.IsExecutingGitAction)
+				if (InstanceViewModel.IsGitRepository && (!GitHelpers.IsExecutingGitAction || isGitFetchCanceled))
 				{
 					_gitFetch = Task.Run(
-						() => GitHelpers.FetchOrigin(InstanceViewModel.GitRepositoryPath),
+						() => GitHelpers.FetchOrigin(InstanceViewModel.GitRepositoryPath, _gitFetchToken.Token),
 						_gitFetchToken.Token);
 				}
 			}


### PR DESCRIPTION
LibGit2Sharp doesn't support asynchronous calls and cancellation, so git fetch may take long time even if it is canceled and we shouldn't wait it in the UI thread.

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- May resolve [FILES-APP-1NH](https://files-org.sentry.io/issues/5834287744/?project=4507376940351488)

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirm that opening multiple Git repositories doesn't cause a crash.