### PR TITLE
Code Quality: Use Win32Helper.GetFileAttributes in GetSpecialPropertiesAsync

### DIFF
--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -98,8 +98,9 @@ namespace Files.App.ViewModels.Properties
 			var isOnDevice = Item.SyncStatusUI.SyncStatus is not CloudDriveSyncStatus.FileOnline and not CloudDriveSyncStatus.FolderOnline;
 
 			// Set basic file attributes
-			ViewModel.IsReadOnly = Win32Helper.HasFileAttribute(Item.ItemPath, System.IO.FileAttributes.ReadOnly);
-			ViewModel.IsHidden = Win32Helper.HasFileAttribute(Item.ItemPath, System.IO.FileAttributes.Hidden);
+			FileAttributes fileAttributes = Win32Helper.GetFileAttributes(Item.ItemPath);
+			ViewModel.IsReadOnly = fileAttributes.HasFlag(FileAttributes.ReadOnly);
+			ViewModel.IsHidden = fileAttributes.HasFlag(FileAttributes.Hidden);
 			ViewModel.CanCompressContent = Win32Helper.CanCompressContent(Item.ItemPath);
 			ViewModel.ItemSizeVisibility = true;
 			ViewModel.ItemSize = Item.FileSizeBytes.ToLongSizeString();
@@ -107,7 +108,7 @@ namespace Files.App.ViewModels.Properties
 			// Only check the compressed attribute and size on disk for items on the device
 			if (isOnDevice)
 			{
-				ViewModel.IsContentCompressed = Win32Helper.HasFileAttribute(Item.ItemPath, System.IO.FileAttributes.Compressed);
+				ViewModel.IsContentCompressed = fileAttributes.HasFlag(FileAttributes.Compressed);
 				ViewModel.ItemSizeOnDisk = Win32Helper.GetFileSizeOnDisk(Item.ItemPath)?.ToLongSizeString() ?? string.Empty;
 			}
 

--- a/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FolderProperties.cs
@@ -74,9 +74,10 @@ namespace Files.App.ViewModels.Properties
 
 		public async override Task GetSpecialPropertiesAsync()
 		{
-			ViewModel.IsHidden = Win32Helper.HasFileAttribute(Item.ItemPath, System.IO.FileAttributes.Hidden);
+			var fileAttributes = Win32Helper.GetFileAttributes(Item.ItemPath);
+			ViewModel.IsHidden = fileAttributes.HasFlag(FileAttributes.Hidden);
 			ViewModel.CanCompressContent = Win32Helper.CanCompressContent(Item.ItemPath);
-			ViewModel.IsContentCompressed = Win32Helper.HasFileAttribute(Item.ItemPath, System.IO.FileAttributes.Compressed);
+			ViewModel.IsContentCompressed = fileAttributes.HasFlag(FileAttributes.Compressed);
 
 			var result = await FileThumbnailHelper.GetIconAsync(
 				Item.ItemPath,

--- a/src/Files.App/ViewModels/Properties/Items/LibraryProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/LibraryProperties.cs
@@ -46,8 +46,9 @@ namespace Files.App.ViewModels.Properties
 
 		public async override Task GetSpecialPropertiesAsync()
 		{
-			ViewModel.IsReadOnly = Win32Helper.HasFileAttribute(Library.ItemPath, System.IO.FileAttributes.ReadOnly);
-			ViewModel.IsHidden = Win32Helper.HasFileAttribute(Library.ItemPath, System.IO.FileAttributes.Hidden);
+			var fileAttributes = Win32Helper.GetFileAttributes(Library.ItemPath);
+			ViewModel.IsReadOnly = fileAttributes.HasFlag(System.IO.FileAttributes.ReadOnly);
+			ViewModel.IsHidden = fileAttributes.HasFlag(System.IO.FileAttributes.Hidden);
 			ViewModel.CanCompressContent = false;
 
 			var result = await FileThumbnailHelper.GetIconAsync(


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #18111 

- I also fixed a few other issues in `CombinedProperties.GetSpecialPropertiesAsync`.

**Steps used to test these changes**

1. Open Files
2. Navigate to a library, open the properties window and inspect the attributes.
2. Select a folder, open the properties window and inspect the attributes.
3. Select a file, open the properties window and inspect the attributes.
4. Select a combination of files, open the properties window and inspect the attributes. Also verify that the number of files and folders is correct.
5. Select a combination of files files and folders, open the properties window and inspect the attributes. Also verify that the number of files and folders is correct.
6. Modify the ReadOnly and/or Hidden attributes of a file and repeat steps 3, 4 and 5.