### PR TITLE
Feature: Add Skip and Skip All buttons to File In Use dialog

### DIFF
--- a/src/Files.App/Dialogs/FilesystemOperationDialog.xaml
+++ b/src/Files.App/Dialogs/FilesystemOperationDialog.xaml
@@ -12,6 +12,7 @@
 	xmlns:vm="using:Files.App.ViewModels.Dialogs.FileSystemDialog"
 	x:Name="RootDialog"
 	Title="{x:Bind ViewModel.Title, Mode=OneWay}"
+	CloseButtonText="{x:Bind ViewModel.CloseButtonText, Mode=OneWay}"
 	Closing="RootDialog_Closing"
 	CornerRadius="{StaticResource OverlayCornerRadius}"
 	DefaultButton="Primary"

--- a/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
+++ b/src/Files.App/Helpers/Dialog/DynamicDialogFactory.cs
@@ -146,8 +146,9 @@ namespace Files.App.Helpers
 				TitleText = Strings.FileInUseDialog_Title.GetLocalizedResource(),
 				SubtitleText = lockingProcess.IsEmpty() ? Strings.FileInUseDialog_Text.GetLocalizedResource() :
 					string.Format(Strings.FileInUseByDialog_Text.GetLocalizedResource(), string.Join(", ", lockingProcess.Select(x => $"{x.AppName ?? x.Name} (PID: {x.Pid})"))),
-				PrimaryButtonText = "OK",
-				DynamicButtons = DynamicDialogButtons.Primary
+				PrimaryButtonText = Strings.Retry.GetLocalizedResource(),
+				SecondaryButtonText = Strings.Skip.GetLocalizedResource(),
+				DynamicButtons = DynamicDialogButtons.Primary | DynamicDialogButtons.Secondary | DynamicDialogButtons.Cancel
 			});
 			return dialog;
 		}

--- a/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
+++ b/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
@@ -857,10 +857,17 @@ namespace Files.App.Utils.Storage
 				? Strings.FileInUseDialog_Text.GetLocalizedResource()
 				: string.Format(Strings.FileInUseByDialog_Text.GetLocalizedResource(), string.Join(", ", lockingProcess.Select(x => $"{x.AppName ?? x.Name} (PID: {x.Pid})")));
 
-			return GetFileListDialog(source, titleText, subtitleText, Strings.Retry.GetLocalizedResource(), Strings.Cancel.GetLocalizedResource());
+			var sourceCount = source.Count();
+
+			return GetFileListDialog(
+				source,
+				titleText,
+				subtitleText,
+				Strings.Retry.GetLocalizedResource(),
+				sourceCount > 1 ? Strings.Skip.GetLocalizedResource() : Strings.Cancel.GetLocalizedResource());
 		}
 
-		private async Task<DialogResult> GetFileListDialog(IEnumerable<string> source, string titleText, string descriptionText = null, string primaryButtonText = null, string secondaryButtonText = null)
+		private async Task<DialogResult> GetFileListDialog(IEnumerable<string> source, string titleText, string descriptionText = null, string primaryButtonText = null, string secondaryButtonText = null, string closeButtonText = null)
 		{
 			var incomingItems = new List<BaseFileSystemDialogItemViewModel>();
 			List<ShellFileItem> binItems = null;
@@ -886,7 +893,7 @@ namespace Files.App.Utils.Storage
 			}
 
 			var dialogViewModel = FileSystemDialogViewModel.GetDialogViewModel(
-				incomingItems, titleText, descriptionText, primaryButtonText, secondaryButtonText);
+				incomingItems, titleText, descriptionText, primaryButtonText, secondaryButtonText, closeButtonText);
 
 			var dialogService = Ioc.Default.GetRequiredService<IDialogService>();
 

--- a/src/Files.App/ViewModels/Dialogs/FileSystemDialog/FileSystemDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/FileSystemDialog/FileSystemDialogViewModel.cs
@@ -216,7 +216,7 @@ namespace Files.App.ViewModels.Dialogs.FileSystemDialog
 			return viewModel;
 		}
 
-		public static FileSystemDialogViewModel GetDialogViewModel(List<BaseFileSystemDialogItemViewModel> nonConflictingItems, string titleText, string descriptionText, string primaryButtonText, string secondaryButtonText)
+		public static FileSystemDialogViewModel GetDialogViewModel(List<BaseFileSystemDialogItemViewModel> nonConflictingItems, string titleText, string descriptionText, string primaryButtonText, string secondaryButtonText, string closeButtonText = null)
 		{
 			var viewModel = new FileSystemDialogViewModel(
 				new()
@@ -230,6 +230,7 @@ namespace Files.App.ViewModels.Dialogs.FileSystemDialog
 				Description = descriptionText,
 				PrimaryButtonText = primaryButtonText,
 				SecondaryButtonText = secondaryButtonText,
+				CloseButtonText = closeButtonText,
 				DeletePermanently = false,
 				IsDeletePermanentlyEnabled = false
 			};


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #8239

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files Dev app
2. Locked a file using PowerShell: $file = [System.IO.File]::Open("D:\testlock.txt", "OpenOrCreate", "ReadWrite", "None")
3. Navigated to the locked file in Files Dev
4. Attempted to delete the locked file
5. Confirmed that Retry, Skip, and Skip All buttons appear correctly in the File In Use dialog
6. Clicked Skip to verify it skips the current file
7. Clicked Skip All to verify it skips all locked files