### PR TITLE
Feature: Added SSH support for Git and progress reporting in Status Center 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,8 +21,7 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Triggers" Version="8.2.251219" />
     <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
     <PackageVersion Include="FluentFTP" Version="53.0.2" />
-    <!-- Note, 0.31 causes issues with repos cloned via ssh -->
-    <PackageVersion Include="LibGit2Sharp" Version="0.30.0" />
+    <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="MessageFormat" Version="7.1.3" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />

--- a/src/Files.App/Actions/Git/GitFetchAction.cs
+++ b/src/Files.App/Actions/Git/GitFetchAction.cs
@@ -24,11 +24,9 @@ namespace Files.App.Actions
 			_context.PropertyChanged += Context_PropertyChanged;
 		}
 
-		public Task ExecuteAsync(object? parameter = null)
+		public async Task ExecuteAsync(object? parameter = null)
 		{
-			GitHelpers.FetchOrigin(_context.ShellPage!.InstanceViewModel.GitRepositoryPath);
-
-			return Task.CompletedTask;
+			await GitHelpers.FetchOrigin(_context.ShellPage!.InstanceViewModel.GitRepositoryPath);
 		}
 
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Files.App/Data/Enums/FileOperationType.cs
+++ b/src/Files.App/Data/Enums/FileOperationType.cs
@@ -72,5 +72,20 @@ namespace Files.App.Data.Enums
 		/// A font has been installed
 		/// </summary>
 		InstallFont = 13,
+
+		/// <summary>
+		/// A git repo has been pushed
+		/// </summary>
+		GitPush = 14,
+
+		/// <summary>
+		/// A git repo has been fetched
+		/// </summary>
+		GitFetch = 15,
+
+		/// <summary>
+		/// A git repo has been pulled
+		/// </summary>
+		GitPull = 16,
 	}
 }

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3738,6 +3738,102 @@
     <value>Failed to empty Recycle Bin</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
+  <data name="StatusCenter_GitPushCanceled_Header" xml:space="preserve">
+    <value>Canceled pushing to "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPushCanceled_SubHeader" xml:space="preserve">
+    <value>Canceled pushing branch "{0}" to "{1}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPushComplete_Header" xml:space="preserve">
+    <value>Pushed to "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPushComplete_SubHeader" xml:space="preserve">
+    <value>Pushed branch "{0}" to "{1}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPushFailed_Header" xml:space="preserve">
+    <value>Error pushing to "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPushFailed_SubHeader" xml:space="preserve">
+    <value>Failed to push branch "{0}" to "{1}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPushInProgress_Header" xml:space="preserve">
+    <value>Pushing to "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPushInProgress_SubHeader" xml:space="preserve">
+    <value>Pushing branch "{0}" to "{1}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitFetchCanceled_Header" xml:space="preserve">
+    <value>Canceled fetching from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitFetchCanceled_SubHeader" xml:space="preserve">
+    <value>Canceled fetching from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitFetchComplete_Header" xml:space="preserve">
+    <value>Fetched from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitFetchComplete_SubHeader" xml:space="preserve">
+    <value>Fetched from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitFetchFailed_Header" xml:space="preserve">
+    <value>Error fetching from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitFetchFailed_SubHeader" xml:space="preserve">
+    <value>Failed to fetch from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitFetchInProgress_Header" xml:space="preserve">
+    <value>Fetching from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitFetchInProgress_SubHeader" xml:space="preserve">
+    <value>Fetching from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPullCanceled_Header" xml:space="preserve">
+    <value>Canceled pulling from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPullCanceled_SubHeader" xml:space="preserve">
+    <value>Canceled pulling branch "{0}" from "{1}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPullComplete_Header" xml:space="preserve">
+    <value>Pulled from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPullComplete_SubHeader" xml:space="preserve">
+    <value>Pulled branch "{0}" from "{1}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPullFailed_Header" xml:space="preserve">
+    <value>Error pulling from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPullFailed_SubHeader" xml:space="preserve">
+    <value>Failed to pull branch "{0}" from "{1}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPullInProgress_Header" xml:space="preserve">
+    <value>Pulling from "{0}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
+  <data name="StatusCenter_GitPullInProgress_SubHeader" xml:space="preserve">
+    <value>Pulling branch "{0}" from "{1}"</value>
+    <comment>Shown in a StatusCenter card.</comment>
+  </data>
   <data name="StatusCenter_Prepare_Header" xml:space="preserve">
     <value>Preparing the operation...</value>
     <comment>Shown in a StatusCenter card.</comment>

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -3823,7 +3823,10 @@
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_GitPullFailed_SubHeader" xml:space="preserve">
-    <value>Failed to pull branch "{0}" from "{1}"</value>
+    <value>We couldn't pull the latest changes from the remote right now.</value>
+  </data>
+  <data name="GitError_UncommittedChanges" xml:space="preserve">
+    <value>Please commit or stash your changes before pulling.</value>
     <comment>Shown in a StatusCenter card.</comment>
   </data>
   <data name="StatusCenter_GitPullInProgress_Header" xml:space="preserve">

--- a/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
+++ b/src/Files.App/Utils/StatusCenter/StatusCenterHelper.cs
@@ -538,6 +538,191 @@ namespace Files.App.Utils.StatusCenter
 			}
 		}
 
+		public static StatusCenterItem AddCard_GitPush(
+			string destination,
+			string branchName,
+			ReturnResult returnStatus,
+			long itemsCount = 0,
+			long totalSize = 0)
+		{
+			if (returnStatus == ReturnResult.Cancelled)
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitPushCanceled_Header",
+					"StatusCenter_GitPushCanceled_SubHeader",
+					ReturnResult.Cancelled,
+					FileOperationType.GitPush,
+					branchName.CreateEnumerable(),
+					destination.CreateEnumerable(),
+					false,
+					itemsCount,
+					totalSize);
+			}
+			else if (returnStatus == ReturnResult.InProgress)
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitPushInProgress_Header",
+					"StatusCenter_GitPushInProgress_SubHeader",
+					ReturnResult.InProgress,
+					FileOperationType.GitPush,
+					branchName.CreateEnumerable(),
+					destination.CreateEnumerable(),
+					true,
+					itemsCount,
+					totalSize,
+					new CancellationTokenSource());
+			}
+			else if (returnStatus == ReturnResult.Success)
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitPushComplete_Header",
+					"StatusCenter_GitPushComplete_SubHeader",
+					ReturnResult.Success,
+					FileOperationType.GitPush,
+					branchName.CreateEnumerable(),
+					destination.CreateEnumerable(),
+					false,
+					itemsCount,
+					totalSize);
+			}
+			else
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitPushFailed_Header",
+					"StatusCenter_GitPushFailed_SubHeader",
+					ReturnResult.Failed,
+					FileOperationType.GitPush,
+					branchName.CreateEnumerable(),
+					destination.CreateEnumerable(),
+					false,
+					itemsCount,
+					totalSize);
+			}
+		}
+
+		public static StatusCenterItem AddCard_GitFetch(
+			string remoteName,
+			ReturnResult returnStatus,
+			long itemsCount = 0,
+			long totalSize = 0)
+		{
+			if (returnStatus == ReturnResult.Cancelled)
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitFetchCanceled_Header",
+					"StatusCenter_GitFetchCanceled_SubHeader",
+					ReturnResult.Cancelled,
+					FileOperationType.GitFetch,
+					remoteName.CreateEnumerable(),
+					null,
+					false,
+					itemsCount,
+					totalSize);
+			}
+			else if (returnStatus == ReturnResult.InProgress)
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitFetchInProgress_Header",
+					"StatusCenter_GitFetchInProgress_SubHeader",
+					ReturnResult.InProgress,
+					FileOperationType.GitFetch,
+					remoteName.CreateEnumerable(),
+					null,
+					true,
+					itemsCount,
+					totalSize,
+					new CancellationTokenSource());
+			}
+			else if (returnStatus == ReturnResult.Success)
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitFetchComplete_Header",
+					"StatusCenter_GitFetchComplete_SubHeader",
+					ReturnResult.Success,
+					FileOperationType.GitFetch,
+					remoteName.CreateEnumerable(),
+					null,
+					false,
+					itemsCount,
+					totalSize);
+			}
+			else
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitFetchFailed_Header",
+					"StatusCenter_GitFetchFailed_SubHeader",
+					ReturnResult.Failed,
+					FileOperationType.GitFetch,
+					remoteName.CreateEnumerable(),
+					null,
+					false,
+					itemsCount,
+					totalSize);
+			}
+		}
+
+		public static StatusCenterItem AddCard_GitPull(
+			string destination,
+			string branchName,
+			ReturnResult returnStatus,
+			long itemsCount = 0,
+			long totalSize = 0)
+		{
+			if (returnStatus == ReturnResult.Cancelled)
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitPullCanceled_Header",
+					"StatusCenter_GitPullCanceled_SubHeader",
+					ReturnResult.Cancelled,
+					FileOperationType.GitPull,
+					branchName.CreateEnumerable(),
+					destination.CreateEnumerable(),
+					false,
+					itemsCount,
+					totalSize);
+			}
+			else if (returnStatus == ReturnResult.InProgress)
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitPullInProgress_Header",
+					"StatusCenter_GitPullInProgress_SubHeader",
+					ReturnResult.InProgress,
+					FileOperationType.GitPull,
+					branchName.CreateEnumerable(),
+					destination.CreateEnumerable(),
+					true,
+					itemsCount,
+					totalSize,
+					new CancellationTokenSource());
+			}
+			else if (returnStatus == ReturnResult.Success)
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitPullComplete_Header",
+					"StatusCenter_GitPullComplete_SubHeader",
+					ReturnResult.Success,
+					FileOperationType.GitPull,
+					branchName.CreateEnumerable(),
+					destination.CreateEnumerable(),
+					false,
+					itemsCount,
+					totalSize);
+			}
+			else
+			{
+				return _statusCenterViewModel.AddItem(
+					"StatusCenter_GitPullFailed_Header",
+					"StatusCenter_GitPullFailed_SubHeader",
+					ReturnResult.Failed,
+					FileOperationType.GitPull,
+					branchName.CreateEnumerable(),
+					destination.CreateEnumerable(),
+					false,
+					itemsCount,
+					totalSize);
+			}
+		}
+
 		public static StatusCenterItem AddCard_InstallFont(
 			IEnumerable<string> source,
 			ReturnResult returnStatus,
@@ -752,6 +937,40 @@ namespace Files.App.Utils.StatusCenter
 
 						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
 							: card.SubHeaderStringResource.GetLocalizedFormatResource(card.TotalItemsCount, sourcePath);
+						card.SubHeader = subHeaderString;
+						break;
+					}
+
+				case FileOperationType.GitPush:
+					{
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(destinationDirName);
+						card.Header = headerString;
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(sourceFileName, destinationDirName);
+						card.SubHeader = subHeaderString;
+						break;
+					}
+				case FileOperationType.GitFetch:
+					{
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(sourceFileName);
+						card.Header = headerString;
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(sourceFileName);
+						card.SubHeader = subHeaderString;
+						break;
+					}
+				case FileOperationType.GitPull:
+					{
+						string headerString = string.IsNullOrWhiteSpace(card.HeaderStringResource) ? string.Empty
+							: card.HeaderStringResource.GetLocalizedFormatResource(destinationDirName);
+						card.Header = headerString;
+
+						string subHeaderString = string.IsNullOrWhiteSpace(card.SubHeaderStringResource) ? string.Empty
+							: card.SubHeaderStringResource.GetLocalizedFormatResource(sourceFileName, destinationDirName);
 						card.SubHeader = subHeaderString;
 						break;
 					}


### PR DESCRIPTION
**Resolved / Related Issues**

Closes #17692

**Changes**

- **SSH Support**: Implemented SSH key authentication via the system OpenSSH Agent. This resolves compatibility issues with LibGit2Sharp 0.31.0 and adds support for passphrase-protected keys without custom dialogs.
- **Status Center Integration**: Git Push, Fetch, and Pull operations now report real-time progress (items processed, transfer bytes) to the Status Center.
- **Real-time Refresh**: Fixed the Git Status Bar (commits ahead/behind) not refreshing automatically after remote operations.
- **Performance**: Refactored [FetchOrigin](cci:1://file:///c:/Github/Fork/Files/src/Files.App/Utils/Git/GitHelpers.cs:357:2-442:3) and [PullOriginAsync](cci:1://file:///c:/Github/Fork/Files/src/Files.App/Utils/Git/GitHelpers.cs:444:2-538:3) to use `async/await` and run on background threads, preventing UI freezes during network operations.
- **Cleanup**: Removed the obsolete `GitPassphraseDialog` and custom SSH credential logic.

**Steps used to test these changes**

1. **SSH Push/Pull**:
   - Cloned a repository using an SSH URL (`git@github.com:...`).
   - Verified that `git push` and `git pull` work seamlessly using the system SSH Agent (with both passphrase-protected and standard keys).
2. **Status Center Feedback**:
   - Performed a long-running push operation.
   - Observed the Status Center card appearing with "Pushing..." status.
   - Verified that progress percentages and item counts updated in real-time.
   - Verified that success/failure cards are displayed correctly after completion.
3. **UI Refresh**:
   - Committed a change locally.
   - Pushed the change to origin.
   - Verified that the "Commits Ahead" count in the status bar (bottom right) automatically cleared to 0 without needing a manual refresh.
4. **HTTPS Fallback**:
   - Verified that standard HTTPS repositories still work correctly with username/password (Personal Access Token) authentication.