### PR TITLE
Fix: Fixed an issue where Windows Terminal wouldn't open when launched from Files

### DIFF
--- a/src/Files.App/Actions/Open/OpenTerminalAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalAction.cs
@@ -93,7 +93,7 @@ namespace Files.App.Actions
 				{
 					FileName = "wt.exe",
 					Arguments = args.ToString(),
-					UseShellExecute = true
+					UseShellExecute = false
 				};
 			}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Closes #18709

**Steps used to test these changes**

1. Navigate to a folder
2. Press the "Open in Windows Terminal" context menu item
3. Windows Terminal now opens correctly
