### PR TITLE
Fix: Fixed an issue where right-clicking on a file caused the applica…

### DIFF
--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -24,6 +24,7 @@
         <UseWinUI>true</UseWinUI>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<CETCompat>false</CETCompat>
         <Configurations>Debug;Release</Configurations>
         <CsWinRTIncludes>Files.App.Server;Microsoft.UI.Content.ContentExternalOutputLink;Microsoft.UI.Content.IContentExternalOutputLink</CsWinRTIncludes>
         <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>


### PR DESCRIPTION
**Resolved / Related Issues**

Closes #17535
Fixed the crash issue by opting out of Intel CET compatibility

**Steps used to test these changes**

1. Open the Files app and navigate to a directory that contains both files and folders.
2. Right-click on a folder and the context menu is shown.
3. Right-click on a file (e.g., .txt, .jpg, .pdf, .exe) and the context menu is shown.
4. The application does not crash.