### PR TITLE
Fix: Fixed an issue where git remotes pointing to a local bare repository were not displaying

### DIFF
--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -126,9 +126,9 @@ namespace Files.App.Utils.Git
 					using var repository = new Repository(path);
 
 					branches = GetValidBranches(repository.Branches)
-						.Where(b => !b.IsRemote || b.RemoteName == "origin")
 						.OrderByDescending(b => b.Tip?.Committer.When)
-						.Take(MAX_NUMBER_OF_BRANCHES)
+						.GroupBy(b => b.IsRemote)
+						.SelectMany(g => g.Take(MAX_NUMBER_OF_BRANCHES))
 						.OrderByDescending(b => b.IsCurrentRepositoryHead)
 						.Select(b => new BranchItem(b.FriendlyName, b.IsCurrentRepositoryHead, b.IsRemote, TryGetTrackingDetails(b)?.AheadBy ?? 0, TryGetTrackingDetails(b)?.BehindBy ?? 0))
 						.ToArray();


### PR DESCRIPTION
Resolved / Related Issues

Fixed an issue where git remotes pointing to a local bare repository were not appearing in the Remotes tab. 

Closes #18185

Steps used to test these changes
1. Clone a repository as bare.
2. Create a non-bare repo and add the bare clone as a remote with a non-origin name.
3. Open the non-bare repo in Files
4. Click the branch name in the status bar and switch to the Remotes tab
5. Verify the branches now appear
