### PR TITLE
Fix: Fixed wrong scroll position when switching out of semantic zoom

### DIFF
--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -911,6 +911,20 @@ namespace Files.App.Views.Layouts
 		private void FileList_Loaded(object sender, RoutedEventArgs e)
 		{
 			ContentScroller = FileList.FindDescendant<ScrollViewer>(x => x.Name == "ScrollViewer");
+			const double OffsetCorrection = 88; // HeaderGrid (40) + ListViewHeaderItem (44 + 4 margin)
+
+			RootGridZoom.ViewChangeStarted += (_, args) =>
+			{
+				var scroller = ContentScroller;
+				if (args.IsSourceZoomedInView || scroller is null)
+					return;
+				void OnZoomScrolled(object? s, ScrollViewerViewChangedEventArgs ve)
+				{
+					scroller.ViewChanged -= OnZoomScrolled; 
+					scroller.ChangeView(0, Math.Max(0, scroller.VerticalOffset - OffsetCorrection), null, true);
+				}
+				scroller.ViewChanged += OnZoomScrolled;
+			};
 		}
 
 		private void SetDetailsColumnsAsDefault_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where navigating to a group from the Group Selection page in the Details Layout scrolled to an incorrect position, causing the group header to be partially hidden and the Name column to be out of view.

Closes #18203

**Steps used to test these changes**
1. Open a folder with grouping enabled in Details Layout
2. Click the group header to open the zoomed-out group overview
3. Click a group header (e.g. "November 2025") to zoom back in
4. Verify the group header is visible just below the column header bar
5. Verify the Name column is visible (horizontal scroll reset to 0)
