### PR TITLE
Fix: Report failed status when copying or moving items that no longer exist

### DIFF
--- a/src/Files.App/Utils/Storage/Operations/FileOperationsHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FileOperationsHelpers.cs
@@ -469,7 +469,8 @@ namespace Files.App.Utils.Storage
 							Succeeded = false,
 							Source = fileToMovePath[i],
 							Destination = moveDestination[i],
-							HResult = -1
+							// HResult -1 makes the caller retry with the StorageFile API (ADS); a missing source must map to NotFound instead
+							HResult = MainStreamExists(fileToMovePath[i]) ? -1 : CopyEngineResult.COPYENGINE_E_PATH_NOT_FOUND_SRC
 						});
 					}
 				}
@@ -608,7 +609,8 @@ namespace Files.App.Utils.Storage
 							Succeeded = false,
 							Source = fileToCopyPath[i],
 							Destination = copyDestination[i],
-							HResult = -1
+							// HResult -1 makes the caller retry with the StorageFile API (ADS); a missing source must map to NotFound instead
+							HResult = MainStreamExists(fileToCopyPath[i]) ? -1 : CopyEngineResult.COPYENGINE_E_PATH_NOT_FOUND_SRC
 						});
 					}
 				}
@@ -1139,6 +1141,17 @@ namespace Files.App.Utils.Storage
 				index++;
 
 			return Path.GetFileName(genFilePath(index));
+		}
+
+		private static bool MainStreamExists(string path)
+		{
+			// Path.Exists is always false for ADS paths (file.txt:stream), so check the main stream's path
+			var fileName = Path.GetFileName(path);
+			var colonIndex = fileName.IndexOf(':');
+			if (colonIndex is not -1)
+				path = path[..(path.Length - fileName.Length + colonIndex)];
+
+			return Path.Exists(path);
 		}
 	}
 }

--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -315,7 +315,8 @@ namespace Files.App.Utils.Storage
 
 			IStorageHistory history = await filesystemOperations.CopyItemsAsync((IList<IStorageItemWithPath>)source, (IList<string>)destination, collisions, banner.ProgressEventSource, token);
 
-			banner.Progress.ReportStatus(FileSystemStatusCode.Success);
+			if (returnStatus == ReturnResult.InProgress || returnStatus == ReturnResult.Success)
+				banner.Progress.ReportStatus(FileSystemStatusCode.Success);
 
 			if (registerHistory && history is not null && source.Any((item) => !string.IsNullOrWhiteSpace(item.Path)))
 			{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17213

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Copied a file
2. Deleted it externally
3. Pasted it in another folder and verified the "File Not Found" dialog appears and the Status Center reports "Error copying 1 item"
4. Repeated the above with cut/paste
5. Copied and pasted existing files/folders and confirmed it worked as expected
