### PR TITLE
Fix: Update desktop Recycle Bin icon after bin operations (Fixes #9946)

### DIFF
--- a/src/Files.App/Data/Contracts/IStorageTrashBinService.cs
+++ b/src/Files.App/Data/Contracts/IStorageTrashBinService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Files Community
+// Copyright (c) Files Community
 // Licensed under the MIT License.
 
 namespace Files.App.Data.Contracts
@@ -63,5 +63,10 @@ namespace Files.App.Data.Contracts
 		/// </summary>
 		/// <returns>True if succeeded; otherwise, false</returns>
 		Task<bool> RestoreAllTrashesAsync();
+
+		/// <summary>
+		/// Refreshes the desktop Recycle Bin icon to reflect the current bin state.
+		/// </summary>
+		void UpdateDesktopRecycleBinIcon();
 	}
 }

--- a/src/Files.App/Services/Storage/StorageTrashBinService.cs
+++ b/src/Files.App/Services/Storage/StorageTrashBinService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Logging;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
@@ -106,6 +107,9 @@ namespace Files.App.Services
 				0x00000001 | 0x00000002 /* SHERB_NOCONFIRMATION | SHERB_NOPROGRESSUI */)
 			.Succeeded;
 
+			if (fRes)
+				UpdateDesktopRecycleBinIcon();
+
 			return fRes;
 		}
 
@@ -163,10 +167,23 @@ namespace Files.App.Services
 			// Perform
 			hr = pFileOperation.Get()->PerformOperations();
 
-			// Reset the icon
-			PInvoke.SHUpdateRecycleBinIcon();
+			if (hr == HRESULT.S_OK)
+				UpdateDesktopRecycleBinIcon();
 
-			return true;
+			return hr == HRESULT.S_OK;
+		}
+
+		/// <inheritdoc/>
+		public void UpdateDesktopRecycleBinIcon()
+		{
+			try
+			{
+				PInvoke.SHUpdateRecycleBinIcon();
+			}
+			catch (Exception ex)
+			{
+				App.Logger?.LogWarning(ex, "Failed to update the Recycle Bin desktop icon.");
+			}
 		}
 	}
 }

--- a/src/Files.App/Utils/Storage/Operations/FilesystemOperations.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemOperations.cs
@@ -550,6 +550,8 @@ namespace Files.App.Utils.Storage
 
 				if (!permanently)
 				{
+					StorageTrashBinService.UpdateDesktopRecycleBinIcon();
+
 					// Enumerate Recycle Bin
 					IEnumerable<ShellFileItem> nameMatchItems, items = await StorageTrashBinService.GetAllRecycleBinFoldersAsync();
 
@@ -564,6 +566,9 @@ namespace Files.App.Utils.Storage
 
 					return new StorageHistory(FileOperationType.Recycle, source, StorageHelpers.FromPathAndType(item?.RecyclePath, source.ItemType));
 				}
+
+				if (deleteFromRecycleBin)
+					StorageTrashBinService.UpdateDesktopRecycleBinIcon();
 
 				return new StorageHistory(FileOperationType.Delete, source, null);
 			}
@@ -784,6 +789,8 @@ namespace Files.App.Utils.Storage
 
 				await _associatedInstance.ShellViewModel.GetFileFromPathAsync(iFilePath, cancellationToken)
 					.OnSuccess(iFile => iFile.DeleteAsync(StorageDeleteOption.PermanentDelete).AsTask());
+
+				StorageTrashBinService.UpdateDesktopRecycleBinIcon();
 			}
 
 			fsProgress.ReportStatus(fsResult);

--- a/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
+++ b/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
@@ -393,6 +393,8 @@ namespace Files.App.Utils.Storage
 				var recycledSources = deleteResult.Items.Where(x => x.Succeeded && x.Destination is not null && x.Source != x.Destination);
 				if (recycledSources.Any())
 				{
+					StorageTrashBinService.UpdateDesktopRecycleBinIcon();
+
 					var sourceMatch = await recycledSources.Select(x => source.DistinctBy(x => x.Path)
 						.SingleOrDefault(s => s.Path.Equals(x.Source, StringComparison.OrdinalIgnoreCase))).Where(x => x is not null).ToListAsync();
 
@@ -402,6 +404,9 @@ namespace Files.App.Utils.Storage
 						await recycledSources.Zip(sourceMatch, (rSrc, oSrc) => new { rSrc, oSrc })
 							.Select(item => StorageHelpers.FromPathAndType(item.rSrc.Destination, item.oSrc.ItemType)).ToListAsync());
 				}
+
+				if (deleteFromRecycleBin)
+					StorageTrashBinService.UpdateDesktopRecycleBinIcon();
 
 				return new StorageHistory(FileOperationType.Delete, source, null);
 			}
@@ -780,6 +785,8 @@ namespace Files.App.Utils.Storage
 						.Select(src => StorageHelpers.FromPathAndType(
 							Path.Combine(Path.GetDirectoryName(src.rSrc.Source), Path.GetFileName(src.rSrc.Source).Replace("$R", "$I", StringComparison.Ordinal)),
 							src.oSrc.ItemType)).ToListAsync(), null, true, cancellationToken);
+
+					StorageTrashBinService.UpdateDesktopRecycleBinIcon();
 
 					return new StorageHistory(FileOperationType.Restore,
 						sourceMatch,


### PR DESCRIPTION
Fixes #9946

## Summary
The Windows desktop Recycle Bin icon now updates after recycle bin operations performed in Files.

- Added `UpdateDesktopRecycleBinIcon()` to `IStorageTrashBinService` and implemented it in `StorageTrashBinService` using the existing `SHUpdateRecycleBinIcon` P/Invoke
- Call icon refresh after: empty bin, restore all, send to recycle bin, restore items, and permanently delete from bin
- Fixed `RestoreAllTrashesInternal` to only refresh the icon and return success when `PerformOperations` succeeds

## Test plan
- [x] Move a file to the bin from Files → desktop icon shows full bin
- [x] Empty the bin from Files → desktop icon shows empty bin
- [x] Restore a file from the bin → desktop icon updates correctly
- [x] Permanently delete from the bin → desktop icon updates correctly
- [x] Restore all from the bin → desktop icon shows empty bin