### PR TITLE
Fix: Fixed issue with opening images in Microsoft Photos

### DIFF
--- a/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
@@ -631,10 +631,19 @@ namespace Files.App.Helpers
 								{
 									//try using launcher first
 									bool launchSuccess = false;
+
+									// The Windows 11 Photos app ignores NeighboringFilesQuery when launched as default app.
+									// Use the app URI only when this extension is associated with Microsoft Photos.
+									if (FileAssociationHelpers.IsMicrosoftPhotosDefaultAssociation(fileExtension))
+									{
+										string uri = $"ms-photos:viewer?fileName={Uri.EscapeDataString(path)}";
+										launchSuccess = await Launcher.LaunchUriAsync(new Uri(uri));
+									}
+
 									BaseStorageFileQueryResult? fileQueryResult = null;
 									//Get folder to create a file query (to pass to apps like Photos, Movies & TV..., needed to scroll through the folder like what Windows Explorer does)
 									BaseStorageFolder currentFolder = await shellViewModel.GetFolderFromPathAsync(PathNormalization.GetParentDir(path));
-									if (currentFolder is not null)
+									if (!launchSuccess && currentFolder is not null)
 									{
 										QueryOptions queryOptions = new(CommonFileQuery.DefaultQuery, null);
 										//We can have many sort entries

--- a/src/Files.App/Utils/Shell/FileAssociationHelpers.cs
+++ b/src/Files.App/Utils/Shell/FileAssociationHelpers.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.Shell;
+
+namespace Files.App.Utils.Shell
+{
+	public static class FileAssociationHelpers
+	{
+		// Known identifiers used by classic and AppX registrations for Microsoft Photos.
+		private static readonly string[] PhotosAssociationMarkers =
+		[
+			"Microsoft.Windows.Photos",
+			"ms-photos",
+			"AppX43hnxtbyyps62jhe9sqpdzxn1790zetc"
+		];
+
+		// PROGID and APPID are enough for modern default-app detection and cheaper than probing command/exe every time.
+		private static readonly ASSOCSTR[] PhotosAssociationSources =
+		[
+			ASSOCSTR.ASSOCSTR_PROGID,
+			ASSOCSTR.ASSOCSTR_APPID,
+		];
+
+		/// <summary>
+		/// Returns true when the specified extension is currently associated with Microsoft Photos.
+		/// </summary>
+		/// <param name="fileExtension">File extension with or without leading dot (e.g. ".jpg" or "jpg").</param>
+		public static bool IsMicrosoftPhotosDefaultAssociation(string? fileExtension)
+		{
+			if (string.IsNullOrWhiteSpace(fileExtension))
+				return false;
+
+			string normalizedExtension = fileExtension.StartsWith(".", StringComparison.Ordinal)
+				? fileExtension
+				: $".{fileExtension}";
+
+			return IsMicrosoftPhotosDefaultAssociationCore(normalizedExtension);
+		}
+
+		private static bool IsMicrosoftPhotosDefaultAssociationCore(string fileExtension)
+		{
+
+			foreach (var source in PhotosAssociationSources)
+			{
+				if (TryGetAssociationString(fileExtension, source, out string value) && IsPhotosAssociationValue(value))
+					return true;
+			}
+
+			return false;
+		}
+
+		private static bool IsPhotosAssociationValue(string associationValue)
+			=> PhotosAssociationMarkers.Any(marker => associationValue.Contains(marker, StringComparison.OrdinalIgnoreCase));
+
+		private static unsafe bool TryGetAssociationString(string fileExtension, ASSOCSTR association, out string value)
+		{
+			value = string.Empty;
+
+			try
+			{
+				fixed (char* pszAssoc = fileExtension)
+				{
+					PWSTR pwszAssoc = new(pszAssoc);
+					uint cchOutput = 0;
+
+					// First call retrieves the required buffer length.
+					_ = PInvoke.AssocQueryString(
+						ASSOCF.ASSOCF_INIT_IGNOREUNKNOWN,
+						association,
+						pwszAssoc,
+						default,
+						default,
+						&cchOutput);
+
+					if (cchOutput <= 1)
+						return false;
+
+					char[] outputBuffer = new char[cchOutput];
+					fixed (char* pszOutput = outputBuffer)
+					{
+						PWSTR pwszOutput = new(pszOutput);
+
+						// Second call fills the buffer with the resolved association string.
+						var result = PInvoke.AssocQueryString(
+							ASSOCF.ASSOCF_INIT_IGNOREUNKNOWN,
+							association,
+							pwszAssoc,
+							default,
+							pwszOutput,
+							&cchOutput);
+
+						if (result.Failed)
+							return false;
+
+						value = pwszOutput.ToString();
+						return !string.IsNullOrWhiteSpace(value);
+					}
+				}
+			}
+			catch
+			{
+				return false;
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15409

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed that you can cycle between images in Microsoft Photos
2. Confirmed this code only runs when Microsoft Photos is the default app for the selected file extension