### PR TITLE
GitHub: Mass-update workflow dependencies

### DIFF
--- a/.github/workflows/cd-sideload-preview.yml
+++ b/.github/workflows/cd-sideload-preview.yml
@@ -159,7 +159,7 @@ jobs:
         timestamp-digest: SHA256
 
     - name: Upload packages to Cloudflare
-      uses: ryand56/r2-upload-action@v1
+      uses: ryand56/r2-upload-action@latest
       with:
         r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
         r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/cd-sideload-preview.yml
+++ b/.github/workflows/cd-sideload-preview.yml
@@ -33,7 +33,7 @@ jobs:
       WORKING_DIR:                '${{ github.workspace }}' # D:\a\Files\Files\
       ARTIFACTS_STAGING_DIR:      '${{ github.workspace }}\artifacts'
       APPX_PACKAGE_DIR:           '${{ github.workspace }}\artifacts\AppxPackages\'
-      APP_PROJECT_PATH:            'src\Files.App\Files.App.csproj'
+      APP_PROJECT_PATH:           'src\Files.App\Files.App.csproj'
       PACKAGE_MANIFEST_PATH:      'src\Files.App\Package.appxmanifest'
       LAUNCHER_PROJECT_PATH:      'src\Files.App.Launcher\Files.App.Launcher.vcxproj'
       TEST_PROJECT_PATH:          'tests\Files.InteractionTests\Files.InteractionTests.csproj'
@@ -41,13 +41,13 @@ jobs:
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v2
+      uses: NuGet/setup-nuget@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: global.json
 
@@ -95,7 +95,7 @@ jobs:
         -v:quiet
 
     - name: Sign launcher EXE with Azure Trusted Signing
-      uses: azure/trusted-signing-action@v0.4.0
+      uses: Azure/artifact-signing-action@v1
       with:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -142,7 +142,7 @@ jobs:
       run: find $ARTIFACTS_STAGING_DIR -empty -delete
 
     - name: Sign Files with Azure Trusted Signing
-      uses: azure/trusted-signing-action@v0.4.0
+      uses: Azure/artifact-signing-action@v1
       with:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -159,7 +159,7 @@ jobs:
         timestamp-digest: SHA256
 
     - name: Upload packages to Cloudflare
-      uses: ryand56/r2-upload-action@latest
+      uses: ryand56/r2-upload-action@v1
       with:
         r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
         r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -169,7 +169,7 @@ jobs:
         destination-dir: ./files/preview
 
     - name: Upload the packages to GitHub Actions
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: 'Appx Packages (${{ env.CONFIGURATION }}, ${{ env.PLATFORM }})'
         path: ${{ env.ARTIFACTS_STAGING_DIR }}

--- a/.github/workflows/cd-sideload-stable.yml
+++ b/.github/workflows/cd-sideload-stable.yml
@@ -33,7 +33,7 @@ jobs:
       WORKING_DIR:                '${{ github.workspace }}' # D:\a\Files\Files\
       ARTIFACTS_STAGING_DIR:      '${{ github.workspace }}\artifacts'
       APPX_PACKAGE_DIR:           '${{ github.workspace }}\artifacts\AppxPackages\'
-      APP_PROJECT_PATH:            'src\Files.App\Files.App.csproj'
+      APP_PROJECT_PATH:           'src\Files.App\Files.App.csproj'
       PACKAGE_MANIFEST_PATH:      'src\Files.App\Package.appxmanifest'
       LAUNCHER_PROJECT_PATH:      'src\Files.App.Launcher\Files.App.Launcher.vcxproj'
       TEST_PROJECT_PATH:          'tests\Files.InteractionTests\Files.InteractionTests.csproj'
@@ -41,13 +41,13 @@ jobs:
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v2
+      uses: NuGet/setup-nuget@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: global.json
 
@@ -67,7 +67,7 @@ jobs:
         SECRET_BINGMAPS_KEY: ${{ secrets.BING_MAPS_SECRET }}
         SECRET_SENTRY: ${{ secrets.SENTRY_SECRET }}
         SECRET_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
-  
+
     - name: Restore Files
       shell: pwsh
       run: |
@@ -84,7 +84,7 @@ jobs:
         nuget restore "$env:LAUNCHER_PROJECT_PATH" `
           -SolutionDirectory "$env:WORKING_DIR" `
           -Verbosity detailed
-    
+
     - name: Build launcher project
       shell: pwsh
       run: |
@@ -95,7 +95,7 @@ jobs:
         -v:quiet
 
     - name: Sign launcher EXE with Azure Trusted Signing
-      uses: azure/trusted-signing-action@v0.4.0
+      uses: Azure/artifact-signing-action@v1
       with:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -142,7 +142,7 @@ jobs:
       run: find $ARTIFACTS_STAGING_DIR -empty -delete
 
     - name: Sign Files with Azure Trusted Signing
-      uses: azure/trusted-signing-action@v0.4.0
+      uses: Azure/artifact-signing-action@v1
       with:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -159,7 +159,7 @@ jobs:
         timestamp-digest: SHA256
 
     - name: Upload packages to Cloudflare
-      uses: ryand56/r2-upload-action@latest
+      uses: ryand56/r2-upload-action@v1
       with:
         r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
         r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -167,9 +167,9 @@ jobs:
         r2-bucket: ${{ secrets.R2_BUCKET }}
         source-dir: ${{ env.APPX_PACKAGE_DIR }}
         destination-dir: ./files/stable
-          
+
     - name: Upload the packages to GitHub Actions
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: 'Appx Packages (${{ env.CONFIGURATION }}, ${{ env.PLATFORM }})'
         path: ${{ env.ARTIFACTS_STAGING_DIR }}

--- a/.github/workflows/cd-sideload-stable.yml
+++ b/.github/workflows/cd-sideload-stable.yml
@@ -159,7 +159,7 @@ jobs:
         timestamp-digest: SHA256
 
     - name: Upload packages to Cloudflare
-      uses: ryand56/r2-upload-action@v1
+      uses: ryand56/r2-upload-action@latest
       with:
         r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
         r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/cd-store-preview.yml
+++ b/.github/workflows/cd-store-preview.yml
@@ -32,19 +32,19 @@ jobs:
       WORKING_DIR:                '${{ github.workspace }}' # D:\a\Files\Files\
       ARTIFACTS_STAGING_DIR:      '${{ github.workspace }}\artifacts'
       APPX_PACKAGE_DIR:           '${{ github.workspace }}\artifacts\AppxPackages\'
-      APP_PROJECT_PATH:            '${{ github.workspace }}\src\Files.App\Files.App.csproj'
+      APP_PROJECT_PATH:           '${{ github.workspace }}\src\Files.App\Files.App.csproj'
       PACKAGE_MANIFEST_PATH:      '${{ github.workspace }}\src\Files.App\Package.appxmanifest'
       LAUNCHER_PROJECT_PATH:      'src\Files.App.Launcher\Files.App.Launcher.vcxproj'
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v2
+      uses: NuGet/setup-nuget@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: global.json
 
@@ -64,7 +64,7 @@ jobs:
         SECRET_BINGMAPS_KEY: ${{ secrets.BING_MAPS_SECRET }}
         SECRET_SENTRY: ${{ secrets.SENTRY_SECRET }}
         SECRET_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
-  
+
     - name: Restore Files
       shell: pwsh
       run: |
@@ -81,7 +81,7 @@ jobs:
         nuget restore "$env:LAUNCHER_PROJECT_PATH" `
           -SolutionDirectory "$env:WORKING_DIR" `
           -Verbosity detailed
-          
+
     - name: Build launcher project
       shell: pwsh
       run: |
@@ -92,7 +92,7 @@ jobs:
         -v:quiet
 
     - name: Sign launcher EXE with Azure Trusted Signing
-      uses: azure/trusted-signing-action@v0.4.0
+      uses: Azure/artifact-signing-action@v1
       with:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -135,9 +135,9 @@ jobs:
     - name: Remove empty files from the packages
       shell: bash
       run: find $ARTIFACTS_STAGING_DIR -empty -delete
-        
+
     - name: Upload the packages to GitHub Actions
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: 'Appx Packages (${{ env.CONFIGURATION }}, ${{ env.PLATFORM }})'
         path: ${{ env.ARTIFACTS_STAGING_DIR }}

--- a/.github/workflows/cd-store-stable.yml
+++ b/.github/workflows/cd-store-stable.yml
@@ -32,19 +32,19 @@ jobs:
       WORKING_DIR:                '${{ github.workspace }}' # D:\a\Files\Files\
       ARTIFACTS_STAGING_DIR:      '${{ github.workspace }}\artifacts'
       APPX_PACKAGE_DIR:           '${{ github.workspace }}\artifacts\AppxPackages\'
-      APP_PROJECT_PATH:            '${{ github.workspace }}\src\Files.App\Files.App.csproj'
+      APP_PROJECT_PATH:           '${{ github.workspace }}\src\Files.App\Files.App.csproj'
       PACKAGE_MANIFEST_PATH:      '${{ github.workspace }}\src\Files.App\Package.appxmanifest'
       LAUNCHER_PROJECT_PATH:      'src\Files.App.Launcher\Files.App.Launcher.vcxproj'
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v2
+      uses: NuGet/setup-nuget@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: global.json
 
@@ -92,7 +92,7 @@ jobs:
         -v:quiet
 
     - name: Sign launcher EXE with Azure Trusted Signing
-      uses: azure/trusted-signing-action@v0.4.0
+      uses: Azure/artifact-signing-action@v1
       with:
         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -137,7 +137,7 @@ jobs:
       run: find $ARTIFACTS_STAGING_DIR -empty -delete
 
     - name: Upload the packages to GitHub Actions
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: 'Appx Packages (${{ env.CONFIGURATION }}, ${{ env.PLATFORM }})'
         path: ${{ env.ARTIFACTS_STAGING_DIR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
             --report-trx-filename testResults.trx
 
     - if: github.event_name == 'pull_request'
-      uses: geekyeggo/delete-artifact@v6
+      uses: GeekyEggo/delete-artifact@v6
       with:
         name: '*'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
     #     Get-Content $env:AUTOMATED_TESTS_ASSEMBLY_DIR\testResults.md
 
     # - name: Publish tests result
-    #   uses: marocchino/sticky-pull-request-comment@v3
+    #   uses: marocchino/sticky-pull-request-comment@v2
     #   with:
     #     header: test-result
     #     path: '${{ env.AUTOMATED_TESTS_ASSEMBLY_DIR }}\testResults.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,15 @@ env:
   WINAPPDRIVER_EXE64_PATH: 'C:\Program Files\Windows Application Driver\WinAppDriver.exe'
 
 jobs:
+
   check-formatting:
+
     if: github.repository_owner == 'files-community'
 
     runs-on: windows-2025-vs2026
 
     steps:
+
     - name: Checkout the repository
       uses: actions/checkout@v6
       with:
@@ -78,6 +81,7 @@ jobs:
       run: exit 1
 
   build:
+
     if: github.repository_owner == 'files-community'
 
     runs-on: windows-2025-vs2026
@@ -91,6 +95,7 @@ jobs:
       ARCHITECTURE: ${{ matrix.platform }}
 
     steps:
+
     - name: Checkout the repository
       uses: actions/checkout@v6
     - name: Setup MSBuild
@@ -174,6 +179,7 @@ jobs:
         path: ${{ env.ARTIFACTS_STAGING_DIR }}
 
   test:
+
     if: github.repository_owner == 'files-community' && always()
 
     needs: [build]
@@ -190,6 +196,7 @@ jobs:
       pull-requests: write
 
     steps:
+
     - if: contains(join(needs.*.result, ','), 'failure')
       name: Fail if necessary
       run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,28 +36,25 @@ env:
   AUTOMATED_TESTS_PROJECT_DIR: '${{ github.workspace }}\tests\Files.InteractionTests'
   AUTOMATED_TESTS_PROJECT_PATH: '${{ github.workspace }}\tests\Files.InteractionTests\Files.InteractionTests.csproj'
   AUTOMATED_TESTS_ASSEMBLY_DIR: '${{ github.workspace }}\artifacts\TestsAssembly'
-  ARTIFACTS_STAGING_DIR:  '${{ github.workspace }}\artifacts'
+  ARTIFACTS_STAGING_DIR: '${{ github.workspace }}\artifacts'
   APPX_PACKAGE_DIR: '${{ github.workspace }}\artifacts\AppxPackages\'
   APPX_SELFSIGNED_CERT_PATH: '${{ github.workspace }}\.github\workflows\FilesApp_SelfSigned.pfx'
   WINAPPDRIVER_EXE86_PATH: 'C:\Program Files (x86)\Windows Application Driver\WinAppDriver.exe'
   WINAPPDRIVER_EXE64_PATH: 'C:\Program Files\Windows Application Driver\WinAppDriver.exe'
 
 jobs:
-
   check-formatting:
-
     if: github.repository_owner == 'files-community'
 
     runs-on: windows-2025-vs2026
 
     steps:
-
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
 
     - name: Install XamlStyler.Console
       run: 'dotnet tool install --global XamlStyler.Console'
@@ -75,13 +72,12 @@ jobs:
           }
         }
       continue-on-error: true
-    
+
     - name: Fail if necessary
       if: steps.check-step.outcome == 'failure'
       run: exit 1
 
   build:
-
     if: github.repository_owner == 'files-community'
 
     runs-on: windows-2025-vs2026
@@ -95,15 +91,14 @@ jobs:
       ARCHITECTURE: ${{ matrix.platform }}
 
     steps:
-
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@v3
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v2
+      uses: NuGet/setup-nuget@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: global.json
 
@@ -117,7 +112,7 @@ jobs:
           -p:PublishReadyToRun=true `
           -v:quiet
 
-    - if: env.CONFIGURATION != env.AUTOMATED_TESTS_CONFIGURATION || env.ARCHITECTURE != env.AUTOMATED_TESTS_ARCHITECTURE 
+    - if: env.CONFIGURATION != env.AUTOMATED_TESTS_CONFIGURATION || env.ARCHITECTURE != env.AUTOMATED_TESTS_ARCHITECTURE
       name: Build Files
       run: |
         msbuild `
@@ -173,13 +168,12 @@ jobs:
 
     - if: env.ARCHITECTURE == env.AUTOMATED_TESTS_ARCHITECTURE && env.CONFIGURATION == env.AUTOMATED_TESTS_CONFIGURATION
       name: Upload the packages to the Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: 'Appx Packages (${{ env.CONFIGURATION }}, ${{ env.ARCHITECTURE }})'
         path: ${{ env.ARTIFACTS_STAGING_DIR }}
 
   test:
-
     if: github.repository_owner == 'files-community' && always()
 
     needs: [build]
@@ -196,20 +190,19 @@ jobs:
       pull-requests: write
 
     steps:
-
     - if: contains(join(needs.*.result, ','), 'failure')
       name: Fail if necessary
       run: exit 1
 
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: global.json
 
     - name: Download the packages from the Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: 'Appx Packages (${{ env.CONFIGURATION }}, ${{ env.AUTOMATED_TESTS_ARCHITECTURE }})'
         path: ${{ env.ARTIFACTS_STAGING_DIR }}
@@ -251,7 +244,7 @@ jobs:
 
     # Retry integration tests if first attempt fails
     - name: Run interaction tests
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 15
         max_attempts: 2
@@ -265,9 +258,9 @@ jobs:
             --report-trx-filename testResults.trx
 
     - if: github.event_name == 'pull_request'
-      uses: geekyeggo/delete-artifact@v5
+      uses: geekyeggo/delete-artifact@v6
       with:
-          name: '*'
+        name: '*'
 
     # - name: Generate markdown from the tests result
     #   shell: pwsh
@@ -284,7 +277,7 @@ jobs:
     #     Get-Content $env:AUTOMATED_TESTS_ASSEMBLY_DIR\testResults.md
 
     # - name: Publish tests result
-    #   uses: marocchino/sticky-pull-request-comment@v2
+    #   uses: marocchino/sticky-pull-request-comment@v3
     #   with:
     #     header: test-result
     #     path: '${{ env.AUTOMATED_TESTS_ASSEMBLY_DIR }}\testResults.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
 
     # Retry integration tests if first attempt fails
     - name: Run interaction tests
-      uses: nick-fields/retry@v4
+      uses: nick-fields/retry@v3
       with:
         timeout_minutes: 15
         max_attempts: 2
@@ -265,7 +265,7 @@ jobs:
             --report-trx-filename testResults.trx
 
     - if: github.event_name == 'pull_request'
-      uses: GeekyEggo/delete-artifact@v6
+      uses: geekyeggo/delete-artifact@v5
       with:
         name: '*'
 

--- a/.github/workflows/format-xaml.yml
+++ b/.github/workflows/format-xaml.yml
@@ -8,13 +8,13 @@ jobs:
     if: github.event.issue.pull_request && github.event.comment.body == '/format'
     runs-on: windows-2025-vs2026
     environment: Pull Requests
-    permissions: 
+    permissions:
       contents: write
 
     steps:
       - name: Generate GitHub Apps token
         id: generate
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_PRIVATE_KEY }}
@@ -23,7 +23,7 @@ jobs:
         run: |
           # this is required for early termination in case any conditions aren't satisfied
           # https://github.com/actions/runner/issues/662
-          
+
           "CAN_RUN=1" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Login to gh cli
@@ -37,14 +37,14 @@ jobs:
             gh pr comment ${{ github.event.issue.number }} -b "🔒 This PR cannot be committed to. Ensure that Allow edits from maintainers is enabled."
             "CAN_RUN=0" | Out-File -FilePath $env:GITHUB_ENV -Append
           }
-          
+
           # all steps after this one must have the env.CAN_RUN == 1 condition
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: env.CAN_RUN == 1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
 
       - name: Set git identity
         if: env.CAN_RUN == 1
@@ -73,11 +73,11 @@ jobs:
             gh pr comment ${{ github.event.issue.number }} -b "⛔ No XAML files found to format."
             "CAN_RUN=0" | Out-File -FilePath $env:GITHUB_ENV -Append
           }
-  
+
       - name: Install XamlStyler.Console
         if: env.CAN_RUN == 1
         run: dotnet tool install --global XamlStyler.Console
-  
+
       - name: Format XAML files
         if: env.CAN_RUN == 1
         run: |
@@ -122,7 +122,7 @@ jobs:
               }
             }
           }' -F owner=$owner -F name=$name -F number=$number --jq '{Branch: .data.repository.pullRequest.headRef.name, Url: .data.repository.pullRequest.headRepository.url}' | ConvertFrom-Json
-          
+
           $url = [UriBuilder]($data.Url)
           $url.UserName = 'x-access-token'
           $url.Password = '${{ steps.generate.outputs.token }}'


### PR DESCRIPTION
A lot of the GitHub Actions dependencies haven't been updated in quite a while, so this PR is meant to update all dependencies to their latest major version. All Actions now use Node 24 instead of Node 20, which will reach EOL by the end of this month.

I also noticed that the YAML wasn't formatted correctly, so I fixed that, too. If necessary, the changes to formatting can be reverted.

**Resolved / Related Issues**

None. This PR simply updates dependencies.

**Steps used to test these changes**

Testing most of the workflows is not easily possible. I only properly tested `ci.yml`, as it does not rely on Secrets and can be enabled on a fork by simply removing the org check.

Instead, I read through all relevant release notes for all dependencies to find breaking changes that may affect the workflows. Luckily, it seems like none of the breaking changes actually break any of the wokflows.
