### PR TITLE
Fix: Fixed multi-part RAR extraction failure and improved error logging

### DIFF
--- a/src/Files.App/Services/Storage/StorageArchiveService.cs
+++ b/src/Files.App/Services/Storage/StorageArchiveService.cs
@@ -410,9 +410,10 @@ namespace Files.App.Services
 		{
 			return await FilesystemTasks.Wrap(async () =>
 			{
+				BaseStorageFile archive = await StorageHelpers.ToStorageItem<BaseStorageFile>(archiveFilePath);
 				var extractor = string.IsNullOrEmpty(password)
-					? new SevenZipExtractor(archiveFilePath)
-					: new SevenZipExtractor(archiveFilePath, password);
+					? new SevenZipExtractor(archive.Path)
+					: new SevenZipExtractor(archive.Path, password);
 
 				// Force to load archive (1665013614u)
 				return extractor?.ArchiveFileData is null ? null : extractor;

--- a/src/Files.App/Services/Storage/StorageArchiveService.cs
+++ b/src/Files.App/Services/Storage/StorageArchiveService.cs
@@ -4,6 +4,7 @@
 using Files.Shared.Helpers;
 using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
+using Microsoft.Extensions.Logging;
 using SevenZip;
 using System.IO;
 using System.Text;
@@ -137,9 +138,10 @@ namespace Files.App.Services
 
 				isSuccess = true;
 			}
-			catch
+			catch (Exception ex)
 			{
 				isSuccess = false;
+				App.Logger.LogError(ex, "SevenZipLib error extracting archive file.");
 			}
 			finally
 			{
@@ -288,7 +290,7 @@ namespace Files.App.Services
 			catch (Exception ex)
 			{
 				isSuccess = false;
-				Console.WriteLine($"Error during decompression: {ex.Message}");
+				App.Logger.LogError(ex, "SharpZipLib error during decompression.");
 			}
 			finally
 			{
@@ -362,7 +364,7 @@ namespace Files.App.Services
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine($"SharpZipLib error: {ex.Message}");
+				App.Logger.LogError(ex, "SharpZipLib error.");
 				return true;
 			}
 		}
@@ -398,7 +400,7 @@ namespace Files.App.Services
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine($"SharpZipLib error: {ex.Message}");
+				App.Logger.LogError(ex, "SharpZipLib error detecting encoding.");
 				return null;
 			}
 		}
@@ -408,9 +410,9 @@ namespace Files.App.Services
 		{
 			return await FilesystemTasks.Wrap(async () =>
 			{
-				BaseStorageFile archive = await StorageHelpers.ToStorageItem<BaseStorageFile>(archiveFilePath);
-
-				var extractor = new SevenZipExtractor(await archive.OpenStreamForReadAsync(), password);
+				var extractor = string.IsNullOrEmpty(password)
+					? new SevenZipExtractor(archiveFilePath)
+					: new SevenZipExtractor(archiveFilePath, password);
 
 				// Force to load archive (1665013614u)
 				return extractor?.ArchiveFileData is null ? null : extractor;


### PR DESCRIPTION
**Resolved / Related Issues**

Fixed issue where multi-part RAR files failed to extract with "File is corrupted. Data error has occurred" exception. Changed SevenZipExtractor to use file path constructor instead of stream-based approach, allowing SevenZip to automatically locate and open subsequent archive parts (.part01.rar, .part02.rar, etc.). Also improved error logging by replacing Console.WriteLine with App.Logger.LogError.

Closes #14328

**Steps used to test these changes**

1. Create a multi-part RAR archive
2. Open the Files app
3. Navigate to the folder containing the multi-part RAR files
4. Right-click on the first part (eg: test.part01.rar) and select "Extract > Extract here"
5. Verify the extraction completes successfully without errors
6. Verify all files from all parts are extracted correctly