### PR TITLE
Fix: Fixed issue where the Customize tab was shown for folders that don't support custom icons

### DIFF
--- a/src/Files.App/Data/Factories/PropertiesNavigationItemsFactory.cs
+++ b/src/Files.App/Data/Factories/PropertiesNavigationItemsFactory.cs
@@ -62,10 +62,15 @@ namespace Files.App.Data.Factories
 				var fileExt = listedItem.FileExtension;
 				var isFolder = listedItem.PrimaryItemAttribute == Windows.Storage.StorageItemTypes.Folder;
 
+				var isMtpPath = DriveHelpers.IsMtpPath(listedItem.ItemPath);
+				var isNetworkPath = isFolder && DriveHelpers.IsNetworkPath(listedItem.ItemPath);
+
 				var securityItemEnabled = !isLibrary && !listedItem.IsRecycleBinItem;
 				var hashItemEnabled = !(isFolder && !listedItem.IsArchive) && !isLibrary && !listedItem.IsRecycleBinItem;
 				var detailsItemEnabled = !(isFolder && !listedItem.IsArchive) && !isLibrary && !listedItem.IsRecycleBinItem;
-				var customizationItemEnabled = !isLibrary && (isFolder && !listedItem.IsArchive || isShortcut);
+				var customizationItemEnabled =
+					!isLibrary &&
+					(isFolder && !listedItem.IsArchive && !listedItem.IsFtpItem && !listedItem.IsRecycleBinItem && !isMtpPath && !isNetworkPath || isShortcut);
 				var compatibilityItemEnabled = FileExtensionHelpers.IsExecutableFile(listedItem is IShortcutItem sht ? sht.TargetPath : fileExt, true);
 				var signaturesItemEnabled =
 					!isFolder &&

--- a/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
@@ -93,6 +93,27 @@ namespace Files.App.Utils.Storage
 			return null;
 		}
 
+		public static bool IsMtpPath(string path)
+		{
+			return path.StartsWith(@"\\?\", StringComparison.Ordinal);
+		}
+
+		public static bool IsNetworkPath(string path)
+		{
+			if (IsMtpPath(path))
+				return false;
+
+			try
+			{
+				return path.StartsWith(@"\\", StringComparison.Ordinal) ||
+					GetDriveType(new SystemIO.DriveInfo(path)) is Data.Items.DriveType.Network;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
 		public static Data.Items.DriveType GetDriveType(System.IO.DriveInfo drive)
 		{
 			if (drive.DriveType is System.IO.DriveType.Unknown)


### PR DESCRIPTION
**Resolved / Related Issues**

Closes #6689

**Steps used to test these changes**
1. Opened Files, navigated to a UNC network share (\\server\share\folder), right-clicked a subfolder > Properties > confirmed the Customize tab no longer appears.
2. Opened Properties on a local folder (e.g. under C:\) > confirmed the Customize tab still appears and setting a custom icon still works.