### PR TITLE
Feature: Added right click menu to open breadcrumbs in a new tab

### DIFF
--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.Events.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.Events.cs
@@ -19,6 +19,12 @@ namespace Files.App.Controls
 				FlyoutBase.ShowAttachedFlyout(_itemChevronButton);
 		}
 
+		private void ItemChevronButton_RightTapped(object sender, RightTappedRoutedEventArgs e)
+		{
+			// Stop bubbling so the BreadcrumbBarItem's RightTapped doesn't open a context menu over the chevron.
+			e.Handled = true;
+		}
+
 		private void ItemContentButton_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
 		{
 			if (e.Key == VirtualKey.Down)

--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.cs
@@ -54,6 +54,10 @@ namespace Files.App.Controls
 				PointerReleasedEvent,
 				new PointerEventHandler((s, e) =>
 				{
+					// Skip right-button releases so RightTapped can drive the context menu without also navigating
+					if (e.GetCurrentPoint(null).Properties.PointerUpdateKind is PointerUpdateKind.RightButtonReleased)
+						return;
+
 					OnItemClicked(e);
 					e.Handled = true;
 				}),

--- a/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.cs
+++ b/src/Files.App.Controls/BreadcrumbBar/BreadcrumbBarItem.cs
@@ -66,6 +66,7 @@ namespace Files.App.Controls
 			_itemContentButton.PreviewKeyDown += ItemContentButton_PreviewKeyDown;
 			_itemChevronButton.Click += ItemChevronButton_Click;
 			_itemChevronButton.PreviewKeyDown += ItemChevronButton_PreviewKeyDown;
+			_itemChevronButton.RightTapped += ItemChevronButton_RightTapped;
 			_itemChevronDropDownMenuFlyout.Opening += ChevronDropDownMenuFlyout_Opening;
 			_itemChevronDropDownMenuFlyout.Opened += ChevronDropDownMenuFlyout_Opened;
 			_itemChevronDropDownMenuFlyout.Closed += ChevronDropDownMenuFlyout_Closed;

--- a/src/Files.App/UserControls/NavigationToolbar.xaml
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml
@@ -270,7 +270,8 @@
 									DataContext="{x:Bind}"
 									DragLeave="BreadcrumbBarItem_DragLeave"
 									DragOver="BreadcrumbBarItem_DragOver"
-									Drop="BreadcrumbBarItem_Drop" />
+									Drop="BreadcrumbBarItem_Drop"
+									RightTapped="BreadcrumbBarItem_RightTapped" />
 							</DataTemplate>
 						</controls:BreadcrumbBar.ItemTemplate>
 					</controls:BreadcrumbBar>

--- a/src/Files.App/UserControls/NavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml.cs
@@ -6,6 +6,7 @@ using Files.App.Controls;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
@@ -468,6 +469,67 @@ namespace Files.App.UserControls
 		private async void BreadcrumbBarItem_Drop(object sender, DragEventArgs e)
 		{
 			await ViewModel.PathBoxItem_Drop(sender, e);
+		}
+
+		private void BreadcrumbBarItem_RightTapped(object sender, RightTappedRoutedEventArgs e)
+		{
+			if (sender is not FrameworkElement element || element.DataContext is not PathBoxItem pathBoxItem)
+				return;
+
+			var path = pathBoxItem.Path;
+			if (string.IsNullOrEmpty(path))
+				return;
+
+			var flyout = new MenuFlyout();
+
+			var openInNewTabItem = new MenuFlyoutItemWithThemedIcon
+			{
+				Text = Strings.OpenInNewTab.GetLocalizedResource(),
+				ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.OpenInTab"],
+			};
+			openInNewTabItem.Click += async (_, _) =>
+				await NavigationHelpers.AddNewTabByPathAsync(typeof(ShellPanesPage), path, true);
+
+			var openInNewWindowItem = new MenuFlyoutItemWithThemedIcon
+			{
+				Text = Strings.OpenInNewWindow.GetLocalizedResource(),
+				ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.OpenInWindow"],
+			};
+			openInNewWindowItem.Click += async (_, _) =>
+				await NavigationHelpers.OpenPathInNewWindowAsync(path);
+
+			flyout.Items.Add(openInNewTabItem);
+			flyout.Items.Add(openInNewWindowItem);
+
+			var paneHolder = ContentPageContext.ShellPage?.PaneHolder;
+			if (userSettingsService.GeneralSettingsService.ShowOpenInNewPane && paneHolder is not null)
+			{
+				var openInNewPaneSubItem = new MenuFlyoutSubItem
+				{
+					Text = Strings.OpenInNewPane.GetLocalizedResource(),
+				};
+
+				var splitVerticallyItem = new MenuFlyoutItemWithThemedIcon
+				{
+					Text = Strings.SplitPaneVertically.GetLocalizedResource(),
+					ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.OpenInPaneVertical"],
+				};
+				splitVerticallyItem.Click += (_, _) => paneHolder.OpenSecondaryPane(path, ShellPaneArrangement.Vertical);
+
+				var splitHorizontallyItem = new MenuFlyoutItemWithThemedIcon
+				{
+					Text = Strings.SplitPaneHorizontally.GetLocalizedResource(),
+					ThemedIconStyle = (Style)Application.Current.Resources["App.ThemedIcons.OpenInPaneHorizontal"],
+				};
+				splitHorizontallyItem.Click += (_, _) => paneHolder.OpenSecondaryPane(path, ShellPaneArrangement.Horizontal);
+
+				openInNewPaneSubItem.Items.Add(splitVerticallyItem);
+				openInNewPaneSubItem.Items.Add(splitHorizontallyItem);
+				flyout.Items.Add(openInNewPaneSubItem);
+			}
+
+			flyout.ShowAt(element, new FlyoutShowOptions { Position = e.GetPosition(element) });
+			e.Handled = true;
 		}
 	}
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #15988

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Right clicked a breadcrumb
2. Confirmed each of the menu options works as expected
3. Confirmed the context menu doesn't open when right clicking a chevron

<img width="905" height="363" alt="image" src="https://github.com/user-attachments/assets/eb330180-e3df-43db-a150-4f0ea101140a" />

