### PR TITLE
Feature: Always show file extensions when renaming items

### DIFF
--- a/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
@@ -46,7 +46,7 @@ namespace Files.App.Helpers
 				await associatedInstance.RefreshIfNoWatcherExistsAsync();
 		}
 
-		public static async Task<bool> RenameFileItemAsync(ListedItem item, string newName, IShellPage associatedInstance, bool showExtensionDialog = true)
+		public static async Task<bool> RenameFileItemAsync(ListedItem item, string newName, IShellPage associatedInstance, bool showExtensionDialog = true, bool nameIsComplete = false)
 		{
 			if (item is AlternateStreamItem ads) // For alternate streams Name is not a substring ItemNameRaw
 			{
@@ -56,13 +56,12 @@ namespace Files.App.Helpers
 					StringComparison.Ordinal);
 				newName = $"{ads.MainStreamName}:{newName}";
 			}
-			else if (string.IsNullOrEmpty(item.Name))
+			else if (!nameIsComplete)
 			{
-				newName = string.Concat(newName, item.FileExtension);
-			}
-			else
-			{
-				newName = item.ItemNameRaw.Replace(item.Name, newName, StringComparison.Ordinal);
+				if (string.IsNullOrEmpty(item.Name))
+					newName = string.Concat(newName, item.FileExtension);
+				else
+					newName = item.ItemNameRaw.Replace(item.Name, newName, StringComparison.Ordinal);
 			}
 
 			if (item.ItemNameRaw == newName || string.IsNullOrEmpty(newName))

--- a/src/Files.App/Views/Layouts/BaseGroupableLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseGroupableLayoutPage.cs
@@ -255,7 +255,7 @@ namespace Files.App.Views.Layouts
 		}
 
 		protected static bool ShouldShowExtensionInRename(ListedItem item) =>
-			!item.IsFolder && !item.IsShortcut && item is not AlternateStreamItem;
+			(!item.IsFolder || item.IsArchive) && !item.IsShortcut && item is not AlternateStreamItem;
 
 		protected virtual void StartRenameItem(string itemNameTextBox)
 		{

--- a/src/Files.App/Views/Layouts/BaseGroupableLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseGroupableLayoutPage.cs
@@ -254,6 +254,9 @@ namespace Files.App.Views.Layouts
 			ListViewBase.Focus(FocusState.Programmatic);
 		}
 
+		protected static bool ShouldShowExtensionInRename(ListedItem item) =>
+			!item.IsFolder && !item.IsShortcut && item is not AlternateStreamItem;
+
 		protected virtual void StartRenameItem(string itemNameTextBox)
 		{
 			RenamingItem = SelectedItem;
@@ -269,9 +272,10 @@ namespace Files.App.Views.Layouts
 			TextBox? textBox = null;
 			TextBlock? textBlock = listViewItem.FindDescendant("ItemName") as TextBlock;
 			textBox = listViewItem.FindDescendant(itemNameTextBox) as TextBox;
-			textBox!.Text = textBlock!.Text;
-			OldItemName = textBlock.Text;
-			textBlock.Visibility = Visibility.Collapsed;
+			string editText = ShouldShowExtensionInRename(RenamingItem) ? RenamingItem.ItemNameRaw : textBlock!.Text;
+			textBox!.Text = editText;
+			OldItemName = editText;
+			textBlock!.Visibility = Visibility.Collapsed;
 			textBox.Visibility = Visibility.Visible;
 
 			if (textBox.FindParent<Grid>() is null)
@@ -287,9 +291,9 @@ namespace Files.App.Views.Layouts
 			textBox.LostFocus += RenameTextBox_LostFocus;
 			textBox.KeyDown += RenameTextBox_KeyDown;
 
-			int selectedTextLength = SelectedItem.Name.Length;
+			int selectedTextLength = editText.Length;
 
-			if (!SelectedItem.IsShortcut && UserSettingsService.FoldersSettingsService.ShowFileExtensions)
+			if (!SelectedItem.IsShortcut && (ShouldShowExtensionInRename(SelectedItem) || UserSettingsService.FoldersSettingsService.ShowFileExtensions))
 				selectedTextLength -= extensionLength;
 
 			textBox.Select(0, selectedTextLength);
@@ -301,7 +305,7 @@ namespace Files.App.Views.Layouts
 			EndRename(textBox);
 			string newItemName = textBox.Text.Trim().TrimEnd('.');
 
-			await UIFilesystemHelpers.RenameFileItemAsync(RenamingItem, newItemName, ParentShellPageInstance);
+			await UIFilesystemHelpers.RenameFileItemAsync(RenamingItem, newItemName, ParentShellPageInstance, nameIsComplete: ShouldShowExtensionInRename(RenamingItem));
 		}
 
 		protected virtual async void RenameTextBox_LostFocus(object sender, RoutedEventArgs e)

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml.cs
@@ -376,6 +376,7 @@ namespace Files.App.Views.Layouts
 				return;
 
 			TextBox? textBox = null;
+			string editText = ShouldShowExtensionInRename(RenamingItem) ? RenamingItem.ItemNameRaw : textBlock.Text;
 
 			// Grid View
 			if (FolderSettings.LayoutMode == FolderLayoutModes.GridView)
@@ -387,10 +388,10 @@ namespace Files.App.Views.Layouts
 				if (textBox is null)
 					return;
 
-				textBox.Text = textBlock.Text;
+				textBox.Text = editText;
 				textBlock.Opacity = 0;
 				popup.IsOpen = true;
-				OldItemName = textBlock.Text;
+				OldItemName = editText;
 			}
 			// List View
 			else if (FolderSettings.LayoutMode == FolderLayoutModes.ListView)
@@ -399,8 +400,8 @@ namespace Files.App.Views.Layouts
 				if (textBox is null)
 					return;
 
-				textBox.Text = textBlock.Text;
-				OldItemName = textBlock.Text;
+				textBox.Text = editText;
+				OldItemName = editText;
 				textBlock.Visibility = Visibility.Collapsed;
 				textBox.Visibility = Visibility.Visible;
 
@@ -418,8 +419,8 @@ namespace Files.App.Views.Layouts
 				if (textBox is null)
 					return;
 
-				textBox.Text = textBlock.Text;
-				OldItemName = textBlock.Text;
+				textBox.Text = editText;
+				OldItemName = editText;
 				textBox.Visibility = Visibility.Visible;
 
 				if (textBox.FindParent<Grid>() is null)
@@ -433,8 +434,8 @@ namespace Files.App.Views.Layouts
 			textBox.LostFocus += RenameTextBox_LostFocus;
 			textBox.KeyDown += RenameTextBox_KeyDown;
 
-			int selectedTextLength = RenamingItem.Name.Length;
-			if (!RenamingItem.IsShortcut && UserSettingsService.FoldersSettingsService.ShowFileExtensions)
+			int selectedTextLength = editText.Length;
+			if (!RenamingItem.IsShortcut && (ShouldShowExtensionInRename(RenamingItem) || UserSettingsService.FoldersSettingsService.ShowFileExtensions))
 				selectedTextLength -= extensionLength;
 
 			textBox.Select(0, selectedTextLength);


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16635

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed file extensions are displayed when renaming files even when file extensions are turned off
2. Tested in each layout