### PR TITLE
Feature: Added theme shadow to Omnibar flyout

### DIFF
--- a/src/Files.App.Controls/Omnibar/Omnibar.xaml
+++ b/src/Files.App.Controls/Omnibar/Omnibar.xaml
@@ -89,7 +89,11 @@
 								Background="{ThemeResource AutoSuggestBoxSuggestionsListBackground}"
 								BorderBrush="{ThemeResource AutoSuggestBoxSuggestionsListBorderBrush}"
 								BorderThickness="{ThemeResource AutoSuggestListBorderThemeThickness}"
-								CornerRadius="{ThemeResource OverlayCornerRadius}">
+								CornerRadius="{ThemeResource OverlayCornerRadius}"
+								Translation="0,0,32">
+								<Border.Shadow>
+									<ThemeShadow />
+								</Border.Shadow>
 								<ListView
 									x:Name="PART_SuggestionsListView"
 									MaxHeight="{ThemeResource AutoSuggestListMaxHeight}"


### PR DESCRIPTION
### Resolved / Related Issues

Added the shadow back to the popup.

<img width="904" height="117" alt="image" src="https://github.com/user-attachments/assets/93d26ca4-7702-4b60-b43f-e80c3a1732b9" />

- #16029

### Steps used to test these changes

1. Open Files app
2. Click on empty space of Omnibar