### PR TITLE
Fix: Fixed operation status when moving files from protected/administrator folder

### DIFF
--- a/src/Files.App/Utils/Storage/Operations/FileSizeCalculator.cs
+++ b/src/Files.App/Utils/Storage/Operations/FileSizeCalculator.cs
@@ -11,7 +11,7 @@ namespace Files.App.Utils.Storage.Operations
 	internal sealed class FileSizeCalculator
 	{
 		private readonly string[] _paths;
-		private readonly ConcurrentDictionary<string, long> _computedFiles = new();
+		private readonly ConcurrentDictionary<string, long> _computedFiles = new(StringComparer.OrdinalIgnoreCase);
 		private long _size;
 
 		public long Size => _size;

--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -432,8 +432,11 @@ namespace Files.App.Utils.Storage
 				source,
 				destination);
 
-			banner.ProgressEventSource.ProgressChanged += (s, e)
-				=> returnStatus = returnStatus < ReturnResult.Failed ? e.Status!.Value.ToStatus() : returnStatus;
+			banner.ProgressEventSource.ProgressChanged += (s, e) =>
+			{
+				var newStatus = e.Status!.Value.ToStatus();
+				returnStatus = newStatus == ReturnResult.Success || returnStatus < ReturnResult.Failed ? newStatus : returnStatus;
+			};
 
 			var token = banner.CancellationToken;
 
@@ -450,7 +453,8 @@ namespace Files.App.Utils.Storage
 
 			IStorageHistory history = await filesystemOperations.MoveItemsAsync((IList<IStorageItemWithPath>)source, (IList<string>)destination, collisions, banner.ProgressEventSource, token);
 
-			banner.Progress.ReportStatus(FileSystemStatusCode.Success);
+			if (returnStatus == ReturnResult.InProgress || returnStatus == ReturnResult.Success)
+				banner.Progress.ReportStatus(FileSystemStatusCode.Success);
 
 			await Task.Yield();
 


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed false error card and incorrect item count issues in Status Center when moving files from protected/administrator folders

Closes #18297

**Steps used to test these changes**
1. Move a file from a protected folder (e.g. C:\ProgramData\Microsoft\Windows\Start Menu\Programs) to a subfolder
2. Approve the elevation prompt - verify status centre shows "Moved 1 item to ..." (success)
3. Decline the elevation prompt - verify status centre shows "Error moving 1 item to ..." (not a false success)
4. Move a regular non-protected file - verify normal success behaviour is unchanged