### PR TITLE
Fix: Fixed issue where properties window sometimes opened in the background

### DIFF
--- a/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
+++ b/src/Files.App.Controls/Omnibar/Omnibar.Events.cs
@@ -17,9 +17,15 @@ namespace Files.App.Controls
 		private void AutoSuggestBox_GettingFocus(UIElement sender, GettingFocusEventArgs args)
 		{
 			if (args.OldFocusedElement is null)
+			{
+				// Window is regaining activation and restoring focus to the TextBox - redirect
+				// to whatever was focused before, so the omnibar doesn't get stuck in edit mode.
+				if (args.InputDevice is FocusInputDeviceKind.None &&
+					_previouslyFocusedElement.TryGetTarget(out var previous) &&
+					previous is not null)
+					args.TrySetNewFocusedElement(previous);
 				return;
-
-			GlobalHelper.WriteDebugStringForOmnibar("The TextBox is getting the focus.");
+			}
 
 			_previouslyFocusedElement = new(args.OldFocusedElement as UIElement);
 		}
@@ -65,14 +71,6 @@ namespace Files.App.Controls
 
 			IsFocused = false;
 			IsFocusedChanged?.Invoke(this, new(IsFocused));
-
-			// Workaround to prevent an issue where if the window loses focus and then regains focus,
-			// the AutoSuggestBox will regain focus and the suggestions popup will open again.
-			if (element is TextBox)
-			{
-				_previouslyFocusedElement.TryGetTarget(out var previouslyFocusedElement);
-				previouslyFocusedElement?.Focus(FocusState.Programmatic);
-			}
 		}
 
 		private async void AutoSuggestBox_KeyDown(object sender, KeyRoutedEventArgs e)

--- a/src/Files.App/Views/ShellPanesPage.xaml.cs
+++ b/src/Files.App/Views/ShellPanesPage.xaml.cs
@@ -413,14 +413,20 @@ namespace Files.App.Views
 		/// <inheritdoc/>
 		public void FocusActivePane()
 		{
-			if (ActivePane == (IShellPage)GetPane(0)!)
-				GetPane(0)?.Focus(FocusState.Programmatic);
-			else
-				GetPane(1)?.Focus(FocusState.Programmatic);
+			var activePane = ActivePane == (IShellPage)GetPane(0)! ? GetPane(0) : GetPane(1);
 
-			// Focus file list
-			if (ActivePane is BaseShellPage baseShellPage)
-				baseShellPage.ContentPage?.ItemManipulationModel.FocusFileList();
+			// Skip when the file list is empty and no text input currently has focus:
+			// focusing the pane in that state lands XAML focus on the outer ListView
+			// element itself, which causes subsequent popup-dismissal to push newly
+			// opened top-level windows behind main (Files #13697). If a text input
+			// currently has focus (e.g. omnibar after Enter), we still need to move
+			// focus off it so keyboard shortcuts work.
+			if (activePane?.ShellViewModel?.FilesAndFolders?.Count == 0 &&
+				!UIHelpers.IsTextInputFocused(activePane.XamlRoot))
+				return;
+
+			activePane?.Focus(FocusState.Programmatic);
+			activePane?.ContentPage?.ItemManipulationModel.FocusFileList();
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #13697

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened empty folder
2. Right clicked item in sidebar and clicked the properties icon
3. Properties window opened in foreground
4. Repeated test with populated folder
5. Confirmed that pressing enter on Omnibar correctly moved focus to file list
