### PR TITLE
Fix: Fixed crash when sidebar receives data changes during window shutdown

### DIFF
--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -239,6 +239,7 @@ namespace Files.App.ViewModels.UserControls
 		public SidebarViewModel()
 		{
 			dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+			dispatcherQueue.ShutdownStarting += DispatcherQueue_ShutdownStarting;
 			fileTagsService = Ioc.Default.GetRequiredService<IFileTagsService>();
 
 			sidebarItems = [];
@@ -683,10 +684,23 @@ namespace Files.App.ViewModels.UserControls
 			}
 		}
 
+		private void DispatcherQueue_ShutdownStarting(DispatcherQueue sender, DispatcherQueueShutdownStartingEventArgs args)
+		{
+			UnsubscribeDataChangedEvents();
+		}
+
 		public void Dispose()
 		{
 			UserSettingsService.OnSettingChangedEvent -= UserSettingsService_OnSettingChangedEvent;
+			dispatcherQueue.ShutdownStarting -= DispatcherQueue_ShutdownStarting;
 
+			UnsubscribeDataChangedEvents();
+
+			dispatcherQueue = null;
+		}
+
+		private void UnsubscribeDataChangedEvents()
+		{
 			App.QuickAccessManager.Model.DataChanged -= Manager_DataChanged;
 			App.LibraryManager.DataChanged -= Manager_DataChanged;
 			drivesViewModel.Drives.CollectionChanged -= Manager_DataChangedForDrives;
@@ -694,8 +708,6 @@ namespace Files.App.ViewModels.UserControls
 			NetworkService.Computers.CollectionChanged -= Manager_DataChangedForNetworkComputers;
 			WSLDistroManager.DataChanged -= Manager_DataChanged;
 			App.FileTagsManager.DataChanged -= Manager_DataChanged;
-
-			dispatcherQueue = null;
 		}
 
 		public void UpdateTabControlMargin()


### PR DESCRIPTION
**Description**

When the app window is closing, background services (`QuickAccessManager`, `LibraryManager`, `DriveManager`, etc.) could still fire `DataChanged` events after the UI dispatcher queue had started shutting down. `Manager_DataChanged` is `async void`, so when `EnqueueAsync` failed with `InvalidOperationException: Failed to enqueue the operation`, the exception became an unhandled fatal crash reported via `Application.UnhandledException`.

The fix subscribes to `DispatcherQueue.ShutdownStarting` in `SidebarViewModel` and unsubscribes all data change event handlers as soon as the dispatcher begins shutting down — before it stops accepting work. This prevents any in-flight events from reaching `Manager_DataChanged` during teardown. `Dispose()` also calls the same unsubscribe helper, which is safe to call twice since removing an already-removed handler is a no-op.

For #17988