### PR TITLE
Feature: Improved behavior when opening encrypted archives

### DIFF
--- a/src/Files.App/Dialogs/CredentialDialog.xaml
+++ b/src/Files.App/Dialogs/CredentialDialog.xaml
@@ -10,6 +10,7 @@
 	Title="{helpers:ResourceString Name=AskCredentialDialog/Title}"
 	CornerRadius="{StaticResource OverlayCornerRadius}"
 	HighContrastAdjustment="None"
+	Opened="ContentDialog_Opened"
 	PrimaryButtonClick="ContentDialog_PrimaryButtonClick"
 	PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
 	PrimaryButtonText="{helpers:ResourceString Name=OK}"
@@ -50,6 +51,14 @@
 				Margin="4"
 				IsEnabled="{x:Bind ViewModel.IsAnonymous, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
 				PlaceholderText="{helpers:ResourceString Name=Password}" />
+
+			<TextBlock
+				x:Name="WrongPasswordMessage"
+				Margin="4"
+				Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+				Text="{helpers:ResourceString Name=CredentialDialogIncorrectPassword}"
+				TextWrapping="Wrap"
+				Visibility="{x:Bind ViewModel.IsWrongPassword, Mode=OneWay}" />
 
 			<CheckBox
 				x:Name="Anonymous"

--- a/src/Files.App/Dialogs/CredentialDialog.xaml.cs
+++ b/src/Files.App/Dialogs/CredentialDialog.xaml.cs
@@ -28,9 +28,43 @@ namespace Files.App.Dialogs
 			return (DialogResult)await base.ShowAsync();
 		}
 
-		private void ContentDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+		private void ContentDialog_Opened(ContentDialog sender, ContentDialogOpenedEventArgs args)
 		{
-			ViewModel.PrimaryButtonClickCommand.Execute(new DisposableArray(Encoding.UTF8.GetBytes(Password.Password)));
+			// Focus the first editable input so the user can type without clicking first
+			var target = UserName is { IsLoaded: true, IsEnabled: true } ? UserName : (Control)Password;
+			target.Focus(FocusState.Programmatic);
+		}
+
+		private async void ContentDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+		{
+			var password = new DisposableArray(Encoding.UTF8.GetBytes(Password.Password));
+
+			if (ViewModel.PasswordValidator is null)
+			{
+				ViewModel.PrimaryButtonClickCommand.Execute(password);
+				return;
+			}
+
+			var deferral = args.GetDeferral();
+			try
+			{
+				IsPrimaryButtonEnabled = false;
+				if (await ViewModel.PasswordValidator(password))
+				{
+					ViewModel.PrimaryButtonClickCommand.Execute(password);
+				}
+				else
+				{
+					args.Cancel = true;
+					ViewModel.IsWrongPassword = true;
+					password.Dispose();
+				}
+			}
+			finally
+			{
+				IsPrimaryButtonEnabled = true;
+				deferral.Complete();
+			}
 		}
 	}
 }

--- a/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
+++ b/src/Files.App/Helpers/UI/UIFilesystemHelpers.cs
@@ -260,11 +260,24 @@ namespace Files.App.Helpers
 			var isFtp = FtpHelpers.IsFtpPath(path);
 
 			var credentialDialogViewModel = new CredentialDialogViewModel() { CanBeAnonymous = isFtp, PasswordOnly = !isFtp };
+
+			if (sender is ZipStorageFolder zipFolder)
+			{
+				credentialDialogViewModel.PasswordValidator = async (password) =>
+				{
+					zipFolder.Credentials = new StorageCredential(null, Encoding.UTF8.GetString(password.Bytes));
+					return await Task.Run(zipFolder.ValidateCredentialsAsync);
+				};
+			}
+
 			IDialogService dialogService = Ioc.Default.GetRequiredService<IDialogService>();
 			var dialogResult = await MainWindow.Instance.DispatcherQueue.EnqueueOrInvokeAsync(() =>
 				dialogService.ShowDialogAsync(credentialDialogViewModel));
 
-			if (dialogResult != DialogResult.Primary || credentialDialogViewModel.IsAnonymous)
+			if (dialogResult != DialogResult.Primary)
+				throw new OperationCanceledException();
+
+			if (credentialDialogViewModel.IsAnonymous)
 				return new();
 
 			// Can't do more than that to mitigate immutability of strings. Perhaps convert DisposableArray to SecureString immediately?

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -1781,6 +1781,15 @@
   <data name="CredentialDialogDescription.Text" xml:space="preserve">
     <value>Provide your credential:</value>
   </data>
+  <data name="CredentialDialogIncorrectPassword" xml:space="preserve">
+    <value>The password is incorrect. Try again.</value>
+  </data>
+  <data name="PasswordRequired" xml:space="preserve">
+    <value>Password required</value>
+  </data>
+  <data name="PasswordRequiredMessage" xml:space="preserve">
+    <value>This location is password protected. Refresh to enter the password.</value>
+  </data>
   <data name="CredentialDialogUserName.PlaceholderText" xml:space="preserve">
     <value>UserName</value>
   </data>

--- a/src/Files.App/Utils/Storage/Enumerators/UniversalStorageEnumerator.cs
+++ b/src/Files.App/Utils/Storage/Enumerators/UniversalStorageEnumerator.cs
@@ -61,6 +61,10 @@ namespace Files.App.Utils.Storage
 				{
 					break;
 				}
+				catch (OperationCanceledException) // Password dialog dismissed - let the caller handle it
+				{
+					throw;
+				}
 				catch (Exception ex) when (
 					ex is UnauthorizedAccessException ||
 					ex is FileNotFoundException ||

--- a/src/Files.App/Utils/Storage/StorageItems/ZipStorageFolder.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/ZipStorageFolder.cs
@@ -563,6 +563,19 @@ namespace Files.App.Utils.Storage
 			return true;
 		}
 
+		public async Task<bool> ValidateCredentialsAsync()
+		{
+			try
+			{
+				using SevenZipExtractor zipFile = await OpenZipFileAsync();
+				return zipFile?.ArchiveFileData is not null;
+			}
+			catch (Exception) // SevenZipOpenFailedException(WrongPassword) for bad credentials; IO exceptions (e.g. archive deleted meanwhile) equally mean the credentials can't be verified
+			{
+				return false;
+			}
+		}
+
 		private IAsyncOperation<SevenZipExtractor> OpenZipFileAsync()
 		{
 			return AsyncInfo.Run<SevenZipExtractor>(async (cancellationToken) =>

--- a/src/Files.App/ViewModels/Dialogs/CredentialDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/CredentialDialogViewModel.cs
@@ -33,6 +33,18 @@ namespace Files.App.ViewModels.Dialogs
 			set => SetProperty(ref _CanBeAnonymous, value);
 		}
 
+		private bool _IsWrongPassword;
+		public bool IsWrongPassword
+		{
+			get => _IsWrongPassword;
+			set => SetProperty(ref _IsWrongPassword, value);
+		}
+
+		/// <summary>
+		/// When set, the dialog stays open on OK until the entered password passes validation.
+		/// </summary>
+		public Func<DisposableArray, Task<bool>>? PasswordValidator { get; set; }
+
 		public DisposableArray? Password { get; private set; }
 
 		public IRelayCommand PrimaryButtonClickCommand { get; }

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -356,6 +356,7 @@ namespace Files.App.ViewModels
 			AccessDenied,
 			NotFound,
 			DriveUnplugged,
+			PasswordRequired,
 		}
 
 		private void ShowLocationUnavailable(LocationUnavailableKind kind, string? message = null)
@@ -364,6 +365,7 @@ namespace Files.App.ViewModels
 			{
 				LocationUnavailableKind.AccessDenied => ("\uE72E", Strings.AccessDenied.GetLocalizedResource(), Strings.AccessDeniedToFolder.GetLocalizedResource()),
 				LocationUnavailableKind.NotFound => ("\uE838", Strings.FolderNotFoundDialogTitle.GetLocalizedResource(), Strings.FolderNotFoundDialogText.GetLocalizedResource()),
+				LocationUnavailableKind.PasswordRequired => ("\uE8D7", Strings.PasswordRequired.GetLocalizedResource(), Strings.PasswordRequiredMessage.GetLocalizedResource()),
 				_ => ("\uE7BA", Strings.DriveUnpluggedDialogTitle.GetLocalizedResource(), message ?? Strings.DriveUnpluggedDialogText.GetLocalizedResource()),
 			};
 
@@ -2237,28 +2239,42 @@ namespace Files.App.ViewModels
 				return;
 
 			if (rootFolder is IPasswordProtectedItem ppis)
-				ppis.PasswordRequestedCallback = UIFilesystemHelpers.RequestPassword;
+				ppis.PasswordRequestedCallback = async (item) =>
+				{
+					await dispatcherQueue.EnqueueOrInvokeAsync(() => ShowLocationUnavailable(LocationUnavailableKind.PasswordRequired));
 
-			await Task.Run(async () =>
+					return await UIFilesystemHelpers.RequestPassword(item);
+				};
+
+			try
 			{
-				List<ListedItem> finalList = await UniversalStorageEnumerator.ListEntries(
-					rootFolder,
-					currentStorageFolder,
-					cancellationToken,
-					-1,
-					async (intermediateList) =>
-					{
-						filesAndFolders.AddRange(intermediateList);
+				await Task.Run(async () =>
+				{
+					List<ListedItem> finalList = await UniversalStorageEnumerator.ListEntries(
+						rootFolder,
+						currentStorageFolder,
+						cancellationToken,
+						-1,
+						async (intermediateList) =>
+						{
+							filesAndFolders.AddRange(intermediateList);
 
-						await OrderFilesAndFoldersAsync();
-						await ApplyFilesAndFoldersChangesAsync();
-					});
+							await OrderFilesAndFoldersAsync();
+							await ApplyFilesAndFoldersChangesAsync();
+						});
 
-				filesAndFolders.AddRange(finalList);
+					filesAndFolders.AddRange(finalList);
 
-				await OrderFilesAndFoldersAsync();
-				await ApplyFilesAndFoldersChangesAsync();
-			}, cancellationToken);
+					await OrderFilesAndFoldersAsync();
+					await ApplyFilesAndFoldersChangesAsync();
+				}, cancellationToken);
+
+				IsLocationUnavailable = false;
+			}
+			catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) // Password dialog dismissed
+			{
+				ShowLocationUnavailable(LocationUnavailableKind.PasswordRequired);
+			}
 
 			if (rootFolder is IPasswordProtectedItem ppiu)
 				ppiu.PasswordRequestedCallback = null;


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #17978

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened encrypted archive
2. Confirmed that entering wrong password notifies the user while keeping the dialog open
3. Confirmed that canceling the dialog displays text in the file area informing the user that the location is password protected