### PR TITLE
Fix: Reduce selection lag during drag selection by throttling SelectionChanged events

### DIFF
--- a/src/Files.App/UserControls/Selection/RectangleSelection_ListViewBase.cs
+++ b/src/Files.App/UserControls/Selection/RectangleSelection_ListViewBase.cs
@@ -19,6 +19,10 @@ namespace Files.App.UserControls.Selection
 		private ScrollViewer scrollViewer;
 		private SelectionChangedEventHandler selectionChanged;
 		private DispatcherQueueTimer timer;
+		private DispatcherQueueTimer selectionUpdateTimer;
+		private List<object>? pendingSelectedItems;
+		private List<object>? pendingRemovedItems;
+		private bool isSelectionUpdatePending;
 		private Point originDragPoint;
 		private Dictionary<object, System.Drawing.Rectangle> itemsPosition;
 		private List<object> prevSelectedItems;
@@ -32,7 +36,21 @@ namespace Files.App.UserControls.Selection
 			this.selectionChanged = selectionChanged;
 			itemsPosition = [];
 			timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+			selectionUpdateTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+			selectionUpdateTimer.Interval = TimeSpan.FromMilliseconds(8);
+			selectionUpdateTimer.Tick += SelectionUpdateTimer_Tick;
 			InitEvents(null, null);
+		}
+
+		private void SelectionUpdateTimer_Tick(object? sender, object e)
+		{
+			selectionUpdateTimer.Stop();
+			if (isSelectionUpdatePending && pendingSelectedItems is not null && selectionChanged is not null)
+			{
+				selectionChanged(this, new SelectionChangedEventArgs(pendingRemovedItems ?? [], pendingSelectedItems));
+				isSelectionUpdatePending = false;
+				pendingRemovedItems = null;
+			}
 		}
 
 		private void RectangleSelection_PointerMoved(object sender, PointerRoutedEventArgs e)
@@ -102,9 +120,14 @@ namespace Files.App.UserControls.Selection
 					var currentSelectedItemsDrag = uiElement.SelectedItems.Cast<object>().ToList();
 					if (prevSelectedItemsDrag is null || !prevSelectedItemsDrag.SequenceEqual(currentSelectedItemsDrag))
 					{
-						// Trigger SelectionChanged event if the selection has changed
 						var removedItems = selectedItemsBeforeChange.Except(currentSelectedItemsDrag).ToList();
-						selectionChanged(sender, new SelectionChangedEventArgs(removedItems, currentSelectedItemsDrag));
+						pendingSelectedItems = currentSelectedItemsDrag;
+						pendingRemovedItems = pendingRemovedItems is null 
+							? removedItems 
+							: pendingRemovedItems.Union(removedItems).ToList();
+						isSelectionUpdatePending = true;
+						selectionUpdateTimer.Stop();
+						selectionUpdateTimer.Start();
 						prevSelectedItemsDrag = currentSelectedItemsDrag;
 					}
 				}
@@ -192,6 +215,17 @@ namespace Files.App.UserControls.Selection
 
 			scrollViewer.ViewChanged -= ScrollViewer_ViewChanged;
 			uiElement.ReleasePointerCapture(e.Pointer);
+
+			if (selectionUpdateTimer.IsRunning)
+			{
+				selectionUpdateTimer.Stop();
+				if (isSelectionUpdatePending && pendingSelectedItems is not null && selectionChanged is not null)
+				{
+					selectionChanged(this, new SelectionChangedEventArgs(pendingRemovedItems ?? [], pendingSelectedItems));
+					isSelectionUpdatePending = false;
+				}
+			}
+
 			if (selectionChanged is not null)
 			{
 				// Restore and trigger SelectionChanged event


### PR DESCRIPTION
## Resolved / Related Issues

- Closes #18289

## Summary of Changes

Introduced a selection update timer to reduce the frequency of `SelectionChanged` events during drag selection, improving performance through batched selection updates.

### Key Changes:
- Added `selectionUpdateTimer` with 8ms interval (~120fps)
- Added `pendingSelectedItems` and `pendingRemovedItems` lists to buffer pending changes
- Unified selection state updates when the timer triggers
- Ensured correct final selection state when pointer is released
- Accumulated removed items to prevent state loss during rapid dragging

### Technical Details:
- Uses `DispatcherQueueTimer` for 8ms throttling interval
- Accumulates `pendingRemovedItems` to ensure all selection changes are correctly processed during rapid dragging
- Batch triggers `SelectionChanged` event in timer callback

## Steps used to test these changes

1. Opened Files and navigated to a folder with many files (100+)
2. Performed drag selection (box selection) across multiple files
3. Verified smooth selection updates during drag
4. Verified correct final selection state after releasing pointer
5. Tested rapid drag selection to ensure no selection state is lost
6. Tested with Ctrl+drag (invert selection) and Shift+drag (extend selection)