### PR TITLE
Perf: Defer file tags database scan off the startup UI path

### DIFF
--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -117,9 +117,8 @@ namespace Files.App.Utils
 					// only set the tags if the file tags have been changed
 					if (fileTagsInitialized)
 					{
-						var dbInstance = FileTagsHelper.GetDbInstance();
-						dbInstance.SetTags(ItemPath, FileFRN, value);
-						FileTagsHelper.WriteFileTag(ItemPath, value);
+						// Update the registry index and ADS as one synchronized operation.
+						_ = FileTagsHelper.SetTagsAndWriteFileTagAsync(ItemPath, FileFRN, value);
 					}
 
 					HasTags = !FileTags.IsEmpty();

--- a/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
+++ b/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
@@ -111,22 +111,32 @@ namespace Files.App.Helpers
 			// Start non-critical tasks without waiting for them to complete
 			_ = Task.Run(async () =>
 			{
-				await Task.WhenAll(
-					OptionalTaskAsync(CloudDrivesManager.UpdateDrivesAsync(), generalSettingsService.ShowCloudDrivesSection),
-					App.LibraryManager.UpdateLibrariesAsync(),
-					OptionalTaskAsync(WSLDistroManager.UpdateDrivesAsync(), generalSettingsService.ShowWslSection),
-					OptionalTaskAsync(App.FileTagsManager.UpdateFileTagsAsync(), generalSettingsService.ShowFileTagsSection),
-					jumpListService.InitializeAsync()
-				);
+				try
+				{
+					await Task.WhenAll(
+						OptionalTaskAsync(CloudDrivesManager.UpdateDrivesAsync(), generalSettingsService.ShowCloudDrivesSection),
+						App.LibraryManager.UpdateLibrariesAsync(),
+						OptionalTaskAsync(WSLDistroManager.UpdateDrivesAsync(), generalSettingsService.ShowWslSection),
+						OptionalTaskAsync(App.FileTagsManager.UpdateFileTagsAsync(), generalSettingsService.ShowFileTagsSection),
+						jumpListService.InitializeAsync()
+					);
 
-				//Start the tasks separately to reduce resource contention
-				await Task.WhenAll(
-					addItemService.InitializeAsync(),
-					ContextMenu.WarmUpQueryContextMenuAsync()
-				);
+					// Run these tasks after the preceding initialization to reduce resource contention.
+					await Task.WhenAll(
+						addItemService.InitializeAsync(),
+						ContextMenu.WarmUpQueryContextMenuAsync()
+					);
+				}
+				catch (Exception ex)
+				{
+					App.Logger.LogWarning(ex, "Failed to initialize non-critical app services.");
+				}
+				finally
+				{
+					// Run the tag database scan even if a preceding background task fails.
+					SafetyExtensions.IgnoreExceptions(FileTagsHelper.UpdateTagsDb, App.Logger);
+				}
 			});
-
-			FileTagsHelper.UpdateTagsDb();
 
 			_ = Task.Run(async () =>
 			{

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -337,9 +337,8 @@ namespace Files.App
 							if (fileFRN is not null)
 							{
 								var tagUid = tag is not null ? new[] { tag.Uid } : [];
-								var dbInstance = FileTagsHelper.GetDbInstance();
-								dbInstance.SetTags(file, fileFRN, tagUid);
-								FileTagsHelper.WriteFileTag(file, tagUid);
+								// Update the registry index and ADS as one synchronized operation.
+								_ = FileTagsHelper.SetTagsAndWriteFileTagAsync(file, fileFRN, tagUid);
 							}
 						}
 						break;

--- a/src/Files.App/Utils/FileTags/FileTagsDatabase.cs
+++ b/src/Files.App/Utils/FileTags/FileTagsDatabase.cs
@@ -14,9 +14,30 @@ namespace Files.App.Utils.FileTags
 	public sealed class FileTagsDatabase
 	{
 		private static string? _FileTagsKey;
+
+		// Protect the registry path and FRN indices from concurrent updates.
+		internal static object SyncRoot { get; } = new();
+
 		private string? FileTagsKey => _FileTagsKey ??= SafetyExtensions.IgnoreExceptions(() => @$"Software\Files Community\{Package.Current.Id.Name}\v1\FileTags");
 
+		internal static void RunSynchronized(Action action)
+		{
+			lock (SyncRoot)
+				action();
+		}
+
+		internal static T RunSynchronized<T>(Func<T> action)
+		{
+			lock (SyncRoot)
+				return action();
+		}
+
 		public void SetTags(string filePath, ulong? frn, string[] tags)
+		{
+			RunSynchronized(() => SetTagsCore(filePath, frn, tags));
+		}
+
+		private void SetTagsCore(string filePath, ulong? frn, string[] tags)
 		{
 			if (FileTagsKey is null)
 				return;
@@ -95,6 +116,11 @@ namespace Files.App.Utils.FileTags
 
 		public void UpdateTag(string oldFilePath, ulong? frn, string? newFilePath)
 		{
+			RunSynchronized(() => UpdateTagCore(oldFilePath, frn, newFilePath));
+		}
+
+		private void UpdateTagCore(string oldFilePath, ulong? frn, string? newFilePath)
+		{
 			if (FileTagsKey is null)
 				return;
 
@@ -122,6 +148,11 @@ namespace Files.App.Utils.FileTags
 		}
 
 		public void UpdateTag(ulong oldFrn, ulong? frn, string? newFilePath)
+		{
+			RunSynchronized(() => UpdateTagCore(oldFrn, frn, newFilePath));
+		}
+
+		private void UpdateTagCore(ulong oldFrn, ulong? frn, string? newFilePath)
 		{
 			if (FileTagsKey is null)
 				return;
@@ -151,10 +182,15 @@ namespace Files.App.Utils.FileTags
 
 		public string[] GetTags(string? filePath, ulong? frn)
 		{
-			return FindTag(filePath, frn)?.Tags ?? [];
+			return RunSynchronized(() => FindTag(filePath, frn)?.Tags ?? []);
 		}
 
 		public IEnumerable<TaggedFile> GetAll()
+		{
+			return RunSynchronized(GetAllCore);
+		}
+
+		private IEnumerable<TaggedFile> GetAllCore()
 		{
 			var list = new List<TaggedFile>();
 
@@ -175,6 +211,11 @@ namespace Files.App.Utils.FileTags
 
 		public IEnumerable<TaggedFile> GetAllUnderPath(string folderPath)
 		{
+			return RunSynchronized(() => GetAllUnderPathCore(folderPath));
+		}
+
+		private IEnumerable<TaggedFile> GetAllUnderPathCore(string folderPath)
+		{
 			folderPath = folderPath.Replace('/', '\\').TrimStart('\\');
 			var list = new List<TaggedFile>();
 
@@ -194,6 +235,11 @@ namespace Files.App.Utils.FileTags
 		}
 
 		public void Import(string json)
+		{
+			RunSynchronized(() => ImportCore(json));
+		}
+
+		private void ImportCore(string json)
 		{
 			if (FileTagsKey is null)
 				return;
@@ -218,6 +264,11 @@ namespace Files.App.Utils.FileTags
 		}
 
 		public string Export()
+		{
+			return RunSynchronized(ExportCore);
+		}
+
+		private string ExportCore()
 		{
 			var list = new List<TaggedFile>();
 

--- a/src/Files.App/Utils/FileTags/FileTagsHelper.cs
+++ b/src/Files.App/Utils/FileTags/FileTagsHelper.cs
@@ -19,12 +19,41 @@ namespace Files.App.Utils.FileTags
 
 		public static string[] ReadFileTag(string filePath)
 		{
-			var tagString = Win32Helper.ReadStringFromFile($"{filePath}:files");
-			return tagString?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? [];
+			lock (FileTagsDatabase.SyncRoot)
+			{
+				var tagString = Win32Helper.ReadStringFromFile($"{filePath}:files");
+				return tagString?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? [];
+			}
 		}
 
 		public static async void WriteFileTag(string filePath, string[] tag)
 		{
+			bool result;
+			lock (FileTagsDatabase.SyncRoot)
+			{
+				result = WriteFileTagCore(filePath, tag);
+			}
+
+			if (!result)
+				await ShowTagWriteErrorAsync();
+		}
+
+		public static Task SetTagsAndWriteFileTagAsync(string filePath, ulong? frn, string[] tags)
+		{
+			bool result;
+			lock (FileTagsDatabase.SyncRoot)
+			{
+				// Update the registry index and ADS without allowing another tag operation to interleave.
+				GetDbInstance().SetTags(filePath, frn, tags);
+				result = WriteFileTagCore(filePath, tags);
+			}
+
+			return result ? Task.CompletedTask : ShowTagWriteErrorAsync();
+		}
+
+		private static bool WriteFileTagCore(string filePath, string[] tag)
+		{
+			var result = true;
 			var isDateOk = Win32Helper.GetFileDateModified(filePath, out var dateModified); // Backup date modified
 			var isReadOnly = Win32Helper.HasFileAttribute(filePath, IO.FileAttributes.ReadOnly);
 			if (isReadOnly) // Unset read-only attribute (#7534)
@@ -37,24 +66,7 @@ namespace Files.App.Utils.FileTags
 			}
 			else if (ReadFileTag(filePath) is not string[] arr || !tag.SequenceEqual(arr))
 			{
-				var result = Win32Helper.WriteStringToFile($"{filePath}:files", string.Join(',', tag));
-				if (result == false)
-				{
-					await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
-					{
-						ContentDialog dialog = new()
-						{
-							Title = Strings.ErrorApplyingTagTitle.GetLocalizedResource(),
-							Content = Strings.ErrorApplyingTagContent.GetLocalizedResource(),
-							PrimaryButtonText = "Ok".GetLocalizedResource()
-						};
-
-						if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
-							dialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
-
-						await dialog.TryShowAsync();
-					});
-				}
+				result = Win32Helper.WriteStringToFile($"{filePath}:files", string.Join(',', tag));
 			}
 			if (isReadOnly) // Restore read-only attribute (#7534)
 			{
@@ -64,6 +76,27 @@ namespace Files.App.Utils.FileTags
 			{
 				Win32Helper.SetFileDateModified(filePath, dateModified); // Restore date modified
 			}
+
+			return result;
+		}
+
+		private static Task ShowTagWriteErrorAsync()
+		{
+			return MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(async () =>
+			{
+				// Show the error dialog on the UI thread after releasing the file operation lock.
+				ContentDialog dialog = new()
+				{
+					Title = Strings.ErrorApplyingTagTitle.GetLocalizedResource(),
+					Content = Strings.ErrorApplyingTagContent.GetLocalizedResource(),
+					PrimaryButtonText = "Ok".GetLocalizedResource()
+				};
+
+				if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+					dialog.XamlRoot = MainWindow.Instance.Content.XamlRoot;
+
+				await dialog.TryShowAsync();
+			});
 		}
 
 		public static void UpdateTagsDb()
@@ -71,39 +104,43 @@ namespace Files.App.Utils.FileTags
 			var dbInstance = GetDbInstance();
 			foreach (var file in dbInstance.GetAll())
 			{
-				var pathFromFrn = Win32Helper.PathFromFileId(file.Frn ?? 0, file.FilePath);
-				if (pathFromFrn is not null)
+				lock (FileTagsDatabase.SyncRoot)
 				{
-					// Frn is valid, update file path
-					var tag = ReadFileTag(pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal));
-					if (tag is not null && tag.Any())
+					// Keep validation and updates for one item atomic with user tag changes.
+					var pathFromFrn = Win32Helper.PathFromFileId(file.Frn ?? 0, file.FilePath);
+					if (pathFromFrn is not null)
 					{
-						dbInstance.UpdateTag(file.Frn ?? 0, null, pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal));
-						dbInstance.SetTags(pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal), file.Frn, tag);
-					}
-					else
-					{
-						dbInstance.SetTags(pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal), file.Frn, []);
-					}
-				}
-				else
-				{
-					var tag = ReadFileTag(file.FilePath);
-					if (tag is not null && tag.Any())
-					{
-						if (!SafetyExtensions.IgnoreExceptions(() =>
+						// Frn is valid, update file path
+						var tag = ReadFileTag(pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal));
+						if (tag is not null && tag.Any())
 						{
-							var frn = GetFileFRN(file.FilePath);
-							dbInstance.UpdateTag(file.FilePath, frn, null);
-							dbInstance.SetTags(file.FilePath, frn, tag);
-						}, App.Logger))
+							dbInstance.UpdateTag(file.Frn ?? 0, null, pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal));
+							dbInstance.SetTags(pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal), file.Frn, tag);
+						}
+						else
 						{
-							dbInstance.SetTags(file.FilePath, null, []);
+							dbInstance.SetTags(pathFromFrn.Replace(@"\\?\", "", StringComparison.Ordinal), file.Frn, []);
 						}
 					}
 					else
 					{
-						dbInstance.SetTags(file.FilePath, null, []);
+						var tag = ReadFileTag(file.FilePath);
+						if (tag is not null && tag.Any())
+						{
+							if (!SafetyExtensions.IgnoreExceptions(() =>
+							{
+								var frn = GetFileFRN(file.FilePath);
+								dbInstance.UpdateTag(file.FilePath, frn, null);
+								dbInstance.SetTags(file.FilePath, frn, tag);
+							}, App.Logger))
+							{
+								dbInstance.SetTags(file.FilePath, null, []);
+							}
+						}
+						else
+						{
+							dbInstance.SetTags(file.FilePath, null, []);
+						}
 					}
 				}
 			}

--- a/src/Files.App/Utils/Storage/Operations/FileOperationsHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FileOperationsHelpers.cs
@@ -1022,12 +1022,14 @@ namespace Files.App.Utils.Storage
 						{
 							var tag = dbInstance.GetTags(sourcePath, null);
 
-							dbInstance.SetTags(destination, FileTagsHelper.GetFileFRN(destination), tag); // copy tag to new files
 							using var si = new ShellItem(destination);
 							if (si.IsFolder) // File tag is not copied automatically for folders
 							{
-								FileTagsHelper.WriteFileTag(destination, tag);
+								// Update the registry index and ADS together when copying a folder.
+								_ = FileTagsHelper.SetTagsAndWriteFileTagAsync(destination, FileTagsHelper.GetFileFRN(destination), tag);
 							}
+							else
+								dbInstance.SetTags(destination, FileTagsHelper.GetFileFRN(destination), tag); // copy tag to new files
 						}
 						else
 						{

--- a/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/SidebarViewModel.cs
@@ -1438,7 +1438,6 @@ namespace Files.App.ViewModels.UserControls
 		private async Task HandleTagItemDroppedAsync(FileTagItem fileTagItem, ItemDroppedEventArgs args)
 		{
 			var storageItems = await Utils.Storage.FilesystemHelpers.GetDraggedStorageItems(args.DroppedItem);
-			var dbInstance = FileTagsHelper.GetDbInstance();
 			var pathToTags = new Dictionary<string, string[]>();
 			foreach (var item in storageItems.Where(x => !string.IsNullOrEmpty(x.Path)))
 			{
@@ -1447,8 +1446,8 @@ namespace Files.App.ViewModels.UserControls
 				{
 					filesTags = [.. filesTags, fileTagItem.FileTag.Uid];
 					var fileFRN = await FileTagsHelper.GetFileFRN(item.Item);
-					dbInstance.SetTags(item.Path, fileFRN, filesTags);
-					FileTagsHelper.WriteFileTag(item.Path, filesTags);
+					// Update the registry index and ADS as one synchronized operation.
+					_ = FileTagsHelper.SetTagsAndWriteFileTagAsync(item.Path, fileFRN, filesTags);
 					pathToTags[item.Path] = filesTags;
 				}
 			}


### PR DESCRIPTION
### **Resolved / Related Issues**

- Related to #18616
- Related to #17678

### **Why this change is needed**

`InitializeAppComponentsAsync()` resumes on the UI context after quick access initialization and then calls `UpdateTagsDb()` synchronously. That method recursively enumerates the registry-backed tag index and validates every entry against its FRN, path, and alternate data stream. The work is maintenance rather than a prerequisite for showing the main window.

### **What changed**

- Run the tag database scan after the existing non-critical background initialization instead of blocking the UI thread.
- Execute the scan from `finally` so a failure in another background initializer does not silently skip tag maintenance.
- Log failures from the fire-and-forget initialization task.
- Serialize registry path/FRN index operations and ADS writes because they are multi-step updates and can now overlap with user actions.
- Keep each scanned item atomic rather than locking the entire scan, avoiding a long wait if the user applies a tag while maintenance is running.
- Update paired database and ADS writes through one helper and show write-error UI only after releasing the lock.

This does not change the registry schema or stored tag format.

### **Steps used to test these changes**

1. Built `src\Files.App\Files.App.csproj` for Debug x64 without packaging.
2. Built and signed the Release x64 sideload MSIX bundle with the same package settings used by CI.
3. Verified the generated MSIX bundle signature successfully.
4. Built `tests\Files.InteractionTests\Files.InteractionTests.csproj` for Release x64.
5. Built the parent commit (`af9128ecc`) as FilesDev 4.1.4.1 and this PR (`b98e185a7`) as FilesDev 4.1.4.2. Both packages used the same `FilesDev` identity.
6. Before every launch, restored the same registry snapshot containing 276,160 empty path-index keys and 95,340 empty FRN-index keys, with zero value-bearing tag records.
7. Ran three 20-second cold-launch trials per build. UI responsiveness was probed every 50 ms with `SendMessageTimeout(WM_NULL)`.

| Median of three trials | Parent commit | This PR |
| --- | ---: | ---: |
| Window handle created | 0.72 s | 0.76 s |
| Longest UI-unresponsive interval | 5.19 s | 0.30 s |
| Process CPU during first 20 s | 19.72 s | 19.84 s |
| Peak working set | 787.1 MB | 738.7 MB |

The controlled A/B test confirms that the PR reduces the longest UI stall by 94.1% with the same package identity and registry data. CPU time is effectively unchanged, confirming that the scan is deferred rather than eliminated.

There are currently no focused unit tests for the registry-backed `FileTagsDatabase`; the synchronization paths were additionally reviewed against all current `SetTags`, `UpdateTag`, `GetAll`, import, export, and ADS write call sites.

### **Status / Follow-up investigation**

Further investigation after opening this draft found that the affected user had never assigned a file tag, but the stable package registry hive contained 276,160 empty path-index keys and 95,340 empty FRN-index keys, with zero value-bearing tag records. Normal item loading calls `SetTags()` with an empty tag array, and the current registry implementation creates path and FRN keys before removing values, so ordinary browsing can grow an empty tag index indefinitely. The full code-path analysis and hive measurements are documented in #18616.

The controlled A/B test above confirms that this PR genuinely mitigates the visible startup freeze, rather than only appearing faster because a Dev package uses a clean registry hive. However, it does not prevent empty-key accumulation or reduce the scan's CPU cost. The root cause in #18616 should be addressed first; this draft can then be evaluated separately to determine whether background maintenance is still needed.

_Note: This pull request was created with the assistance of AI._
