### PR TITLE
Code Quality: Avoid redownloading Satori package

### DIFF
--- a/src/Satori.targets
+++ b/src/Satori.targets
@@ -16,7 +16,7 @@
       <SatoriDownloadedThisRun>true</SatoriDownloadedThisRun>
     </PropertyGroup>
     <DownloadFile
-        SourceUrl="https://github.com/files-community/Satori/releases/latest/download/windows_$(Platform).zip"
+        SourceUrl="https://github.com/files-community/Satori/releases/latest/download/$(SatoriArchiveName)"
         DestinationFolder="$(IntermediateOutputPath)SatoriPackage\$(SatoriDownloadDate)"
         Retries="3"
         Condition="!Exists('$(SatoriArchivePath)')">


### PR DESCRIPTION
Add date-based archive path and flags to skip downloading when a matching Satori archive already exists. DownloadFile now targets a dated subfolder and only runs if the archive is missing; a SatoriDownloadedThisRun flag ensures the archive is only deleted when it was downloaded during this run. This reduces redundant downloads across builds and preserves existing archives.