### PR TITLE
Code Quality: Enable NuGet Transitive Pinning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="ByteSize" Version="2.1.2" />


### PR DESCRIPTION
**Resolved / Related Issues**
N/A

**Steps used to test these changes**
Build (no behavioral changes expected)

**Changes**
This enables [Transitive Pinning](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management#transitive-pinning) which essentially makes your `Directory.Packages.props` a partial lock file. If a package is listed in `Directory.Packages.props`, that will be the version, even if a project doesn't explicitly reference that package and it's just a transitive dependency. This is the primary benefit of transitive pinning, to ensure all projects within the repo are using the same version of all packages. It also allows security issues in transitive dependencies to be more easily addressed by simply updating `Directory.Packages.props` instead of adding a top-level dependency to all impacted projects, which is far messier and less maintainable.