### PR TITLE
Feature: Added support for cloning GitLab repository URLs

### DIFF
--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -943,7 +943,7 @@ namespace Files.App.Utils.Git
 				ReturnResult.Failed);
 		}
 
-		[GeneratedRegex(@"^(?:https?:\/\/)?(?:www\.)?github\.com\/(?<user>[^\/]+)\/(?<repo>[^\/]+?)(?=\.git|\/|$)(?:\.git)?(?:\/)?", RegexOptions.IgnoreCase)]
+		[GeneratedRegex(@"^(?:https?:\/\/)?(?:www\.)?(github|gitlab)\.com\/(?<user>[^\/]+)\/(?<repo>[^\/]+?)(?=\.git|\/|$)(?:\.git)?(?:\/)?", RegexOptions.IgnoreCase)]
 		private static partial Regex GitHubRepositoryRegex();
 	}
 }

--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -870,10 +870,11 @@ namespace Files.App.Utils.Git
 			if (!match.Success)
 				return (string.Empty, string.Empty);
 
+			string platform = match.Groups["domain"].Value;
 			string userOrOrg = match.Groups["user"].Value;
 			string repoName = match.Groups["repo"].Value;
 
-			string repoUrl = $"https://github.com/{userOrOrg}/{repoName}";
+			string repoUrl = $"https://{platform}.com/{userOrOrg}/{repoName}";
 			return (repoUrl, repoName);
 		}
 
@@ -943,7 +944,7 @@ namespace Files.App.Utils.Git
 				ReturnResult.Failed);
 		}
 
-		[GeneratedRegex(@"^(?:https?:\/\/)?(?:www\.)?(github|gitlab)\.com\/(?<user>[^\/]+)\/(?<repo>[^\/]+?)(?=\.git|\/|$)(?:\.git)?(?:\/)?", RegexOptions.IgnoreCase)]
+		[GeneratedRegex(@"^(?:https?:\/\/)?(?:www\.)?(?<domain>github|gitlab)\.com\/(?<user>[^\/]+)\/(?<repo>[^\/]+?)(?=\.git|\/|$)(?:\.git)?(?:\/)?", RegexOptions.IgnoreCase)]
 		private static partial Regex GitHubRepositoryRegex();
 	}
 }


### PR DESCRIPTION
**Resolved / Related Issues**

Closes https://github.com/files-community/Files/issues/17385

**Steps used to test these changes**

_Method 1: Using Command Palette_
Opened the Files app and navigated to an available folder.
Pressed Ctrl + Shift + P to open the command palette.
Entered Clone and selected Clone Git Repository.
Pasted https://gitlab.com/es-de/emulationstation-de.git in the repository URL text box.
Verified that the Clone button was enabled.
Clicked the Clone button, and the repository was successfully cloned to the local folder.

_Method 2: Using Drag & Drop_
Opened the Files app and navigated to an available folder.
Dragged and dropped the repository link (https://gitlab.com/es-de/emulationstation-de.git) into the Files window.
Verified that the Clone button was enabled.
Clicked the Clone button, and the repository was successfully cloned to the local folder.

Note:

Repeated the above steps with https://github.com/files-community/Files.git to ensure there was no impact on cloning existing GitHub URLs.