### PR TITLE
Fix fr-FR: rename legacy dotted keys, add 9 missing translations

### DIFF
--- a/src/Files.App/Strings/fr-FR/Resources.resw
+++ b/src/Files.App/Strings/fr-FR/Resources.resw
@@ -180,10 +180,10 @@
   <data name="Accessed" xml:space="preserve">
     <value>Accédé :</value>
   </data>
-  <data name="RecentItemClearAll.Text" xml:space="preserve">
+  <data name="RecentItemClearAllText" xml:space="preserve">
     <value>Effacer tous les éléments</value>
   </data>
-  <data name="NavigationToolbarVisiblePath.PlaceholderText" xml:space="preserve">
+  <data name="NavigationToolbarVisiblePathPlaceholderText" xml:space="preserve">
     <value>Entrez un chemin pour naviguer ou tapez « &gt; » pour ouvrir la palette de commandes</value>
   </data>
   <data name="Search" xml:space="preserve">
@@ -198,7 +198,7 @@
   <data name="RecentItemDescription.Text" xml:space="preserve">
     <value>Les fichiers précédemment ouverts s'afficheront ici</value>
   </data>
-  <data name="RecentItemRemove.Text" xml:space="preserve">
+  <data name="RecentItemRemoveText" xml:space="preserve">
     <value>Supprimer cet élément</value>
   </data>
   <data name="OpenGitHubRepo" xml:space="preserve">
@@ -312,13 +312,13 @@
   <data name="PinFolderToSidebar" xml:space="preserve">
     <value>Épingler à la barre latérale</value>
   </data>
-  <data name="WelcomeDialog.Title" xml:space="preserve">
+  <data name="WelcomeDialogTitle" xml:space="preserve">
     <value>Bienvenue dans Files !</value>
   </data>
   <data name="WelcomeDialog.PrimaryButtonText" xml:space="preserve">
     <value>Accorder l'autorisation</value>
   </data>
-  <data name="WelcomeDialogTextBlock.Text" xml:space="preserve">
+  <data name="WelcomeDialogTextBlockText" xml:space="preserve">
     <value>Pour commencer, vous devrez nous accorder l'autorisation d'afficher vos fichiers. Cela ouvrira une page de paramètres où vous pourrez nous accorder cette autorisation. Vous devrez relancer l'application une fois cette étape terminée.</value>
   </data>
   <data name="Display" xml:space="preserve">
@@ -384,16 +384,16 @@
   <data name="SetAsAppBackground" xml:space="preserve">
     <value>Définir comme fond d'écran de l'application</value>
   </data>
-  <data name="AccessDeniedDeleteDialog.Text" xml:space="preserve">
+  <data name="AccessDeniedDeleteDialogText" xml:space="preserve">
     <value>Impossible de supprimer cet élément</value>
   </data>
-  <data name="DriveUnpluggedDialog.Text" xml:space="preserve">
+  <data name="DriveUnpluggedDialogText" xml:space="preserve">
     <value>Veuillez insérer le lecteur nécessaire pour accéder à cet élément.</value>
   </data>
-  <data name="DriveUnpluggedDialog.Title" xml:space="preserve">
+  <data name="DriveUnpluggedDialogTitle" xml:space="preserve">
     <value>Lecteur débranché</value>
   </data>
-  <data name="FileNotFoundDialog.Text" xml:space="preserve">
+  <data name="FileNotFoundDialogText" xml:space="preserve">
     <value>Le fichier auquel vous tentez d'accéder a peut-être été déplacé ou supprimé.</value>
   </data>
   <data name="CannotAccessPropertiesTitle" xml:space="preserve">
@@ -402,22 +402,22 @@
   <data name="CannotAccessPropertiesContent" xml:space="preserve">
     <value>Le fichier auquel vous tentez d'accéder a peut-être été déplacé ou supprimé.</value>
   </data>
-  <data name="FileNotFoundDialog.Title" xml:space="preserve">
+  <data name="FileNotFoundDialogTitle" xml:space="preserve">
     <value>Fichier introuvable</value>
   </data>
-  <data name="FolderNotFoundDialog.Text" xml:space="preserve">
+  <data name="FolderNotFoundDialogText" xml:space="preserve">
     <value>Le dossier auquel vous tentez d'accéder a peut-être été déplacé ou supprimé.</value>
   </data>
-  <data name="FolderNotFoundDialog.Title" xml:space="preserve">
+  <data name="FolderNotFoundDialogTitle" xml:space="preserve">
     <value>Avez-vous supprimé ce dossier ?</value>
   </data>
-  <data name="FileInUseByDialog.Text" xml:space="preserve">
+  <data name="FileInUseByDialogText" xml:space="preserve">
     <value>Le fichier auquel vous tentez d'accéder est actuellement utilisé par {0}</value>
   </data>
-  <data name="FileInUseDialog.Text" xml:space="preserve">
+  <data name="FileInUseDialogText" xml:space="preserve">
     <value>Le fichier auquel vous tentez d'accéder est actuellement utilisé par une autre application</value>
   </data>
-  <data name="FileInUseDialog.Title" xml:space="preserve">
+  <data name="FileInUseDialogTitle" xml:space="preserve">
     <value>Le fichier est en cours d'utilisation</value>
   </data>
   <data name="Layout" xml:space="preserve">
@@ -524,7 +524,7 @@
   <data name="PropertiesFilesAndFoldersAndLocationsCount" xml:space="preserve">
     <value>{0, number} {0, plural, one {fichier} other {fichiers}}, {1, number} {1, plural, one {dossier} other {dossiers}} depuis {2, number} {2, plural, one {emplacement} other {emplacements}}</value>
   </data>
-  <data name="BaseLayoutContextFlyoutRunAsAnotherUser.Text" xml:space="preserve">
+  <data name="BaseLayoutContextFlyoutRunAsAnotherUserText" xml:space="preserve">
     <value>Exécuter en tant qu'autre utilisateur</value>
   </data>
   <data name="PropertiesDriveItemTypesEquals" xml:space="preserve">
@@ -635,22 +635,22 @@
   <data name="ShareDialogTitleMultipleItems" xml:space="preserve">
     <value>Partage de {0} {1}</value>
   </data>
-  <data name="RenameError.ItemDeleted.Text" xml:space="preserve">
+  <data name="RenameErrorItemDeletedText" xml:space="preserve">
     <value>L'élément que vous tentez de renommer n'existe plus. Veuillez vérifier l'emplacement correct de l'élément que vous avez besoin de renommer.</value>
   </data>
-  <data name="RenameError.ItemDeleted.Title" xml:space="preserve">
+  <data name="RenameErrorItemDeletedTitle" xml:space="preserve">
     <value>L'élément n'existe plus</value>
   </data>
-  <data name="RenameError.NameInvalid.Text" xml:space="preserve">
+  <data name="RenameErrorNameInvalidText" xml:space="preserve">
     <value>Le nom spécifié est invalide. Veuillez vérifier le nom désiré et essayez à nouveau.</value>
   </data>
-  <data name="RenameError.NameInvalid.Title" xml:space="preserve">
+  <data name="RenameErrorNameInvalidTitle" xml:space="preserve">
     <value>Nom d'élément invalide</value>
   </data>
-  <data name="RenameError.TooLong.Text" xml:space="preserve">
+  <data name="RenameErrorTooLongText" xml:space="preserve">
     <value>La longueur du nom de l'élément dépasse la limite maximum. Veuillez vérifier le nom désiré et essayer à nouveau.</value>
   </data>
-  <data name="RenameError.TooLong.Title" xml:space="preserve">
+  <data name="RenameErrorTooLongTitle" xml:space="preserve">
     <value>Le nom de l'élément est trop long</value>
   </data>
   <data name="ShowMoreOptions" xml:space="preserve">
@@ -662,13 +662,13 @@
   <data name="SponsorUsOnGitHub" xml:space="preserve">
     <value>Soutenez-nous sur GitHub</value>
   </data>
-  <data name="AccessDeniedCreateDialog.Text" xml:space="preserve">
+  <data name="AccessDeniedCreateDialogText" xml:space="preserve">
     <value>Cet élément n'a pas pu être créé</value>
   </data>
   <data name="AccessDenied" xml:space="preserve">
     <value>Accès refusé</value>
   </data>
-  <data name="BaseLayoutItemContextFlyoutSetAs.Text" xml:space="preserve">
+  <data name="BaseLayoutItemContextFlyoutSetAsText" xml:space="preserve">
     <value>Définir comme</value>
   </data>
   <data name="Cancel" xml:space="preserve">
@@ -710,10 +710,10 @@
   <data name="ShowConfirmationWhenDeletingItems" xml:space="preserve">
     <value>Afficher une boîte de dialogue lors de la suppression d'éléments</value>
   </data>
-  <data name="PropertySaveErrorMessage.Text" xml:space="preserve">
+  <data name="PropertySaveErrorMessageText" xml:space="preserve">
     <value>Il y a eu un problème lors de l'enregistrement de certaines propriétés.</value>
   </data>
-  <data name="PropertySaveErrorDialog.Title" xml:space="preserve">
+  <data name="PropertySaveErrorDialogTitle" xml:space="preserve">
     <value>Erreur</value>
   </data>
   <data name="PropertySaveErrorDialog.SecondaryButtonText" xml:space="preserve">
@@ -1205,7 +1205,7 @@
   <data name="CloudDriveSyncStatus_Unknown" xml:space="preserve">
     <value>Inconnu</value>
   </data>
-  <data name="RenameFileDialog.Text" xml:space="preserve">
+  <data name="RenameFileDialogText" xml:space="preserve">
     <value>Si vous changez l'extension du fichier, celui-ci peut devenir inutilisable. Êtes-vous sûr de vouloir la changer ?</value>
   </data>
   <data name="DriveTypeCDRom" xml:space="preserve">
@@ -1244,7 +1244,7 @@
   <data name="MoreOptions" xml:space="preserve">
     <value>Plus d'options…</value>
   </data>
-  <data name="DrivesWidgetOptionsFlyoutMapNetDriveMenuItem.Text" xml:space="preserve">
+  <data name="DrivesWidgetOptionsFlyoutMapNetDriveMenuItemText" xml:space="preserve">
     <value>Connecter un lecteur réseau</value>
   </data>
   <data name="Pinned" xml:space="preserve">
@@ -1277,10 +1277,10 @@
   <data name="ColumnsShortcutTooltip" xml:space="preserve">
     <value>Colonnes (Ctrl+Maj+6)</value>
   </data>
-  <data name="PinItemToStart.Text" xml:space="preserve">
+  <data name="PinItemToStartText" xml:space="preserve">
     <value>Épingler au menu Démarrer</value>
   </data>
-  <data name="UnpinItemFromStart.Text" xml:space="preserve">
+  <data name="UnpinItemFromStartText" xml:space="preserve">
     <value>Désépingler du menu Démarrer</value>
   </data>
   <data name="Library" xml:space="preserve">
@@ -1526,13 +1526,13 @@
   <data name="SecurityUnknownAccount" xml:space="preserve">
     <value>Compte inconnu</value>
   </data>
-  <data name="SecurityCannotReadProperties.Text" xml:space="preserve">
+  <data name="SecurityCannotReadPropertiesText" xml:space="preserve">
     <value>Vous n'avez pas les autorisations pour voir les propriétés de sécurité de cet objet. Cliquez sur « Autorisations avancées » pour continuer.</value>
   </data>
   <data name="SecurityOwnerLabel.Text" xml:space="preserve">
     <value>Propriétaire :</value>
   </data>
-  <data name="SecurityUnknownOwnerText.Text" xml:space="preserve">
+  <data name="SecurityUnknownOwnerTextText" xml:space="preserve">
     <value>Propriétaire inconnu</value>
   </data>
   <data name="ExtractArchive" xml:space="preserve">
@@ -1544,10 +1544,10 @@
   <data name="BaseLayoutItemContextFlyoutExtractToChildFolder" xml:space="preserve">
     <value>Extraire vers {0}\</value>
   </data>
-  <data name="SideBarCreateNewLibrary.Text" xml:space="preserve">
+  <data name="SideBarCreateNewLibraryText" xml:space="preserve">
     <value>Créer une nouvelle bibliothèque</value>
   </data>
-  <data name="SideBarRestoreLibraries.Text" xml:space="preserve">
+  <data name="SideBarRestoreLibrariesText" xml:space="preserve">
     <value>Restaurer les bibliothèques par défaut</value>
   </data>
   <data name="DialogRestoreLibrariesSubtitleText" xml:space="preserve">
@@ -1559,7 +1559,7 @@
   <data name="PropertyFileOwner" xml:space="preserve">
     <value>Propriétaire</value>
   </data>
-  <data name="SecuritySpecialLabel.Text" xml:space="preserve">
+  <data name="SecuritySpecialLabelText" xml:space="preserve">
     <value>Autorisations spéciales</value>
   </data>
   <data name="Access" xml:space="preserve">
@@ -1586,7 +1586,7 @@
   <data name="Permissions" xml:space="preserve">
     <value>Autorisations</value>
   </data>
-  <data name="SecurityAdvancedCannotReadProperties.Text" xml:space="preserve">
+  <data name="SecurityAdvancedCannotReadPropertiesText" xml:space="preserve">
     <value>Vous n'avez pas les autorisations pour voir les propriétés de sécurité de cet objet. Vous pouvez essayer de prendre possession de cet objet.</value>
   </data>
   <data name="SecurityAdvancedFolderFiles.Text" xml:space="preserve">
@@ -1610,49 +1610,49 @@
   <data name="SecurityAdvancedFolderSubfolders.Text" xml:space="preserve">
     <value>Ce dossier et ses sous-dossiers</value>
   </data>
-  <data name="SecurityAppendDataLabel.Text" xml:space="preserve">
+  <data name="SecurityAppendDataLabelText" xml:space="preserve">
     <value>Ajouter des données</value>
   </data>
-  <data name="SecurityChangePermissionsLabel.Text" xml:space="preserve">
+  <data name="SecurityChangePermissionsLabelText" xml:space="preserve">
     <value>Modifier l'autorisation</value>
   </data>
-  <data name="SecurityCreateDirectoriesLabel.Text" xml:space="preserve">
+  <data name="SecurityCreateDirectoriesLabelText" xml:space="preserve">
     <value>Créer des dossiers</value>
   </data>
-  <data name="SecurityCreateFilesLabel.Text" xml:space="preserve">
+  <data name="SecurityCreateFilesLabelText" xml:space="preserve">
     <value>Créer des fichiers</value>
   </data>
-  <data name="SecurityDeleteSubdirectoriesAndFilesLabel.Text" xml:space="preserve">
+  <data name="SecurityDeleteSubdirectoriesAndFilesLabelText" xml:space="preserve">
     <value>Supprimer les sous-dossiers et fichiers</value>
   </data>
-  <data name="SecurityExecuteFileLabel.Text" xml:space="preserve">
+  <data name="SecurityExecuteFileLabelText" xml:space="preserve">
     <value>Exécuter les fichiers</value>
   </data>
-  <data name="SecurityReadAttributesLabel.Text" xml:space="preserve">
+  <data name="SecurityReadAttributesLabelText" xml:space="preserve">
     <value>Lire les attributs</value>
   </data>
-  <data name="SecurityReadDataLabel.Text" xml:space="preserve">
+  <data name="SecurityReadDataLabelText" xml:space="preserve">
     <value>Lire les données</value>
   </data>
-  <data name="SecurityReadExtendedAttributesLabel.Text" xml:space="preserve">
+  <data name="SecurityReadExtendedAttributesLabelText" xml:space="preserve">
     <value>Lire les attributs étendus</value>
   </data>
-  <data name="SecurityReadPermissionsLabel.Text" xml:space="preserve">
+  <data name="SecurityReadPermissionsLabelText" xml:space="preserve">
     <value>Lire les autorisations</value>
   </data>
-  <data name="SecurityTakeOwnershipLabel.Text" xml:space="preserve">
+  <data name="SecurityTakeOwnershipLabelText" xml:space="preserve">
     <value>Prendre possession</value>
   </data>
-  <data name="SecurityTraverseLabel.Text" xml:space="preserve">
+  <data name="SecurityTraverseLabelText" xml:space="preserve">
     <value>Visiter le dossier</value>
   </data>
-  <data name="SecurityWriteAttributesLabel.Text" xml:space="preserve">
+  <data name="SecurityWriteAttributesLabelText" xml:space="preserve">
     <value>Écrire les attributs</value>
   </data>
-  <data name="SecurityWriteDataLabel.Text" xml:space="preserve">
+  <data name="SecurityWriteDataLabelText" xml:space="preserve">
     <value>Écrire les données</value>
   </data>
-  <data name="SecurityWriteExtendedAttributesLabel.Text" xml:space="preserve">
+  <data name="SecurityWriteExtendedAttributesLabelText" xml:space="preserve">
     <value>Écrire les attributs étendus</value>
   </data>
   <data name="SecurityAdvancedInheritedConvert.Text" xml:space="preserve">
@@ -1709,7 +1709,7 @@
   <data name="WSL" xml:space="preserve">
     <value>WSL</value>
   </data>
-  <data name="SideBarHideSectionFromSideBar.Text" xml:space="preserve">
+  <data name="SideBarHideSectionFromSideBarText" xml:space="preserve">
     <value>Cacher la section {0}</value>
   </data>
   <data name="AddFile" xml:space="preserve">
@@ -1739,7 +1739,7 @@
   <data name="ExtractingCompleteText" xml:space="preserve">
     <value>Extraction terminée !</value>
   </data>
-  <data name="BaseLayoutItemContextFlyoutOpenParentFolder.Text" xml:space="preserve">
+  <data name="BaseLayoutItemContextFlyoutOpenParentFolderText" xml:space="preserve">
     <value>Ouvrir le dossier parent</value>
   </data>
   <data name="Unknown" xml:space="preserve">
@@ -1754,10 +1754,10 @@
   <data name="InsertDiscDialog.OpenDriveButton" xml:space="preserve">
     <value>Ouvrir le lecteur</value>
   </data>
-  <data name="InsertDiscDialog.Text" xml:space="preserve">
+  <data name="InsertDiscDialogText" xml:space="preserve">
     <value>Veuillez insérer un disque dans le lecteur {0}</value>
   </data>
-  <data name="InsertDiscDialog.Title" xml:space="preserve">
+  <data name="InsertDiscDialogTitle" xml:space="preserve">
     <value>Insérer un disque</value>
   </data>
   <data name="OK" xml:space="preserve">
@@ -4595,5 +4595,32 @@
   </data>
   <data name="ConfirmRemoveTagsDialogContent" xml:space="preserve">
     <value>Êtes-vous sûr de vouloir supprimer les étiquettes des éléments sélectionnés ?</value>
+  </data>
+  <data name="AutoFitColumns" xml:space="preserve">
+    <value>Ajuster automatiquement les colonnes</value>
+  </data>
+  <data name="AutoFitColumnsDescription" xml:space="preserve">
+    <value>Redimensionne les colonnes pour ajuster leur contenu</value>
+  </data>
+  <data name="AutoSizeColumnsInDetailsLayout" xml:space="preserve">
+    <value>Ajuster automatiquement les colonnes au contenu</value>
+  </data>
+  <data name="CannotRunFileDialogText" xml:space="preserve">
+    <value>Pour trouver une version compatible avec votre PC, contactez l'éditeur du logiciel.</value>
+  </data>
+  <data name="CannotRunFileDialogTitle" xml:space="preserve">
+    <value>Cette application ne peut pas s'exécuter sur votre PC</value>
+  </data>
+  <data name="CompressSkippedItemsDialogText" xml:space="preserve">
+    <value>{0, plural, one {L'élément suivant ne peut pas être compressé} other {Les éléments suivants ne peuvent pas être compressés}}. Voulez-vous {0, plural, one {l'ignorer} other {les ignorer}} ?</value>
+  </data>
+  <data name="CompressSkippedItemsDialogTitle" xml:space="preserve">
+    <value>Certains éléments ne peuvent pas être compressés</value>
+  </data>
+  <data name="OpenCurrentFolderInOtherPane" xml:space="preserve">
+    <value>Ouvrir le dossier actuel dans l'autre volet</value>
+  </data>
+  <data name="OpenCurrentFolderInOtherPaneDescription" xml:space="preserve">
+    <value>Ouvre le dossier actuel dans l'autre volet</value>
   </data>
 </root>


### PR DESCRIPTION
This PR fixes 64 strings that Crowdin reports as missing in fr-FR/Resources.resw.

Investigation showed that 55 of these already had a French translation, but under
an old dotted naming convention (e.g. `RenameError.ItemDeleted.Text`) that no longer
matches the current en-US key names (e.g. `RenameErrorItemDeletedText`). This PR
renames those 55 keys to match en-US, preserving the existing translations.

The remaining 9 strings were genuinely untranslated and have been translated:
- AutoFitColumns / AutoFitColumnsDescription
- AutoSizeColumnsInDetailsLayout
- CannotRunFileDialogText / CannotRunFileDialogTitle
- CompressSkippedItemsDialogText / CompressSkippedItemsDialogTitle
- OpenCurrentFolderInOtherPane / OpenCurrentFolderInOtherPaneDescription

After this change, fr-FR has 0 missing keys compared to en-US.