### PR TITLE
Code Quality: Fixed typo in Files.App.UITests.csproj‎

### DIFF
--- a/tests/Files.App.UITests/Files.App.UITests.csproj
+++ b/tests/Files.App.UITests/Files.App.UITests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <Manifest Include="$(ApplicationManifest)" />
-    <Content Include="Assetts\**\*.png" />
+    <Content Include="Assets\**\*.png" />
     <Content Include="Data\**\*.png" />
   </ItemGroup>
 


### PR DESCRIPTION
A small typo in `tests/Files.App.UITests/Files.App.UITests.csproj` prevents assets inside assets folder to be loaded

- Closes #17642

1. Opened Files ...
2. Was looking through the codebase and spotted it