### PR TITLE
Feature: Open a new tab by middle-clicking the empty space in the horizontal tab control

### DIFF
--- a/src/Files.App/UserControls/TabBar/TabBar.xaml
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml
@@ -261,7 +261,8 @@
 						HorizontalAlignment="Stretch"
 						VerticalAlignment="Stretch"
 						Fill="Transparent"
-						Loaded="DragAreaRectangle_Loaded" />
+						Loaded="DragAreaRectangle_Loaded"
+						PointerPressed="DragAreaRectangle_PointerPressed" />
 
 				</Grid>
 			</TabView.TabStripFooter>

--- a/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
+++ b/src/Files.App/UserControls/TabBar/TabBar.xaml.cs
@@ -377,5 +377,14 @@ namespace Files.App.UserControls.TabBar
 				Math.Max(0, HorizontalTabView.ActualWidth - TabBarAddNewTabButton.Width - titleBarInset),
 				Math.Max(0, HorizontalTabView.ActualHeight)));
 		}
+
+		private async void DragAreaRectangle_PointerPressed(object sender, PointerRoutedEventArgs e)
+		{
+			if (e.GetCurrentPoint(null).Properties.IsMiddleButtonPressed)
+			{
+				await NavigationHelpers.AddNewTabAsync();
+				e.Handled = true;
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Description

This PR adds the ability to open a new tab by middle-clicking on the empty space in the horizontal tab control (the area next to the "+" add-tab button).

## Changes

- Added a `PointerPressed` event handler on the `DragAreaRectangle` (the transparent rectangle occupying the empty space in the tab strip footer)
- When the middle mouse button is pressed on this area, `NavigationHelpers.AddNewTabAsync()` is called to open a new tab

## Related Issue

Closes #3808