### PR TITLE
Fix: Fixed issue where shortcut overlay was too large

### DIFF
--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml
@@ -261,16 +261,15 @@
 										Source="{x:Bind IconOverlay, Mode=OneWay}"
 										Stretch="Uniform" />
 
-									<Border
+									<Viewbox
 										x:Name="ShortcutGlyphElement"
+										Width="10"
+										Height="10"
 										HorizontalAlignment="Left"
 										VerticalAlignment="Bottom"
 										Visibility="{x:Bind IsShortcut}">
-										<controls:ThemedIcon
-											Width="12"
-											Height="12"
-											Style="{StaticResource App.ThemedIcons.Shortcut}" />
-									</Border>
+										<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Shortcut}" />
+									</Viewbox>
 									<Image
 										x:Name="ShieldOverlay"
 										Width="8"

--- a/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/DetailsLayoutPage.xaml
@@ -950,16 +950,15 @@
 												x:Load="True"
 												Source="{x:Bind IconOverlay, Mode=OneWay}"
 												Stretch="Uniform" />
-											<Border
+											<Viewbox
 												x:Name="ShortcutGlyphElement"
+												Width="10"
+												Height="10"
 												HorizontalAlignment="Left"
 												VerticalAlignment="Bottom"
 												x:Load="{x:Bind IsShortcut}">
-												<controls:ThemedIcon
-													Width="12"
-													Height="12"
-													Style="{StaticResource App.ThemedIcons.Shortcut}" />
-											</Border>
+												<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Shortcut}" />
+											</Viewbox>
 											<Image
 												x:Name="ShieldOverlay"
 												Width="8"

--- a/src/Files.App/Views/Layouts/GridLayoutPage.xaml
+++ b/src/Files.App/Views/Layouts/GridLayoutPage.xaml
@@ -334,16 +334,15 @@
 								x:Load="True"
 								Source="{x:Bind IconOverlay, Mode=OneWay}"
 								Stretch="Uniform" />
-							<Border
+							<Viewbox
 								x:Name="ShortcutGlyphElement"
+								Width="10"
+								Height="10"
 								HorizontalAlignment="Left"
 								VerticalAlignment="Bottom"
 								x:Load="{x:Bind IsShortcut}">
-								<controls:ThemedIcon
-									Width="12"
-									Height="12"
-									Style="{StaticResource App.ThemedIcons.Shortcut}" />
-							</Border>
+								<controls:ThemedIcon Style="{StaticResource App.ThemedIcons.Shortcut}" />
+							</Viewbox>
 							<Image
 								x:Name="ShieldOverlay"
 								Width="8"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #18204

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed the shortcut icon overlay is the same size in the Grid and Card layouts.
2. Confirmed the shortcut icon overlay is now smaller in the Details, List, and Column View layouts.