### PR TITLE
Fix: Fixed an issue where Smart Extract would sometimes extract to the wrong location

### DIFF
--- a/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/BaseDecompressArchiveAction.cs
@@ -55,11 +55,14 @@ namespace Files.App.Actions
 			if (context.SelectedItems.Count is 0)
 				return;
 
-			foreach (var selectedItem in context.SelectedItems)
+			var selectedItems = context.SelectedItems.ToList();
+			var currentFolderPath = context.ShellPage?.ShellViewModel.CurrentFolder?.ItemPath ?? string.Empty;
+			BaseStorageFolder currentFolder = await StorageHelpers.ToStorageItem<BaseStorageFolder>(currentFolderPath);
+
+			foreach (var selectedItem in selectedItems)
 			{
 				var password = string.Empty;
 				BaseStorageFile archive = await StorageHelpers.ToStorageItem<BaseStorageFile>(selectedItem.ItemPath);
-				BaseStorageFolder currentFolder = await StorageHelpers.ToStorageItem<BaseStorageFolder>(context.ShellPage?.ShellViewModel.CurrentFolder?.ItemPath ?? string.Empty);
 
 				if (archive?.Path is null)
 					return;


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where Smart Extract would decompress archives into the currently viewed folder instead of the source folder when switching tabs during extraction.

Closes #17718

**Steps used to test these changes**
1. Open two tabs. Tab A with multiple archives and Tab B with an unrelated folder
2. In Tab A, select multiple archives and invoke Smart Extract
3. Immediately switch to Tab B while extraction is in progress
4. Verify all archives extract into their correct destination in Tab A's folder, not Tab B
