### PR TITLE
Code Quality: Optimize large folder enumeration performance

### DIFF
--- a/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
+++ b/src/Files.App/Utils/Storage/Enumerators/Win32StorageEnumerator.cs
@@ -25,9 +25,10 @@ namespace Files.App.Utils.Storage
 			Func<List<ListedItem>, Task> intermediateAction
 		)
 		{
-			var sampler = new IntervalSampler(500);
+			var sampler = new IntervalSampler(5000);
 			var tempList = new List<ListedItem>();
 			var count = 0;
+			var disableIntermediateUpdates = false;
 
 			IUserSettingsService userSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
 			bool CalculateFolderSizes = userSettingsService.FoldersSettingsService.CalculateFolderSizes;
@@ -89,7 +90,10 @@ namespace Files.App.Utils.Storage
 				if (cancellationToken.IsCancellationRequested || count == countLimit)
 					break;
 
-				if (intermediateAction is not null && (count == 32 || sampler.CheckNow()))
+				if (count > 50000 && !disableIntermediateUpdates)
+					disableIntermediateUpdates = true;
+
+				if (intermediateAction is not null && !disableIntermediateUpdates && (count % 10000 == 0 || sampler.CheckNow()))
 				{
 					await intermediateAction(tempList);
 


### PR DESCRIPTION
**Resolved / Related Issues**

Fixed performance issues when enumerating large folders that would cause the UI to freeze or become unresponsive during folder scanning operations.

**Steps used to test these changes**

1. Open the Files app and navigate to a directory containing a large number of files (100,000+).
2. Observe the folder enumeration process and UI responsiveness.
3. The UI remains responsive during large folder operations without freezing.
