### PR TITLE
Fix: Fixed an issue where search didn't work for tags with spaces in their name

### DIFF
--- a/src/Files.App/Data/Items/WidgetFileTagsContainerItem.cs
+++ b/src/Files.App/Data/Items/WidgetFileTagsContainerItem.cs
@@ -68,7 +68,7 @@ namespace Files.App.Data.Items
 
 		private Task<bool> ViewMore()
 		{
-			return NavigationHelpers.OpenPath($"tag:{Name}", ContentPageContext.ShellPage!);
+			return NavigationHelpers.OpenPath(FolderSearch.FormatTagQuery(Name!), ContentPageContext.ShellPage!);
 		}
 
 		private Task OpenAll()

--- a/src/Files.App/UserControls/Pane/InfoPane.xaml.cs
+++ b/src/Files.App/UserControls/Pane/InfoPane.xaml.cs
@@ -90,7 +90,7 @@ namespace Files.App.UserControls
 			if (tagName is null)
 				return;
 
-			contentPageContext.ShellPage?.SubmitSearch($"tag:{tagName}");
+			contentPageContext.ShellPage?.SubmitSearch(FolderSearch.FormatTagQuery(tagName));
 		}
 	}
 }

--- a/src/Files.App/Utils/FileTags/FileTagsManager.cs
+++ b/src/Files.App/Utils/FileTags/FileTagsManager.cs
@@ -48,14 +48,14 @@ namespace Files.App.Utils.FileTags
 					var tagItem = new FileTagItem
 					{
 						Text = tag.Name,
-						Path = $"tag:{tag.Name}",
+						Path = FolderSearch.FormatTagQuery(tag.Name),
 						FileTag = tag,
 						MenuOptions = new ContextMenuOptions { IsLocationItem = true },
 					};
 
 					lock (fileTags)
 					{
-						if (fileTags.Any(x => x.Path == $"tag:{tag.Name}"))
+						if (fileTags.Any(x => x.Path == FolderSearch.FormatTagQuery(tag.Name)))
 						{
 							continue;
 						}

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -983,7 +983,7 @@ namespace Files.App.Views.Layouts
 			if (tagName is null)
 				return;
 
-			ParentShellPageInstance?.SubmitSearch($"tag:{tagName}");
+			ParentShellPageInstance?.SubmitSearch(FolderSearch.FormatTagQuery(tagName));
 		}
 
 		private void FileTag_PointerEntered(object sender, PointerRoutedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where search didn't work for tags with spaces in their names. When users created tags with spaces (e.g., "My Project") and tried to search for them by clicking the tag in the sidebar or applying them to files, no results were displayed.

Closes #18007

**Steps used to test these changes**
1. Create a tag with spaces in the name (e.g: "Project Work")
2. Apply the tag to files and folders
3. Click the tag in the sidebar - verify files are displayed
4. Search manually using tag:"My Tag" - verify results are shown
5. Test backward compatibility with simple tags without spaces (e.g., tag:Work)
6. Test complex queries with AND/OR operators (e.g., tag:"My Project" AND tag:Urgent)
7. Verify tag folders created/renamed with spaces now display tagged items correctly
