### PR TITLE
Code Quality: Moved markdown extension check to helpers

### DIFF
--- a/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
@@ -284,7 +284,7 @@ namespace Files.App.ViewModels.UserControls
 				return new MediaPreview(model);
 			}
 
-			if (MarkdownPreviewViewModel.ContainsExtension(ext))
+			if (FileExtensionHelpers.IsMarkdownFile(ext))
 			{
 				var model = new MarkdownPreviewViewModel(item);
 				await model.LoadAsync();

--- a/src/Files.App/ViewModels/UserControls/Previews/MarkdownPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/MarkdownPreviewViewModel.cs
@@ -19,9 +19,6 @@ namespace Files.App.ViewModels.Previews
 		{
 		}
 
-		public static bool ContainsExtension(string extension)
-			=> extension is ".md" or ".markdown";
-
 		public override async Task<List<FileProperty>> LoadPreviewAndDetailsAsync()
 		{
 			var text = await ReadFileAsTextAsync(Item.ItemFile);

--- a/src/Files.Shared/Helpers/FileExtensionHelpers.cs
+++ b/src/Files.Shared/Helpers/FileExtensionHelpers.cs
@@ -307,5 +307,15 @@ namespace Files.Shared.Helpers
 
 			return _signableTypes.Contains(filePathToCheck);
 		}
+
+		/// <summary>
+		/// Check if the file extension is a markdown file.
+		/// </summary>
+		/// <param name="filePathToCheck"></param>
+		/// <returns><c>true</c> if the filePathToCheck is a markdown file; otherwise, <c>false</c>.</returns>
+		public static bool IsMarkdownFile(string? filePathToCheck)
+		{
+			return HasExtension(filePathToCheck, ".md", ".markdown");
+		}
 	}
 }


### PR DESCRIPTION
Replace MarkdownPreviewViewModel.ContainsExtension usage with FileExtensionHelpers.IsMarkdownFile and remove the now-unused ContainsExtension method. Add IsMarkdownFile to FileExtensionHelpers (wrapping HasExtension for ".md" and ".markdown") so extension checks are centralized and reusable. Update InfoPaneViewModel to call the new helper.

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

For #18049

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Selected markdown file and confirmed the file preview displayed correctly
