### PR TITLE
Fix: Fixed PowerToys Peek detection for custom install paths

### DIFF
--- a/src/Files.App/Services/PreviewPopupProviders/PowerToysPeekProvider.cs
+++ b/src/Files.App/Services/PreviewPopupProviders/PowerToysPeekProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.IO;
+using Microsoft.Win32;
 
 namespace Files.App.Services.PreviewPopupProviders
 {
@@ -48,28 +49,59 @@ namespace Files.App.Services.PreviewPopupProviders
 		public async Task<bool> DetectAvailability()
 		{
 			var exeName = "PowerToys.Peek.UI.exe";
-			var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-			var perUserPath = Path.Combine(localAppData, "PowerToys", "WinUI3Apps", exeName);
-
-			// User path
-			if (File.Exists(perUserPath))
+			if (FindPeekPathFromRegistry(exeName) is { } registryPath && File.Exists(registryPath))
 			{
-				_peekExecutablePath = perUserPath;
-				return true;
-			}
-
-			// Machine-wide path
-			string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-			string machinePath = Path.Combine(programFiles, "PowerToys", "WinUI3Apps", exeName);
-
-			if (File.Exists(machinePath))
-			{
-				_peekExecutablePath = machinePath;
+				_peekExecutablePath = registryPath;
 				return true;
 			}
 
 			// Not found
 			return false;
+		}
+
+		private static string? FindPeekPathFromRegistry(string exeName)
+		{
+			string[] uninstallRegistryPaths =
+			[
+				@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+				@"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+			];
+
+			foreach (var hive in new[] { RegistryHive.CurrentUser, RegistryHive.LocalMachine })
+			{
+				foreach (var uninstallPath in uninstallRegistryPaths)
+				{
+					try
+					{
+						using var baseKey = RegistryKey.OpenBaseKey(hive, RegistryView.Default);
+						using var uninstallKey = baseKey.OpenSubKey(uninstallPath);
+						if (uninstallKey is null)
+							continue;
+
+						foreach (var subKeyName in uninstallKey.GetSubKeyNames())
+						{
+							using var appKey = uninstallKey.OpenSubKey(subKeyName);
+							if (appKey is null)
+								continue;
+
+							var displayName = appKey.GetValue("DisplayName") as string;
+							if (string.IsNullOrWhiteSpace(displayName)
+								|| displayName.IndexOf("PowerToys", StringComparison.OrdinalIgnoreCase) < 0)
+								continue;
+
+							var installLocation = appKey.GetValue("InstallLocation") as string;
+							if (!string.IsNullOrWhiteSpace(installLocation))
+								return Path.Combine(installLocation, "WinUI3Apps", exeName);
+						}
+					}
+					catch
+					{
+						// Ignore registry access issues and continue fallback resolution.
+					}
+				}
+			}
+
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #18348

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed Peek works
