### PR TITLE
Fix: Fixed an issue where private repos could not be cloned

### DIFF
--- a/src/Files.App/Services/Git/LibGit2Service.cs
+++ b/src/Files.App/Services/Git/LibGit2Service.cs
@@ -1,6 +1,7 @@
 using LibGit2Sharp;
 using Microsoft.Extensions.Logging;
 using Sentry;
+using System.Security.Cryptography.Xml;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -399,6 +400,75 @@ internal sealed partial class LibGit2Service // : IVersionControl
 			IsExecutingGitAction = false;
 			GitFetchCompleted?.Invoke(null, EventArgs.Empty);
 		});
+	}
+
+	public async Task CloneRepoAsync(string repoUrl, string repoName, string targetDirectory)
+	{
+		var banner = StatusCenterHelper.AddCard_GitClone(repoName.CreateEnumerable(), targetDirectory.CreateEnumerable(), ReturnResult.InProgress);
+		var fsProgress = new StatusCenterItemProgressModel(banner.ProgressEventSource, enumerationCompleted: true, FileSystemStatusCode.InProgress);
+		var errorMessage = string.Empty;
+
+		bool isSuccess = await Task.Run(() =>
+		{
+			try
+			{
+				var cloneOptions = new CloneOptions
+				{
+					FetchOptions =
+						{
+							OnTransferProgress = progress =>
+							{
+								banner.CancellationToken.ThrowIfCancellationRequested();
+								fsProgress.ItemsCount = progress.TotalObjects;
+								fsProgress.SetProcessedSize(progress.ReceivedBytes);
+								fsProgress.AddProcessedItemsCount(1);
+								fsProgress.Report((int)((progress.ReceivedObjects / (double)progress.TotalObjects) * 100));
+								return true;
+							},
+							OnProgress = _ => !banner.CancellationToken.IsCancellationRequested,
+						},
+					OnCheckoutProgress = (path, completed, total) =>
+						banner.CancellationToken.ThrowIfCancellationRequested()
+				};
+
+				var token = CredentialsHelpers.GetPassword(GIT_RESOURCE_NAME, GIT_RESOURCE_USERNAME);
+				var signature = Configuration.BuildFrom(null, null).BuildSignature(DateTimeOffset.Now);
+
+				if (signature is not null && !string.IsNullOrWhiteSpace(token))
+				{
+					cloneOptions.FetchOptions.CredentialsProvider = (url, user, cred)
+						=> new UsernamePasswordCredentials
+						{
+							Username = signature.Name,
+							Password = token
+						};
+				}
+
+				Repository.Clone(repoUrl, targetDirectory, cloneOptions);
+				return true;
+			}
+			catch (Exception ex)
+			{
+				errorMessage = ex.Message;
+				return false;
+			}
+		}, banner.CancellationToken);
+
+		if (!string.IsNullOrEmpty(errorMessage))
+		{
+			UIHelpers.CloseAllDialogs();
+			await Task.Delay(500);
+			await DynamicDialogFactory.ShowFor_CannotCloneRepo(errorMessage);
+		}
+
+		StatusCenterViewModel.RemoveItem(banner);
+
+		StatusCenterHelper.AddCard_GitClone(
+			repoName.CreateEnumerable(),
+			targetDirectory.CreateEnumerable(),
+			isSuccess ? ReturnResult.Success :
+			banner.CancellationToken.IsCancellationRequested ? ReturnResult.Cancelled :
+			ReturnResult.Failed);
 	}
 
 	private static bool IsRepoValid(string path)

--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -45,6 +45,9 @@ namespace Files.App.Utils.Git
 		/// <inheritdoc cref="IVersionControlService.FetchOrigin(string?, CancellationToken)"/>
 		public static async void FetchOrigin(string? repositoryPath, CancellationToken cancellationToken = default) => _implementation.FetchOrigin(repositoryPath, cancellationToken);
 
+		/// <inheritdoc cref="IVersionControlService.CloneRepoAsync(string, string, string)"/>
+		public static Task CloneRepoAsync(string repoUrl, string repoName, string targetDirectory) => _implementation.CloneRepoAsync(repoUrl, repoName, targetDirectory);
+
 		/// <inheritdoc cref="IVersionControlService.IsExecutingGitAction"/>
 		public static bool IsExecutingGitAction => _implementation.IsExecutingGitAction;
 
@@ -598,62 +601,6 @@ namespace Files.App.Utils.Git
 		public static bool IsValidRepoUrl(string url)
 		{
 			return GitHubRepositoryRegex().IsMatch(url);
-		}
-
-		public static async Task CloneRepoAsync(string repoUrl, string repoName, string targetDirectory)
-		{
-			var banner = StatusCenterHelper.AddCard_GitClone(repoName.CreateEnumerable(), targetDirectory.CreateEnumerable(), ReturnResult.InProgress);
-			var fsProgress = new StatusCenterItemProgressModel(banner.ProgressEventSource, enumerationCompleted: true, FileSystemStatusCode.InProgress);
-			var errorMessage = string.Empty;
-
-			bool isSuccess = await Task.Run(() =>
-			{
-				try
-				{
-					var cloneOptions = new CloneOptions
-					{
-						FetchOptions =
-						{
-							OnTransferProgress = progress =>
-							{
-								banner.CancellationToken.ThrowIfCancellationRequested();
-								fsProgress.ItemsCount = progress.TotalObjects;
-								fsProgress.SetProcessedSize(progress.ReceivedBytes);
-								fsProgress.AddProcessedItemsCount(1);
-								fsProgress.Report((int)((progress.ReceivedObjects / (double)progress.TotalObjects) * 100));
-								return true;
-							},
-							OnProgress = _ => !banner.CancellationToken.IsCancellationRequested
-						},
-						OnCheckoutProgress = (path, completed, total) =>
-							banner.CancellationToken.ThrowIfCancellationRequested()
-					};
-
-					Repository.Clone(repoUrl, targetDirectory, cloneOptions);
-					return true;
-				}
-				catch (Exception ex)
-				{
-					errorMessage = ex.Message;
-					return false;
-				}
-			}, banner.CancellationToken);
-
-			if (!string.IsNullOrEmpty(errorMessage))
-			{
-				UIHelpers.CloseAllDialogs();
-				await Task.Delay(500);
-				await DynamicDialogFactory.ShowFor_CannotCloneRepo(errorMessage);
-			}
-
-			StatusCenterViewModel.RemoveItem(banner);
-
-			StatusCenterHelper.AddCard_GitClone(
-				repoName.CreateEnumerable(),
-				targetDirectory.CreateEnumerable(),
-				isSuccess ? ReturnResult.Success :
-				banner.CancellationToken.IsCancellationRequested ? ReturnResult.Cancelled :
-				ReturnResult.Failed);
 		}
 
 		// Method already moved into abstraction


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Closes #18648
- Related #16738

**Steps used to test these changes**

1. Created an OAuth app (https://github.com/settings/developers)
2. Copied the OAuth app client ID into [this line of code](https://github.com/files-community/Files/blob/d3b400fcb0802d1502073701804bf9ea7a2fdcb0/src/Files.App/Utils/Git/GitHelpers.cs#L99)
3. Opened the app
4. Navigated to developer tools settings and logged in with GitHub
5. Navigated to a folder and ran the "Clone a Git repo" action
6. Entered a private GitHub repo URL that I have access to
7. Observed that the app now clones authenticated private repos correctly