### PR TITLE
Fix: Fixed issue where double click to rename had a delay

### DIFF
--- a/src/Files.App.CsWin32/NativeMethods.txt
+++ b/src/Files.App.CsWin32/NativeMethods.txt
@@ -266,3 +266,4 @@ HCERTSTORE
 CERT_QUERY_ENCODING_TYPE
 CertGetNameString
 MessageBox
+GetDoubleClickTime

--- a/src/Files.App/Constants.cs
+++ b/src/Files.App/Constants.cs
@@ -104,6 +104,9 @@ namespace Files.App
 			public const double ContextMenuItemsMaxWidth = 250;
 
 			public const double MultiplePaneWidthThreshold = 750;
+
+			public const int RenameDelayBufferMs = 150;
+
 		}
 
 		public static class Appearance

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -73,6 +73,7 @@ namespace Files.App.Views.Layouts
 		private ListedItem? dragOverItem = null;
 		private ListedItem? hoveredItem = null;
 		private ListedItem? preRenamingItem = null;
+		private DateTime preRenamingItemTime;
 
 		// Properties
 
@@ -274,6 +275,7 @@ namespace Files.App.Views.Layouts
 								// Tapped event must be executed first
 								await Task.Delay(50);
 								preRenamingItem = SelectedItem;
+								preRenamingItemTime = DateTime.UtcNow;
 							});
 						}
 						else
@@ -1547,7 +1549,7 @@ namespace Files.App.Views.Layouts
 		{
 			if (clickedItem is ListedItem item)
 			{
-				var doubleClickTimeDelay = PInvoke.GetDoubleClickTime() + Constants.UI.RenameDelayBufferMs;
+				var doubleClickTimeDelay = Math.Max(0, PInvoke.GetDoubleClickTime() + Constants.UI.RenameDelayBufferMs - (DateTime.UtcNow - preRenamingItemTime).TotalMilliseconds);
 
 				if (item == preRenamingItem)
 				{
@@ -1565,6 +1567,7 @@ namespace Files.App.Views.Layouts
 				{
 					tapDebounceTimer.Stop();
 					preRenamingItem = item;
+					preRenamingItemTime = DateTime.UtcNow;
 				}
 			}
 			else

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -23,6 +23,7 @@ using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Storage;
 using Windows.System;
+using Windows.Win32;
 using static Files.App.Helpers.PathNormalization;
 using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
 using SortDirection = Files.App.Data.Enums.SortDirection;
@@ -53,7 +54,6 @@ namespace Files.App.Views.Layouts
 		public BaseLayoutViewModel? CommandsViewModel { get; protected set; }
 
 		// Fields
-
 		private readonly DispatcherQueueTimer jumpTimer;
 		private readonly DispatcherQueueTimer dragOverTimer;
 		private readonly DispatcherQueueTimer tapDebounceTimer;
@@ -1547,6 +1547,8 @@ namespace Files.App.Views.Layouts
 		{
 			if (clickedItem is ListedItem item)
 			{
+				var doubleClickTimeDelay = PInvoke.GetDoubleClickTime() + Constants.UI.RenameDelayBufferMs;
+
 				if (item == preRenamingItem)
 				{
 					tapDebounceTimer.Debounce(() =>
@@ -1557,7 +1559,7 @@ namespace Files.App.Views.Layouts
 							tapDebounceTimer.Stop();
 						}
 					},
-					TimeSpan.FromMilliseconds(1500));
+					TimeSpan.FromMilliseconds(doubleClickTimeDelay));
 				}
 				else
 				{


### PR DESCRIPTION
**Resolved / Related Issues**
Replace hardcoded 1500ms rename delay with Windows system double-click time retrieved via GetDoubleClickTime() Win32 API.

The rename delay now respects the user's Windows double-click speed setting (Control Panel → Mouse → Buttons tab), making the app more accessible and consistent with File Explorer behavior.

Changes:
- Added GetDoubleClickTime to CsWin32 NativeMethods.txt
- Replaced hardcoded 1500ms with PInvoke.GetDoubleClickTime() + 150ms buffer
- Extracted 150ms buffer to RenameDelayBufferMs constant

This allows users with motor control issues who set slower double-click speeds system-wide to have Files respect their preference.

Closes #17332

**Steps used to test these changes**
Pre-check the delay before testing this PR and note the delay.

1. Open file, try renaming expected mouse behavior. The delay should be less now.
2. To check if the correct settings is being read from the system, go to Accessibility -> Mouse and change the double click time. And test again.
3. A comparison can be done by pulling up a file explore window and files and check directly. 

