### PR TITLE
Code Quality: Use FileExtensionHelpers.IsRichTextFile for RTF

### DIFF
--- a/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
@@ -324,7 +324,7 @@ namespace Files.App.ViewModels.UserControls
 				return new HtmlPreview(model);
 			}*/
 
-			if (RichTextPreviewViewModel.ContainsExtension(ext))
+			if (FileExtensionHelpers.IsRichTextFile(ext))
 			{
 				var model = new RichTextPreviewViewModel(item);
 				await model.LoadAsync();

--- a/src/Files.App/ViewModels/UserControls/Previews/RichTextPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/RichTextPreviewViewModel.cs
@@ -12,9 +12,6 @@ namespace Files.App.ViewModels.Previews
 
 		public RichTextPreviewViewModel(ListedItem item) : base(item) { }
 
-		public static bool ContainsExtension(string extension)
-			=> extension is ".rtf";
-
 		public async override Task<List<FileProperty>> LoadPreviewAndDetailsAsync()
 		{
 			Stream = await Item.ItemFile.OpenReadAsync();

--- a/src/Files.Shared/Helpers/FileExtensionHelpers.cs
+++ b/src/Files.Shared/Helpers/FileExtensionHelpers.cs
@@ -327,5 +327,15 @@ namespace Files.Shared.Helpers
 		{
 			return HasExtension(fileExtensionToCheck, ".txt");
 		}
+
+		/// <summary>
+		/// Check if the file extension is a rich text file.
+		/// </summary>
+		/// <param name="fileExtensionToCheck"></param>
+		/// <returns><c>true</c> if the fileExtensionToCheck is a rich text file; otherwise, <c>false</c>.</returns>
+		public static bool IsRichTextFile(string? fileExtensionToCheck)
+		{
+			return HasExtension(fileExtensionToCheck, ".rtf");
+		}
 	}
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**
Replace RichTextPreviewViewModel.ContainsExtension with a shared helper and remove the redundant method. InfoPaneViewModel now calls FileExtensionHelpers.IsRichTextFile to detect .rtf files. Added IsRichTextFile to Files.Shared.Helpers with XML documentation, implemented via HasExtension.

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- For #18049

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Selected rich text file
2. Confirmed preview displayed