### PR TITLE
Feature: Added default name when creating new files

### DIFF
--- a/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
+++ b/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
@@ -55,7 +55,7 @@ namespace Files.App.Helpers
 			return dialog;
 		}
 
-		public static DynamicDialog GetFor_CreateItemDialog(string itemType)
+		public static DynamicDialog GetFor_CreateItemDialog(string itemType, string? itemName)
 		{
 			DynamicDialog? dialog = null;
 			TextBox inputText = new()
@@ -95,13 +95,14 @@ namespace Files.App.Helpers
 
 			inputText.Loaded += (s, e) =>
 			{
-				// dispatching to the ui thread fixes an issue where the primary dialog button would steal focus
-				_ = inputText.DispatcherQueue.EnqueueOrInvokeAsync(() => 
+				// Dispatching to the UI thread fixes an issue where the primary dialog button would steal focus
+				_ = inputText.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 				{
-					if(itemType.Equals("Folder", StringComparison.OrdinalIgnoreCase))
-					{
+					// Prefill text box with default name #17845
+					if (itemType.Equals("Folder", StringComparison.OrdinalIgnoreCase))
 						inputText.Text = Strings.NewFolder.GetLocalizedResource();
-					}
+					else if (itemName is not null)
+						inputText.Text = string.Format(Strings.CreateNewFile.GetLocalizedResource(), itemName);
 
 					inputText.Focus(FocusState.Programmatic);
 					inputText.SelectAll();

--- a/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
@@ -107,7 +107,7 @@ namespace Files.App.Helpers
 			string? userInput = null;
 			if (itemType != AddItemDialogItemType.File || itemInfo?.Command is null)
 			{
-				DynamicDialog dialog = DynamicDialogFactory.GetFor_CreateItemDialog(itemType.ToString().GetLocalizedResource().ToLower());
+				DynamicDialog dialog = DynamicDialogFactory.GetFor_CreateItemDialog(itemType.ToString().GetLocalizedResource().ToLower(), itemInfo?.Name);
 				await dialog.TryShowAsync(); // Show rename dialog
 
 				if (dialog.DynamicResult != DynamicDialogResult.Primary)

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -4347,4 +4347,7 @@
   <data name="OnlyInColumnsView" xml:space="preserve">
     <value>Only in Columns View</value>
   </data>
+  <data name="CreateNewFile" xml:space="preserve">
+    <value>New {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
Issue:
Closes #17845

Changes:
- Adds subtitle "Enter an item name" in create-item dialog
- Sets default name to "New folder" when creating folder
- Selects name by default to allow fast rename

Test steps: 
1. Launch Files (debug build)
2. Create new folder via Ctrl+Shift+N
3. Check that:
   - The dialog shows subtitle "Enter an item name"
   - "New folder" is prefilled
   - Text is fully selected on open
