### PR TITLE
Fix: Fixed issue where search continued running after navigating away or closing a tab

### DIFF
--- a/src/Files.App/UserControls/NavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml.cs
@@ -422,6 +422,11 @@ namespace Files.App.UserControls
 			}
 			else
 			{
+				if (Omnibar.CurrentSelectedMode == OmnibarSearchMode)
+				{
+					ViewModel?.CancelSuggestionSearch();
+				}
+
 				// When Omnibar loses focus, revert to Path Mode to display BreadcrumbBar
 				Omnibar.CurrentSelectedMode = OmnibarPathMode;
 			}

--- a/src/Files.App/Utils/Storage/Search/FolderSearch.cs
+++ b/src/Files.App/Utils/Storage/Search/FolderSearch.cs
@@ -92,6 +92,7 @@ namespace Files.App.Utils.Storage
 			}
 			catch (OperationCanceledException)
 			{
+				return;
 			}
 			catch (Exception e)
 			{
@@ -149,7 +150,7 @@ namespace Files.App.Utils.Storage
 			var options = ToQueryOptions();
 
 			var queryResult = folder.CreateItemQueryWithOptions(options);
-			var items = await queryResult.GetItemsAsync(0, stepSize);
+			var items = await queryResult.GetItemsAsync(0, stepSize).AsTask(token);
 
 			while (items.Count > 0)
 			{
@@ -178,7 +179,7 @@ namespace Files.App.Utils.Storage
 
 				index += (uint)items.Count;
 				stepSize = Math.Min(defaultStepSize, UsedMaxItemCount - (uint)results.Count);
-				items = await queryResult.GetItemsAsync(index, stepSize);
+				items = await queryResult.GetItemsAsync(index, stepSize).AsTask(token);
 			}
 		}
 

--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -44,6 +44,7 @@ namespace Files.App.ViewModels.UserControls
 		private string? _dragOverPath;
 		private bool _lockFlag;
 		private PointerRoutedEventArgs? _pointerRoutedEventArgs;
+		private CancellationTokenSource _suggestSearchCTS = new();
 
 		// Events
 
@@ -1127,6 +1128,10 @@ namespace Files.App.ViewModels.UserControls
 				return;
 			}
 
+			_suggestSearchCTS.Cancel();
+			_suggestSearchCTS = new CancellationTokenSource();
+			var token = _suggestSearchCTS.Token;
+
 			List<SuggestionModel> newSuggestions = [];
 
 			if (string.IsNullOrWhiteSpace(OmnibarSearchModeText))
@@ -1137,16 +1142,29 @@ namespace Files.App.ViewModels.UserControls
 			}
 			else
 			{
-				var search = new FolderSearch
+				try
 				{
-					Query = OmnibarSearchModeText,
-					Folder = ContentPageContext.ShellPage.ShellViewModel.WorkingDirectory,
-					MaxItemCount = 10,
-				};
+					await Task.Delay(200, token);
 
-				var results = await search.SearchAsync();
-				newSuggestions.AddRange(results.Select(result => new SuggestionModel(result)));
+					var search = new FolderSearch
+					{
+						Query = OmnibarSearchModeText,
+						Folder = ContentPageContext.ShellPage.ShellViewModel.WorkingDirectory,
+						MaxItemCount = 10,
+					};
+
+					var results = new List<ListedItem>();
+					await search.SearchAsync(results, token);
+					newSuggestions.AddRange(results.Select(result => new SuggestionModel(result)));
+				}
+				catch (OperationCanceledException)
+				{
+					return;
+				}
 			}
+
+			if (token.IsCancellationRequested)
+				return;
 
 			// Remove outdated suggestions
 			var toRemove = OmnibarSearchModeSuggestionItems
@@ -1211,10 +1229,17 @@ namespace Files.App.ViewModels.UserControls
 			}
 		}
 
+		public void CancelSuggestionSearch()
+		{
+			_suggestSearchCTS.Cancel();
+		}
+
 		// Disposer
 
 		public void Dispose()
 		{
+			_suggestSearchCTS.Cancel();
+			_suggestSearchCTS.Dispose();
 			UserSettingsService.OnSettingChangedEvent -= UserSettingsService_OnSettingChangedEvent;
 		}
 	}


### PR DESCRIPTION
**Resolved / Related Issues**
Fixed an issue where search queries kept running in the background even after the user cleared the search, navigated to a different folder, or closed the tab, causing sustained CPU usage.

Closes #18393

**Steps used to test these changes**
1. Open Files and navigate to a large drive
2. Open the search bar and type a query slowly to confirm suggestion searches cancel per keystroke and only fire after a ~200ms pause
3. Type a full query and press Enter and confirm search results load correctly
4. While results are loading, navigate to a different folder and confirm the search stops promptly

**Note:** A brief CPU in Files.exe after cancellation is expected due to Windows Search runs as an in-process COM server and its native thread pool work drains briefly after the .NET task unblocks.  Please find the profiler screenshot attached
<img width="776" height="596" alt="image" src="https://github.com/user-attachments/assets/9cf3a7ef-d287-4011-bf92-4d761ffc062a" />
