### PR TITLE
Fix: Fixed an issue where archives with reserved item names wouldn't extract correctly

### DIFF
--- a/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
@@ -97,12 +97,8 @@ namespace Files.App.Actions
 							return null;
 
 						var parts = fileName.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
-						foreach (var part in parts)
-						{
-							if (part is "." or "..")
-								continue;
+						foreach (var part in parts.Where(part => part is not "." and not ".."))
 							return part;
-						}
 
 						return null;
 					}

--- a/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
@@ -97,15 +97,29 @@ namespace Files.App.Actions
 					if (zipFile is null)
 						return true;
 
-					return zipFile.ArchiveFileData.Select(file =>
+					static string? GetFirstMeaningfulSegment(string? fileName)
 					{
-						var pathCharIndex = file.FileName.IndexOfAny(['/', '\\']);
-						if (pathCharIndex == -1)
-							return file.FileName;
-						else
-							return file.FileName.Substring(0, pathCharIndex);
-					})
-					.Distinct().Count() > 1;
+						if (string.IsNullOrEmpty(fileName))
+							return null;
+
+						var parts = fileName.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
+						foreach (var part in parts)
+						{
+							if (part is "." or "..")
+								continue;
+							return part;
+						}
+
+						return null;
+					}
+
+					var topLevelEntries = zipFile.ArchiveFileData
+						.Select(file => GetFirstMeaningfulSegment(file.FileName))
+						.Where(x => !string.IsNullOrEmpty(x))
+						.Distinct()
+						.Count();
+
+					return topLevelEntries > 1;
 				});
 
 				if (smart && currentFolder is not null && isMultipleItems)

--- a/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
@@ -103,12 +103,8 @@ namespace Files.App.Actions
 							return null;
 
 						var parts = fileName.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
-						foreach (var part in parts)
-						{
-							if (part is "." or "..")
-								continue;
+						foreach (var part in parts.Where(part => part is not "." and not ".."))
 							return part;
-						}
 
 						return null;
 					}

--- a/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
@@ -97,25 +97,44 @@ namespace Files.App.Actions
 					if (zipFile is null)
 						return true;
 
-					static string? GetFirstMeaningfulSegment(string? fileName)
+					static ReadOnlySpan<char> GetFirstMeaningfulSegment(ReadOnlySpan<char> path)
 					{
-						if (string.IsNullOrEmpty(fileName))
-							return null;
+						while (!path.IsEmpty)
+						{
+							while (!path.IsEmpty && (path[0] == '/' || path[0] == '\\'))
+								path = path[1..];
 
-						var parts = fileName.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
-						foreach (var part in parts.Where(part => part is not "." and not ".."))
-							return part;
+							if (path.IsEmpty)
+								break;
 
-						return null;
+							int sep = path.IndexOfAny('/', '\\');
+							ReadOnlySpan<char> seg = sep < 0 ? path : path[..sep];
+
+							path = sep < 0 ? ReadOnlySpan<char>.Empty : path[(sep + 1)..];
+
+							if (seg.SequenceEqual(".") || seg.SequenceEqual(".."))
+								continue;
+
+							return seg;
+						}
+
+						return default;
 					}
 
-					var topLevelEntries = zipFile.ArchiveFileData
-						.Select(file => GetFirstMeaningfulSegment(file.FileName))
-						.Where(x => !string.IsNullOrEmpty(x))
-						.Distinct()
-						.Count();
+					string? firstTopLevel = null;
+					foreach (var file in zipFile.ArchiveFileData)
+					{
+						var segment = GetFirstMeaningfulSegment(file.FileName);
+						if (segment.IsEmpty)
+							continue;
 
-					return topLevelEntries > 1;
+						if (firstTopLevel is null)
+							firstTopLevel = segment.ToString();
+						else if (!segment.SequenceEqual(firstTopLevel))
+							return true;
+					}
+
+					return false;
 				});
 
 				if (smart && currentFolder is not null && isMultipleItems)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Closes #18035

**Steps used to test these changes**

1. Opened Files
2. Create an archive in a directory using `tar --exclude=archive.tar -cf archive.tar .` in Powershell
3. Do the 'Extract (smart)' action on the newly created tar archive
4. See that the folder '.' in the archive gets renamed to the archive name 'archive'
