### PR TITLE
Code Quality: Fixed items processed string in status center

### DIFF
--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3718,7 +3718,7 @@
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_ProcessedItems_Header" xml:space="preserve">
-    <value>{0}/{1} {0, plural, one {item} other {items}} processed</value>
+    <value>{0}/{1, plural, one {# item} other {# items}} processed</value>
     <comment>Shown in a StatusCenter card. Used as "8/20 items processed"</comment>
   </data>
   <data name="UnblockDownloadedFile" xml:space="preserve">

--- a/src/Files.App/Utils/StatusCenter/StatusCenterItem.cs
+++ b/src/Files.App/Utils/StatusCenter/StatusCenterItem.cs
@@ -301,7 +301,7 @@ namespace Files.App.Utils.StatusCenter
 					{
 						Message =
 							$"{string.Format(
-								Strings.StatusCenter_ProcessedItems_Header.GetLocalizedFormatResource(value.ProcessedItemsCount),
+								Strings.StatusCenter_ProcessedItems_Header.GetLocalizedFormatResource(value.ProcessedItemsCount, value.ItemsCount),
 								value.ProcessedItemsCount,
 								value.ItemsCount)}";
 					}


### PR DESCRIPTION
The string returned by `StatusCenter_ProcessedItems_Header.GetLocalizedFormatResource` is empty and does not display anything in the Status Center.

- Pass the correct number of parameters to `GetLocalizedFormatResource` to get the real format string instead of "".
- Correct plural form for fraction. The divisor must be in accordance to the plural form, not the dividend.

8/20 items processed = Processed 8 out of 20 items.

**Steps used to test these changes**

<img width="481" height="309" alt="image" src="https://github.com/user-attachments/assets/f28afab8-7d0d-4a25-81f9-e26d72330a13" />

