### PR TITLE
Code Quality: Fixed "Sponsor us on GitHub" hyperlink button in release notes page

### DIFF
--- a/src/Files.App/ViewModels/ReleaseNotesViewModel.cs
+++ b/src/Files.App/ViewModels/ReleaseNotesViewModel.cs
@@ -8,6 +8,9 @@ namespace Files.App.ViewModels
 		public string BlogPostUrl =>
 			Constants.ExternalUrl.ReleaseNotesUrl;
 
+		public string SupportUsUrl =>
+			Constants.ExternalUrl.SupportUsUrl;
+
 		public ReleaseNotesViewModel()
 		{
 		}

--- a/src/Files.App/Views/ReleaseNotesPage.xaml
+++ b/src/Files.App/Views/ReleaseNotesPage.xaml
@@ -38,7 +38,7 @@
 			<HyperlinkButton
 				HorizontalAlignment="Left"
 				Content="{helpers:ResourceString Name=SponsorUsOnGitHub}"
-				NavigateUri="https://github.com/sponsors/yaira2" />
+				NavigateUri="{x:Bind ViewModel.SupportUsUrl, Mode=OneTime}" />
 		</Border>
 	</Grid>
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

N/A

**Steps used to test these changes**

the hyperlink button now links to the repo sponsor dialogue

https://github.com/user-attachments/assets/4d0c59d4-4e24-451f-a6d0-17f41e39a1d9

