### PR TITLE
Code Quality: Update StorageBar.xaml - Replace Storyboard with VisualState Setters

### DIFF
--- a/src/Files.App.Controls/Storage/StorageBar/StorageBar.xaml
+++ b/src/Files.App.Controls/Storage/StorageBar/StorageBar.xaml
@@ -137,36 +137,24 @@
 								<VisualState x:Name="Safe" />
 
 								<VisualState x:Name="Caution">
-									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ValueBar" Storyboard.TargetProperty="Background">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource StorageBarValueCautionBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_TrackBar" Storyboard.TargetProperty="Background">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource StorageBarTrackCautionBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
+									<VisualState.Setters>
+										<Setter Target="PART_ValueBar.Background" Value="{ThemeResource StorageBarValueCautionBrush}" />
+										<Setter Target="PART_TrackBar.Background" Value="{ThemeResource StorageBarTrackCautionBrush}" />
+									</VisualState.Setters>
 								</VisualState>
 
 								<VisualState x:Name="Critical">
-									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ValueBar" Storyboard.TargetProperty="Background">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource StorageBarValueCriticalBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_TrackBar" Storyboard.TargetProperty="Background">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource StorageBarTrackCriticalBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
+									<VisualState.Setters>
+										<Setter Target="PART_ValueBar.Background" Value="{ThemeResource StorageBarValueCriticalBrush}" />
+										<Setter Target="PART_TrackBar.Background" Value="{ThemeResource StorageBarTrackCriticalBrush}" />
+									</VisualState.Setters>
 								</VisualState>
 
 								<VisualState x:Name="Disabled">
-									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ValueBar" Storyboard.TargetProperty="Background">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource StorageBarValueDisabledBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_TrackBar" Storyboard.TargetProperty="Background">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource StorageBarTrackDisabledBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
+									<VisualState.Setters>
+										<Setter Target="PART_ValueBar.Background" Value="{ThemeResource StorageBarValueDisabledBrush}" />
+										<Setter Target="PART_TrackBar.Background" Value="{ThemeResource StorageBarTrackDisabledBrush}" />
+									</VisualState.Setters>
 								</VisualState>
 
 							</VisualStateGroup>


### PR DESCRIPTION
https://github.com/user-attachments/assets/08d51890-0eb7-4e5e-abf8-8796e48db0b9

Based on what we are seeing with the WinUI Perf2026 changes, I thought I would start by updating our StorageBar to use VisualStateSetters, instead of Storyboards.

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

It does not resolve or close any existing issues

**Steps used to test these changes**
I ran the UITests app and the control behaves the same as it did before.

If possible, @0x5bfa could make some kind of test to ensure there is nothing that has been overlooked.  It should just be 1:1 behaviour though, and I suppose if Microsoft felt moving from storyboards offered a performance improvement, there may be some gains from this change.