### PR TITLE
Feature: Display hidden folders when clicking chevron on path bar

### DIFF
--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -635,11 +635,18 @@ namespace Files.App.ViewModels.UserControls
 		public async Task SetPathBoxDropDownFlyoutAsync(MenuFlyout flyout, PathBoxItem pathItem)
 		{
 			var nextPathItemTitle = PathComponents[PathComponents.IndexOf(pathItem) + 1].Title;
-			IList<StorageFolderWithPath>? childFolders = null;
+			var childFolders = GetSubfolders(pathItem.Path);
 
-			StorageFolderWithPath folder = await ContentPageContext.ShellPage.ShellViewModel.GetFolderWithPathFromPathAsync(pathItem.Path);
-			if (folder is not null)
-				childFolders = (await FilesystemTasks.Wrap(() => folder.GetFoldersWithPathAsync(string.Empty))).Result;
+			// Fall back to StorageFolder API for non-filesystem paths (e.g. FTP)
+			if (childFolders is null)
+			{
+				StorageFolderWithPath folder = await ContentPageContext.ShellPage.ShellViewModel.GetFolderWithPathFromPathAsync(pathItem.Path);
+				if (folder is not null)
+				{
+					var result = (await FilesystemTasks.Wrap(() => folder.GetFoldersWithPathAsync(string.Empty))).Result;
+					childFolders = result?.Select(f => (f.Item.Name, f.Path, false)).ToList();
+				}
+			}
 
 			flyout.Items?.Clear();
 
@@ -663,28 +670,78 @@ namespace Files.App.ViewModels.UserControls
 			var workingPath =
 				PathComponents[PathComponents.Count - 1].Path?.TrimEnd(Path.DirectorySeparatorChar);
 
-			foreach (var childFolder in childFolders)
+			foreach (var (name, path, isHidden) in childFolders)
 			{
 				var flyoutItem = new MenuFlyoutItem
 				{
 					Icon = new FontIcon { Glyph = "\uE8B7" }, // Use font icon as placeholder
-					Text = childFolder.Item.Name,
+					Text = name,
+					Opacity = isHidden ? Constants.UI.DimItemOpacity : 1.0,
 				};
 
-				if (workingPath != childFolder.Path)
+				if (workingPath != path)
 				{
 					flyoutItem.Click += (sender, args) =>
 					{
 						// Navigate to the directory
-						ContentPageContext.ShellPage.NavigateToPath(childFolder.Path);
+						ContentPageContext.ShellPage.NavigateToPath(path);
 					};
 				}
 
 				flyout.Items?.Add(flyoutItem);
 
 				// Start loading the thumbnail in the background
-				_ = LoadFlyoutItemIconAsync(flyoutItem, childFolder.Path);
+				_ = LoadFlyoutItemIconAsync(flyoutItem, path);
 			}
+		}
+
+		/// <summary>
+		/// Enumerates subfolders using Win32 API, including hidden folders based on user settings.
+		/// Returns null if the path cannot be enumerated with Win32.
+		/// </summary>
+		private List<(string Name, string Path, bool IsHidden)>? GetSubfolders(string parentPath)
+		{
+			IntPtr hFile = Win32PInvoke.FindFirstFileExFromApp(
+				$"{parentPath}{Path.DirectorySeparatorChar}*.*",
+				Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
+				out Win32PInvoke.WIN32_FIND_DATA findData,
+				Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch,
+				IntPtr.Zero,
+				Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH);
+
+			if (hFile.ToInt64() == -1)
+				return null;
+
+			var showHidden = UserSettingsService.FoldersSettingsService.ShowHiddenItems;
+			var showSystem = UserSettingsService.FoldersSettingsService.ShowProtectedSystemFiles;
+			var showDot = UserSettingsService.FoldersSettingsService.ShowDotFiles;
+			var folders = new List<(string Name, string Path, bool IsHidden)>();
+
+			do
+			{
+				if (findData.cFileName is "." or "..")
+					continue;
+
+				if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == 0)
+					continue;
+
+				bool isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) != 0;
+				bool isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) != 0;
+
+				if (isHidden && (!showHidden || (isSystem && !showSystem)))
+					continue;
+
+				if (findData.cFileName.StartsWith('.') && !showDot)
+					continue;
+
+				folders.Add((findData.cFileName, Path.Combine(parentPath, findData.cFileName), isHidden));
+			}
+			while (Win32PInvoke.FindNextFile(hFile, out findData));
+
+			Win32PInvoke.FindClose(hFile);
+			folders.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+
+			return folders;
 		}
 
 		private async Task LoadFlyoutItemIconAsync(MenuFlyoutItem flyoutItem, string path)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #8269

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed the breadcrumb flyout now displays hidden folders (when enabled in settings)