### PR TITLE
Feature: Added support for dragging tab to create new pane

### DIFF
--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -55,6 +55,8 @@ namespace Files.App.UserControls.TabBar
 		// Events
 
 		public static event EventHandler<TabBarItem?>? SelectedTabItemChanged;
+		public static event EventHandler<TabBarItem?>? TabDragStarted;
+		public static event EventHandler<TabBarItem?>? TabDragCompleted;
 
 		// Constructor
 
@@ -147,6 +149,8 @@ namespace Files.App.UserControls.TabBar
 			// and the PreviewKeyDown event won't trigger.
 			Focus(FocusState.Programmatic);
 			PreviewKeyDown += TabDragging_PreviewKeyDown;
+
+			TabDragStarted?.Invoke(this, args.Item as TabBarItem);
 		}
 
 		private void TabDragging_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
@@ -212,6 +216,8 @@ namespace Files.App.UserControls.TabBar
 		{
 			// Unsubscribe from the key down event, it's only needed when a tab is actively being dragged
 			PreviewKeyDown -= TabDragging_PreviewKeyDown;
+
+			TabDragCompleted?.Invoke(this, args.Item as TabBarItem);
 
 			if (ApplicationData.Current.LocalSettings.Values.ContainsKey(TabDropHandledIdentifier) &&
 				(bool)ApplicationData.Current.LocalSettings.Values[TabDropHandledIdentifier])

--- a/src/Files.App/Views/ShellPanesPage.xaml
+++ b/src/Files.App/Views/ShellPanesPage.xaml
@@ -28,7 +28,7 @@
 		<!--  TabFocusNavigation is set to 'once' to prevent focus from auto switching to the next pane  -->
 		<Grid x:Name="RootGrid" TabFocusNavigation="Once" />
 
-		<Grid
+		<Border
 			x:Name="TabDropOverlay"
 			AllowDrop="True"
 			Background="Transparent"

--- a/src/Files.App/Views/ShellPanesPage.xaml
+++ b/src/Files.App/Views/ShellPanesPage.xaml
@@ -24,6 +24,18 @@
 		</ResourceDictionary>
 	</Page.Resources>
 
-	<!--  TabFocusNavigation is set to 'once' to prevent focus from auto switching to the next pane  -->
-	<Grid x:Name="RootGrid" TabFocusNavigation="Once" />
+	<Grid>
+		<!--  TabFocusNavigation is set to 'once' to prevent focus from auto switching to the next pane  -->
+		<Grid x:Name="RootGrid" TabFocusNavigation="Once" />
+
+		<!--  Hit-testing host for the tab-to-pane drop target. The animated accent overlay is a SpriteVisual attached in code-behind.  -->
+		<Grid
+			x:Name="TabDropOverlay"
+			AllowDrop="True"
+			Background="Transparent"
+			DragLeave="TabDropOverlay_DragLeave"
+			DragOver="TabDropOverlay_DragOver"
+			Drop="TabDropOverlay_Drop"
+			Visibility="Collapsed" />
+	</Grid>
 </Page>

--- a/src/Files.App/Views/ShellPanesPage.xaml
+++ b/src/Files.App/Views/ShellPanesPage.xaml
@@ -28,7 +28,6 @@
 		<!--  TabFocusNavigation is set to 'once' to prevent focus from auto switching to the next pane  -->
 		<Grid x:Name="RootGrid" TabFocusNavigation="Once" />
 
-		<!--  Hit-testing host for the tab-to-pane drop target. The animated accent overlay is a SpriteVisual attached in code-behind.  -->
 		<Grid
 			x:Name="TabDropOverlay"
 			AllowDrop="True"

--- a/src/Files.App/Views/ShellPanesPage.xaml.cs
+++ b/src/Files.App/Views/ShellPanesPage.xaml.cs
@@ -3,12 +3,19 @@
 
 using Files.App.Controls;
 using Microsoft.Extensions.Logging;
+using Microsoft.UI.Composition;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using System.Numerics;
 using System.Runtime.CompilerServices;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.UI.ViewManagement;
 using GridSplitter = Files.App.Controls.GridSplitter;
 
 namespace Files.App.Views
@@ -279,6 +286,9 @@ namespace Files.App.Views
 			if (IsMultiPaneAvailable &&
 				GeneralSettingsService.AlwaysOpenDualPaneInNewTab)
 				AddPane();
+
+			TabBar.TabDragStarted += TabBar_TabDragStarted;
+			TabBar.TabDragCompleted += TabBar_TabDragCompleted;
 		}
 
 		// Public methods
@@ -671,6 +681,251 @@ namespace Files.App.Views
 			return ActivePane?.TabItemDrop(sender, e) ?? Task.CompletedTask;
 		}
 
+		private TabBarItem? _draggedTabItem;
+
+		private void TabBar_TabDragStarted(object? sender, TabBarItem? draggedItem)
+		{
+			if (!IsCurrentInstance ||
+				draggedItem is null ||
+				(draggedItem.NavigationParameter?.NavigationParameter is PaneNavigationArguments p && !string.IsNullOrEmpty(p.RightPaneNavPathParam)) ||
+				GetPaneCount() != 1 ||
+				!IsMultiPaneAvailable)
+				return;
+
+			_draggedTabItem = draggedItem;
+			TabDropOverlay.Visibility = Visibility.Visible;
+		}
+
+		private void TabBar_TabDragCompleted(object? sender, TabBarItem? draggedItem)
+		{
+			TabDropOverlay.Visibility = Visibility.Collapsed;
+			HideDropIndicator();
+			_indicatorInitialized = false;
+			_draggedTabItem = null;
+		}
+
+		private SpriteVisual? _indicatorVisual;
+		private RectangleClip? _indicatorClip;
+		private bool _indicatorInitialized;
+
+		private static readonly string[] _cornerProps =
+			["TopLeftRadius", "TopRightRadius", "BottomRightRadius", "BottomLeftRadius"];
+
+		private SpriteVisual GetOrCreateIndicatorVisual()
+		{
+			if (_indicatorVisual is not null)
+				return _indicatorVisual;
+
+			var compositor = ElementCompositionPreview.GetElementVisual(TabDropOverlay).Compositor;
+			var accent = ((SolidColorBrush)Application.Current.Resources["AccentFillColorDefaultBrush"]).Color;
+
+			var sprite = compositor.CreateSpriteVisual();
+			sprite.Brush = compositor.CreateColorBrush(accent);
+			sprite.Opacity = 0f;
+			// AnchorPoint center makes Offset the visual's center, so it can grow outward from a point.
+			sprite.AnchorPoint = new Vector2(0.5f, 0.5f);
+
+			// Rounded-corner clip whose Right/Bottom expression-bind to the sprite's Size.
+			var clip = compositor.CreateRectangleClip();
+			clip.StartAnimation("Right", BindToSize("X"));
+			clip.StartAnimation("Bottom", BindToSize("Y"));
+			sprite.Clip = clip;
+			_indicatorClip = clip;
+
+			// Skip implicit animations if the OS "Show animations" setting is off.
+			if (new UISettings().AnimationsEnabled)
+			{
+				var anims = compositor.CreateImplicitAnimationCollection();
+				anims["Offset"] = Tween(compositor.CreateVector3KeyFrameAnimation(), "Offset", 180);
+				anims["Size"] = Tween(compositor.CreateVector2KeyFrameAnimation(), "Size", 180);
+				anims["Opacity"] = Tween(compositor.CreateScalarKeyFrameAnimation(), "Opacity", 120);
+				sprite.ImplicitAnimations = anims;
+
+				var clipAnims = compositor.CreateImplicitAnimationCollection();
+				foreach (var corner in _cornerProps)
+					clipAnims[corner] = Tween(compositor.CreateVector2KeyFrameAnimation(), corner, 180);
+				clip.ImplicitAnimations = clipAnims;
+			}
+
+			ElementCompositionPreview.SetElementChildVisual(TabDropOverlay, sprite);
+			_indicatorVisual = sprite;
+			return sprite;
+
+			ExpressionAnimation BindToSize(string axis)
+			{
+				var anim = compositor.CreateExpressionAnimation($"v.Size.{axis}");
+				anim.SetReferenceParameter("v", sprite);
+				return anim;
+			}
+
+			static T Tween<T>(T anim, string target, int durationMs) where T : KeyFrameAnimation
+			{
+				anim.InsertExpressionKeyFrame(1f, "this.FinalValue");
+				anim.Target = target;
+				anim.Duration = TimeSpan.FromMilliseconds(durationMs);
+				return anim;
+			}
+		}
+
+		private void HideDropIndicator()
+		{
+			if (_indicatorVisual is not null)
+				_indicatorVisual.Opacity = 0f;
+		}
+
+		// Round only the outer (window-facing) corners of the indicator; the inner edge sits
+		// against the splitter and stays flat. Assigning these tweens via the clip's implicit
+		// animations when motion is enabled.
+		private void ApplyZoneCorners(PaneDropZone zone)
+		{
+			if (_indicatorClip is null)
+				return;
+
+			var (tl, tr, br, bl) = zone switch
+			{
+				PaneDropZone.Left => (8f, 0f, 0f, 8f),
+				PaneDropZone.Right => (0f, 8f, 8f, 0f),
+				PaneDropZone.Top => (8f, 8f, 0f, 0f),
+				_ => (0f, 0f, 8f, 8f),
+			};
+			_indicatorClip.TopLeftRadius = new Vector2(tl);
+			_indicatorClip.TopRightRadius = new Vector2(tr);
+			_indicatorClip.BottomRightRadius = new Vector2(br);
+			_indicatorClip.BottomLeftRadius = new Vector2(bl);
+		}
+
+		private enum PaneDropZone { None, Left, Top, Right, Bottom }
+
+		// Overlay diagonals carve it into four triangles; the cursor's triangle picks the edge to split toward.
+		private PaneDropZone GetDropZone(DragEventArgs e)
+		{
+			var w = TabDropOverlay.ActualWidth;
+			var h = TabDropOverlay.ActualHeight;
+			if (w <= 0 || h <= 0)
+				return PaneDropZone.None;
+
+			var pos = e.GetPosition(TabDropOverlay);
+			var nx = pos.X / w;
+			var ny = pos.Y / h;
+
+			if (ny < nx && ny < 1 - nx)
+				return PaneDropZone.Top;
+			if (ny > nx && ny > 1 - nx)
+				return PaneDropZone.Bottom;
+			return ny > nx ? PaneDropZone.Left : PaneDropZone.Right;
+		}
+
+		private void TabDropOverlay_DragOver(object sender, DragEventArgs e)
+		{
+			e.Handled = true;
+
+			if (!e.DataView.Properties.ContainsKey(BaseTabBar.TabPathIdentifier))
+			{
+				HideDropIndicator();
+				return;
+			}
+
+			var zone = GetDropZone(e);
+			if (zone is PaneDropZone.None)
+			{
+				HideDropIndicator();
+				e.AcceptedOperation = DataPackageOperation.None;
+				return;
+			}
+
+			var w = (float)TabDropOverlay.ActualWidth;
+			var h = (float)TabDropOverlay.ActualHeight;
+			var vertical = zone is PaneDropZone.Left or PaneDropZone.Right;
+			var size = vertical ? new Vector2(w / 2, h) : new Vector2(w, h / 2);
+			var offset = zone switch
+			{
+				PaneDropZone.Left => new Vector3(w / 4, h / 2, 0),
+				PaneDropZone.Right => new Vector3(3 * w / 4, h / 2, 0),
+				PaneDropZone.Top => new Vector3(w / 2, h / 4, 0),
+				_ => new Vector3(w / 2, 3 * h / 4, 0),
+			};
+
+			var visual = GetOrCreateIndicatorVisual();
+
+			// First DragOver: seed a zero-size state at the cursor with flat corners (no animation)
+			// so the assignment below grows out from there with the zone's corners morphing in.
+			if (!_indicatorInitialized)
+			{
+				var cursor = e.GetPosition(TabDropOverlay);
+				var visualAnims = visual.ImplicitAnimations;
+				var clipAnims = _indicatorClip!.ImplicitAnimations;
+				visual.ImplicitAnimations = null;
+				_indicatorClip.ImplicitAnimations = null;
+				visual.Offset = new Vector3((float)cursor.X, (float)cursor.Y, 0);
+				visual.Size = Vector2.Zero;
+				_indicatorClip.TopLeftRadius = _indicatorClip.TopRightRadius =
+					_indicatorClip.BottomRightRadius = _indicatorClip.BottomLeftRadius = Vector2.Zero;
+				visual.ImplicitAnimations = visualAnims;
+				_indicatorClip.ImplicitAnimations = clipAnims;
+				_indicatorInitialized = true;
+			}
+
+			ApplyZoneCorners(zone);
+			visual.Offset = offset;
+			visual.Size = size;
+			visual.Opacity = 0.35f;
+
+			e.AcceptedOperation = DataPackageOperation.Move;
+			e.DragUIOverride.Caption = (vertical
+				? Strings.AddVerticalPaneDescription
+				: Strings.SplitPaneHorizontallyDescription).GetLocalizedResource();
+			e.DragUIOverride.IsCaptionVisible = true;
+			e.DragUIOverride.IsGlyphVisible = false;
+		}
+
+		private void TabDropOverlay_DragLeave(object sender, DragEventArgs e)
+			=> HideDropIndicator();
+
+		private void TabDropOverlay_Drop(object sender, DragEventArgs e)
+		{
+			HideDropIndicator();
+
+			if (!e.DataView.Properties.TryGetValue(BaseTabBar.TabPathIdentifier, out var raw) ||
+				raw is not string serialized)
+				return;
+
+			var zone = GetDropZone(e);
+			if (zone is PaneDropZone.None)
+				return;
+
+			TabBarItemParameter tabArgs;
+			try
+			{
+				tabArgs = TabBarItemParameter.Deserialize(serialized);
+			}
+			catch (JsonException)
+			{
+				return;
+			}
+
+			var draggedPath = (tabArgs.NavigationParameter as PaneNavigationArguments)?.LeftPaneNavPathParam
+				?? tabArgs.NavigationParameter as string
+				?? string.Empty;
+			var nearSide = zone is PaneDropZone.Left or PaneDropZone.Top;
+			var arrangement = zone is PaneDropZone.Left or PaneDropZone.Right
+				? ShellPaneArrangement.Vertical
+				: ShellPaneArrangement.Horizontal;
+			var currentPath = GetPane(0)?.TabBarItemParameter?.NavigationParameter as string ?? "Home";
+
+			OpenSecondaryPane(nearSide ? currentPath : draggedPath, arrangement);
+			if (nearSide)
+			{
+				NavParamsLeft = new() { NavPath = string.IsNullOrEmpty(draggedPath) ? "Home" : draggedPath };
+				// AddPane focuses the new secondary pane; for near-side drops the dropped content lives in the primary pane.
+				ActivePane = GetPane(0);
+			}
+
+			// Self-drop (current tab split onto its own pane) keeps the source tab open;
+			// otherwise the source tab is absorbed into the new split.
+			if (!ReferenceEquals(_draggedTabItem?.TabItemContent, this))
+				ApplicationData.Current.LocalSettings.Values[BaseTabBar.TabDropHandledIdentifier] = true;
+		}
+
 		private void MainWindow_SizeChanged(object sender, WindowSizeChangedEventArgs e)
 		{
 			WindowIsCompact = MainWindow.Instance.Bounds.Width <= Constants.UI.MultiplePaneWidthThreshold;
@@ -794,6 +1049,9 @@ namespace Files.App.Views
 		public void Dispose()
 		{
 			App.Logger.LogInformation($"ShellPanesPage.Dispose: PaneCount={GetPaneCount()}, ActivePane={LogPathHelper.GetPathIdentifier(ActivePane?.TabBarItemParameter?.NavigationParameter?.ToString())}");
+
+			TabBar.TabDragStarted -= TabBar_TabDragStarted;
+			TabBar.TabDragCompleted -= TabBar_TabDragCompleted;
 
 			MainWindow.Instance.SizeChanged -= MainWindow_SizeChanged;
 

--- a/src/Files.App/Views/ShellPanesPage.xaml.cs
+++ b/src/Files.App/Views/ShellPanesPage.xaml.cs
@@ -722,17 +722,14 @@ namespace Files.App.Views
 			var sprite = compositor.CreateSpriteVisual();
 			sprite.Brush = compositor.CreateColorBrush(accent);
 			sprite.Opacity = 0f;
-			// AnchorPoint center makes Offset the visual's center, so it can grow outward from a point.
 			sprite.AnchorPoint = new Vector2(0.5f, 0.5f);
 
-			// Rounded-corner clip whose Right/Bottom expression-bind to the sprite's Size.
 			var clip = compositor.CreateRectangleClip();
 			clip.StartAnimation("Right", BindToSize("X"));
 			clip.StartAnimation("Bottom", BindToSize("Y"));
 			sprite.Clip = clip;
 			_indicatorClip = clip;
 
-			// Skip implicit animations if the OS "Show animations" setting is off.
 			if (new UISettings().AnimationsEnabled)
 			{
 				var anims = compositor.CreateImplicitAnimationCollection();
@@ -773,9 +770,6 @@ namespace Files.App.Views
 				_indicatorVisual.Opacity = 0f;
 		}
 
-		// Round only the outer (window-facing) corners of the indicator; the inner edge sits
-		// against the splitter and stays flat. Assigning these tweens via the clip's implicit
-		// animations when motion is enabled.
 		private void ApplyZoneCorners(PaneDropZone zone)
 		{
 			if (_indicatorClip is null)
@@ -847,8 +841,7 @@ namespace Files.App.Views
 
 			var visual = GetOrCreateIndicatorVisual();
 
-			// First DragOver: seed a zero-size state at the cursor with flat corners (no animation)
-			// so the assignment below grows out from there with the zone's corners morphing in.
+			// Seed a zero-size state at the cursor with flat corners (no animation) so the assignment below grows out from there.
 			if (!_indicatorInitialized)
 			{
 				var cursor = e.GetPosition(TabDropOverlay);
@@ -916,12 +909,11 @@ namespace Files.App.Views
 			if (nearSide)
 			{
 				NavParamsLeft = new() { NavPath = string.IsNullOrEmpty(draggedPath) ? "Home" : draggedPath };
-				// AddPane focuses the new secondary pane; for near-side drops the dropped content lives in the primary pane.
+				// Override AddPane's focus on the new pane; the dropped content lives in pane 0 here.
 				ActivePane = GetPane(0);
 			}
 
-			// Self-drop (current tab split onto its own pane) keeps the source tab open;
-			// otherwise the source tab is absorbed into the new split.
+			// Self-drop: leave the close-on-drop flag unset so the source tab survives the split.
 			if (!ReferenceEquals(_draggedTabItem?.TabItemContent, this))
 				ApplicationData.Current.LocalSettings.Values[BaseTabBar.TabDropHandledIdentifier] = true;
 		}

--- a/src/Files.App/Views/ShellPanesPage.xaml.cs
+++ b/src/Files.App/Views/ShellPanesPage.xaml.cs
@@ -41,6 +41,7 @@ namespace Files.App.Views
 
 		private bool _wasRightPaneVisible;
 		private NavigationParams? _savedNavParamsRight;
+		private readonly PointerEventHandler _panePointerPressedHandler;
 
 		// Properties
 
@@ -259,6 +260,7 @@ namespace Files.App.Views
 
 		public ShellPanesPage()
 		{
+			_panePointerPressedHandler = Pane_PointerPressed;
 			InitializeComponent();
 
 			ShellPaneArrangement = GeneralSettingsService.ShellPaneArrangementOption;
@@ -929,7 +931,7 @@ namespace Files.App.Views
 			{
 				element.GotFocus += Pane_GotFocus;
 				element.RightTapped += Pane_RightTapped;
-				element.PointerPressed += Pane_PointerPressed;
+				element.AddHandler(UIElement.PointerPressedEvent, _panePointerPressedHandler, true);
 			}
 		}
 
@@ -1054,7 +1056,7 @@ namespace Files.App.Views
 				pane.ContentChanged -= Pane_ContentChanged;
 				pane.GotFocus -= Pane_GotFocus;
 				pane.RightTapped -= Pane_RightTapped;
-				pane.PointerPressed -= Pane_PointerPressed;
+				pane.RemoveHandler(UIElement.PointerPressedEvent, _panePointerPressedHandler);
 				pane.Dispose();
 			}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #8129

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Dragged tab to file area and confirmed drop targets were displayed based on the cursor position.
2. Confirmed drop targets don't display when dragged tab already has multiple panes.
3. Confirmed drop targets don't display when active tab already has multiple panes.

<img width="865" height="564" alt="image" src="https://github.com/user-attachments/assets/87d7e6ae-1099-4e9e-9043-eda069af6ce0" />

