### PR TITLE
Fix : mirrored WebView content in RTL mode (#17615)

### DIFF
--- a/src/Files.App/Views/ReleaseNotesPage.xaml.cs
+++ b/src/Files.App/Views/ReleaseNotesPage.xaml.cs
@@ -83,6 +83,8 @@ namespace Files.App.Views
 
 		private async void BlogPostWebView_CoreWebView2Initialized(WebView2 sender, CoreWebView2InitializedEventArgs args)
 		{
+            sender.FlowDirection = FlowDirection.LeftToRight;
+
 			sender.CoreWebView2.Profile.PreferredColorScheme = (CoreWebView2PreferredColorScheme)RootAppElement.RequestedTheme;
 			sender.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
 			sender.CoreWebView2.Settings.AreDevToolsEnabled = false;


### PR DESCRIPTION

**Description**
When the Files app is in RTL mode, the WebView content in Release Notes was mirrored. This PR forces the WebView to display content Left-to-Right.

**Resolved / Related Issues**
- Closes #17615

**Steps used to test these changes**
1. Opened Files.
2. Changed app language to an RTL language (e.g., Arabic or Hebrew) from Settings → Preferences → Language.
3. Navigated to Release Notes page.
4. Verified that the sidebar, toolbar, and other app UI correctly display in RTL.
5. Verified that the Release Notes WebView content stays in LTR (not mirrored).
6. Tested switching back to English (LTR) to confirm that Release Notes still display correctly.
7. Clicked a few links inside Release Notes to ensure normal behavior (open in browser).
