### PR TITLE
Migrate from VSTest to Microsoft.Testing.Platform

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,5 +6,7 @@
     <MinimalWindowsVersion>10.0.19041.0</MinimalWindowsVersion>
     <WindowsSdkPackageVersion>10.0.26100.67-preview</WindowsSdkPackageVersion>
     <WindowsTargetFramework>$(TargetFrameworkVersion)-windows$(TargetWindowsVersion)</WindowsTargetFramework>
+
+    <EnableMSTestRunner>true</EnableMSTestRunner>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,7 +55,6 @@
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.9" />
     <PackageVersion Include="Appium.WebDriver" Version="4.4.5" />
     <PackageVersion Include="Axe.Windows" Version="2.4.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.0.2" />
     <PackageVersion Include="Dongle.GuidRVAGen" Version="1.0.5" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,9 @@
 {
   "sdk": {
-    "version": "9.0.200",
+    "version": "10.0.101",
     "rollForward": "latestMajor"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/tests/Files.InteractionTests/Files.InteractionTests.csproj
+++ b/tests/Files.InteractionTests/Files.InteractionTests.csproj
@@ -7,12 +7,12 @@
         <Configurations>Debug;Release</Configurations>
         <Platforms>x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Appium.WebDriver" />
         <PackageReference Include="Axe.Windows" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="MSTest.TestAdapter" />
         <PackageReference Include="MSTest.TestFramework" />
     </ItemGroup>


### PR DESCRIPTION
This PR migrates from VSTest to the newer modern alternative, Microsoft.Testing.Platform.