### PR TITLE
Fix: Fixed an issue where SEER would reopen after manual closure

### DIFF
--- a/src/Files.App/Services/PreviewPopupProviders/SeerProProvider.cs
+++ b/src/Files.App/Services/PreviewPopupProviders/SeerProProvider.cs
@@ -15,6 +15,7 @@ namespace Files.App.Services.PreviewPopupProviders
 		public static SeerProProvider Instance { get; } = new();
 
 		private string? CurrentPath;
+		private HWND? _cachedSeerWindowHandle;
 
 		private bool? _IsTrackSelectionSettingEnabledCache;
 		private bool IsTrackSelectionSettingEnabled
@@ -27,6 +28,12 @@ namespace Files.App.Services.PreviewPopupProviders
 			}
 		}
 
+		private HWND GetSeerWindowHandle()
+		{
+			_cachedSeerWindowHandle ??= PInvoke.FindWindow("SeerWindowClass", null);
+			return _cachedSeerWindowHandle.Value;
+		}
+
 		public unsafe async Task TogglePreviewPopupAsync(string path)
 		{
 			COPYDATASTRUCT data = default;
@@ -37,7 +44,7 @@ namespace Files.App.Services.PreviewPopupProviders
 			var pData = Marshal.AllocHGlobal(Marshal.SizeOf(data));
 			Marshal.StructureToPtr(data, pData, false);
 
-			HWND hWnd = PInvoke.FindWindow("SeerWindowClass", null);
+			HWND hWnd = GetSeerWindowHandle();
 			var result = PInvoke.SendMessage(hWnd, 0x004A /*WM_COPYDATA*/, 0, pData);
 
 			bool isVisible = PInvoke.IsWindowVisible(hWnd);
@@ -49,7 +56,7 @@ namespace Files.App.Services.PreviewPopupProviders
 
 		public async Task SwitchPreviewAsync(string path)
 		{
-			HWND hWnd = PInvoke.FindWindow("SeerWindowClass", null);
+			HWND hWnd = GetSeerWindowHandle();
 			bool isWindowVisible = PInvoke.IsWindowVisible(hWnd);
 
 			if (CurrentPath is not null && !isWindowVisible)
@@ -72,7 +79,7 @@ namespace Files.App.Services.PreviewPopupProviders
 
 		public async unsafe Task<bool> DetectAvailability()
 		{
-			var hWnd = (nint)PInvoke.FindWindow("SeerWindowClass", null).Value;
+			var hWnd = (nint)GetSeerWindowHandle().Value;
 			return hWnd != nint.Zero && hWnd.ToInt64() != -1;
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where SEER would automatically reopen when selecting files after the user manually closed the SEER window.

Closes #17724

**Steps used to test these changes**
1. Enable track selection in SEER settings
2. Press Space on File A > Verify SEER opens
3. Manually close SEER window (click X)
4. Click File B without pressing Space > Verify SEER stays closed
5. Press Space on File B > Verify SEER opens normally
