### PR TITLE
Feature: Added setting to disable smooth scrolling

### DIFF
--- a/src/Files.App/Data/Contracts/IAppearanceSettingsService.cs
+++ b/src/Files.App/Data/Contracts/IAppearanceSettingsService.cs
@@ -122,10 +122,5 @@ namespace Files.App.Data.Contracts
 		/// Gets or sets a value indicating when to display the Status Center button.
 		/// </summary>
 		StatusCenterVisibility StatusCenterVisibility { get; set; }
-
-		/// <summary>
-		/// Gets or sets a value indicating whether smooth scrolling is enabled.
-		/// </summary>
-		bool EnableSmoothScrolling { get; set; }
 	}
 }

--- a/src/Files.App/Data/Contracts/IGeneralSettingsService.cs
+++ b/src/Files.App/Data/Contracts/IGeneralSettingsService.cs
@@ -314,5 +314,10 @@ namespace Files.App.Data.Contracts
 		/// Gets or sets a value whether the filter header should be displayed.
 		/// </summary>
 		bool ShowFilterHeader { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether smooth scrolling is enabled.
+		/// </summary>
+		bool EnableSmoothScrolling { get; set; }
 	}
 }

--- a/src/Files.App/Services/App/AppResourcesService.cs
+++ b/src/Files.App/Services/App/AppResourcesService.cs
@@ -14,16 +14,16 @@ namespace Files.App.Services
 
 		public ResourcesService()
 		{
-			SetScrollInertiaEnabled(UserSettingsService.AppearanceSettingsService.EnableSmoothScrolling);
+			SetScrollInertiaEnabled(UserSettingsService.GeneralSettingsService.EnableSmoothScrolling);
 
-			UserSettingsService.AppearanceSettingsService.PropertyChanged += AppearanceSettingsService_PropertyChanged;
+			UserSettingsService.GeneralSettingsService.PropertyChanged += GeneralSettingsService_PropertyChanged;
 		}
 
-		private void AppearanceSettingsService_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+		private void GeneralSettingsService_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == nameof(IAppearanceSettingsService.EnableSmoothScrolling))
+			if (e.PropertyName == nameof(IGeneralSettingsService.EnableSmoothScrolling))
 			{
-				SetScrollInertiaEnabled(UserSettingsService.AppearanceSettingsService.EnableSmoothScrolling);
+				SetScrollInertiaEnabled(UserSettingsService.GeneralSettingsService.EnableSmoothScrolling);
 				ApplyResources();
 			}
 		}

--- a/src/Files.App/Services/Settings/AppearanceSettingsService.cs
+++ b/src/Files.App/Services/Settings/AppearanceSettingsService.cs
@@ -166,13 +166,6 @@ namespace Files.App.Services.Settings
 			set => Set(value);
 		}
 
-		/// <inheritdoc/>
-		public bool EnableSmoothScrolling
-		{
-			get => Get(true);
-			set => Set(value);
-		}
-
 		protected override void RaiseOnSettingChangedEvent(object sender, SettingChangedEventArgs e)
 		{
 			base.RaiseOnSettingChangedEvent(sender, e);

--- a/src/Files.App/Services/Settings/GeneralSettingsService.cs
+++ b/src/Files.App/Services/Settings/GeneralSettingsService.cs
@@ -387,6 +387,13 @@ namespace Files.App.Services.Settings
 			set => Set(value);
 		}
 
+		/// <inheritdoc/>
+		public bool EnableSmoothScrolling
+		{
+			get => Get(true);
+			set => Set(value);
+		}
+
 		protected override void RaiseOnSettingChangedEvent(object sender, SettingChangedEventArgs e)
 		{
 			base.RaiseOnSettingChangedEvent(sender, e);

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -4353,4 +4353,7 @@
   <data name="EnableSmoothScrolling" xml:space="preserve">
     <value>Enable smooth scrolling</value>
   </data>
+  <data name="Scrolling" xml:space="preserve">
+    <value>Scrolling</value>
+  </data>
 </root>

--- a/src/Files.App/ViewModels/Settings/AppearanceViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AppearanceViewModel.cs
@@ -351,20 +351,6 @@ namespace Files.App.ViewModels.Settings
 			}
 		}
 
-		public bool EnableSmoothScrolling
-		{
-			get => UserSettingsService.AppearanceSettingsService.EnableSmoothScrolling;
-			set
-			{
-				if (value != UserSettingsService.AppearanceSettingsService.EnableSmoothScrolling)
-				{
-					UserSettingsService.AppearanceSettingsService.EnableSmoothScrolling = value;
-
-					OnPropertyChanged();
-				}
-			}
-		}
-
 		public bool IsAppEnvironmentDev
 		{
 			get => AppLifecycleHelper.AppEnvironment is AppEnvironment.Dev;

--- a/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/GeneralViewModel.cs
@@ -547,6 +547,20 @@ namespace Files.App.ViewModels.Settings
 			}
 		}
 
+		public bool EnableSmoothScrolling
+		{
+			get => UserSettingsService.GeneralSettingsService.EnableSmoothScrolling;
+			set
+			{
+				if (value != UserSettingsService.GeneralSettingsService.EnableSmoothScrolling)
+				{
+					UserSettingsService.GeneralSettingsService.EnableSmoothScrolling = value;
+
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		public void Dispose()
 		{
 			if (!disposed)

--- a/src/Files.App/Views/Settings/AppearancePage.xaml
+++ b/src/Files.App/Views/Settings/AppearancePage.xaml
@@ -283,17 +283,6 @@
 					AutomationProperties.Name="{helpers:ResourceString Name=ShowStatusBar}"
 					IsOn="{x:Bind ViewModel.ShowStatusBar, Mode=TwoWay}" />
 			</wctcontrols:SettingsCard>
-
-			<!--  Enable Smooth Scrolling  -->
-			<wctcontrols:SettingsCard
-				Header="{helpers:ResourceString Name=EnableSmoothScrolling}">
-				<wctcontrols:SettingsCard.HeaderIcon>
-					<FontIcon Glyph="&#xEC8F;" />
-				</wctcontrols:SettingsCard.HeaderIcon>
-				<ToggleSwitch
-					AutomationProperties.Name="{helpers:ResourceString Name=EnableSmoothScrolling}"
-					IsOn="{x:Bind ViewModel.EnableSmoothScrolling, Mode=TwoWay}" />
-			</wctcontrols:SettingsCard>
 		</StackPanel>
 	</Grid>
 </Page>

--- a/src/Files.App/Views/Settings/GeneralPage.xaml
+++ b/src/Files.App/Views/Settings/GeneralPage.xaml
@@ -321,13 +321,27 @@
 				</wctcontrols:SettingsExpander.Items>
 			</wctcontrols:SettingsExpander>
 
-
 			<!--  Overflow Options  -->
 			<wctcontrols:SettingsCard Header="{helpers:ResourceString Name=SettingsContextMenuOverflow}">
 				<wctcontrols:SettingsCard.HeaderIcon>
 					<FontIcon Glyph="&#xE712;" />
 				</wctcontrols:SettingsCard.HeaderIcon>
 				<ToggleSwitch AutomationProperties.Name="{helpers:ResourceString Name=SettingsContextMenuOverflow}" IsOn="{x:Bind ViewModel.MoveShellExtensionsToSubMenu, Mode=TwoWay}" />
+			</wctcontrols:SettingsCard>
+
+			<!--  Scrolling  -->
+			<TextBlock
+				Padding="0,16,0,4"
+				FontSize="16"
+				FontWeight="Medium"
+				Text="{helpers:ResourceString Name=Scrolling}" />
+
+			<!--  Enable Smooth Scrolling  -->
+			<wctcontrols:SettingsCard Header="{helpers:ResourceString Name=EnableSmoothScrolling}">
+				<wctcontrols:SettingsCard.HeaderIcon>
+					<FontIcon Glyph="&#xEC8F;" />
+				</wctcontrols:SettingsCard.HeaderIcon>
+				<ToggleSwitch AutomationProperties.Name="{helpers:ResourceString Name=EnableSmoothScrolling}" IsOn="{x:Bind ViewModel.EnableSmoothScrolling, Mode=TwoWay}" />
 			</wctcontrols:SettingsCard>
 		</StackPanel>
 


### PR DESCRIPTION
**Resolved / Related Issues**
Added a new setting to disable smooth scrolling across all layouts and scrollable components in the application

Closes #15962

**Steps used to test these changes**
1. Navigate to Settings > Appearance
2. Toggle "Enable smooth scrolling" setting
3. Verify scrolling behavior in all layout modes:
   - Details layout
   - List layout
   - Cards layout
   - Grid layout
   - Columns layout
4. Verify scrolling behavior in the sidebar navigation
5. Verify scrolling behavior on the home page
6. Verify scrolling behavior on the Settings page
7. Verify setting persists after app restart
8. Verify smooth scrolling is enabled by default for new users
