### PR TITLE
Fix several issues in Command Palette

### DIFF
--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -134,13 +134,13 @@ namespace Files.App.Controls
 			if (string.Compare(_textBox.Text, CurrentSelectedMode!.Text, StringComparison.OrdinalIgnoreCase) is not 0)
 				CurrentSelectedMode!.Text = _textBox.Text;
 
-			// UpdateSuggestionListView();
-
 			if (_textChangeReason is OmnibarTextChangeReason.ProgrammaticChange)
 				_textBox.SelectAll();
 			else
 			{
 				_userInput = _textBox.Text;
+				if (_userInput.Length == 0)
+					_textChangeReason = OmnibarTextChangeReason.UserInput;
 			}
 
 			TextChanged?.Invoke(this, new(CurrentSelectedMode, _textChangeReason));

--- a/src/Files.App/Data/Items/NavigationBarSuggestionItem.cs
+++ b/src/Files.App/Data/Items/NavigationBarSuggestionItem.cs
@@ -3,97 +3,60 @@
 
 using Files.App.Controls;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Media;
 
 namespace Files.App.Data.Items
 {
 	[Obsolete("Remove once Omnibar goes out of experimental.")]
-	public sealed partial class NavigationBarSuggestionItem : ObservableObject, IOmnibarTextMemberPathProvider
+	public sealed partial class NavigationBarSuggestionItem : IOmnibarTextMemberPathProvider
 	{
-		private ImageSource? _ActionIconSource;
-		public ImageSource? ActionIconSource { get => _ActionIconSource; set => SetProperty(ref _ActionIconSource, value); }
+		public IRichCommand? Command { get; }
 
-		private Style? _ThemedIconStyle;
-		public Style? ThemedIconStyle { get => _ThemedIconStyle; set => SetProperty(ref _ThemedIconStyle, value); }
+		public Style? ThemedIconStyle { get; }
 
-		private string? _Glyph;
-		public string? Glyph { get => _Glyph; set => SetProperty(ref _Glyph, value); }
+		public string? Glyph { get; }
 
-		private string? _Text;
-		public string? Text { get => _Text; set => SetProperty(ref _Text, value); }
+		public string Text { get; }
 
-		private string? _PrimaryDisplay;
-		public string? PrimaryDisplay
+		public string? PrimaryDisplayPreMatched { get; }
+
+		public string? PrimaryDisplayMatched { get; }
+
+		public string? PrimaryDisplayPostMatched { get; }
+
+		public HotKeyCollection HotKeys { get; }
+
+		public NavigationBarSuggestionItem(string? searchText, IRichCommand? command)
 		{
-			get => _PrimaryDisplay;
-			set
+			Command = command;
+
+			if (command is null)
 			{
-				if (SetProperty(ref _PrimaryDisplay, value))
-					UpdatePrimaryDisplay();
-			}
-		}
-
-		private string? _SearchText;
-		public string? SearchText
-		{
-			get => _SearchText;
-			set
-			{
-				if (SetProperty(ref _SearchText, value))
-					UpdatePrimaryDisplay();
-			}
-		}
-
-		private string? _PrimaryDisplayPreMatched;
-		public string? PrimaryDisplayPreMatched
-		{
-			get => _PrimaryDisplayPreMatched;
-			private set => SetProperty(ref _PrimaryDisplayPreMatched, value);
-		}
-
-		private string? _PrimaryDisplayMatched;
-		public string? PrimaryDisplayMatched
-		{
-			get => _PrimaryDisplayMatched;
-			private set => SetProperty(ref _PrimaryDisplayMatched, value);
-		}
-
-		private string? _PrimaryDisplayPostMatched;
-		public string? PrimaryDisplayPostMatched
-		{
-			get => _PrimaryDisplayPostMatched;
-			private set => SetProperty(ref _PrimaryDisplayPostMatched, value);
-		}
-
-		private HotKeyCollection _HotKeys = new();
-		public HotKeyCollection HotKeys
-		{
-			get => _HotKeys;
-			set => SetProperty(ref _HotKeys, value);
-		}
-
-		private void UpdatePrimaryDisplay()
-		{
-			if (SearchText is null || PrimaryDisplay is null)
-			{
-				PrimaryDisplayPreMatched = null;
-				PrimaryDisplayMatched = PrimaryDisplay;
-				PrimaryDisplayPostMatched = null;
+				Text = string.Format(Strings.NoCommandsFound.GetLocalizedResource(), searchText);
 			}
 			else
 			{
-				var index = PrimaryDisplay.IndexOf(SearchText, StringComparison.OrdinalIgnoreCase);
+				ThemedIconStyle = command.ThemedIconStyle;
+				Glyph = command.Glyph.BaseGlyph;
+				Text = command.Description;
+				HotKeys = command.HotKeys;
+			}
+
+			if (searchText is null)
+			{
+				PrimaryDisplayMatched = Text;
+			}
+			else
+			{
+				var index = Text.IndexOf(searchText, StringComparison.OrdinalIgnoreCase);
 				if (index < 0)
 				{
-					PrimaryDisplayPreMatched = PrimaryDisplay;
-					PrimaryDisplayMatched = null;
-					PrimaryDisplayPostMatched = null;
+					PrimaryDisplayPreMatched = Text;
 				}
 				else
 				{
-					PrimaryDisplayPreMatched = PrimaryDisplay.Substring(0, index);
-					PrimaryDisplayMatched = PrimaryDisplay.Substring(index, SearchText.Length);
-					PrimaryDisplayPostMatched = PrimaryDisplay.Substring(index + SearchText.Length);
+					PrimaryDisplayPreMatched = Text.Substring(0, index);
+					PrimaryDisplayMatched = Text.Substring(index, searchText.Length);
+					PrimaryDisplayPostMatched = Text.Substring(index + searchText.Length);
 				}
 			}
 		}
@@ -103,8 +66,6 @@ namespace Files.App.Data.Items
 			return textMemberPath switch
 			{
 				nameof(Text) => Text,
-				nameof(PrimaryDisplay) => PrimaryDisplay,
-				nameof(SearchText) => SearchText,
 				_ => string.Empty
 			};
 		}

--- a/src/Files.App/UserControls/NavigationToolbar.xaml
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml
@@ -309,11 +309,10 @@
 								<Viewbox
 									Width="16"
 									Height="16"
-									Visibility="{x:Bind Glyph, Converter={StaticResource NullToVisibilityCollapsedConverter}, Mode=OneWay}">
-									<FontIcon Foreground="{ThemeResource App.Theme.IconBaseBrush}" Glyph="{x:Bind Glyph, Mode=OneWay}" />
+									Visibility="{x:Bind Glyph, Converter={StaticResource NullToVisibilityCollapsedConverter}, Mode=OneTime}">
+									<FontIcon Foreground="{ThemeResource App.Theme.IconBaseBrush}" Glyph="{x:Bind Glyph, Mode=OneTime}" />
 								</Viewbox>
-								<controls:ThemedIcon Style="{x:Bind ThemedIconStyle, Mode=OneWay}" Visibility="{x:Bind ThemedIconStyle, Converter={StaticResource NullToVisibilityCollapsedConverter}, Mode=OneWay}" />
-								<Image Source="{x:Bind ActionIconSource, Mode=OneWay}" />
+								<controls:ThemedIcon Style="{x:Bind ThemedIconStyle, Mode=OneTime}" Visibility="{x:Bind ThemedIconStyle, Converter={StaticResource NullToVisibilityCollapsedConverter}, Mode=OneTime}" />
 							</Grid>
 
 							<!--  Primary Title  -->
@@ -324,7 +323,7 @@
 								Foreground="{ThemeResource TextFillColorPrimaryBrush}"
 								TextTrimming="CharacterEllipsis"
 								TextWrapping="NoWrap">
-								<Run FontWeight="Normal" Text="{x:Bind PrimaryDisplayPreMatched, Mode=OneWay}" /><Run FontWeight="Bold" Text="{x:Bind PrimaryDisplayMatched, Mode=OneWay}" /><Run FontWeight="Normal" Text="{x:Bind PrimaryDisplayPostMatched, Mode=OneWay}" />
+								<Run FontWeight="Normal" Text="{x:Bind PrimaryDisplayPreMatched, Mode=OneTime}" /><Run FontWeight="Bold" Text="{x:Bind PrimaryDisplayMatched, Mode=OneTime}" /><Run FontWeight="Normal" Text="{x:Bind PrimaryDisplayPostMatched, Mode=OneTime}" />
 							</TextBlock>
 
 							<!--  Keyboard Shortcuts  -->
@@ -332,7 +331,7 @@
 								x:Name="RightAlignedKeyboardShortcut"
 								Grid.Column="2"
 								VerticalAlignment="Center"
-								HotKeys="{x:Bind HotKeys, Mode=OneWay}" />
+								HotKeys="{x:Bind HotKeys, Mode=OneTime}" />
 						</Grid>
 					</DataTemplate>
 				</controls:OmnibarMode.ItemTemplate>

--- a/src/Files.App/UserControls/NavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml.cs
@@ -183,9 +183,20 @@ namespace Files.App.UserControls
 			// Command palette mode
 			else if (mode == OmnibarCommandPaletteMode)
 			{
-				var item = args.Item as NavigationBarSuggestionItem;
+				IRichCommand? command = null;
 
-				if (item?.Command is { } command)
+				if (args.Item is NavigationBarSuggestionItem item)
+					command = item.Command;
+				else
+					// Maybe the user typed the full command description without selecting a suggestion, so search for it
+					foreach (var c in Commands)
+						if (c != Commands.None && string.Equals(c.Description, args.Text, StringComparison.OrdinalIgnoreCase))
+						{
+							command = c;
+							break;
+						}
+
+				if (command is not null)
 					await command.ExecuteAsync();
 				else
 					await DialogDisplayHelper.ShowDialogAsync(Strings.InvalidCommand.GetLocalizedResource(),

--- a/src/Files.App/UserControls/NavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml.cs
@@ -185,23 +185,11 @@ namespace Files.App.UserControls
 			{
 				var item = args.Item as NavigationBarSuggestionItem;
 
-				// Try invoking built-in command
-				foreach (var command in Commands)
-				{
-					if (command == Commands.None)
-						continue;
-
-					if (!string.Equals(command.Description, item?.Text, StringComparison.OrdinalIgnoreCase) &&
-						!string.Equals(command.Description, args.Text, StringComparison.OrdinalIgnoreCase))
-						continue;
-
+				if (item?.Command is { } command)
 					await command.ExecuteAsync();
-					ContentPageContext.ShellPage!.PaneHolder.FocusActivePane();
-					return;
-				}
-
-				await DialogDisplayHelper.ShowDialogAsync(Strings.InvalidCommand.GetLocalizedResource(),
-					string.Format(Strings.InvalidCommandContent.GetLocalizedResource(), args.Text));
+				else
+					await DialogDisplayHelper.ShowDialogAsync(Strings.InvalidCommand.GetLocalizedResource(),
+						string.Format(Strings.InvalidCommandContent.GetLocalizedResource(), args.Text));
 
 				ContentPageContext.ShellPage!.PaneHolder.FocusActivePane();
 				return;

--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -5,7 +5,6 @@ using CommunityToolkit.WinUI;
 using Files.App.Controls;
 using Files.App.ViewModels.Settings;
 using Files.Shared.Helpers;
-using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -1030,12 +1029,12 @@ namespace Files.App.ViewModels.UserControls
 			void AddNoResultsItem()
 			{
 				PathModeSuggestionItems.Clear();
-				
+
 				// Use null-safe access to avoid NullReferenceException during app lifecycle transitions
 				var workingDirectory = string.IsNullOrEmpty(ContentPageContext.ShellPage?.ShellViewModel?.WorkingDirectory)
 					? Constants.UserEnvironmentPaths.HomePath
 					: ContentPageContext.ShellPage.ShellViewModel.WorkingDirectory;
-				
+
 				PathModeSuggestionItems.Add(new(
 					workingDirectory,
 					Strings.NavigationToolbarVisiblePathNoResults.GetLocalizedResource()));
@@ -1044,97 +1043,54 @@ namespace Files.App.ViewModels.UserControls
 
 		public async Task PopulateOmnibarSuggestionsForCommandPaletteMode()
 		{
-			var (suggestionsToProcess, commandsToProcess) = await Task.Run(() =>
+			string? omnibarCommandPaletteModeText = OmnibarCommandPaletteModeText;
+
+			var commandsToProcess = await Task.Run(() =>
 			{
-				var suggestions = new List<NavigationBarSuggestionItem>();
-
-				var commandsData = Commands
-					.Where(command => command.IsAccessibleGlobally
-						&& (command.Description.Contains(OmnibarCommandPaletteModeText, StringComparison.OrdinalIgnoreCase)
-							|| command.Code.ToString().Contains(OmnibarCommandPaletteModeText, StringComparison.OrdinalIgnoreCase)))
-					.Where(command => command.Description != Commands.OpenCommandPalette.Description.ToString())
-					.ToList();
-
-				return (suggestions, commandsData);
+				if (string.IsNullOrEmpty(OmnibarCommandPaletteModeText))
+					return Commands.Where(static command => command.IsAccessibleGlobally && command.Code != CommandCodes.OpenCommandPalette).ToList();
+				else
+					return Commands
+						.Where(command => command.IsAccessibleGlobally
+							&& (command.Description.Contains(OmnibarCommandPaletteModeText, StringComparison.OrdinalIgnoreCase)
+								|| command.Code.ToString().Contains(OmnibarCommandPaletteModeText, StringComparison.OrdinalIgnoreCase))
+							&& command.Code != CommandCodes.OpenCommandPalette)
+						.ToList();
 			});
 
-			var newSuggestions = new List<NavigationBarSuggestionItem>(suggestionsToProcess);
-			int processedCount = 0;
+			if (OmnibarCommandPaletteModeText != omnibarCommandPaletteModeText)
+				// We're still processing old input, user has typed in the mean time.
+				return;
+
+			int count = 0;
 
 			foreach (var command in commandsToProcess)
-			{				
-				if (!command.IsExecutable)
-				{
-					processedCount++;
-					// To allow UI updates
-					if (processedCount % 3 == 0)
-						await Task.Yield();
-					continue;
-				}
-
-				var newItem = new NavigationBarSuggestionItem
-				{
-					ThemedIconStyle = command.Glyph.ToThemedIconStyle(),
-					Glyph = command.Glyph.BaseGlyph,
-					Text = command.Description,
-					PrimaryDisplay = command.Description,
-					HotKeys = command.HotKeys,
-					SearchText = OmnibarCommandPaletteModeText,
-				};
-
-				newSuggestions.Add(newItem);
-				processedCount++;
-
-				// To allow UI updates
-				if (processedCount % 3 == 0)
-					await Task.Yield();
-			}
-
-			UpdateCommandPaletteSuggestions(newSuggestions);
-		}
-
-		private void UpdateCommandPaletteSuggestions(List<NavigationBarSuggestionItem> newSuggestions)
-		{
-			if (newSuggestions.Count == 0)
 			{
-				newSuggestions.Add(new NavigationBarSuggestionItem()
+				if (command.IsExecutable)
 				{
-					PrimaryDisplay = string.Format(Strings.NoCommandsFound.GetLocalizedResource(), OmnibarCommandPaletteModeText),
-					SearchText = OmnibarCommandPaletteModeText,
-				});
-			}
+					var newSuggestion = new NavigationBarSuggestionItem(OmnibarCommandPaletteModeText, command);
 
-			if (!OmnibarCommandPaletteModeSuggestionItems.IntersectBy(newSuggestions, x => x.PrimaryDisplay).Any())
-			{
-				for (int index = 0; index < newSuggestions.Count; index++)
-				{
-					if (index < OmnibarCommandPaletteModeSuggestionItems.Count)
-						OmnibarCommandPaletteModeSuggestionItems[index] = newSuggestions[index];
+					if (count < OmnibarCommandPaletteModeSuggestionItems.Count)
+						OmnibarCommandPaletteModeSuggestionItems[count] = newSuggestion;
 					else
-						OmnibarCommandPaletteModeSuggestionItems.Add(newSuggestions[index]);
-				}
+						OmnibarCommandPaletteModeSuggestionItems.Add(newSuggestion);
 
-				while (OmnibarCommandPaletteModeSuggestionItems.Count > newSuggestions.Count)
-					OmnibarCommandPaletteModeSuggestionItems.RemoveAt(OmnibarCommandPaletteModeSuggestionItems.Count - 1);
+					count++;
+
+					// To allow UI updates
+					if (count % 4 == 0)
+						await Task.Yield();
+				}
+			}
+
+			if (count == 0)
+			{
+				OmnibarCommandPaletteModeSuggestionItems.Clear();
+				OmnibarCommandPaletteModeSuggestionItems.Add(new NavigationBarSuggestionItem(OmnibarCommandPaletteModeText, null));
 			}
 			else
-			{
-				foreach (var s in OmnibarCommandPaletteModeSuggestionItems.ExceptBy(newSuggestions, x => x.PrimaryDisplay).ToList())
-					OmnibarCommandPaletteModeSuggestionItems.Remove(s);
-
-				for (int index = 0; index < newSuggestions.Count; index++)
-				{
-					if (OmnibarCommandPaletteModeSuggestionItems.Count > index
-						&& OmnibarCommandPaletteModeSuggestionItems[index].PrimaryDisplay == newSuggestions[index].PrimaryDisplay)
-					{
-						OmnibarCommandPaletteModeSuggestionItems[index] = newSuggestions[index];
-					}
-					else
-					{
-						OmnibarCommandPaletteModeSuggestionItems.Insert(index, newSuggestions[index]);
-					}
-				}
-			}
+				while (OmnibarCommandPaletteModeSuggestionItems.Count > count)
+					OmnibarCommandPaletteModeSuggestionItems.RemoveAt(OmnibarCommandPaletteModeSuggestionItems.Count - 1);
 		}
 
 		public async Task PopulateOmnibarSuggestionsForSearchMode()


### PR DESCRIPTION
**Resolved / Related Issues**

Closes #18395 

- The main problem was a bug in `NavigationToolbarViewModel.UpdateCommandPaletteSuggestions`, more specifically in the `else` branch loop. That `else` branch was completely removed. We now always replace all items in the `OmnibarCommandPaletteModeSuggestionItems` collection. This also results in simpler and more efficient code.
- In fact, `NavigationToolbarViewModel.UpdateCommandPaletteSuggestions` has become so simple that it was inlined into its caller, `PopulateOmnibarSuggestionsForCommandPaletteMode`. Because of that change, we no longer need the intermediate `newSuggestions` collection, saving memory and resulting in a more responsive UI update.
- The number of `await Task.Yield()` calls is reduced. There were too many, resulting is too much pointless overhead.
- Building the `commandsToProcess` list has been optimized, especially for the case where the `OmnibarCommandPaletteModeText` search string is empty, i.e. the first list to be calculated when the command palette is opened.
- Because the calculation of the the `commandsToProcess` list happens on a background thread, we now test whether `OmnibarCommandPaletteModeText` has not changed by the time the list calculation is finished, and prevent further processing of stale results if it did.
- The `NavigationBarSuggestionItem` objects are now immutable. They were never mutated anyway. This also simplifies their construction.
- The `NavigationBarSuggestionItem.ActionIconSource` property was removed as it was never assigned and always had the value `null`.
- The `NavigationBarSuggestionItem.PrimaryDisplay` property was removed as it always had the same value as the `Text` property.
- The `NavigationBarSuggestionItem.SearchText` property was removed as it was never read.
- A `NavigationBarSuggestionItem.Command` property was added, storing the command used to construct the `NavigationBarSuggestionItem`. That property is used in `NavigationToolbar.Omnibar_QuerySubmitted`, eliminating the need to search for the command.
- Because `NavigationBarSuggestionItem` is now immutable, it no longer inherits from `ObservableObject` and it no longer tries to raise pointless `PropertyChanging` and `PropertyChanged` events during its construction.
- Also because `NavigationBarSuggestionItem` is now immutable, data binding in NavigationToolbar.xaml now uses `Mode=OneTime` instead of `Mode=OneWay`. As a result, the UI no longer needs to wire up listeners for events that will never be raised anyway.
- Finally, in `Omnibar.AutoSuggestBox_TextChanged`, we set `_textChangeReason` to `OmnibarTextChangeReason.UserInput` when it's not `OmnibarTextChangeReason.ProgrammaticChange` and `_userInput.Length == 0`. This fixes the bug where clicking the `X` button at the right of the textbox to clear it did not cause a recalculation of the suggestions list.

As a result of the above
- several bugs were fixed,
- the code is significantly simplified,
- and UI responsiveness and memory usage have improved considerably.

**Steps used to test these changes**

1. Opened Files
2. Opened the command palette using Ctrl-Shift-P and tested several scenarios:
   1. Searched for existing commands by typing `terminal` one character at a time, as well as removing characters using Backspace, and observed that suggestions are now correct.
   2. Executed commands after searching for them. Observed that the correct command is still executed when selecting the suggestion. 
   3. Searched for non-existing commands by typing `xyz`. Observed that the `NoCommandsFound` message is still displayed correctly.
   4. Tried to execute non-existing commands such as `xyz`. Observed that the dialog box is still displayed correctly.
   5. Clicked the `X` button in the textbox to clear it. Observed that this now correctly causes suggestions to be recalculated.
   6. Type the full description of a command manually and execute it without selecting a suggestion. Observe that the correct command is still executed.
