### PR TITLE
Code Quality: Reduce redundant SelectedItems updates in SelectionChanged

### DIFF
--- a/src/Files.App/Views/Layouts/BaseGroupableLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseGroupableLayoutPage.cs
@@ -225,10 +225,29 @@ namespace Files.App.Views.Layouts
 			RootZoom.IsZoomedInViewActive = true;
 		}
 
-		protected virtual void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		protected virtual void FileList_SelectionChanged(object sender, SelectionChangedEventArgs? e)
 		{
-			SelectedItems = ListViewBase.SelectedItems.Cast<ListedItem>().Where(x => x is not null).ToList();
+
+			if (e is null && SelectedItems?.Count == 0)
+				return;
+
+			if (e is not null && e.AddedItems.Count == 0 && e.RemovedItems.Count == 0)
+				return;
+
+			var selectedItems = ListViewBase.SelectedItems.Cast<ListedItem>().Where(x => x is not null).ToList();
+
+			if (SelectedItems is not null && SelectedItems.SequenceEqual(selectedItems))
+				return;
+
+			SelectedItems = selectedItems;
+
+			if (e is null)
+				return;
+
+			OnSelectionChanged(e);
 		}
+
+		protected abstract void OnSelectionChanged(SelectionChangedEventArgs e);
 
 		protected virtual void SelectionRectangle_SelectionEnded(object? sender, EventArgs e)
 		{

--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
@@ -326,12 +326,8 @@ namespace Files.App.Views.Layouts
 			columnsOwner = null;
 		}
 
-		protected override void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		protected override void OnSelectionChanged(SelectionChangedEventArgs e)
 		{
-			base.FileList_SelectionChanged(sender, e);
-			if (e is null)
-				return;
-
 			if (e.AddedItems.Count > 0)
 				columnsOwner?.HandleSelectionChange(this);
 
@@ -353,8 +349,8 @@ namespace Files.App.Views.Layouts
 					return;
 
 				// Open the selected folder if selected through tap
-				if (UserSettingsService.FoldersSettingsService.OpenFoldersInColumnsViewWithSingleClick.ShouldOpenWithSingleClick(lastPointerDeviceType) &&
-					!isDraggingSelectionRectangle) ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (SelectedItem is IShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
+				if (UserSettingsService.FoldersSettingsService.OpenFoldersInColumnsViewWithSingleClick.ShouldOpenWithSingleClick(lastPointerDeviceType))
+					ItemInvoked?.Invoke(new ColumnParam { Source = this, NavPathParam = (SelectedItem is IShortcutItem sht ? sht.TargetPath : SelectedItem.ItemPath), ListView = FileList }, EventArgs.Empty);
 				else
 					CloseFolder();
 			}

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -362,9 +362,20 @@ namespace Files.App.Views.Layouts
 
 		protected override void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
-			SelectedItems = FileList.SelectedItems.Cast<ListedItem>().Where(x => x is not null).ToList();
+			if (e is null && SelectedItems?.Count == 0)
+				return;
 
-			if (e != null)
+			if (e is not null && e.AddedItems.Count == 0 && e.RemovedItems.Count == 0)
+				return;
+
+			var selectedItems = FileList.SelectedItems.Cast<ListedItem>().Where(x => x is not null).ToList();
+
+			if (SelectedItems is not null && SelectedItems.SequenceEqual(selectedItems))
+				return;
+
+			SelectedItems = selectedItems;
+
+			if (e is not null)
 			{
 				foreach (var item in e.AddedItems)
 					SetCheckboxSelectionState(item);

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -360,29 +360,13 @@ namespace Files.App.Views.Layouts
 
 		}
 
-		protected override void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		protected override void OnSelectionChanged(SelectionChangedEventArgs e)
 		{
-			if (e is null && SelectedItems?.Count == 0)
-				return;
+			foreach (var item in e.AddedItems)
+				SetCheckboxSelectionState(item);
 
-			if (e is not null && e.AddedItems.Count == 0 && e.RemovedItems.Count == 0)
-				return;
-
-			var selectedItems = FileList.SelectedItems.Cast<ListedItem>().Where(x => x is not null).ToList();
-
-			if (SelectedItems is not null && SelectedItems.SequenceEqual(selectedItems))
-				return;
-
-			SelectedItems = selectedItems;
-
-			if (e is not null)
-			{
-				foreach (var item in e.AddedItems)
-					SetCheckboxSelectionState(item);
-
-				foreach (var item in e.RemovedItems)
-					SetCheckboxSelectionState(item);
-			}
+			foreach (var item in e.RemovedItems)
+				SetCheckboxSelectionState(item);
 		}
 
 		override public void StartRenameItem()

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -338,18 +338,13 @@ namespace Files.App.Views.Layouts
 			ContentScroller = FileList.FindDescendant<ScrollViewer>(x => x.Name == "ScrollViewer");
 		}
 
-		protected override void FileList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		protected override void OnSelectionChanged(SelectionChangedEventArgs e)
 		{
-			base.FileList_SelectionChanged(sender, e);
+			foreach (var item in e.AddedItems)
+				SetCheckboxSelectionState(item);
 
-			if (e != null)
-			{
-				foreach (var item in e.AddedItems)
-					SetCheckboxSelectionState(item);
-
-				foreach (var item in e.RemovedItems)
-					SetCheckboxSelectionState(item);
-			}
+			foreach (var item in e.RemovedItems)
+				SetCheckboxSelectionState(item);
 		}
 
 		override public void StartRenameItem()


### PR DESCRIPTION
**Resolved / Related Issues**

- https://github.com/files-community/Files/issues/4180

When selecting files or folders, `SelectionChanged` is raised multiple times even when the actual selection does not change.
For example, when opening a folder by double-clicking, `SelectionChanged` is fired repeatedly without any real change in `SelectedItems`.

The root cause is that `SelectedItems` was always assigned from a new list instance:

```
SelectedItems = FileList.SelectedItems.Cast<ListedItem>().Where(x => x is not null).ToList();
```

Since `ToList()` creates a new list instance on every call, the setter was always triggered and caused unnecessary side effects (such as PropertyChanged-driven updates).

**Steps used to test these changes**

- Open a file by double-clicking
- Open a folder by double-clicking
- Open a folder using keyboard navigation
- Select multiple items by mouse
