### PR TITLE
Fix: Fixed an issue where thumbnails failed to refresh after modifying the file

### DIFF
--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -1182,6 +1182,8 @@ namespace Files.App.ViewModels
 					{
 						item.NeedsDelayedThumbnailLoad = true;
 
+						// Some writers never emit a FILE_ACTION_MODIFIED event after finalizing the file, so the normal event-driven retry never fires.
+						// Schedule a 2s timer as a fallback; the FILE_ACTION_MODIFIED handler cancels it if the event arrives first.
 						if (scheduleTimerRetry)
 						{
 							var retryCts = new CancellationTokenSource();

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -1077,7 +1077,7 @@ namespace Files.App.ViewModels
 			return shieldIcon;
 		}
 
-		private async Task LoadThumbnailAsync(ListedItem item, CancellationToken cancellationToken)
+		private async Task LoadThumbnailAsync(ListedItem item, CancellationToken cancellationToken, bool scheduleTimerRetry = true)
 		{
 			var loadNonCachedThumbnail = false;
 			var thumbnailSize = LayoutSizeKindHelper.GetIconSize(folderSettings.LayoutMode);
@@ -1181,6 +1181,38 @@ namespace Files.App.ViewModels
 					if (result is null)
 					{
 						item.NeedsDelayedThumbnailLoad = true;
+
+						if (scheduleTimerRetry)
+						{
+							var retryCts = new CancellationTokenSource();
+							if (thumbnailRetryDebounce.TryAdd(item.ItemPath, retryCts))
+							{
+								App.Logger.LogWarning("Thumbnail load failed [{Id}] '{Extension}'; scheduling 2s timer retry.", item.ItemPath.GetHashCode(), Path.GetExtension(item.ItemPath));
+
+								var retryToken = retryCts.Token;
+								_ = Task.Delay(2000, retryToken)
+									.ContinueWith(_ =>
+									{
+										if (thumbnailRetryDebounce.TryRemove(item.ItemPath, out var cts))
+											cts.Dispose();
+
+										App.Logger.LogInformation("Timer-based thumbnail retry firing [{Id}] '{Extension}'.", item.ItemPath.GetHashCode(), Path.GetExtension(item.ItemPath));
+
+										item.NeedsDelayedThumbnailLoad = false;
+										return LoadThumbnailAsync(item, retryToken, scheduleTimerRetry: false);
+									}, retryToken, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default)
+									.Unwrap();
+							}
+							else
+							{
+								App.Logger.LogWarning("Thumbnail load failed [{Id}] '{Extension}'; mod-retry already pending, skipping timer.", item.ItemPath.GetHashCode(), Path.GetExtension(item.ItemPath));
+								retryCts.Dispose();
+							}
+						}
+						else
+						{
+							App.Logger.LogWarning("Thumbnail load failed [{Id}] '{Extension}' on timer retry; awaiting next FILE_ACTION_MODIFIED.", item.ItemPath.GetHashCode(), Path.GetExtension(item.ItemPath));
+						}
 					}
 					else
 					{
@@ -2667,6 +2699,8 @@ namespace Files.App.ViewModels
 				var item = filesAndFolders.ToList().FirstOrDefault(x => x.ItemPath.Equals(path, StringComparison.OrdinalIgnoreCase));
 				if (item is not null && item.NeedsDelayedThumbnailLoad)
 				{
+					App.Logger.LogInformation("FILE_ACTION_MODIFIED thumbnail retry triggered [{Id}] '{Extension}'.", path.GetHashCode(), Path.GetExtension(path));
+
 					if (thumbnailRetryDebounce.TryGetValue(path, out var existingCts))
 					{
 						existingCts.Cancel();


### PR DESCRIPTION
Fixed an issue where file thumbnails failed to appear after saving a file using Chrome "Save as PDF", Adobe PDF printer, or Microsoft PDF printer.

This fix adds a 2-second timer-based self-retry directly in LoadThumbnailAsync as a fallback for when no FILE_ACTION_MODIFIED event follows a thumbnail failure. Diagnostic logging also added to investigate the issue.

Closes #18352

Steps used to test these changes
1. Navigate to a folder in Files
2. Print to PDF from Chrome using "Save as PDF" into that folder and verify thumbnail appears within ~2 seconds
3. Repeat using Adobe PDF printer or Microsoft PDF printer and verify whether thumbnail appears 