### PR TITLE
Code Quality: Update StorageRing.xaml - Replace Storyboard with VisualState Setters

### DIFF
--- a/src/Files.App.Controls/Storage/StorageRing/StorageRing.xaml
+++ b/src/Files.App.Controls/Storage/StorageRing/StorageRing.xaml
@@ -157,36 +157,24 @@
 								<VisualState x:Name="Safe" />
 
 								<VisualState x:Name="Caution">
-									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ValueRingShape" Storyboard.TargetProperty="Stroke">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource StorageRingValueCautionBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_TrackRingShape" Storyboard.TargetProperty="Stroke">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource StorageRingTrackCautionBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
+									<VisualState.Setters>
+										<Setter Target="PART_ValueRingShape.Stroke" Value="{ThemeResource StorageRingValueCautionBrush}" />
+										<Setter Target="PART_TrackRingShape.Stroke" Value="{ThemeResource StorageRingTrackCautionBrush}" />
+									</VisualState.Setters>
 								</VisualState>
 
 								<VisualState x:Name="Critical">
-									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ValueRingShape" Storyboard.TargetProperty="Stroke">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource StorageRingValueCriticalBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_TrackRingShape" Storyboard.TargetProperty="Stroke">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource StorageRingTrackCriticalBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
+									<VisualState.Setters>
+										<Setter Target="PART_ValueRingShape.Stroke" Value="{ThemeResource StorageRingValueCriticalBrush}" />
+										<Setter Target="PART_TrackRingShape.Stroke" Value="{ThemeResource StorageRingTrackCriticalBrush}" />
+									</VisualState.Setters>
 								</VisualState>
 
 								<VisualState x:Name="Disabled">
-									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ValueRingShape" Storyboard.TargetProperty="Stroke">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ControlStrongStrokeColorDisabledBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_TrackRingShape" Storyboard.TargetProperty="Stroke">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ControlStrongStrokeColorDisabledBrush}" />
-										</ObjectAnimationUsingKeyFrames>
-									</Storyboard>
+									<VisualState.Setters>
+										<Setter Target="PART_ValueRingShape.Stroke" Value="{ThemeResource ControlStrongStrokeColorDisabledBrush}" />
+										<Setter Target="PART_TrackRingShape.Stroke" Value="{ThemeResource ControlStrongStrokeColorDisabledBrush}" />
+									</VisualState.Setters>
 								</VisualState>
 
 							</VisualStateGroup>


### PR DESCRIPTION
https://github.com/user-attachments/assets/9471c2b9-d199-4639-b013-e77519c8e5d0

Based on what we are seeing with the WinUI Perf2026 changes, I thought I would start by updating our StorageRing to use VisualStateSetters, instead of Storyboards.

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

This does not close or resolve any existing issues

**Steps used to test these changes**
I ran the UITests app and the control behaves the same as it did before.

If possible, @0x5bfa  could make some kind of test to ensure there is nothing that has been overlooked. It should just be 1:1 behaviour though, and I suppose if Microsoft felt moving from storyboards offered a performance improvement, there may be some gains from this change.