### PR TITLE
GitHub: Removed the extra link space between the download badges

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -26,15 +26,13 @@ You can also use the preview version alongside the stable release to get early a
   <a style="text-decoration:none" href="https://apps.microsoft.com/detail/9NGHP3DX8HDX?launch=true&mode=full">
     <picture>
       <source media="(prefers-color-scheme: light)" srcset="./assets/StoreBadge-dark.png" height="80" />
-      <img src="./assets/StoreBadge-light.png" height="80" />
-    </picture></a>
+      <img src="./assets/StoreBadge-light.png" height="80" /></picture></a>
   &ensp;
   <!-- Classic Installer Badge -->
   <a style="text-decoration:none" href="https://files.community/appinstallers/Files.stable.appinstaller">
     <picture>
       <source media="(prefers-color-scheme: light)" srcset="./assets/ClassicInstallerBadge-dark.png" height="80" />
-      <img src="./assets/ClassicInstallerBadge-light.png" height="80" />
-    </picture></a>
+      <img src="./assets/ClassicInstallerBadge-light.png" height="80" /></picture></a>
 </p>
 
 ## Building from source


### PR DESCRIPTION
### Resolved / Related Issues

_None_

### Steps used to test these changes

_None_

<img width="1279" height="256" alt="image" src="https://github.com/user-attachments/assets/febe0c78-6c42-473c-9699-dd12d93fee95" />
