### PR TITLE
Feature: Added previous locations dropdown to the extract archive dialog

### DIFF
--- a/src/Files.App/Data/Contracts/IGeneralSettingsService.cs
+++ b/src/Files.App/Data/Contracts/IGeneralSettingsService.cs
@@ -56,6 +56,11 @@ namespace Files.App.Data.Contracts
 		List<string> PreviousSearchQueriesList { get; set; }
 
 		/// <summary>
+		/// Stores list of paths where archives have previously been extracted.
+		/// </summary>
+		List<string> PreviousArchiveExtractionLocations { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating which date and time format to use.
 		/// </summary>
 		DateTimeFormats DateTimeFormat { get; set; }

--- a/src/Files.App/Dialogs/DecompressArchiveDialog.xaml
+++ b/src/Files.App/Dialogs/DecompressArchiveDialog.xaml
@@ -12,6 +12,7 @@
 	CornerRadius="{StaticResource OverlayCornerRadius}"
 	DefaultButton="Primary"
 	HighContrastAdjustment="None"
+	IsPrimaryButtonEnabled="{x:Bind ViewModel.IsDestinationPathValid, Mode=OneWay}"
 	PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
 	PrimaryButtonText="{helpers:ResourceString Name=Extract}"
 	RequestedTheme="{x:Bind RootAppElement.RequestedTheme, Mode=OneWay}"
@@ -44,13 +45,14 @@
 					Text="{helpers:ResourceString Name=ExtractToPath}" />
 
 				<!--  Path Box  -->
-				<TextBox
+				<AutoSuggestBox
 					x:Name="DestinationFolderPath"
 					Grid.Row="1"
 					Grid.Column="0"
 					HorizontalAlignment="Stretch"
-					IsReadOnly="True"
-					Text="{x:Bind ViewModel.DestinationFolderPath, Mode=OneWay}" />
+					ItemsSource="{x:Bind ViewModel.PreviousExtractionLocations, Mode=OneWay}"
+					Text="{x:Bind ViewModel.DestinationFolderPath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+					TextChanged="DestinationFolderPath_TextChanged" />
 
 				<Button
 					x:Name="SelectDestination"

--- a/src/Files.App/Dialogs/DecompressArchiveDialog.xaml.cs
+++ b/src/Files.App/Dialogs/DecompressArchiveDialog.xaml.cs
@@ -28,5 +28,13 @@ namespace Files.App.Dialogs
 			if (ViewModel.IsArchiveEncrypted)
 				ViewModel.PrimaryButtonClickCommand.Execute(new DisposableArray(Encoding.UTF8.GetBytes(Password.Password)));
 		}
+
+		private void DestinationFolderPath_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+		{
+			if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+			{
+				ViewModel.UpdateSuggestions(sender.Text);
+			}
+		}
 	}
 }

--- a/src/Files.App/Services/Settings/GeneralSettingsService.cs
+++ b/src/Files.App/Services/Settings/GeneralSettingsService.cs
@@ -71,6 +71,12 @@ namespace Files.App.Services.Settings
 			set => Set(value);
 		}
 
+		public List<string> PreviousArchiveExtractionLocations
+		{
+			get => Get<List<string>>(null);
+			set => Set(value);
+		}
+
 		public DateTimeFormats DateTimeFormat
 		{
 			get => Get(DateTimeFormats.Application);

--- a/src/Files.App/Services/Settings/UserSettingsService.cs
+++ b/src/Files.App/Services/Settings/UserSettingsService.cs
@@ -70,6 +70,7 @@ namespace Files.App.Services.Settings
 			export.Remove(nameof(GeneralSettingsService.LastCrashedTabList));
 			export.Remove(nameof(GeneralSettingsService.PathHistoryList));
 			export.Remove(nameof(GeneralSettingsService.PreviousSearchQueriesList));
+			export.Remove(nameof(GeneralSettingsService.PreviousArchiveExtractionLocations));
 
 			return JsonSettingsSerializer.SerializeToJson(export);
 		}

--- a/src/Files.App/ViewModels/Dialogs/DecompressArchiveDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/DecompressArchiveDialogViewModel.cs
@@ -10,17 +10,57 @@ namespace Files.App.ViewModels.Dialogs
 {
 	public sealed partial class DecompressArchiveDialogViewModel : ObservableObject
 	{
+		// Services
 		private ICommonDialogService CommonDialogService { get; } = Ioc.Default.GetRequiredService<ICommonDialogService>();
+		private readonly IUserSettingsService UserSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
 
+		// Fields
 		private readonly IStorageFile archive;
 
+		// Properties
 		public BaseStorageFolder DestinationFolder { get; private set; }
 
 		private string destinationFolderPath;
 		public string DestinationFolderPath
 		{
 			get => destinationFolderPath;
-			private set => SetProperty(ref destinationFolderPath, value);
+			set
+			{
+				if (SetProperty(ref destinationFolderPath, value))
+				{
+					OnPropertyChanged(nameof(IsDestinationPathValid));
+				}
+			}
+		}
+
+		public bool IsDestinationPathValid
+		{
+			get
+			{
+				try
+				{
+					if (string.IsNullOrWhiteSpace(DestinationFolderPath))
+						return false;
+
+					string parentDir = Path.GetDirectoryName(DestinationFolderPath);
+					string finalSegment = Path.GetFileName(DestinationFolderPath);
+
+					// Check parent directory exists
+					if (string.IsNullOrWhiteSpace(parentDir) || !Directory.Exists(parentDir))
+						return false;
+
+					// Check for invalid characters (IsValidForFilename already does this)
+					if (!FilesystemHelpers.IsValidForFilename(finalSegment))
+						return false;
+
+					return true;
+				}
+				catch
+				{
+					// Catch any exception to prevent crashes
+					return false;
+				}
+			}
 		}
 
 		private bool openDestinationFolderOnCompletion;
@@ -65,8 +105,45 @@ namespace Files.App.ViewModels.Dialogs
 		public DisposableArray? Password { get; private set; }
 
 		public EncodingItem[] EncodingOptions { get; set; } = EncodingItem.Defaults;
+
 		public EncodingItem SelectedEncoding { get; set; }
-		void RefreshEncodingOptions()
+
+		public ObservableCollection<string> PreviousExtractionLocations { get; } = [];
+
+		// Commands
+		public IRelayCommand PrimaryButtonClickCommand { get; private set; }
+		public ICommand SelectDestinationCommand { get; private set; }
+		public ICommand QuerySubmittedCommand { get; private set; }
+
+		// Constructor
+		public DecompressArchiveDialogViewModel(IStorageFile archive)
+		{
+			this.archive = archive;
+			destinationFolderPath = DefaultDestinationFolderPath();
+			SelectedEncoding = EncodingOptions[0];
+
+			// Create commands
+			SelectDestinationCommand = new AsyncRelayCommand(SelectDestinationAsync);
+			PrimaryButtonClickCommand = new RelayCommand<DisposableArray>(password => Password = password);
+		}
+
+		// Private Methods
+		private string DefaultDestinationFolderPath()
+		{
+			return Path.Combine(Path.GetDirectoryName(archive.Path), Path.GetFileNameWithoutExtension(archive.Path));
+		}
+
+		private async Task SelectDestinationAsync()
+		{
+			bool result = CommonDialogService.Open_FileOpenDialog(MainWindow.Instance.WindowHandle, true, [], Environment.SpecialFolder.Desktop, out var filePath);
+			if (!result)
+				return;
+
+			DestinationFolder = await StorageHelpers.ToStorageItem<BaseStorageFolder>(filePath);
+			DestinationFolderPath = (DestinationFolder is not null) ? DestinationFolder.Path : DefaultDestinationFolderPath();
+		}
+
+		private void RefreshEncodingOptions()
 		{
 			if (detectedEncoding != null)
 			{
@@ -84,36 +161,24 @@ namespace Files.App.ViewModels.Dialogs
 			SelectedEncoding = EncodingOptions.FirstOrDefault();
 		}
 
-
-
-		public IRelayCommand PrimaryButtonClickCommand { get; private set; }
-
-		public ICommand SelectDestinationCommand { get; private set; }
-
-		public DecompressArchiveDialogViewModel(IStorageFile archive)
+		// Public Methods
+		public void UpdateSuggestions(string query)
 		{
-			this.archive = archive;
-			destinationFolderPath = DefaultDestinationFolderPath();
-			SelectedEncoding = EncodingOptions[0];
-
-			// Create commands
-			SelectDestinationCommand = new AsyncRelayCommand(SelectDestinationAsync);
-			PrimaryButtonClickCommand = new RelayCommand<DisposableArray>(password => Password = password);
-		}
-
-		private async Task SelectDestinationAsync()
-		{
-			bool result = CommonDialogService.Open_FileOpenDialog(MainWindow.Instance.WindowHandle, true, [], Environment.SpecialFolder.Desktop, out var filePath);
-			if (!result)
+			var allItems = UserSettingsService.GeneralSettingsService.PreviousArchiveExtractionLocations;
+			if (allItems is null)
 				return;
 
-			DestinationFolder = await StorageHelpers.ToStorageItem<BaseStorageFolder>(filePath);
-			DestinationFolderPath = (DestinationFolder is not null) ? DestinationFolder.Path : DefaultDestinationFolderPath();
-		}
+			var filtered = allItems
+				.Where(item => item.StartsWith(query, StringComparison.OrdinalIgnoreCase))
+				.ToList();
 
-		private string DefaultDestinationFolderPath()
-		{
-			return Path.Combine(Path.GetDirectoryName(archive.Path), Path.GetFileNameWithoutExtension(archive.Path));
+			// Only update if results changed to prevent flickering
+			if (!filtered.SequenceEqual(PreviousExtractionLocations))
+			{
+				PreviousExtractionLocations.Clear();
+				foreach (var item in filtered)
+					PreviousExtractionLocations.Add(item);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17586

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Selected an archive
2. Opened the Extract Archive dialog
3. Extract the archive
4. Opened the Extract Archive dialog a second time
5. Cleared the prefilled location
6. Confirmed the previous locations are displayed in a dropdown
7. Confirmed that the dropdown is filtered as the text input changes
