### PR TITLE
Code Quality: Skip USERNAME env var when launching processes

### DIFF
--- a/src/Files.App/Utils/Shell/LaunchHelper.cs
+++ b/src/Files.App/Utils/Shell/LaunchHelper.cs
@@ -105,7 +105,7 @@ namespace Files.App.Utils.Shell
 						string key = (string)ent.Key;
 
 						// Skip USERNAME to avoid issues where files were executed as SYSTEM user (#12139)
-						if (key == "USERNAME")
+						if (string.Equals(key, "USERNAME", StringComparison.OrdinalIgnoreCase)) 
 							continue;
 
 						process.StartInfo.EnvironmentVariables[key] = (string)ent.Value;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

This is a new approach to solving #12139 and replaces the solution implemented in #14101. This PR adds back the code removed in #14101 and instead skips the USERNAME environment variable when getting the Machine variables.