### PR TITLE
Fix: Added conditional checking for virtual network path

### DIFF
--- a/src/Files.App/Services/Storage/StorageNetworkService.cs
+++ b/src/Files.App/Services/Storage/StorageNetworkService.cs
@@ -18,6 +18,14 @@ namespace Files.App.Services
 
 		private readonly static string guid = "::{f02c1a0d-be21-4350-88b0-7367fc96ef3c}";
 
+		// Virtual disk path prefixes that don't work with Windows networking APIs
+		private readonly static string[] VirtualDiskPrefixes =
+		[
+			@"\\RaiDrive-",
+			@"\\cryptomator-vault\",
+			@"\\EgnyteDrive\"
+		];
+
 
 		private ObservableCollection<IFolder> _Computers = [];
 		/// <inheritdoc/>
@@ -227,10 +235,9 @@ namespace Files.App.Services
 
 				}
 
-				// Skip authentication for RaiDrive virtual shares
-				// RaiDrive creates virtual UNC paths that don't work with Windows networking APIs
-				// Format is \\RaiDrive-{user}\{drive-custom-name}\
-				if (path.StartsWith(@"\\RaiDrive-", StringComparison.OrdinalIgnoreCase))
+				// Skip authentication for virtual disk shares
+				// These providers create virtual disk paths that don't work with Windows networking APIs
+				if (VirtualDiskPrefixes.Any(prefix => path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
 				{
 					return true;
 				}


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #17144

**Steps used to test these changes**
1. Download and install RaiDrive client application
2. Configure RaiDrive to mount an SFTP server connection via the RaiDrive GUI client
3. Verify the SFTP drive appears in Windows File Explorer as a network location
<img width="461" height="42" alt="image" src="https://github.com/user-attachments/assets/3a1c331b-dbd7-4eeb-a860-705135d78fb3" />

4. Attempt to access the RaiDrive SFTP drive using the Files application
5. Upon step debugging through AuthenticateNetworkShare function, observe that
RaiDrive SFTP paths follow the format \\RaiDrive-{username}\{drive-custom-name}\

<img width="494" height="57" alt="image" src="https://github.com/user-attachments/assets/811d5978-534f-4f67-ab08-c698b6bac29c" />

<img width="926" height="42" alt="image" src="https://github.com/user-attachments/assets/1efb7f50-0509-4fe2-803a-696417ecbed0" />

8. Notice that WNetAddConnection3W fails when attempting to resolve the RaiDrive
remoteName with either ERROR_BAD_NET_NAME or ERROR_NO_NET_OR_BAD_PATH

<img width="921" height="26" alt="image" src="https://github.com/user-attachments/assets/861eef83-5d40-4dd0-bf44-6043358a46ec" />

9. After applying the fix, successfully access RaiDrive SFTP drives through Files
application without errors

10. Checked with SSHFS to test behavior. 

<img width="902" height="27" alt="image" src="https://github.com/user-attachments/assets/84530185-41e8-40ff-a086-fb0ede542051" />


<img width="923" height="25" alt="image" src="https://github.com/user-attachments/assets/333bc5f4-a7d0-40e7-9274-6066254ba1a8" />

<img width="444" height="307" alt="image" src="https://github.com/user-attachments/assets/8bd0bd2d-f324-44b2-a983-da03f4d55f9c" />


11. SSHFS connecting to a SFTP server seems fine as it does prompt user to key in credentials and after inputting details the folder is accessible.