### PR TITLE
Fix: Fixed issue where the Customize tab was hidden for network folders that support custom icons

### DIFF
--- a/src/Files.App/Data/Factories/PropertiesNavigationItemsFactory.cs
+++ b/src/Files.App/Data/Factories/PropertiesNavigationItemsFactory.cs
@@ -70,7 +70,8 @@ namespace Files.App.Data.Factories
 				var detailsItemEnabled = !(isFolder && !listedItem.IsArchive) && !isLibrary && !listedItem.IsRecycleBinItem;
 				var customizationItemEnabled =
 					!isLibrary &&
-					(isFolder && !listedItem.IsArchive && !listedItem.IsFtpItem && !listedItem.IsRecycleBinItem && !isMtpPath && !isNetworkPath || isShortcut);
+					(isFolder && !listedItem.IsArchive && !listedItem.IsFtpItem && !listedItem.IsRecycleBinItem && !isMtpPath &&
+						(!isNetworkPath || PolicyHelpers.IsShellShortcutIconRemotePathEnabled()) || isShortcut);
 				var compatibilityItemEnabled = FileExtensionHelpers.IsExecutableFile(listedItem is IShortcutItem sht ? sht.TargetPath : fileExt, true);
 				var signaturesItemEnabled =
 					!isFolder &&

--- a/src/Files.App/Helpers/Environment/PolicyHelpers.cs
+++ b/src/Files.App/Helpers/Environment/PolicyHelpers.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using Microsoft.Win32;
+
+namespace Files.App.Helpers
+{
+	internal static class PolicyHelpers
+	{
+		private const string ExplorerPolicyRegistryKey = @"SOFTWARE\Policies\Microsoft\Windows\Explorer";
+
+		public static bool IsShellShortcutIconRemotePathEnabled()
+		{
+			try
+			{
+				using var policySubkey = Registry.LocalMachine.OpenSubKey(ExplorerPolicyRegistryKey);
+
+				return Convert.ToBoolean(policySubkey?.GetValue("EnableShellShortcutIconRemotePath", false));
+			}
+			catch
+			{
+				return false;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Related to #6689

Follow-up to #18762, which hid the Customize tab for every network location. Windows only allows folder icon customization on remote paths when the respective group policy is enabled, so the tab is now hidden only when that policy is off. The policy value doesn't exist by default, which is treated as disabled.

**Steps used to test these changes**
1. Created 'HKLM\SOFTWARE\Policies\Microsoft\Windows\Explorer\EnableShellShortcutIconRemotePath'   as a 'REG_DWORD' set to '1', restarted Files, and confirmed the Customize tab appears for the same network folder and that setting a custom icon works.
2. Set the value to `0` and confirmed the tab is hidden again.