### PR TITLE
Code Quality: Prevent double-tap event for group headers

### DIFF
--- a/src/Files.App.Controls/Sidebar/SidebarItem.cs
+++ b/src/Files.App.Controls/Sidebar/SidebarItem.cs
@@ -317,7 +317,15 @@ namespace Files.App.Controls
 			=> e.Handled = TryToggleExpansion();
 
 		private void ItemBorder_DoubleTapped(object sender, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs e)
-			=> e.Handled = TryToggleExpansion();
+		{
+			// Group-header rows already toggle on every PointerReleased via Clicked, so a DoubleTapped toggle stacks on top of the per-click toggles and lands the section in the opposite state (the rapid-click stutter). Leaves-with-children navigate on row click and only toggle via the chevron, so double-tap on the row is still the expected toggle path there.
+			if (IsGroupHeader && Item?.IsLeafWithChildren != true)
+			{
+				e.Handled = true;
+				return;
+			}
+			e.Handled = TryToggleExpansion();
+		}
 
 		private bool TryToggleExpansion()
 		{


### PR DESCRIPTION
Stop DoubleTapped from toggling group-header expansion to avoid a rapid-click stutter where Clicked (PointerReleased) already toggles the row. For group headers we now swallow DoubleTapped unless the item is a leaf-with-children (which should still allow double-tap toggling); otherwise DoubleTapped continues to call TryToggleExpansion().

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #18622

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed double tap event is swallowed for sidebar group headers