### PR TITLE
Code Quality: Add AI contribution guidance files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,27 @@
 root = true
 
+[*]
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+charset = utf-8
+trim_trailing_whitespace = false
+
+[*.{cs,xaml,slnx,json,yml,yaml,ps1,cmd,bat}]
+charset = utf-8
+
+[*.{csproj,props,targets,vcxproj,vcxproj.filters,config,manifest,appxmanifest}]
+charset = utf-8-bom
+
 [**/*.cs]
 indent_style = tab
 indent_size = 4
 tab_width = 4
 
 [**/*.xaml]
+charset = utf-8
 indent_style = tab
 indent_size = 4
 tab_width = 4

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,11 @@
+# Copilot instructions for Files
+
+Follow [../AGENTS.md](../AGENTS.md) for repository-specific guidance.
+
+Key reminders:
+- Work from one linked issue and keep the pull request surface narrow.
+- `Files.slnx` is the main solution, and `src/Files.App` is the default startup project for local debugging.
+- Follow MVVM, existing naming and brace conventions, and XAML Styler for `.xaml` files.
+- Preserve CRLF line endings. `.cs` and `.xaml` files use tab indentation.
+- `Files.App.Server` is trimmed in Release builds, so avoid trim-hostile runtime patterns.
+- Prefer `src/Files.App.CsWin32` for new Win32 or COM bindings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+This is the primary repository guidance for AI coding agents. Keep `CLAUDE.md` and `.github/copilot-instructions.md` as thin entry points that refer back here instead of drifting into separate rule sets.
+
+## Goal
+- Submit small, issue-linked contributions that fit the current maintainer direction.
+- Keep changes reviewable and avoid speculative product work.
+- Do not mix unrelated fixes into the same PR.
+
+## Approval and scope
+- Work from a linked issue.
+- Prefer issues marked `Ready to build`.
+- If an issue is not marked `Ready to build`, treat a comment from a Files organization member as the minimum approval signal before implementing.
+- Use one pull request per issue and link it in the PR body with `Closes #...`.
+- Follow the repository PR template. Prefer `Fix:` or `Feature:` titles; if maintainers explicitly framed the linked issue as `Code Quality:`, mirroring that wording is acceptable.
+- Always include concrete manual test steps, even for non-product or repo-hygiene changes.
+- Do not add website-repo changes or unrelated `docs/` work from this repository unless the linked issue explicitly requires it.
+
+## Repository map
+- `Files.slnx`: main solution file.
+- `src/Files.App`: main WinUI app and default startup project for local debugging.
+- `src/Files.App.Server`: out-of-process COM server built before `Files.App` resolves assemblies.
+- `src/Files.App.Storage`, `src/Files.Core.Storage`, `src/Files.Shared`: shared storage and runtime layers.
+- `src/Files.Core.SourceGenerator`: Roslyn source generators and analyzers.
+- `src/Files.App.CsWin32`: Win32 projections and `NativeMethods.txt`.
+- `src/Files.App.OpenDialog`, `src/Files.App.SaveDialog`, `src/Files.App.Launcher`: native C++ helper projects; treat them as interop-sensitive.
+- `tests/Files.InteractionTests`: packaged interaction tests run in CI.
+- `tests/Files.App.UITests`: UITest host app and page coverage assets.
+
+## Setup and validation
+- Follow the official build guide: <https://files.community/docs/contributing/building-from-source>.
+- Use Visual Studio 2022 17.13 or later with Windows 11 SDK `10.0.26100.0`, .NET SDK `10.0.102`, Windows App SDK `1.8`, MSVC v145 C++ tools, ATL, and Git for Windows.
+- Open `Files.slnx`, set `Files.App` as the startup project, and use `Debug` with your local architecture for everyday development.
+- For CI-aligned validation, inspect `.github/workflows/ci.yml`: XAML is checked with XAML Styler, the solution is restored and built across configurations, and `tests/Files.InteractionTests` runs from packaged `Release/x64` artifacts.
+- Only run heavy packaging or interaction-test flows when the touched surface warrants it.
+
+## Style
+- Follow the official coding style guide: <https://files.community/docs/contributing/code-style>.
+- Keep the codebase on the MVVM path and preserve existing architecture boundaries.
+- Use XAML Styler for `.xaml` edits.
+- Keep `.cs` and `.xaml` files tab-indented with a width of 4 and preserve CRLF line endings.
+- Follow existing naming conventions: PascalCase for classes, methods, and properties; `I`-prefixed interfaces; `_camelCase` private fields; and `Async` suffixes for async methods.
+- Put braces on new lines, avoid `#region`, and avoid broad style-only rewrites.
+- UI changes should consider accessibility; use Accessibility Insights for Windows when the change touches keyboarding, focus, or visible controls.
+- Prefer the smallest viable change and check for nearby occurrences of the same issue before submitting.
+
+## Trimming and interop guardrails
+- `src/Files.App.Server/Files.App.Server.csproj` enables `PublishTrimmed=true` outside `Debug`. Keep new code compatible with trimming.
+- Avoid unconstrained reflection, runtime type scanning, serializer patterns that depend on unpreserved metadata, or ad-hoc dynamic loading without explicit justification.
+- When adding Win32 or COM interop, prefer `src/Files.App.CsWin32` and `NativeMethods.txt` over new `DllImport` or `ComImport` declarations when practical.
+- Be extra conservative when editing COM-server, source-generator, or native helper projects: small changes, explicit validation, and no incidental refactors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+Claude Code contributors should follow [AGENTS.md](./AGENTS.md).
+
+Keep repository guidance centralized in `AGENTS.md`. If something here conflicts with `AGENTS.md`, `AGENTS.md` wins.


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #18224

**Summary of Changes**

- Added `AGENTS.md` as the canonical repository guidance for AI coding agents.
- Added `CLAUDE.md` and `.github/copilot-instructions.md` as thin entry points that defer to `AGENTS.md`.
- Expanded `.editorconfig` with explicit CRLF, final-newline, and file-family charset rules based on the repository's current conventions.
- Added trimming guidance for `Files.App.Server` and a preference for `Files.App.CsWin32`, matching the member feedback on the issue.
- Intentionally kept this PR scoped to repository guidance only and did not include `docs/` or `src/` behavior changes.

**Steps used to test these changes**

1. Confirmed `#18224` is still open and requested `AGENTS.md`, `CLAUDE.md`, `copilot-instructions.md`, and `.editorconfig` guidance.
2. Verified the repository only adds `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md`, and updates `.editorconfig`.
3. Verified the linked build/style documentation URLs resolve.
4. Ran `git diff --check` to confirm clean patch formatting.
5. Spot-checked encoding and CRLF expectations for the updated file families.