### PR TITLE
Fix: resolve incorrect sorting for files by tags

### DIFF
--- a/src/Files.App/Utils/Storage/Collection/SortingHelper.cs
+++ b/src/Files.App/Utils/Storage/Collection/SortingHelper.cs
@@ -20,7 +20,7 @@ namespace Files.App.Utils.Storage
 				SortOption.FileType => item => item.ItemType,
 				SortOption.Size => item => item.FileSizeBytes,
 				SortOption.SyncStatus => item => item.SyncStatusString,
-				SortOption.FileTag => item => item.FileTags?.FirstOrDefault(),
+				SortOption.FileTag => item => item.FileTags?.FirstOrDefault()?.Text,
 				SortOption.Path => item => item.ItemPath,
 				SortOption.OriginalFolder => item => (item as RecycleBinItem)?.ItemOriginalFolder,
 				SortOption.DateDeleted => item => (item as RecycleBinItem)?.ItemDateDeletedReal,
@@ -28,68 +28,68 @@ namespace Files.App.Utils.Storage
 			};
 		}
 
-		public static IEnumerable<ListedItem> OrderFileList(IList<ListedItem> filesAndFolders, SortOption directorySortOption, SortDirection directorySortDirection,
-			bool sortDirectoriesAlongsideFiles, bool sortFilesFirst)
-		{
-			var orderFunc = GetSortFunc(directorySortOption);
-			var naturalStringComparer = NaturalStringComparer.GetForProcessor();
+            public static IEnumerable<ListedItem> OrderFileList(IList<ListedItem> filesAndFolders, SortOption directorySortOption, SortDirection directorySortDirection,
+            bool sortDirectoriesAlongsideFiles, bool sortFilesFirst)
+        {
+            var orderFunc = GetSortFunc(directorySortOption);
+            var naturalStringComparer = NaturalStringComparer.GetForProcessor();
 
-			// Function to prioritize folders (if sortFilesFirst is false) or files (if sortFilesFirst is true)
-			bool PrioritizeFilesOrFolders(ListedItem listedItem)
-				=> (listedItem.PrimaryItemAttribute == StorageItemTypes.File || listedItem.IsShortcut || listedItem.IsArchive) ^ sortFilesFirst;
+            // Function to prioritize folders (if sortFilesFirst is false) or files (if sortFilesFirst is true)
+            bool PrioritizeFilesOrFolders(ListedItem listedItem)
+                => (listedItem.PrimaryItemAttribute == StorageItemTypes.File || listedItem.IsShortcut || listedItem.IsArchive) ^ sortFilesFirst;
 
-			IOrderedEnumerable<ListedItem> ordered;
+            IOrderedEnumerable<ListedItem> ordered;
 
-			if (directorySortDirection == SortDirection.Ascending)
-			{
-				ordered = directorySortOption switch
-				{
-					SortOption.Name => sortDirectoriesAlongsideFiles
-						? filesAndFolders.OrderBy(orderFunc, naturalStringComparer)
-						: filesAndFolders.OrderBy(PrioritizeFilesOrFolders).ThenBy(orderFunc, naturalStringComparer),
+            if (directorySortDirection == SortDirection.Ascending)
+            {
+                ordered = directorySortOption switch
+                {
+                    SortOption.Name => sortDirectoriesAlongsideFiles
+                        ? filesAndFolders.OrderBy(orderFunc, naturalStringComparer)
+                        : filesAndFolders.OrderBy(PrioritizeFilesOrFolders).ThenBy(orderFunc, naturalStringComparer),
 
-					SortOption.FileTag => sortDirectoriesAlongsideFiles
-						? filesAndFolders.OrderBy(x => string.IsNullOrEmpty(orderFunc(x) as string)).ThenBy(orderFunc)
-						: filesAndFolders.OrderBy(PrioritizeFilesOrFolders)
-							.ThenBy(x => string.IsNullOrEmpty(orderFunc(x) as string))
-							.ThenBy(orderFunc),
+                    SortOption.FileTag => sortDirectoriesAlongsideFiles
+                        ? filesAndFolders.OrderBy(x => string.IsNullOrEmpty(orderFunc(x) as string)).ThenBy(orderFunc, naturalStringComparer)
+                        : filesAndFolders.OrderBy(PrioritizeFilesOrFolders)
+                            .ThenBy(x => string.IsNullOrEmpty(orderFunc(x) as string))
+                            .ThenBy(orderFunc, naturalStringComparer),
 
-					_ => sortDirectoriesAlongsideFiles
-						? filesAndFolders.OrderBy(orderFunc)
-						: filesAndFolders.OrderBy(PrioritizeFilesOrFolders).ThenBy(orderFunc)
-				};
-			}
-			else
-			{
-				ordered = directorySortOption switch
-				{
-					SortOption.Name => sortDirectoriesAlongsideFiles
-						? filesAndFolders.OrderByDescending(orderFunc, naturalStringComparer)
-						: filesAndFolders.OrderBy(PrioritizeFilesOrFolders)
-							.ThenByDescending(orderFunc, naturalStringComparer),
+                    _ => sortDirectoriesAlongsideFiles
+                        ? filesAndFolders.OrderBy(orderFunc)
+                        : filesAndFolders.OrderBy(PrioritizeFilesOrFolders).ThenBy(orderFunc)
+                };
+            }
+            else
+            {
+                ordered = directorySortOption switch
+                {
+                    SortOption.Name => sortDirectoriesAlongsideFiles
+                        ? filesAndFolders.OrderByDescending(orderFunc, naturalStringComparer)
+                        : filesAndFolders.OrderBy(PrioritizeFilesOrFolders)
+                            .ThenByDescending(orderFunc, naturalStringComparer),
 
-					SortOption.FileTag => sortDirectoriesAlongsideFiles
-						? filesAndFolders.OrderBy(x => string.IsNullOrEmpty(orderFunc(x) as string))
-							.ThenByDescending(orderFunc)
-						: filesAndFolders.OrderBy(PrioritizeFilesOrFolders)
-							.ThenBy(x => string.IsNullOrEmpty(orderFunc(x) as string))
-							.ThenByDescending(orderFunc),
+                    SortOption.FileTag => sortDirectoriesAlongsideFiles
+                        ? filesAndFolders.OrderBy(x => string.IsNullOrEmpty(orderFunc(x) as string))
+                            .ThenByDescending(orderFunc, naturalStringComparer)
+                        : filesAndFolders.OrderBy(PrioritizeFilesOrFolders)
+                            .ThenBy(x => string.IsNullOrEmpty(orderFunc(x) as string))
+                            .ThenByDescending(orderFunc, naturalStringComparer),
 
-					_ => sortDirectoriesAlongsideFiles
-						? filesAndFolders.OrderByDescending(orderFunc)
-						: filesAndFolders.OrderBy(PrioritizeFilesOrFolders).ThenByDescending(orderFunc)
-				};
-			}
+                    _ => sortDirectoriesAlongsideFiles
+                        ? filesAndFolders.OrderByDescending(orderFunc)
+                        : filesAndFolders.OrderBy(PrioritizeFilesOrFolders).ThenByDescending(orderFunc)
+                };
+            }
 
-			// Further order by name if applicable
-			if (directorySortOption != SortOption.Name)
-			{
-				ordered = directorySortDirection == SortDirection.Ascending
-					? ordered.ThenBy(OrderByNameFunc, naturalStringComparer)
-					: ordered.ThenByDescending(OrderByNameFunc, naturalStringComparer);
-			}
+            // Further order by name if applicable
+            if (directorySortOption != SortOption.Name)
+            {
+                ordered = directorySortDirection == SortDirection.Ascending
+                    ? ordered.ThenBy(OrderByNameFunc, naturalStringComparer)
+                    : ordered.ThenByDescending(OrderByNameFunc, naturalStringComparer);
+            }
 
-			return ordered;
-		}
+            return ordered;
+        }
 	}
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #18583

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Built the project locally via `dotnet build` to ensure code integrity.
2. Verified the fix in `SortingHelper.cs` to ensure that `FileTag` sorting logic correctly extracts the tag text.
3. Implemented `naturalStringComparer` to ensure consistent alphanumeric sorting for tags.
4. Confirmed through manual verification that sorting by Tags groups files correctly and respects ascending/descending order.