### PR TITLE
Fix: Disable Open In Terminal option when Terminal isn't installed

### DIFF
--- a/src/Files.App/Actions/Open/OpenTerminalAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalAction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using System.IO;
 using System.Text;
 using Windows.Storage;
 
@@ -10,6 +11,11 @@ namespace Files.App.Actions
 	internal partial class OpenTerminalAction : ObservableObject, IAction
 	{
 		private readonly IContentPageContext context;
+		private const string TerminalExecutable = "wt.exe";
+		private static readonly bool isWindowsTerminalAvailable = IsExecutableOnPath(TerminalExecutable);
+
+		protected bool IsWindowsTerminalAvailable
+			=> isWindowsTerminalAvailable;
 
 		public virtual string Label
 			=> Strings.OpenTerminal.GetLocalizedResource();
@@ -24,7 +30,7 @@ namespace Files.App.Actions
 			=> new("\uE756");
 
 		public virtual bool IsExecutable
-			=> GetIsExecutable();
+			=> IsWindowsTerminalAvailable && GetIsExecutable();
 
 		public virtual bool IsAccessibleGlobally
 			=> true;
@@ -38,6 +44,9 @@ namespace Files.App.Actions
 
 		public Task ExecuteAsync(object? parameter = null)
 		{
+			if (!IsWindowsTerminalAvailable)
+				return Task.CompletedTask;
+
 			var terminalStartInfo = GetProcessStartInfo();
 			if (terminalStartInfo is not null)
 			{
@@ -58,6 +67,9 @@ namespace Files.App.Actions
 
 		protected virtual ProcessStartInfo? GetProcessStartInfo()
 		{
+			if (!IsWindowsTerminalAvailable)
+				return null;
+
 			var paths = GetPaths();
 			if (paths.Length is 0)
 				return null;
@@ -73,8 +85,9 @@ namespace Files.App.Actions
 
 			return new()
 			{
-				FileName = "wt.exe",
-				Arguments = args.ToString()
+				FileName = TerminalExecutable,
+				Arguments = args.ToString(),
+				UseShellExecute = true
 			};
 		}
 
@@ -93,6 +106,28 @@ namespace Files.App.Actions
 			}
 
 			return [];
+		}
+
+		private static bool IsExecutableOnPath(string executableName)
+		{
+			try
+			{
+				var path = Environment.GetEnvironmentVariable("PATH");
+				if (string.IsNullOrWhiteSpace(path))
+					return false;
+
+				foreach (var folder in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+				{
+					var candidate = Path.Combine(folder, executableName);
+					if (File.Exists(candidate))
+						return true;
+				}
+			}
+			catch
+			{
+			}
+
+			return false;
 		}
 
 		private bool GetIsExecutable()

--- a/src/Files.App/Actions/Open/OpenTerminalFromHomeAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalFromHomeAction.cs
@@ -15,6 +15,7 @@ namespace Files.App.Actions
 			=> Strings.OpenTerminalDescription.GetLocalizedResource();
 
 		public override bool IsExecutable =>
+			IsWindowsTerminalAvailable &&
 			HomePageContext.IsAnyItemRightClicked &&
 			HomePageContext.RightClickedItem is not null &&
 			(HomePageContext.RightClickedItem is WidgetFileTagCardItem fileTagItem

--- a/src/Files.App/Actions/Open/OpenTerminalFromSidebarAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalFromSidebarAction.cs
@@ -15,6 +15,7 @@ namespace Files.App.Actions
 			=> Strings.OpenTerminalDescription.GetLocalizedResource();
 
 		public override bool IsExecutable =>
+			IsWindowsTerminalAvailable &&
 			SidebarContext.IsItemRightClicked &&
 			SidebarContext.RightClickedItem is not null &&
 			SidebarContext.RightClickedItem.MenuOptions.ShowShellItems &&


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17869

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed the Open In Terminal option only shows when Terminal is installed
