### PR TITLE
Improve Recycle Bin item existence check performance

### DIFF
--- a/src/Files.App/Services/Storage/StorageTrashBinService.cs
+++ b/src/Files.App/Services/Storage/StorageTrashBinService.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.Com;
@@ -42,7 +44,34 @@ namespace Files.App.Services
 		/// <inheritdoc/>
 		public bool HasItems()
 		{
-			return QueryRecycleBin().NumItems > 0;
+			var sid = WindowsIdentity.GetCurrent().User?.Value;
+			if (string.IsNullOrEmpty(sid))
+				return false;
+
+			foreach (DriveInfo drive in DriveInfo.GetDrives())
+			{
+				if (!drive.IsReady || drive.DriveType == System.IO.DriveType.Network)
+					continue;
+
+				string recyclePath = Path.Combine(drive.RootDirectory.FullName, "$RECYCLE.BIN", sid);
+				if (!Directory.Exists(recyclePath))
+					continue;
+
+				try
+				{
+					var files = Directory.EnumerateFiles(recyclePath, "$I*", SearchOption.TopDirectoryOnly);
+					if (files.Any())
+						return true;
+				}
+				catch (UnauthorizedAccessException)
+				{
+				}
+				catch (IOException)
+				{
+				}
+			}
+
+			return false;
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
**Resolved / Related Issues**

Bug: Slow file selection when Recycle Bin has many files #18420

**Steps used to test these changes**

* When a file is selected, the state updates in under 1 second.
* StorageTrashBinService.HasItems() returns true when the Recycle Bin contains items, and false when it is empty.

