### PR TITLE
Feature: Opening a file location from external applications now selects the item in Files

### DIFF
--- a/src/Files.App.Launcher/FilesLauncher.cpp
+++ b/src/Files.App.Launcher/FilesLauncher.cpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <dwmapi.h>
 #include <exdisp.h>
 #include <iostream>
 #include <objbase.h>
@@ -10,6 +11,7 @@
 #include <shtypes.h>
 #include <ShlObj_core.h>
 #include <ShObjIdl_core.h>
+#include <tlhelp32.h>
 #include <vector>
 #include <wil/resource.h>
 
@@ -20,11 +22,13 @@
 #pragma comment(lib, "Propsys.lib")
 #pragma comment(lib, "user32.lib")
 #pragma comment(lib, "uuid.lib")
+#pragma comment(lib, "dwmapi.lib")
 
 constexpr auto ID_TIMEREXPIRED = 101;
 
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 bool OpenInExistingShellWindow(const TCHAR* folderPath);
+bool IsLaunchedByExplorer();
 void RunFileExplorer(const TCHAR* openDirectory);
 size_t strifind(const std::wstring& strHaystack, const std::wstring& strNeedle);
 bool comparei(std::wstring stringA, std::wstring stringB);
@@ -102,7 +106,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 	if (withArgs)
 	{
-		if (OpenInExistingShellWindow(openDirectory))
+		if (IsLaunchedByExplorer() && OpenInExistingShellWindow(openDirectory))
 		{
 			if (_debugStream)
 				fclose(_debugStream);
@@ -121,19 +125,20 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		wcex.lpszClassName = CLASS_NAME;
 		RegisterClassEx(&wcex);
 
-		OpenInFolder openInFolder;
+		winrt::com_ptr<OpenInFolder> openInFolder;
+		openInFolder.attach(new OpenInFolder());
 
 		// Create the window.
 		HWND hwnd = CreateWindowEx(
-			0,
+			WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE,
 			CLASS_NAME,
 			L"Files Launcher",
 			0,
 			0, 0, 0, 0,
-			HWND_MESSAGE,
+			NULL,
 			NULL,
 			hInstance,
-			&openInFolder
+			openInFolder.get()
 		);
 
 		if (hwnd == NULL)
@@ -146,9 +151,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 		SetTimer(hwnd, ID_TIMEREXPIRED, 500, NULL);
 
-		ShowWindow(hwnd, SW_SHOWNORMAL);
-		//UpdateWindow(hwnd);
-
 		MSG msg = { };
 		while (GetMessage(&msg, NULL, 0, 0) > 0)
 		{
@@ -156,11 +158,22 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 			DispatchMessage(&msg);
 		}
 
-		auto item = openInFolder.GetResult();
+		auto item = openInFolder->GetResult();
+		openInFolder->RevokeShellWindow();
+		if (IsWindow(hwnd))
+			DestroyWindow(hwnd);
 
 		TCHAR args[1024];
 		if (item.empty())
 		{
+			if (OpenInExistingShellWindow(openDirectory))
+			{
+				if (_debugStream)
+					fclose(_debugStream);
+
+				return 0;
+			}
+
 			std::wcout << L"No item selected" << std::endl;
 			//swprintf(args, _countof(args) - 1, L"-directory \"%s\"", openDirectory);
 			swprintf(args, _countof(args) - 1, L"\"%s\" -directory \"%s\"", szBuf, openDirectory);
@@ -241,6 +254,9 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 		pContainer->SetWindow(hwnd);
 		SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)pContainer);
+
+		BOOL cloak = TRUE;
+		DwmSetWindowAttribute(hwnd, DWMWA_CLOAK, &cloak, sizeof(cloak));
 		break;
 	}
 
@@ -338,6 +354,30 @@ void RunFileExplorer(const TCHAR* openDirectory)
 
 	ShExecInfo.nShow = SW_SHOW;
 	ShellExecuteEx(&ShExecInfo);
+}
+
+bool IsLaunchedByExplorer()
+{
+	DWORD explorerProcessId = 0;
+	GetWindowThreadProcessId(GetShellWindow(), &explorerProcessId);
+	if (!explorerProcessId)
+		return false;
+
+	wil::unique_handle snapshot(CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0));
+	if (!snapshot)
+		return false;
+
+	PROCESSENTRY32 processEntry{ sizeof(processEntry) };
+	if (!Process32First(snapshot.get(), &processEntry))
+		return false;
+
+	do
+	{
+		if (processEntry.th32ProcessID == GetCurrentProcessId())
+			return processEntry.th32ParentProcessID == explorerProcessId;
+	} while (Process32Next(snapshot.get(), &processEntry));
+
+	return false;
 }
 
 bool OpenInExistingShellWindow(const TCHAR* folderPath)

--- a/src/Files.App.Launcher/OpenInFolder.cpp
+++ b/src/Files.App.Launcher/OpenInFolder.cpp
@@ -3,9 +3,417 @@
 
 #include "OpenInFolder.h"
 
-OpenInFolder::OpenInFolder() : m_hwnd(NULL)
+#pragma comment(lib, "oleaut32.lib")
+
+OpenInFolder::OpenInFolder()
 {
 	m_shellWindows = winrt::create_instance<IShellWindows>(CLSID_ShellWindows, CLSCTX_ALL);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::QueryInterface(REFIID riid, void** ppvObject)
+{
+	RETURN_HR_IF_NULL(E_POINTER, ppvObject);
+	*ppvObject = nullptr;
+
+	if (riid == IID_IUnknown || riid == IID_IDispatch || riid == IID_IWebBrowser || riid == IID_IWebBrowserApp)
+		*ppvObject = static_cast<IWebBrowserApp*>(this);
+	else if (riid == IID_IServiceProvider)
+		*ppvObject = static_cast<IServiceProvider*>(this);
+	else if (riid == IID_IShellView || riid == IID_IOleWindow)
+		*ppvObject = static_cast<IShellView*>(this);
+	else
+		return E_NOINTERFACE;
+
+	AddRef();
+	return S_OK;
+}
+
+ULONG STDMETHODCALLTYPE OpenInFolder::AddRef()
+{
+	return ++m_referenceCount;
+}
+
+ULONG STDMETHODCALLTYPE OpenInFolder::Release()
+{
+	ULONG referenceCount = --m_referenceCount;
+	if (!referenceCount)
+		delete this;
+
+	return referenceCount;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GetTypeInfoCount(UINT* pctinfo)
+{
+	RETURN_HR_IF_NULL(E_POINTER, pctinfo);
+	*pctinfo = 0;
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GetTypeInfo(UINT, LCID, ITypeInfo** ppTInfo)
+{
+	if (ppTInfo)
+		*ppTInfo = nullptr;
+
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GetIDsOfNames(REFIID, LPOLESTR*, UINT, LCID, DISPID*)
+{
+	return DISP_E_UNKNOWNNAME;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::Invoke(DISPID, REFIID, LCID, WORD, DISPPARAMS*, VARIANT*, EXCEPINFO*, UINT*)
+{
+	return DISP_E_MEMBERNOTFOUND;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GoBack()
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GoForward()
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GoHome()
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GoSearch()
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::Navigate(BSTR, VARIANT*, VARIANT*, VARIANT*, VARIANT*)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::Refresh2(VARIANT*)
+{
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::Stop()
+{
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Application(IDispatch** ppDisp)
+{
+	RETURN_HR_IF_NULL(E_POINTER, ppDisp);
+	*ppDisp = static_cast<IWebBrowserApp*>(this);
+	AddRef();
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Parent(IDispatch** ppDisp)
+{
+	return get_Application(ppDisp);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Container(IDispatch** ppDisp)
+{
+	return get_Application(ppDisp);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Document(IDispatch** ppDisp)
+{
+	return get_Application(ppDisp);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_TopLevelContainer(VARIANT_BOOL* pBool)
+{
+	RETURN_HR_IF_NULL(E_POINTER, pBool);
+	*pBool = VARIANT_TRUE;
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Type(BSTR* type)
+{
+	RETURN_HR_IF_NULL(E_POINTER, type);
+	*type = SysAllocString(L"Files");
+	return *type ? S_OK : E_OUTOFMEMORY;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Left(long* value)
+{
+	RETURN_HR_IF_NULL(E_POINTER, value);
+	*value = 0;
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::put_Left(long)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Top(long* value)
+{
+	return get_Left(value);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::put_Top(long)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Width(long* value)
+{
+	return get_Left(value);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::put_Width(long)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Height(long* value)
+{
+	return get_Left(value);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::put_Height(long)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_LocationName(BSTR* locationName)
+{
+	RETURN_HR_IF_NULL(E_POINTER, locationName);
+	*locationName = SysAllocString(L"");
+	return *locationName ? S_OK : E_OUTOFMEMORY;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_LocationURL(BSTR* locationUrl)
+{
+	return get_LocationName(locationUrl);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Busy(VARIANT_BOOL* pBool)
+{
+	RETURN_HR_IF_NULL(E_POINTER, pBool);
+	*pBool = VARIANT_FALSE;
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::Quit()
+{
+	PostMessage(m_hwnd, WM_CLOSE, 0, 0);
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::ClientToWindow(int* width, int* height)
+{
+	return width && height ? S_OK : E_POINTER;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::PutProperty(BSTR, VARIANT)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GetProperty(BSTR, VARIANT* value)
+{
+	RETURN_HR_IF_NULL(E_POINTER, value);
+	VariantInit(value);
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Name(BSTR* name)
+{
+	return get_Type(name);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_HWND(SHANDLE_PTR* hwnd)
+{
+	RETURN_HR_IF_NULL(E_POINTER, hwnd);
+	*hwnd = reinterpret_cast<SHANDLE_PTR>(m_hwnd);
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_FullName(BSTR* fullName)
+{
+	RETURN_HR_IF_NULL(E_POINTER, fullName);
+	wchar_t modulePath[MAX_PATH];
+	if (!GetModuleFileNameW(nullptr, modulePath, _countof(modulePath)))
+		return HRESULT_FROM_WIN32(GetLastError());
+
+	*fullName = SysAllocString(modulePath);
+	return *fullName ? S_OK : E_OUTOFMEMORY;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Path(BSTR* path)
+{
+	return get_FullName(path);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_Visible(VARIANT_BOOL* value)
+{
+	RETURN_HR_IF_NULL(E_POINTER, value);
+	*value = VARIANT_FALSE;
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::put_Visible(VARIANT_BOOL)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_StatusBar(VARIANT_BOOL* value)
+{
+	return get_Visible(value);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::put_StatusBar(VARIANT_BOOL)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_StatusText(BSTR* statusText)
+{
+	return get_LocationName(statusText);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::put_StatusText(BSTR)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_ToolBar(int* value)
+{
+	RETURN_HR_IF_NULL(E_POINTER, value);
+	*value = 0;
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::put_ToolBar(int)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_MenuBar(VARIANT_BOOL* value)
+{
+	return get_Visible(value);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::put_MenuBar(VARIANT_BOOL)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::get_FullScreen(VARIANT_BOOL* value)
+{
+	return get_Visible(value);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::put_FullScreen(VARIANT_BOOL)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::QueryService(REFGUID, REFIID riid, void** ppvObject)
+{
+	RETURN_HR_IF_NULL(E_POINTER, ppvObject);
+	*ppvObject = nullptr;
+	return QueryInterface(riid, ppvObject);
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GetWindow(HWND* phwnd)
+{
+	RETURN_HR_IF_NULL(E_POINTER, phwnd);
+	*phwnd = m_hwnd;
+	return m_hwnd ? S_OK : E_FAIL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::ContextSensitiveHelp(BOOL)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::TranslateAccelerator(MSG*)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::EnableModeless(BOOL)
+{
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::UIActivate(UINT)
+{
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::Refresh()
+{
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::CreateViewWindow(IShellView*, LPCFOLDERSETTINGS, IShellBrowser*, RECT*, HWND* phWnd)
+{
+	if (phWnd)
+		*phWnd = NULL;
+
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::DestroyViewWindow()
+{
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GetCurrentInfo(LPFOLDERSETTINGS pfs)
+{
+	RETURN_HR_IF_NULL(E_POINTER, pfs);
+	*pfs = {};
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::AddPropertySheetPages(DWORD, LPFNSVADDPROPSHEETPAGE, LPARAM)
+{
+	return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::SaveViewState()
+{
+	return S_OK;
+}
+
+HRESULT OpenInFolder::GetSelectedItem(PCUITEMID_CHILD pidlItem, PIDLIST_ABSOLUTE* pidlAbsolute)
+{
+	RETURN_HR_IF_NULL(E_INVALIDARG, pidlItem);
+	RETURN_HR_IF_NULL(E_POINTER, pidlAbsolute);
+	*pidlAbsolute = nullptr;
+	RETURN_HR_IF_NULL(E_UNEXPECTED, m_folderPidl);
+
+	*pidlAbsolute = ILCombine(m_folderPidl, pidlItem);
+	return *pidlAbsolute ? S_OK : E_OUTOFMEMORY;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::SelectItem(PCUITEMID_CHILD pidlItem, SVSIF uFlags)
+{
+	if (!pidlItem || !(uFlags & (SVSI_SELECT | SVSI_FOCUSED | SVSI_ENSUREVISIBLE | SVSI_EDIT)))
+		return S_OK;
+
+	PIDLIST_ABSOLUTE pidlAbsolute = nullptr;
+	RETURN_IF_FAILED(GetSelectedItem(pidlItem, &pidlAbsolute));
+
+	OnItemSelected(pidlAbsolute);
+	CoTaskMemFree(pidlAbsolute);
+	return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE OpenInFolder::GetItemObject(UINT, REFIID, void** ppv)
+{
+	if (ppv)
+		*ppv = nullptr;
+
+	return E_NOINTERFACE;
 }
 
 void OpenInFolder::SetWindow(HWND hwnd)
@@ -31,22 +439,20 @@ void OpenInFolder::OnCreate()
 
 	LocalFree(szArglist);
 
-	IShellItem* psi;
-	PIDLIST_ABSOLUTE pidlDirectory = NULL;
-
-	if (!SUCCEEDED(SHCreateItemFromParsingName(openDirectory, NULL, IID_IShellItem, (void**)&psi)))
-	{
+	winrt::com_ptr<IShellFolder> desktop;
+	if (FAILED(SHGetDesktopFolder(desktop.put())))
 		return;
-	}
-	if (!SUCCEEDED(SHGetIDListFromObject(psi, &pidlDirectory)))
-	{
-		psi->Release();
+
+	if (FAILED(desktop->ParseDisplayName(
+		nullptr,
+		nullptr,
+		openDirectory,
+		nullptr,
+		&m_folderPidl,
+		nullptr)))
 		return;
-	}
 
-	psi->Release();
-
-	if (!SUCCEEDED(NotifyShellOfNavigation(pidlDirectory)))
+	if (!SUCCEEDED(NotifyShellOfNavigation(m_folderPidl)))
 		return;
 }
 
@@ -77,9 +483,10 @@ HRESULT OpenInFolder::NotifyShellOfNavigation(PCIDLIST_ABSOLUTE pidl)
 
 	wil::unique_variant empty;
 	RETURN_IF_FAILED(m_shellWindows->RegisterPending(GetCurrentThreadId(), &pidlVariant, &empty, SWC_BROWSER, &m_shellWindowCookie));
+	m_isRegistered = true;
+	RETURN_IF_FAILED(m_shellWindows->Register(static_cast<IDispatch*>(this), HandleToLong(m_hwnd), SWC_BROWSER, &m_shellWindowCookie));
 
-	m_shellWindows->OnNavigate(m_shellWindowCookie, &pidlVariant);
-	//m_shellWindows->OnActivated(m_shellWindowCookie, VARIANT_TRUE);
+	RETURN_IF_FAILED(m_shellWindows->OnNavigate(m_shellWindowCookie, &pidlVariant));
 
 	return S_OK;
 }
@@ -106,8 +513,16 @@ std::wstring OpenInFolder::GetResult()
 	return m_selectedItem;
 }
 
+void OpenInFolder::RevokeShellWindow()
+{
+	if (m_shellWindows && m_isRegistered)
+	{
+		m_isRegistered = false;
+		m_shellWindows->Revoke(m_shellWindowCookie);
+	}
+}
+
 OpenInFolder::~OpenInFolder()
 {
-	if (m_shellWindows)
-		m_shellWindows->Revoke(m_shellWindowCookie);
+	CoTaskMemFree(m_folderPidl);
 }

--- a/src/Files.App.Launcher/OpenInFolder.h
+++ b/src/Files.App.Launcher/OpenInFolder.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <iostream>
 #include <objbase.h>
 #include <exdisp.h>
@@ -13,14 +14,17 @@
 #include <winrt/base.h>
 #include <wil/resource.h>
 
-class OpenInFolder
+class OpenInFolder final : public IWebBrowserApp, public IServiceProvider, public IShellView
 {
-	HWND m_hwnd;
+	std::atomic<ULONG> m_referenceCount{ 1 };
+	HWND m_hwnd = NULL;
 	winrt::com_ptr<IShellWindows> m_shellWindows;
-
-	long m_shellWindowCookie;
+	PIDLIST_ABSOLUTE m_folderPidl = NULL;
+	long m_shellWindowCookie = 0;
+	bool m_isRegistered = false;
 
 	HRESULT NotifyShellOfNavigation(PCIDLIST_ABSOLUTE pidl);
+	HRESULT GetSelectedItem(PCUITEMID_CHILD pidlItem, PIDLIST_ABSOLUTE* pidlAbsolute);
 
 	std::wstring m_selectedItem;
 
@@ -28,9 +32,87 @@ public:
 	OpenInFolder();
 	~OpenInFolder();
 
+	// IUnknown
+	HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) override;
+	ULONG STDMETHODCALLTYPE AddRef() override;
+	ULONG STDMETHODCALLTYPE Release() override;
+
+	// IDispatch
+	HRESULT STDMETHODCALLTYPE GetTypeInfoCount(UINT* pctinfo) override;
+	HRESULT STDMETHODCALLTYPE GetTypeInfo(UINT iTInfo, LCID lcid, ITypeInfo** ppTInfo) override;
+	HRESULT STDMETHODCALLTYPE GetIDsOfNames(REFIID riid, LPOLESTR* rgszNames, UINT cNames, LCID lcid, DISPID* rgDispId) override;
+	HRESULT STDMETHODCALLTYPE Invoke(DISPID dispIdMember, REFIID riid, LCID lcid, WORD wFlags, DISPPARAMS* pDispParams, VARIANT* pVarResult, EXCEPINFO* pExcepInfo, UINT* puArgErr) override;
+
+	// IWebBrowserApp
+	HRESULT STDMETHODCALLTYPE GoBack() override;
+	HRESULT STDMETHODCALLTYPE GoForward() override;
+	HRESULT STDMETHODCALLTYPE GoHome() override;
+	HRESULT STDMETHODCALLTYPE GoSearch() override;
+	HRESULT STDMETHODCALLTYPE Navigate(BSTR url, VARIANT* flags, VARIANT* targetFrameName, VARIANT* postData, VARIANT* headers) override;
+	HRESULT STDMETHODCALLTYPE Refresh2(VARIANT* level) override;
+	HRESULT STDMETHODCALLTYPE Stop() override;
+	HRESULT STDMETHODCALLTYPE get_Application(IDispatch** ppDisp) override;
+	HRESULT STDMETHODCALLTYPE get_Parent(IDispatch** ppDisp) override;
+	HRESULT STDMETHODCALLTYPE get_Container(IDispatch** ppDisp) override;
+	HRESULT STDMETHODCALLTYPE get_Document(IDispatch** ppDisp) override;
+	HRESULT STDMETHODCALLTYPE get_TopLevelContainer(VARIANT_BOOL* pBool) override;
+	HRESULT STDMETHODCALLTYPE get_Type(BSTR* type) override;
+	HRESULT STDMETHODCALLTYPE get_Left(long* value) override;
+	HRESULT STDMETHODCALLTYPE put_Left(long value) override;
+	HRESULT STDMETHODCALLTYPE get_Top(long* value) override;
+	HRESULT STDMETHODCALLTYPE put_Top(long value) override;
+	HRESULT STDMETHODCALLTYPE get_Width(long* value) override;
+	HRESULT STDMETHODCALLTYPE put_Width(long value) override;
+	HRESULT STDMETHODCALLTYPE get_Height(long* value) override;
+	HRESULT STDMETHODCALLTYPE put_Height(long value) override;
+	HRESULT STDMETHODCALLTYPE get_LocationName(BSTR* locationName) override;
+	HRESULT STDMETHODCALLTYPE get_LocationURL(BSTR* locationUrl) override;
+	HRESULT STDMETHODCALLTYPE get_Busy(VARIANT_BOOL* pBool) override;
+	HRESULT STDMETHODCALLTYPE Quit() override;
+	HRESULT STDMETHODCALLTYPE ClientToWindow(int* width, int* height) override;
+	HRESULT STDMETHODCALLTYPE PutProperty(BSTR property, VARIANT value) override;
+	HRESULT STDMETHODCALLTYPE GetProperty(BSTR property, VARIANT* value) override;
+	HRESULT STDMETHODCALLTYPE get_Name(BSTR* name) override;
+	HRESULT STDMETHODCALLTYPE get_HWND(SHANDLE_PTR* hwnd) override;
+	HRESULT STDMETHODCALLTYPE get_FullName(BSTR* fullName) override;
+	HRESULT STDMETHODCALLTYPE get_Path(BSTR* path) override;
+	HRESULT STDMETHODCALLTYPE get_Visible(VARIANT_BOOL* value) override;
+	HRESULT STDMETHODCALLTYPE put_Visible(VARIANT_BOOL value) override;
+	HRESULT STDMETHODCALLTYPE get_StatusBar(VARIANT_BOOL* value) override;
+	HRESULT STDMETHODCALLTYPE put_StatusBar(VARIANT_BOOL value) override;
+	HRESULT STDMETHODCALLTYPE get_StatusText(BSTR* statusText) override;
+	HRESULT STDMETHODCALLTYPE put_StatusText(BSTR statusText) override;
+	HRESULT STDMETHODCALLTYPE get_ToolBar(int* value) override;
+	HRESULT STDMETHODCALLTYPE put_ToolBar(int value) override;
+	HRESULT STDMETHODCALLTYPE get_MenuBar(VARIANT_BOOL* value) override;
+	HRESULT STDMETHODCALLTYPE put_MenuBar(VARIANT_BOOL value) override;
+	HRESULT STDMETHODCALLTYPE get_FullScreen(VARIANT_BOOL* value) override;
+	HRESULT STDMETHODCALLTYPE put_FullScreen(VARIANT_BOOL value) override;
+
+	// IServiceProvider
+	HRESULT STDMETHODCALLTYPE QueryService(REFGUID guidService, REFIID riid, void** ppvObject) override;
+
+	// IOleWindow
+	HRESULT STDMETHODCALLTYPE GetWindow(HWND* phwnd) override;
+	HRESULT STDMETHODCALLTYPE ContextSensitiveHelp(BOOL fEnterMode) override;
+
+	// IShellView
+	HRESULT STDMETHODCALLTYPE TranslateAccelerator(MSG* pmsg) override;
+	HRESULT STDMETHODCALLTYPE EnableModeless(BOOL fEnable) override;
+	HRESULT STDMETHODCALLTYPE UIActivate(UINT uState) override;
+	HRESULT STDMETHODCALLTYPE Refresh() override;
+	HRESULT STDMETHODCALLTYPE CreateViewWindow(IShellView* psvPrevious, LPCFOLDERSETTINGS pfs, IShellBrowser* psb, RECT* prcView, HWND* phWnd) override;
+	HRESULT STDMETHODCALLTYPE DestroyViewWindow() override;
+	HRESULT STDMETHODCALLTYPE GetCurrentInfo(LPFOLDERSETTINGS pfs) override;
+	HRESULT STDMETHODCALLTYPE AddPropertySheetPages(DWORD dwReserved, LPFNSVADDPROPSHEETPAGE pfn, LPARAM lparam) override;
+	HRESULT STDMETHODCALLTYPE SaveViewState() override;
+	HRESULT STDMETHODCALLTYPE SelectItem(PCUITEMID_CHILD pidlItem, SVSIF uFlags) override;
+	HRESULT STDMETHODCALLTYPE GetItemObject(UINT uItem, REFIID riid, void** ppv) override;
+
 	LRESULT CALLBACK WindowProcedure(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam);
 	void SetWindow(HWND hwnd);
 	void OnItemSelected(PIDLIST_ABSOLUTE pidl);
 	void OnCreate();
+	void RevokeShellWindow();
 	std::wstring GetResult();
 };


### PR DESCRIPTION
### Resolved / Related Issues

- Fixes #14429

The launcher had only handled:

- Retrieving the target folder path
- Searching for existing shell windows
- Launching the app with `files-dev:?cmd=... -directory` if none found
- Calling `IShellWindows::RegisterPending` and `OnNavigate`

However, Chromium browsers call `windows.storage!SHOpenFolderAndSelectItems`, which calls `SHOpenOrGetFolderView`, which then calls `IShellView::SelectItem`, meaning it requires a shell view. I also discovered that `SHOpenOrGetFolderView` calls `IWebBrowserApp::get_Document` then it calls `IServiceProvider::QueryService` with `IID_IFolderView` and `IID_IShellView`.

https://github.com/chromium/chromium/blob/d86b833661437c96234c43b172f83561e583ee0d/chrome/browser/platform_util_win.cc#L73-L85

### Steps used to test these changes

1. Open Files app
2. Open a Chromium browser (I've tested this only for Edge and Chrome)
3. Click "Open in folder" in Downloads
4. Confirm the target item is selected as the Explorer does

https://github.com/user-attachments/assets/6a571f46-bcd3-4c07-ad21-a17aa34ba56a
