### PR TITLE
Fix: Checked out existing local branch when checking out remote branch

### DIFF
--- a/src/Files.App/Services/Git/LibGit2Service.cs
+++ b/src/Files.App/Services/Git/LibGit2Service.cs
@@ -473,9 +473,15 @@ internal sealed partial class LibGit2Service // : IVersionControl
 	{
 		var uniqueName = branch.FriendlyName.Substring(END_OF_ORIGIN_PREFIX);
 
-		// TODO: This is a temp fix to avoid an issue where Files would create many branches in a loop
 		if (repository.Branches.Any(b => !b.IsRemote && b.FriendlyName == uniqueName))
+		{
+			var localBranch = repository.Branches[uniqueName];
+			if (repository.Head.FriendlyName != localBranch.FriendlyName)
+			{
+				LibGit2Sharp.Commands.Checkout(repository, localBranch);
+			}
 			return;
+		}
 
 		//var discriminator = 0;
 		//while (repository.Branches.Any(b => !b.IsRemote && b.FriendlyName == uniqueName))

--- a/src/Files.App/Utils/Git/GitHelpers.cs
+++ b/src/Files.App/Utils/Git/GitHelpers.cs
@@ -535,9 +535,15 @@ namespace Files.App.Utils.Git
 		{
 			var uniqueName = branch.FriendlyName.Substring(END_OF_ORIGIN_PREFIX);
 
-			// TODO: This is a temp fix to avoid an issue where Files would create many branches in a loop
 			if (repository.Branches.Any(b => !b.IsRemote && b.FriendlyName == uniqueName))
+			{
+				var localBranch = repository.Branches[uniqueName];
+				if (repository.Head.FriendlyName != localBranch.FriendlyName)
+				{
+					LibGit2Sharp.Commands.Checkout(repository, localBranch);
+				}
 				return;
+			}
 
 			//var discriminator = 0;
 			//while (repository.Branches.Any(b => !b.IsRemote && b.FriendlyName == uniqueName))


### PR DESCRIPTION
This PR resolves the issue where selecting a remote branch in the Git branches list silently did nothing if the local tracking branch already existed.

It updates CheckoutRemoteBranch to check out the existing local branch instead of returning early.