### PR TITLE
Fix: Fixed issue where repository names lost casing and retained .git suffix

### DIFF
--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -943,7 +943,7 @@ namespace Files.App.Utils.Git
 				ReturnResult.Failed);
 		}
 
-		[GeneratedRegex(@"^(?:https?:\/\/)?(?:www\.)?github\.com\/(?<user>[^\/]+)\/(?<repo>[^\/]+?)(?:\.git)?(?:\/)?$", RegexOptions.IgnoreCase)]
+		[GeneratedRegex(@"^(?:https?:\/\/)?(?:www\.)?github\.com\/(?<user>[^\/]+)\/(?<repo>[^\/]+?)(?=\.git|\/|$)(?:\.git)?(?:\/)?", RegexOptions.IgnoreCase)]
 		private static partial Regex GitHubRepositoryRegex();
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #17386

**Steps used to test these changes**
1. Used the clone action from the command palette (or drag and drop the URL)
2. Pasted url `https://github.com/files-community/Files.git` or `https://github.com/files-community/Files` 
3. Verified that casing was preserved (uppercase F) and the .git suffix was removed.

<img width="1399" height="635" alt="image" src="https://github.com/user-attachments/assets/9a950817-dc4f-439c-b2ef-057ddd29e9ed" />

<img width="1399" height="635" alt="image" src="https://github.com/user-attachments/assets/f70f087a-4713-4fb3-b777-94410061bacd" />
