### PR TITLE
Code Quality: TreeViewSidebarViewModel with async folder enumeration, tag icons, and improved selection

### DIFF
--- a/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
+++ b/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
@@ -269,6 +269,7 @@ namespace Files.App.Helpers
 					.AddSingleton<MainPageViewModel>()
 					.AddSingleton<InfoPaneViewModel>()
 					.AddSingleton<SidebarViewModel>()
+					.AddSingleton<TreeViewSidebarViewModel>()
 					.AddSingleton<DrivesViewModel>()
 					.AddSingleton<ShelfViewModel>()
 					.AddSingleton<StatusCenterViewModel>()

--- a/src/Files.App/UserControls/FolderNode.cs
+++ b/src/Files.App/UserControls/FolderNode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Files Community
+﻿// Copyright (c) Files Community
 // Licensed under the MIT License.
 
 using Microsoft.UI.Xaml.Media;
@@ -55,6 +55,14 @@ namespace Files.App.UserControls
 		{
 			get => _Opacity;
 			set => SetProperty(ref _Opacity, value);
+		}
+
+		// Custom selection flag driving the DataTemplate's overlay Border. Set by the path-mirror code in TreeViewSidebar — we deliberately do NOT go through TreeView.SelectedItem, since assigning that to a data node whose TreeViewItem container isn't realized crashes WinUI's native selection machinery (ExecutionEngineException).
+		private bool _IsSelected;
+		public bool IsSelected
+		{
+			get => _IsSelected;
+			set => SetProperty(ref _IsSelected, value);
 		}
 	}
 }

--- a/src/Files.App/UserControls/FolderNode.cs
+++ b/src/Files.App/UserControls/FolderNode.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Files Community
+// Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 
 namespace Files.App.UserControls
@@ -14,26 +15,36 @@ namespace Files.App.UserControls
 
 	public sealed partial class FolderNode : ObservableObject
 	{
-		public FolderNode(string path, string name, FolderNodeKind kind, ImageSource? icon)
+		public FolderNode(string path, string name, FolderNodeKind kind, ImageSource? icon, INavigationControlItem? sourceItem = null)
 		{
 			Path = path;
 			Name = name;
 			Kind = kind;
 			_Icon = icon;
+			SourceItem = sourceItem;
 		}
 
 		public string Path { get; }
 		public string Name { get; }
 		public FolderNodeKind Kind { get; }
 		public bool IsSection => Kind == FolderNodeKind.Section;
+		public INavigationControlItem? SourceItem { get; }
 
 		public ObservableCollection<FolderNode> Children { get; } = new();
 
+		// ImageSource (not IconElement/FrameworkElement) — UIElements can only have one visual parent; storing one in a data model crashes WinUI when a TreeViewItem container is recycled.
 		private ImageSource? _Icon;
 		public ImageSource? Icon
 		{
 			get => _Icon;
 			set => SetProperty(ref _Icon, value);
+		}
+
+		private IconSource? _TagIconSource;
+		public IconSource? TagIconSource
+		{
+			get => _TagIconSource;
+			set => SetProperty(ref _TagIconSource, value);
 		}
 
 		private bool _IsExpanded;

--- a/src/Files.App/UserControls/TreeViewSidebar.xaml
+++ b/src/Files.App/UserControls/TreeViewSidebar.xaml
@@ -1,4 +1,4 @@
-<!--  Copyright (c) Files Community. Licensed under the MIT License.  -->
+﻿<!--  Copyright (c) Files Community. Licensed under the MIT License.  -->
 <UserControl
 	x:Class="Files.App.UserControls.TreeViewSidebar"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -31,6 +31,7 @@
 				<controls:TreeViewItem
 					HasUnrealizedChildren="{x:Bind HasUnrealizedChildren, Mode=OneWay}"
 					IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}"
+					IsSelected="{x:Bind IsSelected, Mode=TwoWay}"
 					ItemsSource="{x:Bind Children}">
 					<StackPanel
 						Padding="0,2"

--- a/src/Files.App/UserControls/TreeViewSidebar.xaml
+++ b/src/Files.App/UserControls/TreeViewSidebar.xaml
@@ -24,7 +24,7 @@
 		CanReorderItems="False"
 		Expanding="Tree_Expanding"
 		ItemInvoked="Tree_ItemInvoked"
-		ItemsSource="{x:Bind RootFolders, Mode=OneWay}"
+		ItemsSource="{x:Bind ViewModel.RootFolders, Mode=OneWay}"
 		SelectionMode="Single">
 		<controls:TreeView.ItemTemplate>
 			<DataTemplate x:DataType="local:FolderNode">
@@ -32,7 +32,9 @@
 					HasUnrealizedChildren="{x:Bind HasUnrealizedChildren, Mode=OneWay}"
 					IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}"
 					IsSelected="{x:Bind IsSelected, Mode=TwoWay}"
-					ItemsSource="{x:Bind Children}">
+					ItemsSource="{x:Bind Children}"
+					RightTapped="Item_RightTapped"
+					Tag="{x:Bind}">
 					<StackPanel
 						Padding="0,2"
 						DoubleTapped="Item_DoubleTapped"
@@ -48,6 +50,11 @@
 							Source="{x:Bind Icon, Mode=OneWay}"
 							Stretch="Uniform"
 							Visibility="{x:Bind Icon, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}" />
+						<controls:IconSourceElement
+							Width="16"
+							Height="16"
+							IconSource="{x:Bind TagIconSource, Mode=OneWay}"
+							Visibility="{x:Bind TagIconSource, Mode=OneWay, Converter={StaticResource NullToVisibilityConverter}}" />
 						<TextBlock
 							VerticalAlignment="Center"
 							Text="{x:Bind Name}"

--- a/src/Files.App/UserControls/TreeViewSidebar.xaml.cs
+++ b/src/Files.App/UserControls/TreeViewSidebar.xaml.cs
@@ -1,12 +1,14 @@
-﻿// Copyright (c) Files Community
+// Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using CommunityToolkit.WinUI;
+using Files.App.Controls;
 using Microsoft.Extensions.Logging;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
-using System.Collections.Specialized;
 using System.IO;
 using Windows.ApplicationModel.DataTransfer;
 
@@ -15,29 +17,12 @@ namespace Files.App.UserControls
 	public sealed partial class TreeViewSidebar : UserControl
 	{
 		// Lazy DI resolution — eager field-init resolves singletons during MainPage XAML parsing, before MainPage's constructor body has finished. That ordering caused process-level crashes.
-		private readonly Lazy<SidebarViewModel> _sidebarViewModel = new(() => Ioc.Default.GetRequiredService<SidebarViewModel>());
-		private readonly Lazy<IIconCacheService> _iconCacheService = new(() => Ioc.Default.GetRequiredService<IIconCacheService>());
-		private readonly Lazy<IContentPageContext> _contentPageContext = new(() => Ioc.Default.GetRequiredService<IContentPageContext>());
-		private readonly Lazy<MainPageViewModel> _mainPageViewModel = new(() => Ioc.Default.GetRequiredService<MainPageViewModel>());
-		private readonly Lazy<IUserSettingsService> _userSettingsService = new(() => Ioc.Default.GetRequiredService<IUserSettingsService>());
+		private readonly Lazy<TreeViewSidebarViewModel> _viewModel = new(() => Ioc.Default.GetRequiredService<TreeViewSidebarViewModel>());
 
-		public ObservableCollection<FolderNode> RootFolders { get; } = new();
+		[GeneratedDependencyProperty]
+		public partial TreeViewSidebarViewModel? ViewModel { get; set; }
 
-		// Per-tab set of expanded node IDs (section ID like "section:Pinned" OR a folder path like "C:\Users"). Seeded with default expanded sections for new tabs.
-		private readonly Dictionary<TabBarItem, HashSet<string>> _tabExpansionState = new();
-		private static readonly string[] DefaultExpandedSectionIds =
-		{
-			"section:Pinned",
-			"section:Drives",
-			"section:CloudDrives",
-		};
-
-		private TabBarItem? _currentTab;
 		private bool _isUnloaded;
-		private bool _applyingState;
-
-		// Currently-selected node per the path mirror — kept so we can clear its IsSelected before flipping the new one without walking the whole tree.
-		private FolderNode? _selectedNode;
 
 		public TreeViewSidebar()
 		{
@@ -45,6 +30,13 @@ namespace Files.App.UserControls
 
 			// TreeView's internal control template falls through to {Binding Children} on its inherited DataContext when our binding hasn't fully primed it. From MainPage, that's MainPageViewModel (no Children property) — leaving inheritance in place was the source of native AccessViolation crashes.
 			Tree.DataContext = null;
+		}
+
+		partial void OnViewModelChanged(TreeViewSidebarViewModel? newValue)
+		{
+			if (newValue is null)
+				return;
+			newValue.PropertyChanged += OnViewModelPropertyChanged;
 		}
 
 		private void UserControl_Loaded(object sender, RoutedEventArgs e)
@@ -55,14 +47,8 @@ namespace Files.App.UserControls
 				{
 					if (_isUnloaded)
 						return;
-					_mainPageViewModel.Value.PropertyChanged += OnMainPageViewModelPropertyChanged;
-					_sidebarViewModel.Value.PropertyChanged += OnSidebarViewModelPropertyChanged;
-					if (_sidebarViewModel.Value.SidebarItems is INotifyCollectionChanged inc)
-						inc.CollectionChanged += OnSidebarItemsChanged;
-					MainPageViewModel.AppInstances.CollectionChanged += OnAppInstancesChanged;
-					_currentTab = _mainPageViewModel.Value.SelectedTabItem;
-					RebuildAndApply();
-					UpdateSelectionFromCurrentPath();
+					ViewModel = _viewModel.Value;
+					ViewModel.OnControlLoaded();
 				}
 				catch (Exception ex)
 				{
@@ -76,16 +62,11 @@ namespace Files.App.UserControls
 			_isUnloaded = true;
 			try
 			{
-				if (_mainPageViewModel.IsValueCreated)
-					_mainPageViewModel.Value.PropertyChanged -= OnMainPageViewModelPropertyChanged;
-				if (_sidebarViewModel.IsValueCreated)
+				if (_viewModel.IsValueCreated)
 				{
-					_sidebarViewModel.Value.PropertyChanged -= OnSidebarViewModelPropertyChanged;
-					if (_sidebarViewModel.Value.SidebarItems is INotifyCollectionChanged inc)
-						inc.CollectionChanged -= OnSidebarItemsChanged;
+					_viewModel.Value.PropertyChanged -= OnViewModelPropertyChanged;
+					_viewModel.Value.OnControlUnloaded();
 				}
-				MainPageViewModel.AppInstances.CollectionChanged -= OnAppInstancesChanged;
-				DetachAllNodeHandlers();
 			}
 			// Cleanup must never throw; the page is being torn down
 			catch (Exception ex)
@@ -94,265 +75,34 @@ namespace Files.App.UserControls
 			}
 		}
 
-		private void DetachAllNodeHandlers()
+		private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
-			foreach (var section in RootFolders)
-				DetachRecursive(section);
+			if (e.PropertyName == nameof(TreeViewSidebarViewModel.SelectedNode))
+				DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, ScrollSelectedIntoView);
 		}
 
-		private void DetachRecursive(FolderNode node)
+		private void ScrollSelectedIntoView()
 		{
-			node.PropertyChanged -= OnNodePropertyChanged;
-			foreach (var child in node.Children)
-				DetachRecursive(child);
-		}
-
-		// Snapshot the sidebar sections + their direct child items. Drive subfolders are loaded lazily via Tree_Expanding or via state-driven expansion in ApplyTabState.
-		private void Rebuild()
-		{
-			DetachAllNodeHandlers();
-			// The old _selectedNode is about to be replaced by fresh FolderNode instances — drop it so UpdateSelectionFromCurrentPath re-finds the match against the new tree.
-			_selectedNode = null;
-			RootFolders.Clear();
-
-			if (_sidebarViewModel.Value.SidebarItems is not IEnumerable<INavigationControlItem> headers)
+			var node = ViewModel?.SelectedNode;
+			if (node is null || _isUnloaded)
 				return;
 
-			foreach (var item in headers)
-			{
-				if (item is not LocationItem header || !header.IsHeader)
-					continue;
-
-				if (header.Section == SectionType.Home)
-				{
-					var homeNode = new FolderNode(header.Path, header.Text, FolderNodeKind.Leaf, header.Icon);
-					homeNode.PropertyChanged += OnNodePropertyChanged;
-					RootFolders.Add(homeNode);
-					continue;
-				}
-
-				var section = new FolderNode($"section:{header.Section}", header.Text, FolderNodeKind.Section, icon: null);
-
-				if (header.ChildItems is not null)
-				{
-					foreach (var childObj in header.ChildItems)
-					{
-						if (childObj is not INavigationControlItem child)
-							continue;
-						var path = child.Path;
-						var name = child.Text;
-						if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(name))
-							continue;
-						var icon = child switch
-						{
-							LocationItem loc => loc.Icon,
-							DriveItem drv => drv.Icon,
-							_ => null,
-						};
-						var hasRootedPath = (child is LocationItem loc2 && Path.IsPathRooted(loc2.Path)) || child is DriveItem;
-						var isExpandable = hasRootedPath && header.Section != SectionType.Pinned;
-						var kind = isExpandable ? FolderNodeKind.Folder : FolderNodeKind.Leaf;
-						var node = new FolderNode(path, name, kind, icon);
-						if (isExpandable)
-							_ = ProbeHasChildrenAsync(node);
-						node.PropertyChanged += OnNodePropertyChanged;
-						section.Children.Add(node);
-					}
-				}
-
-				section.PropertyChanged += OnNodePropertyChanged;
-				RootFolders.Add(section);
-			}
-		}
-
-		// Walk the tree and apply the per-tab expansion state. For folders with HasUnrealizedChildren that should be expanded, lazy-load children synchronously and recurse so deep state restores correctly.
-		private void ApplyTabState()
-		{
-			if (_currentTab is null)
-				return;
-			var state = GetOrInitState(_currentTab);
-			_applyingState = true;
-			try
-			{
-				foreach (var section in RootFolders)
-					ApplyExpansionRecursive(section, state);
-			}
-			finally
-			{
-				_applyingState = false;
-			}
-		}
-
-		private void ApplyExpansionRecursive(FolderNode node, HashSet<string> state)
-		{
-			var shouldExpand = state.Contains(node.Path);
-			if (shouldExpand && node.Kind == FolderNodeKind.Folder && node.HasUnrealizedChildren)
-				LoadChildrenSync(node);
-
-			node.IsExpanded = shouldExpand;
-
-			if (shouldExpand)
-			{
-				foreach (var child in node.Children.ToList())
-					ApplyExpansionRecursive(child, state);
-			}
-		}
-
-		private void RebuildAndApply()
-		{
-			if (_isUnloaded)
-				return;
-			try
-			{
-				Rebuild();
-				ApplyTabState();
-				// Re-evaluate the selection against the fresh tree — drives plugged in, cloud sync arriving, tab change, etc.
-				UpdateSelectionFromCurrentPath();
-			}
-			catch (Exception ex)
-			{
-				App.Logger?.LogWarning(ex, "TreeViewSidebar: rebuild failed");
-			}
-		}
-
-		// CurrentPath updates whenever the user navigates (via address bar, breadcrumbs, sidebar click, etc.). Mirror it onto the tree so the deepest already-loaded ancestor highlights.
-		private void OnSidebarViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
-		{
-			if (e.PropertyName != nameof(SidebarViewModel.CurrentPath))
-				return;
-			if (DispatcherQueue.HasThreadAccess)
-				UpdateSelectionFromCurrentPath();
-			else
-				DispatcherQueue.TryEnqueue(UpdateSelectionFromCurrentPath);
-		}
-
-		// Walks the tree finding the deepest already-realized ancestor of CurrentPath and flips IsSelected on it (clearing the previous selection). The DataTemplate's overlay Border paints the visual — we never touch TreeView.SelectedItem, since assigning that to a data node with an unrealized container AVs WinUI's native selection code.
-		private void UpdateSelectionFromCurrentPath()
-		{
-			if (_isUnloaded)
-				return;
-			var target = _sidebarViewModel.Value.CurrentPath;
-			var match = string.IsNullOrEmpty(target) ? null : FindDeepestAncestor(RootFolders, target);
-			if (ReferenceEquals(match, _selectedNode))
-				return;
-			if (_selectedNode is not null)
-				_selectedNode.IsSelected = false;
-			_selectedNode = match;
-			if (_selectedNode is not null)
-				_selectedNode.IsSelected = true;
-		}
-
-		private static FolderNode? FindDeepestAncestor(IEnumerable<FolderNode> nodes, string targetPath)
-		{
-			FolderNode? best = null;
-			foreach (var node in nodes)
-			{
-				// Section nodes use a "section:..." pseudo-path that never matches a real folder — recurse into children instead.
-				if (node.IsSection)
-				{
-					var deeperInSection = FindDeepestAncestor(node.Children, targetPath);
-					if (deeperInSection is not null && (best is null || deeperInSection.Path.Length > best.Path.Length))
-						best = deeperInSection;
-					continue;
-				}
-				if (string.IsNullOrEmpty(node.Path))
-					continue;
-				if (targetPath.Equals(node.Path, StringComparison.OrdinalIgnoreCase))
-					return node;
-				// Treat drive-style paths ending without a separator ("C:") as ancestors of "C:\..." by appending the separator before comparing.
-				var withSeparator = node.Path.EndsWith(Path.DirectorySeparatorChar) ? node.Path : node.Path + Path.DirectorySeparatorChar;
-				if (targetPath.StartsWith(withSeparator, StringComparison.OrdinalIgnoreCase))
-				{
-					var deeper = FindDeepestAncestor(node.Children, targetPath);
-					var candidate = deeper ?? node;
-					if (best is null || candidate.Path.Length > best.Path.Length)
-						best = candidate;
-				}
-			}
-			return best;
-		}
-
-		private HashSet<string> GetOrInitState(TabBarItem tab)
-		{
-			if (_tabExpansionState.TryGetValue(tab, out var state))
-				return state;
-			state = new HashSet<string>(DefaultExpandedSectionIds, StringComparer.OrdinalIgnoreCase);
-			_tabExpansionState[tab] = state;
-			return state;
-		}
-
-		// Persist any node's expansion state (sections AND lazy-loaded folders) to the current tab.
-		private void OnNodePropertyChanged(object? sender, PropertyChangedEventArgs e)
-		{
-			if (_applyingState || e.PropertyName != nameof(FolderNode.IsExpanded))
-				return;
-			if (sender is not FolderNode node || _currentTab is null)
-				return;
-			var state = GetOrInitState(_currentTab);
-			if (node.IsExpanded)
-				state.Add(node.Path);
-			else
-				state.Remove(node.Path);
-		}
-
-		private void OnSidebarItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
-		{
-			if (DispatcherQueue.HasThreadAccess)
-				RebuildAndApply();
-			else
-				DispatcherQueue.TryEnqueue(RebuildAndApply);
-		}
-
-		private void OnAppInstancesChanged(object? sender, NotifyCollectionChangedEventArgs e)
-		{
-			if (e.Action == NotifyCollectionChangedAction.Remove && e.OldItems is not null)
-			{
-				foreach (var item in e.OldItems.OfType<TabBarItem>())
-					_tabExpansionState.Remove(item);
-			}
-			else if (e.Action == NotifyCollectionChangedAction.Reset)
-			{
-				_tabExpansionState.Clear();
-			}
-		}
-
-		private void OnMainPageViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
-		{
-			if (e.PropertyName != nameof(MainPageViewModel.SelectedTabItem))
-				return;
-			if (DispatcherQueue.HasThreadAccess)
-				HandleTabChange();
-			else
-				DispatcherQueue.TryEnqueue(HandleTabChange);
-		}
-
-		private void HandleTabChange()
-		{
-			if (_isUnloaded)
-				return;
-			try
-			{
-				var newTab = _mainPageViewModel.Value.SelectedTabItem;
-				if (newTab is null || ReferenceEquals(newTab, _currentTab))
-					return;
-				_currentTab = newTab;
-				ApplyTabState();
-			}
-			catch (Exception ex)
-			{
-				App.Logger?.LogWarning(ex, "TreeViewSidebar: tab change handler failed");
-			}
+			// Re-assert selection: WinUI resets TreeViewItem.IsSelected during container realization (PrepareContainerForItemOverride),
+			// and the TwoWay binding propagates that false back to FolderNode.IsSelected before this dispatch runs.
+			node.IsSelected = true;
+			// The inner TreeViewItem in the DataTemplate carries Tag=FolderNode — find it and ask the layout system to scroll it into view.
+			var item = DependencyObjectHelpers.FindChild<TreeViewItem>(Tree, tvi => ReferenceEquals(tvi.Tag, node));
+			item?.StartBringIntoView(new BringIntoViewOptions { AnimationDesired = false, VerticalAlignmentRatio = 0.5 });
 		}
 
 		private async void Tree_Expanding(TreeView sender, TreeViewExpandingEventArgs args)
 		{
 			try
 			{
-				if (args.Node.Content is not FolderNode fn)
+				if (args.Node.Content is not FolderNode fn || ViewModel is null)
 					return;
-				await LoadChildrenAsync(fn);
-				// The just-loaded children may contain a deeper ancestor of CurrentPath — let the highlight descend.
-				UpdateSelectionFromCurrentPath();
+				await ViewModel.LoadChildrenAsync(fn);
+				ViewModel.UpdateSelectionFromCurrentPath();
 			}
 			catch (Exception ex)
 			{
@@ -360,114 +110,11 @@ namespace Files.App.UserControls
 			}
 		}
 
-		private async Task LoadChildrenAsync(FolderNode parent)
-		{
-			if (parent.Kind != FolderNodeKind.Folder || !parent.HasUnrealizedChildren)
-				return;
-
-			// Mark before awaiting so a stray re-entry doesn't double-load
-			parent.HasUnrealizedChildren = false;
-
-			var parentPath = parent.Path;
-			var loaded = await Task.Run(() =>
-			{
-				var results = new List<(string Sub, string Name, bool HasGrandchildren, bool IsHidden)>();
-				foreach (var sub in SafeEnumerateSubdirectories(parentPath))
-				{
-					var subName = Path.GetFileName(sub);
-					if (string.IsNullOrEmpty(subName))
-						continue;
-					results.Add((sub, subName, SafeHasSubdirectories(sub), GetIsHidden(sub)));
-				}
-				return results;
-			});
-
-			if (_isUnloaded)
-				return;
-
-			foreach (var (sub, subName, hasGrandchildren, isHidden) in loaded)
-			{
-				var kind = hasGrandchildren ? FolderNodeKind.Folder : FolderNodeKind.Leaf;
-				var child = new FolderNode(sub, subName, kind, icon: null)
-				{
-					HasUnrealizedChildren = hasGrandchildren,
-					Opacity = isHidden ? Constants.UI.DimItemOpacity : 1.0,
-				};
-				child.PropertyChanged += OnNodePropertyChanged;
-				_ = LoadIconAsync(child);
-				parent.Children.Add(child);
-			}
-		}
-
-		// Synchronous lazy load. Called from ApplyExpansionRecursive (state restore) to keep tab-switch restoration synchronous.
-		private void LoadChildrenSync(FolderNode parent)
-		{
-			if (parent.Kind != FolderNodeKind.Folder || !parent.HasUnrealizedChildren)
-				return;
-
-			// Mark before populating so a stray re-entry doesn't double-load
-			parent.HasUnrealizedChildren = false;
-
-			foreach (var sub in SafeEnumerateSubdirectories(parent.Path))
-			{
-				var subName = Path.GetFileName(sub);
-				if (string.IsNullOrEmpty(subName))
-					continue;
-				var hasGrandchildren = SafeHasSubdirectories(sub);
-				var kind = hasGrandchildren ? FolderNodeKind.Folder : FolderNodeKind.Leaf;
-				var child = new FolderNode(sub, subName, kind, icon: null)
-				{
-					HasUnrealizedChildren = hasGrandchildren,
-					Opacity = GetIsHidden(sub) ? Constants.UI.DimItemOpacity : 1.0,
-				};
-				child.PropertyChanged += OnNodePropertyChanged;
-				_ = LoadIconAsync(child);
-				parent.Children.Add(child);
-			}
-		}
-
-		private async Task LoadIconAsync(FolderNode node)
-		{
-			try
-			{
-				var bytes = await _iconCacheService.Value.GetIconAsync(node.Path, null, isFolder: true);
-				if (bytes is null || _isUnloaded)
-					return;
-				var bmp = await bytes.ToBitmapAsync();
-				if (bmp is not null && !_isUnloaded)
-					node.Icon = bmp;
-			}
-			// Icon resolution can fail for inaccessible paths (network down, missing folder) — leave icon null
-			catch (Exception ex)
-			{
-				App.Logger?.LogDebug(ex, "TreeViewSidebar: icon load failed for {Path}", node.Path);
-			}
-		}
-
-		private async Task ProbeHasChildrenAsync(FolderNode node)
-		{
-			var path = node.Path;
-			var hasChildren = await Task.Run(() => SafeHasSubdirectories(path));
-			if (_isUnloaded)
-				return;
-			node.HasUnrealizedChildren = hasChildren;
-		}
-
 		private void Tree_ItemInvoked(TreeView sender, TreeViewItemInvokedEventArgs args)
 		{
 			if (args.InvokedItem is not FolderNode fn)
 				return;
-			if (fn.IsSection)
-			{
-				fn.IsExpanded = !fn.IsExpanded;
-				return;
-			}
-			if (_contentPageContext.Value.ShellPage is not { } page)
-				return;
-			if (string.Equals(fn.Path, "Home", StringComparison.OrdinalIgnoreCase))
-				page.NavigateHome();
-			else
-				page.NavigateToPath(fn.Path);
+			ViewModel?.HandleItemInvoked(fn);
 		}
 
 		private async void Item_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
@@ -476,8 +123,8 @@ namespace Files.App.UserControls
 				return;
 			if (fn.Kind != FolderNodeKind.Folder)
 				return;
-			if (!fn.IsExpanded && fn.HasUnrealizedChildren)
-				await LoadChildrenAsync(fn);
+			if (!fn.IsExpanded && fn.HasUnrealizedChildren && ViewModel is not null)
+				await ViewModel.LoadChildrenAsync(fn);
 			fn.IsExpanded = !fn.IsExpanded;
 			e.Handled = true;
 		}
@@ -487,10 +134,17 @@ namespace Files.App.UserControls
 			if (sender is not FrameworkElement el || el.Tag is not FolderNode fn || fn.IsSection)
 				return;
 
+			if (fn.SourceItem is not null)
+			{
+				ViewModel?.HandleItemContextInvoked(el, new ItemContextInvokedArgs(fn.SourceItem, e.GetPosition(el)));
+				e.Handled = true;
+				return;
+			}
+
 			var flyout = new MenuFlyout();
 
 			var open = new MenuFlyoutItem { Text = Strings.Open.GetLocalizedResource() };
-			open.Click += (_, _) => _contentPageContext.Value.ShellPage?.NavigateToPath(fn.Path);
+			open.Click += (_, _) => ViewModel?.NavigateToPath(fn.Path);
 			flyout.Items.Add(open);
 
 			var openNewTab = new MenuFlyoutItem { Text = Strings.OpenInNewTab.GetLocalizedResource() };
@@ -521,66 +175,6 @@ namespace Files.App.UserControls
 
 			flyout.ShowAt(el, new FlyoutShowOptions { Position = e.GetPosition(el) });
 			e.Handled = true;
-		}
-
-		private IEnumerable<string> SafeEnumerateSubdirectories(string path)
-		{
-			// UnauthorizedAccessException for protected folders; IOException for unavailable drives (empty optical drive, disconnected network)
-			IEnumerable<string>? results = null;
-			try
-			{
-				var folders = _userSettingsService.Value.FoldersSettingsService;
-				var showHidden = folders.ShowHiddenItems;
-				var showProtected = folders.ShowProtectedSystemFiles;
-				var showDot = folders.ShowDotFiles;
-				results = Directory.EnumerateDirectories(path)
-					.Where(p => IsVisible(p, showHidden, showProtected, showDot))
-					.OrderBy(p => Path.GetFileName(p), StringComparer.OrdinalIgnoreCase)
-					.Take(1000)
-					.ToList();
-			}
-			catch (UnauthorizedAccessException) { }
-			catch (IOException) { }
-			return results ?? Enumerable.Empty<string>();
-		}
-
-		private bool SafeHasSubdirectories(string path)
-		{
-			// Same exception conditions as SafeEnumerateSubdirectories — we just need yes/no for the disclosure indicator
-			try
-			{
-				var folders = _userSettingsService.Value.FoldersSettingsService;
-				var showHidden = folders.ShowHiddenItems;
-				var showProtected = folders.ShowProtectedSystemFiles;
-				var showDot = folders.ShowDotFiles;
-				return Directory.EnumerateDirectories(path).Any(p => IsVisible(p, showHidden, showProtected, showDot));
-			}
-			catch (UnauthorizedAccessException) { return false; }
-			catch (IOException) { return false; }
-		}
-
-		private static bool GetIsHidden(string path)
-		{
-			try { return (File.GetAttributes(path) & FileAttributes.Hidden) == FileAttributes.Hidden; }
-			catch (UnauthorizedAccessException) { return false; }
-			catch (IOException) { return false; }
-		}
-
-		private static bool IsVisible(string path, bool showHidden, bool showProtected, bool showDot)
-		{
-			if (!showDot && Path.GetFileName(path) is string name && name.StartsWith('.'))
-				return false;
-			FileAttributes attr;
-			try { attr = File.GetAttributes(path); }
-			catch (UnauthorizedAccessException) { return false; }
-			catch (IOException) { return false; }
-			var isHidden = (attr & FileAttributes.Hidden) == FileAttributes.Hidden;
-			var isSystem = (attr & FileAttributes.System) == FileAttributes.System;
-			if (isHidden && !showHidden)
-				return false;
-			if (isHidden && isSystem && !showProtected)
-				return false;
-			return true;
 		}
 	}
 }

--- a/src/Files.App/UserControls/TreeViewSidebar.xaml.cs
+++ b/src/Files.App/UserControls/TreeViewSidebar.xaml.cs
@@ -7,10 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
-using System.IO;
-using Windows.ApplicationModel.DataTransfer;
 
 namespace Files.App.UserControls
 {
@@ -131,49 +128,9 @@ namespace Files.App.UserControls
 
 		private void Item_RightTapped(object sender, RightTappedRoutedEventArgs e)
 		{
-			if (sender is not FrameworkElement el || el.Tag is not FolderNode fn || fn.IsSection)
+			if (sender is not FrameworkElement el || el.Tag is not FolderNode fn || fn.IsSection || fn.SourceItem is null)
 				return;
-
-			if (fn.SourceItem is not null)
-			{
-				ViewModel?.HandleItemContextInvoked(el, new ItemContextInvokedArgs(fn.SourceItem, e.GetPosition(el)));
-				e.Handled = true;
-				return;
-			}
-
-			var flyout = new MenuFlyout();
-
-			var open = new MenuFlyoutItem { Text = Strings.Open.GetLocalizedResource() };
-			open.Click += (_, _) => ViewModel?.NavigateToPath(fn.Path);
-			flyout.Items.Add(open);
-
-			var openNewTab = new MenuFlyoutItem { Text = Strings.OpenInNewTab.GetLocalizedResource() };
-			openNewTab.Click += async (_, _) => await NavigationHelpers.OpenPathInNewTab(fn.Path, true);
-			flyout.Items.Add(openNewTab);
-
-			var copyPath = new MenuFlyoutItem { Text = Strings.CopyPath.GetLocalizedResource() };
-			copyPath.Click += (_, _) =>
-			{
-				var dp = new DataPackage();
-				dp.SetText(fn.Path);
-				Clipboard.SetContent(dp);
-			};
-			flyout.Items.Add(copyPath);
-
-			flyout.Items.Add(new MenuFlyoutSeparator());
-
-			var openExplorer = new MenuFlyoutItem { Text = "Open in File Explorer" };
-			openExplorer.Click += (_, _) =>
-			{
-				// Win32Exception from Process.Start when the shell launch fails (invalid path or denied access)
-				try { System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo { FileName = fn.Path, UseShellExecute = true }); }
-				catch (System.ComponentModel.Win32Exception) { }
-				catch (InvalidOperationException) { }
-				catch (FileNotFoundException) { }
-			};
-			flyout.Items.Add(openExplorer);
-
-			flyout.ShowAt(el, new FlyoutShowOptions { Position = e.GetPosition(el) });
+			ViewModel?.HandleItemContextInvoked(el, new ItemContextInvokedArgs(fn.SourceItem, e.GetPosition(el)));
 			e.Handled = true;
 		}
 	}

--- a/src/Files.App/UserControls/TreeViewSidebar.xaml.cs
+++ b/src/Files.App/UserControls/TreeViewSidebar.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Files Community
+﻿// Copyright (c) Files Community
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
@@ -36,6 +36,9 @@ namespace Files.App.UserControls
 		private bool _isUnloaded;
 		private bool _applyingState;
 
+		// Currently-selected node per the path mirror — kept so we can clear its IsSelected before flipping the new one without walking the whole tree.
+		private FolderNode? _selectedNode;
+
 		public TreeViewSidebar()
 		{
 			InitializeComponent();
@@ -53,11 +56,13 @@ namespace Files.App.UserControls
 					if (_isUnloaded)
 						return;
 					_mainPageViewModel.Value.PropertyChanged += OnMainPageViewModelPropertyChanged;
+					_sidebarViewModel.Value.PropertyChanged += OnSidebarViewModelPropertyChanged;
 					if (_sidebarViewModel.Value.SidebarItems is INotifyCollectionChanged inc)
 						inc.CollectionChanged += OnSidebarItemsChanged;
 					MainPageViewModel.AppInstances.CollectionChanged += OnAppInstancesChanged;
 					_currentTab = _mainPageViewModel.Value.SelectedTabItem;
 					RebuildAndApply();
+					UpdateSelectionFromCurrentPath();
 				}
 				catch (Exception ex)
 				{
@@ -73,8 +78,12 @@ namespace Files.App.UserControls
 			{
 				if (_mainPageViewModel.IsValueCreated)
 					_mainPageViewModel.Value.PropertyChanged -= OnMainPageViewModelPropertyChanged;
-				if (_sidebarViewModel.IsValueCreated && _sidebarViewModel.Value.SidebarItems is INotifyCollectionChanged inc)
-					inc.CollectionChanged -= OnSidebarItemsChanged;
+				if (_sidebarViewModel.IsValueCreated)
+				{
+					_sidebarViewModel.Value.PropertyChanged -= OnSidebarViewModelPropertyChanged;
+					if (_sidebarViewModel.Value.SidebarItems is INotifyCollectionChanged inc)
+						inc.CollectionChanged -= OnSidebarItemsChanged;
+				}
 				MainPageViewModel.AppInstances.CollectionChanged -= OnAppInstancesChanged;
 				DetachAllNodeHandlers();
 			}
@@ -102,6 +111,8 @@ namespace Files.App.UserControls
 		private void Rebuild()
 		{
 			DetachAllNodeHandlers();
+			// The old _selectedNode is about to be replaced by fresh FolderNode instances — drop it so UpdateSelectionFromCurrentPath re-finds the match against the new tree.
+			_selectedNode = null;
 			RootFolders.Clear();
 
 			if (_sidebarViewModel.Value.SidebarItems is not IEnumerable<INavigationControlItem> headers)
@@ -195,11 +206,70 @@ namespace Files.App.UserControls
 			{
 				Rebuild();
 				ApplyTabState();
+				// Re-evaluate the selection against the fresh tree — drives plugged in, cloud sync arriving, tab change, etc.
+				UpdateSelectionFromCurrentPath();
 			}
 			catch (Exception ex)
 			{
 				App.Logger?.LogWarning(ex, "TreeViewSidebar: rebuild failed");
 			}
+		}
+
+		// CurrentPath updates whenever the user navigates (via address bar, breadcrumbs, sidebar click, etc.). Mirror it onto the tree so the deepest already-loaded ancestor highlights.
+		private void OnSidebarViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName != nameof(SidebarViewModel.CurrentPath))
+				return;
+			if (DispatcherQueue.HasThreadAccess)
+				UpdateSelectionFromCurrentPath();
+			else
+				DispatcherQueue.TryEnqueue(UpdateSelectionFromCurrentPath);
+		}
+
+		// Walks the tree finding the deepest already-realized ancestor of CurrentPath and flips IsSelected on it (clearing the previous selection). The DataTemplate's overlay Border paints the visual — we never touch TreeView.SelectedItem, since assigning that to a data node with an unrealized container AVs WinUI's native selection code.
+		private void UpdateSelectionFromCurrentPath()
+		{
+			if (_isUnloaded)
+				return;
+			var target = _sidebarViewModel.Value.CurrentPath;
+			var match = string.IsNullOrEmpty(target) ? null : FindDeepestAncestor(RootFolders, target);
+			if (ReferenceEquals(match, _selectedNode))
+				return;
+			if (_selectedNode is not null)
+				_selectedNode.IsSelected = false;
+			_selectedNode = match;
+			if (_selectedNode is not null)
+				_selectedNode.IsSelected = true;
+		}
+
+		private static FolderNode? FindDeepestAncestor(IEnumerable<FolderNode> nodes, string targetPath)
+		{
+			FolderNode? best = null;
+			foreach (var node in nodes)
+			{
+				// Section nodes use a "section:..." pseudo-path that never matches a real folder — recurse into children instead.
+				if (node.IsSection)
+				{
+					var deeperInSection = FindDeepestAncestor(node.Children, targetPath);
+					if (deeperInSection is not null && (best is null || deeperInSection.Path.Length > best.Path.Length))
+						best = deeperInSection;
+					continue;
+				}
+				if (string.IsNullOrEmpty(node.Path))
+					continue;
+				if (targetPath.Equals(node.Path, StringComparison.OrdinalIgnoreCase))
+					return node;
+				// Treat drive-style paths ending without a separator ("C:") as ancestors of "C:\..." by appending the separator before comparing.
+				var withSeparator = node.Path.EndsWith(Path.DirectorySeparatorChar) ? node.Path : node.Path + Path.DirectorySeparatorChar;
+				if (targetPath.StartsWith(withSeparator, StringComparison.OrdinalIgnoreCase))
+				{
+					var deeper = FindDeepestAncestor(node.Children, targetPath);
+					var candidate = deeper ?? node;
+					if (best is null || candidate.Path.Length > best.Path.Length)
+						best = candidate;
+				}
+			}
+			return best;
 		}
 
 		private HashSet<string> GetOrInitState(TabBarItem tab)
@@ -281,6 +351,8 @@ namespace Files.App.UserControls
 				if (args.Node.Content is not FolderNode fn)
 					return;
 				await LoadChildrenAsync(fn);
+				// The just-loaded children may contain a deeper ancestor of CurrentPath — let the highlight descend.
+				UpdateSelectionFromCurrentPath();
 			}
 			catch (Exception ex)
 			{

--- a/src/Files.App/Utils/Storage/Helpers/FolderHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FolderHelpers.cs
@@ -5,6 +5,8 @@ using System.IO;
 
 namespace Files.App.Utils.Storage
 {
+	public readonly record struct SubfolderEntry(string Path, string Name, bool HasSubfolders, bool IsHidden);
+
 	public static class FolderHelpers
 	{
 		public static bool CheckFolderAccessWithWin32(string path)
@@ -47,6 +49,89 @@ namespace Files.App.Utils.Storage
 			var result = Win32PInvoke.FindNextFile(hFile, out _);
 			Win32PInvoke.FindClose(hFile);
 			return result;
+		}
+
+		public static List<SubfolderEntry> EnumerateSubfolders(string path, bool showHidden, bool showProtected, bool showDot, int limit = 1000)
+		{
+			var results = new List<SubfolderEntry>();
+
+			IntPtr hFind = Win32PInvoke.FindFirstFileExFromApp(
+				path + "\\*.*",
+				Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
+				out Win32PInvoke.WIN32_FIND_DATA findData,
+				Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch,
+				IntPtr.Zero,
+				Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH);
+
+			if (hFind.ToInt64() == -1)
+				return results;
+
+			try
+			{
+				do
+				{
+					if (findData.cFileName == "." || findData.cFileName == "..")
+						continue;
+
+					if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) != FileAttributes.Directory)
+						continue;
+
+					var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
+					var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
+
+					if (!showDot && findData.cFileName.StartsWith('.'))
+						continue;
+					if (isHidden && !showHidden)
+						continue;
+					if (isHidden && isSystem && !showProtected)
+						continue;
+
+					var subPath = Path.Combine(path, findData.cFileName);
+					results.Add(new SubfolderEntry(subPath, findData.cFileName, HasSubfolders(subPath), isHidden));
+
+					if (results.Count == limit)
+						break;
+				}
+				while (Win32PInvoke.FindNextFile(hFind, out findData));
+			}
+			finally
+			{
+				Win32PInvoke.FindClose(hFind);
+			}
+
+			results.Sort((a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.Name, b.Name));
+			return results;
+		}
+
+		public static bool HasSubfolders(string path)
+		{
+			IntPtr hFind = Win32PInvoke.FindFirstFileExFromApp(
+				path + "\\*.*",
+				Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
+				out Win32PInvoke.WIN32_FIND_DATA findData,
+				Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch,
+				IntPtr.Zero,
+				Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH);
+
+			if (hFind.ToInt64() == -1)
+				return false;
+
+			try
+			{
+				do
+				{
+					if (findData.cFileName == "." || findData.cFileName == "..")
+						continue;
+					if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
+						return true;
+				}
+				while (Win32PInvoke.FindNextFile(hFind, out findData));
+				return false;
+			}
+			finally
+			{
+				Win32PInvoke.FindClose(hFind);
+			}
 		}
 	}
 }

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -93,9 +93,18 @@ namespace Files.App.ViewModels.UserControls
 			OnPropertyChanged(nameof(SidebarSelectedItem));
 		}
 
+		// Current absolute navigation path. Mirrored to the TreeViewSidebar so the embedded tree highlights the deepest ancestor of this path.
+		private string? currentPath;
+		public string? CurrentPath
+		{
+			get => currentPath;
+			private set => SetProperty(ref currentPath, value);
+		}
+
 		public void UpdateSidebarSelectedItemFromArgs(string? arg)
 		{
 			var value = arg;
+			CurrentPath = value;
 
 			INavigationControlItem? item = null;
 			var filteredItems = sidebarItems

--- a/src/Files.App/ViewModels/UserControls/TreeViewSidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/TreeViewSidebarViewModel.cs
@@ -1,0 +1,622 @@
+// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using CommunityToolkit.WinUI.Helpers;
+using Files.App.Controls;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+using System.Collections.Specialized;
+using System.IO;
+
+namespace Files.App.ViewModels.UserControls
+{
+	public sealed partial class TreeViewSidebarViewModel : ObservableObject
+	{
+		// Dependency injections
+
+		private readonly IIconCacheService IconCacheService = Ioc.Default.GetRequiredService<IIconCacheService>();
+		private readonly IContentPageContext ContentPageContext = Ioc.Default.GetRequiredService<IContentPageContext>();
+		private readonly IUserSettingsService UserSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
+		private readonly SidebarViewModel SidebarViewModel = Ioc.Default.GetRequiredService<SidebarViewModel>();
+		private readonly MainPageViewModel MainPageViewModel = Ioc.Default.GetRequiredService<MainPageViewModel>();
+
+		// Fields
+
+		private readonly DispatcherQueue _dispatcherQueue;
+
+		private readonly Dictionary<TabBarItem, HashSet<string>> _tabExpansionState = new();
+
+		private static readonly string[] DefaultExpandedSectionIds =
+		{
+			"section:Pinned",
+			"section:Drives",
+			"section:CloudDrives",
+		};
+
+		private readonly List<(INotifyCollectionChanged Source, NotifyCollectionChangedEventHandler Handler)> _childItemsHandlers = new();
+
+		private TabBarItem? _currentTab;
+		private bool _isActive;
+		private bool _applyingState;
+		private bool _rebuildPending;
+
+		// Properties
+
+		public ObservableCollection<FolderNode> RootFolders { get; } = new();
+
+		private FolderNode? _selectedNode;
+		public FolderNode? SelectedNode
+		{
+			get => _selectedNode;
+			private set => SetProperty(ref _selectedNode, value);
+		}
+
+		// Constructor
+
+		public TreeViewSidebarViewModel()
+		{
+			_dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+		}
+
+		// Methods
+
+		public void OnControlLoaded()
+		{
+			_isActive = true;
+			SidebarViewModel.PropertyChanged += OnSidebarViewModelPropertyChanged;
+			if (SidebarViewModel.SidebarItems is INotifyCollectionChanged inc)
+				inc.CollectionChanged += OnSidebarItemsChanged;
+			MainPageViewModel.AppInstances.CollectionChanged += OnAppInstancesChanged;
+			MainPageViewModel.PropertyChanged += OnMainPageViewModelPropertyChanged;
+			_currentTab = MainPageViewModel.SelectedTabItem;
+			RebuildAndApply();
+			UpdateSelectionFromCurrentPath();
+		}
+
+		public void OnControlUnloaded()
+		{
+			_isActive = false;
+			SidebarViewModel.PropertyChanged -= OnSidebarViewModelPropertyChanged;
+			if (SidebarViewModel.SidebarItems is INotifyCollectionChanged inc)
+				inc.CollectionChanged -= OnSidebarItemsChanged;
+			MainPageViewModel.AppInstances.CollectionChanged -= OnAppInstancesChanged;
+			MainPageViewModel.PropertyChanged -= OnMainPageViewModelPropertyChanged;
+			DetachChildItemsHandlers();
+			DetachAllNodeHandlers();
+		}
+
+		private void DetachAllNodeHandlers()
+		{
+			foreach (var section in RootFolders)
+				DetachRecursive(section);
+		}
+
+		private void DetachChildItemsHandlers()
+		{
+			foreach (var (source, handler) in _childItemsHandlers)
+				source.CollectionChanged -= handler;
+			_childItemsHandlers.Clear();
+		}
+
+		private void DetachRecursive(FolderNode node)
+		{
+			node.PropertyChanged -= OnNodePropertyChanged;
+			if (node.SourceItem is not null)
+				node.SourceItem.PropertyChanged -= OnSourceItemPropertyChanged;
+			foreach (var child in node.Children)
+				DetachRecursive(child);
+		}
+
+		private void Rebuild()
+		{
+			DetachChildItemsHandlers();
+			DetachAllNodeHandlers();
+			SelectedNode = null;
+			RootFolders.Clear();
+
+			if (SidebarViewModel.SidebarItems is not IEnumerable<INavigationControlItem> headers)
+				return;
+
+			foreach (var item in headers)
+			{
+				if (item is not LocationItem header || !header.IsHeader)
+					continue;
+
+				if (header.Section == SectionType.Home)
+				{
+					var homeNode = new FolderNode(header.Path, header.Text, FolderNodeKind.Leaf, GetIcon(header), header);
+					homeNode.PropertyChanged += OnNodePropertyChanged;
+					header.PropertyChanged += OnSourceItemPropertyChanged;
+					RootFolders.Add(homeNode);
+					continue;
+				}
+
+				var section = new FolderNode($"section:{header.Section}", header.Text, FolderNodeKind.Section, icon: null);
+
+				if (header.ChildItems is not null)
+				{
+					NotifyCollectionChangedEventHandler childHandler = OnSectionChildItemsChanged;
+					header.ChildItems.CollectionChanged += childHandler;
+					_childItemsHandlers.Add((header.ChildItems, childHandler));
+
+					foreach (var childObj in header.ChildItems)
+					{
+						if (childObj is not INavigationControlItem child)
+							continue;
+						var path = child.Path;
+						var name = child.Text;
+						if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(name))
+							continue;
+						var hasRootedPath = (child is LocationItem loc2 && Path.IsPathRooted(loc2.Path)) || child is DriveItem;
+						var isExpandable = hasRootedPath && header.Section != SectionType.Pinned;
+						var kind = isExpandable ? FolderNodeKind.Folder : FolderNodeKind.Leaf;
+						var node = new FolderNode(path, name, kind, GetIcon(child), child)
+						{
+							TagIconSource = GetTagIconSource(child),
+						};
+						if (isExpandable)
+						{
+							node.HasUnrealizedChildren = true;
+							_ = ProbeHasChildrenAsync(node);
+						}
+						node.PropertyChanged += OnNodePropertyChanged;
+						child.PropertyChanged += OnSourceItemPropertyChanged;
+						section.Children.Add(node);
+					}
+				}
+
+				section.PropertyChanged += OnNodePropertyChanged;
+				RootFolders.Add(section);
+			}
+		}
+
+		private void ApplyTabState()
+		{
+			if (_currentTab is null)
+				return;
+			var state = GetOrInitState(_currentTab);
+			_applyingState = true;
+			try
+			{
+				foreach (var section in RootFolders)
+					ApplyExpansionRecursive(section, state);
+			}
+			finally
+			{
+				_applyingState = false;
+			}
+		}
+
+		private void ApplyExpansionRecursive(FolderNode node, HashSet<string> state)
+		{
+			var shouldExpand = state.Contains(node.Path);
+			if (shouldExpand && node.Kind == FolderNodeKind.Folder && node.HasUnrealizedChildren)
+				LoadChildrenSync(node);
+
+			node.IsExpanded = shouldExpand;
+
+			if (shouldExpand)
+			{
+				foreach (var child in node.Children.ToList())
+					ApplyExpansionRecursive(child, state);
+			}
+		}
+
+		private void RebuildAndApply()
+		{
+			if (!_isActive)
+				return;
+			try
+			{
+				Rebuild();
+				ApplyTabState();
+				UpdateSelectionFromCurrentPath();
+			}
+			catch (Exception ex)
+			{
+				App.Logger?.LogWarning(ex, "TreeViewSidebar: rebuild failed");
+			}
+		}
+
+		private void OnSidebarViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName != nameof(SidebarViewModel.CurrentPath))
+				return;
+			var target = SidebarViewModel.CurrentPath;
+			if (_dispatcherQueue.HasThreadAccess)
+				_ = ExpandToPathAsync(target);
+			else
+				_dispatcherQueue.TryEnqueue(() => _ = ExpandToPathAsync(target));
+		}
+
+		// Walks the tree to find the deepest already-realized ancestor of CurrentPath and sets IsSelected on it. We deliberately never touch TreeView.SelectedItem — assigning it to a node whose container isn't realized crashes WinUI's native selection machinery (ExecutionEngineException).
+		public void UpdateSelectionFromCurrentPath()
+		{
+			if (!_isActive)
+				return;
+			var target = SidebarViewModel.CurrentPath;
+			var match = string.IsNullOrEmpty(target) ? null : FindDeepestAncestor(RootFolders, target);
+			if (ReferenceEquals(match, SelectedNode))
+				return;
+			if (SelectedNode is not null)
+				SelectedNode.IsSelected = false;
+			SelectedNode = match;
+			if (SelectedNode is not null)
+				SelectedNode.IsSelected = true;
+		}
+
+		private static FolderNode? FindDeepestAncestor(IEnumerable<FolderNode> nodes, string targetPath)
+		{
+			FolderNode? best = null;
+			foreach (var node in nodes)
+			{
+				if (node.IsSection)
+				{
+					var deeperInSection = FindDeepestAncestor(node.Children, targetPath);
+					if (deeperInSection is not null && (best is null || deeperInSection.Path.Length > best.Path.Length))
+						best = deeperInSection;
+					continue;
+				}
+				if (string.IsNullOrEmpty(node.Path))
+					continue;
+				if (targetPath.Equals(node.Path, StringComparison.OrdinalIgnoreCase))
+					return node;
+				// Drive-style paths like "C:" need a separator appended before comparing against "C:\...".
+				var withSeparator = node.Path.EndsWith(Path.DirectorySeparatorChar) ? node.Path : node.Path + Path.DirectorySeparatorChar;
+				if (targetPath.StartsWith(withSeparator, StringComparison.OrdinalIgnoreCase))
+				{
+					var deeper = FindDeepestAncestor(node.Children, targetPath);
+					var candidate = deeper ?? node;
+					if (best is null || candidate.Path.Length > best.Path.Length)
+						best = candidate;
+				}
+			}
+			return best;
+		}
+
+		private async Task ExpandToPathAsync(string? targetPath)
+		{
+			if (string.IsNullOrEmpty(targetPath) || !_isActive)
+			{
+				UpdateSelectionFromCurrentPath();
+				return;
+			}
+
+			FolderNode? bestMatch = null;
+			foreach (var section in RootFolders.ToList())
+			{
+				if (!_isActive)
+					return;
+				if (section.IsSection)
+				{
+					foreach (var child in section.Children.ToList())
+					{
+						if (PathIsAncestorOrMatch(child.Path, targetPath))
+						{
+							if (bestMatch is null || child.Path.Length > bestMatch.Path.Length)
+								bestMatch = child;
+						}
+					}
+				}
+				else if (PathIsAncestorOrMatch(section.Path, targetPath))
+				{
+					if (bestMatch is null || section.Path.Length > bestMatch.Path.Length)
+						bestMatch = section;
+				}
+			}
+
+			if (bestMatch is not null)
+			{
+				await ExpandTowardAsync(bestMatch, targetPath);
+				UpdateSelectionFromCurrentPath();
+				return;
+			}
+
+			UpdateSelectionFromCurrentPath();
+		}
+
+		private async Task ExpandTowardAsync(FolderNode node, string targetPath)
+		{
+			if (!_isActive || node.Kind != FolderNodeKind.Folder)
+				return;
+			if (targetPath.Equals(node.Path, StringComparison.OrdinalIgnoreCase))
+				return;
+			await LoadChildrenAsync(node);
+			if (!node.IsExpanded)
+				node.IsExpanded = true;
+			foreach (var child in node.Children.ToList())
+			{
+				if (!_isActive)
+					return;
+				if (PathIsAncestorOrMatch(child.Path, targetPath))
+				{
+					await ExpandTowardAsync(child, targetPath);
+					return;
+				}
+			}
+		}
+
+		private static bool PathIsAncestorOrMatch(string nodePath, string targetPath)
+		{
+			if (string.IsNullOrEmpty(nodePath))
+				return false;
+			if (targetPath.Equals(nodePath, StringComparison.OrdinalIgnoreCase))
+				return true;
+			var withSep = nodePath.EndsWith(Path.DirectorySeparatorChar) ? nodePath : nodePath + Path.DirectorySeparatorChar;
+			return targetPath.StartsWith(withSep, StringComparison.OrdinalIgnoreCase);
+		}
+
+		private HashSet<string> GetOrInitState(TabBarItem tab)
+		{
+			if (_tabExpansionState.TryGetValue(tab, out var state))
+				return state;
+			state = new HashSet<string>(DefaultExpandedSectionIds, StringComparer.OrdinalIgnoreCase);
+			_tabExpansionState[tab] = state;
+			return state;
+		}
+
+		private void OnNodePropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (_applyingState || e.PropertyName != nameof(FolderNode.IsExpanded))
+				return;
+			if (sender is not FolderNode node || _currentTab is null)
+				return;
+			var state = GetOrInitState(_currentTab);
+			if (node.IsExpanded)
+				state.Add(node.Path);
+			else
+				state.Remove(node.Path);
+		}
+
+		private void ScheduleRebuildAndApply()
+		{
+			if (_rebuildPending || !_isActive)
+				return;
+			_rebuildPending = true;
+			_dispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () =>
+			{
+				_rebuildPending = false;
+				RebuildAndApply();
+			});
+		}
+
+		private void OnSidebarItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (_dispatcherQueue.HasThreadAccess)
+				ScheduleRebuildAndApply();
+			else
+				_dispatcherQueue.TryEnqueue(ScheduleRebuildAndApply);
+		}
+
+		private void OnSectionChildItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (_dispatcherQueue.HasThreadAccess)
+				ScheduleRebuildAndApply();
+			else
+				_dispatcherQueue.TryEnqueue(ScheduleRebuildAndApply);
+		}
+
+		private void OnAppInstancesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (e.Action == NotifyCollectionChangedAction.Remove && e.OldItems is not null)
+			{
+				foreach (var item in e.OldItems.OfType<TabBarItem>())
+					_tabExpansionState.Remove(item);
+			}
+			else if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				_tabExpansionState.Clear();
+			}
+		}
+
+		private void OnMainPageViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName != nameof(MainPageViewModel.SelectedTabItem))
+				return;
+			if (_dispatcherQueue.HasThreadAccess)
+				HandleTabChange();
+			else
+				_dispatcherQueue.TryEnqueue(HandleTabChange);
+		}
+
+		private void HandleTabChange()
+		{
+			if (!_isActive)
+				return;
+			try
+			{
+				var newTab = MainPageViewModel.SelectedTabItem;
+				if (newTab is null || ReferenceEquals(newTab, _currentTab))
+					return;
+				_currentTab = newTab;
+				ApplyTabState();
+				UpdateSelectionFromCurrentPath();
+			}
+			catch (Exception ex)
+			{
+				App.Logger?.LogWarning(ex, "TreeViewSidebar: tab change handler failed");
+			}
+		}
+
+		public async Task LoadChildrenAsync(FolderNode parent)
+		{
+			if (parent.Kind != FolderNodeKind.Folder || !parent.HasUnrealizedChildren)
+				return;
+
+			// Mark before awaiting so a stray re-entry doesn't double-load
+			parent.HasUnrealizedChildren = false;
+
+			var folders = UserSettingsService.FoldersSettingsService;
+			var showHidden = folders.ShowHiddenItems;
+			var showProtected = folders.ShowProtectedSystemFiles;
+			var showDot = folders.ShowDotFiles;
+			var parentPath = parent.Path;
+
+			var entries = await Task.Run(() => FolderHelpers.EnumerateSubfolders(parentPath, showHidden, showProtected, showDot));
+
+			if (!_isActive)
+				return;
+
+			foreach (var entry in entries)
+			{
+				var kind = entry.HasSubfolders ? FolderNodeKind.Folder : FolderNodeKind.Leaf;
+				var child = new FolderNode(entry.Path, entry.Name, kind, icon: null)
+				{
+					HasUnrealizedChildren = entry.HasSubfolders,
+					Opacity = entry.IsHidden ? Constants.UI.DimItemOpacity : 1.0,
+				};
+				child.PropertyChanged += OnNodePropertyChanged;
+				_ = LoadIconAsync(child);
+				parent.Children.Add(child);
+			}
+		}
+
+		// Synchronous lazy load. Called from ApplyExpansionRecursive (state restore) to keep tab-switch restoration synchronous.
+		private void LoadChildrenSync(FolderNode parent)
+		{
+			if (parent.Kind != FolderNodeKind.Folder || !parent.HasUnrealizedChildren)
+				return;
+
+			// Mark before populating so a stray re-entry doesn't double-load
+			parent.HasUnrealizedChildren = false;
+
+			var folders = UserSettingsService.FoldersSettingsService;
+			var entries = FolderHelpers.EnumerateSubfolders(parent.Path, folders.ShowHiddenItems, folders.ShowProtectedSystemFiles, folders.ShowDotFiles);
+
+			foreach (var entry in entries)
+			{
+				var kind = entry.HasSubfolders ? FolderNodeKind.Folder : FolderNodeKind.Leaf;
+				var child = new FolderNode(entry.Path, entry.Name, kind, icon: null)
+				{
+					HasUnrealizedChildren = entry.HasSubfolders,
+					Opacity = entry.IsHidden ? Constants.UI.DimItemOpacity : 1.0,
+				};
+				child.PropertyChanged += OnNodePropertyChanged;
+				_ = LoadIconAsync(child);
+				parent.Children.Add(child);
+			}
+		}
+
+		private async Task LoadIconAsync(FolderNode node)
+		{
+			try
+			{
+				var bytes = await IconCacheService.GetIconAsync(node.Path, null, isFolder: true);
+				if (bytes is null || !_isActive)
+					return;
+				var bmp = await bytes.ToBitmapAsync();
+				if (bmp is not null && _isActive)
+					node.Icon = bmp;
+			}
+			// Icon resolution can fail for inaccessible paths (network down, missing folder) — leave icon null
+			catch (Exception ex)
+			{
+				App.Logger?.LogDebug(ex, "TreeViewSidebar: icon load failed for {Path}", node.Path);
+			}
+		}
+
+		private void OnSourceItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName != "IconElement")
+				return;
+			if (sender is not INavigationControlItem sourceItem)
+				return;
+			if (_dispatcherQueue.HasThreadAccess)
+				SyncIconFromSourceItem(sourceItem);
+			else
+				_dispatcherQueue.TryEnqueue(() => SyncIconFromSourceItem(sourceItem));
+		}
+
+		private void SyncIconFromSourceItem(INavigationControlItem sourceItem)
+		{
+			if (!_isActive)
+				return;
+			var icon = GetIcon(sourceItem);
+			var tagIconSource = GetTagIconSource(sourceItem);
+			foreach (var section in RootFolders)
+			{
+				if (section.SourceItem == sourceItem)
+				{
+					section.Icon = icon;
+					section.TagIconSource = tagIconSource;
+					return;
+				}
+				foreach (var child in section.Children)
+				{
+					if (child.SourceItem == sourceItem)
+					{
+						child.Icon = icon;
+						child.TagIconSource = tagIconSource;
+						return;
+					}
+				}
+			}
+		}
+
+		private static ImageSource? GetIcon(INavigationControlItem item)
+		{
+			if (item is LocationItem loc)
+				return loc.Icon;
+			if (item is DriveItem drv)
+				return drv.Icon;
+			if (item is WslDistroItem wsl && wsl.Icon is not null)
+				return new BitmapImage(wsl.Icon);
+			return null;
+		}
+
+		private static IconSource? GetTagIconSource(INavigationControlItem item)
+		{
+			if (item is not FileTagItem tagItem)
+				return null;
+			return new PathIconSource()
+			{
+				Data = (Geometry)XamlBindingHelper.ConvertValue(typeof(Geometry), (string)Application.Current.Resources["App.Theme.PathIcon.FilledTag"]),
+				Foreground = new SolidColorBrush(tagItem.FileTag.Color.ToColor()),
+			};
+		}
+
+		private async Task ProbeHasChildrenAsync(FolderNode node)
+		{
+			var path = node.Path;
+			var hasChildren = await Task.Run(() => FolderHelpers.HasSubfolders(path));
+			if (!_isActive)
+				return;
+			// Only retract the chevron — never re-assert it after children have been loaded.
+			if (!hasChildren && node.Children.Count == 0)
+				node.HasUnrealizedChildren = false;
+		}
+
+		public void HandleItemInvoked(FolderNode fn)
+		{
+			if (fn.IsSection)
+			{
+				fn.IsExpanded = !fn.IsExpanded;
+				return;
+			}
+			if (fn.SourceItem is not null)
+			{
+				SidebarViewModel.HandleItemInvokedAsync(fn.SourceItem, PointerUpdateKind.Other);
+				return;
+			}
+			if (ContentPageContext.ShellPage is not { } page)
+				return;
+			page.NavigateToPath(fn.Path);
+		}
+
+		public void HandleItemContextInvoked(FrameworkElement element, ItemContextInvokedArgs args)
+		{
+			SidebarViewModel.HandleItemContextInvokedAsync(element, args);
+		}
+
+		public void NavigateToPath(string path)
+		{
+			ContentPageContext.ShellPage?.NavigateToPath(path);
+		}
+	}
+}

--- a/src/Files.App/ViewModels/UserControls/TreeViewSidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/TreeViewSidebarViewModel.cs
@@ -466,7 +466,7 @@ namespace Files.App.ViewModels.UserControls
 			foreach (var entry in entries)
 			{
 				var kind = entry.HasSubfolders ? FolderNodeKind.Folder : FolderNodeKind.Leaf;
-				var child = new FolderNode(entry.Path, entry.Name, kind, icon: null)
+				var child = new FolderNode(entry.Path, entry.Name, kind, icon: null, CreateSubfolderLocationItem(entry.Path, entry.Name))
 				{
 					HasUnrealizedChildren = entry.HasSubfolders,
 					Opacity = entry.IsHidden ? Constants.UI.DimItemOpacity : 1.0,
@@ -492,7 +492,7 @@ namespace Files.App.ViewModels.UserControls
 			foreach (var entry in entries)
 			{
 				var kind = entry.HasSubfolders ? FolderNodeKind.Folder : FolderNodeKind.Leaf;
-				var child = new FolderNode(entry.Path, entry.Name, kind, icon: null)
+				var child = new FolderNode(entry.Path, entry.Name, kind, icon: null, CreateSubfolderLocationItem(entry.Path, entry.Name))
 				{
 					HasUnrealizedChildren = entry.HasSubfolders,
 					Opacity = entry.IsHidden ? Constants.UI.DimItemOpacity : 1.0,
@@ -501,6 +501,21 @@ namespace Files.App.ViewModels.UserControls
 				_ = LoadIconAsync(child);
 				parent.Children.Add(child);
 			}
+		}
+
+		private static LocationItem CreateSubfolderLocationItem(string path, string name)
+		{
+			return new LocationItem
+			{
+				Path = path,
+				Text = name,
+				MenuOptions = new ContextMenuOptions
+				{
+					IsLocationItem = true,
+					ShowProperties = true,
+					ShowShellItems = true,
+				},
+			};
 		}
 
 		private async Task LoadIconAsync(FolderNode node)
@@ -600,13 +615,7 @@ namespace Files.App.ViewModels.UserControls
 				return;
 			}
 			if (fn.SourceItem is not null)
-			{
 				SidebarViewModel.HandleItemInvokedAsync(fn.SourceItem, PointerUpdateKind.Other);
-				return;
-			}
-			if (ContentPageContext.ShellPage is not { } page)
-				return;
-			page.NavigateToPath(fn.Path);
 		}
 
 		public void HandleItemContextInvoked(FrameworkElement element, ItemContextInvokedArgs args)


### PR DESCRIPTION
**Resolved / Related Issues**
TreeViewSidebarViewModel with async folder enumeration, tag icons, and improved selection

**Steps used to test these changes**
1. Navigate to different folders and verify TreeView selection highlights the correct ancestor
2. Expand folders with many subfolders and verify lazy-loading works smoothly
3. Navigate to deeply nested folders and verify tree expands and scrolls correctly
4. Switch between tabs and verify TreeView state (expansion) is preserved per-tab
5. Check file tag items in sidebar and verify tag icons display correctly
6. Verify the Tree view state on split view

**Notes:**
Incorporates all changes from ya/TreeViewConcept. Lazy-loaded subfolder nodes now route right-click through SidebarViewModel.HandleItemContextInvokedAsync instead of a custom flyout.