### PR TITLE
Fix: Fixed issue where the 'layout' icon didn't match the select layout

### DIFF
--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.Properties.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.Properties.cs
@@ -97,5 +97,22 @@ namespace Files.App.Controls
 		{
 			UpdateVisualStates();
 		}
+
+		private void OnStylePropertyChanged(DependencyObject sender, DependencyProperty dp)
+		{
+			if (dp != StyleProperty)
+				return;
+
+			DispatcherQueue.TryEnqueue(() =>
+			{
+				GetTemplateParts();
+				OnFilledIconChanged();
+				OnOutlineIconChanged();
+				OnLayeredIconChanged();
+				OnIconTypeChanged();
+				OnIconColorTypeChanged();
+				OnIconSizeChanged();
+			});
+		}
 	}
 }

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
@@ -26,11 +26,14 @@ namespace Files.App.Controls
 				StyleProperty,
 				OnStylePropertyChanged
 			);
+
+			Unloaded += OnUnloaded;
 		}
 
-		~ThemedIcon()
+		private void OnUnloaded(object sender, RoutedEventArgs e)
 		{
 			UnregisterPropertyChangedCallback(StyleProperty, _stylePropertyChangedToken);
+			Unloaded -= OnUnloaded;
 		}
 
 		protected override void OnApplyTemplate()

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
@@ -17,10 +17,20 @@ namespace Files.App.Controls
 		private Viewbox? _layeredViewBox;
 		private Canvas? _layeredCanvas;
 
+		private long _stylePropertyChangedToken;
+
 		public ThemedIcon()
 		{
 			DefaultStyleKey = typeof(ThemedIcon);
-			RegisterPropertyChangedCallback(StyleProperty, OnStylePropertyChanged);
+			_stylePropertyChangedToken = RegisterPropertyChangedCallback(
+				StyleProperty,
+				OnStylePropertyChanged
+			);
+		}
+
+		~ThemedIcon()
+		{
+			UnregisterPropertyChangedCallback(StyleProperty, _stylePropertyChangedToken);
 		}
 
 		protected override void OnApplyTemplate()

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
@@ -20,6 +20,7 @@ namespace Files.App.Controls
 		public ThemedIcon()
 		{
 			DefaultStyleKey = typeof(ThemedIcon);
+			RegisterPropertyChangedCallback(StyleProperty, OnStylePropertyChanged);
 		}
 
 		protected override void OnApplyTemplate()

--- a/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
+++ b/src/Files.App.Controls/ThemedIcon/ThemedIcon.cs
@@ -33,6 +33,7 @@ namespace Files.App.Controls
 		private void OnUnloaded(object sender, RoutedEventArgs e)
 		{
 			UnregisterPropertyChangedCallback(StyleProperty, _stylePropertyChangedToken);
+			IsEnabledChanged -= OnIsEnabledChanged;
 			Unloaded -= OnUnloaded;
 		}
 

--- a/src/Files.App/UserControls/NavigationToolbar.xaml
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml
@@ -297,12 +297,12 @@
 					<DataTemplate x:DataType="dataitems:NavigationBarSuggestionItem">
 						<Grid Padding="0,0,4,0" ColumnSpacing="12">
 							<Grid.ColumnDefinitions>
-								<!--<ColumnDefinition Width="Auto" />-->
+								<ColumnDefinition Width="Auto" />
 								<ColumnDefinition Width="*" />
 								<ColumnDefinition Width="Auto" />
 							</Grid.ColumnDefinitions>
 
-							<!--<Grid
+							<Grid
 								Grid.Column="0"
 								Width="16"
 								Height="16">
@@ -314,12 +314,12 @@
 								</Viewbox>
 								<controls:ThemedIcon Style="{x:Bind ThemedIconStyle, Mode=OneWay}" Visibility="{x:Bind ThemedIconStyle, Converter={StaticResource NullToVisibilityCollapsedConverter}, Mode=OneWay}" />
 								<Image Source="{x:Bind ActionIconSource, Mode=OneWay}" />
-							</Grid>-->
+							</Grid>
 
 							<!--  Primary Title  -->
 							<TextBlock
 								x:Name="PrimaryDisplayBlock"
-								Grid.Column="0"
+								Grid.Column="1"
 								VerticalAlignment="Center"
 								Foreground="{ThemeResource TextFillColorPrimaryBrush}"
 								TextTrimming="CharacterEllipsis"
@@ -330,7 +330,7 @@
 							<!--  Keyboard Shortcuts  -->
 							<keyboard:KeyboardShortcut
 								x:Name="RightAlignedKeyboardShortcut"
-								Grid.Column="1"
+								Grid.Column="2"
 								VerticalAlignment="Center"
 								HotKeys="{x:Bind HotKeys, Mode=OneWay}" />
 						</Grid>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17347 

**Notes**
- It seems that `Style` changes do not invoke `OnApplyTemplate`, so this solution is basically a workaround.
- I can't remember if we have anything against `Finalizer`s... should I dispose the object in a different way?


**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open a folder
2. Change the layout using the toolbar's button
3. See that the icon changes
4. Try swapping panes
5. Check if this fixes a similar issue with `Cloud Sync Status` (I can't test this myself)
