### PR TITLE
Code Quality: Update the CI and CDs to use the VS2026-installed runner image

### DIFF
--- a/.github/workflows/cd-sideload-preview.yml
+++ b/.github/workflows/cd-sideload-preview.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     environment: Deployments
     strategy:
       fail-fast: false

--- a/.github/workflows/cd-sideload-stable.yml
+++ b/.github/workflows/cd-sideload-stable.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     environment: Deployments
     strategy:
       fail-fast: false

--- a/.github/workflows/cd-store-preview.yml
+++ b/.github/workflows/cd-store-preview.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     environment: Deployments
     strategy:
       fail-fast: false

--- a/.github/workflows/cd-store-stable.yml
+++ b/.github/workflows/cd-store-stable.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     environment: Deployments
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
     if: github.repository_owner == 'files-community'
 
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
 
@@ -84,7 +84,7 @@ jobs:
 
     if: github.repository_owner == 'files-community'
 
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     strategy:
       fail-fast: false
       matrix:
@@ -183,7 +183,7 @@ jobs:
     if: github.repository_owner == 'files-community' && always()
 
     needs: [build]
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/format-xaml.yml
+++ b/.github/workflows/format-xaml.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   format-xaml:
     if: github.event.issue.pull_request && github.event.comment.body == '/format'
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     environment: Pull Requests
     permissions: 
       contents: write

--- a/src/Files.App.Launcher/Files.App.Launcher.vcxproj
+++ b/src/Files.App.Launcher/Files.App.Launcher.vcxproj
@@ -37,7 +37,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <LinkIncremental>true</LinkIncremental>
     <OutDir>..\..\artifacts\$(Configuration)\$(Platform)\$(MSBuildProjectName)\</OutDir>

--- a/src/Files.App.OpenDialog/Files.App.OpenDialog.Win32.vcxproj
+++ b/src/Files.App.OpenDialog/Files.App.OpenDialog.Win32.vcxproj
@@ -33,7 +33,7 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/Files.App.OpenDialog/Files.App.OpenDialog.vcxproj
+++ b/src/Files.App.OpenDialog/Files.App.OpenDialog.vcxproj
@@ -33,7 +33,7 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/Files.App.SaveDialog/Files.App.SaveDialog.Win32.vcxproj
+++ b/src/Files.App.SaveDialog/Files.App.SaveDialog.Win32.vcxproj
@@ -33,7 +33,7 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/Files.App.SaveDialog/Files.App.SaveDialog.vcxproj
+++ b/src/Files.App.SaveDialog/Files.App.SaveDialog.vcxproj
@@ -32,7 +32,7 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
### Resolved / Related Issues

Update the CI and CDs to use the VS2026-installed runner image

### Steps used to test these changes

_None_