### PR TITLE
Fix: Fixed issue where password popup was displayed multiple times when copying from an encrypted archive

### DIFF
--- a/src/Files.App/Utils/Storage/StorageBaseItems/IPasswordProtectedItem.cs
+++ b/src/Files.App/Utils/Storage/StorageBaseItems/IPasswordProtectedItem.cs
@@ -12,6 +12,9 @@ namespace Files.App.Utils.Storage
 
 		Func<IPasswordProtectedItem, Task<StorageCredential>> PasswordRequestedCallback { get; set; }
 
+		// Called after an operation succeeds with credentials obtained from PasswordRequestedCallback
+		void OnCredentialsVerified() { }
+
 		async Task<TOut> RetryWithCredentialsAsync<TOut>(Func<Task<TOut>> func, Exception exception)
 		{
 			var handled = exception is SevenZipOpenFailedException szofex && szofex.Result is OperationResult.WrongPassword ||
@@ -23,7 +26,9 @@ namespace Files.App.Utils.Storage
 
 			Credentials = await PasswordRequestedCallback(this);
 
-			return await func();
+			var result = await func();
+			OnCredentialsVerified();
+			return result;
 		}
 
 		async Task RetryWithCredentialsAsync(Func<Task> func, Exception exception)
@@ -38,6 +43,7 @@ namespace Files.App.Utils.Storage
 			Credentials = await PasswordRequestedCallback(this);
 
 			await func();
+			OnCredentialsVerified();
 		}
 
 		void CopyFrom(IPasswordProtectedItem parent)

--- a/src/Files.App/Utils/Storage/StorageItems/ZipStorageFile.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/ZipStorageFile.cs
@@ -49,6 +49,17 @@ namespace Files.App.Utils.Storage
 
 		public Func<IPasswordProtectedItem, Task<StorageCredential>> PasswordRequestedCallback { get; set; }
 
+		void IPasswordProtectedItem.OnCredentialsVerified()
+		{
+			using var password = Credentials.SecurePassword;
+			ZipStorageFolder.CachedCredentials[containerPath] = new StorageCredential(Credentials.UserName, password);
+		}
+
+		private string ArchivePassword
+			=> string.IsNullOrEmpty(Credentials.Password) && ZipStorageFolder.CachedCredentials.TryGetValue(containerPath, out var cached)
+				? cached.Password
+				: Credentials.Password;
+
 		public ZipStorageFile(string path, string containerPath)
 		{
 			Name = IO.Path.GetFileName(path.TrimEnd('\\', '/'));
@@ -329,7 +340,7 @@ namespace Files.App.Utils.Storage
 							compressor.CustomParameters.Add("cu", "on");
 							compressor.SetFormatFromExistingArchive(archiveStream);
 							var fileName = IO.Path.GetRelativePath(containerPath, IO.Path.Combine(IO.Path.GetDirectoryName(Path), desiredName));
-							await compressor.ModifyArchiveAsync(archiveStream, new Dictionary<int, string>() { { index, fileName } }, Credentials.Password, ms);
+							await compressor.ModifyArchiveAsync(archiveStream, new Dictionary<int, string>() { { index, fileName } }, ArchivePassword, ms);
 						}
 
 						await using (var archiveStream = await OpenZipFileAsync(FileAccessMode.ReadWrite))
@@ -378,7 +389,7 @@ namespace Files.App.Utils.Storage
 							SevenZipCompressor compressor = new SevenZipCompressor() { CompressionMode = CompressionMode.Append };
 							compressor.CustomParameters.Add("cu", "on");
 							compressor.SetFormatFromExistingArchive(archiveStream);
-							await compressor.ModifyArchiveAsync(archiveStream, new Dictionary<int, string>() { { index, null } }, Credentials.Password, ms);
+							await compressor.ModifyArchiveAsync(archiveStream, new Dictionary<int, string>() { { index, null } }, ArchivePassword, ms);
 						}
 						await using (var archiveStream = await OpenZipFileAsync(FileAccessMode.ReadWrite))
 						{
@@ -463,7 +474,7 @@ namespace Files.App.Utils.Storage
 			return AsyncInfo.Run<SevenZipExtractor>(async (cancellationToken) =>
 			{
 				var zipFile = await OpenZipFileAsync(FileAccessMode.Read);
-				return zipFile is not null ? new SevenZipExtractor(zipFile, Credentials.Password) : null;
+				return zipFile is not null ? new SevenZipExtractor(zipFile, ArchivePassword) : null;
 			});
 		}
 

--- a/src/Files.App/Utils/Storage/StorageItems/ZipStorageFolder.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/ZipStorageFolder.cs
@@ -35,6 +35,20 @@ namespace Files.App.Utils.Storage
 
 		public Func<IPasswordProtectedItem, Task<StorageCredential>> PasswordRequestedCallback { get; set; }
 
+		// Verified credentials per archive file path, shared with ZipStorageFile; SecureString-backed like FtpManager.Credentials
+		internal static readonly ConcurrentDictionary<string, StorageCredential> CachedCredentials = new(StringComparer.OrdinalIgnoreCase);
+
+		void IPasswordProtectedItem.OnCredentialsVerified()
+		{
+			using var password = Credentials.SecurePassword;
+			CachedCredentials[containerPath] = new StorageCredential(Credentials.UserName, password);
+		}
+
+		private string ArchivePassword
+			=> string.IsNullOrEmpty(Credentials.Password) && CachedCredentials.TryGetValue(containerPath, out var cached)
+				? cached.Password
+				: Credentials.Password;
+
 		public ZipStorageFolder(string path, string containerPath)
 		{
 			Name = IO.Path.GetFileName(path.TrimEnd('\\', '/'));
@@ -316,7 +330,7 @@ namespace Files.App.Utils.Storage
 						compressor.CustomParameters.Add("cu", "on");
 						compressor.SetFormatFromExistingArchive(archiveStream);
 						var fileName = IO.Path.GetRelativePath(containerPath, zipDesiredName);
-						await compressor.CompressStreamDictionaryAsync(archiveStream, new Dictionary<string, Stream>() { { fileName, null } }, Credentials.Password, ms);
+						await compressor.CompressStreamDictionaryAsync(archiveStream, new Dictionary<string, Stream>() { { fileName, null } }, ArchivePassword, ms);
 					}
 					await using (var archiveStream = await OpenZipFileAsync(FileAccessMode.ReadWrite))
 					{
@@ -371,7 +385,7 @@ namespace Files.App.Utils.Storage
 							var folderDes = IO.Path.Combine(IO.Path.GetDirectoryName(folderKey), desiredName);
 							var entriesMap = new Dictionary<int, string>(index.Select(x => new KeyValuePair<int, string>(x.Index,
 								IO.Path.Combine(folderDes, IO.Path.GetRelativePath(folderKey, x.Key)))));
-							await compressor.ModifyArchiveAsync(archiveStream, entriesMap, Credentials.Password, ms);
+							await compressor.ModifyArchiveAsync(archiveStream, entriesMap, ArchivePassword, ms);
 						}
 						await using (var archiveStream = await OpenZipFileAsync(FileAccessMode.ReadWrite))
 						{
@@ -420,7 +434,7 @@ namespace Files.App.Utils.Storage
 							compressor.CustomParameters.Add("cu", "on");
 							compressor.SetFormatFromExistingArchive(archiveStream);
 							var entriesMap = new Dictionary<int, string>(index.Select(x => new KeyValuePair<int, string>(x.Index, null)));
-							await compressor.ModifyArchiveAsync(archiveStream, entriesMap, Credentials.Password, ms);
+							await compressor.ModifyArchiveAsync(archiveStream, entriesMap, ArchivePassword, ms);
 						}
 						await using (var archiveStream = await OpenZipFileAsync(FileAccessMode.ReadWrite))
 						{
@@ -581,7 +595,7 @@ namespace Files.App.Utils.Storage
 			return AsyncInfo.Run<SevenZipExtractor>(async (cancellationToken) =>
 			{
 				var zipFile = await OpenZipFileAsync(FileAccessMode.Read);
-				return zipFile is not null ? new SevenZipExtractor(zipFile, Credentials.Password) : null;
+				return zipFile is not null ? new SevenZipExtractor(zipFile, ArchivePassword) : null;
 			});
 		}
 
@@ -645,7 +659,7 @@ namespace Files.App.Utils.Storage
 						compressor.CustomParameters.Add("cu", "on");
 						compressor.SetFormatFromExistingArchive(archiveStream);
 						var fileName = IO.Path.GetRelativePath(containerPath, zipDesiredName);
-						await compressor.CompressStreamDictionaryAsync(archiveStream, new Dictionary<string, Stream>() { { fileName, contents } }, Credentials.Password, ms);
+						await compressor.CompressStreamDictionaryAsync(archiveStream, new Dictionary<string, Stream>() { { fileName, contents } }, ArchivePassword, ms);
 					}
 					await using (var archiveStream = await OpenZipFileAsync(FileAccessMode.ReadWrite))
 					{


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #18656

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Confirmed password prompt was only displayed once
