### PR TITLE
Fix: Fixed crash that would sometimes occur when resizing the window

### DIFF
--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -28,7 +28,7 @@ namespace Files.App
 		{
 			InitializeComponent();
 
-			WindowHandle = WinUIEx.WindowExtensions.GetWindowHandle(this); 
+			WindowHandle = WinUIEx.WindowExtensions.GetWindowHandle(this);
 			MinHeight = 316;
 			MinWidth = 416;
 			ExtendsContentIntoTitleBar = true;


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed a crash (DivideByZeroException) that occurred when resizing the window with multiple panes split vertically.

Closes #17739

**Steps used to test these changes**
1. Open Files with dual pane (vertical split)
2. Resize the window to smaller sizes
3. Resize window back to larger size and verify right pane restores with correct folder
4. Test multiple resize cycles and layouts to ensure stability