### PR TITLE
Code Quality: Fix bugs in StringPropertyGenerator and StringsPropertyAnalyzer

### DIFF
--- a/src/Files.Core.SourceGenerator/Parser/JsonParser.cs
+++ b/src/Files.Core.SourceGenerator/Parser/JsonParser.cs
@@ -14,12 +14,11 @@ namespace Files.Core.SourceGenerator.Parser
 		/// <summary>
 		/// Parses a JSON file and extracts keys with optional context information.
 		/// </summary>
-		/// <param name="file">The <see cref="AdditionalText"/> representing the JSON file to parse.</param>
+		/// <param name="text">The text in the JSON file to parse.</param>
 		/// <returns>An <see cref="IEnumerable{ParserItem}"/> containing the extracted keys and their associated values.</returns>
-		internal static IEnumerable<ParserItem> GetKeys(AdditionalText file)
+		internal static IEnumerable<ParserItem> GetKeys(string text)
 		{
-			var jsonText = new SystemIO.StreamReader(file.Path).ReadToEnd();
-			var jsonDocument = JsonDocument.Parse(jsonText);
+			var jsonDocument = JsonDocument.Parse(text);
 			var result = new List<ParserItem>();
 			ProcessJsonObject(jsonDocument.RootElement, string.Empty, result);
 			return result.OrderBy(item => item.Key);

--- a/src/Files.Core.SourceGenerator/Parser/ReswParser.cs
+++ b/src/Files.Core.SourceGenerator/Parser/ReswParser.cs
@@ -14,11 +14,11 @@ namespace Files.Core.SourceGenerator.Parser
 		/// <summary>
 		/// Parses a RESW (Resource) file and extracts keys with optional comments.
 		/// </summary>
-		/// <param name="file">The <see cref="AdditionalText"/> representing the RESW file to parse.</param>
+		/// <param name="text">The text in the RESW file to parse.</param>
 		/// <returns>An <see cref="IEnumerable{ParserItem}"/> containing the extracted keys and their corresponding values and comments.</returns>
-		internal static IEnumerable<ParserItem> GetKeys(AdditionalText file)
+		internal static IEnumerable<ParserItem> GetKeys(string text)
 		{
-			var document = XDocument.Load(file.Path);
+			var document = XDocument.Parse(text);
 			var keys = document
 				.Descendants("data")
 				.Select(element => new ParserItem


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #18159

**Steps used to test these changes**

1. Ensure that the project "Files.Core.SourceGenerator" has been built.
2. In Files.App, class `Program`, add the line `string test = "Actions".ToLocalized();`
3. Observe that a FSG1002 diagnostic is reported.
4. Change the line to `string test = "Kris".ToLocalized();`
5. Observe that the diagnostic is no longer reported.
6. Open "src\Files.App\Strings\en-US\Resources.resw" in the IDE's XML editor and add
   ```xml
   <data name="Kris" xml:space="preserve">
     <value>Kris</value>
   </data>
   ```
   Don't save the file.
7. Go back to the line added in step 3 and observe that a FSG1002 diagnostic is reported.
