### PR TITLE
Code Quality: Moved file tags database reconciliation off the startup path

### DIFF
--- a/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
+++ b/src/Files.App/Helpers/Application/AppLifecycleHelper.cs
@@ -127,7 +127,7 @@ namespace Files.App.Helpers
 				);
 			});
 
-			FileTagsHelper.UpdateTagsDb();
+			_ = Task.Run(FileTagsHelper.UpdateTagsDb);
 
 			_ = Task.Run(async () =>
 			{

--- a/src/Files.App/Utils/FileTags/FileTagsDatabase.cs
+++ b/src/Files.App/Utils/FileTags/FileTagsDatabase.cs
@@ -21,19 +21,23 @@ namespace Files.App.Utils.FileTags
 			if (FileTagsKey is null)
 				return;
 
-			using var filePathKey = Registry.CurrentUser.CreateSubKey(CombineKeys(FileTagsKey, filePath));
-
 			if (tags is [])
 			{
-				SaveValues(filePathKey, null);
+				using var existingFilePathKey = Registry.CurrentUser.OpenSubKey(CombineKeys(FileTagsKey, filePath), writable: true);
+				if (existingFilePathKey is not null)
+					SaveValues(existingFilePathKey, null);
+
 				if (frn is not null)
 				{
-					using var frnKey = Registry.CurrentUser.CreateSubKey(CombineKeys(FileTagsKey, "FRN", frn.Value.ToString()));
-					SaveValues(frnKey, null);
+					using var existingFrnKey = Registry.CurrentUser.OpenSubKey(CombineKeys(FileTagsKey, "FRN", frn.Value.ToString()), writable: true);
+					if (existingFrnKey is not null)
+						SaveValues(existingFrnKey, null);
 				}
 
 				return;
 			}
+
+			using var filePathKey = Registry.CurrentUser.CreateSubKey(CombineKeys(FileTagsKey, filePath));
 
 			var newTag = new TaggedFile()
 			{
@@ -57,8 +61,8 @@ namespace Files.App.Utils.FileTags
 
 			if (filePath is not null)
 			{
-				using var filePathKey = Registry.CurrentUser.CreateSubKey(CombineKeys(FileTagsKey, filePath));
-				if (filePathKey.ValueCount > 0)
+				using var filePathKey = Registry.CurrentUser.OpenSubKey(CombineKeys(FileTagsKey, filePath), writable: true);
+				if (filePathKey is not null && filePathKey.ValueCount > 0)
 				{
 					var tag = new TaggedFile();
 					BindValues(filePathKey, tag);
@@ -75,8 +79,8 @@ namespace Files.App.Utils.FileTags
 
 			if (frn is not null)
 			{
-				using var frnKey = Registry.CurrentUser.CreateSubKey(CombineKeys(FileTagsKey, "FRN", frn.Value.ToString()));
-				if (frnKey.ValueCount > 0)
+				using var frnKey = Registry.CurrentUser.OpenSubKey(CombineKeys(FileTagsKey, "FRN", frn.Value.ToString()), writable: true);
+				if (frnKey is not null && frnKey.ValueCount > 0)
 				{
 					var tag = new TaggedFile();
 					BindValues(frnKey, tag);
@@ -99,8 +103,9 @@ namespace Files.App.Utils.FileTags
 				return;
 
 			var tag = FindTag(oldFilePath, null);
-			using var filePathKey = Registry.CurrentUser.CreateSubKey(CombineKeys(FileTagsKey, oldFilePath));
-			SaveValues(filePathKey, null);
+			using var filePathKey = Registry.CurrentUser.OpenSubKey(CombineKeys(FileTagsKey, oldFilePath), writable: true);
+			if (filePathKey is not null)
+				SaveValues(filePathKey, null);
 
 			if (tag is not null)
 			{
@@ -127,8 +132,9 @@ namespace Files.App.Utils.FileTags
 				return;
 
 			var tag = FindTag(null, oldFrn);
-			using var frnKey = Registry.CurrentUser.CreateSubKey(CombineKeys(FileTagsKey, "FRN", oldFrn.ToString()));
-			SaveValues(frnKey, null);
+			using var frnKey = Registry.CurrentUser.OpenSubKey(CombineKeys(FileTagsKey, "FRN", oldFrn.ToString()), writable: true);
+			if (frnKey is not null)
+				SaveValues(frnKey, null);
 
 			if (tag is not null)
 			{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #18616

**Steps used to test these changes**

1. Confirmed the app launches, enumerates, and shuts down normally with `UpdateTagsDb` running via `Task.Run` off the startup path.
