### PR TITLE
Fix: Fixed an issue where AND OR operators didn't work when searching for tags

### DIFF
--- a/src/Files.App/Utils/Storage/Search/TagQueryExpression.cs
+++ b/src/Files.App/Utils/Storage/Search/TagQueryExpression.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Utils.Storage
+{
+	public sealed class TagQueryExpression
+	{
+		public List<List<TagTerm>> OrGroups { get; set; } = new();
+	}
+}

--- a/src/Files.App/Utils/Storage/Search/TagTerm.cs
+++ b/src/Files.App/Utils/Storage/Search/TagTerm.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+namespace Files.App.Utils.Storage
+{
+	public class TagTerm
+	{
+		public HashSet<string> TagUids { get; set; } = new();
+
+		public bool IsExclude { get; set; }
+	}
+}


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where combining tag searches with the NOT operator did not work properly. Additionally enhanced tag search functionality with AND/OR operator support and improved query handling.

Closes #17808

**Steps used to test these changes**
1. Search 'tag:Mountain' - returns files with Mountain tag
2. Search 'tag:Bird' - returns files with Bird tag
3. Search 'tag:Mountain NOT tag:Bird' - returns files with Mountain but NOT Bird
4. Search 'NOT tag:Bird' - returns all files without Bird tag
5. Search 'tag:Mountain AND tag:River' - returns files with both tags
6. Search 'tag:Mountain OR tag:River' - returns files with either tag
7. Search 'tag:red,blue' - returns files with red OR blue tags
