### PR TITLE
Code Quality: Fixed shortcut (.lnk/.url) files showing wrong placeholder icon briefly

### DIFF
--- a/src/Files.App/Services/Storage/IconCacheService.cs
+++ b/src/Files.App/Services/Storage/IconCacheService.cs
@@ -9,7 +9,7 @@ namespace Files.App.Services
 {
 	internal sealed class IconCacheService : IIconCacheService
 	{
-		// Dummy path to generate generic icons for folders and executables.
+		// Dummy path to generate generic icons for folders, executables, and shortcuts.
 		private static readonly string _dummyPath = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory)!, "x46696c6573");
 
 		private readonly ConcurrentDictionary<string, byte[]?> _cache = new();
@@ -24,7 +24,7 @@ namespace Files.App.Services
 			string iconPath;
 			if (isFolder)
 				iconPath = _dummyPath;
-			else if (FileExtensionHelpers.IsExecutableFile(extension))
+			else if (FileExtensionHelpers.IsExecutableFile(extension) || FileExtensionHelpers.IsShortcutOrUrlFile(extension))
 				iconPath = _dummyPath + extension;
 			else
 				iconPath = itemPath;


### PR DESCRIPTION
**Resolved / Related Issues**

Fixed an issue where .lnk and .url shortcut files briefly displayed the wrong icon as a placeholder before their real icon loaded. The first shortcut's target icon was incorrectly cached and reused as the generic placeholder for all subsequent shortcuts.

Fixes #18194

**Steps used to test these changes**
1. Open a folder containing multiple .lnk shortcuts pointing to different targets
2. Scroll away and back, or navigate in and out, to trigger placeholder rendering
3. Verify all shortcuts show the correct generic shortcut icon as the placeholder instead of another shortcut's target icon
4. Verify the real icons load correctly afterward