### PR TITLE
Fix: Enabled Play action for single media file selection

### DIFF
--- a/src/Files.App/Actions/Content/PlayAllAction.cs
+++ b/src/Files.App/Actions/Content/PlayAllAction.cs
@@ -11,7 +11,9 @@ namespace Files.App.Actions
 		private readonly IContentPageContext context;
 
 		public string Label
-			=> Strings.PlayAll.GetLocalizedResource();
+			=> context.SelectedItems.Count > 1
+				? Strings.PlayAll.GetLocalizedResource()
+				: Strings.Play.GetLocalizedResource();
 
 		public string Description
 			=> Strings.PlayAllDescription.GetLocalizedResource();
@@ -24,7 +26,7 @@ namespace Files.App.Actions
 
 		public bool IsExecutable =>
 			context.PageType != ContentPageTypes.RecycleBin &&
-			context.SelectedItems.Count > 1 &&
+			context.SelectedItems.Count > 0 &&
 			context.SelectedItems.All(item => FileExtensionHelpers.IsMediaFile(item.FileExtension));
 
 		public PlayAllAction()
@@ -46,6 +48,7 @@ namespace Files.App.Actions
 				case nameof(IContentPageContext.PageType):
 				case nameof(IContentPageContext.SelectedItems):
 					OnPropertyChanged(nameof(IsExecutable));
+					OnPropertyChanged(nameof(Label));
 					break;
 			}
 		}

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -2412,6 +2412,9 @@
     <value>Are you sure you want to delete this tag?</value>
   </data>
   <data name="PlayAll" xml:space="preserve">
+    <value>Play All</value>
+  </data>
+  <data name="Play" xml:space="preserve">
     <value>Play</value>
   </data>
   <data name="Height" xml:space="preserve">

--- a/src/Files.Shared/Helpers/FileExtensionHelpers.cs
+++ b/src/Files.Shared/Helpers/FileExtensionHelpers.cs
@@ -259,7 +259,8 @@ namespace Files.Shared.Helpers
 		{
 			return HasExtension(
 				filePathToCheck, ".mp4", ".m4v", ".mp4v", ".3g2", ".3gp2", ".3gp", ".3gpp",
-				".mpg", ".mp2", ".mpeg", ".mpe", ".mpv", ".mkv", ".ogg", ".avi", ".wmv", ".mov", ".qt");
+				".mpg", ".mp2", ".mpeg", ".mpe", ".mpv", ".mkv", ".ogg", ".avi", ".wmv", ".mov", ".qt",
+				".mp3", ".m4a", ".oga", ".wav", ".wma", ".aac", ".flac");
 		}
 
 		/// <summary>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #18511

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed 'Play' is displayed on toolbar when single media file is selected