### PR TITLE
Fix: prevent tab button displacement when dragging non-tab items

### DIFF
--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -288,7 +288,10 @@ namespace Files.App.UserControls.TabBar
 		private async void TabBarAddNewTabButton_Drop(object sender, DragEventArgs e)
 		{
 			if (_lockDropOperation || !FilesystemHelpers.HasDraggedStorageItems(e.DataView))
+			{
+				e.Handled = true; // Prevent event from bubbling up to TabView
 				return;
+			}
 
 			_lockDropOperation = true;
 
@@ -314,6 +317,7 @@ namespace Files.App.UserControls.TabBar
 			if (!FilesystemHelpers.HasDraggedStorageItems(e.DataView))
 			{
 				e.AcceptedOperation = DataPackageOperation.None;
+				e.Handled = true; // Prevent event from bubbling up to TabView
 				return;
 			}
 
@@ -324,6 +328,7 @@ namespace Files.App.UserControls.TabBar
 			if (!hasValidDraggedItems)
 			{
 				e.AcceptedOperation = DataPackageOperation.None;
+				e.Handled = true; // Prevent event from bubbling up to TabView
 				return;
 			}
 


### PR DESCRIPTION
## Resolved / Related Issues

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as Ready to build. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.

- Closes #14143

## Steps used to test these changes

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Open Files application
2. Create a new tab (click the + button or press Ctrl+T)
3. Drag a non-tab item (e.g., a file or folder from Windows Explorer) over the tab bar area near the add new tab button
4. Observe that the tab buttons no longer shift/move when the dragged item is released over the tab bar
5. Verify that valid tab items can still be dropped onto the tab bar to create new tabs
6. Repeat the test with multiple tabs open to ensure stability

## Description

### Problem

When dragging non-tab items (files, folders) near the tab bar in Files, the tab buttons shift/move unexpectedly, causing visual glitches and potential UX issues.

### Root Cause

In TabBarAddNewTabButton_DragOver and TabBarAddNewTabButton_Drop, non-tab items were not being handled properly. The drag event propagated to the TabView control, causing tab reordering.

### Solution

Added e.Handled = true in the early return branches for non-tab items, preventing the drag event from bubbling up to the TabView control.

### Files Changed

- src/Files.App/UserControls/TabBar/TabBar.xaml.cs