### PR TITLE
Fix: Fixed an issue where start menu pins had the wrong icon

### DIFF
--- a/src/Files.App.CsWin32/NativeMethods.txt
+++ b/src/Files.App.CsWin32/NativeMethods.txt
@@ -337,4 +337,3 @@ FileOpenDialog
 FileSaveDialog
 DesktopWallpaper
 ApplicationActivationManager
-PrivateExtractIcons

--- a/src/Files.App.CsWin32/NativeMethods.txt
+++ b/src/Files.App.CsWin32/NativeMethods.txt
@@ -337,3 +337,4 @@ FileOpenDialog
 FileSaveDialog
 DesktopWallpaper
 ApplicationActivationManager
+PrivateExtractIcons

--- a/src/Files.App/Actions/Open/OpenTerminalAction.cs
+++ b/src/Files.App/Actions/Open/OpenTerminalAction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Files Community
+// Copyright (c) Files Community
 // Licensed under the MIT License.
 
 using Microsoft.Win32;

--- a/src/Files.App/Actions/Start/PinToStartAction.cs
+++ b/src/Files.App/Actions/Start/PinToStartAction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Files Community
+﻿// Copyright (c) Files Community
 // Licensed under the MIT License.
 
 namespace Files.App.Actions
@@ -25,7 +25,7 @@ namespace Files.App.Actions
 			=> ActionCategory.Start;
 
 		public bool IsExecutable
-			=> context.ShellPage is not null;
+			=> context.ShellPage is not null && context.SelectedItems.Any(item => !item.IsItemPinnedToStart);
 
 		public PinToStartAction()
 		{

--- a/src/Files.App/Actions/Start/PinToStartAction.cs
+++ b/src/Files.App/Actions/Start/PinToStartAction.cs
@@ -32,6 +32,7 @@ namespace Files.App.Actions
 			context = Ioc.Default.GetRequiredService<IContentPageContext>();
 		}
 
+		// Logic must stay consistent with UnpinFromStartAction.ExecuteAsync()
 		public async Task ExecuteAsync(object? parameter = null)
 		{
 			if (context.SelectedItems.Count > 0 && context.ShellPage?.SlimContentPage?.SelectedItems is not null)

--- a/src/Files.App/Actions/Start/PinToStartAction.cs
+++ b/src/Files.App/Actions/Start/PinToStartAction.cs
@@ -25,7 +25,7 @@ namespace Files.App.Actions
 			=> ActionCategory.Start;
 
 		public bool IsExecutable
-			=> context.ShellPage is not null && context.SelectedItems.Any(item => !item.IsItemPinnedToStart);
+			=> context.ShellPage is not null && context.SelectedItems.Any(item => !item.IsItemPinnedToStart) && context.PageType is not ContentPageTypes.ZipFolder;
 
 		public PinToStartAction()
 		{

--- a/src/Files.App/Actions/Start/PinToStartAction.cs
+++ b/src/Files.App/Actions/Start/PinToStartAction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Files Community
+// Copyright (c) Files Community
 // Licensed under the MIT License.
 
 namespace Files.App.Actions

--- a/src/Files.App/Actions/Start/PinToStartAction.cs
+++ b/src/Files.App/Actions/Start/PinToStartAction.cs
@@ -24,8 +24,8 @@ namespace Files.App.Actions
 		public ActionCategory Category
 			=> ActionCategory.Start;
 
-		public bool IsExecutable =>
-			context.ShellPage is not null;
+		public bool IsExecutable
+			=> context.ShellPage is not null;
 
 		public PinToStartAction()
 		{

--- a/src/Files.App/Actions/Start/UnpinFromStartAction.cs
+++ b/src/Files.App/Actions/Start/UnpinFromStartAction.cs
@@ -25,7 +25,7 @@ namespace Files.App.Actions
 			=> ActionCategory.Start;
 
 		public bool IsExecutable
-			=> context.ShellPage is not null && context.SelectedItems.Any(item => item.IsItemPinnedToStart);
+			=> context.ShellPage is not null && context.SelectedItems.Any(item => item.IsItemPinnedToStart) && context.PageType is not ContentPageTypes.ZipFolder;
 
 		public UnpinFromStartAction()
 		{

--- a/src/Files.App/Actions/Start/UnpinFromStartAction.cs
+++ b/src/Files.App/Actions/Start/UnpinFromStartAction.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Files Community
+// Copyright (c) Files Community
 // Licensed under the MIT License.
 
 namespace Files.App.Actions
@@ -29,11 +29,12 @@ namespace Files.App.Actions
 			context = Ioc.Default.GetRequiredService<IContentPageContext>();
 		}
 
+		// Logic must stay consistent with PinToStartAction.ExecuteAsync()
 		public async Task ExecuteAsync(object? parameter = null)
 		{
-			if (context.SelectedItems.Count > 0)
+			if (context.SelectedItems.Count > 0 && context.ShellPage?.SlimContentPage?.SelectedItems is not null)
 			{
-				foreach (ListedItem listedItem in context.ShellPage?.SlimContentPage.SelectedItems)
+				foreach (ListedItem listedItem in context.ShellPage.SlimContentPage.SelectedItems)
 				{
 					await SafetyExtensions.IgnoreExceptions(async () =>
 					{
@@ -47,7 +48,7 @@ namespace Files.App.Actions
 					});
 				}
 			}
-			else
+			else if (context.ShellPage?.ShellViewModel?.CurrentFolder is not null)
 			{
 				await SafetyExtensions.IgnoreExceptions(async () =>
 				{

--- a/src/Files.App/Actions/Start/UnpinFromStartAction.cs
+++ b/src/Files.App/Actions/Start/UnpinFromStartAction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Files Community
+﻿// Copyright (c) Files Community
 // Licensed under the MIT License.
 
 namespace Files.App.Actions
@@ -23,6 +23,9 @@ namespace Files.App.Actions
 
 		public ActionCategory Category
 			=> ActionCategory.Start;
+
+		public bool IsExecutable
+			=> context.ShellPage is not null && context.SelectedItems.Any(item => item.IsItemPinnedToStart);
 
 		public UnpinFromStartAction()
 		{

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -262,6 +262,7 @@ namespace Files.App
 
 		private async Task InitializeFromCmdLineArgsAsync(Frame rootFrame, ParsedCommands parsedCommands, string activationPath = "")
 		{
+			// Navigate to a folder in the UI
 			async Task PerformNavigationAsync(string payload, string selectItem = null)
 			{
 				if (!string.IsNullOrEmpty(payload))
@@ -315,12 +316,42 @@ namespace Files.App
 				else
 					rootFrame.Navigate(typeof(MainPage), paneNavigationArgs, new SuppressNavigationTransitionInfo());
 			}
+
+			// Open a path (navigate to a folder in the UI / open a file depending on what the path attributes are)
+			async Task OpenPathAsync(string payload)
+			{
+				if (!string.IsNullOrEmpty(payload))
+				{
+					try
+					{
+						var target = IO.Path.GetFullPath(IO.Path.Combine(activationPath, payload));
+						var attributes = IO.File.GetAttributes(target);
+						if ((attributes & IO.FileAttributes.Directory) == IO.FileAttributes.Directory)
+							await PerformNavigationAsync(target);
+						else
+							await LaunchHelper.LaunchAppAsync("explorer", payload, activationPath);
+					}
+					catch
+					{
+						await LaunchHelper.LaunchAppAsync("explorer", payload, activationPath);
+					}
+				}
+				else
+				{
+					await PerformNavigationAsync(null!);
+				}
+			}
+
 			foreach (var command in parsedCommands)
 			{
 				switch (command.Type)
 				{
 					case ParsedCommandType.OpenDirectory:
+						await OpenPathAsync(command.Payload);
+						break;
 					case ParsedCommandType.OpenPath:
+						await OpenPathAsync(command.Payload);
+						break;
 					case ParsedCommandType.ExplorerShellCommand:
 						var selectItemCommand = parsedCommands.FirstOrDefault(x => x.Type == ParsedCommandType.SelectItem);
 						await PerformNavigationAsync(command.Payload, selectItemCommand?.Payload);
@@ -355,15 +386,8 @@ namespace Files.App
 						}
 						else
 						{
-							if (!string.IsNullOrEmpty(command.Payload))
-							{
-								var target = IO.Path.GetFullPath(IO.Path.Combine(activationPath, command.Payload));
-								await PerformNavigationAsync(target);
-							}
-							else
-							{
-								await PerformNavigationAsync(null);
-							}
+							await OpenPathAsync(command.Payload);
+							break;
 						}
 						break;
 

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using Files.Shared.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
@@ -337,7 +338,7 @@ namespace Files.App
 					{
 						var target = Path.IsPathFullyQualified(payload) ? IO.Path.GetFullPath(payload) : IO.Path.GetFullPath(IO.Path.Combine(activationPath, payload));
 						var attributes = IO.File.GetAttributes(target);
-						if (attributes.HasFlag(IO.FileAttributes.Directory) || attributes.HasFlag(IO.FileAttributes.Archive))
+						if (attributes.HasFlag(IO.FileAttributes.Directory) || FileExtensionHelpers.IsBrowsableZipFile(target, out _))
 							await PerformNavigationAsync(target);
 						else
 							await LaunchHelper.LaunchAppAsync("explorer", payload, activationPath);

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -107,13 +107,24 @@ namespace Files.App
 					}
 					else
 					{
-						var parsedArgs = eventArgs.Uri.Query.TrimStart('?').Split('=');
-						var unescapedValue = Uri.UnescapeDataString(parsedArgs[1].Split('&')[0]);
-						if (parsedArgs[0] == "tab" && parsedArgs.Length > 3 &&
-							int.TryParse(parsedArgs[2].Split('&')[0], out var dx) &&
-							int.TryParse(parsedArgs[3], out var dy))
-							AppWindow?.Move(new(dx - 100, dy - 16));
-						var folder = (StorageFolder)await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(unescapedValue).AsTask());
+						string[] parsedArgs;
+						string? unescapedValue;
+						StorageFolder? folder;
+						try
+						{
+							parsedArgs = eventArgs.Uri.Query.TrimStart('?').Split('=');
+							unescapedValue = Uri.UnescapeDataString(parsedArgs[1].Split('&')[0]);
+							if (parsedArgs[0] == "tab" && parsedArgs.Length > 3 &&
+								int.TryParse(parsedArgs[2].Split('&')[0], out var dx) &&
+								int.TryParse(parsedArgs[3], out var dy))
+								AppWindow?.Move(new(dx - 100, dy - 16));
+							folder = (StorageFolder)await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(unescapedValue).AsTask());
+						}
+						catch
+						{
+							rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+							break;
+						}
 						if (folder is not null && !string.IsNullOrEmpty(folder.Path))
 						{
 							// Convert short name to long name (#6190)

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -335,9 +335,9 @@ namespace Files.App
 				{
 					try
 					{
-						var target = IO.Path.GetFullPath(IO.Path.Combine(activationPath, payload));
+						var target = Path.IsPathFullyQualified(payload) ? IO.Path.GetFullPath(payload) : IO.Path.GetFullPath(IO.Path.Combine(activationPath, payload));
 						var attributes = IO.File.GetAttributes(target);
-						if ((attributes & IO.FileAttributes.Directory) == IO.FileAttributes.Directory)
+						if (attributes.HasFlag(IO.FileAttributes.Directory) || attributes.HasFlag(IO.FileAttributes.Archive))
 							await PerformNavigationAsync(target);
 						else
 							await LaunchHelper.LaunchAppAsync("explorer", payload, activationPath);

--- a/src/Files.App/Services/Windows/WindowsStartMenuService.cs
+++ b/src/Files.App/Services/Windows/WindowsStartMenuService.cs
@@ -103,9 +103,6 @@ namespace Files.App.Services
 			{
 				using (var managedIcon = Icon.ExtractAssociatedIcon(file.Id))
 				{
-					//if (managedIcon is null)
-					//	return new Uri($"ms-appx:///Assets/AppTiles/Release/Square44x44Logo.scale-100.png");
-
 					using (var bitmap = managedIcon!.ToBitmap())
 					{
 						bitmap.Save(iconPath, ImageFormat.Png);
@@ -120,9 +117,6 @@ namespace Files.App.Services
 
 				using (var managedIcon = Icon.ExtractIcon(Path.Combine(Environment.SystemDirectory, "shell32.dll"), shell32IconId))
 				{
-					if (managedIcon is null)
-						return new Uri($"ms-appx:///Assets/AppTiles/Release/Square44x44Logo.scale-100.png");
-
 					using (var bitmap = managedIcon!.ToBitmap())
 					{
 						bitmap.Save(iconPath, ImageFormat.Png);

--- a/src/Files.App/Services/Windows/WindowsStartMenuService.cs
+++ b/src/Files.App/Services/Windows/WindowsStartMenuService.cs
@@ -29,8 +29,11 @@ namespace Files.App.Services
 
 			try
 			{
-				var path150x150 = new Uri("ms-appx:///Assets/tile-0-300x300.png");
-				var path71x71 = new Uri("ms-appx:///Assets/tile-0-250x250.png");
+				var path150x150 = new Uri("ms-appx:///Assets/AppTiles/Preview/Square150x150Logo.scale-100.png");
+				var path71x71 = new Uri("ms-appx:///Assets/AppTiles/Preview/Small71x71Logo.scale-100.png");
+				var path44x44 = new Uri("ms-appx:///Assets/AppTiles/Preview/Square44x44Logo.scale-100.png");
+				var path30x30 = new Uri("ms-appx:///Assets/AppTiles/Preview/Square44x44Logo.targetsize-30.png");
+				var path310x150 = new Uri("ms-appx:///Assets/AppTiles/Preview/Wide310x150Logo.scale-100.png");
 
 				var tile = new SecondaryTile(
 					tileId,
@@ -42,7 +45,12 @@ namespace Files.App.Services
 					VisualElements =
 					{
 						Square71x71Logo = path71x71,
-						ShowNameOnSquare150x150Logo = true
+						Square150x150Logo = path150x150,
+						Square44x44Logo = path44x44,
+						Square30x30Logo = path30x30,
+						Wide310x150Logo = path310x150,
+						ShowNameOnSquare150x150Logo = true,
+						//BackgroundColor = Microsoft.UI.Colors.
 					}
 				};
 

--- a/src/Files.App/Services/Windows/WindowsStartMenuService.cs
+++ b/src/Files.App/Services/Windows/WindowsStartMenuService.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
 using Windows.Storage;
 using Windows.UI.StartScreen;
 using Windows.Win32;
@@ -97,29 +99,38 @@ namespace Files.App.Services
 			var iconPath = Path.Combine(iconFolder, fileName);
 			Directory.CreateDirectory(iconFolder);
 
-			HICON hIcon = default;
-			uint piconid = 0;
-			uint extractedCount = 0;
-
-			extractedCount = PInvoke.PrivateExtractIcons(
-				file.Id,
-				0,
-				44,
-				44,
-				new Span<HICON>(&hIcon, 1),
-				out piconid,
-				0
-			);
-
-			using (var managedIcon = System.Drawing.Icon.FromHandle((nint)hIcon.Value))
-			using (var bitmap = managedIcon.ToBitmap())
+			try
 			{
-				bitmap.Save(iconPath, System.Drawing.Imaging.ImageFormat.Png);
+				using (var managedIcon = Icon.ExtractAssociatedIcon(file.Id))
+				{
+					//if (managedIcon is null)
+					//	return new Uri($"ms-appx:///Assets/AppTiles/Release/Square44x44Logo.scale-100.png");
+
+					using (var bitmap = managedIcon!.ToBitmap())
+					{
+						bitmap.Save(iconPath, ImageFormat.Png);
+					}
+				}
+
+				return new Uri($"ms-appdata:///local/startmenu/{fileName}");
 			}
+			catch
+			{
+				int shell32IconId = file is IFolder ? 4 : 0;
 
-			var destroyResult = PInvoke.DestroyIcon(hIcon);
+				using (var managedIcon = Icon.ExtractIcon(Path.Combine(Environment.SystemDirectory, "shell32.dll"), shell32IconId))
+				{
+					if (managedIcon is null)
+						return new Uri($"ms-appx:///Assets/AppTiles/Release/Square44x44Logo.scale-100.png");
 
-			return new Uri($"ms-appdata:///local/startmenu/{fileName}");
+					using (var bitmap = managedIcon!.ToBitmap())
+					{
+						bitmap.Save(iconPath, ImageFormat.Png);
+					}
+				}
+
+				return new Uri($"ms-appdata:///local/startmenu/{fileName}");
+			}
 		}
 	}
 }

--- a/src/Files.App/Services/Windows/WindowsStartMenuService.cs
+++ b/src/Files.App/Services/Windows/WindowsStartMenuService.cs
@@ -92,7 +92,7 @@ namespace Files.App.Services
 			return str;
 		}
 
-		private static unsafe Uri ExtractFileIcon(IStorable file, string id)
+		private static Uri ExtractFileIcon(IStorable file, string id)
 		{
 			var fileName = $"{id}.png";
 			var iconFolder = Path.Combine(ApplicationData.Current.LocalFolder.Path, "startmenu");

--- a/src/Files.App/Services/Windows/WindowsStartMenuService.cs
+++ b/src/Files.App/Services/Windows/WindowsStartMenuService.cs
@@ -41,7 +41,7 @@ namespace Files.App.Services
 				var tile = new SecondaryTile(
 					tileId,
 					displayName,
-					storable.Id,
+					$"files-dev.exe \"{storable.Id}\"",
 					fileIcon,
 					TileSize.Default)
 				{

--- a/src/Files.App/Services/Windows/WindowsStartMenuService.cs
+++ b/src/Files.App/Services/Windows/WindowsStartMenuService.cs
@@ -1,6 +1,8 @@
 ﻿using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 using Windows.Storage;
 using Windows.UI.StartScreen;
 using Windows.Win32;
@@ -82,14 +84,7 @@ namespace Files.App.Services
 
 		private static string GetNativeTileId(string id)
 		{
-			// Remove symbols because windows doesn't like them in the ID, and will blow up
-			var str = $"folder-{new string(id.Where(c => char.IsLetterOrDigit(c)).ToArray())}";
-
-			// If the id string is too long, Windows will throw an error, so remove every other character
-			if (str.Length > 64)
-				str = new string(str.Where((_, i) => i % 2 == 0).ToArray());
-
-			return str;
+			return new Guid(SHA1.HashData(Encoding.UTF8.GetBytes(id.ToLowerInvariant()))[..16]).ToString();
 		}
 
 		private static Uri ExtractFileIcon(IStorable file, string id)

--- a/src/Files.App/Services/Windows/WindowsStartMenuService.cs
+++ b/src/Files.App/Services/Windows/WindowsStartMenuService.cs
@@ -1,4 +1,9 @@
-﻿using Windows.UI.StartScreen;
+﻿using System.IO;
+using Windows.Storage;
+using Windows.UI.StartScreen;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Files.App.Services
 {
@@ -29,18 +34,18 @@ namespace Files.App.Services
 
 			try
 			{
-				var path150x150 = new Uri("ms-appx:///Assets/AppTiles/Preview/Square150x150Logo.scale-100.png");
-				var path71x71 = new Uri("ms-appx:///Assets/AppTiles/Preview/Small71x71Logo.scale-100.png");
-				var path44x44 = new Uri("ms-appx:///Assets/AppTiles/Preview/Square44x44Logo.scale-100.png");
-				var path30x30 = new Uri("ms-appx:///Assets/AppTiles/Preview/Square44x44Logo.targetsize-30.png");
-				var path310x150 = new Uri("ms-appx:///Assets/AppTiles/Preview/Wide310x150Logo.scale-100.png");
+				var path150x150 = ExtractFileIcon(storable, tileId);
+				var path71x71 = path150x150;
+				var path44x44 = path150x150;
+				var path30x30 = path150x150;
+				var path310x150 = path150x150;
 
 				var tile = new SecondaryTile(
 					tileId,
 					displayName,
 					storable.Id,
 					path150x150,
-					TileSize.Square150x150)
+					TileSize.Default)
 				{
 					VisualElements =
 					{
@@ -73,6 +78,14 @@ namespace Files.App.Services
 			var tileId = GetNativeTileId(storable.Id);
 
 			await startScreen.TryRemoveSecondaryTileAsync(tileId);
+
+			try
+			{
+				var iconFolder = await ApplicationData.Current.LocalFolder.CreateFolderAsync("startmenu", CreationCollisionOption.OpenIfExists);
+				var iconFile = await iconFolder.GetFileAsync($"{tileId}.png");
+				await iconFile.DeleteAsync(StorageDeleteOption.PermanentDelete);
+			}
+			catch (FileNotFoundException) { }
 		}
 
 		private static string GetNativeTileId(string id)
@@ -85,6 +98,38 @@ namespace Files.App.Services
 				str = new string(str.Where((_, i) => i % 2 == 0).ToArray());
 
 			return str;
+		}
+
+		private static unsafe Uri ExtractFileIcon(IStorable file, string id)
+		{
+			var fileName = $"{id}.png";
+			var iconFolder = Path.Combine(ApplicationData.Current.LocalFolder.Path, "startmenu");
+			var iconPath = Path.Combine(iconFolder, fileName);
+			Directory.CreateDirectory(iconFolder);
+
+			HICON hIcon = default;
+			uint piconid = 0;
+			uint extractedCount = 0;
+
+			extractedCount = PInvoke.PrivateExtractIcons(
+				file.Id,
+				0,
+				256,
+				256,
+				new Span<HICON>(&hIcon, 1),
+				out piconid,
+				0
+			);
+
+			using (var managedIcon = System.Drawing.Icon.FromHandle((nint)hIcon.Value))
+			using (var bitmap = managedIcon.ToBitmap())
+			{
+				bitmap.Save(iconPath, System.Drawing.Imaging.ImageFormat.Png);
+			}
+
+			var destroyResult = PInvoke.DestroyIcon(hIcon);
+
+			return new Uri($"ms-appdata:///local/startmenu/{fileName}");
 		}
 	}
 }

--- a/src/Files.App/Services/Windows/WindowsStartMenuService.cs
+++ b/src/Files.App/Services/Windows/WindowsStartMenuService.cs
@@ -34,28 +34,19 @@ namespace Files.App.Services
 
 			try
 			{
-				var path150x150 = ExtractFileIcon(storable, tileId);
-				var path71x71 = path150x150;
-				var path44x44 = path150x150;
-				var path30x30 = path150x150;
-				var path310x150 = path150x150;
+				var fileIcon = ExtractFileIcon(storable, tileId);
 
 				var tile = new SecondaryTile(
 					tileId,
 					displayName,
 					storable.Id,
-					path150x150,
+					fileIcon,
 					TileSize.Default)
 				{
 					VisualElements =
 					{
-						Square71x71Logo = path71x71,
-						Square150x150Logo = path150x150,
-						Square44x44Logo = path44x44,
-						Square30x30Logo = path30x30,
-						Wide310x150Logo = path310x150,
-						ShowNameOnSquare150x150Logo = true,
-						//BackgroundColor = Microsoft.UI.Colors.
+						Square44x44Logo = fileIcon,
+						ShowNameOnSquare150x150Logo = true
 					}
 				};
 
@@ -68,7 +59,6 @@ namespace Files.App.Services
 				Debug.WriteLine(tileId);
 				Debug.WriteLine(e.ToString());
 			}
-
 		}
 
 		/// <inheritdoc/>
@@ -114,8 +104,8 @@ namespace Files.App.Services
 			extractedCount = PInvoke.PrivateExtractIcons(
 				file.Id,
 				0,
-				256,
-				256,
+				44,
+				44,
 				new Span<HICON>(&hIcon, 1),
 				out piconid,
 				0


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

### Resolved / Related Issues

- Closes #12191

### Steps used to test these changes

_This PR is pretty complicated, but this is how you can test every part of it:_

- **The pin/unpin from start actions are now only executable if they are appropriate (you can only pin if the item is not already pinned, and you can only unpin if the item is already pinned)**

	1. Opened the app
	2. Selected a single item in the file browser
	3. Observed that the 'unpin' action cannot be executed whereas the 'pin' action can
	4. Ran the 'pin' action on the file via the omnibar
	5. Observed that the 'pin' action can no longer be executed on that item whereas the 'unpin' action can
	6. Ran the 'unpin' action on the file via the omnibar
	7. Observed that the state reset and now the unpin button is greyed out again

- **Pinning/unpinning is possible and works correctly when multiple files/folders are selected**
- **Pinning an item to the start menu now shows the item's icon in the start menu**

	1. Pinned a file to the Start menu via the 'pin' action
	2. Ran the 'pin' action and accepted the dialogue
	3. Opened the Start menu
	4. Observed that the item is now pinned, and that the file thumbnail is its icon

		<img width="284" height="159" alt="image" src="https://github.com/user-attachments/assets/989eaf3b-441a-4e98-ab42-a7ad9a894c6e" />

- **Start menu tile IDs are now fully unique**

	1. Pinned a file to the Start menu via the 'pin' action
	2. Opened `%localappdata%\FilesDev_ykqwq8d6ps0ag\LocalState\startmenu` in File Explorer
	3. Observed that there are now thumbnail images with a GUID name (e.g. `5a346596-28e7-bf9a-1743-91335747ad8e.png`) - each image name corresponds to its identical pinned start tile ID (this ensures that start tile IDs will _always_ be the same)
	5. Observed that unpinning a start tile (using the 'unpin' action) deletes the image file