### PR TITLE
Fix: Fixed issue where the delete tag button had poor styling

### DIFF
--- a/src/Files.App/Views/Settings/TagsPage.xaml
+++ b/src/Files.App/Views/Settings/TagsPage.xaml
@@ -274,10 +274,10 @@
 																<Button Click="CancelRemoveTag_Click" Content="{helpers:ResourceString Name=Cancel}" />
 
 																<Button
-																	Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}"
 																	BorderBrush="Transparent"
 																	Click="RemoveTag_Click"
-																	Content="{helpers:ResourceString Name=Delete}" />
+																	Content="{helpers:ResourceString Name=Delete}"
+																	Style="{StaticResource AccentButtonStyle}" />
 															</StackPanel>
 														</StackPanel>
 													</Flyout>


### PR DESCRIPTION
Replaces the critical background brush with the AccentButtonStyle for the delete button in the tag removal flyout, ensuring consistent styling with other accent buttons.

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17623

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open settings > tags
2. Clicked 'delete'
3. Hovered over 'delete' button and confirmed it no longer flashes