### PR TITLE
Fix: Replace BitmapImage.SetSourceAsync with SoftwareBitmapSource for…

### DIFF
--- a/src/Files.App/Data/Items/IListedItem.cs
+++ b/src/Files.App/Data/Items/IListedItem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Files.App.ViewModels.Properties;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Windows.Storage;
 
@@ -18,7 +19,7 @@ namespace Files.App.Utils
 		ObservableCollection<FileProperty> FileDetails { get; set; }
 		string FileExtension { get; set; }
 		ulong? FileFRN { get; set; }
-		BitmapImage FileImage { get; set; }
+		ImageSource FileImage { get; set; }
 		string FileSize { get; set; }
 		long FileSizeBytes { get; set; }
 		string FileSizeDisplay { get; }

--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -5,6 +5,7 @@ using Files.App.ViewModels.Properties;
 using Files.Shared.Helpers;
 using FluentFTP;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System.IO;
 using System.Text;
@@ -172,15 +173,15 @@ namespace Files.App.Utils
 			get => string.IsNullOrEmpty(SyncStatusUI?.SyncStatusString) ? Strings.CloudDriveSyncStatus_Unknown.GetLocalizedResource() : SyncStatusUI.SyncStatusString;
 		}
 
-		private BitmapImage fileImage;
-		public BitmapImage FileImage
+		private ImageSource fileImage;
+		public ImageSource FileImage
 		{
 			get => fileImage;
 			set
 			{
 				if (SetProperty(ref fileImage, value))
 				{
-					if (value is BitmapImage)
+					if (value is not null)
 					{
 						LoadFileIcon = true;
 						NeedsPlaceholderGlyph = false;

--- a/src/Files.App/Data/Models/SuggestionModel.cs
+++ b/src/Files.App/Data/Models/SuggestionModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Files.App.Controls;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 
 namespace Files.App.Data.Models
@@ -18,8 +19,8 @@ namespace Files.App.Data.Models
 
 		public string Name { get; set; }
 
-		private BitmapImage? fileImage;
-		public BitmapImage? FileImage
+		private ImageSource? fileImage;
+		public ImageSource? FileImage
 		{
 			get => fileImage;
 			set
@@ -41,6 +42,11 @@ namespace Files.App.Data.Models
 						{
 							img.ImageOpened += Img_ImageOpened;
 						}
+					}
+					else if (value is SoftwareBitmapSource)
+					{
+						LoadFileIcon = true;
+						NeedsPlaceholderGlyph = false;
 					}
 				}
 			}

--- a/src/Files.App/Helpers/BitmapHelper.cs
+++ b/src/Files.App/Helpers/BitmapHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System.IO;
@@ -13,6 +14,24 @@ namespace Files.App.Helpers
 {
 	internal static class BitmapHelper
 	{
+		public static async Task<SoftwareBitmap?> ToSoftwareBitmapAsync(this byte[]? data)
+		{
+			if (data is null)
+				return null;
+
+			try
+			{
+				using var ms = new MemoryStream(data);
+				var decoder = await BitmapDecoder.CreateAsync(ms.AsRandomAccessStream());
+				return await decoder.GetSoftwareBitmapAsync(BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied);
+			}
+			catch (Exception ex)
+			{
+				App.Logger.LogWarning(ex, "Failed to decode bitmap, size={Bytes}b", data.Length);
+				return null;
+			}
+		}
+
 		public static async Task<BitmapImage?> ToBitmapAsync(this byte[]? data, int decodeSize = -1)
 		{
 			if (data is null)

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -15,6 +15,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Vanara.Windows.Shell;
 using Windows.Foundation;
+using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Search;
@@ -1122,14 +1123,7 @@ namespace Files.App.ViewModels
 
 			if (result is not null)
 			{
-				await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
-				{
-					// Assign FileImage property
-					var image = await result.ToBitmapAsync();
-					if (image is not null)
-						item.FileImage = image;
-				}, Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal);
-
+				await SetFileImageAsync(item, result, cancellationToken);
 				cancellationToken.ThrowIfCancellationRequested();
 			}
 
@@ -1172,15 +1166,25 @@ namespace Files.App.ViewModels
 
 					if (result is not null)
 					{
-						await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
-						{
-							// Assign FileImage property
-							var image = await result.ToBitmapAsync();
-							if (image is not null)
-								item.FileImage = image;
-						}, Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal);
+						await SetFileImageAsync(item, result, cancellationToken);
 					}
 				}, cancellationToken);
+			}
+		}
+
+		private async Task SetFileImageAsync(ListedItem item, byte[] data, CancellationToken cancellationToken)
+		{
+			// Decode off UI thread
+			var softwareBitmap = await data.ToSoftwareBitmapAsync();
+			if (softwareBitmap is not null)
+			{
+				await dispatcherQueue.EnqueueOrInvokeAsync(async () =>
+				{
+					// Assign FileImage property — only SoftwareBitmapSource creation on UI thread
+					var source = new SoftwareBitmapSource();
+					await source.SetBitmapAsync(softwareBitmap);
+					item.FileImage = source;
+				}, Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal);
 			}
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
Replaced 'BitmapImage.SetSourceAsync' with 'SoftwareBitmapSource.SetBitmapAsync' in the thumbnail loading path to eliminate WIC decoder contention under concurrent load.

**Changes**
- Pixel decoding moved off the UI thread via 'BitmapDecoder' ('ToSoftwareBitmapAsync')
- Only the final GPU upload ('SetBitmapAsync') runs on the UI thread

**Steps used to test these changes**
1. Open a folder with many image files
2. Scroll rapidly through the folder
3. Navigate between folders and verify thumbnails load correctly
4. Check Grid and other layouts