### PR TITLE
Code Quality: Improved Tree View IO

### DIFF
--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.FlatTree.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.FlatTree.cs
@@ -323,14 +323,20 @@ namespace Files.App.ViewModels.UserControls
 				FlatSidebarItems.InsertRange(insertAt, batch);
 				return;
 			}
+			var currentInsertAt = insertAt;
 			for (int i = 0; i < batch.Count; i += FlatTreeInsertChunkSize)
 			{
 				var chunkEnd = Math.Min(i + FlatTreeInsertChunkSize, batch.Count);
 				var chunk = batch.GetRange(i, chunkEnd - i);
 				RegisterNodes(chunk);
-				FlatSidebarItems.InsertRange(insertAt + i, chunk);
+				FlatSidebarItems.InsertRange(currentInsertAt, chunk);
 				if (chunkEnd < batch.Count)
+				{
 					await Task.Delay(1);
+					currentInsertAt = FlatSidebarItems.IndexOf(batch[chunkEnd - 1]) + 1;
+					if (currentInsertAt <= 0)
+						return;
+				}
 			}
 		}
 


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where rapidly expanding multiple folders on slow IO could cause sidebar items to appear in the wrong order. 

**Steps used to test these changes**
1. Expand a folder with more than 100 subfolders to trigger the chunked insert path
2. Rapidly expand multiple folders in quick succession while on a slow drive
3. Verify sidebar items appear in the correct alphabetical order after all expansions settle
4. Collapse and re-expand to confirm ordering is stable