### PR TITLE
Fix: Fixed an issue where tags widget had duplicate items

### DIFF
--- a/src/Files.App/Data/Items/WidgetFileTagsContainerItem.cs
+++ b/src/Files.App/Data/Items/WidgetFileTagsContainerItem.cs
@@ -16,6 +16,7 @@ namespace Files.App.Data.Items
 		private IContentPageContext ContentPageContext { get; } = Ioc.Default.GetRequiredService<IContentPageContext>();
 
 		private readonly string _tagUid;
+		private CancellationTokenSource _initCTS = new();
 
 		// Properties
 
@@ -59,16 +60,20 @@ namespace Files.App.Data.Items
 		/// <inheritdoc/>
 		public async Task InitAsync(CancellationToken cancellationToken = default)
 		{
+			_initCTS.Cancel();
+			_initCTS = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			var linkedToken = _initCTS.Token;
+
 			Tags.Clear();
-			
-			await foreach (var item in FileTagsService.GetItemsForTagAsync(_tagUid, cancellationToken))
+
+			await foreach (var item in FileTagsService.GetItemsForTagAsync(_tagUid, linkedToken))
 			{
 				// Create item without waiting for icon
 				var cardItem = new WidgetFileTagCardItem(item.Storable, null);
 				Tags.Add(cardItem);
-				
+
 				// Load icon asynchronously in background
-				_ = LoadIconAsync(cardItem, item.Storable, cancellationToken);
+				_ = LoadIconAsync(cardItem, item.Storable, linkedToken);
 			}
 		}
 

--- a/src/Files.App/ViewModels/UserControls/Widgets/FileTagsWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/FileTagsWidgetViewModel.cs
@@ -72,7 +72,6 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				{
 					matchingItem.Name = item.Name;
 					matchingItem.Color = item.Color;
-					matchingItem.Tags.Clear();
 					_ = matchingItem.InitAsync(_updateCTS.Token);
 				}
 			}


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where tagged items in the home page tags widget appeared duplicated on first load. 

refs #17128

**Steps used to test these changes**
1. Enable the Tags widget on the home page
2. Create several tags with a few tagged files/folders each
3. Close the app completely (not running in background)
4. Launch a fresh instance and verify items appear once, not duplicated
5. Navigate away from home and back and verify no duplicates on return
