### PR TITLE
Code Quality: Fixed keyboard shortcuts when refocusing window

### DIFF
--- a/src/Files.App/Actions/Navigation/NextTabAction.cs
+++ b/src/Files.App/Actions/Navigation/NextTabAction.cs
@@ -9,6 +9,7 @@ namespace Files.App.Actions
 	internal sealed partial class NextTabAction : ObservableObject, IAction
 	{
 		private readonly IMultitaskingContext multitaskingContext;
+		private readonly IContentPageContext contentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		public string Label
 			=> Strings.NextTab.GetLocalizedResource();
@@ -37,7 +38,7 @@ namespace Files.App.Actions
 			await Task.Delay(500);
 
 			// Focus the content of the selected tab item (needed for keyboard navigation)
-			(multitaskingContext.CurrentTabItem.TabItemContent as Control)?.Focus(FocusState.Programmatic);
+			contentPageContext.ShellPage!.PaneHolder.FocusActivePane();
 		}
 
 		private void MultitaskingContext_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Files.App/Actions/Navigation/PreviousTabAction.cs
+++ b/src/Files.App/Actions/Navigation/PreviousTabAction.cs
@@ -9,6 +9,7 @@ namespace Files.App.Actions
 	internal sealed partial class PreviousTabAction : ObservableObject, IAction
 	{
 		private readonly IMultitaskingContext multitaskingContext;
+		private readonly IContentPageContext contentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		public string Label
 			=> Strings.PreviousTab.GetLocalizedResource();
@@ -40,7 +41,7 @@ namespace Files.App.Actions
 			await Task.Delay(500);
 
 			// Focus the content of the selected tab item (needed for keyboard navigation)
-			(multitaskingContext.CurrentTabItem.TabItemContent as Control)?.Focus(FocusState.Programmatic);
+			contentPageContext.ShellPage!.PaneHolder.FocusActivePane();
 		}
 
 		private void MultitaskingContext_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Files.App/Data/Contracts/IShellPanesPage.cs
+++ b/src/Files.App/Data/Contracts/IShellPanesPage.cs
@@ -70,6 +70,11 @@ namespace Files.App.Data.Contracts
 		public void FocusActivePane();
 
 		/// <summary>
+		/// Locks the active pane.
+		/// </summary>
+		public void LockActivePane();
+
+		/// <summary>
 		/// Gets open panes.
 		/// </summary>
 		/// <returns>An enumerable containing open panes.</returns>

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml
@@ -261,8 +261,7 @@
 						HorizontalAlignment="Stretch"
 						VerticalAlignment="Stretch"
 						Fill="Transparent"
-						Loaded="DragAreaRectangle_Loaded"
-						PointerReleased="DragAreaRectangle_PointerReleased" />
+						Loaded="DragAreaRectangle_Loaded" />
 
 				</Grid>
 			</TabView.TabStripFooter>

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml
@@ -145,7 +145,7 @@
 								x:Name="SplitPaneMenuItem"
 								x:Load="{x:Bind Commands.SplitPaneHorizontally.IsExecutable, Mode=OneWay}"
 								Text="{helpers:ResourceString Name=SplitPane}">
-								<MenuFlyoutSubItem.Items>									
+								<MenuFlyoutSubItem.Items>
 									<!--  Vertical  -->
 									<uc:MenuFlyoutItemWithThemedIcon
 										x:Name="AddVerticalPaneTabActionButton"
@@ -261,7 +261,8 @@
 						HorizontalAlignment="Stretch"
 						VerticalAlignment="Stretch"
 						Fill="Transparent"
-						Loaded="DragAreaRectangle_Loaded" />
+						Loaded="DragAreaRectangle_Loaded"
+						PointerReleased="DragAreaRectangle_PointerReleased" />
 
 				</Grid>
 			</TabView.TabStripFooter>

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -19,6 +19,7 @@ namespace Files.App.UserControls.TabBar
 		private readonly ICommandManager Commands = Ioc.Default.GetRequiredService<ICommandManager>();
 		private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 		private readonly IWindowContext WindowContext = Ioc.Default.GetRequiredService<IWindowContext>();
+		private readonly IContentPageContext ContentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		// Fields
 
@@ -371,6 +372,13 @@ namespace Files.App.UserControls.TabBar
 			HorizontalTabView.Measure(new(
 				HorizontalTabView.ActualWidth - TabBarAddNewTabButton.Width - titleBarInset,
 				HorizontalTabView.ActualHeight));
+		}
+
+		private void DragAreaRectangle_PointerReleased(object sender, PointerRoutedEventArgs e)
+		{
+			// Workaround for issue where clicking the drag area prevents keyboard
+			// shortcuts from working, see https://github.com/microsoft/microsoft-ui-xaml/issues/6467
+			DispatcherQueue.TryEnqueue(() => ContentPageContext.ShellPage!.PaneHolder.FocusActivePane());
 		}
 	}
 }

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -19,7 +19,6 @@ namespace Files.App.UserControls.TabBar
 		private readonly ICommandManager Commands = Ioc.Default.GetRequiredService<ICommandManager>();
 		private readonly IAppearanceSettingsService AppearanceSettingsService = Ioc.Default.GetRequiredService<IAppearanceSettingsService>();
 		private readonly IWindowContext WindowContext = Ioc.Default.GetRequiredService<IWindowContext>();
-		private readonly IContentPageContext ContentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		// Fields
 

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -373,12 +373,5 @@ namespace Files.App.UserControls.TabBar
 				HorizontalTabView.ActualWidth - TabBarAddNewTabButton.Width - titleBarInset,
 				HorizontalTabView.ActualHeight));
 		}
-
-		private void DragAreaRectangle_PointerReleased(object sender, PointerRoutedEventArgs e)
-		{
-			// Workaround for issue where clicking the drag area prevents keyboard
-			// shortcuts from working, see https://github.com/microsoft/microsoft-ui-xaml/issues/6467
-			DispatcherQueue.TryEnqueue(() => ContentPageContext.ShellPage!.PaneHolder.FocusActivePane());
-		}
 	}
 }

--- a/src/Files.App/UserControls/Toolbar.xaml
+++ b/src/Files.App/UserControls/Toolbar.xaml
@@ -60,8 +60,7 @@
 		BackgroundSizing="InnerBorderEdge"
 		BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
 		BorderThickness="1"
-		CornerRadius="8"
-		PointerReleased="RootGrid_PointerReleased">
+		CornerRadius="8">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="*" />
 			<ColumnDefinition Width="Auto" />
@@ -688,7 +687,10 @@
 				<controls:ThemedIcon Style="{x:Bind ViewModel.LayoutThemedIcon, Mode=OneWay}" />
 
 				<AppBarButton.Flyout>
-					<Flyout contract8Present:ShouldConstrainToRootBounds="False" Placement="Bottom">
+					<Flyout
+						x:Name="LayoutFlyout"
+						contract8Present:ShouldConstrainToRootBounds="False"
+						Placement="Bottom">
 						<StackPanel Spacing="12">
 
 							<!--  Header  -->
@@ -700,6 +702,7 @@
 								<!--  Details  -->
 								<RadioButton
 									AutomationProperties.Name="{x:Bind Commands.LayoutDetails.AutomationName}"
+									Click="LayoutButton_Click"
 									Command="{x:Bind Commands.LayoutDetails}"
 									GroupName="LayoutRadio"
 									IsChecked="{x:Bind ViewModel.IsDetailsLayout, Mode=OneWay}"
@@ -723,6 +726,7 @@
 								<!--  List  -->
 								<RadioButton
 									AutomationProperties.Name="{x:Bind Commands.LayoutList.AutomationName}"
+									Click="LayoutButton_Click"
 									Command="{x:Bind Commands.LayoutList}"
 									GroupName="LayoutRadio"
 									IsChecked="{x:Bind ViewModel.IsListLayout, Mode=OneWay}"
@@ -747,6 +751,7 @@
 								<!--  Cards  -->
 								<RadioButton
 									AutomationProperties.Name="{x:Bind Commands.LayoutCards.AutomationName}"
+									Click="LayoutButton_Click"
 									Command="{x:Bind Commands.LayoutCards}"
 									GroupName="LayoutRadio"
 									IsChecked="{x:Bind ViewModel.IsCardsLayout, Mode=OneWay}"
@@ -771,6 +776,7 @@
 								<!--  Grid  -->
 								<RadioButton
 									AutomationProperties.Name="{x:Bind Commands.LayoutGrid.AutomationName}"
+									Click="LayoutButton_Click"
 									Command="{x:Bind Commands.LayoutGrid}"
 									GroupName="LayoutRadio"
 									IsChecked="{x:Bind ViewModel.IsGridLayout, Mode=OneWay}"
@@ -795,6 +801,7 @@
 								<!--  Columns  -->
 								<RadioButton
 									AutomationProperties.Name="{x:Bind Commands.LayoutColumns.AutomationName}"
+									Click="LayoutButton_Click"
 									Command="{x:Bind Commands.LayoutColumns}"
 									GroupName="LayoutRadio"
 									IsChecked="{x:Bind ViewModel.IsColumnLayout, Mode=OneWay}"

--- a/src/Files.App/UserControls/Toolbar.xaml
+++ b/src/Files.App/UserControls/Toolbar.xaml
@@ -60,7 +60,8 @@
 		BackgroundSizing="InnerBorderEdge"
 		BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
 		BorderThickness="1"
-		CornerRadius="8">
+		CornerRadius="8"
+		PointerReleased="RootGrid_PointerReleased">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="*" />
 			<ColumnDefinition Width="Auto" />

--- a/src/Files.App/UserControls/Toolbar.xaml.cs
+++ b/src/Files.App/UserControls/Toolbar.xaml.cs
@@ -17,7 +17,6 @@ namespace Files.App.UserControls
 		private readonly ICommandManager Commands = Ioc.Default.GetRequiredService<ICommandManager>();
 		private readonly IModifiableCommandManager ModifiableCommands = Ioc.Default.GetRequiredService<IModifiableCommandManager>();
 		private readonly IAddItemService addItemService = Ioc.Default.GetRequiredService<IAddItemService>();
-		private readonly IContentPageContext ContentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		[GeneratedDependencyProperty]
 		public partial NavigationToolbarViewModel? ViewModel { get; set; }
@@ -110,11 +109,10 @@ namespace Files.App.UserControls
 				args.Handled = true;
 		}
 
-		private void RootGrid_PointerReleased(object sender, PointerRoutedEventArgs e)
+		private void LayoutButton_Click(object sender, RoutedEventArgs e)
 		{
-			// Workaround for issue where clicking the toolbar prevents keyboard
-			// shortcuts from working, see https://github.com/microsoft/microsoft-ui-xaml/issues/6467
-			DispatcherQueue.TryEnqueue(() => ContentPageContext.ShellPage!.PaneHolder.FocusActivePane());
+			// Hide flyout after choosing a layout
+			LayoutFlyout.Hide();
 		}
 	}
 }

--- a/src/Files.App/UserControls/Toolbar.xaml.cs
+++ b/src/Files.App/UserControls/Toolbar.xaml.cs
@@ -17,6 +17,7 @@ namespace Files.App.UserControls
 		private readonly ICommandManager Commands = Ioc.Default.GetRequiredService<ICommandManager>();
 		private readonly IModifiableCommandManager ModifiableCommands = Ioc.Default.GetRequiredService<IModifiableCommandManager>();
 		private readonly IAddItemService addItemService = Ioc.Default.GetRequiredService<IAddItemService>();
+		private readonly IContentPageContext ContentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		[GeneratedDependencyProperty]
 		public partial NavigationToolbarViewModel? ViewModel { get; set; }
@@ -107,6 +108,13 @@ namespace Files.App.UserControls
 			// Suppress access key invocation if any dialog is open
 			if (VisualTreeHelper.GetOpenPopupsForXamlRoot(MainWindow.Instance.Content.XamlRoot).Any())
 				args.Handled = true;
+		}
+
+		private void RootGrid_PointerReleased(object sender, PointerRoutedEventArgs e)
+		{
+			// Workaround for issue where clicking the toolbar prevents keyboard
+			// shortcuts from working, see https://github.com/microsoft/microsoft-ui-xaml/issues/6467
+			DispatcherQueue.TryEnqueue(() => ContentPageContext.ShellPage!.PaneHolder.FocusActivePane());
 		}
 	}
 }

--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -391,7 +391,7 @@ namespace Files.App.ViewModels
 				await Task.Delay(500);
 
 				// Focus the content of the selected tab item (needed for keyboard navigation)
-				(SelectedTabItem?.TabItemContent as Control)?.Focus(FocusState.Programmatic);
+				context.ShellPage!.PaneHolder.FocusActivePane();
 			}
 
 			e.Handled = true;

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -584,6 +584,13 @@ namespace Files.App.ViewModels
 
 		private async void LayoutModeChangeRequested(object? sender, LayoutModeEventArgs e)
 		{
+			// Layout changes can cause the active pane to lose focus. To prevent this,
+			// the pane is locked here and focus is restored when file loading completes
+			// in the RefreshItem() method in BaseLayoutPage.cs.
+			// See https://github.com/files-community/Files/issues/15397
+			// See https://github.com/files-community/Files/issues/16530
+			ContentPageContext.ShellPage!.PaneHolder.LockActivePane();
+
 			await dispatcherQueue.EnqueueOrInvokeAsync(CheckForBackgroundImage, Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
 		}
 

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1240,8 +1240,14 @@ namespace Files.App.Views.Layouts
 						if (ParentShellPageInstance.ShellViewModel.EnabledGitProperties is not GitProperties.None && listedItem is IGitItem gitItem)
 							await ParentShellPageInstance.ShellViewModel.LoadGitPropertiesAsync(gitItem);
 
-						// Focus file list when items finish loading (#16530)
-						ItemManipulationModel.FocusFileList();
+						// Layout changes can cause the active pane to lose focus. To prevent this,
+						// the pane is locked in LayoutModeChangeRequested() and focus is restored here
+						// when file loading completes.
+						// See https://github.com/files-community/Files/issues/15397
+						// See https://github.com/files-community/Files/issues/16530
+
+						if (ParentShellPageInstance.IsCurrentPane && !ParentShellPageInstance.IsColumnView)
+							ItemManipulationModel.FocusFileList();
 					});
 				}
 			}

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -22,6 +22,7 @@
 	KeyboardAcceleratorPlacementMode="Hidden"
 	Loaded="Page_Loaded"
 	NavigationCacheMode="Required"
+	PointerReleased="Page_PointerReleased"
 	SizeChanged="Page_SizeChanged"
 	mc:Ignorable="d">
 

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -481,7 +481,7 @@ namespace Files.App.Views
 		{
 			// Workaround for issue where clicking an empty area in the window (toolbar, title bar etc) prevents keyboard
 			// shortcuts from working properly, see https://github.com/microsoft/microsoft-ui-xaml/issues/6467
-			DispatcherQueue.TryEnqueue(() => ContentPageContext.ShellPage!.PaneHolder.FocusActivePane());
+			DispatcherQueue.TryEnqueue(() => ContentPageContext.ShellPage?.PaneHolder.FocusActivePane());
 		}
 	}
 }

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -476,5 +476,12 @@ namespace Files.App.Views
 			if (VisualTreeHelper.GetOpenPopupsForXamlRoot(MainWindow.Instance.Content.XamlRoot).Any())
 				args.Handled = true;
 		}
+
+		private void Page_PointerReleased(object sender, PointerRoutedEventArgs e)
+		{
+			// Workaround for issue where clicking an empty area in the window (toolbar, title bar etc) prevents keyboard
+			// shortcuts from working properly, see https://github.com/microsoft/microsoft-ui-xaml/issues/6467
+			DispatcherQueue.TryEnqueue(() => ContentPageContext.ShellPage!.PaneHolder.FocusActivePane());
+		}
 	}
 }

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -162,7 +162,6 @@ namespace Files.App.Views
 			// Focus the content of the selected tab item (this also avoids an issue where the Omnibar sometimes steals the focus)
 			await Task.Delay(100);
 			ContentPageContext.ShellPage!.PaneHolder.FocusActivePane();
-
 		}
 
 		private void PaneHolder_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Files.App/Views/ShellPanesPage.xaml.cs
+++ b/src/Files.App/Views/ShellPanesPage.xaml.cs
@@ -20,6 +20,7 @@ namespace Files.App.Views
 		// Dependency injections
 
 		private IGeneralSettingsService GeneralSettingsService { get; } = Ioc.Default.GetRequiredService<IGeneralSettingsService>();
+		private IContentPageContext ContentPageContext { get; } = Ioc.Default.GetRequiredService<IContentPageContext>();
 		private AppModel AppModel { get; } = Ioc.Default.GetRequiredService<AppModel>();
 
 		// Constants
@@ -383,12 +384,14 @@ namespace Files.App.Views
 		/// <inheritdoc/>
 		public void FocusActivePane()
 		{
-			if (ActivePane is BaseShellPage baseShellPage)
-				baseShellPage.ContentPage?.ItemManipulationModel.FocusFileList();
-			else if (ActivePane == (IShellPage)GetPane(0)!)
+			if (ActivePane == (IShellPage)GetPane(0)!)
 				GetPane(0)?.Focus(FocusState.Programmatic);
 			else
 				GetPane(1)?.Focus(FocusState.Programmatic);
+
+			// Focus file list
+			if (ActivePane is BaseShellPage baseShellPage)
+				baseShellPage.ContentPage?.ItemManipulationModel.FocusFileList();
 		}
 
 		/// <inheritdoc/>

--- a/src/Files.App/Views/ShellPanesPage.xaml.cs
+++ b/src/Files.App/Views/ShellPanesPage.xaml.cs
@@ -383,7 +383,9 @@ namespace Files.App.Views
 		/// <inheritdoc/>
 		public void FocusActivePane()
 		{
-			if (ActivePane == (IShellPage)GetPane(0)!)
+			if (ActivePane is BaseShellPage baseShellPage)
+				baseShellPage.ContentPage?.ItemManipulationModel.FocusFileList();
+			else if (ActivePane == (IShellPage)GetPane(0)!)
 				GetPane(0)?.Focus(FocusState.Programmatic);
 			else
 				GetPane(1)?.Focus(FocusState.Programmatic);


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17500
- Added a new solution for #15397 and #16530
- Fixed an issue where active pane changed when switching tabs via keyboard shortcuts
- Automatically close flyout after choosing a layout

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Clicked Toolbar
2. Confirmed keyboard shortcuts work
3. Repeated test with TitleBar
4. Confirmed these changes don't cause issues with Dual Pane