### PR TITLE
Fix: Fixed issue where opening shell flyouts sometimes closed the context menu

### DIFF
--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -821,6 +821,11 @@ namespace Files.App.Views.Layouts
 				overflowShellMenuItemsUnfiltered[i + 1 < overflowShellMenuItemsUnfiltered.Count ? i + 1 : i].ItemType != ContextMenuFlyoutItemType.Separator)
 				|| x.ItemType != ContextMenuFlyoutItemType.Separator).ToList();
 
+			var subMenuLoadTasks = mainShellMenuItems.Concat(overflowShellMenuItems)
+				.Where(x => x.LoadSubMenuAction is not null)
+				.Select(x => x.LoadSubMenuAction());
+			await Task.WhenAll(subMenuLoadTasks);
+
 			var overflowItems = ContextFlyoutModelToElementHelper.GetMenuFlyoutItemsFromModel(overflowShellMenuItems);
 			var mainItems = ContextFlyoutModelToElementHelper.GetAppBarButtonsFromModelIgnorePrimary(mainShellMenuItems);
 


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where clicking a first-level shell extension context menu item (e.g. NanaZip, 7-Zip, WinRAR, TortoiseGit) caused the entire context menu to close instead of opening the sub-menu.

Closes #18475

**Steps used to test these changes**
1. Install any shell extension that adds a context menu entry with sub-items (e.g. 7-Zip, WinRAR, NanaZip, TortoiseGit)
2. Right-click a file in the Files app
3. Click directly on the shell extension item (e.g. "7-Zip") and verify the sub-menu opens instead of the context menu closing
4. Verify hover still opens the sub-menu as before