### PR TITLE
Feature: Added multiline support for the comment property in the Properties Window

### DIFF
--- a/src/Files.App/Assets/Resources/PreviewPanePropertiesInformation.json
+++ b/src/Files.App/Assets/Resources/PreviewPanePropertiesInformation.json
@@ -406,6 +406,7 @@
 		"SectionResource": "PropertySectionCore",
 		"Property": "System.Comment",
 		"IsReadOnly": false,
+    "IsMultiLine": true,
 		"ID": null
 	},
 	{

--- a/src/Files.App/Assets/Resources/PreviewPanePropertiesInformation.json
+++ b/src/Files.App/Assets/Resources/PreviewPanePropertiesInformation.json
@@ -406,7 +406,7 @@
 		"SectionResource": "PropertySectionCore",
 		"Property": "System.Comment",
 		"IsReadOnly": false,
-    "IsMultiLine": true,
+		"IsMultiLine": true,
 		"ID": null
 	},
 	{

--- a/src/Files.App/Assets/Resources/PropertiesInformation.json
+++ b/src/Files.App/Assets/Resources/PropertiesInformation.json
@@ -578,6 +578,7 @@
 		"SectionResource": "PropertySectionCore",
 		"Property": "System.Comment",
 		"IsReadOnly": false,
+		"IsMultiLine": true,
 		"ID": null
 	},
 	{

--- a/src/Files.App/ViewModels/Properties/Items/FileProperty.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperty.cs
@@ -103,6 +103,11 @@ namespace Files.App.ViewModels.Properties
 		public string ID { get; set; }
 
 		/// <summary>
+		/// True if the property accepts multiple lines of text (e.g., System.Comment)
+		/// </summary>
+		public bool IsMultiLine { get; set; }
+
+		/// <summary>
 		/// True if the property value has been modified by the user
 		/// </summary>
 		public bool Modified { get; private set; }

--- a/src/Files.App/Views/Properties/DetailsPage.xaml
+++ b/src/Files.App/Views/Properties/DetailsPage.xaml
@@ -105,9 +105,11 @@
 												Grid.Column="1"
 												HorizontalAlignment="Stretch"
 												x:Load="{x:Bind IsReadOnly, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+												AcceptsReturn="{x:Bind IsMultiLine, Mode=OneWay}"
 												PlaceholderText="{x:Bind PlaceholderText, Mode=OneWay}"
 												Style="{StaticResource PropertyValueTextBox}"
-												Text="{x:Bind ValueText, Mode=TwoWay}" />
+												Text="{x:Bind ValueText, Mode=TwoWay}"
+												TextWrapping="Wrap" />
 
 										</Grid>
 									</DataTemplate>


### PR DESCRIPTION
**Resolved / Related Issues**

Fixed an issue where the "Comment" field in the file properties Details pane only displayed and saved a single line of text. This was caused by the default `TextBox` behavior restricting return characters. The fix introduces an `IsMultiLine` flag to the property JSON configuration and updates the XAML to bind the `AcceptsReturn` property, allowing multiple lines of text to be correctly rendered and saved for properties like `System.Comment`.
- Closes #18277 

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files and right-clicked a file (e.g., an image) to open its Properties window.
2. Navigated to the "Details" tab and located the "Comment" field.
3. Entered multiple lines of text (e.g., a formatted JSON from yt-dlp) into the field using `Shift + Enter`.
4. Clicked the "Apply" button to save the changes.
5. Closed the Properties window and reopened it.
6. Confirmed that all lines of the comment were correctly retrieved and fully displayed in the multiline text box.
