### PR TITLE
Code Quality: Resolve some of AOT warnings in Files.App.Controls

### DIFF
--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBar.xaml
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBar.xaml
@@ -59,7 +59,7 @@
 							ChevronToolTip="{TemplateBinding RootItemChevronToolTip}"
 							CornerRadius="{StaticResource BreadcrumbBarRootItemCornerRadius}"
 							ItemToolTip="{TemplateBinding RootItemToolTip}">
-							<ContentPresenter Content="{Binding RootItem, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+							<ContentPresenter Content="{TemplateBinding RootItem}" />
 						</local:BreadcrumbBarItem>
 
 						<local:BreadcrumbBarItem
@@ -77,8 +77,8 @@
 							Grid.Column="2"
 							Margin="{StaticResource BreadcrumbBarItemMargin}"
 							HorizontalAlignment="Left"
-							ItemTemplate="{Binding ItemTemplate, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-							ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+							ItemTemplate="{TemplateBinding ItemTemplate}"
+							ItemsSource="{TemplateBinding ItemsSource}" />
 
 					</Grid>
 				</ControlTemplate>

--- a/src/Files.App.Controls/Omnibar/Omnibar.xaml
+++ b/src/Files.App.Controls/Omnibar/Omnibar.xaml
@@ -53,7 +53,7 @@
 							Grid.Row="0"
 							Width="{TemplateBinding Width}"
 							Height="{TemplateBinding Height}"
-							Padding="{Binding AutoSuggestBoxPadding, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+							Padding="{TemplateBinding AutoSuggestBoxPadding}"
 							HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
 							VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
 							Background="{TemplateBinding Background}"
@@ -136,12 +136,12 @@
 							Height="{StaticResource OmnibarModeDefaultHeight}"
 							Margin="1"
 							AutomationProperties.AccessibilityView="Content"
-							AutomationProperties.Name="{Binding ModeName, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+							AutomationProperties.Name="{TemplateBinding ModeName}"
 							Background="{TemplateBinding Background}"
 							BorderBrush="{TemplateBinding BorderBrush}"
 							BorderThickness="0"
 							CornerRadius="{TemplateBinding CornerRadius}"
-							ToolTipService.ToolTip="{Binding ModeName, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}">
+							ToolTipService.ToolTip="{TemplateBinding ModeName}">
 							<Button.Resources>
 								<SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{ThemeResource SubtleFillColorSecondary}" />
 								<SolidColorBrush x:Key="ButtonBackgroundPressed" Color="{ThemeResource SubtleFillColorTertiary}" />
@@ -152,14 +152,14 @@
 									x:Name="PART_ModeButtonInactiveIconPresenter"
 									HorizontalAlignment="Center"
 									VerticalAlignment="Center"
-									Content="{Binding IconOnInactive, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+									Content="{TemplateBinding IconOnInactive}"
 									Visibility="Visible" />
 
 								<ContentPresenter
 									x:Name="PART_ModeButtonActiveIconPresenter"
 									HorizontalAlignment="Center"
 									VerticalAlignment="Center"
-									Content="{Binding IconOnActive, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+									Content="{TemplateBinding IconOnActive}"
 									Visibility="Collapsed" />
 							</Grid>
 						</Button>
@@ -169,7 +169,7 @@
 							HorizontalAlignment="Stretch"
 							VerticalAlignment="Stretch"
 							HorizontalContentAlignment="Stretch"
-							Content="{Binding ContentOnInactive, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+							Content="{TemplateBinding ContentOnInactive}"
 							Visibility="Collapsed" />
 
 						<VisualStateManager.VisualStateGroups>
@@ -349,7 +349,7 @@
 							<TextBlock
 								x:Name="PlaceholderTextContentPresenter"
 								VerticalAlignment="Center"
-								Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource TextControlPlaceholderForeground}}"
+								Foreground="{TemplateBinding PlaceholderForeground}"
 								IsHitTestVisible="False"
 								Text="{TemplateBinding PlaceholderText}"
 								TextAlignment="{TemplateBinding TextAlignment}"
@@ -395,7 +395,7 @@
 								<VisualState x:Name="Normal" />
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
-										<Setter Target="PlaceholderTextContentPresenter.Foreground" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource TextControlPlaceholderForegroundDisabled}}" />
+										<Setter Target="PlaceholderTextContentPresenter.Foreground" Value="{ThemeResource TextControlPlaceholderForegroundDisabled}" />
 										<Setter Target="HeaderContentPresenter.Foreground" Value="{ThemeResource TextControlHeaderForegroundDisabled}" />
 										<Setter Target="BorderElement.Background" Value="{ThemeResource TextControlBackgroundDisabled}" />
 										<Setter Target="BorderElement.BorderBrush" Value="{ThemeResource TextControlBorderBrushDisabled}" />
@@ -404,7 +404,7 @@
 								</VisualState>
 								<VisualState x:Name="PointerOver">
 									<VisualState.Setters>
-										<Setter Target="PlaceholderTextContentPresenter.Foreground" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource TextControlPlaceholderForegroundPointerOver}}" />
+										<Setter Target="PlaceholderTextContentPresenter.Foreground" Value="{ThemeResource TextControlPlaceholderForegroundPointerOver}" />
 										<Setter Target="HeaderContentPresenter.Foreground" Value="{ThemeResource TextControlHeaderForegroundDisabled}" />
 										<Setter Target="BorderElement.Background" Value="{ThemeResource TextControlBackgroundPointerOver}" />
 										<Setter Target="BorderElement.BorderBrush" Value="{ThemeResource CircleElevationBorderBrush}" />
@@ -413,7 +413,7 @@
 								</VisualState>
 								<VisualState x:Name="Focused">
 									<VisualState.Setters>
-										<Setter Target="PlaceholderTextContentPresenter.Foreground" Value="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}, TargetNullValue={ThemeResource TextControlPlaceholderForegroundFocused}}" />
+										<Setter Target="PlaceholderTextContentPresenter.Foreground" Value="{ThemeResource TextControlPlaceholderForegroundFocused}" />
 										<Setter Target="BorderElement.Background" Value="{ThemeResource TextControlBackgroundFocused}" />
 										<Setter Target="BorderElement.BorderBrush" Value="{ThemeResource AccentFillColorDefaultBrush}" />
 										<Setter Target="BorderElement.BorderThickness" Value="{ThemeResource OmnibarBorderThicknessFocused}" />

--- a/src/Files.App.Controls/SamplePanel/SamplePanel.xaml
+++ b/src/Files.App.Controls/SamplePanel/SamplePanel.xaml
@@ -33,7 +33,7 @@
 						<TextBlock
 							Grid.Row="0"
 							Style="{StaticResource BodyStrongTextBlockStyle}"
-							Text="{Binding Header, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+							Text="{TemplateBinding Header}" />
 
 						<Grid
 							x:Name="PART_RootPanel"
@@ -50,7 +50,7 @@
 							<ContentPresenter
 								Grid.Column="0"
 								Padding="{TemplateBinding Padding}"
-								Content="{Binding MainContent, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+								Content="{TemplateBinding MainContent}" />
 
 							<StackPanel
 								Grid.Column="1"
@@ -74,7 +74,7 @@
 									</SelectorBarItem>
 								</SelectorBar>
 
-								<ContentPresenter Margin="0,12,0,0" Content="{Binding SideContent, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+								<ContentPresenter Margin="0,12,0,0" Content="{TemplateBinding SideContent}" />
 
 								<TextBlock
 									x:Name="PART_NothingToShowTextBlock"


### PR DESCRIPTION
### Resolved / Related Issues

- #4180

### Steps used to test these changes

1. Open Files app
2. Try use BreadcrumbBar and Omnibar to change their state at runtime.

---

Here's the latest build log:

```
1>------ Build started: Project: Files.App.Controls, Configuration: Debug x64 ------
1>Sidebar\SidebarStyles.xaml(228,8): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(198,12): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(203,15): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(204,15): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(205,15): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(206,15): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(209,15): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(210,15): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(373,14): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(340,14): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(318,53): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(301,14): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(41,4): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(42,4): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(43,4): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(44,4): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(46,4): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>Sidebar\SidebarStyles.xaml(47,4): XamlCompiler warning WMC1510: Ensure the property path is trimming and AOT compatible by making use of 'Compiled Bindings (x:bind)' if possible or by specifying the 'x:DataType' directive with the respective binding data context and marking the type declaration with the 'WinRT.GeneratedBindableCustomProperty' attribute or the 'Microsoft.UI.Xaml.Data.Bindable' attribute. If you are unable to do either but can ensure the data type is attributed correctly, then you can also suppress the warning by specifying `x:SuppressXamlTrimWarnings=True` within the closest element. If not, the property path might be trimmed and will not be AOT compatible.
1>  0 IID calculations/fetches patched
1>  Files.App.Controls -> D:\Source\Files\src\Files.App.Controls\bin\x64\Debug\net10.0-windows10.0.26100.0\Files.App.Controls.dll
```

We now only have AOT warnings that come from SidebarStyles. We cannot fix this in this PR because it requires lots of refactoring to resolve AOT warnings.