### PR TITLE
Fix: Fixed issue where `Open With` menu was missing for script files

### DIFF
--- a/src/Files.App/Actions/FileSystem/OpenItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/OpenItemAction.cs
@@ -70,7 +70,7 @@ namespace Files.App.Actions
 			context.HasSelection &&
 			context.PageType != ContentPageTypes.RecycleBin &&
 			context.SelectedItems.All(i =>
-				(i.PrimaryItemAttribute == StorageItemTypes.File && !i.IsShortcut && !i.IsExecutable) ||
+				(i.PrimaryItemAttribute == StorageItemTypes.File && !i.IsShortcut && (!i.IsExecutable || i.IsScriptFile)) ||
 				(i.PrimaryItemAttribute == StorageItemTypes.Folder && i.IsArchive));
 
 		public OpenItemWithApplicationPickerAction()


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #18139 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files and navigated to a folder containing script files (e.g., `.bat`, `.ps1`, `.cmd`).
2. Selected a script file.
3. Validated that the "Open with" option is now available in the context menu.
4. Verified that standard `.exe` files still do not show the "Open with" option, preserving the original behavior for non-script executables.
