### PR TITLE
Code Quality: Refactored VisualStates for InfoPane

### DIFF
--- a/src/Files.App.Controls/GridSplitter/GridSplitter.Data.cs
+++ b/src/Files.App.Controls/GridSplitter/GridSplitter.Data.cs
@@ -4,153 +4,147 @@
 namespace Files.App.Controls
 {
 	/// <summary>
-	/// Represents the control that redistributes space between columns or rows of a Grid control.
+	/// Enum to indicate whether GridSplitter resizes Columns or Rows
 	/// </summary>
-	public partial class GridSplitter
+	public enum GridResizeDirection
 	{
 		/// <summary>
-		/// Enum to indicate whether GridSplitter resizes Columns or Rows
+		/// Determines whether to resize rows or columns based on its Alignment and
+		/// width compared to height
 		/// </summary>
-		public enum GridResizeDirection
-		{
-			/// <summary>
-			/// Determines whether to resize rows or columns based on its Alignment and
-			/// width compared to height
-			/// </summary>
-			Auto,
-
-			/// <summary>
-			/// Resize columns when dragging Splitter.
-			/// </summary>
-			Columns,
-
-			/// <summary>
-			/// Resize rows when dragging Splitter.
-			/// </summary>
-			Rows
-		}
+		Auto,
 
 		/// <summary>
-		/// Enum to indicate what Columns or Rows the GridSplitter resizes
+		/// Resize columns when dragging Splitter.
 		/// </summary>
-		public enum GridResizeBehavior
-		{
-			/// <summary>
-			/// Determine which columns or rows to resize based on its Alignment.
-			/// </summary>
-			BasedOnAlignment,
-
-			/// <summary>
-			/// Resize the current and next Columns or Rows.
-			/// </summary>
-			CurrentAndNext,
-
-			/// <summary>
-			/// Resize the previous and current Columns or Rows.
-			/// </summary>
-			PreviousAndCurrent,
-
-			/// <summary>
-			/// Resize the previous and next Columns or Rows.
-			/// </summary>
-			PreviousAndNext
-		}
+		Columns,
 
 		/// <summary>
-		///  Enum to indicate the supported gripper cursor types.
+		/// Resize rows when dragging Splitter.
 		/// </summary>
-		public enum GripperCursorType
-		{
-			/// <summary>
-			/// Change the cursor based on the splitter direction
-			/// </summary>
-			Default = -1,
+		Rows
+	}
 
-			/// <summary>
-			/// Standard Arrow cursor
-			/// </summary>
-			Arrow,
-
-			/// <summary>
-			/// Standard Cross cursor
-			/// </summary>
-			Cross,
-
-			/// <summary>
-			/// Standard Custom cursor
-			/// </summary>
-			Custom,
-
-			/// <summary>
-			/// Standard Hand cursor
-			/// </summary>
-			Hand,
-
-			/// <summary>
-			/// Standard Help cursor
-			/// </summary>
-			Help,
-
-			/// <summary>
-			/// Standard IBeam cursor
-			/// </summary>
-			IBeam,
-
-			/// <summary>
-			/// Standard SizeAll cursor
-			/// </summary>
-			SizeAll,
-
-			/// <summary>
-			/// Standard SizeNortheastSouthwest cursor
-			/// </summary>
-			SizeNortheastSouthwest,
-
-			/// <summary>
-			/// Standard SizeNorthSouth cursor
-			/// </summary>
-			SizeNorthSouth,
-
-			/// <summary>
-			/// Standard SizeNorthwestSoutheast cursor
-			/// </summary>
-			SizeNorthwestSoutheast,
-
-			/// <summary>
-			/// Standard SizeWestEast cursor
-			/// </summary>
-			SizeWestEast,
-
-			/// <summary>
-			/// Standard UniversalNo cursor
-			/// </summary>
-			UniversalNo,
-
-			/// <summary>
-			/// Standard UpArrow cursor
-			/// </summary>
-			UpArrow,
-
-			/// <summary>
-			/// Standard Wait cursor
-			/// </summary>
-			Wait
-		}
+	/// <summary>
+	/// Enum to indicate what Columns or Rows the GridSplitter resizes
+	/// </summary>
+	public enum GridResizeBehavior
+	{
+		/// <summary>
+		/// Determine which columns or rows to resize based on its Alignment.
+		/// </summary>
+		BasedOnAlignment,
 
 		/// <summary>
-		///  Enum to indicate the behavior of window cursor on grid splitter hover
+		/// Resize the current and next Columns or Rows.
 		/// </summary>
-		public enum SplitterCursorBehavior
-		{
-			/// <summary>
-			/// Update window cursor on Grid Splitter hover
-			/// </summary>
-			ChangeOnSplitterHover,
+		CurrentAndNext,
 
-			/// <summary>
-			/// Update window cursor on Grid Splitter Gripper hover
-			/// </summary>
-			ChangeOnGripperHover
-		}
+		/// <summary>
+		/// Resize the previous and current Columns or Rows.
+		/// </summary>
+		PreviousAndCurrent,
+
+		/// <summary>
+		/// Resize the previous and next Columns or Rows.
+		/// </summary>
+		PreviousAndNext
+	}
+
+	/// <summary>
+	///  Enum to indicate the supported gripper cursor types.
+	/// </summary>
+	public enum GripperCursorType
+	{
+		/// <summary>
+		/// Change the cursor based on the splitter direction
+		/// </summary>
+		Default = -1,
+
+		/// <summary>
+		/// Standard Arrow cursor
+		/// </summary>
+		Arrow,
+
+		/// <summary>
+		/// Standard Cross cursor
+		/// </summary>
+		Cross,
+
+		/// <summary>
+		/// Standard Custom cursor
+		/// </summary>
+		Custom,
+
+		/// <summary>
+		/// Standard Hand cursor
+		/// </summary>
+		Hand,
+
+		/// <summary>
+		/// Standard Help cursor
+		/// </summary>
+		Help,
+
+		/// <summary>
+		/// Standard IBeam cursor
+		/// </summary>
+		IBeam,
+
+		/// <summary>
+		/// Standard SizeAll cursor
+		/// </summary>
+		SizeAll,
+
+		/// <summary>
+		/// Standard SizeNortheastSouthwest cursor
+		/// </summary>
+		SizeNortheastSouthwest,
+
+		/// <summary>
+		/// Standard SizeNorthSouth cursor
+		/// </summary>
+		SizeNorthSouth,
+
+		/// <summary>
+		/// Standard SizeNorthwestSoutheast cursor
+		/// </summary>
+		SizeNorthwestSoutheast,
+
+		/// <summary>
+		/// Standard SizeWestEast cursor
+		/// </summary>
+		SizeWestEast,
+
+		/// <summary>
+		/// Standard UniversalNo cursor
+		/// </summary>
+		UniversalNo,
+
+		/// <summary>
+		/// Standard UpArrow cursor
+		/// </summary>
+		UpArrow,
+
+		/// <summary>
+		/// Standard Wait cursor
+		/// </summary>
+		Wait
+	}
+
+	/// <summary>
+	///  Enum to indicate the behavior of window cursor on grid splitter hover
+	/// </summary>
+	public enum SplitterCursorBehavior
+	{
+		/// <summary>
+		/// Update window cursor on Grid Splitter hover
+		/// </summary>
+		ChangeOnSplitterHover,
+
+		/// <summary>
+		/// Update window cursor on Grid Splitter Gripper hover
+		/// </summary>
+		ChangeOnGripperHover
 	}
 }

--- a/src/Files.App.Controls/GridSplitter/GridSplitter.Options.cs
+++ b/src/Files.App.Controls/GridSplitter/GridSplitter.Options.cs
@@ -67,7 +67,7 @@ namespace Files.App.Controls
 		public static readonly DependencyProperty GripperCursorProperty =
 			DependencyProperty.RegisterAttached(
 				nameof(GripperCursor),
-				typeof(InputSystemCursorShape?),
+				typeof(GripperCursorType),
 				typeof(GridSplitter),
 				new PropertyMetadata(GripperCursorType.Default, OnGripperCursorPropertyChanged));
 

--- a/src/Files.App.Controls/GridSplitter/GripperHoverWrapper.cs
+++ b/src/Files.App.Controls/GridSplitter/GripperHoverWrapper.cs
@@ -8,16 +8,16 @@ namespace Files.App.Controls
 {
 	internal class GripperHoverWrapper
 	{
-		private readonly GridSplitter.GridResizeDirection _gridSplitterDirection;
+		private readonly GridResizeDirection _gridSplitterDirection;
 
 		private InputCursor _splitterPreviousPointer;
 		private InputCursor _previousCursor;
-		private GridSplitter.GripperCursorType _gripperCursor;
+		private GripperCursorType _gripperCursor;
 		private int _gripperCustomCursorResource;
 		private bool _isDragging;
 		private UIElement _element;
 
-		internal GridSplitter.GripperCursorType GripperCursor
+		internal GripperCursorType GripperCursor
 		{
 			get
 			{
@@ -50,7 +50,7 @@ namespace Files.App.Controls
 		/// <param name="gridSplitterDirection">GridSplitter resize direction</param>
 		/// <param name="gripperCursor">GridSplitter gripper on hover cursor type</param>
 		/// <param name="gripperCustomCursorResource">GridSplitter gripper custom cursor resource number</param>
-		internal GripperHoverWrapper(UIElement element, GridSplitter.GridResizeDirection gridSplitterDirection, GridSplitter.GripperCursorType gripperCursor, int gripperCustomCursorResource)
+		internal GripperHoverWrapper(UIElement element, GridResizeDirection gridSplitterDirection, GripperCursorType gripperCursor, int gripperCustomCursorResource)
 		{
 			_gridSplitterDirection = gridSplitterDirection;
 			_gripperCursor = gripperCursor;
@@ -113,13 +113,13 @@ namespace Files.App.Controls
 				return;
 			}
 
-			if (_gripperCursor == GridSplitter.GripperCursorType.Default)
+			if (_gripperCursor == GripperCursorType.Default)
 			{
-				if (_gridSplitterDirection == GridSplitter.GridResizeDirection.Columns)
+				if (_gridSplitterDirection == GridResizeDirection.Columns)
 				{
 					// Window.Current.CoreWindow.PointerCursor = GridSplitter.ColumnsSplitterCursor;
 				}
-				else if (_gridSplitterDirection == GridSplitter.GridResizeDirection.Rows)
+				else if (_gridSplitterDirection == GridResizeDirection.Rows)
 				{
 					// Window.Current.CoreWindow.PointerCursor = GridSplitter.RowSplitterCursor;
 				}
@@ -127,7 +127,7 @@ namespace Files.App.Controls
 			else
 			{
 				var inputSystemCursorShape = (InputSystemCursorShape)((int)_gripperCursor);
-				if (_gripperCursor == GridSplitter.GripperCursorType.Custom)
+				if (_gripperCursor == GripperCursorType.Custom)
 				{
 					if (_gripperCustomCursorResource > GridSplitter.GripperCustomCursorDefaultResource)
 					{

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -199,7 +199,7 @@
 							Height="*"
 							MinHeight="100" />
 						<RowDefinition Height="Auto" />
-						<RowDefinition x:Name="PaneRow" Height="Auto" />
+						<RowDefinition x:Name="InfoPaneRowDefinition" Height="Auto" />
 						<RowDefinition Height="Auto" MinHeight="8" />
 					</Grid.RowDefinitions>
 					<Grid.ColumnDefinitions>
@@ -208,7 +208,7 @@
 							Width="*"
 							MinWidth="208" />
 						<ColumnDefinition Width="Auto" />
-						<ColumnDefinition x:Name="PaneColumn" Width="Auto" />
+						<ColumnDefinition x:Name="InfoPaneColumnDefinition" Width="Auto" />
 						<ColumnDefinition x:Name="ShelfPaneColumn" Width="Auto" />
 					</Grid.ColumnDefinitions>
 
@@ -233,9 +233,9 @@
 						HorizontalContentAlignment="Stretch"
 						Content="{x:Bind ViewModel.SelectedTabItem.ContentFrame, Mode=OneWay}" />
 
-					<!--  Preview Pane Splitter  -->
+					<!--  Info Pane Splitter  -->
 					<controls:GridSplitter
-						x:Name="PaneSplitter"
+						x:Name="InfoPaneSizer"
 						Grid.Row="1"
 						Grid.Column="1"
 						x:Load="{x:Bind ViewModel.ShouldPreviewPaneBeActive, Mode=OneWay}"
@@ -433,7 +433,7 @@
 				</VisualState>
 			</VisualStateGroup>
 
-			<VisualStateGroup>
+			<VisualStateGroup x:Name="SidebarStates">
 				<VisualState x:Name="NormalSidebarState">
 					<VisualState.StateTriggers>
 						<AdaptiveTrigger MinWindowWidth="0" />
@@ -449,6 +449,44 @@
 					</VisualState.StateTriggers>
 				</VisualState>
 			</VisualStateGroup>
+
+			<VisualStateGroup x:Name="InfoPanePositionStates">
+				<VisualState x:Name="InfoPanePositionNone">
+					<VisualState.Setters>
+						<Setter Target="InfoPaneRowDefinition.MinHeight" Value="0" />
+						<Setter Target="InfoPaneRowDefinition.Height" Value="0" />
+						<Setter Target="InfoPaneColumnDefinition.MinWidth" Value="0" />
+						<Setter Target="InfoPaneColumnDefinition.Width" Value="0" />
+					</VisualState.Setters>
+				</VisualState>
+				<VisualState x:Name="InfoPanePositionRight">
+					<VisualState.Setters>
+						<Setter Target="InfoPane.(Grid.Row)" Value="1" />
+						<Setter Target="InfoPane.(Grid.Column)" Value="2" />
+						<Setter Target="InfoPaneSizer.(Grid.Row)" Value="1" />
+						<Setter Target="InfoPaneSizer.(Grid.Column)" Value="1" />
+						<Setter Target="InfoPaneSizer.Width" Value="2" />
+						<Setter Target="InfoPaneSizer.GripperCursor" Value="SizeWestEast" />
+						<Setter Target="InfoPaneColumnDefinition.MinWidth" Value="{x:Bind InfoPane.MinWidth, Mode=OneWay}" />
+						<Setter Target="InfoPaneRowDefinition.MinHeight" Value="0" />
+						<Setter Target="InfoPaneRowDefinition.Height" Value="0" />
+					</VisualState.Setters>
+				</VisualState>
+				<VisualState x:Name="InfoPanePositionBottom">
+					<VisualState.Setters>
+						<Setter Target="InfoPane.(Grid.Row)" Value="3" />
+						<Setter Target="InfoPane.(Grid.Column)" Value="0" />
+						<Setter Target="InfoPaneSizer.(Grid.Row)" Value="2" />
+						<Setter Target="InfoPaneSizer.(Grid.Column)" Value="0" />
+						<Setter Target="InfoPaneSizer.Height" Value="2" />
+						<Setter Target="InfoPaneSizer.GripperCursor" Value="SizeNorthSouth" />
+						<Setter Target="InfoPaneColumnDefinition.Width" Value="0" />
+						<Setter Target="InfoPaneColumnDefinition.MinWidth" Value="0" />
+						<Setter Target="InfoPaneRowDefinition.MinHeight" Value="{x:Bind InfoPane.MinHeight, Mode=OneWay}" />
+					</VisualState.Setters>
+				</VisualState>
+			</VisualStateGroup>
+
 		</VisualStateManager.VisualStateGroups>
 	</Grid>
 </Page>

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -335,20 +335,11 @@ namespace Files.App.Views
 
 		private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e) => LoadPaneChanged();
 
-		/// <summary>
-		/// Call this function to update the positioning of the preview pane.
-		/// This is a workaround as the VisualStateManager causes problems.
-		/// </summary>
 		private void UpdatePositioning()
 		{
 			if (InfoPane is null || !ViewModel.ShouldPreviewPaneBeActive)
 			{
-				PaneRow.MinHeight = 0;
-				PaneRow.MaxHeight = double.MaxValue;
-				PaneRow.Height = new GridLength(0);
-				PaneColumn.MinWidth = 0;
-				PaneColumn.MaxWidth = double.MaxValue;
-				PaneColumn.Width = new GridLength(0);
+				VisualStateManager.GoToState(this, "InfoPanePositionNone", true);
 			}
 			else
 			{
@@ -356,42 +347,17 @@ namespace Files.App.Views
 				switch (InfoPane.Position)
 				{
 					case PreviewPanePositions.None:
-						PaneRow.MinHeight = 0;
-						PaneRow.Height = new GridLength(0);
-						PaneColumn.MinWidth = 0;
-						PaneColumn.Width = new GridLength(0);
+						VisualStateManager.GoToState(this, "InfoPanePositionNone", true);
 						break;
 					case PreviewPanePositions.Right:
-						InfoPane.SetValue(Grid.RowProperty, 1);
-						InfoPane.SetValue(Grid.ColumnProperty, 2);
-						PaneSplitter.SetValue(Grid.RowProperty, 1);
-						PaneSplitter.SetValue(Grid.ColumnProperty, 1);
-						PaneSplitter.Width = 2;
-						PaneSplitter.Height = RootGrid.ActualHeight;
-						PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeWestEast;
-						PaneSplitter.ChangeCursor(InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast));
-						PaneColumn.MinWidth = InfoPane.MinWidth;
-						PaneColumn.MaxWidth = InfoPane.MaxWidth;
-						PaneColumn.Width = new GridLength(UserSettingsService.InfoPaneSettingsService.VerticalSizePx, GridUnitType.Pixel);
-						PaneRow.MinHeight = 0;
-						PaneRow.MaxHeight = double.MaxValue;
-						PaneRow.Height = new GridLength(0);
+						InfoPaneSizer.ChangeCursor(InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast));
+						InfoPaneColumnDefinition.Width = new(UserSettingsService.InfoPaneSettingsService.VerticalSizePx);
+						VisualStateManager.GoToState(this, "InfoPanePositionRight", true);
 						break;
 					case PreviewPanePositions.Bottom:
-						InfoPane.SetValue(Grid.RowProperty, 3);
-						InfoPane.SetValue(Grid.ColumnProperty, 0);
-						PaneSplitter.SetValue(Grid.RowProperty, 2);
-						PaneSplitter.SetValue(Grid.ColumnProperty, 0);
-						PaneSplitter.Height = 2;
-						PaneSplitter.Width = RootGrid.ActualWidth;
-						PaneSplitter.GripperCursor = GridSplitter.GripperCursorType.SizeNorthSouth;
-						PaneSplitter.ChangeCursor(InputSystemCursor.Create(InputSystemCursorShape.SizeNorthSouth));
-						PaneColumn.MinWidth = 0;
-						PaneColumn.MaxWidth = double.MaxValue;
-						PaneColumn.Width = new GridLength(0);
-						PaneRow.MinHeight = InfoPane.MinHeight;
-						PaneRow.MaxHeight = InfoPane.MaxHeight;
-						PaneRow.Height = new GridLength(UserSettingsService.InfoPaneSettingsService.HorizontalSizePx, GridUnitType.Pixel);
+						InfoPaneSizer.ChangeCursor(InputSystemCursor.Create(InputSystemCursorShape.SizeNorthSouth));
+						InfoPaneRowDefinition.Height = new(UserSettingsService.InfoPaneSettingsService.HorizontalSizePx);
+						VisualStateManager.GoToState(this, "InfoPanePositionBottom", true);
 						break;
 				}
 			}


### PR DESCRIPTION
### Resolved / Related Issues

The reason why visual state manager failed to apply these changes within XAML was probably because the enums are inside the class. Now everything works as expected, removing extra lines of code.

> [!IMPORTANT]
> You should "Hide whitespace" in the diff view

- #4180

### Steps used to test these changes

1. Open Files app
2. Open InfoPane
3. Resize it left and right
4. Shrink the window enough small for InfoPane to go to the bottom
5. Resize it up and down