### PR TITLE
Fix: Fixed issue where 7z archive files could not be previewed or compressed

### DIFF
--- a/src/Files.App/Data/Models/CompressArchiveModel.cs
+++ b/src/Files.App/Data/Models/CompressArchiveModel.cs
@@ -161,7 +161,7 @@ namespace Files.App.Data.Models
 			//Use UTF-8 encoding. 
 			//References: 7-zip chm --> Command Line Version --> Switches
 			//--> -m --> cu=[off | on].
-			//See https://github.com/files-community/Files/issues/17257
+			//Don't add "cu" parameter for 7zip files, see https://github.com/files-community/Files/issues/17257
 			if (FileFormat != ArchiveFormats.SevenZip)
 				compressor.CustomParameters.Add("cu", "on");
 

--- a/src/Files.App/Data/Models/CompressArchiveModel.cs
+++ b/src/Files.App/Data/Models/CompressArchiveModel.cs
@@ -161,6 +161,7 @@ namespace Files.App.Data.Models
 			//Use UTF-8 encoding. 
 			//References: 7-zip chm --> Command Line Version --> Switches
 			//--> -m --> cu=[off | on].
+			//See https://github.com/files-community/Files/issues/17257
 			if (FileFormat != ArchiveFormats.SevenZip)
 				compressor.CustomParameters.Add("cu", "on");
 

--- a/src/Files.App/Data/Models/CompressArchiveModel.cs
+++ b/src/Files.App/Data/Models/CompressArchiveModel.cs
@@ -161,7 +161,6 @@ namespace Files.App.Data.Models
 			//Use UTF-8 encoding. 
 			//References: 7-zip chm --> Command Line Version --> Switches
 			//--> -m --> cu=[off | on].
-			compressor.CustomParameters.Add("cu", "on");
 
 			compressor.Compressing += Compressor_Compressing;
 			compressor.FileCompressionStarted += Compressor_FileCompressionStarted;

--- a/src/Files.App/Data/Models/CompressArchiveModel.cs
+++ b/src/Files.App/Data/Models/CompressArchiveModel.cs
@@ -158,10 +158,10 @@ namespace Files.App.Data.Models
 			};
 
 			compressor.CustomParameters.Add("mt", CPUThreads.ToString());
-			//Use UTF-8 encoding. 
-			//References: 7-zip chm --> Command Line Version --> Switches
-			//--> -m --> cu=[off | on].
-			//Don't add "cu" parameter for 7zip files, see https://github.com/files-community/Files/issues/17257
+			// Use UTF-8 encoding. 
+			// References: 7-zip chm --> Command Line Version --> Switches
+			// --> -m --> cu=[off | on].
+			// Don't add "cu" parameter for 7zip files, see https://github.com/files-community/Files/issues/17257
 			if (FileFormat != ArchiveFormats.SevenZip)
 				compressor.CustomParameters.Add("cu", "on");
 

--- a/src/Files.App/Data/Models/CompressArchiveModel.cs
+++ b/src/Files.App/Data/Models/CompressArchiveModel.cs
@@ -161,6 +161,8 @@ namespace Files.App.Data.Models
 			//Use UTF-8 encoding. 
 			//References: 7-zip chm --> Command Line Version --> Switches
 			//--> -m --> cu=[off | on].
+			if (FileFormat != ArchiveFormats.SevenZip)
+				compressor.CustomParameters.Add("cu", "on");
 
 			compressor.Compressing += Compressor_Compressing;
 			compressor.FileCompressionStarted += Compressor_FileCompressionStarted;


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #17257

**Steps used to test these changes**

1. Trace the logic of 7z archive compression by Right-clicking the mouse and selecting "Create xxx.7z" under the "Compress" option in the context menu.
2. Upon step debugging, found out that adding the custom parameter `cu` was throwing an exception from the file with the error of `System.ArgumentException: Value does not fall within the expected range`
3. After applying the fixes, compress multiple files by selecting `Create xxx.7z` under the `Compress` option in the context menu and then extract the created `7z` archive.

**Fix Description**
- Upon checking the documentation from the [site](https://7-zip.opensource.jp/chm/cmdline/switches/method.htm#7Z), I noticed that the `7z` archive does not contain the parameter `cu`.
- I assume this could be the one causing the issue as when I tested without the `cu` archive, the bug reported by the original poster is fixed.
- I also checked the `.chm` file from my downloaded `7zip` instance. The version is 7-Zip 24.09 (x64)