### PR TITLE
Fix: Fixed issue where 'Open with' option was shown in context menu when multiple items were selected

### DIFF
--- a/src/Files.App/Actions/FileSystem/OpenItemAction.cs
+++ b/src/Files.App/Actions/FileSystem/OpenItemAction.cs
@@ -74,6 +74,7 @@ namespace Files.App.Actions
 
 		public bool IsExecutable =>
 			context.HasSelection &&
+			context.SelectedItems.Count == 1 &&
 			context.PageType != ContentPageTypes.RecycleBin &&
 			context.SelectedItems.All(i =>
 				(i.PrimaryItemAttribute == StorageItemTypes.File && !i.IsShortcut && (!i.IsExecutable || i.IsScriptFile)) ||

--- a/src/Files.App/Data/Factories/ContentPageContextFlyoutFactory.cs
+++ b/src/Files.App/Data/Factories/ContentPageContextFlyoutFactory.cs
@@ -86,7 +86,7 @@ namespace Files.App.Data.Factories
 			bool canDecompress = selectedItems.Any() && selectedItems.All(x => x.IsArchive)
 				|| selectedItems.All(x => x.PrimaryItemAttribute == StorageItemTypes.File && FileExtensionHelpers.IsZipFile(x.FileExtension));
 			bool canCompress = !canDecompress || selectedItems.Count > 1;
-			bool showOpenItemWith = selectedItems.All(
+			bool showOpenItemWith = selectedItems.Count == 1 && selectedItems.All(
 				i => (i.PrimaryItemAttribute == StorageItemTypes.File && !i.IsShortcut && !i.IsExecutable) || (i.PrimaryItemAttribute == StorageItemTypes.Folder && i.IsArchive));
 			bool areAllItemsFolders = selectedItems.All(i => i.PrimaryItemAttribute == StorageItemTypes.Folder);
 			bool isFirstFileExecutable = FileExtensionHelpers.IsExecutableFile(selectedItems.FirstOrDefault()?.FileExtension);


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16342

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Right clicked single item and confirmed 'Open with' was displayed
2. Right clicked a selection of multiple items and confirmed 'Open with' was not displayed
3. Confirmed the same behaviors with the 'Open with' action in the Command Palette