### PR TITLE
fix: correct RemoveFrom off-by-one behavior

### DIFF
--- a/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
+++ b/src/Files.App/Actions/Content/Archives/Decompress/DecompressArchive.cs
@@ -135,7 +135,7 @@ namespace Files.App.Actions
 			previousArchiveExtractionLocations.Insert(0, path);
 
 			if (previousArchiveExtractionLocations.Count > 10)
-				UserSettingsService.GeneralSettingsService.PreviousArchiveExtractionLocations = previousArchiveExtractionLocations.RemoveFrom(11);
+				UserSettingsService.GeneralSettingsService.PreviousArchiveExtractionLocations = previousArchiveExtractionLocations.RemoveFrom(10);
 			else
 				UserSettingsService.GeneralSettingsService.PreviousArchiveExtractionLocations = previousArchiveExtractionLocations;
 		}

--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -913,7 +913,7 @@ namespace Files.App.ViewModels.UserControls
 			pathHistoryList.Insert(0, path);
 
 			if (pathHistoryList.Count > MaxSuggestionsCount)
-				UserSettingsService.GeneralSettingsService.PathHistoryList = pathHistoryList.RemoveFrom(MaxSuggestionsCount + 1);
+				UserSettingsService.GeneralSettingsService.PathHistoryList = pathHistoryList.RemoveFrom(MaxSuggestionsCount);
 			else
 				UserSettingsService.GeneralSettingsService.PathHistoryList = pathHistoryList;
 		}
@@ -925,7 +925,7 @@ namespace Files.App.ViewModels.UserControls
 			previousSearchQueriesList.Insert(0, searchQuery);
 
 			if (previousSearchQueriesList.Count > MaxSuggestionsCount)
-				UserSettingsService.GeneralSettingsService.PreviousSearchQueriesList = previousSearchQueriesList.RemoveFrom(MaxSuggestionsCount + 1);
+				UserSettingsService.GeneralSettingsService.PreviousSearchQueriesList = previousSearchQueriesList.RemoveFrom(MaxSuggestionsCount);
 			else
 				UserSettingsService.GeneralSettingsService.PreviousSearchQueriesList = previousSearchQueriesList;
 		}

--- a/src/Files.Shared/Extensions/LinqExtensions.cs
+++ b/src/Files.Shared/Extensions/LinqExtensions.cs
@@ -171,7 +171,7 @@ namespace Files.Shared.Extensions
 
 			return index <= 0
 				? []
-				: list.Take(index - 1).ToList();
+				: list.Take(index).ToList();
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fixed `RemoveFrom` so it keeps all items before the requested removal index.
- Updated history trimming callers to preserve their existing 10-item caps after the helper fix.

## Root Cause
`RemoveFrom` used `Take(index - 1)`, which removed one extra item before the requested index. For example, `RemoveFrom(2)` returned only the item at index `0` instead of keeping indexes `0` and `1`.

## Verification
- `git diff --check`

Not run locally:
- `msbuild -restore src\Files.App\Files.App.csproj /p:Configuration=Debug /p:Platform=x64`

The build could not be run in this environment because `msbuild` is not installed/on PATH and `dotnet --info` reports no installed SDKs.