### PR TITLE
Code Quality: Categorize package dependencies for better tracking of AOT safety

### DIFF
--- a/.github/NOTICE.md
+++ b/.github/NOTICE.md
@@ -671,19 +671,3 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
-
-## Dongle.GuidRVAGen
-
-**Source**: [https://github.com/dongle-the-gadget/GuidRVAGen](https://github.com/dongle-the-gadget/GuidRVAGen)
-
-### License
-
-```
-Copyright (c) 2024 Dongle
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-```

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="ByteSize" Version="2.1.2" />
+    <!-- Microsoft / WCT dependencies -->
     <PackageVersion Include="ColorCode.WinUI" Version="2.0.15" />
     <PackageVersion Include="CommunityToolkit.Labs.WinUI.Controls.MarkdownTextBlock" Version="0.1.250206-build.2040" />
     <PackageVersion Include="CommunityToolkit.Labs.WinUI.DependencyPropertyGenerator" Version="0.1.250206-build.2040" />
@@ -19,42 +19,43 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Extensions" Version="8.2.251219" />
     <PackageVersion Include="CommunityToolkit.WinUI.Helpers" Version="8.2.251219" />
     <PackageVersion Include="CommunityToolkit.WinUI.Triggers" Version="8.2.251219" />
-    <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
-    <PackageVersion Include="FluentFTP" Version="53.0.2" />
-    <!-- Note, 0.31 causes issues with repos cloned via ssh -->
-    <PackageVersion Include="LibGit2Sharp" Version="0.30.0" />
-    <PackageVersion Include="MessageFormat" Version="7.1.3" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.298" />
+    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.1" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.2" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
+    <!-- Community project dependencies -->
+    <PackageVersion Include="ByteSize" Version="2.1.2" />
+    <PackageVersion Include="DiscUtils.Udf" Version="0.16.13" />
+    <PackageVersion Include="FluentFTP" Version="53.0.2" />
+    <PackageVersion Include="LibGit2Sharp" Version="0.30.0" /> <!-- Note, 0.31 causes issues with repos cloned via ssh -->
+    <PackageVersion Include="MessageFormat" Version="7.1.3" />
     <PackageVersion Include="OwlCore.Storage" Version="0.14.0.999" />
     <PackageVersion Include="Sentry" Version="6.8.0" />
     <PackageVersion Include="SevenZipSharp" Version="1.0.2" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
-    <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
     <PackageVersion Include="TagLibSharp" Version="2.3.0" />
     <PackageVersion Include="UTF.Unknown" Version="2.6.0" />
-    <PackageVersion Include="WinUIEx" Version="2.9.0" />
     <PackageVersion Include="Vanara.Windows.Extensions" Version="4.0.1" />
     <PackageVersion Include="Vanara.Windows.Shell" Version="4.0.1" />
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.298" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.6.0" />
-    <PackageVersion Include="PolySharp" Version="1.16.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.2" />
+    <PackageVersion Include="WinUIEx" Version="2.9.0" />
+    <!-- Side dependencies -->
     <PackageVersion Include="Appium.WebDriver" Version="4.4.5" />
     <PackageVersion Include="Axe.Windows" Version="2.4.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.3.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.3.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
-    <PackageVersion Include="Dongle.GuidRVAGen" Version="1.0.5" />
+    <PackageVersion Include="PolySharp" Version="1.16.0" />
   </ItemGroup>
 </Project>

--- a/src/Files.App.CsWin32/Files.App.CsWin32.csproj
+++ b/src/Files.App.CsWin32/Files.App.CsWin32.csproj
@@ -17,12 +17,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
-        <PackageReference Include="Dongle.GuidRVAGen" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\Files.Shared\Files.Shared.csproj" />
-      <ProjectReference Include="..\Files.Core.SourceGenerator\Files.Core.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
 </Project>

--- a/src/Files.App/ViewModels/Settings/AboutViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AboutViewModel.cs
@@ -76,7 +76,6 @@ namespace Files.App.ViewModels.Settings
 				new ("https://github.com/microsoft/CsWin32", "CsWin32"),
 				new ("https://github.com/microsoft/CsWinRT", "CsWinRT"),
 				new ("https://github.com/GihanSoft/NaturalStringComparer", "NaturalStringComparer"),
-				new ("https://github.com/dongle-the-gadget/GuidRVAGen", "Dongle.GuidRVAGen"),
 				new ("https://github.com/leeqwind/PESignAnalyzer", "PESignAnalyzer"),
 			];
 


### PR DESCRIPTION
### Resolved / Related Issues

Please check the `Directory.Packages.props` diff thoroughly

- Categorized package dependencies
- Removed `Dongle.GuidRVAGen` for being unused

### Steps used to test these changes

_None._
