### PR TITLE
Feature: Added option to calculate folder size on demand

### DIFF
--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -280,10 +280,38 @@ namespace Files.App.Utils
 			{
 				SetProperty(ref fileSize, value);
 				OnPropertyChanged(nameof(FileSizeDisplay));
+				OnPropertyChanged(nameof(ShowViewSizeButton));
+				OnPropertyChanged(nameof(SizeText));
 			}
 		}
 
 		public string FileSizeDisplay => string.IsNullOrEmpty(FileSize) ? Strings.ItemSizeNotCalculated.GetLocalizedResource() : FileSize;
+
+		public bool ShowViewSizeButton => !IsCalculatingSize && string.IsNullOrEmpty(FileSize) && PrimaryItemAttribute == StorageItemTypes.Folder;
+
+		public string SizeText => ShowCalculatingText ? Strings.Calculating.GetLocalizedResource() : FileSize;
+
+		private bool isCalculatingSize;
+		public bool IsCalculatingSize
+		{
+			get => isCalculatingSize;
+			set
+			{
+				SetProperty(ref isCalculatingSize, value);
+				OnPropertyChanged(nameof(ShowViewSizeButton));
+			}
+		}
+
+		private bool showCalculatingText;
+		public bool ShowCalculatingText
+		{
+			get => showCalculatingText;
+			set
+			{
+				SetProperty(ref showCalculatingText, value);
+				OnPropertyChanged(nameof(SizeText));
+			}
+		}
 
 		public long FileSizeBytes { get; set; }
 

--- a/src/Files.App/Services/SizeProvider/CachedSizeProvider.cs
+++ b/src/Files.App/Services/SizeProvider/CachedSizeProvider.cs
@@ -23,14 +23,8 @@ namespace Files.App.Services.SizeProvider
 		public async Task UpdateAsync(string path, CancellationToken cancellationToken)
 		{
 			await Task.Yield();
-			if (sizes.TryGetValue(path, out ulong cachedSize))
-			{
-				RaiseSizeChanged(path, cachedSize, SizeChangedValueState.Final);
-			}
-			else
-			{
+			if (!sizes.ContainsKey(path))
 				RaiseSizeChanged(path, 0, SizeChangedValueState.None);
-			}
 
 			var stopwatch = Stopwatch.StartNew();
 			ulong size = await Calculate(path);

--- a/src/Files.App/Services/SizeProvider/UserSizeProvider.cs
+++ b/src/Files.App/Services/SizeProvider/UserSizeProvider.cs
@@ -41,7 +41,7 @@ namespace Files.App.Services
 		}
 
 		private ISizeProvider GetProvider()
-			=> folderPreferences.CalculateFolderSizes ? new DrivesSizeProvider() : new NoSizeProvider();
+			=> new DrivesSizeProvider();
 
 		private async void FolderPreferences_PropertyChanged(object sender, PropertyChangedEventArgs e)
 		{

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -1196,6 +1196,9 @@
   <data name="ItemSizeNotCalculated" xml:space="preserve">
     <value>Not calculated</value>
   </data>
+  <data name="ViewSize" xml:space="preserve">
+    <value>View size</value>
+  </data>
   <data name="CloudDriveSyncStatus_Unknown" xml:space="preserve">
     <value>Unknown</value>
   </data>

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -654,12 +654,18 @@ namespace Files.App.ViewModels
 						if (e.ValueState is SizeChangedValueState.None)
 						{
 							matchingItem.FileSizeBytes = 0;
-							matchingItem.FileSize = Strings.ItemSizeNotCalculated.GetLocalizedResource();
+							matchingItem.IsCalculatingSize = true;
+							matchingItem.ShowCalculatingText = true;
 						}
 						else if (e.ValueState is SizeChangedValueState.Final || (long)e.NewSize > matchingItem.FileSizeBytes)
 						{
 							matchingItem.FileSizeBytes = (long)e.NewSize;
 							matchingItem.FileSize = e.NewSize.ToSizeString();
+							if (e.ValueState is SizeChangedValueState.Final)
+							{
+								matchingItem.ShowCalculatingText = false;
+								matchingItem.IsCalculatingSize = false;
+							}
 						}
 
 						DirectoryInfoUpdated?.Invoke(this, EventArgs.Empty);

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml
@@ -1268,8 +1268,6 @@
 											FontFamily="{ThemeResource ContentControlThemeFontFamily}"
 											FontSize="{StaticResource CaptionTextBlockFontSize}"
 											FontWeight="Normal"
-											Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-											Opacity="0.6"
 											Visibility="{x:Bind ShowViewSizeButton, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
 									</Grid>
 

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml
@@ -1246,17 +1246,32 @@
 										Visibility="{Binding ColumnsViewModel.ItemTypeColumn.Visibility, ElementName=PageRoot, Mode=OneWay}" />
 
 									<!--  Item Size  -->
-									<TextBlock
+									<Grid
 										x:Name="ItemSize"
 										Width="{Binding ColumnsViewModel.SizeColumn.LengthIncludingGridSplitter.Value, ElementName=PageRoot, Mode=OneWay}"
 										Padding="10,0,0,0"
 										HorizontalAlignment="Stretch"
 										VerticalAlignment="Center"
-										DataContextChanged="TextBlock_DataContextChanged"
-										IsTextTrimmedChanged="TextBlock_IsTextTrimmedChanged"
-										Style="{StaticResource ColumnContentTextBlock}"
-										Text="{x:Bind FileSize, Mode=OneWay}"
-										Visibility="{Binding ColumnsViewModel.SizeColumn.Visibility, ElementName=PageRoot, Mode=OneWay}" />
+										Visibility="{Binding ColumnsViewModel.SizeColumn.Visibility, ElementName=PageRoot, Mode=OneWay}">
+										<TextBlock
+											DataContextChanged="TextBlock_DataContextChanged"
+											IsTextTrimmedChanged="TextBlock_IsTextTrimmedChanged"
+											Style="{StaticResource ColumnContentTextBlock}"
+											Text="{x:Bind SizeText, Mode=OneWay}"
+											Visibility="{x:Bind ShowViewSizeButton, Mode=OneWay, Converter={StaticResource NegatedBoolToVisibilityConverter}}" />
+										<HyperlinkButton
+											Padding="0"
+											HorizontalAlignment="Left"
+											VerticalAlignment="Center"
+											Click="ViewSizeButton_Click"
+											Content="{helpers:ResourceString Name=ViewSize}"
+											FontFamily="{ThemeResource ContentControlThemeFontFamily}"
+											FontSize="{StaticResource CaptionTextBlockFontSize}"
+											FontWeight="Normal"
+											Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+											Opacity="0.6"
+											Visibility="{x:Bind ShowViewSizeButton, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+									</Grid>
 
 									<!--  Item Sync Status Badge  -->
 									<Border

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml.cs
@@ -1075,6 +1075,28 @@ namespace Files.App.Views.Layouts
 			ToolTipService.SetToolTip(textBlock, textBlock.IsTextTrimmed ? textBlock.Text : null);
 		}
 
+		private async void ViewSizeButton_Click(object sender, RoutedEventArgs e)
+		{
+			if (sender is not FrameworkElement { DataContext: ListedItem item })
+				return;
+
+			item.IsCalculatingSize = true;
+			var sizeProvider = Ioc.Default.GetRequiredService<Services.SizeProvider.ISizeProvider>();
+			var updateTask = Task.Run(() => sizeProvider.UpdateAsync(item.ItemPath, default));
+
+			try
+			{
+				if (await Task.WhenAny(updateTask, Task.Delay(300)) != updateTask)
+					item.ShowCalculatingText = true;
+				await updateTask;
+			}
+			finally
+			{
+				item.ShowCalculatingText = false;
+				item.IsCalculatingSize = false;
+			}
+		}
+
 		private void FileList_LosingFocus(UIElement sender, LosingFocusEventArgs args)
 		{
 			// Fixes an issue where clicking an empty space would scroll to the top of the file list


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #13752

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed 'View size' option shows for folders
2. Confirmed clicking 'View size' calculates the folder size
3. Confirmed placeholder 'Calculating...' text is displayed while larger sizes are calculated
4. Confirmed the option to always calculate folder sizes works properly