### PR TITLE
Fix: Fixed issue with clearing selection via touch

### DIFF
--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
@@ -538,6 +538,11 @@ namespace Files.App.Views.Layouts
 			else
 			{
 				CloseFolder();
+
+				// Clear selection when clicking empty area via touch
+				// https://github.com/files-community/Files/issues/15051
+				if (e.PointerDeviceType == PointerDeviceType.Touch)
+					ItemManipulationModel.ClearSelection();
 			}
 		}
 

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -567,6 +567,13 @@ namespace Files.App.Views.Layouts
 							await CommitRenameAsync(textBox);
 					}
 				}
+				else
+				{
+					// Clear selection when clicking empty area via touch
+					// https://github.com/files-community/Files/issues/15051
+					if (e.PointerDeviceType == PointerDeviceType.Touch)
+						ItemManipulationModel.ClearSelection();
+				}
 				return;
 			}
 

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -615,6 +615,8 @@ namespace Files.App.Views.Layouts
 				// https://github.com/files-community/Files/issues/15051
 				if (e.PointerDeviceType == PointerDeviceType.Touch)
 					ItemManipulationModel.ClearSelection();
+
+				return;
 			}
 
 			// Skip code if the control or shift key is pressed or if the user is using multiselect

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -610,7 +610,12 @@ namespace Files.App.Views.Layouts
 
 			var item = (e.OriginalSource as FrameworkElement)?.DataContext as ListedItem;
 			if (item is null)
-				return;
+			{
+				// Clear selection when clicking empty area via touch
+				// https://github.com/files-community/Files/issues/15051
+				if (e.PointerDeviceType == PointerDeviceType.Touch)
+					ItemManipulationModel.ClearSelection();
+			}
 
 			// Skip code if the control or shift key is pressed or if the user is using multiselect
 			if (ctrlPressed ||


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15051

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Select items
2. Tapped empty space using touch screen
3. Confirmed selection is cleared
4. Confirmed long touch and hold still opens right click menu
5. Confirmed clicking with mouse clears selection
6. Confirmed right clicking with mouse clears selection