### PR TITLE
Fix: Fixed an issue where opening new columns in Columns View didn't always scroll them into view

### DIFF
--- a/src/Files.App.Controls/BladeView/BladeView.cs
+++ b/src/Files.App.Controls/BladeView/BladeView.cs
@@ -150,6 +150,17 @@ namespace Files.App.Controls
 			return _scrollViewer ?? (_scrollViewer = this.FindDescendant<ScrollViewer>());
 		}
 
+		public void ScrollToEnd()
+		{
+			LayoutUpdated += OnLayoutUpdatedScrollToEnd;
+		}
+
+		private void OnLayoutUpdatedScrollToEnd(object sender, object e)
+		{
+			LayoutUpdated -= OnLayoutUpdatedScrollToEnd;
+			GetScrollViewer()?.ChangeView(_scrollViewer.ScrollableWidth, null, null, false);
+		}
+
 		private void AdjustBladeItemSize()
 		{
 			// Adjust blade items to be full screen
@@ -182,7 +193,8 @@ namespace Files.App.Controls
 			else if (e.CollectionChange == CollectionChange.ItemInserted)
 			{
 				UpdateLayout();
-				GetScrollViewer()?.ChangeView(_scrollViewer.ScrollableWidth, null, null);
+				// The following line doesn't work as expected due to the items not being fully loaded yet and thus the scrollable width not being accurate.
+				//GetScrollViewer()?.ChangeView(_scrollViewer.ScrollableWidth, null, null);
 			}
 		}
 	}

--- a/src/Files.App/Views/Layouts/ColumnsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnsLayoutPage.xaml.cs
@@ -89,6 +89,8 @@ namespace Files.App.Views.Layouts
 
 			var blade = activeBlades[index];
 			blade?.SetWidth();
+
+			ColumnHost.ScrollToEnd();
 		}
 
 		private void ContentChanged(IShellPage p)


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where the horizontal scrollbar in Columns Layout did not automatically scroll to show newly opened folder columns, leaving them partially visible.

Closes #17755

**Steps used to test these changes**
1. Single folder navigation
   - Open Files app in Columns Layout view
   - Click on any subfolder
   - Verify the new column is fully visible and scrolled into view
2. Deep folder navigation with long file/folder name
   - Navigate to a deep path (e.g., C:\Users\[Name]\Documents\Folder1\Folder2\My very very long folder in Windows)
   - Verify each newly opened column scrolls into view smoothly
   - Verify columns are fully visible regardless of width