### PR TITLE
Fix: Fixed home page freeze caused by active tags widget

### DIFF
--- a/src/Files.App/Data/Contracts/IFileTagsService.cs
+++ b/src/Files.App/Data/Contracts/IFileTagsService.cs
@@ -44,5 +44,12 @@ namespace Files.App.Data.Contracts
 		/// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
 		/// <returns>Returns an async operation represented by <see cref="IAsyncEnumerable{T}"/> of type <see cref="TaggedItemModel"/> of tags saved in the database.</returns>
 		IAsyncEnumerable<TaggedItemModel> GetAllFileTagsAsync(CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Gets all tagged items grouped by tag UID using a single database scan.
+		/// </summary>
+		/// <param name="cancellationToken">A <see cref="CancellationToken"/> that cancels this action.</param>
+		/// <returns>A lookup of tag UID to its tagged items.</returns>
+		Task<ILookup<string, TaggedItemModel>> GetAllItemsGroupedByTagAsync(CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Files.App/Data/Items/WidgetFileTagsContainerItem.cs
+++ b/src/Files.App/Data/Items/WidgetFileTagsContainerItem.cs
@@ -77,6 +77,30 @@ namespace Files.App.Data.Items
 			}
 		}
 
+		public Task InitAsync(IEnumerable<TaggedItemModel> preloadedItems, CancellationToken cancellationToken = default)
+		{
+			_initCTS.Cancel();
+			_initCTS = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			var linkedToken = _initCTS.Token;
+
+			Tags.Clear();
+
+			foreach (var item in preloadedItems)
+			{
+				if (linkedToken.IsCancellationRequested)
+					break;
+
+				// Create item without waiting for icon
+				var cardItem = new WidgetFileTagCardItem(item.Storable, null);
+				Tags.Add(cardItem);
+
+				// Load icon asynchronously in background
+				_ = LoadIconAsync(cardItem, item.Storable, linkedToken);
+			}
+
+			return Task.CompletedTask;
+		}
+
 		private async Task LoadIconAsync(WidgetFileTagCardItem cardItem, IStorable storable, CancellationToken cancellationToken)
 		{
 			var icon = await ImageService.GetIconAsync(storable, default);

--- a/src/Files.App/Services/App/FileTagsService.cs
+++ b/src/Files.App/Services/App/FileTagsService.cs
@@ -66,5 +66,28 @@ namespace Files.App.Services
 
 			await Task.CompletedTask;
 		}
+
+		/// <inheritdoc/>
+		public async Task<ILookup<string, TaggedItemModel>> GetAllItemsGroupedByTagAsync(CancellationToken cancellationToken = default)
+		{
+			var allDbItems = FileTagsHelper.GetDbInstance().GetAll().ToList();
+			var result = new List<(string TagUid, TaggedItemModel Model)>();
+
+			foreach (var dbItem in allDbItems)
+			{
+				if (StorageTrashBinService.IsUnderTrashBin(dbItem.FilePath))
+					continue;
+
+				var storable = await StorageService.TryGetStorableAsync(dbItem.FilePath, cancellationToken);
+				if (storable is null)
+					continue;
+
+				var model = new TaggedItemModel(dbItem.Tags, storable);
+				foreach (var tagUid in dbItem.Tags)
+					result.Add((tagUid, model));
+			}
+
+			return result.ToLookup(x => x.TagUid, x => x.Model);
+		}
 	}
 }

--- a/src/Files.App/ViewModels/UserControls/Widgets/FileTagsWidgetViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Widgets/FileTagsWidgetViewModel.cs
@@ -13,6 +13,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 	public sealed partial class FileTagsWidgetViewModel : BaseWidgetViewModel, IWidgetViewModel
 	{
 		private CancellationTokenSource _updateCTS;
+		private bool _isInitialized;
 
 		// Properties
 
@@ -34,9 +35,9 @@ namespace Files.App.ViewModels.UserControls.Widgets
 
 		public FileTagsWidgetViewModel()
 		{
-			_ = InitializeWidget();
-
 			FileTagsSettingsService.OnTagsUpdated += FileTagsSettingsService_OnTagsUpdated;
+
+			_ = InitializeWidget();
 
 			PinToSidebarCommand = new AsyncRelayCommand<WidgetCardItem>(ExecutePinToSidebarCommand);
 			UnpinFromSidebarCommand = new AsyncRelayCommand<WidgetCardItem>(ExecuteUnpinFromSidebarCommand);
@@ -48,17 +49,27 @@ namespace Files.App.ViewModels.UserControls.Widgets
 
 		public async Task InitializeWidget()
 		{
-			await foreach (var item in FileTagsService.GetTagsAsync())
+			_isInitialized = false;
+
+			var grouped = await FileTagsService.GetAllItemsGroupedByTagAsync();
+			await foreach (var tag in FileTagsService.GetTagsAsync())
 			{
-				CreateTagContainerItem(item);
+				CreateTagContainerItem(tag, grouped[tag.Uid]);
 			}
+
+			_isInitialized = true;
 		}
 
 		public async Task RefreshWidgetAsync()
 		{
+			if (!_isInitialized)
+				return;
+
 			_updateCTS?.Cancel();
 			_updateCTS = new CancellationTokenSource();
-			await foreach (var item in FileTagsService.GetTagsAsync())
+
+			var grouped = await FileTagsService.GetAllItemsGroupedByTagAsync(_updateCTS.Token);
+			await foreach (var item in FileTagsService.GetTagsAsync(_updateCTS.Token))
 			{
 				if (_updateCTS.IsCancellationRequested)
 					break;
@@ -66,18 +77,18 @@ namespace Files.App.ViewModels.UserControls.Widgets
 				var matchingItem = Containers.FirstOrDefault(c => c.Uid == item.Uid);
 				if (matchingItem is null)
 				{
-					CreateTagContainerItem(item);
+					CreateTagContainerItem(item, grouped[item.Uid]);
 				}
 				else
 				{
 					matchingItem.Name = item.Name;
 					matchingItem.Color = item.Color;
-					_ = matchingItem.InitAsync(_updateCTS.Token);
+					_ = matchingItem.InitAsync(grouped[item.Uid], _updateCTS.Token);
 				}
 			}
 		}
 
-		private void CreateTagContainerItem(TagViewModel tag)
+		private void CreateTagContainerItem(TagViewModel tag, IEnumerable<TaggedItemModel> preloadedItems)
 		{
 			// Don't create duplicate containers
 			if (Containers.Any(c => c.Uid == tag.Uid))
@@ -92,7 +103,7 @@ namespace Files.App.ViewModels.UserControls.Widgets
 			};
 
 			Containers.Add(container);
-			_ = container.InitAsync();
+			_ = container.InitAsync(preloadedItems);
 		}
 
 		public override List<ContextMenuFlyoutItemViewModel> GetItemMenuItems(WidgetCardItem item, bool isPinned, bool isFolder = false)


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where the home page would freeze or load slowly when the file tags widget was active and large number of files tagged, caused by the widget performing a separate database scan for each tag.

refs #17128

**Steps used to test these changes**
1. Open the app with the file tags widget enabled on the home page and verify it loads without freezing
2. Add multiple tags with several files each and verify all containers populate correctly
3. Tag a new file and check it appears in the widget after refresh
