### PR TITLE
Fix: Fixed issue with opening files from jar archives

### DIFF
--- a/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
+++ b/src/Files.App/Helpers/Navigation/NavigationHelpers.cs
@@ -759,6 +759,24 @@ namespace Files.App.Helpers
 									if (!launchSuccess)
 										await Win32Helper.InvokeWin32ComponentAsync(path, associatedInstance, args);
 								}
+								else if (childFile.Item is ZipStorageFile zipStorageFile)
+								{
+									var options = InitializeWithWindow(new LauncherOptions());
+									var storageItem = (StorageFile)await FilesystemTasks.Wrap(() => zipStorageFile.ToStorageFileAsync().AsTask());
+									if (storageItem is null)
+									{
+										await Win32Helper.InvokeWin32ComponentAsync(path, associatedInstance, args);
+									}
+									else if (!await Launcher.LaunchFileAsync(storageItem, options))
+									{
+										var pickerOptions = InitializeWithWindow(new LauncherOptions
+										{
+											DisplayApplicationPicker = true
+										});
+										if (!await Launcher.LaunchFileAsync(storageItem, pickerOptions))
+											await Win32Helper.InvokeWin32ComponentAsync(path, associatedInstance, args);
+									}
+								}
 								else
 								{
 									await Win32Helper.InvokeWin32ComponentAsync(path, associatedInstance, args);


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #18533

**Summary**

- Launch files inside browsable archives through their streamed `StorageFile` representation instead of passing the virtual archive path to the Win32 shell path.
- Initialize `LauncherOptions` with the Files window handle for the archive-entry launch path, matching the nearby user-initiated launcher flows.
- Keep the existing Win32 fallback if the WinRT file launch fails.
- Leave normal filesystem files and the existing image-specific neighboring-files flow unchanged.

**Why**

Files inside archives such as `.jar` have virtual paths like `archive.jar\path\File.class`. Passing that path to the Win32 shell does not point at a real filesystem item, so double-clicking non-image files inside `.jar` archives can do nothing. `ZipStorageFile.ToStorageFileAsync()` already materializes archive entries as streamed `StorageFile` objects, which is the launch path used for archive images.

**Steps used to test these changes**

1. Ran `git diff --check`.
2. Restored the missing server assets with `dotnet restore src\Files.App.Server\Files.App.Server.csproj -p:Platform=x64 --nologo`.
3. Ran `dotnet build src\Files.App\Files.App.csproj -c Debug -p:Platform=x64 --no-restore --nologo`; the build reached the app XAML compilation stage, then failed with `WMC9999` because the local XAML compiler package could not load `Microsoft.UI.Xaml.Markup.Compiler.ErrorMessages.resources`.
4. Compared the new archive-entry launch path with the existing image and app-picker launch paths in `NavigationHelpers.OpenFile`.