### PR TITLE
Fix: Fixed issue where pinned folder icons didn't load until restarting the app

### DIFF
--- a/src/Files.App/Data/Models/PinnedFoldersManager.cs
+++ b/src/Files.App/Data/Models/PinnedFoldersManager.cs
@@ -104,13 +104,13 @@ namespace Files.App.Data.Models
 			{
 				locationItem.IsInvalid = false;
 				if (res.Result is not null)
-					_ = LoadIconForLocationItemAsync(locationItem, res.Result.Path);
+					await LoadIconForLocationItemAsync(locationItem, res.Result.Path);
 			}
 			else
 			{
 				locationItem.IsInvalid = true;
 				Debug.WriteLine($"Pinned item was invalid {res?.ErrorCode}, item: {path}");
-				_ = LoadDefaultIconForLocationItemAsync(locationItem);
+				await LoadDefaultIconForLocationItemAsync(locationItem);
 			}
 
 			return locationItem;


### PR DESCRIPTION
**Resolved / Related Issues**

Fixed issue where newly pinned folders don't display their icons in the sidebar until the application is completely restarted. The icon now loads immediately when a folder is pinned.

Closes: #17660

**Steps used to test these changes**

1. Open the Files app
2. Navigate to any folder
3. Right-click on the folder and select "Pin to Sidebar"
4. Observe the sidebar. The folder icon should now appear immediately
5. Verify that icons persist correctly after app restart