### PR TITLE
Add tab button shifts when non-tab item is dragged over tab strip

### DIFF
--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -170,6 +170,7 @@ namespace Files.App.UserControls.TabBar
 			else
 			{
 				HorizontalTabView.CanReorderTabs = false;
+				e.AcceptedOperation = DataPackageOperation.None;
 			}
 		}
 


### PR DESCRIPTION
Fixes #14143

When a non-tab item is dragged over the tab strip, the add tab button 
incorrectly shifts to the right. This happens because the drag over 
event was only setting CanReorderTabs to false but not explicitly 
rejecting the drag operation.

The fix sets AcceptedOperation to None in the else branch of 
TabView_TabStripDragOver, which correctly signals that non-tab items 
are not valid drop targets on the tab strip.

Note: Developed on Mac, unable to run the app locally. 
Would appreciate maintainer verification on Windows.
