### PR TITLE
Fix: Sidebar group header double-click stutter

### DIFF
--- a/src/Files.App.Controls/Sidebar/SidebarItem.cs
+++ b/src/Files.App.Controls/Sidebar/SidebarItem.cs
@@ -317,7 +317,13 @@ namespace Files.App.Controls
 			=> e.Handled = TryToggleExpansion();
 
 		private void ItemBorder_DoubleTapped(object sender, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs e)
-			=> e.Handled = TryToggleExpansion();
+		{
+			// Section headers already toggle expansion on single click
+			if (IsGroupHeader && Item?.IsLeafWithChildren != true)
+				return;
+
+			e.Handled = TryToggleExpansion();
+		}
 
 		private bool TryToggleExpansion()
 		{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

### Title
Fix: Sidebar group header double-click stutter

**Resolved / Related Issues**
- Closes #18622 

**Description of changes**

In WinUI 3, double-clicking triggers a `DoubleTapped` event as well as `PointerReleased` events on both clicks. Since group headers (like *Pinned* or *Drives*) toggle expansion on single click (via `PointerReleased`), the double-click event flow causes them to toggle three times, creating a stuttering effect (closing and instantly reopening) on consecutive clicks.

This PR ignores `DoubleTapped` events specifically on group headers in `SidebarItem.cs` since they already handle expansion via single click. Tree-view folders (leaves-with-children) still handle double-taps normally.

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files.
2. Clicked a sidebar group header (e.g., **Pinned**) to collapse it (Click 1), verified it collapsed.
3. Clicked it again to expand it (Click 2), verified it expanded.
4. Clicked it a third time in rapid succession (Click 3), verified it collapsed instantly and cleanly without stuttering or reopening.
5. Clicked it multiple times very quickly to confirm that expansion/collapse toggles instantly on every click.
6. Double-clicked a tree-view folder containing subfolders (leaves-with-children) in the sidebar to verify it still toggles expansion on double-tap as expected.