### PR TITLE
Code Quality: Fixed an issue where the "This app can't run on your PC" dialogue displayed inappropriately

### DIFF
--- a/src/Files.App/Utils/Shell/LaunchHelper.cs
+++ b/src/Files.App/Utils/Shell/LaunchHelper.cs
@@ -128,9 +128,10 @@ namespace Files.App.Utils.Shell
 
 				return true;
 			}
-			catch (Win32Exception ex) when (ex.NativeErrorCode is 193 or 216)
+			catch (Win32Exception ex) when (ex.NativeErrorCode is 216)
 			{
-				// ERROR_BAD_EXE_FORMAT (193) / ERROR_EXE_MACHINE_TYPE_MISMATCH (216)
+				// ERROR_EXE_MACHINE_TYPE_MISMATCH (216)
+				// "This app can't run on your PC"
 				await DialogDisplayHelper.ShowDialogAsync(DynamicDialogFactory.GetFor_CannotRunFileDialog());
 				return false;
 			}

--- a/src/Files.App/Utils/Shell/LaunchHelper.cs
+++ b/src/Files.App/Utils/Shell/LaunchHelper.cs
@@ -128,7 +128,7 @@ namespace Files.App.Utils.Shell
 
 				return true;
 			}
-			catch (Win32Exception ex) when (ex.NativeErrorCode is 216)
+			catch (Win32Exception ex) when (ex.NativeErrorCode is 193 or 216 && FileExtensionHelpers.IsExecutableFile(application, exeOnly: true))
 			{
 				// ERROR_EXE_MACHINE_TYPE_MISMATCH (216)
 				// "This app can't run on your PC"


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Closes #18737 
- Related #17454

**Steps used to test these changes**

1. Created a file "dnskjdnjkf.exe" with bad binary contents
2. Opened Files
3. Opened the executable via Files and observed that the "This app can't run on your PC" dialogue still displays
4. Opened one of the erroneous file types as listed in #18737 (e.g. an HTML file)
5. Observed that the file opens correctly and the "This app can't run on your PC" did not appear

Note that creating an executable file with _no_ contents will not result in the dialogue showing anymore. However, this is justified by the fact that in practice, a user will never be opening an executable file with no binary contents unless they are just playing around with their PC.