### PR TITLE
Feature: Added discovering phase to the Status Center

### DIFF
--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3487,6 +3487,9 @@
   <data name="ProcessingItems" xml:space="preserve">
     <value>Processing items...</value>
   </data>
+  <data name="DiscoveringItems" xml:space="preserve">
+    <value>Discovery in progress...</value>
+  </data>
   <data name="SpeedWithColon" xml:space="preserve">
     <value>Speed:</value>
   </data>
@@ -3618,6 +3621,10 @@
     <value>Copying {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
+  <data name="StatusCenter_CopyDiscovery_Header" xml:space="preserve">
+    <value>Discovered {0, plural, one {# item} other {# items}}</value>
+    <comment>Shown in a StatusCenter card during file discovery phase.</comment>
+  </data>
   <data name="StatusCenter_DecompressCanceled_Header" xml:space="preserve">
     <value>Canceled extracting "{0}" to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
@@ -3670,6 +3677,10 @@
     <value>Deleting {0, plural, one {# item} other {# items}} from "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
+  <data name="StatusCenter_DeleteDiscovery_Header" xml:space="preserve">
+    <value>Discovered {0, plural, one {# item} other {# items}}</value>
+    <comment>Shown in a StatusCenter card during file discovery phase.</comment>
+  </data>
   <data name="StatusCenter_MoveCanceled_Header" xml:space="preserve">
     <value>Canceled moving {0, plural, one {# item} other {# items}} to "{1}"</value>
     <comment>Shown in a StatusCenter card.</comment>
@@ -3693,6 +3704,10 @@
   <data name="StatusCenter_MoveInProgress_SubHeader" xml:space="preserve">
     <value>Moving {0, plural, one {# item} other {# items}} from "{1}" to "{2}"</value>
     <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_MoveDiscovery_Header" xml:space="preserve">
+    <value>Discovered {0, plural, one {# item} other {# items}}</value>
+    <comment>Shown in a StatusCenter card during file discovery phase.</comment>
   </data>
   <data name="StatusCenter_MoveFailed_Header" xml:space="preserve">
     <value>Error moving {0, plural, one {# item} other {# items}} to "{1}"</value>

--- a/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
+++ b/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
@@ -659,7 +659,7 @@ namespace Files.App.Utils.StatusCenter
 
 						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
 							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath, destinationPath);
-						card.SubHeader = subHeaderString; 
+						card.SubHeader = subHeaderString;
 						break;
 					}
 				case FileOperationType.Move:

--- a/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
+++ b/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
@@ -611,7 +611,7 @@ namespace Files.App.Utils.StatusCenter
 				false);
 		}
 
-		public static void UpdateCardStrings(StatusCenterItem card)
+		public static void UpdateCardStrings(StatusCenterItem card, StatusCenterItemProgressModel? progressValue = null)
 		{
 			// Aren't used for now
 			string sourcePath = string.Empty;
@@ -645,20 +645,36 @@ namespace Files.App.Utils.StatusCenter
 			{
 				case FileOperationType.Copy:
 					{
-						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
-							: card.HeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, destinationDirName);
-						card.Header = headerString;
+						string headerResource = card.HeaderStringResource;
+
+						if (card.IsDiscovering && card.TotalItemsCount > 0 && card.IsInProgress)
+							headerResource = "StatusCenter_CopyDiscovery_Header";
+
+						if (string.IsNullOrWhiteSpace(headerResource))
+							card.Header = string.Empty;
+						else if (headerResource == "StatusCenter_CopyDiscovery_Header")
+							card.Header = headerResource.GetLocalizedFormatResource(card.TotalItemsCount);
+						else
+							card.Header = headerResource.GetLocalizedFormatResource(card.TotalItemsCount, destinationDirName);
 
 						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
 							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath, destinationPath);
-						card.SubHeader = subHeaderString;
+						card.SubHeader = subHeaderString; 
 						break;
 					}
 				case FileOperationType.Move:
 					{
-						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
-							: card.HeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, destinationDirName);
-						card.Header = headerString;
+						string headerResource = card.HeaderStringResource;
+
+						if (card.IsDiscovering && card.TotalItemsCount > 0 && card.IsInProgress)
+							headerResource = "StatusCenter_MoveDiscovery_Header";
+
+						if (string.IsNullOrWhiteSpace(headerResource))
+							card.Header = string.Empty;
+						else if (headerResource == "StatusCenter_MoveDiscovery_Header")
+							card.Header = headerResource.GetLocalizedFormatResource(card.TotalItemsCount);
+						else
+							card.Header = headerResource.GetLocalizedFormatResource(card.TotalItemsCount, destinationDirName);
 
 						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
 							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath, destinationPath);
@@ -667,9 +683,17 @@ namespace Files.App.Utils.StatusCenter
 					}
 				case FileOperationType.Delete:
 					{
-						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
-							: card.HeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourceDirName);
-						card.Header = headerString;
+						string headerResource = card.HeaderStringResource;
+
+						if (card.IsDiscovering && card.TotalItemsCount > 0 && card.IsInProgress)
+							headerResource = "StatusCenter_DeleteDiscovery_Header";
+
+						if (string.IsNullOrWhiteSpace(headerResource))
+							card.Header = string.Empty;
+						else if (headerResource == "StatusCenter_DeleteDiscovery_Header")
+							card.Header = headerResource.GetLocalizedFormatResource(card.TotalItemsCount);
+						else
+							card.Header = headerResource.GetLocalizedFormatResource(card.TotalItemsCount, sourceDirName);
 
 						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
 							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath);

--- a/src/Files.App/Utils/StatusCenter/StatusCenterItem.cs
+++ b/src/Files.App/Utils/StatusCenter/StatusCenterItem.cs
@@ -147,6 +147,8 @@ namespace Files.App.Utils.StatusCenter
 
 		public bool IsInProgress { get; private set; }
 
+		public bool IsDiscovering { get; private set; } = true;
+
 		public IEnumerable<string>? Source { get; private set; }
 
 		public IEnumerable<string>? Destination { get; private set; }
@@ -199,7 +201,7 @@ namespace Files.App.Utils.StatusCenter
 			AnimatedIconState = "NormalOff";
 			SpeedGraphValues = [];
 			CancelCommand = new RelayCommand(ExecuteCancelCommand);
-			Message = Strings.ProcessingItems.GetLocalizedResource();
+			Message = Strings.DiscoveringItems.GetLocalizedResource();
 			Source = source;
 			Destination = destination;
 
@@ -299,7 +301,7 @@ namespace Files.App.Utils.StatusCenter
 						Operation == FileOperationType.Compressed ||
 						Operation == FileOperationType.GitClone)
 					{
-						Message =
+						Message = 
 							$"{string.Format(
 								Strings.StatusCenter_ProcessedItems_Header.GetLocalizedFormatResource(value.ProcessedItemsCount, value.ItemsCount),
 								value.ProcessedItemsCount,
@@ -307,7 +309,7 @@ namespace Files.App.Utils.StatusCenter
 					}
 					else
 					{
-						Message =
+						Message = 
 							$"{string.Format(
 								Strings.StatusCenter_ProcessedSize_Header.GetLocalizedResource(),
 								value.ProcessedSize.ToSizeString(),
@@ -327,8 +329,14 @@ namespace Files.App.Utils.StatusCenter
 			if (TotalSize < value.TotalSize)
 				TotalSize = value.TotalSize;
 
+			if (value.EnumerationCompleted && IsDiscovering)
+			{
+				IsDiscovering = false;
+				Message = Strings.ProcessingItems.GetLocalizedResource();
+			}
+
 			// Update UI for strings
-			StatusCenterHelper.UpdateCardStrings(this);
+			StatusCenterHelper.UpdateCardStrings(this, value);
 			OnPropertyChanged(nameof(HeaderTooltip));
 
 			// Graph item point
@@ -382,7 +390,7 @@ namespace Files.App.Utils.StatusCenter
 				SpeedGraphValues?.Add(point);
 
 			// Add percentage to the header
-			if (!IsIndeterminateProgress)
+			if (!IsIndeterminateProgress && value.EnumerationCompleted)
 				Header = $"{Header} ({ProgressPercentage}%)";
 
 			// Update UI of the address bar

--- a/src/Files.App/Utils/StatusCenter/StatusCenterItem.cs
+++ b/src/Files.App/Utils/StatusCenter/StatusCenterItem.cs
@@ -301,7 +301,7 @@ namespace Files.App.Utils.StatusCenter
 						Operation == FileOperationType.Compressed ||
 						Operation == FileOperationType.GitClone)
 					{
-						Message = 
+						Message =
 							$"{string.Format(
 								Strings.StatusCenter_ProcessedItems_Header.GetLocalizedFormatResource(value.ProcessedItemsCount, value.ItemsCount),
 								value.ProcessedItemsCount,
@@ -309,7 +309,7 @@ namespace Files.App.Utils.StatusCenter
 					}
 					else
 					{
-						Message = 
+						Message =
 							$"{string.Format(
 								Strings.StatusCenter_ProcessedSize_Header.GetLocalizedResource(),
 								value.ProcessedSize.ToSizeString(),

--- a/src/Files.App/Utils/Storage/Operations/FileOperationsHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FileOperationsHelpers.cs
@@ -207,6 +207,14 @@ namespace Files.App.Utils.Storage
 
 			var cts = new CancellationTokenSource();
 			var sizeCalculator = new FileSizeCalculator(fileToDeletePath);
+			
+			// Track the count and update the progress
+			sizeCalculator.ItemsCountChanged += (newCount) =>
+			{
+				fsProgress.ItemsCount = newCount;
+				fsProgress.Report();
+			};
+
 			var sizeTask = sizeCalculator.ComputeSizeAsync(cts.Token);
 			sizeTask.ContinueWith(_ =>
 			{
@@ -405,6 +413,14 @@ namespace Files.App.Utils.Storage
 
 			var cts = new CancellationTokenSource();
 			var sizeCalculator = new FileSizeCalculator(fileToMovePath);
+			
+			// Track the count and update the progress
+			sizeCalculator.ItemsCountChanged += (newCount) =>
+			{
+				fsProgress.ItemsCount = newCount;
+				fsProgress.Report();
+			};
+
 			var sizeTask = sizeCalculator.ComputeSizeAsync(cts.Token);
 			sizeTask.ContinueWith(_ =>
 			{
@@ -533,6 +549,14 @@ namespace Files.App.Utils.Storage
 
 			var cts = new CancellationTokenSource();
 			var sizeCalculator = new FileSizeCalculator(fileToCopyPath);
+
+			// Track the count and update the progress
+			sizeCalculator.ItemsCountChanged += (newCount) =>
+			{
+				fsProgress.ItemsCount = newCount;
+				fsProgress.Report();
+			};
+
 			var sizeTask = sizeCalculator.ComputeSizeAsync(cts.Token);
 			sizeTask.ContinueWith(_ =>
 			{

--- a/src/Files.App/Utils/Storage/Operations/FileOperationsHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FileOperationsHelpers.cs
@@ -207,7 +207,7 @@ namespace Files.App.Utils.Storage
 
 			var cts = new CancellationTokenSource();
 			var sizeCalculator = new FileSizeCalculator(fileToDeletePath);
-			
+
 			// Track the count and update the progress
 			sizeCalculator.ItemsCountChanged += (newCount) =>
 			{
@@ -413,7 +413,7 @@ namespace Files.App.Utils.Storage
 
 			var cts = new CancellationTokenSource();
 			var sizeCalculator = new FileSizeCalculator(fileToMovePath);
-			
+
 			// Track the count and update the progress
 			sizeCalculator.ItemsCountChanged += (newCount) =>
 			{

--- a/src/Files.App/Utils/Storage/Operations/FileSizeCalculator.cs
+++ b/src/Files.App/Utils/Storage/Operations/FileSizeCalculator.cs
@@ -18,6 +18,8 @@ namespace Files.App.Utils.Storage.Operations
 		public int ItemsCount => _computedFiles.Count;
 		public bool Completed { get; private set; }
 
+		public event Action<int>? ItemsCountChanged;
+
 		public FileSizeCalculator(params string[] paths)
 		{
 			_paths = paths;
@@ -118,7 +120,10 @@ namespace Files.App.Utils.Storage.Operations
 				null);
 
 			if (!hFile.IsInvalid && PInvoke.GetFileSizeEx(hFile, out size) && _computedFiles.TryAdd(path, size))
+			{
 				Interlocked.Add(ref _size, size);
+				ItemsCountChanged?.Invoke(ItemsCount);
+			}
 
 			return size;
 		}

--- a/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
+++ b/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
@@ -49,7 +49,7 @@ namespace Files.App.Utils.Storage
 
 			StatusCenterItemProgressModel fsProgress = new(
 				progress,
-				true,
+				false,
 				FileSystemStatusCode.InProgress,
 				source.Count);
 


### PR DESCRIPTION
**Resolved / Related Issues**

Fixed UX issues during large folder operations where Status Center appears doing nothing. Users now see real-time discovery progress showing the actual number of items being discovered during the enumeration phase.

Closes: #14057

**Steps used to test these changes**

1. Open the Files app and navigate to a directory containing a large number of files (100k+)
2. Initiate a copy, move, or delete operation on the large folder
3. Observe the Status Center popup during the operation:
  - Initially shows "Discovered X items..." with real-time count updates during enumeration
  - Transitions to "Copying/Moving/Deleting X items..." after enumeration completes
4. Verify the UI remains responsive during large folder operations without freezing
5. Test with different operation types (Copy, Move, Delete) to ensure consistent behavior
6. Confirm that it shows the appropriate status text and completed operations display proper completion messages
