### PR TITLE
Code Quality: Replaced manual DP definitions in the Sidebar controls with the Toolkit's source generator

### DIFF
--- a/src/Files.App.Controls/Sidebar/SidebarItem.Properties.cs
+++ b/src/Files.App.Controls/Sidebar/SidebarItem.Properties.cs
@@ -1,90 +1,41 @@
 // Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using CommunityToolkit.WinUI;
+
 namespace Files.App.Controls
 {
 	public sealed partial class SidebarItem : Control
 	{
-		public SidebarView? Owner
-		{
-			get { return (SidebarView?)GetValue(OwnerProperty); }
-			set { SetValue(OwnerProperty, value); }
-		}
-		public static readonly DependencyProperty OwnerProperty =
-			DependencyProperty.Register(nameof(Owner), typeof(SidebarView), typeof(SidebarItem), new PropertyMetadata(null));
+		[GeneratedDependencyProperty]
+		public partial SidebarView? Owner { get; set; }
 
-		public bool IsSelected
-		{
-			get { return (bool)GetValue(IsSelectedProperty); }
-			set { SetValue(IsSelectedProperty, value); }
-		}
-		public static readonly DependencyProperty IsSelectedProperty =
-			DependencyProperty.Register(nameof(IsSelected), typeof(bool), typeof(SidebarItem), new PropertyMetadata(false, OnPropertyChanged));
+		[GeneratedDependencyProperty]
+		public partial bool IsSelected { get; set; }
 
-		public bool IsExpanded
-		{
-			get { return (bool)GetValue(IsExpandedProperty); }
-			set { SetValue(IsExpandedProperty, value); }
-		}
-		public static readonly DependencyProperty IsExpandedProperty =
-			DependencyProperty.Register(nameof(IsExpanded), typeof(bool), typeof(SidebarItem), new PropertyMetadata(true, OnPropertyChanged));
+		[GeneratedDependencyProperty(DefaultValue = true)]
+		public partial bool IsExpanded { get; set; }
 
-		public bool IsInFlyout
-		{
-			get { return (bool)GetValue(IsInFlyoutProperty); }
-			set { SetValue(IsInFlyoutProperty, value); }
-		}
-		public static readonly DependencyProperty IsInFlyoutProperty =
-			DependencyProperty.Register(nameof(IsInFlyout), typeof(bool), typeof(SidebarItem), new PropertyMetadata(false));
+		[GeneratedDependencyProperty]
+		public partial bool IsInFlyout { get; set; }
 
-		public double ChildrenPresenterHeight
-		{
-			get { return (double)GetValue(ChildrenPresenterHeightProperty); }
-			set { SetValue(ChildrenPresenterHeightProperty, value); }
-		}
-		// Using 30 as a default in case something goes wrong
-		public static readonly DependencyProperty ChildrenPresenterHeightProperty =
-			DependencyProperty.Register(nameof(ChildrenPresenterHeight), typeof(double), typeof(SidebarItem), new PropertyMetadata(30d));
+		[GeneratedDependencyProperty(DefaultValue = 30D)]
+		public partial double ChildrenPresenterHeight { get; set; }
 
-		public ISidebarItemModel? Item
-		{
-			get { return (ISidebarItemModel)GetValue(ItemProperty); }
-			set { SetValue(ItemProperty, value); }
-		}
-		public static readonly DependencyProperty ItemProperty =
-			DependencyProperty.Register(nameof(Item), typeof(ISidebarItemModel), typeof(SidebarItem), new PropertyMetadata(null));
+		[GeneratedDependencyProperty]
+		public partial ISidebarItemModel? Item { get; set; }
 
-		public bool UseReorderDrop
-		{
-			get { return (bool)GetValue(UseReorderDropProperty); }
-			set { SetValue(UseReorderDropProperty, value); }
-		}
-		public static readonly DependencyProperty UseReorderDropProperty =
-			DependencyProperty.Register(nameof(UseReorderDrop), typeof(bool), typeof(SidebarItem), new PropertyMetadata(false));
+		[GeneratedDependencyProperty]
+		public partial bool UseReorderDrop { get; set; }
 
-		public FrameworkElement? Icon
-		{
-			get { return (FrameworkElement?)GetValue(IconProperty); }
-			set { SetValue(IconProperty, value); }
-		}
-		public static readonly DependencyProperty IconProperty =
-			DependencyProperty.Register(nameof(Icon), typeof(FrameworkElement), typeof(SidebarItem), new PropertyMetadata(null));
+		[GeneratedDependencyProperty]
+		public partial FrameworkElement? Icon { get; set; }
 
-		public FrameworkElement? Decorator
-		{
-			get { return (FrameworkElement?)GetValue(DecoratorProperty); }
-			set { SetValue(DecoratorProperty, value); }
-		}
-		public static readonly DependencyProperty DecoratorProperty =
-			DependencyProperty.Register(nameof(Decorator), typeof(FrameworkElement), typeof(SidebarItem), new PropertyMetadata(null));
+		[GeneratedDependencyProperty]
+		public partial FrameworkElement? Decorator { get; set; }
 
-		public SidebarDisplayMode DisplayMode
-		{
-			get { return (SidebarDisplayMode)GetValue(DisplayModeProperty); }
-			set { SetValue(DisplayModeProperty, value); }
-		}
-		public static readonly DependencyProperty DisplayModeProperty =
-			DependencyProperty.Register(nameof(DisplayMode), typeof(SidebarDisplayMode), typeof(SidebarItem), new PropertyMetadata(SidebarDisplayMode.Expanded, OnPropertyChanged));
+		[GeneratedDependencyProperty(DefaultValue = SidebarDisplayMode.Expanded)]
+		public partial SidebarDisplayMode DisplayMode { get; set; }
 
 		public static void SetTemplateRoot(DependencyObject target, FrameworkElement value)
 		{
@@ -95,31 +46,26 @@ namespace Files.App.Controls
 			return (FrameworkElement)target.GetValue(TemplateRootProperty);
 		}
 		public static readonly DependencyProperty TemplateRootProperty =
-			DependencyProperty.Register("TemplateRoot", typeof(FrameworkElement), typeof(FrameworkElement), new PropertyMetadata(null));
+			DependencyProperty.Register("TemplateRoot", typeof(FrameworkElement), typeof(SidebarItem), new PropertyMetadata(null));
 
-		public static void OnPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+		partial void OnIsSelectedPropertyChanged(DependencyPropertyChangedEventArgs e)
 		{
-			if (sender is not SidebarItem item) return;
-			if (e.Property == DisplayModeProperty)
-			{
-				item.SidebarDisplayModeChanged((SidebarDisplayMode)e.OldValue);
-			}
-			else if (e.Property == IsSelectedProperty)
-			{
-				item.UpdateSelectionState();
-			}
-			else if (e.Property == IsExpandedProperty)
-			{
-				item.UpdateExpansionState();
-			}
-			else if (e.Property == ItemProperty)
-			{
-				item.HandleItemChange();
-			}
-			else
-			{
-				Debug.Write(e.Property.ToString());
-			}
+			UpdateSelectionState();
+		}
+
+		partial void OnIsExpandedPropertyChanged(DependencyPropertyChangedEventArgs e)
+		{
+			UpdateExpansionState();
+		}
+
+		partial void OnItemPropertyChanged(DependencyPropertyChangedEventArgs e)
+		{
+			HandleItemChange();
+		}
+
+		partial void OnDisplayModePropertyChanged(DependencyPropertyChangedEventArgs e)
+		{
+			SidebarDisplayModeChanged((SidebarDisplayMode)e.OldValue);
 		}
 	}
 }

--- a/src/Files.App.Controls/Sidebar/SidebarItemAutomationPeer.cs
+++ b/src/Files.App.Controls/Sidebar/SidebarItemAutomationPeer.cs
@@ -15,19 +15,25 @@ namespace Files.App.Controls
 		{
 			get
 			{
-				if (Owner.HasChildren)
-					return Owner.IsExpanded ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed;
-				return ExpandCollapseState.LeafNode;
+				return Owner.HasChildren
+					? Owner.IsExpanded
+						? ExpandCollapseState.Expanded
+						: ExpandCollapseState.Collapsed
+					: ExpandCollapseState.LeafNode;
 			}
 		}
-		public bool IsSelected => Owner.IsSelected;
-		public IRawElementProviderSimple SelectionContainer => ProviderFromPeer(CreatePeerForElement(Owner.Owner));
+
+		public bool IsSelected
+			=> Owner.IsSelected;
+
+		public IRawElementProviderSimple SelectionContainer
+			=> ProviderFromPeer(CreatePeerForElement(Owner.Owner));
 
 		private new SidebarItem Owner { get; init; }
 
 		public SidebarItemAutomationPeer(SidebarItem owner) : base(owner)
 		{
-			this.Owner = owner;
+			Owner = owner;
 		}
 
 		protected override AutomationControlType GetAutomationControlTypeCore()
@@ -59,18 +65,13 @@ namespace Files.App.Controls
 		public void Collapse()
 		{
 			if (Owner.CollapseEnabled)
-			{
 				Owner.IsExpanded = false;
-			}
 		}
 
 		public void Expand()
 		{
-
 			if (Owner.CollapseEnabled)
-			{
 				Owner.IsExpanded = true;
-			}
 		}
 
 		public void Invoke()
@@ -106,13 +107,10 @@ namespace Files.App.Controls
 		private IList GetOwnerCollection()
 		{
 			if (Owner.FindAscendant<SidebarItem>() is SidebarItem parent && parent.Item?.Children is IList list)
-			{
 				return list;
-			}
 			if (Owner?.Owner is not null && Owner.Owner.ViewModel.SidebarItems is IList items)
-			{
 				return items;
-			}
+
 			return new List<object>();
 		}
 	}

--- a/src/Files.App.Controls/Sidebar/SidebarView.Properties.cs
+++ b/src/Files.App.Controls/Sidebar/SidebarView.Properties.cs
@@ -1,113 +1,56 @@
 // Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using CommunityToolkit.WinUI;
+
 namespace Files.App.Controls
 {
 	public sealed partial class SidebarView
 	{
-		public SidebarDisplayMode DisplayMode
+		[GeneratedDependencyProperty(DefaultValue = SidebarDisplayMode.Expanded)]
+		public partial SidebarDisplayMode DisplayMode { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial UIElement? InnerContent { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial UIElement? SidebarContent { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial UIElement? Footer { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial bool IsPaneOpen { get; set; }
+
+		[GeneratedDependencyProperty(DefaultValue = 240D)]
+		public partial double OpenPaneLength { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial double NegativeOpenPaneLength { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial ISidebarViewModel? ViewModel { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial ISidebarItemModel? SelectedItem { get; set; }
+
+		[GeneratedDependencyProperty]
+		public partial object? MenuItemsSource { get; set; }
+
+		partial void OnDisplayModePropertyChanged(DependencyPropertyChangedEventArgs e)
 		{
-			get { return (SidebarDisplayMode)GetValue(DisplayModeProperty); }
-			set { SetValue(DisplayModeProperty, value); }
+			UpdateDisplayMode();
 		}
-		public static readonly DependencyProperty DisplayModeProperty =
-			DependencyProperty.Register(nameof(DisplayMode), typeof(SidebarDisplayMode), typeof(SidebarView), new PropertyMetadata(SidebarDisplayMode.Expanded, OnPropertyChanged));
 
-		public UIElement InnerContent
+		partial void OnIsPaneOpenPropertyChanged(DependencyPropertyChangedEventArgs e)
 		{
-			get { return (UIElement)GetValue(InnerContentProperty); }
-			set { SetValue(InnerContentProperty, value); }
+			UpdateMinimalMode();
 		}
-		public static readonly DependencyProperty InnerContentProperty =
-			DependencyProperty.Register(nameof(InnerContent), typeof(UIElement), typeof(SidebarView), new PropertyMetadata(null));
 
-		public UIElement SidebarContent
+		partial void OnOpenPaneLengthPropertyChanged(DependencyPropertyChangedEventArgs e)
 		{
-			get { return (UIElement)GetValue(SidebarContentProperty); }
-			set { SetValue(SidebarContentProperty, value); }
-		}
-		public static readonly DependencyProperty SidebarContentProperty =
-			DependencyProperty.Register("SidebarContent", typeof(UIElement), typeof(SidebarView), new PropertyMetadata(null));
-
-		public UIElement Footer
-		{
-			get { return (UIElement)GetValue(FooterProperty); }
-			set { SetValue(FooterProperty, value); }
-		}
-		public static readonly DependencyProperty FooterProperty =
-			DependencyProperty.Register("Footer", typeof(UIElement), typeof(SidebarView), new PropertyMetadata(null));
-
-		public bool IsPaneOpen
-		{
-			get { return (bool)GetValue(IsPaneOpenProperty); }
-			set { SetValue(IsPaneOpenProperty, value); }
-		}
-		public static readonly DependencyProperty IsPaneOpenProperty =
-			DependencyProperty.Register(nameof(IsPaneOpen), typeof(bool), typeof(SidebarView), new PropertyMetadata(false, OnPropertyChanged));
-
-		public double OpenPaneLength
-		{
-			get { return (double)GetValue(OpenPaneLengthProperty); }
-			set
-			{
-				SetValue(OpenPaneLengthProperty, value);
-				NegativeOpenPaneLength = -value;
-			}
-		}
-		public static readonly DependencyProperty OpenPaneLengthProperty =
-			DependencyProperty.Register(nameof(OpenPaneLength), typeof(double), typeof(SidebarView), new PropertyMetadata(240d, OnPropertyChanged));
-
-		public double NegativeOpenPaneLength
-		{
-			get { return (double)GetValue(NegativeOpenPaneLengthProperty); }
-			set { SetValue(NegativeOpenPaneLengthProperty, value); }
-		}
-		public static readonly DependencyProperty NegativeOpenPaneLengthProperty =
-			DependencyProperty.Register(nameof(NegativeOpenPaneLength), typeof(double), typeof(SidebarView), new PropertyMetadata(null));
-
-		public ISidebarViewModel ViewModel
-		{
-			get => (ISidebarViewModel)GetValue(ViewModelProperty);
-			set => SetValue(ViewModelProperty, value);
-		}
-		public static readonly DependencyProperty ViewModelProperty =
-			DependencyProperty.Register(nameof(ViewModel), typeof(ISidebarViewModel), typeof(SidebarView), new PropertyMetadata(null));
-
-		public ISidebarItemModel SelectedItem
-		{
-			get => (ISidebarItemModel)GetValue(SelectedItemProperty);
-			set
-			{
-				SetValue(SelectedItemProperty, value);
-			}
-		}
-		public static readonly DependencyProperty SelectedItemProperty =
-			DependencyProperty.Register(nameof(SelectedItem), typeof(ISidebarItemModel), typeof(SidebarView), new PropertyMetadata(null));
-
-		public object MenuItemsSource
-		{
-			get => (object)GetValue(MenuItemsSourceProperty);
-			set => SetValue(MenuItemsSourceProperty, value);
-		}
-		public static readonly DependencyProperty MenuItemsSourceProperty =
-			DependencyProperty.Register(nameof(MenuItemsSource), typeof(object), typeof(SidebarView), new PropertyMetadata(null));
-
-		public static void OnPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
-		{
-			if (sender is not SidebarView control) return;
-
-			if (e.Property == OpenPaneLengthProperty)
-			{
-				control.UpdateOpenPaneLengthColumn();
-			}
-			else if (e.Property == DisplayModeProperty)
-			{
-				control.UpdateDisplayMode();
-			}
-			else if (e.Property == IsPaneOpenProperty)
-			{
-				control.UpdateMinimalMode();
-			}
+			NegativeOpenPaneLength = -(double)(e.NewValue);
+			UpdateOpenPaneLengthColumn();
 		}
 	}
 }

--- a/src/Files.App.Controls/Sidebar/SidebarViewAutomationPeer.cs
+++ b/src/Files.App.Controls/Sidebar/SidebarViewAutomationPeer.cs
@@ -21,19 +21,16 @@ namespace Files.App.Controls
 		protected override object GetPatternCore(PatternInterface patternInterface)
 		{
 			if (patternInterface == PatternInterface.Selection)
-			{
 				return this;
-			}
+
 			return base.GetPatternCore(patternInterface);
 		}
 
 		public IRawElementProviderSimple[] GetSelection()
 		{
 			if (Owner.SelectedItemContainer != null)
-				return
-				[
-				ProviderFromPeer(CreatePeerForElement(Owner.SelectedItemContainer))
-				];
+				return [ProviderFromPeer(CreatePeerForElement(Owner.SelectedItemContainer))];
+
 			return [];
 		}
 	}


### PR DESCRIPTION
### Vision towards NativeAOT in the Sidebar functionalities

The current Quick Access helper and its watcher is powered by the reflection-based `Activator` to instantiate the Quick Access's `IShellFolder` to enumerate Quick Access items instead of Win32 `CoCreateInstance` due to UWP limitations. This is now blocking us from leveraging NAOT for faster startup and Trimming for a smaller package size.

I have already refactored the codebase of the Home page, which is relatively ready for the next Storage Abstraction concept. However, that of the Sidebar controls is not yet at all, which is overly complicated and requires to a major refactoring for the NAOT/Trimming adoption.

The first example of the complication is the specifically implemented receivers of events that come from Quick Access, Drives, etc.

https://github.com/files-community/Files/blob/868a6f1da8c079c0ca08ad25a0f395eb0299cbe5/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs#L607-L633

Secondly, the decoupled control `SidebarView` takes a view model for it. We should be passing references to DPs controlled in the `MainPageViewModel` instead of having a dedicated view model for this control.

https://github.com/files-community/Files/blob/868a6f1da8c079c0ca08ad25a0f395eb0299cbe5/src/Files.App/Views/MainPage.xaml#L176-L187

Thirdly, `SidebarView` is a `UserControl` instead of a control that derives from `Control`, so-called being a custom control. As aforementioned, since the control depends on an instance of a dedicated view model, there's a strong bond between this control and the view model. We should make use of events instead and isolate the control from the implementation details of the view model.

https://github.com/files-community/Files/blob/868a6f1da8c079c0ca08ad25a0f395eb0299cbe5/src/Files.App.Controls/Sidebar/SidebarView.xaml.cs#L14

---

With these reasons, we should be going to refactor the sidebar implementations to get rid of the view model reference and to implement better bindings of sidebar items collection. This PR is the first one of the series of improvements, the next one would refactor the sidebar item models and probably replace the view model.

### Resolved / Related Issues

- Related to #15000

### Steps used to test these changes

Since this has no functionality change, this PR can be validated by just deploying and running the app.

1. Open Files app

- [ ] Ejected device
- [x] Opened properties window
- [x] Pinned item
- [x] Unpinned item
- [x] Hid section
- [ ] Unhid section
- [x] Opened reorder items dialog
- [ ] Created library
- [ ] Restored libraries
- [x] Loaded shell extensions in the context menu
- [x] Resized sidebar
- [x] Double clicked to collapse sidebar
- [x] Confirmed sidebar state is saved across sessions
- [x] Confirmed the sidebar collapses on smaller windows
- [x] Confirmed the expanded state for sidebar sections is saved