### PR TITLE
Feature: Add User Folders section to the sidebar

### DIFF
--- a/src/Files.App/Data/Contracts/IGeneralSettingsService.cs
+++ b/src/Files.App/Data/Contracts/IGeneralSettingsService.cs
@@ -196,6 +196,16 @@ namespace Files.App.Data.Contracts
 		bool IsFileTagsSectionExpanded { get; set; }
 
 		/// <summary>
+		/// Gets or sets a value indicating if the user folders section should be visible.
+		/// </summary>
+		bool ShowUserFoldersSection { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating if the user folders section should be expanded.
+		/// </summary>
+		bool IsUserFoldersSectionExpanded { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating whether or not to move shell extensions into a sub menu.
 		/// </summary>
 		bool MoveShellExtensionsToSubMenu { get; set; }

--- a/src/Files.App/Data/Contracts/INavigationControlItem.cs
+++ b/src/Files.App/Data/Contracts/INavigationControlItem.cs
@@ -35,7 +35,8 @@ namespace Files.App.Data.Contracts
 		CloudDrives,
 		Network,
 		WSL,
-		FileTag
+		FileTag,
+		UserFolders
 	}
 
 	public sealed class ContextMenuOptions

--- a/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
+++ b/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
@@ -112,6 +112,7 @@ namespace Files.App.Helpers
 			_ = Task.Run(async () =>
 			{
 				await Task.WhenAll(
+					OptionalTaskAsync(UserFoldersManager.UpdateUserFoldersAsync(), generalSettingsService.ShowUserFoldersSection),
 					OptionalTaskAsync(CloudDrivesManager.UpdateDrivesAsync(), generalSettingsService.ShowCloudDrivesSection),
 					App.LibraryManager.UpdateLibrariesAsync(),
 					OptionalTaskAsync(WSLDistroManager.UpdateDrivesAsync(), generalSettingsService.ShowWslSection),

--- a/src/Files.App/Helpers/UI/UIHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIHelpers.cs
@@ -146,7 +146,8 @@ namespace Files.App.Helpers
 					Constants.ImageRes.Libraries,
 					Constants.ImageRes.ThisPC,
 					Constants.ImageRes.CloudDrives,
-					Constants.ImageRes.Folder
+					Constants.ImageRes.Folder,
+					Constants.ImageRes.QuickAccess
 				}, 32);
 
 			return imageResList;

--- a/src/Files.App/Services/Settings/GeneralSettingsService.cs
+++ b/src/Files.App/Services/Settings/GeneralSettingsService.cs
@@ -239,6 +239,18 @@ namespace Files.App.Services.Settings
 			set => Set(value);
 		}
 
+		public bool ShowUserFoldersSection
+		{
+			get => Get(false);
+			set => Set(value);
+		}
+
+		public bool IsUserFoldersSectionExpanded
+		{
+			get => Get(true);
+			set => Set(value);
+		}
+
 		public bool MoveShellExtensionsToSubMenu
 		{
 			get => Get(true);

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -1244,6 +1244,9 @@
   <data name="Pinned" xml:space="preserve">
     <value>Pinned</value>
   </data>
+  <data name="UserFolders" xml:space="preserve">
+    <value>User Folders</value>
+  </data>
   <data name="SidebarLibraries" xml:space="preserve">
     <value>Libraries</value>
   </data>

--- a/src/Files.App/Utils/Global/UserFoldersManager.cs
+++ b/src/Files.App/Utils/Global/UserFoldersManager.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+using System.Collections.Specialized;
+using System.IO;
+
+namespace Files.App.Utils
+{
+	/// <summary>
+	/// Resolves the current user's standard Windows known folders (Desktop, Documents, Downloads,
+	/// Pictures, Music and Videos) and exposes them as sidebar locations.
+	/// </summary>
+	/// <remarks>
+	/// Paths are resolved through the Windows Known Folder / Shell APIs (see <see cref="WindowsFolder"/>),
+	/// so redirected folders (e.g. OneDrive-backed, domain-redirected or moved to another drive) point at
+	/// their real location instead of a hard-coded <c>C:\Users\&lt;user&gt;\…</c> path.
+	/// </remarks>
+	public static class UserFoldersManager
+	{
+		private static readonly ILogger? logger = Ioc.Default.GetService<ILogger<App>>();
+
+		public static EventHandler<NotifyCollectionChangedEventArgs>? DataChanged;
+
+		// The standard user known folders shown in the "User Folders" section, in display order.
+		// The GUIDs are the canonical Windows KNOWNFOLDERID values.
+		private static readonly Guid[] _knownFolderIds =
+		[
+			new("B4BFCC3A-DB2C-424C-B029-7FE99A87C641"), // FOLDERID_Desktop
+			new("FDD39AD0-238F-46AF-ADB4-6C85480369C7"), // FOLDERID_Documents
+			new("374DE290-123F-4565-9164-39C4925E467B"), // FOLDERID_Downloads
+			new("33E28130-4E1E-4676-835A-98395C3BC3BB"), // FOLDERID_Pictures
+			new("4BD8D571-6D19-48D3-BE97-422220080E43"), // FOLDERID_Music
+			new("18989B1D-99B5-455B-841C-AB7C74E4DDFC"), // FOLDERID_Videos
+		];
+
+		private static readonly List<INavigationControlItem> _userFolders = [];
+		public static IReadOnlyList<INavigationControlItem> UserFolderItems
+		{
+			get
+			{
+				lock (_userFolders)
+					return _userFolders.ToList().AsReadOnly();
+			}
+		}
+
+		/// <summary>
+		/// Resolves the known folders and adds them to the sidebar section.
+		/// </summary>
+		public static async Task UpdateUserFoldersAsync()
+		{
+			// The section is hidden by default; only do the work when it is enabled.
+			if (!Ioc.Default.GetRequiredService<IUserSettingsService>().GeneralSettingsService.ShowUserFoldersSection)
+				return;
+
+			// Resolving known folders through the Shell touches disk, so keep it off the UI thread.
+			await Task.Run(() =>
+			{
+				foreach (var folderId in _knownFolderIds)
+				{
+					string path;
+					string name;
+
+					try
+					{
+						// Resolve through the Shell so the real (possibly redirected) path is used.
+						using var shellFolder = new WindowsFolder(folderId);
+						path = shellFolder.Id;
+						name = shellFolder.Name;
+					}
+					catch (Exception ex)
+					{
+						logger?.LogInformation(ex, "Failed to resolve known folder {FolderId}.", folderId);
+						continue;
+					}
+
+					// Skip folders that can't be resolved or no longer exist on disk.
+					if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+						continue;
+
+					var locationItem = new LocationItem()
+					{
+						Text = string.IsNullOrEmpty(name) ? Path.GetFileName(path.TrimEnd('\\')) : name,
+						Path = path,
+						Section = SectionType.UserFolders,
+						IsDefaultLocation = false,
+						MenuOptions = new ContextMenuOptions()
+						{
+							IsLocationItem = true,
+							ShowProperties = true,
+							ShowShellItems = true,
+							// These are standard user folders, not pinned items, so no "Unpin from sidebar".
+							ShowUnpinItem = false,
+						},
+					};
+
+					lock (_userFolders)
+					{
+						// Avoid duplicates when two known folders resolve to the same path.
+						if (_userFolders.Any(x => string.Equals(x.Path, path, StringComparison.OrdinalIgnoreCase)))
+							continue;
+
+						_userFolders.Add(locationItem);
+					}
+
+					_ = LoadIconAsync(locationItem);
+
+					DataChanged?.Invoke(
+						SectionType.UserFolders,
+						new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, locationItem));
+				}
+			});
+		}
+
+		private static async Task LoadIconAsync(LocationItem locationItem)
+		{
+			try
+			{
+				var iconData = await FileThumbnailHelper.GetIconAsync(
+					locationItem.Path,
+					Constants.ShellIconSizes.Small,
+					true,
+					IconOptions.ReturnIconOnly | IconOptions.UseCurrentScale);
+
+				if (iconData is null)
+					return;
+
+				locationItem.IconData = iconData;
+
+				await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async ()
+					=> locationItem.Icon = await iconData.ToBitmapAsync());
+			}
+			catch (Exception ex)
+			{
+				logger?.LogWarning(ex, "Failed to load icon for user folder {Path}.", locationItem.Path);
+			}
+		}
+	}
+}

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -74,6 +74,7 @@ namespace Files.App.ViewModels.UserControls
 		private readonly SectionType[] SectionOrder =
 			[
 				SectionType.Home,
+				SectionType.UserFolders,
 				SectionType.Pinned,
 				SectionType.Library,
 				SectionType.Drives,
@@ -139,6 +140,7 @@ namespace Files.App.ViewModels.UserControls
 		}
 
 		public bool AreSectionsHidden =>
+			!ShowUserFoldersSection &&
 			!ShowPinnedFoldersSection &&
 			!ShowLibrarySection &&
 			!ShowDrivesSection &&
@@ -147,6 +149,18 @@ namespace Files.App.ViewModels.UserControls
 			(!ShowWslSection || WSLDistroManager.Distros.Any() == false) &&
 			!ShowFileTagsSection &&
 			SidebarDisplayMode is not SidebarDisplayMode.Compact;
+
+		public bool ShowUserFoldersSection
+		{
+			get => UserSettingsService.GeneralSettingsService.ShowUserFoldersSection;
+			set
+			{
+				if (value == UserSettingsService.GeneralSettingsService.ShowUserFoldersSection)
+					return;
+
+				UserSettingsService.GeneralSettingsService.ShowUserFoldersSection = value;
+			}
+		}
 
 		public bool ShowPinnedFoldersSection
 		{
@@ -258,6 +272,7 @@ namespace Files.App.ViewModels.UserControls
 			UserSettingsService.OnSettingChangedEvent += UserSettingsService_OnSettingChangedEvent;
 			CreateItemHomeAsync();
 
+			Manager_DataChanged(SectionType.UserFolders, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 			Manager_DataChanged(SectionType.Pinned, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 			Manager_DataChanged(SectionType.Library, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 			Manager_DataChanged(SectionType.Drives, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
@@ -266,6 +281,7 @@ namespace Files.App.ViewModels.UserControls
 			Manager_DataChanged(SectionType.WSL, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 			Manager_DataChanged(SectionType.FileTag, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 
+			UserFoldersManager.DataChanged += Manager_DataChanged;
 			App.QuickAccessManager.Model.DataChanged += Manager_DataChanged;
 			App.LibraryManager.DataChanged += Manager_DataChanged;
 			drivesViewModel.Drives.CollectionChanged += Manager_DataChangedForDrives;
@@ -299,6 +315,7 @@ namespace Files.App.ViewModels.UserControls
 				var section = await GetOrCreateSectionAsync(sectionType);
 				Func<IReadOnlyList<INavigationControlItem>> getElements = () => sectionType switch
 				{
+					SectionType.UserFolders => UserFoldersManager.UserFolderItems,
 					SectionType.Pinned => App.QuickAccessManager.Model.PinnedFolderItems,
 					SectionType.CloudDrives => CloudDrivesManager.Drives,
 					SectionType.Drives => drivesViewModel.Drives.Cast<DriveItem>().ToList().AsReadOnly(),
@@ -430,6 +447,9 @@ namespace Files.App.ViewModels.UserControls
 			{
 				switch (section.Text)
 				{
+					case var text when text == Strings.UserFolders.GetLocalizedResource():
+						UserSettingsService.GeneralSettingsService.IsUserFoldersSectionExpanded = section.IsExpanded;
+						break;
 					case var text when text == Strings.Pinned.GetLocalizedResource():
 						UserSettingsService.GeneralSettingsService.IsPinnedSectionExpanded = section.IsExpanded;
 						break;
@@ -480,6 +500,21 @@ namespace Files.App.ViewModels.UserControls
 						section.Path = "Home";
 						section.Icon = new BitmapImage(new Uri(Constants.FluentIconsPaths.HomeIcon));
 						section.IsHeader = true;
+
+						break;
+					}
+
+				case SectionType.UserFolders:
+					{
+						if (ShowUserFoldersSection == false)
+						{
+							break;
+						}
+
+						section = BuildSection(Strings.UserFolders.GetLocalizedResource(), sectionType, new ContextMenuOptions { ShowHideSection = true }, false);
+						iconIdex = Constants.ImageRes.QuickAccess;
+						section.IsHeader = true;
+						section.IsExpanded = UserSettingsService.GeneralSettingsService.IsUserFoldersSectionExpanded;
 
 						break;
 					}
@@ -628,6 +663,7 @@ namespace Files.App.ViewModels.UserControls
 
 				Func<Task> action = sectionType switch
 				{
+					SectionType.UserFolders when generalSettingsService.ShowUserFoldersSection => UserFoldersManager.UpdateUserFoldersAsync,
 					SectionType.CloudDrives when generalSettingsService.ShowCloudDrivesSection => CloudDrivesManager.UpdateDrivesAsync,
 					SectionType.Drives => drivesViewModel.UpdateDrivesAsync,
 					SectionType.Network when generalSettingsService.ShowNetworkSection => NetworkService.UpdateComputersAsync,
@@ -657,6 +693,11 @@ namespace Files.App.ViewModels.UserControls
 					{
 						OnPropertyChanged(nameof(IsSidebarOpen));
 					}
+					break;
+				case nameof(UserSettingsService.GeneralSettingsService.ShowUserFoldersSection):
+					await UpdateSectionVisibilityAsync(SectionType.UserFolders, ShowUserFoldersSection);
+					OnPropertyChanged(nameof(ShowUserFoldersSection));
+					OnPropertyChanged(nameof(AreSectionsHidden));
 					break;
 				case nameof(UserSettingsService.GeneralSettingsService.ShowPinnedSection):
 					await UpdateSectionVisibilityAsync(SectionType.Pinned, ShowPinnedFoldersSection);
@@ -700,6 +741,7 @@ namespace Files.App.ViewModels.UserControls
 		{
 			UserSettingsService.OnSettingChangedEvent -= UserSettingsService_OnSettingChangedEvent;
 
+			UserFoldersManager.DataChanged -= Manager_DataChanged;
 			App.QuickAccessManager.Model.DataChanged -= Manager_DataChanged;
 			App.LibraryManager.DataChanged -= Manager_DataChanged;
 			drivesViewModel.Drives.CollectionChanged -= Manager_DataChangedForDrives;
@@ -909,6 +951,9 @@ namespace Files.App.ViewModels.UserControls
 		{
 			switch (rightClickedItem.Section)
 			{
+				case SectionType.UserFolders:
+					UserSettingsService.GeneralSettingsService.ShowUserFoldersSection = false;
+					break;
 				case SectionType.Pinned:
 					UserSettingsService.GeneralSettingsService.ShowPinnedSection = false;
 					break;

--- a/src/Files.App/Views/MainPage.xaml
+++ b/src/Files.App/Views/MainPage.xaml
@@ -57,6 +57,7 @@
 
 
 			<MenuFlyout x:Key="SidebarContextMenu">
+				<ToggleMenuFlyoutItem IsChecked="{x:Bind SidebarAdaptiveViewModel.ShowUserFoldersSection, Mode=TwoWay}" Text="{helpers:ResourceString Name=UserFolders}" />
 				<ToggleMenuFlyoutItem IsChecked="{x:Bind SidebarAdaptiveViewModel.ShowPinnedFoldersSection, Mode=TwoWay}" Text="{helpers:ResourceString Name=Pinned}" />
 				<ToggleMenuFlyoutItem IsChecked="{x:Bind SidebarAdaptiveViewModel.ShowLibrarySection, Mode=TwoWay}" Text="{helpers:ResourceString Name=SidebarLibraries}" />
 				<ToggleMenuFlyoutItem IsChecked="{x:Bind SidebarAdaptiveViewModel.ShowDrivesSection, Mode=TwoWay}" Text="{helpers:ResourceString Name=Drives}" />


### PR DESCRIPTION
## ✨ Summary

Adds a dedicated **User Folders** section to the sidebar for standard Windows folders:

- Desktop
- Documents
- Downloads
- Pictures
- Music
- Videos

These folders are resolved through Windows known folders instead of manually building paths from the user profile directory.

## 🎯 Motivation

Currently, users need to pin these folders manually if they want quick access to them. This mixes standard Windows user folders with custom pinned locations, which makes the Pinned section less useful.

This PR separates those concepts:

- **User Folders**: standard Windows folders
- **Pinned**: user-managed shortcuts

This keeps the sidebar cleaner while preserving existing pinned items.

## 🧭 Behavior

- Adds a new sidebar section for User Folders.
- The section can be shown or hidden from the sidebar context menu, consistent with the other sidebar categories.
- Resolves the actual folder paths from Windows known folders.
- Uses the system-provided known folder display names, so folder labels follow the user's Windows language.
- Supports folders moved to another drive, redirected folders, and OneDrive-backed locations.
- Does not automatically pin or unpin anything.
- Existing pinned items remain unchanged.

## 🖼️ Screenshots

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/10b442e9-3232-4735-a7b7-041659457034" />
> Note: The folder names in the screenshot are shown in French because the Windows user profile is configured in French. The section uses the system-provided known folder display names, so these labels follow the user's Windows language.

## ✅ Testing

- Built and launched the app locally.
- Verified the User Folders section appears in the sidebar.
- Verified navigation to Desktop, Documents, Downloads, Pictures, Music, and Videos.
- Verified folders moved to another drive resolve to their actual path.
- Verified existing pinned items are not modified.
- Verified the Pinned section remains separate from User Folders.