### PR TITLE
Fixed issue where clicking home icon on the Omnibar from Tags panel search results would not navigate to home

### DIFF
--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -510,7 +510,8 @@ namespace Files.App.ViewModels.UserControls
 				return;
 
 			if (normalizedInput.Equals(ContentPageContext.ShellPage.ShellViewModel.WorkingDirectory) &&
-				ContentPageContext.ShellPage.CurrentPageType != typeof(HomePage))
+				ContentPageContext.ShellPage.CurrentPageType != typeof(HomePage) &&
+				!ContentPageContext.ShellPage.ShellViewModel.IsSearchResults)
 				return;
 
 			if (normalizedInput.Equals("Home", StringComparison.OrdinalIgnoreCase) ||


### PR DESCRIPTION
**Resolved / Related Issues**

Fixed issue by modifying NavigationToolbarViewModel to allow home navigation when viewing search results

**Steps used to test these changes**

1. Open the Files app and navigate to one of the Tags.
2. Click the Home button.
3. Verified that it navigated to the home page.
4. Also verified home navigation by navigating to other folders and from search results, and all worked as expected.