### PR TITLE
Fix: Made Properties option primary in the sidebar and home page context menus

### DIFF
--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -1013,6 +1013,18 @@ namespace Files.App.ViewModels.UserControls
 				}.Build(),
 				new ContextMenuFlyoutItemViewModel()
 				{
+					Text = Strings.Properties.GetLocalizedResource(),
+					ThemedIconModel = new ThemedIconModel()
+					{
+						ThemedIconStyle = "App.ThemedIcons.Properties",
+					},
+					Command = OpenPropertiesCommand,
+					CommandParameter = menu,
+					IsPrimary = true,
+					ShowItem = options.ShowProperties
+				},
+				new ContextMenuFlyoutItemViewModel()
+				{
 					Text = Strings.PinFolderToSidebar.GetLocalizedResource(),
 					ThemedIconModel = new ThemedIconModel()
 					{
@@ -1050,17 +1062,6 @@ namespace Files.App.ViewModels.UserControls
 					Text = Strings.Eject.GetLocalizedResource(),
 					Command = EjectDeviceCommand,
 					ShowItem = options.ShowEjectDevice
-				},
-				new ContextMenuFlyoutItemViewModel()
-				{
-					Text = Strings.Properties.GetLocalizedResource(),
-					ThemedIconModel = new ThemedIconModel()
-					{
-						ThemedIconStyle = "App.ThemedIcons.Properties",
-					},
-					Command = OpenPropertiesCommand,
-					CommandParameter = menu,
-					ShowItem = options.ShowProperties
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{

--- a/src/Files.App/ViewModels/UserControls/Widgets/DrivesWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/DrivesWidgetViewModel.cs
@@ -115,6 +115,14 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				}.Build(),
 				new()
 				{
+					Text = Strings.Properties.GetLocalizedResource(),
+					ThemedIconModel = new ThemedIconModel() { ThemedIconStyle = "App.ThemedIcons.Properties" },
+					Command = OpenPropertiesCommand,
+					CommandParameter = item,
+					IsPrimary = true
+				},
+				new()
+				{
 					Text = Strings.PinFolderToSidebar.GetLocalizedResource(),
 					ThemedIconModel = new ThemedIconModel() { ThemedIconStyle = "App.ThemedIcons.FavoritePin" },
 					Command = PinToSidebarCommand,
@@ -135,13 +143,6 @@ namespace Files.App.ViewModels.UserControls.Widgets
 					Command = EjectDeviceCommand,
 					CommandParameter = item,
 					ShowItem = options?.ShowEjectDevice ?? false
-				},
-				new()
-				{
-					Text = Strings.Properties.GetLocalizedResource(),
-					ThemedIconModel = new ThemedIconModel() { ThemedIconStyle = "App.ThemedIcons.Properties" },
-					Command = OpenPropertiesCommand,
-					CommandParameter = item
 				},
 				new()
 				{

--- a/src/Files.App/ViewModels/UserControls/Widgets/NetworkLocationsWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/NetworkLocationsWidgetViewModel.cs
@@ -120,6 +120,14 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				}.Build(),
 				new()
 				{
+					Text = Strings.Properties.GetLocalizedResource(),
+					ThemedIconModel = new ThemedIconModel() { ThemedIconStyle = "App.ThemedIcons.Properties" },
+					Command = OpenPropertiesCommand,
+					CommandParameter = item,
+					IsPrimary = true
+				},
+				new()
+				{
 					Text = Strings.PinFolderToSidebar.GetLocalizedResource(),
 					ThemedIconModel = new ThemedIconModel() { ThemedIconStyle = "App.ThemedIcons.FavoritePin" },
 					Command = PinToSidebarCommand,
@@ -142,13 +150,6 @@ namespace Files.App.ViewModels.UserControls.Widgets
 					ShowItem = options?.ShowEjectDevice ?? false
 				},
 				new ContextMenuFlyoutItemViewModelBuilder(CommandManager.FormatDriveFromHome).Build(),
-				new()
-				{
-					Text = Strings.Properties.GetLocalizedResource(),
-					ThemedIconModel = new ThemedIconModel() { ThemedIconStyle = "App.ThemedIcons.Properties" },
-					Command = OpenPropertiesCommand,
-					CommandParameter = item
-				},
 				new()
 				{
 					Text = Strings.TurnOnBitLocker.GetLocalizedResource(),

--- a/src/Files.App/ViewModels/UserControls/Widgets/QuickAccessWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/QuickAccessWidgetViewModel.cs
@@ -111,6 +111,14 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				}.Build(),
 				new()
 				{
+					Text = Strings.Properties.GetLocalizedResource(),
+					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.Properties" },
+					Command = OpenPropertiesCommand,
+					CommandParameter = item,
+					IsPrimary = true
+				},
+				new()
+				{
 					Text = Strings.PinFolderToSidebar.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.FavoritePin" },
 					Command = PinToSidebarCommand,
@@ -130,13 +138,6 @@ namespace Files.App.ViewModels.UserControls.Widgets
 					Text = Strings.SendTo.GetLocalizedResource(),
 					Tag = "SendToPlaceholder",
 					ShowItem = UserSettingsService.GeneralSettingsService.ShowSendToMenu
-				},
-				new()
-				{
-					Text = Strings.Properties.GetLocalizedResource(),
-					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.Properties" },
-					Command = OpenPropertiesCommand,
-					CommandParameter = item
 				},
 				new ContextMenuFlyoutItemViewModel()
 				{

--- a/src/Files.App/ViewModels/UserControls/Widgets/RecentFilesWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/RecentFilesWidgetViewModel.cs
@@ -83,6 +83,14 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				}.Build(),
 				new()
 				{
+					Text = Strings.Properties.GetLocalizedResource(),
+					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.Properties" },
+					Command = OpenPropertiesCommand,
+					CommandParameter = item,
+					IsPrimary = true
+				},
+				new()
+				{
 					Text = Strings.OpenWith.GetLocalizedResource(),
 					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.OpenWith" },
 					Tag = "OpenWithPlaceholder",
@@ -112,13 +120,6 @@ namespace Files.App.ViewModels.UserControls.Widgets
 					Text = Strings.SendTo.GetLocalizedResource(),
 					Tag = "SendToPlaceholder",
 					ShowItem = UserSettingsService.GeneralSettingsService.ShowSendToMenu
-				},
-				new()
-				{
-					Text = Strings.Properties.GetLocalizedResource(),
-					ThemedIconModel = new() { ThemedIconStyle = "App.ThemedIcons.Properties" },
-					Command = OpenPropertiesCommand,
-					CommandParameter = item
 				},
 				new()
 				{


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed inconsistency where the Properties option was displayed as a secondary menu item in sidebar and home widget context menus, while it appeared as a primary icon button in the main file list context menu. Now Properties is consistently displayed as a primary icon button alongside the Copy button across all context menus.

Closes #17977

**Steps used to test these changes**
1. Right-click on items in the Sidebar/Home page (Pinned folders, Drives, etc..)
2. Verify that both Copy and Properties appear as icon buttons at the top of each context menu
3. Verify that Properties functionality works correctly from the new position
