### PR TITLE
Fix: Fixed issue where omnibar would sometimes lose focus

### DIFF
--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -26,6 +26,15 @@ namespace Files.App.Controls
 
 		private void AutoSuggestBox_LosingFocus(UIElement sender, LosingFocusEventArgs args)
 		{
+			// Programmatic focus moves (InputDevice == None) while the user is typing in the
+			// Omnibar - typically a post-folder-load FocusActivePane / FocusFileList - should not
+			// pull focus away and clear the in-progress query. User gestures still pass through.
+			if (args.InputDevice is FocusInputDeviceKind.None && args.FocusState is FocusState.Programmatic)
+			{
+				args.TryCancel();
+				return;
+			}
+
 			// Prevent the TextBox from losing focus when the ModeButton is focused
 			if (args.NewFocusedElement is not Button button ||
 				args.InputDevice is FocusInputDeviceKind.Keyboard ||

--- a/src/Files.App/Helpers/UI/UIHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIHelpers.cs
@@ -1,8 +1,12 @@
 // Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using CommunityToolkit.WinUI;
+using Files.App.Controls;
 using Files.App.Helpers.Application;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System.IO;
@@ -12,6 +16,26 @@ namespace Files.App.Helpers
 	public static class UIHelpers
 	{
 		public static event PropertyChangedEventHandler? PropertyChanged;
+
+		/// <summary>
+		/// True if a user-editable text input currently owns keyboard focus within the given XamlRoot.
+		/// Used to gate code that programmatically reassigns focus on a background-completion
+		/// callback (e.g. folder-load done), so the user's typing isn't yanked away.
+		/// </summary>
+		public static bool IsTextInputFocused(XamlRoot? xamlRoot)
+		{
+			if (xamlRoot is null)
+				return false;
+
+			if (FocusManager.GetFocusedElement(xamlRoot) is TextBox or RichEditBox or PasswordBox or AutoSuggestBox)
+				return true;
+
+			// The Omnibar holds an internal focus DP that stays true while its suggestion popup is
+			// open (the popup root sits outside the omnibar's visual ancestry, so GetFocusedElement
+			// alone misses it). Consult that DP as a fallback.
+			var omnibar = (MainWindow.Instance.Content as Frame)?.FindDescendant<Omnibar>();
+			return omnibar?.IsFocused == true;
+		}
 
 		private static bool canShowDialog = true;
 		public static bool CanShowDialog

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -395,7 +395,10 @@ namespace Files.App.Views.Layouts
 				// Allthough the focus is also set from SetSelectedItemsOnNavigation,
 				// that is only called when switching between a Grid based layout and Details,
 				// not between different Grid based layouts (eg. List and Cards).
-				ParentShellPageInstance!.PaneHolder.FocusActivePane();
+				// Adaptive layout fires this handler on folder-load completion - skip the focus
+				// restore so an in-progress omnibar query isn't lost.
+				if (!UIHelpers.IsTextInputFocused(XamlRoot))
+					ParentShellPageInstance!.PaneHolder.FocusActivePane();
 			}
 		}
 
@@ -542,12 +545,18 @@ namespace Files.App.Views.Layouts
 					];
 
 					ItemManipulationModel.SetSelectedItems(listedItemsToSelect);
-					ItemManipulationModel.FocusSelectedItems();
+
+					// Invoked as a post-load callback that can fire long after navigation if the folder
+					// is slow to enumerate; by then the user may be typing into the omnibar - don't yank
+					// focus away. The omnibar also cancels programmatic LosingFocus moves, but its
+					// FocusSelectedItems path uses FocusState.Keyboard which slips past that guard.
+					if (!UIHelpers.IsTextInputFocused(XamlRoot))
+						ItemManipulationModel.FocusSelectedItems();
 				}
 				else if (navigationArguments is not null && ParentShellPageInstance!.InstanceViewModel.FolderSettings.LayoutMode is not FolderLayoutModes.ColumnView)
 				{
-					// Focus on the active pane in case it was lost during navigation
-					ParentShellPageInstance!.PaneHolder.FocusActivePane();
+					if (!UIHelpers.IsTextInputFocused(XamlRoot))
+						ParentShellPageInstance!.PaneHolder.FocusActivePane();
 				}
 			}
 			catch (Exception) { }

--- a/src/Files.App/Views/Shells/BaseShellPage.cs
+++ b/src/Files.App/Views/Shells/BaseShellPage.cs
@@ -213,8 +213,11 @@ namespace Files.App.Views.Shells
 
 		protected void FilesystemViewModel_OnSelectionRequestedEvent(object sender, List<ListedItem> e)
 		{
-			// Set focus since selection might occur before the UI finishes updating
-			ContentPage.ItemManipulationModel.FocusFileList();
+			// Raised by the directory watcher, which can fire while the user is typing in the
+			// omnibar - don't yank focus in that case (the omnibar's TryCancel doesn't help here
+			// because FocusFileList -> ListViewItem.Focus uses FocusState.Keyboard).
+			if (!UIHelpers.IsTextInputFocused(XamlRoot))
+				ContentPage.ItemManipulationModel.FocusFileList();
 			ContentPage.ItemManipulationModel.SetSelectedItems(e);
 		}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16434

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened large folder and quickly focused address bar
2. Confirmed address bar kept focus even after items finished loading 