### PR TITLE
Fix: Fixed issue where Signatures page sometimes caused crash

### DIFF
--- a/src/Files.App/Utils/Signatures/DigitalSignaturesUtil.cs
+++ b/src/Files.App/Utils/Signatures/DigitalSignaturesUtil.cs
@@ -663,7 +663,7 @@ namespace Files.App.Utils.Signatures
 				return string.Empty;
 
 			var st = new Windows.Win32.Foundation.SYSTEMTIME();
-			var buffer = new ReadOnlySpan<byte>(pbOctetString + positionFound, 18);
+			var buffer = new ReadOnlySpan<byte>(pbOctetString + positionFound, (int)lengthFound);
 
 			_ = ushort.TryParse(buffer.Slice(0, 4), out st.wYear);
 			_ = ushort.TryParse(buffer.Slice(4, 2), out st.wMonth);
@@ -672,7 +672,7 @@ namespace Files.App.Utils.Signatures
 			_ = ushort.TryParse(buffer.Slice(10, 2), out st.wMinute);
 			_ = ushort.TryParse(buffer.Slice(12, 2), out st.wSecond);
 
-			if (buffer[14] == '.')
+			if (buffer.Length >= 18 && buffer[14] == '.')
 				_ = ushort.TryParse(buffer.Slice(15, 3), out st.wMilliseconds);
 
 			PInvoke.SystemTimeToFileTime(st, out var fft);

--- a/src/Files.App/Utils/Signatures/DigitalSignaturesUtil.cs
+++ b/src/Files.App/Utils/Signatures/DigitalSignaturesUtil.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Files Community
 // Licensed under the MIT License.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -224,7 +223,7 @@ namespace Files.App.Utils.Signatures
 					HCRYPTPROV_LEGACY.Null,
 					(CERT_OPEN_STORE_FLAGS)CERT_SYSTEM_STORE_CURRENT_USER,
 					(void*)pRoot
-				); 
+				);
 			}
 			if (hSystemStore == IntPtr.Zero)
 				return false;
@@ -387,7 +386,7 @@ namespace Files.App.Utils.Signatures
 
 			HCERTSTORE hCertStoreTmp = HCERTSTORE.Null;
 			void* hMsgTmp = null;
-			
+
 			fixed (char* pFileName = fileName)
 			{
 				result = PInvoke.CryptQueryObject(
@@ -664,15 +663,17 @@ namespace Files.App.Utils.Signatures
 				return string.Empty;
 
 			var st = new Windows.Win32.Foundation.SYSTEMTIME();
-			var buffer = new string((sbyte*)(pbOctetString + positionFound));
+			var buffer = new ReadOnlySpan<byte>(pbOctetString + positionFound, 18);
 
-			_ = ushort.TryParse(buffer.AsSpan(0, 4), out st.wYear);
-			_ = ushort.TryParse(buffer.AsSpan(4, 2), out st.wMonth);
-			_ = ushort.TryParse(buffer.AsSpan(6, 2), out st.wDay);
-			_ = ushort.TryParse(buffer.AsSpan(8, 2), out st.wHour);
-			_ = ushort.TryParse(buffer.AsSpan(10, 2), out st.wMinute);
-			_ = ushort.TryParse(buffer.AsSpan(12, 2), out st.wSecond);
-			_ = ushort.TryParse(buffer.AsSpan(15, 3), out st.wMilliseconds);
+			_ = ushort.TryParse(buffer.Slice(0, 4), out st.wYear);
+			_ = ushort.TryParse(buffer.Slice(4, 2), out st.wMonth);
+			_ = ushort.TryParse(buffer.Slice(6, 2), out st.wDay);
+			_ = ushort.TryParse(buffer.Slice(8, 2), out st.wHour);
+			_ = ushort.TryParse(buffer.Slice(10, 2), out st.wMinute);
+			_ = ushort.TryParse(buffer.Slice(12, 2), out st.wSecond);
+
+			if (buffer[14] == '.')
+				_ = ushort.TryParse(buffer.Slice(15, 3), out st.wMilliseconds);
 
 			PInvoke.SystemTimeToFileTime(st, out var fft);
 			PInvoke.FileTimeToLocalFileTime(fft, out var lft);


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #18510 

**Steps used to test these changes**

1. Downloaded https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/Git-2.54.0-64-bit.exe
2. Opened Files and viewed the signatures tab in the properties window for the file downloaded above.
3. Also tested that the method continues to work correctly in case milliseconds are present, e.g. on VisualStudioSetup.exe

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0f608a49-69ae-4148-b4ba-831ffca5cc7c" />


@ferrariofilippo 
