### PR TITLE
Fix: Fixed an issue where the items count was sometimes incorrect in the Details Pane

### DIFF
--- a/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/InfoPaneViewModel.cs
@@ -101,6 +101,13 @@ namespace Files.App.ViewModels.UserControls
 			}
 		}
 
+		private string? _DirectoryItemCount;
+		public string? DirectoryItemCount
+		{
+			get => _DirectoryItemCount;
+			set => SetProperty(ref _DirectoryItemCount, value);
+		}
+
 		/// <summary>
 		/// Value indicating if the download cloud files option should be displayed
 		/// </summary>

--- a/src/Files.App/ViewModels/UserControls/Previews/FolderPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/FolderPreviewViewModel.cs
@@ -9,6 +9,7 @@ namespace Files.App.ViewModels.Previews
 {
 	public sealed class FolderPreviewViewModel
 	{
+		private readonly InfoPaneViewModel infoPaneViewModel = Ioc.Default.GetRequiredService<InfoPaneViewModel>();
 		public ListedItem Item { get; }
 
 		public BitmapImage Thumbnail { get; set; } = new();
@@ -46,7 +47,7 @@ namespace Files.App.ViewModels.Previews
 
 			Item.FileDetails =
 			[
-				GetFileProperty("PropertyItemCount", items.Count),
+				GetFileProperty("PropertyItemCount", infoPaneViewModel?.DirectoryItemCount),
 				GetFileProperty("PropertyDateModified", info.DateModified),
 				GetFileProperty("PropertyDateCreated", info.DateCreated),
 				GetFileProperty("PropertyParsingPath", Folder.Path),

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -266,6 +266,7 @@ namespace Files.App.Views.Shells
 			}
 
 			contentPage.StatusBarViewModel.DirectoryItemCount = $"{ShellViewModel.FilesAndFolders.Count} {directoryItemCountLocalization}";
+			contentPage.InfoPaneViewModel.DirectoryItemCount = $"{ShellViewModel.FilesAndFolders.Count} {directoryItemCountLocalization}";
 			contentPage.UpdateSelectionSize();
 		}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

Introduce DirectoryItemCount property on InfoPaneViewModel and populate it from BaseShellPage when updating selection. FolderPreviewViewModel now reads the formatted DirectoryItemCount (via DI) for the item count display instead of using the raw items.Count, keeping the info pane and previews consistent.

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17211

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed the Details Pane and Status Bar both display the number of visible items (consistent with File Explorer)
2. Confirmed the Properties Window displays the actual number of items (consistent with File Explorer)
