### PR TITLE
Implement package identity check for secondary tiles

### DIFF
--- a/src/Files.App/Services/Windows/WindowsStartMenuService.cs
+++ b/src/Files.App/Services/Windows/WindowsStartMenuService.cs
@@ -1,4 +1,4 @@
-﻿using Windows.UI.StartScreen;
+using Windows.UI.StartScreen;
 
 namespace Files.App.Services
 {
@@ -27,6 +27,19 @@ namespace Files.App.Services
 			var tileId = GetNativeTileId(storable.Id);
 			displayName ??= storable.Name;
 
+			// Check whether the app has a package identity. Secondary tiles persist reliably only for
+			// packaged apps; running unpackaged (during development) can cause pins to not stick.
+			bool isPackaged = true;
+			try
+			{
+				_ = Windows.ApplicationModel.Package.Current;
+			}
+			catch
+			{
+				isPackaged = false;
+				Debug.WriteLine($"Start pinning may not persist: app has no package identity (unpackaged). TileId: {tileId}");
+			}
+
 			try
 			{
 				var path150x150 = new Uri("ms-appx:///Assets/tile-0-300x300.png");
@@ -48,7 +61,16 @@ namespace Files.App.Services
 
 				WinRT.Interop.InitializeWithWindow.Initialize(tile, MainWindow.Instance.WindowHandle);
 
-				await tile.RequestCreateAsync();
+				// RequestCreateAsync returns a bool indicating whether the tile was created.
+				var created = await tile.RequestCreateAsync();
+				if (!created)
+				{
+					Debug.WriteLine($"SecondaryTile.RequestCreateAsync returned false for {tileId}");
+				}
+				else
+				{
+					Debug.WriteLine($"SecondaryTile created: {tileId}");
+				}
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
Added check for app package identity before pinning tiles.

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files ...
2. ...
