### PR TITLE
Code Quality: Optimize duplicate calls in toolbar update control

### DIFF
--- a/src/Files.App/UserControls/Toolbar.xaml.cs
+++ b/src/Files.App/UserControls/Toolbar.xaml.cs
@@ -102,9 +102,9 @@ namespace Files.App.UserControls
 				await PageContext.ShellPage.ShellViewModel.RefreshTagGroups();
 		}
 
-		private void RequestToolbarRefresh(bool immediate)
+		private void RequestToolbarRefresh(bool ignoreDebounce)
 		{
-			toolbarRefreshTimer.Debounce(PopulateToolbarItems, TimeSpan.FromMilliseconds(100), immediate);
+			toolbarRefreshTimer.Debounce(PopulateToolbarItems, TimeSpan.FromMilliseconds(100), ignoreDebounce);
 		}
 
 		private void ContextCommandBar_Loaded(object sender, RoutedEventArgs e)

--- a/src/Files.App/UserControls/Toolbar.xaml.cs
+++ b/src/Files.App/UserControls/Toolbar.xaml.cs
@@ -45,7 +45,7 @@ namespace Files.App.UserControls
 		private void Toolbar_Loaded(object sender, RoutedEventArgs e)
 		{
 			foreach (var cmd in Commands) cmd.PropertyChanged += Command_PropertyChanged;
-			PopulateToolbarItems();
+			RequestToolbarRefresh(true);
 			UserSettingsService.AppearanceSettingsService.PropertyChanged += AppearanceSettings_PropertyChanged;
 		}
 
@@ -62,7 +62,7 @@ namespace Files.App.UserControls
 			if (newValue?.InstanceViewModel is not null)
 			{
 				newValue.InstanceViewModel.PropertyChanged += InstanceViewModel_PropertyChanged;
-				PopulateToolbarItems();
+				RequestToolbarRefresh(true);
 			}
 		}
 
@@ -80,20 +80,20 @@ namespace Files.App.UserControls
 			// so we don't need to check if the context visibility actually changed here.
 			// Checking IsContextActive() loops through all commands and is expensive during
 			// file selection when many commands' executability changes rapidly.
-			RequestToolbarRefresh();
+			RequestToolbarRefresh(false);
 		}
 
 		private void InstanceViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName is nameof(CurrentInstanceViewModel.IsPageTypeNotHome)
 				or nameof(CurrentInstanceViewModel.IsPageTypeRecycleBin))
-				RequestToolbarRefresh();
+				RequestToolbarRefresh(false);
 		}
 
 		private void AppearanceSettings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName is nameof(IAppearanceSettingsService.CustomToolbarItems))
-				RequestToolbarRefresh();
+				RequestToolbarRefresh(true);
 		}
 
 		private async void EditTagsMenu_TagsChanged(object? sender, EventArgs e)
@@ -102,13 +102,13 @@ namespace Files.App.UserControls
 				await PageContext.ShellPage.ShellViewModel.RefreshTagGroups();
 		}
 
-		private void RequestToolbarRefresh()
+		private void RequestToolbarRefresh(bool immediate)
 		{
-			toolbarRefreshTimer.Debounce(PopulateToolbarItems, TimeSpan.FromMilliseconds(100));
+			toolbarRefreshTimer.Debounce(PopulateToolbarItems, TimeSpan.FromMilliseconds(100), immediate);
 		}
 
 		private void ContextCommandBar_Loaded(object sender, RoutedEventArgs e)
-			=> PopulateToolbarItems();
+			=> RequestToolbarRefresh(true);
 
 		private void PopulateToolbarItems()
 		{
@@ -367,7 +367,6 @@ namespace Files.App.UserControls
 			{
 				list.RemoveAt(index);
 				UserSettingsService.AppearanceSettingsService.CustomToolbarItems = items;
-				PopulateToolbarItems();
 			}
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**

Closes #18420

This PR reduces unnecessary toolbar rebuilds that occur during file selection changes, significantly improving performance when the Recycle Bin contains many items.

`ToolBar.PopulateToolbarItems()` is invoked multiple times for a single selection change.

This leads to repeated execution of:
```
ToolBar.PopulateToolbarItems()
   -> ...
        -> TrashBinService.QueryRecycleBin()
            -> PInvoke.SHQueryRecycleBin()
```

Since `SHQueryRecycleBin()` is relatively expensive (can take >1s with large Recycle Bin), this results in noticeable UI lag.

The existing debounce logic was insufficient to prevent redundant updates.
By properly controlling when `PopulateToolbarItems()` is executed, redundant calls are eliminated.

- Reduced number of `PopulateToolbarItems()` calls per selection change
- Improved responsiveness when navigating and selecting files


**Steps used to test these changes**

- Confirmed no regression in toolbar updates