### PR TITLE
Code Quality: Added DisableRuntimeMarshalling to the all trim-safe projects

### DIFF
--- a/src/Files.App.BackgroundTasks/Files.App.BackgroundTasks.csproj
+++ b/src/Files.App.BackgroundTasks/Files.App.BackgroundTasks.csproj
@@ -11,6 +11,7 @@
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <IsAotCompatible>true</IsAotCompatible>
+        <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Files.App.CsWin32/Files.App.CsWin32.csproj
+++ b/src/Files.App.CsWin32/Files.App.CsWin32.csproj
@@ -10,6 +10,7 @@
         <Platforms>x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <IsAotCompatible>true</IsAotCompatible>
+        <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Files.App.Server/Files.App.Server.csproj
+++ b/src/Files.App.Server/Files.App.Server.csproj
@@ -28,6 +28,7 @@
         <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
         <CsWinRTEnableLogging>true</CsWinRTEnableLogging>
         <IsAotCompatible>true</IsAotCompatible>
+        <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Files.App.Storage/Files.App.Storage.csproj
+++ b/src/Files.App.Storage/Files.App.Storage.csproj
@@ -11,6 +11,7 @@
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <IsAotCompatible>true</IsAotCompatible>
+        <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Files.Core.Storage/Files.Core.Storage.csproj
+++ b/src/Files.Core.Storage/Files.Core.Storage.csproj
@@ -9,6 +9,7 @@
         <Platforms>x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <IsAotCompatible>true</IsAotCompatible>
+        <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Files.Shared/Files.Shared.csproj
+++ b/src/Files.Shared/Files.Shared.csproj
@@ -9,6 +9,7 @@
         <Platforms>x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <IsAotCompatible>true</IsAotCompatible>
+        <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Resolved / Related Issues

Disabled runtime marshaling in the projects that are already trim-safe in order to prevent people from adding a piece of code that uses runtime marshaling.

- #15000

### Steps used to test these changes

_N/A_
