### PR TITLE
Fix: Load OneDrive icon directly from the exe file

### DIFF
--- a/src/Files.App/Constants.cs
+++ b/src/Files.App/Constants.cs
@@ -39,7 +39,6 @@ namespace Files.App
 			public const int Network = 25;
 			public const int RecycleBin = 55;
 			public const int CloudDrives = 1040;
-			public const int OneDrive = 1043;
 			public const int Libraries = 1023;
 			public const int Folder = 3;
 			public const int ShieldIcon = 78;

--- a/src/Files.App/Helpers/UI/UIHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIHelpers.cs
@@ -146,8 +146,7 @@ namespace Files.App.Helpers
 					Constants.ImageRes.Libraries,
 					Constants.ImageRes.ThisPC,
 					Constants.ImageRes.CloudDrives,
-					Constants.ImageRes.Folder,
-					Constants.ImageRes.OneDrive
+					Constants.ImageRes.Folder
 				}, 32);
 
 			return imageResList;

--- a/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
+++ b/src/Files.App/Utils/Cloud/CloudDrivesDetector.cs
@@ -165,7 +165,7 @@ namespace Files.App.Utils.Cloud
 					{
 						Name = accountName,
 						SyncFolder = userFolder,
-						IconData = UIHelpers.GetSidebarIconResourceInfo(Constants.ImageRes.OneDrive).IconData,
+						IconData = GetIconData($"Environment.GetEnvironmentVariable(\"ProgramFiles\")\\Microsoft OneDrive\\OneDrive.exe"),
 					});
 				}
 			}


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes https://discord.com/channels/725513575971684472/1511510360807575632

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files
2. See OneDrive icon
3. Compare to Windows File Explorer