### PR TITLE
Fix: Fixed an issue where the items count was sometimes incorrect in the Details Pane

### DIFF
--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -64,6 +64,12 @@ namespace Files.App.ViewModels
 		// Only used for Binding and ApplyFilesAndFoldersChangesAsync, don't manipulate on this!
 		public BulkConcurrentObservableCollection<ListedItem> FilesAndFolders { get; }
 
+		/// <summary>
+		/// Gets the total count of all enumerated items including those that may be filtered from the display.
+		/// This represents the actual number of items in the directory, not just the visible ones.
+		/// </summary>
+		public int TotalItemCount => filesAndFolders?.Count ?? 0;
+
 		private LayoutPreferencesManager folderSettings = null;
 
 		private ListedItem? currentFolder;
@@ -2093,7 +2099,7 @@ namespace Files.App.ViewModels
 			else if (matchingStorageItem is BaseStorageFolder folder && folder.Properties != null)
 				return await FilesystemTasks.Wrap(() => folder.Properties.RetrievePropertiesAsync(["System.FreeSpace", "System.Capacity", "System.SFGAOFlags"]).AsTask());
 
-			return null;
+		 return null;
 		}
 
 		private async Task WatchForStorageFolderChangesAsync(BaseStorageFolder? rootFolder)
@@ -2244,6 +2250,7 @@ namespace Files.App.ViewModels
 							do
 							{
 								notifyInfo = ref Unsafe.As<byte, FILE_NOTIFY_INFORMATION>(ref buff[offset]);
+
 								string? FileName = null;
 								unsafe
 								{

--- a/src/Files.App/ViewModels/UserControls/Previews/FolderPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/FolderPreviewViewModel.cs
@@ -9,6 +9,8 @@ namespace Files.App.ViewModels.Previews
 {
 	public sealed class FolderPreviewViewModel
 	{
+		private readonly IContentPageContext _contentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
+
 		public ListedItem Item { get; }
 
 		public BitmapImage Thumbnail { get; set; } = new();
@@ -26,8 +28,8 @@ namespace Files.App.ViewModels.Previews
 			var rootItem = await FilesystemTasks.Wrap(() => DriveHelpers.GetRootFromPathAsync(Item.ItemPath));
 			Folder = await StorageFileExtensions.DangerousGetFolderFromPathAsync(Item.ItemPath, rootItem);
 
-			// Get actual item count including hidden items based on user settings.
-			int itemCount = await Task.Run(() => CountItemsInFolder(Item.ItemPath));
+			// Get actual item count including hidden files based on user settings
+			int itemCount = await GetItemCountAsync();
 
 			var result = await FileThumbnailHelper.GetIconAsync(
 				Item.ItemPath,
@@ -69,6 +71,21 @@ namespace Files.App.ViewModels.Previews
 			}
 		}
 
+		private async Task<int> GetItemCountAsync()
+		{
+			// If this is the current folder being viewed, use ShellViewModel's TotalItemCount
+			// which includes hidden files when the setting is enabled (same as status bar)
+			if (_contentPageContext.ShellPage?.ShellViewModel is not null &&
+				_contentPageContext.Folder?.ItemPath == Item.ItemPath)
+			{
+				return _contentPageContext.ShellPage.ShellViewModel.TotalItemCount;
+			}
+
+			// For other folders (e.g., selected folder in the file list), enumerate directly
+			// This respects the user's "Show hidden files" setting
+			return await Task.Run(() => CountItemsInFolder(Item.ItemPath));
+		}
+
 		private static int CountItemsInFolder(string folderPath)
 		{
 			try
@@ -86,7 +103,7 @@ namespace Files.App.ViewModels.Previews
 					var isHidden = (file.Attributes & System.IO.FileAttributes.Hidden) != 0;
 					var isSystem = (file.Attributes & System.IO.FileAttributes.System) != 0;
 
-					// Skip hidden & system directories if their respective settings are off.
+					// Skip hidden & system files if their respective settings are off
 					if (isHidden && (!showHiddenItems || (isSystem && !showProtectedSystemFiles)))
 						continue;
 

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -223,7 +223,7 @@ namespace Files.App.Views.Shells
 			if (ContentPage is null)
 				return;
 
-			var directoryItemCountLocalization = Strings.Items.GetLocalizedFormatResource(ShellViewModel.FilesAndFolders.Count);
+			var directoryItemCountLocalization = Strings.Items.GetLocalizedFormatResource(ShellViewModel.TotalItemCount);
 
 			BranchItem? headBranch = headBranch = InstanceViewModel.IsGitRepository
 					? await GitHelpers.GetRepositoryHead(InstanceViewModel.GitRepositoryPath)
@@ -265,7 +265,7 @@ namespace Files.App.Views.Shells
 					headBranch);
 			}
 
-			contentPage.StatusBarViewModel.DirectoryItemCount = $"{ShellViewModel.FilesAndFolders.Count} {directoryItemCountLocalization}";
+			contentPage.StatusBarViewModel.DirectoryItemCount = $"{ShellViewModel.TotalItemCount} {directoryItemCountLocalization}";
 			contentPage.UpdateSelectionSize();
 		}
 


### PR DESCRIPTION

**Resolved / Related Issues**


- Closes #17211 


**Steps used to test these changes**

1. Tested if Details pane now shows accurate item counts matching the file list view based on user preferences like: 
i)Show\Hide Hidden files & folders
ii)Show\Hide protected system files & folder
iii)Every possible combination of above 2 cases.

<img width="1487" height="811" alt="image" src="https://github.com/user-attachments/assets/6c373ad1-1db1-44df-8fb4-f06cc0edce8b" />

