### PR TITLE
Fix: Fixed an issue where drives were duplicated on the Home page after changing the drive letter

### DIFF
--- a/src/Files.App/Data/Models/DrivesViewModel.cs
+++ b/src/Files.App/Data/Models/DrivesViewModel.cs
@@ -61,7 +61,11 @@ namespace Files.App.Data.Models
 			logger.LogInformation($"Drive removed: {e}");
 			lock (Drives)
 			{
-				var drive = Drives.FirstOrDefault(x => (x as DriveItem)?.DeviceID == e);
+				// Depending on the event source, drives are identified by a drive letter
+				// or a device interface ID, so match on either.
+				var drive = Drives.FirstOrDefault(x =>
+					(x as DriveItem)?.DeviceID == e ||
+					x.Id.TrimEnd('\\').Equals(e.TrimEnd('\\'), StringComparison.OrdinalIgnoreCase));
 				if (drive is not null)
 					Drives.Remove(drive);
 			}
@@ -77,9 +81,9 @@ namespace Files.App.Data.Models
 				// If drive already in list, remove it first.
 				var matchingDrive = Drives.FirstOrDefault(x =>
 					(x as DriveItem)?.DeviceID == (e as DriveItem)?.DeviceID ||
-					string.IsNullOrEmpty(e.Id)
+					(string.IsNullOrEmpty(e.Id)
 						? x.Id.Contains(e.Name, StringComparison.OrdinalIgnoreCase)
-						: Path.GetFullPath(x.Id) == Path.GetFullPath(e.Id)
+						: Path.GetFullPath(x.Id) == Path.GetFullPath(e.Id))
 				);
 
 				if (matchingDrive is not null)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #18736

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened the Home Page in Files Preview and Files Dev 
2. Changed a USB flash drive's letter while the app was open
3. Confirmed the drive was duplicated in Files Preview
4. Confirmed the drive updated in Files Dev without being duplicated