### PR TITLE
Feature: Hide drives without attached media from sidebar and homepage

### DIFF
--- a/src/Files.App/Services/Storage/StorageDevicesService.cs
+++ b/src/Files.App/Services/Storage/StorageDevicesService.cs
@@ -21,6 +21,9 @@ namespace Files.App.Services
 			var pCloudDrivePath = App.AppModel.PCloudDrivePath;
 			foreach (var drive in list)
 			{
+				if (!drive.IsReady)
+					continue;
+
 				var driveLabel = DriveHelpers.GetExtendedDriveLabel(drive);
 				// Filter out cloud drives
 				// We don't want cloud drives to appear in the plain "Drives" sections.

--- a/src/Files.App/Utils/Global/WindowsStorageDeviceWatcher.cs
+++ b/src/Files.App/Utils/Global/WindowsStorageDeviceWatcher.cs
@@ -52,6 +52,9 @@ namespace Files.App.Utils
 		private async void Win32_OnDeviceAdded(object? sender, DeviceEventArgs e)
 		{
 			var driveAdded = new DriveInfo(e.DeviceId);
+			if (!driveAdded.IsReady)
+				return;
+
 			var rootAdded = await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(e.DeviceId).AsTask());
 			if (!rootAdded)
 			{
@@ -98,6 +101,9 @@ namespace Files.App.Utils
 			{
 				// Check if this drive is associated with a drive letter
 				var driveAdded = new DriveInfo(root.Path);
+				if (!driveAdded.IsReady)
+					return;
+
 				type = DriveHelpers.GetDriveType(driveAdded);
 				label = DriveHelpers.GetExtendedDriveLabel(driveAdded);
 			}


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where drives without attached media (e.g., empty SD card slots) were displayed in the sidebar and homepage, causing errors when trying to open them.

Closes #16426

**Steps used to test these changes**
1. Plug in an SD card reader with multiple slots (no cards inserted)
2. Launch Files and verify empty drives don't appear in sidebar/homepage
3. Insert a card and verify the drive appears
4. Remove the card and verify the drive disappears