### PR TITLE
Fix: Prevent Ctrl+C from overriding Text Block copy behavior

### DIFF
--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -235,6 +235,9 @@ namespace Files.App.Views
 					if (command.Code is CommandCodes.OpenItem && (source?.FindAscendantOrSelf<Omnibar>() is not null || source?.FindAscendantOrSelf<AppBarButton>() is not null))
 						break;
 
+					// Prevent ctrl + c from overriding copy in textblocks 					
+					if (currentModifiers == KeyModifiers.Ctrl && e.Key is VirtualKey.C && (FrameworkElement)FocusManager.GetFocusedElement(MainWindow.Instance.Content.XamlRoot) is TextBlock)
+						break;
 
 					if (command.Code is not CommandCodes.None && keyReleased)
 					{


### PR DESCRIPTION
Adds a check to ensure that Ctrl+C does not override the default copy behavior when a TextBlock is focused, preserving expected text copying functionality.

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17760

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Selected text in details pane
2. Confirmed Ctrl+C copies the selected text
3. Confirmed the selected item can still be copied via the toolbar button
