### PR TITLE
Fix: Fixed an issue where the context menu was missing items in Columns View

### DIFF
--- a/src/Files.App/Views/Layouts/ColumnsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnsLayoutPage.xaml.cs
@@ -365,6 +365,7 @@ namespace Files.App.Views.Layouts
 		{
 			if (navArgs is not null && navArgs.IsSearchResultPage)
 			{
+				navArgs.AssociatedTabInstance = ParentShellPageInstance;
 				ParentShellPageInstance?.NavigateToPath(navArgs.SearchPathParam, typeof(DetailsLayoutPage), navArgs);
 				return;
 			}


### PR DESCRIPTION
### Resolved / Related Issues
Fixed issue where context menu shows incorrect items when right-clicking search results performed from Columns layout view. The menu was missing essential items like Open, Cut, Copy, and Share.

Closes #14058
Closes #13311

### Steps used to test these changes
1. Open the Files app in Columns layout view
2. Navigate to a folder with multiple subfolders and files (e.g., D:\Samples)
3. Use the search box to search for a file (e.g., "program.pdf")
4. Wait for search results to appear in DetailsLayoutPage
5. Select a file from the search results
6. Right-click to open the context menu
7. Verify that Open, Cut, Copy, Share, and other selection-dependent items are enabled
8. Verify the context menu shows the correct items based on file type
9. Test with multiple file selections in search results