### PR TITLE
Fix: Column view trace not updating on theme change

### DIFF
--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
@@ -177,6 +177,7 @@ namespace Files.App.Views.Layouts
 			currentIconSize = LayoutSizeKindHelper.GetIconSize(FolderLayoutModes.ColumnView);
 
 			UserSettingsService.LayoutSettingsService.PropertyChanged += LayoutSettingsService_PropertyChanged;
+			this.ActualThemeChanged += ColumnLayoutPage_ActualThemeChanged;
 
 			SetItemContainerStyle();
 		}
@@ -197,6 +198,7 @@ namespace Files.App.Views.Layouts
 		{
 			base.OnNavigatingFrom(e);
 			UserSettingsService.LayoutSettingsService.PropertyChanged -= LayoutSettingsService_PropertyChanged;
+			this.ActualThemeChanged -= ColumnLayoutPage_ActualThemeChanged;
 			ParentShellPageInstance.ShellViewModel.ItemLoadStatusChanged -= OnItemLoadStatusChanged;
 		}
 
@@ -223,6 +225,15 @@ namespace Files.App.Views.Layouts
 					currentIconSize = newIconSize;
 					_ = ReloadItemIconsAsync();
 				}
+			}
+		}
+
+		private void ColumnLayoutPage_ActualThemeChanged(FrameworkElement sender, object args)
+		{
+			// Reapply the folder background when theme changes
+			if (openedFolderPresenter is not null)
+			{
+				SetFolderBackground(openedFolderPresenter, this.Resources["ListViewItemBackgroundSelected"] as SolidColorBrush);
 			}
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #12577

**Quality Checklist**
- ✅ Follows established code patterns (ActualThemeChanged event handler similar to SpeedGraph.cs)
- ✅ Follows Files coding style guidelines (tabs, PascalCase, proper structure)
- ✅ Code formatting verified with dotnet format
- ✅ Single logical change addressing one specific issue
- ✅ PR linked to approved issue marked as "Ready to build"

**Steps used to test these changes**

Due to system constraints with UWP packaging and deployment, I was unable to run the full app locally to test the fix at runtime. However, I have completed the following verification:

1. ✅ Build verification: Successfully compiled the solution with **0 errors** (Release configuration, x64)
2. ✅ Code pattern validation: Implemented the fix following the exact same pattern used in `SpeedGraph.cs` (lines 88-95)
3. ✅ Code review: Verified the logic correctly reapplies folder background when theme changes
4. ✅ Style compliance: Passed formatting checks against Files coding guidelines

**Implementation Details**

The fix adds an `ActualThemeChanged` event handler to `ColumnLayoutPage.xaml.cs` that reapplies the folder background color when the app theme changes. This ensures the visual trace (highlighted folder background) updates correctly when switching between Light/Dark themes.

**Changes Made:**
- Added event subscription in `OnNavigatedTo()`: `this.ActualThemeChanged += ColumnLayoutPage_ActualThemeChanged;`
- Added event unsubscription in `OnNavigatingFrom()`: `this.ActualThemeChanged -= ColumnLayoutPage_ActualThemeChanged;`
- Added new event handler method that calls `SetFolderBackground()` to reapply the theme-appropriate background color

**Testing Request**

Due to the system limitations mentioned above, I was unable to verify the fix in the running application. It would be greatly appreciated if a maintainer or reviewer could test this change to confirm it resolves the issue as expected. I am eager to address any feedback and make additional changes if needed to ensure this fix works correctly.

The solution builds successfully and the implementation follows established patterns in the codebase, so I'm confident in the approach, but runtime verification would be valuable.