### PR TITLE
Fix: Fixed an issue where activating the app by URI sometimes caused a crash

### DIFF
--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using Files.Shared.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
@@ -107,13 +108,24 @@ namespace Files.App
 					}
 					else
 					{
-						var parsedArgs = eventArgs.Uri.Query.TrimStart('?').Split('=');
-						var unescapedValue = Uri.UnescapeDataString(parsedArgs[1].Split('&')[0]);
-						if (parsedArgs[0] == "tab" && parsedArgs.Length > 3 &&
-							int.TryParse(parsedArgs[2].Split('&')[0], out var dx) &&
-							int.TryParse(parsedArgs[3], out var dy))
-							AppWindow?.Move(new(dx - 100, dy - 16));
-						var folder = (StorageFolder)await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(unescapedValue).AsTask());
+						string[] parsedArgs;
+						string? unescapedValue;
+						StorageFolder? folder;
+						try
+						{
+							parsedArgs = eventArgs.Uri.Query.TrimStart('?').Split('=');
+							unescapedValue = Uri.UnescapeDataString(parsedArgs[1].Split('&')[0]);
+							if (parsedArgs[0] == "tab" && parsedArgs.Length > 3 &&
+								int.TryParse(parsedArgs[2].Split('&')[0], out var dx) &&
+								int.TryParse(parsedArgs[3], out var dy))
+								AppWindow?.Move(new(dx - 100, dy - 16));
+							folder = (StorageFolder)await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(unescapedValue).AsTask());
+						}
+						catch
+						{
+							rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+							break;
+						}
 						if (folder is not null && !string.IsNullOrEmpty(folder.Path))
 						{
 							// Convert short name to long name (#6190)
@@ -262,6 +274,7 @@ namespace Files.App
 
 		private async Task InitializeFromCmdLineArgsAsync(Frame rootFrame, ParsedCommands parsedCommands, string activationPath = "")
 		{
+			// Navigate to a folder in the UI
 			async Task PerformNavigationAsync(string payload, string selectItem = null)
 			{
 				if (!string.IsNullOrEmpty(payload))
@@ -315,12 +328,42 @@ namespace Files.App
 				else
 					rootFrame.Navigate(typeof(MainPage), paneNavigationArgs, new SuppressNavigationTransitionInfo());
 			}
+
+			// Open a path (navigate to a folder in the UI / open a file depending on what the path attributes are)
+			async Task OpenPathAsync(string payload)
+			{
+				if (!string.IsNullOrEmpty(payload))
+				{
+					try
+					{
+						var target = Path.IsPathFullyQualified(payload) ? IO.Path.GetFullPath(payload) : IO.Path.GetFullPath(IO.Path.Combine(activationPath, payload));
+						var attributes = IO.File.GetAttributes(target);
+						if (attributes.HasFlag(IO.FileAttributes.Directory) || FileExtensionHelpers.IsBrowsableZipFile(target, out _))
+							await PerformNavigationAsync(target);
+						else
+							await LaunchHelper.LaunchAppAsync("explorer", payload, activationPath);
+					}
+					catch
+					{
+						await LaunchHelper.LaunchAppAsync("explorer", payload, activationPath);
+					}
+				}
+				else
+				{
+					await PerformNavigationAsync(null!);
+				}
+			}
+
 			foreach (var command in parsedCommands)
 			{
 				switch (command.Type)
 				{
 					case ParsedCommandType.OpenDirectory:
+						await OpenPathAsync(command.Payload);
+						break;
 					case ParsedCommandType.OpenPath:
+						await OpenPathAsync(command.Payload);
+						break;
 					case ParsedCommandType.ExplorerShellCommand:
 						var selectItemCommand = parsedCommands.FirstOrDefault(x => x.Type == ParsedCommandType.SelectItem);
 						await PerformNavigationAsync(command.Payload, selectItemCommand?.Payload);
@@ -355,15 +398,8 @@ namespace Files.App
 						}
 						else
 						{
-							if (!string.IsNullOrEmpty(command.Payload))
-							{
-								var target = IO.Path.GetFullPath(IO.Path.Combine(activationPath, command.Payload));
-								await PerformNavigationAsync(target);
-							}
-							else
-							{
-								await PerformNavigationAsync(null);
-							}
+							await OpenPathAsync(command.Payload);
+							break;
 						}
 						break;
 

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -72,7 +72,7 @@ namespace Files.App
 						// WINUI3: When launching from commandline the argument is not ICommandLineActivatedEventArgs (#10370)
 						var ppm = CommandLineParser.ParseUntrustedCommands(launchArgs.Arguments);
 						if (ppm.IsEmpty())
-							rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+							LaunchMainPage(rootFrame);
 						else
 							await InitializeFromCmdLineArgsAsync(rootFrame, ppm, Program.ConsumeLaunchCwd());
 					}
@@ -91,20 +91,14 @@ namespace Files.App
 					}
 					else
 					{
-						rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+						LaunchMainPage(rootFrame);
 					}
 					break;
 
 				case IProtocolActivatedEventArgs eventArgs:
 					if (eventArgs.Uri.AbsoluteUri == "files-dev:")
 					{
-						rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
-
-						// Bring to foreground (#14730)
-						Win32Helper.BringToForegroundEx(new(WindowHandle));
-
-						// Ensure app-level keyboard shortcuts work immediately after Win+E activation.
-						_ = EnsureContentHasKeyboardFocusAsync();
+						LaunchMainPage(rootFrame);
 					}
 					else
 					{
@@ -123,7 +117,7 @@ namespace Files.App
 						}
 						catch
 						{
-							rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+							LaunchMainPage(rootFrame);
 							break;
 						}
 						if (folder is not null && !string.IsNullOrEmpty(folder.Path))
@@ -148,12 +142,12 @@ namespace Files.App
 							case "cmd":
 								var ppm = CommandLineParser.ParseUntrustedCommands(unescapedValue);
 								if (ppm.IsEmpty())
-									rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+									LaunchMainPage(rootFrame);
 								else
 									await InitializeFromCmdLineArgsAsync(rootFrame, ppm, Environment.CurrentDirectory);
 								break;
 							default:
-								rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+								LaunchMainPage(rootFrame);
 								break;
 						}
 					}
@@ -171,7 +165,7 @@ namespace Files.App
 					}
 					else
 					{
-						rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+						LaunchMainPage(rootFrame);
 					}
 					break;
 
@@ -212,14 +206,8 @@ namespace Files.App
 					}
 					break;
 
-				case IStartupTaskActivatedEventArgs startupArgs:
-					// Just launch the app with no arguments
-					rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
-					break;
-
 				default:
-					// Just launch the app with no arguments
-					rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+					LaunchMainPage(rootFrame);
 					break;
 			}
 
@@ -275,11 +263,11 @@ namespace Files.App
 		private async Task InitializeFromCmdLineArgsAsync(Frame rootFrame, ParsedCommands parsedCommands, string activationPath = "")
 		{
 			// Navigate to a folder in the UI
-			async Task PerformNavigationAsync(string payload, string selectItem = null)
+			async Task PerformNavigationAsync(string? payload, string? selectItem = null)
 			{
 				if (!string.IsNullOrEmpty(payload))
 				{
-					payload = Constants.UserEnvironmentPaths.ShellPlaces.Get(payload.ToUpperInvariant(), payload);
+					payload = Constants.UserEnvironmentPaths.ShellPlaces.Get(payload.ToUpperInvariant(), payload)!;
 					var folder = (StorageFolder)await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(payload).AsTask());
 					if (folder is not null && !string.IsNullOrEmpty(folder.Path))
 						payload = folder.Path; // Convert short name to long name (#6190)
@@ -376,7 +364,7 @@ namespace Files.App
 
 					case ParsedCommandType.TagFiles:
 						var tagService = Ioc.Default.GetService<IFileTagsSettingsService>();
-						var tag = tagService.GetTagsByName(command.Payload).FirstOrDefault();
+						var tag = tagService!.GetTagsByName(command.Payload).FirstOrDefault();
 						foreach (var file in command.Args.Skip(1))
 						{
 							var fileFRN = await FilesystemTasks.Wrap(() => StorageHelpers.ToStorageItem<IStorageItem>(file))
@@ -430,6 +418,17 @@ namespace Files.App
 				Win32Helper.ForceWindowPosition(e.Message.LParam);
 				e.Handled = true;
 			}
+		}
+
+		private void LaunchMainPage(Frame rootFrame)
+		{
+			rootFrame.Navigate(typeof(MainPage), null, new SuppressNavigationTransitionInfo());
+
+			// Bring to foreground (#14730)
+			Win32Helper.BringToForegroundEx(new(WindowHandle));
+
+			// Ensure app-level keyboard shortcuts work immediately after Win+E activation.
+			_ = EnsureContentHasKeyboardFocusAsync();
 		}
 	}
 }


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

### Resolved / Related Issues

- Closes #18743

### Steps used to test these changes

- **Activating the app with an 'open path' argument now results in the correct activation sequence (this means that pinning items now works correctly again, and does not silently fail)**

	*Method 1*
	1. Opened Windows Terminal
	2. Entered `files-dev.exe "C:\Windows\Web\4K\Wallpaper\Windows\img0_1920x1200.jpg"` (for example)
	3. Observed that the Windows 11 bloom image opens

	*Method 2*
	1. Opened the Run dialogue box via <kbd>Win+R</kbd>
	2. Entered a protocol such as `files-dev:?cmd=-Cmdless%20C%3A%5CWindows%5CWeb%5C4K%5CWallpaper%5CWindows%5Cimg0_1920x1200.jpg`
	3. Observed that the Windows 11 bloom image opens

- **Activating the app via an invalid URI protocol no longer crashes the app**

	1. Opened the Run dialogue box via <kbd>Win+R</kbd>
	2. Entered an (invalid) app protocol URI, e.g. `files-dev:test` or `files-dev://`
	3. Observed that the app launches normally without crashing (see #18743 for more info)

- **Activating the app by protocol / command line now correctly brings it to the foreground**

	1. Opened the app
	2. Open another app and ensure that Files is not in the foreground
	3. Opened the Run dialogue box via <kbd>Win+R</kbd>
	4. Entered an app protocol URI, e.g. `files-dev:`, or optionally an executable command, e.g. `files.exe`
	5. Observed that the Files app is brought to the foreground