### PR TITLE
fix: allow Ctrl+C to copy selected text in Details Pane

### DIFF
--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -153,7 +153,7 @@ namespace Files.App.Utils.Storage
 		{
 			if (!App.AppModel.IsMainWindowClosed && sender is WindowEx window)
 			{
-				args.Handled = true;
+				args.Handled = false;
 
 				window.AppWindow.Hide();
 				window.Content = null;


### PR DESCRIPTION
Fixed the bug where Ctrl+C was copying the file instead of the selected text in the Details Pane.
Changed args.Handled = true to args.Handled = false in OnCopyInvoked().
Now, when a text field is focused, Ctrl+C copies the text as expected.