### PR TITLE
Fix: Fixed PNG-based .ico files rendering with black backgrounds

### DIFF
--- a/src/Files.App/Helpers/Win32/Win32Helper.Storage.cs
+++ b/src/Files.App/Helpers/Win32/Win32Helper.Storage.cs
@@ -488,7 +488,7 @@ namespace Files.App.Helpers
 					Color pixelColor = Color.FromArgb(
 						Marshal.ReadInt32(bmpData.Scan0, (bmpData.Stride * y) + (4 * x)));
 
-					if (pixelColor.A > 0 & pixelColor.A < 255)
+					if (pixelColor.A < 255)
 						return true;
 				}
 			}


### PR DESCRIPTION
**Resolved / Related Issues**
- Closes #17923 

**What was wrong**
Custom folder icons using PNG-based `.ico` files displayed with a black background instead of transparency in the sidebar and thumbnail previews. The issue occurred specifically when:
- Icons were rendered at small scales (sidebar icons) and Tab icon.
- Thumbnails were scaled down using Ctrl+Scrollwheel
- The `.ico` file was PNG-based.

**Root Cause**
The `IsAlphaBitmap()` method in [`Win32Helper.Storage.cs`](https://github.com/files-community/Files/blob/main/src/Files.App/Helpers/Win32/Win32Helper.Storage.cs) only detected **semi-transparent pixels** (0 < alpha < 255) but missed **fully transparent pixels** (alpha = 0). 

```csharp
// Only detected semi-transparent pixels
if (pixelColor.A > 0 & pixelColor.A < 255)
    return true;
```

**The Fix**
Changed the alpha detection condition to catch all non-opaque pixels:
```csharp
if (pixelColor.A < 255)
    return true;
```
This ensures that any pixel with transparency (including alpha = 0) is detected, triggering the proper alpha bitmap conversion that preserves transparency.

**Before and After Screenshots:**
<table> <tr> <th align="center">Before</th> <th align="center">After</th> </tr> <tr> <td align="center"> <img src="https://github.com/user-attachments/assets/be1e2445-998e-41ff-bd78-d7cd0d52afc1" alt="BEFORE" height="420"/> </td> <td align="center"> <img src="https://github.com/user-attachments/assets/5e095424-223f-4f04-ba0d-edcaaaa6ab11" alt="AFTER" height="420"/> </td> </tr> </table>


**Steps used to test these changes**

1. Opened Files
2. Created a custom folder icon using a PNG-based `.ico` file with transparent background
3. Applied the icon to a folder via folder properties
4. Pinned the folder to the sidebar
5. Verified the icon displays with proper transparency
6. Scaled thumbnails down using Ctrl+Scrollwheel
7. Confirmed transparency is preserved at all sizes
8. Tested with BMP-based `.ico` files to ensure no regression
9. Tested with system `.dll` icons to confirm they still work correctly