### PR TITLE
Fix: Folder shortcuts could not be restored from Recycle Bin

### DIFF
--- a/src/Files.App/Utils/Shell/ShellFolderExtensions.cs
+++ b/src/Files.App/Utils/Shell/ShellFolderExtensions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using FluentFTP.Helpers;
 using System.IO;
+using System.Text;
 using Vanara.PInvoke;
 using Vanara.Windows.Shell;
 
@@ -42,6 +44,52 @@ namespace Files.App.Utils.Shell
 			return value;
 		}
 
+		private static string? GetOriginalPathFromRecycleBinFile(string? physicalPath)
+		{
+			if (string.IsNullOrEmpty(physicalPath))
+				return null;
+
+			var fileNameFromPath = Path.GetFileName(physicalPath);
+
+			if (!fileNameFromPath.StartsWith("$R", StringComparison.OrdinalIgnoreCase) &&
+				!fileNameFromPath.StartsWith("$I", StringComparison.OrdinalIgnoreCase))
+				return null;
+
+			try
+			{
+				string directory = Path.GetDirectoryName(physicalPath)!;
+
+				string iFileName = fileNameFromPath.StartsWith("$R", StringComparison.OrdinalIgnoreCase) ?
+					"$I" + fileNameFromPath.RemovePrefix("$R") : fileNameFromPath.ToString();
+
+				string filePath = Path.Combine(directory, iFileName);
+
+				if (!File.Exists(filePath) && !Directory.Exists(filePath))
+					return null;
+
+
+				using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+				using var reader = new BinaryReader(stream, Encoding.Unicode);
+
+				// From the 24th to the 28th, contains the number of characters for the originalPath.
+				reader.BaseStream.Seek(24, SeekOrigin.Begin);
+				int pathCharCount = reader.ReadInt32();
+
+				// From the 28th byte, that's where the OriginalPath is.
+				// Windows is UTF-16, so each character takes 2 bytes, hence the multiplication.
+				byte[] pathBytes = reader.ReadBytes(pathCharCount * 2);
+				string originalPath = Encoding.Unicode.GetString(pathBytes).TrimEnd('\0');
+
+				return originalPath;
+			}
+			catch
+			{
+
+			}
+
+			return null;
+		}
+
 		public static ShellFileItem GetShellFileItem(ShellItem folderItem)
 		{
 			if (folderItem is null)
@@ -56,6 +104,8 @@ namespace Files.App.Utils.Shell
 
 			// True path on disk
 			parsingPath ??= folderItem.FileSystemPath;
+
+			string? recycleBinFileOriginalPath = GetOriginalPathFromRecycleBinFile(folderItem.FileSystemPath);
 
 			if (parsingPath is null || !Path.IsPathRooted(parsingPath))
 			{
@@ -110,7 +160,9 @@ namespace Files.App.Utils.Shell
 			string fileSize = fileSizeBytes is not null ? folderItem.Properties.GetPropertyString(Ole32.PROPERTYKEY.System.Size) : null;
 			var fileType = folderItem.Properties.TryGetProperty<string>(Ole32.PROPERTYKEY.System.ItemTypeText);
 
-			return new(isFolder, parsingPath, fileName, filePath, recycleDate, modifiedDate, createdDate, fileSize, fileSizeBytes ?? 0, fileType, folderItem.PIDL.GetBytes());
+			string finalFilePath = string.IsNullOrEmpty(recycleBinFileOriginalPath) ? filePath : recycleBinFileOriginalPath;
+
+			return new(isFolder, parsingPath, fileName, finalFilePath, recycleDate, modifiedDate, createdDate, fileSize, fileSizeBytes ?? 0, fileType, folderItem.PIDL.GetBytes());
 		}
 
 		public static ShellLinkItem GetShellLinkItem(ShellLink linkItem)

--- a/src/Files.App/Utils/Storage/StorageItems/ShellStorageFolder.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/ShellStorageFolder.cs
@@ -84,11 +84,12 @@ namespace Files.App.Utils.Storage
 
 		public static ShellStorageFolder FromShellItem(ShellFileItem item)
 		{
+			if (item.RecyclePath.Contains("$Recycle.Bin", StringComparison.OrdinalIgnoreCase))
+				return new BinStorageFolder(item);
+
 			if (item is ShellLinkItem linkItem)
 				return new ShortcutStorageFolder(linkItem);
 
-			if (item.RecyclePath.Contains("$Recycle.Bin", StringComparison.OrdinalIgnoreCase))
-				return new BinStorageFolder(item);
 
 			return new ShellStorageFolder(item);
 		}


### PR DESCRIPTION
- Fixes: #17110 

**Resolved / Related Issues**

- Folder shortcuts could not be restored at all.
- When folders are thrown in the recycle bin, before refreshing the recycle bin page, it will show the originalPath as the current folder path the file is in.

*What i've found*
After investigating the cascading functions used in order to perform a "Restore" action in the Recycle Bin, certain problems were found:
1. FromShellItem was supposed to return a BinStorageFolder instead of a ShortcutItem, hiding the originalPath.
2. Vanara could not retrieve the "DeletedFrom" path that could be used for an originalPath.
3. The filePath used for restoring a recycle bin file was pointing to the recycle bin itself.

*Why did they happen?:*
1. FromShellItem had an inverted if statement. For the function to work properly, it needs to check a "$Recycle.Bin" presence in the path first than it checks if the type equals "ShellLinkItem".
2. That's probably because Recycle Bin files are not like any other generic files. For Recycle Bin files, you have a "$RXX..." that has its names changed to avoid name conflicts in Recycle Bin and a "$IXX..." file containing the metadata (OriginalPath, DateDeleted, etc). I haven't find an easy way to do that properly.
3. "GetShellFileItem" receives a folderItem. But after debugging and testing, the folderItem would not have a correct originalPath, instead the originalPath would point to the current file path which would be in the recycle bin.

*Other problems found*
- #18744. Items are changing names when restored. It had nothing to do with with the file being able to restore or not. Also, i haven't looked to fix it because it is not marked as "Ready to build".

*What did i do exacly and why*
- Used a FileStream to read its bytes directly from this metadata file. It seems to be the most reliable way to get the originalPath.
- It has checks to prevent non recycle bin files to be read.
- It has fallbacks to prevent passing a null filePath to the ShellFileItem. It will use the filePath itself when the "GetOriginalPathFromRecycleBinFile" returns null.

**Steps used to test these changes**

- Create a folder shortcut
- Delete folder shortcut
- Open recycle bin
- Try to restore shortcut