### PR TITLE
Fix: Fixed issue with stale ADS items after stream delete/move

### DIFF
--- a/src/Files.App/Data/Items/ListedItem.cs
+++ b/src/Files.App/Data/Items/ListedItem.cs
@@ -225,7 +225,11 @@ namespace Files.App.Utils
 		public string ItemPath
 		{
 			get => itemPath;
-			set => SetProperty(ref itemPath, value);
+			set
+			{
+				if (SetProperty(ref itemPath, value))
+					OnPropertyChanged(nameof(Name));
+			}
 		}
 
 		private string itemNameRaw;

--- a/src/Files.App/Helpers/Win32/Win32PInvoke.Consts.cs
+++ b/src/Files.App/Helpers/Win32/Win32PInvoke.Consts.cs
@@ -16,6 +16,9 @@ namespace Files.App.Helpers
 		public const int FILE_NOTIFY_CHANGE_LAST_ACCESS = 32;
 		public const int FILE_NOTIFY_CHANGE_CREATION = 64;
 		public const int FILE_NOTIFY_CHANGE_SECURITY = 256;
+		public const int FILE_NOTIFY_CHANGE_STREAM_NAME = 512;
+		public const int FILE_NOTIFY_CHANGE_STREAM_SIZE = 1024;
+		public const int FILE_NOTIFY_CHANGE_STREAM_WRITE = 2048;
 
 		public const int INVALID_HANDLE_VALUE = -1;
 		public const int FILE_SHARE_READ = 0x00000001;

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -2383,6 +2383,9 @@ namespace Files.App.ViewModels
 				if (hasSyncStatus)
 					notifyFilters |= FILE_NOTIFY_CHANGE_ATTRIBUTES;
 
+				if (UserSettingsService.FoldersSettingsService.AreAlternateStreamsVisible)
+					notifyFilters |= FILE_NOTIFY_CHANGE_STREAM_NAME | FILE_NOTIFY_CHANGE_STREAM_SIZE | FILE_NOTIFY_CHANGE_STREAM_WRITE;
+
 				var overlapped = new OVERLAPPED();
 				using var eventHandle = PInvoke.CreateEvent(null, false, false, null);
 				overlapped.hEvent = eventHandle.DangerousGetHandle();
@@ -2593,6 +2596,9 @@ namespace Files.App.ViewModels
 			const uint FILE_ACTION_MODIFIED = 0x00000003;
 			const uint FILE_ACTION_RENAMED_OLD_NAME = 0x00000004;
 			const uint FILE_ACTION_RENAMED_NEW_NAME = 0x00000005;
+			const uint FILE_ACTION_ADDED_STREAM = 0x00000006;
+			const uint FILE_ACTION_REMOVED_STREAM = 0x00000007;
+			const uint FILE_ACTION_MODIFIED_STREAM = 0x00000008;
 
 			const int UPDATE_BATCH_SIZE = 32;
 			var sampler = new IntervalSampler(200);
@@ -2662,12 +2668,16 @@ namespace Files.App.ViewModels
 										{
 											operationQueue.TryDequeue(out _);
 											var newPath = nextOp.FileName;
+											var oldPath = operation.FileName;
 											await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 											{
 												renamed.ItemPath = newPath;
 												renamed.ItemNameRaw = Path.GetFileName(newPath);
 												if (renamed.PrimaryItemAttribute == StorageItemTypes.File)
 													renamed.FileExtension = Path.GetExtension(newPath);
+
+												foreach (var adsItem in filesAndFolders.ToList().OfType<AlternateStreamItem>().Where(x => x.MainStreamPath.Equals(oldPath, StringComparison.OrdinalIgnoreCase)))
+													adsItem.ItemPath = $"{newPath}:{adsItem.ItemNameRaw}";
 											});
 										}
 										else
@@ -2676,6 +2686,13 @@ namespace Files.App.ViewModels
 											if (itemRenamedOld is not null)
 												anyEdits = true;
 										}
+										break;
+
+									case FILE_ACTION_ADDED_STREAM:
+									case FILE_ACTION_REMOVED_STREAM:
+									case FILE_ACTION_MODIFIED_STREAM:
+										if (await SyncAlternateStreamsAsync(operation.FileName))
+											anyEdits = true;
 										break;
 								}
 							}
@@ -2958,6 +2975,64 @@ namespace Files.App.ViewModels
 			}
 
 			return null;
+		}
+
+		private async Task<bool> SyncAlternateStreamsAsync(string streamPath)
+		{
+			if (!UserSettingsService.FoldersSettingsService.AreAlternateStreamsVisible)
+				return false;
+
+			// Stream notifications name the stream as "<file>:<stream>"; a colon not past the
+			// last separator is the drive colon, i.e. an event for the unnamed data stream
+			var separatorIndex = streamPath.LastIndexOf(':');
+			if (separatorIndex <= streamPath.LastIndexOf('\\'))
+				return false;
+
+			var mainStreamPath = streamPath.Substring(0, separatorIndex);
+
+			try
+			{
+				await enumFolderSemaphore.WaitAsync(semaphoreCTS.Token);
+			}
+			catch (OperationCanceledException)
+			{
+				return false;
+			}
+
+			try
+			{
+				var items = filesAndFolders.ToList();
+				var mainItem = items.FirstOrDefault(x => x is not AlternateStreamItem && x.ItemPath.Equals(mainStreamPath, StringComparison.OrdinalIgnoreCase));
+				if (mainItem is null)
+					return false;
+
+				var onDisk = Win32Helper.GetAlternateStreams(mainStreamPath)
+					.Select(ads => Win32StorageEnumerator.GetAlternateStream(ads, mainItem))
+					.ToDictionary(x => x.ItemPath, StringComparer.OrdinalIgnoreCase);
+
+				var anyChanges = false;
+
+				foreach (var adsItem in items.OfType<AlternateStreamItem>().Where(x => x.MainStreamPath.Equals(mainStreamPath, StringComparison.OrdinalIgnoreCase)))
+				{
+					if (!onDisk.Remove(adsItem.ItemPath))
+					{
+						filesAndFolders.Remove(adsItem);
+						anyChanges = true;
+					}
+				}
+
+				foreach (var adsItem in onDisk.Values)
+				{
+					filesAndFolders.Add(adsItem);
+					anyChanges = true;
+				}
+
+				return anyChanges;
+			}
+			finally
+			{
+				enumFolderSemaphore.Release();
+			}
 		}
 
 		public async Task AddSearchResultsToCollectionAsync(ObservableCollection<ListedItem> searchItems, string currentSearchPath)

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -2962,7 +2962,7 @@ namespace Files.App.ViewModels
 					if (UserSettingsService.FoldersSettingsService.AreAlternateStreamsVisible)
 					{
 						// Main file is removed, remove connected ADS
-						foreach (var adsItem in filesAndFolders.ToList().Where(x => x is AlternateStreamItem ads && ads.MainStreamPath == matchingItem.ItemPath))
+						foreach (var adsItem in filesAndFolders.ToList().Where(x => x is AlternateStreamItem ads && ads.MainStreamPath.Equals(matchingItem.ItemPath, StringComparison.OrdinalIgnoreCase)))
 							filesAndFolders.Remove(adsItem);
 					}
 

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -2653,6 +2653,11 @@ namespace Files.App.ViewModels
 									case FILE_ACTION_MODIFIED:
 										if (!updateQueue.Contains(operation.FileName))
 											updateQueue.Enqueue(operation.FileName);
+
+										// Some filesystems report stream deletion only as a modification
+										// of the host file, without any FILE_ACTION_*_STREAM action
+										if (await SyncAlternateStreamsForFileAsync(operation.FileName))
+											anyEdits = true;
 										break;
 
 									case FILE_ACTION_REMOVED:

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -2600,6 +2600,9 @@ namespace Files.App.ViewModels
 			const uint FILE_ACTION_REMOVED_STREAM = 0x00000007;
 			const uint FILE_ACTION_MODIFIED_STREAM = 0x00000008;
 
+			// Not a system action; requeued by the stream cases below
+			const uint FILE_ACTION_RECHECK_STREAM = 0xFFFFFFFF;
+
 			const int UPDATE_BATCH_SIZE = 32;
 			var sampler = new IntervalSampler(200);
 			var updateQueue = new Queue<string>();
@@ -2679,6 +2682,9 @@ namespace Files.App.ViewModels
 												foreach (var adsItem in filesAndFolders.ToList().OfType<AlternateStreamItem>().Where(x => x.MainStreamPath.Equals(oldPath, StringComparison.OrdinalIgnoreCase)))
 													adsItem.ItemPath = $"{newPath}:{adsItem.ItemNameRaw}";
 											});
+
+											if (await SyncAlternateStreamsForFileAsync(newPath))
+												anyEdits = true;
 										}
 										else
 										{
@@ -2691,8 +2697,19 @@ namespace Files.App.ViewModels
 									case FILE_ACTION_ADDED_STREAM:
 									case FILE_ACTION_REMOVED_STREAM:
 									case FILE_ACTION_MODIFIED_STREAM:
+									case FILE_ACTION_RECHECK_STREAM:
 										if (await SyncAlternateStreamsAsync(operation.FileName))
 											anyEdits = true;
+										else if (operation.Action != FILE_ACTION_RECHECK_STREAM)
+										{
+											// The notification can arrive before the operation is visible on disk
+											var streamPath = operation.FileName;
+											_ = Task.Delay(500).ContinueWith(_ =>
+											{
+												operationQueue.Enqueue((FILE_ACTION_RECHECK_STREAM, streamPath));
+												operationEvent.Set();
+											});
+										}
 										break;
 								}
 							}
@@ -2977,18 +2994,21 @@ namespace Files.App.ViewModels
 			return null;
 		}
 
-		private async Task<bool> SyncAlternateStreamsAsync(string streamPath)
+		private Task<bool> SyncAlternateStreamsAsync(string streamPath)
 		{
-			if (!UserSettingsService.FoldersSettingsService.AreAlternateStreamsVisible)
-				return false;
-
 			// Stream notifications name the stream as "<file>:<stream>"; a colon not past the
 			// last separator is the drive colon, i.e. an event for the unnamed data stream
 			var separatorIndex = streamPath.LastIndexOf(':');
 			if (separatorIndex <= streamPath.LastIndexOf('\\'))
-				return false;
+				return Task.FromResult(false);
 
-			var mainStreamPath = streamPath.Substring(0, separatorIndex);
+			return SyncAlternateStreamsForFileAsync(streamPath.Substring(0, separatorIndex));
+		}
+
+		private async Task<bool> SyncAlternateStreamsForFileAsync(string mainStreamPath)
+		{
+			if (!UserSettingsService.FoldersSettingsService.AreAlternateStreamsVisible)
+				return false;
 
 			try
 			{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #9494

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened a folder containing a file with an ADS and confirmed it was displayed
2. Deleted the stream and confirmed the ADS was removed from the folder
3. Confirmed similar behavior when creating a new stream
4. Deleted the actual file and confirmed the ADS was removed as well
