### PR TITLE
Feature: Added path hints for tabs with the same name

### DIFF
--- a/src/Files.App/Data/Contexts/Multitasking/MultitaskingContext.cs
+++ b/src/Files.App/Data/Contexts/Multitasking/MultitaskingContext.cs
@@ -39,6 +39,7 @@ namespace Files.App.Data.Contexts
 		private void AppInstances_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
 		{
 			UpdateTabCount();
+			NavigationHelpers.RefreshTabPathHints();
 		}
 		private void AppModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{

--- a/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
@@ -148,8 +148,66 @@ namespace Files.App.Helpers
 				var a2 = navigationArg is PaneNavigationArguments pna2 ? pna2 : new PaneNavigationArguments() { LeftPaneNavPathParam = navigationArg as string };
 
 				if (a1.LeftPaneNavPathParam == a2.LeftPaneNavPathParam && a1.RightPaneNavPathParam == a2.RightPaneNavPathParam)
-					(tabItem.Header, tabItem.IconSource, tabItem.ToolTipText) = result;
+				{
+					tabItem.Description = result.Item1;
+					tabItem.IconSource = result.Item2;
+					tabItem.ToolTipText = result.Item3;
+					RefreshTabPathHints();
+				}
 			}
+		}
+
+		internal static void RefreshTabPathHints()
+		{
+			foreach (var group in MainPageViewModel.AppInstances
+				.Where(t => !string.IsNullOrEmpty(t.Description))
+				.GroupBy(t => t.Description!, StringComparer.OrdinalIgnoreCase))
+			{
+				var tabs = group.ToArray();
+
+				foreach (var t in tabs)
+					t.Header = t.Description;
+
+				if (tabs.Length < 2 || tabs[0].Description!.Contains(" | "))
+					continue;
+
+				var hints = tabs.ToDictionary(t => t, t => AncestorHints(t.ToolTipText));
+
+				foreach (var tab in tabs)
+				{
+					for (var d = 0; d < hints[tab].Length; d++)
+					{
+						if (tabs.All(t => t == tab || d >= hints[t].Length || hints[t][d] != hints[tab][d]))
+						{
+							tab.Header = $"{hints[tab][d]}\\{tab.Description}";
+							break;
+						}
+					}
+				}
+			}
+		}
+
+		private static string[] AncestorHints(string? path)
+		{
+			var result = new List<string>();
+
+			try
+			{
+				var root = (PathNormalization.GetPathRoot(path) ?? "").TrimEnd('\\', '/');
+				var prefix = root.Length >= 2 && root[1] == ':'
+					? $"{char.ToUpperInvariant(root[0])}:\\..."
+					: root.Length > 0 ? $"{root}\\..." : "...";
+
+				var dir = path?.TrimEnd('\\', '/');
+				while ((dir = Path.GetDirectoryName(dir)) is not null
+					&& Path.GetFileName(dir) is { Length: > 0 } seg)
+				{
+					result.Add($"{prefix}\\{seg}");
+				}
+			}
+			catch (ArgumentException) { }
+
+			return result.ToArray();
 		}
 
 		public static async Task<ImageSource?> GetIconForPathAsync(string path)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #14175

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed path hint is shown for tabs with same name
2. Confirmed path hint is not shown if the same folder is open in multiple tabs
