### PR TITLE
Fix: Fixed issue where delete key wouldn't work after removing item from selection 

### DIFF
--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -884,18 +884,18 @@ namespace Files.App.Views.Layouts
 
 		private void ItemSelected_Unchecked(object sender, RoutedEventArgs e)
 		{
-			if (sender is CheckBox checkBox)
-			{
-				if (checkBox.DataContext is ListedItem item && FileList.SelectedItems.Contains(item))
-					FileList.SelectedItems.Remove(item);
+			if (sender is not CheckBox checkBox)
+				return;
 
-				// Workaround for #17298
-				checkBox.IsTabStop = false;
-				checkBox.IsEnabled = false;
-				checkBox.IsEnabled = true;
-				checkBox.IsTabStop = true;
-				FileList.Focus(FocusState.Programmatic);
-			}
+			if (checkBox.DataContext is ListedItem item && FileList.SelectedItems.Contains(item))
+				FileList.SelectedItems.Remove(item);
+
+			// Workaround for #17298
+			checkBox.IsTabStop = false;
+			checkBox.IsEnabled = false;
+			checkBox.IsEnabled = true;
+			checkBox.IsTabStop = true;
+			FileList.Focus(FocusState.Programmatic);
 		}
 
 		private new void FileList_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -884,8 +884,18 @@ namespace Files.App.Views.Layouts
 
 		private void ItemSelected_Unchecked(object sender, RoutedEventArgs e)
 		{
-			if (sender is CheckBox checkBox && checkBox.DataContext is ListedItem item && FileList.SelectedItems.Contains(item))
-				FileList.SelectedItems.Remove(item);
+			if (sender is CheckBox checkBox)
+			{
+				if (checkBox.DataContext is ListedItem item && FileList.SelectedItems.Contains(item))
+					FileList.SelectedItems.Remove(item);
+
+				// Workaround for #17298
+				checkBox.IsTabStop = false;
+				checkBox.IsEnabled = false;
+				checkBox.IsEnabled = true;
+				checkBox.IsTabStop = true;
+				FileList.Focus(FocusState.Programmatic);
+			}
 		}
 
 		private new void FileList_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -670,18 +670,18 @@ namespace Files.App.Views.Layouts
 
 		private void ItemSelected_Unchecked(object sender, RoutedEventArgs e)
 		{
-			if (sender is CheckBox checkBox)
-			{
-				if (checkBox.DataContext is ListedItem item && FileList.SelectedItems.Contains(item))
-					FileList.SelectedItems.Remove(item);
+			if (sender is not CheckBox checkBox)
+				return;
 
-				// Workaround for #17298
-				checkBox.IsTabStop = false;
-				checkBox.IsEnabled = false;
-				checkBox.IsEnabled = true;
-				checkBox.IsTabStop = true;
-				FileList.Focus(FocusState.Programmatic);
-			}
+			if (checkBox.DataContext is ListedItem item && FileList.SelectedItems.Contains(item))
+				FileList.SelectedItems.Remove(item);
+
+			// Workaround for #17298
+			checkBox.IsTabStop = false;
+			checkBox.IsEnabled = false;
+			checkBox.IsEnabled = true;
+			checkBox.IsTabStop = true;
+			FileList.Focus(FocusState.Programmatic);
 		}
 
 		private new void FileList_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -670,10 +670,18 @@ namespace Files.App.Views.Layouts
 
 		private void ItemSelected_Unchecked(object sender, RoutedEventArgs e)
 		{
-			if (sender is CheckBox checkBox &&
-				checkBox.DataContext is ListedItem item &&
-				FileList.SelectedItems.Contains(item))
-				FileList.SelectedItems.Remove(item);
+			if (sender is CheckBox checkBox)
+			{
+				if (checkBox.DataContext is ListedItem item && FileList.SelectedItems.Contains(item))
+					FileList.SelectedItems.Remove(item);
+
+				// Workaround for #17298
+				checkBox.IsTabStop = false;
+				checkBox.IsEnabled = false;
+				checkBox.IsEnabled = true;
+				checkBox.IsTabStop = true;
+				FileList.Focus(FocusState.Programmatic);
+			}
 		}
 
 		private new void FileList_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17298 

**Notes**
It seems the issue is caused by the checkbox, which when focused handles all `Key`-related events.
For some reason I don't understand, the bug affects only `Deselection` and not `Selection`
The code below removes the focus from the checkbox once its state is updated

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open a folder with multiple files (test different layouts)
2. Select some of them
3. Deselect one clicking on the checkbox
4. Hit the `Del` key and see that the modal pops-up
5. Repeat 3 and 4 as many times as you wish

https://github.com/user-attachments/assets/edf8b79c-d962-45fd-b08c-5ac6368f5e60