### PR TITLE
Fix: Fixed executable flag for shortcut items in drag operation

### DIFF
--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1100,7 +1100,7 @@ namespace Files.App.Views.Layouts
 					{
 						e.DragUIOverride.IsCaptionVisible = true;
 
-						if (item.IsExecutable || item.IsScriptFile)
+						if (((item as IShortcutItem)?.IsExecutable ?? item.IsExecutable) || ((item as IShortcutItem)?.IsScriptFile ?? item.IsScriptFile))
 						{
 							e.DragUIOverride.Caption = $"{Strings.OpenWith.GetLocalizedResource()} {item.Name}";
 							e.AcceptedOperation = DataPackageOperation.Link;
@@ -1189,7 +1189,7 @@ namespace Files.App.Views.Layouts
 			dragOverItem = null;
 			var item = GetItemFromElement(sender);
 			if (item is not null)
-				await ParentShellPageInstance!.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, (item as IShortcutItem)?.TargetPath ?? item.ItemPath, false, true, (item as IShortcutItem)?.IsExecutable ?? item.IsExecutable, item.IsScriptFile);
+				await ParentShellPageInstance!.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, (item as IShortcutItem)?.TargetPath ?? item.ItemPath, false, true, (item as IShortcutItem)?.IsExecutable ?? item.IsExecutable, (item as IShortcutItem)?.IsScriptFile ?? item.IsScriptFile);
 
 			deferral.Complete();
 		}
@@ -1379,8 +1379,8 @@ namespace Files.App.Views.Layouts
 
 			UninitializeDrag(container);
 			if ((item.PrimaryItemAttribute == StorageItemTypes.Folder && !StorageTrashBinService.IsUnderTrashBin(item.ItemPath))
-				|| item.IsExecutable
-				|| item.IsScriptFile)
+				|| ((item as IShortcutItem)?.IsExecutable ?? item.IsExecutable)
+				|| ((item as IShortcutItem)?.IsScriptFile ?? item.IsScriptFile))
 			{
 				container.AllowDrop = true;
 				container.AddHandler(UIElement.DragOverEvent, Item_DragOverEventHandler, true);


### PR DESCRIPTION
Updates the drag-and-drop operation to correctly use the IsExecutable property from IShortcutItem when available, ensuring proper handling of shortcut items during file operations.

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17554

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
