### PR TITLE
Fix: Fixed issue with opening items from search results in Columns View

### DIFF
--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -458,8 +458,8 @@ namespace Files.App.Views.Layouts
 
 				if (ctrlPressed && !shiftPressed)
 				{
-					var folders = ParentShellPageInstance?.SlimContentPage.SelectedItems?.Where(file => file.PrimaryItemAttribute == StorageItemTypes.Folder);
-					if (folders is not null)
+					var folders = SelectedItems?.Where(file => file.PrimaryItemAttribute == StorageItemTypes.Folder);
+					if (folders?.Any() ?? false)
 					{
 						foreach (ListedItem folder in folders)
 							await NavigationHelpers.OpenPathInNewTab(folder.ItemPath);
@@ -467,15 +467,20 @@ namespace Files.App.Views.Layouts
 				}
 				else if (ctrlPressed && shiftPressed)
 				{
-					var selectedFolder = SelectedItems?.FirstOrDefault(item => item.PrimaryItemAttribute == StorageItemTypes.Folder);
-					if (selectedFolder is not null)
-						NavigationHelpers.OpenInSecondaryPane(ParentShellPageInstance, selectedFolder);
+					var selectedFolders = SelectedItems?.Where(item => item.PrimaryItemAttribute == StorageItemTypes.Folder);
+					if (selectedFolders?.Any() ?? false)
+					{
+						foreach (var selectedFolder in selectedFolders)
+							NavigationHelpers.OpenInSecondaryPane(ParentShellPageInstance, selectedFolder);
+					}
 				}
 				else if (!ctrlPressed && !shiftPressed && !UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
 				{
-					var selectedItem = SelectedItems?.FirstOrDefault();
-					if (selectedItem != null)
-						await OpenItem(selectedItem);
+					if (SelectedItems?.Any() ?? false)
+					{
+						foreach (var selectedItem in SelectedItems)
+							await OpenItem(selectedItem);
+					}
 				}
 			}
 			else if (e.Key == VirtualKey.Enter && e.KeyStatus.IsMenuKeyDown)

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -468,10 +468,9 @@ namespace Files.App.Views.Layouts
 				else if (ctrlPressed && shiftPressed)
 				{
 					var selectedFolders = SelectedItems?.Where(item => item.PrimaryItemAttribute == StorageItemTypes.Folder);
-					if (selectedFolders?.Any() ?? false)
+					if (selectedFolders?.Count() == 1)
 					{
-						foreach (var selectedFolder in selectedFolders)
-							NavigationHelpers.OpenInSecondaryPane(ParentShellPageInstance, selectedFolder);
+						NavigationHelpers.OpenInSecondaryPane(ParentShellPageInstance, selectedFolders.First());
 					}
 				}
 				else if (!ctrlPressed && !shiftPressed && !UserSettingsService.FoldersSettingsService.OpenItemsWithOneClick)
@@ -622,6 +621,7 @@ namespace Files.App.Views.Layouts
 		{
 			if (!Commands.OpenItem.IsExecutable)
 			{
+				// Fallback if the command is not executable. It occurs only when search is performed from the columns view.
 				var itemType = item.PrimaryItemAttribute == StorageItemTypes.Folder ? FilesystemItemType.Directory : FilesystemItemType.File;
 				await NavigationHelpers.OpenPath(item.ItemPath, ParentShellPageInstance, itemType);
 			}

--- a/src/Files.App/Views/Shells/ColumnShellPage.xaml.cs
+++ b/src/Files.App/Views/Shells/ColumnShellPage.xaml.cs
@@ -4,6 +4,7 @@
 using CommunityToolkit.WinUI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Navigation;
 
 namespace Files.App.Views.Shells
@@ -185,7 +186,37 @@ namespace Files.App.Views.Shells
 			if (string.IsNullOrEmpty(navigationPath))
 				return;
 
-			this.FindAscendant<ColumnsLayoutPage>()?.SetSelectedPathOrNavigate(navigationPath, sourcePageType, navArgs);
+			var columnsLayoutPage = this.FindAscendant<ColumnsLayoutPage>();
+			if (columnsLayoutPage != null)
+			{
+				columnsLayoutPage.SetSelectedPathOrNavigate(navigationPath, sourcePageType, navArgs);
+			}
+			else
+			{
+				if (sourcePageType is null)
+					sourcePageType = InstanceViewModel.FolderSettings.GetLayoutType(navigationPath);
+
+				if (navArgs is not null && navArgs.AssociatedTabInstance is not null)
+				{
+					ItemDisplayFrame.Navigate(
+						sourcePageType,
+						navArgs,
+						new SuppressNavigationTransitionInfo());
+				}
+				else
+				{
+					var newNavArgs = new NavigationArguments()
+					{
+						NavPathParam = navigationPath,
+						AssociatedTabInstance = this
+					};
+
+					ItemDisplayFrame.Navigate(
+						sourcePageType,
+						newNavArgs,
+						new SuppressNavigationTransitionInfo());
+				}
+			}
 		}
 
 		public override void NavigateHome()


### PR DESCRIPTION
**Resolved / Related Issues**

Closes #13311
Fixed issue where searches started from Columns view couldn't open results with double-click or Enter.

**Steps used to test these changes**

1. Open the Files app and navigate to a directory.
2. Switch to Columns view and start a search.
3. Confirm results render in Details layout.
4. From the search results, double-click an item or select it and press Enter to open it.
5. Verified the item opens.

Note:
It appears that navigation has issues with Columns view and does not correctly handle the context as it does for other layouts. Due to the complexity involved, I have modified the files specific to the Columns view and implemented an alternative approach.