### PR TITLE
Fix: Fixed reading .gz archives that don't store the original file name

### DIFF
--- a/src/Files.App/Services/Storage/StorageArchiveService.cs
+++ b/src/Files.App/Services/Storage/StorageArchiveService.cs
@@ -169,7 +169,7 @@ namespace Files.App.Services
 				{
 					ThreadingService.ExecuteOnUiThreadAsync(() =>
 					{
-						fsProgress.FileName = e.FileInfo.FileName;
+						fsProgress.FileName = ArchiveEntryHelpers.GetEntryName(e.FileInfo, archiveFilePath);
 						fsProgress.Report();
 					});
 				}
@@ -188,8 +188,21 @@ namespace Files.App.Services
 
 			try
 			{
-				// TODO: Get this method return result
-				await zipFile.ExtractArchiveAsync(destinationFolderPath);
+				var files = zipFile.ArchiveFileData.Where(x => !x.IsDirectory).ToList();
+				var resolvedName = files.Count is 1 ? ArchiveEntryHelpers.GetEntryName(files[0], archiveFilePath) : null;
+
+				if (resolvedName is not null && resolvedName != files[0].FileName)
+				{
+					// ExtractArchive would write the entry's "[no name]" placeholder to disk
+					Directory.CreateDirectory(destinationFolderPath);
+					await using var destinationStream = File.Create(Path.Combine(destinationFolderPath, resolvedName));
+					await zipFile.ExtractFileAsync(files[0].Index, destinationStream);
+				}
+				else
+				{
+					// TODO: Get this method return result
+					await zipFile.ExtractArchiveAsync(destinationFolderPath);
+				}
 
 				if (!statusCard.CancellationToken.IsCancellationRequested)
 					isSuccess = true;

--- a/src/Files.App/Utils/Storage/Helpers/ArchiveEntryHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/ArchiveEntryHelpers.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using SevenZip;
+using IO = System.IO;
+
+namespace Files.App.Utils.Storage
+{
+	public static class ArchiveEntryHelpers
+	{
+		// SevenZipSharp reports this placeholder for entries with no stored name,
+		// e.g. gzip archives created without the optional FNAME header field.
+		private const string NamelessEntryPlaceholder = "[no name]";
+
+		/// <summary>
+		/// Gets the archive's entries with each nameless entry renamed via <see cref="GetEntryName"/>.
+		/// </summary>
+		public static IEnumerable<ArchiveFileInfo> GetArchiveFileData(this SevenZipExtractor extractor, string containerPath)
+		{
+			return extractor.ArchiveFileData.Select(entry =>
+			{
+				entry.FileName = GetEntryName(entry, containerPath);
+				return entry;
+			});
+		}
+
+		/// <summary>
+		/// Gets the name of an archive entry, substituting the archive's own file name
+		/// without its extension when the entry has no stored name, as 7-Zip does.
+		/// </summary>
+		public static string GetEntryName(ArchiveFileInfo entry, string containerPath)
+		{
+			if (!string.IsNullOrEmpty(entry.FileName) && entry.FileName != NamelessEntryPlaceholder)
+				return entry.FileName;
+
+			var fallback = IO.Path.GetFileNameWithoutExtension(containerPath);
+			return string.IsNullOrEmpty(fallback) ? NamelessEntryPlaceholder : fallback;
+		}
+	}
+}

--- a/src/Files.App/Utils/Storage/StorageItems/ZipStorageFile.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/ZipStorageFile.cs
@@ -118,7 +118,7 @@ namespace Files.App.Utils.Storage
 					}
 
 					//zipFile.IsStreamOwner = true;
-					var entry = zipFile.ArchiveFileData.FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
+					var entry = zipFile.GetArchiveFileData(containerPath).FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
 
 					if (entry.FileName is not null)
 					{
@@ -161,7 +161,7 @@ namespace Files.App.Utils.Storage
 				}
 
 				//zipFile.IsStreamOwner = true;
-				var entry = zipFile.ArchiveFileData.FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
+				var entry = zipFile.GetArchiveFileData(containerPath).FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
 				if (entry.FileName is null)
 				{
 					return null;
@@ -199,7 +199,7 @@ namespace Files.App.Utils.Storage
 					return null;
 				}
 				//zipFile.IsStreamOwner = true;
-				var entry = zipFile.ArchiveFileData.FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
+				var entry = zipFile.GetArchiveFileData(containerPath).FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
 				if (entry.FileName is null)
 				{
 					return null;
@@ -235,7 +235,7 @@ namespace Files.App.Utils.Storage
 				}
 
 				//zipFile.IsStreamOwner = true;
-				var entry = zipFile.ArchiveFileData.FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
+				var entry = zipFile.GetArchiveFileData(containerPath).FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
 				if (entry.FileName is null)
 				{
 					return null;
@@ -274,7 +274,7 @@ namespace Files.App.Utils.Storage
 					return;
 				}
 				//zipFile.IsStreamOwner = true;
-				var entry = zipFile.ArchiveFileData.FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
+				var entry = zipFile.GetArchiveFileData(containerPath).FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
 				if (entry.FileName is null)
 				{
 					return;
@@ -433,7 +433,7 @@ namespace Files.App.Utils.Storage
 					return -1;
 				}
 				//zipFile.IsStreamOwner = true;
-				var entry = zipFile.ArchiveFileData.FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
+				var entry = zipFile.GetArchiveFileData(containerPath).FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
 				if (entry.FileName is not null)
 				{
 					return entry.Index;
@@ -451,7 +451,7 @@ namespace Files.App.Utils.Storage
 			}
 
 			//zipFile.IsStreamOwner = true;
-			var entry = zipFile.ArchiveFileData.FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
+			var entry = zipFile.GetArchiveFileData(containerPath).FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
 
 			return entry.FileName is null
 				? new BaseBasicProperties()
@@ -501,7 +501,7 @@ namespace Files.App.Utils.Storage
 						return;
 					}
 					//zipFile.IsStreamOwner = true;
-					var entry = zipFile.ArchiveFileData.FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == name);
+					var entry = zipFile.GetArchiveFileData(containerPath).FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == name);
 					if (entry.FileName is null)
 					{
 						request.FailAndClose(StreamedFileFailureMode.CurrentlyUnavailable);

--- a/src/Files.App/Utils/Storage/StorageItems/ZipStorageFolder.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/ZipStorageFolder.cs
@@ -150,7 +150,7 @@ namespace Files.App.Utils.Storage
 				return new BaseBasicProperties();
 			}
 			//zipFile.IsStreamOwner = true;
-			var entry = zipFile.ArchiveFileData.FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
+			var entry = zipFile.GetArchiveFileData(containerPath).FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == Path);
 			return entry.FileName is null
 				? new BaseBasicProperties()
 				: new ZipFolderBasicProperties(entry);
@@ -181,7 +181,7 @@ namespace Files.App.Utils.Storage
 
 				var filePath = System.IO.Path.Combine(Path, name);
 
-				var entry = zipFile.ArchiveFileData.FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == filePath);
+				var entry = zipFile.GetArchiveFileData(containerPath).FirstOrDefault(x => System.IO.Path.Combine(containerPath, x.FileName) == filePath);
 				if (entry.FileName is null)
 				{
 					return null;
@@ -225,7 +225,7 @@ namespace Files.App.Utils.Storage
 				}
 				//zipFile.IsStreamOwner = true;
 				var items = new List<IStorageItem>();
-				foreach (var entry in zipFile.ArchiveFileData) // Returns all items recursively
+				foreach (var entry in zipFile.GetArchiveFileData(containerPath)) // Returns all items recursively
 				{
 					string winPath = System.IO.Path.Combine(System.IO.Path.GetFullPath(containerPath), entry.FileName);
 					if (winPath.StartsWith(Path.WithEnding("\\"), StringComparison.Ordinal)) // Child of self
@@ -602,7 +602,7 @@ namespace Files.App.Utils.Storage
 					return null;
 				}
 				//zipFile.IsStreamOwner = true;
-				return zipFile.ArchiveFileData.Where(x => System.IO.Path.Combine(containerPath, x.FileName).IsSubPathOf(Path)).Select(e => (e.Index, e.FileName));
+				return zipFile.GetArchiveFileData(containerPath).Where(x => System.IO.Path.Combine(containerPath, x.FileName).IsSubPathOf(Path)).Select(e => (e.Index, e.FileName));
 			}
 		}
 


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #16633

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed entry shows `hello.txt` instead of `[no name]`
2. Confirmed that items open correctly
3. Confirmed extracted items have the correct name
4. Confirmed regular gz files with stored names are not affected