### PR TITLE
Code Quality: Enable TreatWarningsAsErrors in some projects & enable "strict" feature flag globally

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,8 @@
 ﻿<!--  Copyright (c) Files Community. Licensed under the MIT License.  -->
 <Project>
   <PropertyGroup>
+
+    <!--  Generic properties  -->
     <TargetFrameworkVersion>net10.0</TargetFrameworkVersion>
     <TargetWindowsVersion>10.0.26100.0</TargetWindowsVersion>
     <MinimalWindowsVersion>10.0.19041.0</MinimalWindowsVersion>
@@ -8,6 +10,11 @@
     <WindowsTargetFramework>$(TargetFrameworkVersion)-windows$(TargetWindowsVersion)</WindowsTargetFramework>
     <LangVersion>preview</LangVersion>
 
+    <!--  Use Microsoft.Testing.Platform  -->
     <EnableMSTestRunner>true</EnableMSTestRunner>
+
+    <!--  Use strict Roslyn compilation mode  -->
+    <Features>strict</Features>
+
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,6 @@
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.7" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.2" />
-    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="10.0.7" />
     <PackageVersion Include="Appium.WebDriver" Version="4.4.5" />
     <PackageVersion Include="Axe.Windows" Version="2.4.2" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.2.1" />

--- a/src/Files.App.BackgroundTasks/Files.App.BackgroundTasks.csproj
+++ b/src/Files.App.BackgroundTasks/Files.App.BackgroundTasks.csproj
@@ -12,6 +12,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <IsAotCompatible>true</IsAotCompatible>
         <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Files.App.CsWin32/Files.App.CsWin32.csproj
+++ b/src/Files.App.CsWin32/Files.App.CsWin32.csproj
@@ -11,6 +11,7 @@
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <IsAotCompatible>true</IsAotCompatible>
         <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Files.Core.Storage/Files.Core.Storage.csproj
+++ b/src/Files.Core.Storage/Files.Core.Storage.csproj
@@ -10,6 +10,7 @@
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <IsAotCompatible>true</IsAotCompatible>
         <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Files.Shared/Files.Shared.csproj
+++ b/src/Files.Shared/Files.Shared.csproj
@@ -16,7 +16,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="System.IO.Hashing" />
-        <PackageReference Include="System.Threading.Tasks.Dataflow" />
     </ItemGroup>
 
 </Project>

--- a/src/Files.Shared/Files.Shared.csproj
+++ b/src/Files.Shared/Files.Shared.csproj
@@ -10,6 +10,7 @@
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <IsAotCompatible>true</IsAotCompatible>
         <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Resolved / Related Issues

I've introduced [the strict mode](https://www.meziantou.net/csharp-compiler-strict-mode.htm) globally and added `TreatWarningsAsErrors` to some projects.

- #4180

### Steps used to test these changes

_None_

CC: @hez2010 