### PR TITLE
Fix: Fixed an issue with openings programs from search results

### DIFF
--- a/src/Files.App/Helpers/Win32/Win32Helper.Process.cs
+++ b/src/Files.App/Helpers/Win32/Win32Helper.Process.cs
@@ -18,7 +18,9 @@ namespace Files.App.Helpers
 			var application = applicationPaths.FirstOrDefault();
 
 			if (string.IsNullOrEmpty(workingDirectory) && associatedInstance?.ShellViewModel != null && !associatedInstance.ShellViewModel.IsSearchResults)
+			{
 				workingDirectory = associatedInstance.ShellViewModel.WorkingDirectory;
+			}
 
 			if (runAsAdmin)
 			{

--- a/src/Files.App/Helpers/Win32/Win32Helper.Process.cs
+++ b/src/Files.App/Helpers/Win32/Win32Helper.Process.cs
@@ -18,9 +18,7 @@ namespace Files.App.Helpers
 			var application = applicationPaths.FirstOrDefault();
 
 			if (string.IsNullOrEmpty(workingDirectory) && associatedInstance?.ShellViewModel != null && !associatedInstance.ShellViewModel.IsSearchResults)
-			{
 				workingDirectory = associatedInstance.ShellViewModel.WorkingDirectory;
-			}
 
 			if (runAsAdmin)
 			{

--- a/src/Files.App/Helpers/Win32/Win32Helper.Process.cs
+++ b/src/Files.App/Helpers/Win32/Win32Helper.Process.cs
@@ -15,12 +15,10 @@ namespace Files.App.Helpers
 
 		public static async Task<bool> InvokeWin32ComponentsAsync(IEnumerable<string> applicationPaths, IShellPage associatedInstance, string arguments = null, bool runAsAdmin = false, string workingDirectory = null)
 		{
-			if (string.IsNullOrEmpty(workingDirectory))
-				workingDirectory = associatedInstance.ShellViewModel.WorkingDirectory;
-
 			var application = applicationPaths.FirstOrDefault();
-			if (string.IsNullOrEmpty(workingDirectory))
-				workingDirectory = associatedInstance?.ShellViewModel?.WorkingDirectory;
+
+			if (string.IsNullOrEmpty(workingDirectory) && associatedInstance?.ShellViewModel != null && !associatedInstance.ShellViewModel.IsSearchResults)
+				workingDirectory = associatedInstance.ShellViewModel.WorkingDirectory;
 
 			if (runAsAdmin)
 			{

--- a/src/Files.App/Utils/Shell/LaunchHelper.cs
+++ b/src/Files.App/Utils/Shell/LaunchHelper.cs
@@ -64,6 +64,8 @@ namespace Files.App.Utils.Shell
 				return await Win32Helper.MountVhdDisk(application);
 			}
 
+			var resolvedWorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? PathNormalization.GetParentDir(application) : workingDirectory;
+
 			try
 			{
 				using Process process = new Process();
@@ -71,7 +73,7 @@ namespace Files.App.Utils.Shell
 				process.StartInfo.FileName = application;
 
 				// Show window if workingDirectory (opening terminal)
-				process.StartInfo.CreateNoWindow = string.IsNullOrEmpty(workingDirectory);
+				process.StartInfo.CreateNoWindow = string.IsNullOrEmpty(resolvedWorkingDirectory);
 
 				if (arguments == "RunAs")
 				{
@@ -119,7 +121,7 @@ namespace Files.App.Utils.Shell
 						Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User));
 				}
 
-				process.StartInfo.WorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? PathNormalization.GetParentDir(application) : workingDirectory;
+				process.StartInfo.WorkingDirectory = resolvedWorkingDirectory;
 				process.Start();
 
 				Win32Helper.BringToForeground(currentWindows);
@@ -133,7 +135,7 @@ namespace Files.App.Utils.Shell
 				process.StartInfo.FileName = application;
 				process.StartInfo.CreateNoWindow = true;
 				process.StartInfo.Arguments = arguments;
-				process.StartInfo.WorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? PathNormalization.GetParentDir(application) : workingDirectory;
+				process.StartInfo.WorkingDirectory = resolvedWorkingDirectory;
 
 				try
 				{


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where apps launched from the Tags view used the wrong working directory, causing some applications to reset their settings or fail to load their existing configuration.

Closes #18343

**Steps used to test these changes**
1. Add a tag to an application (e.g. Moonlight.exe)
2. Click the tag in the sidebar to open the search results view
3. Double-click the application in the results panel
4. Verify the application launches correctly with its own settings intact
5. Verify the same application double-clicked from a normal folder view still works correctly