### PR TITLE
Code Quality: Fixed duplicate thumbnail loading calls for cached files

### DIFF
--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -1079,7 +1079,7 @@ namespace Files.App.ViewModels
 							IconOptions.ReturnThumbnailOnly | IconOptions.ReturnOnlyIfCached | (useCurrentScale ? IconOptions.UseCurrentScale : IconOptions.None));
 
 					cancellationToken.ThrowIfCancellationRequested();
-					loadNonCachedThumbnail = true;
+					loadNonCachedThumbnail = result is null;
 				}
 
 				if (result is null)


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed unnecessary duplicate thumbnail loading calls for files that already have cached thumbnails.

**Steps used to test these changes**
1. Add logs in 'LoadThumbnailAsync' in 'Files.App/ViewModels/ShellViewModel.cs' to track the FileThumbnailHelper calls.
2. Navigate to any folder with files
3. Press F5 to refresh
4. Check logs - should not see duplicate cache calls for same file with the same options