### PR TITLE
Code Quality: Bump Sentry from 6.1.0 to 6.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.1" />
     <PackageVersion Include="OwlCore.Storage" Version="0.14.0.999" />
-    <PackageVersion Include="Sentry" Version="6.1.0" />
+    <PackageVersion Include="Sentry" Version="6.8.0" />
     <PackageVersion Include="SevenZipSharp" Version="1.0.2" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />

--- a/src/Files.App/Data/Commands/ActionCommand.cs
+++ b/src/Files.App/Data/Commands/ActionCommand.cs
@@ -162,7 +162,7 @@ namespace Files.App.Data.Commands
 		{
 			if (IsExecutable)
 			{
-				SentrySdk.Experimental.Metrics.EmitCounter("actions", 1, [new KeyValuePair<string, object>("command", Code.ToString())]);
+				SentrySdk.Metrics.EmitCounter("actions", 1, [new KeyValuePair<string, object>("command", Code.ToString())]);
 				return Action.ExecuteAsync(parameter);
 			}
 

--- a/src/Files.App/Services/Git/LibGit2Service.cs
+++ b/src/Files.App/Services/Git/LibGit2Service.cs
@@ -162,7 +162,7 @@ internal sealed partial class LibGit2Service // : IVersionControl
 
 	public async Task<bool> Checkout(string? repositoryPath, string? branch)
 	{
-		SentrySdk.Experimental.Metrics.EmitCounter("Triggered git checkout", 1);
+		SentrySdk.Metrics.EmitCounter("Triggered git checkout", 1);
 
 		if (string.IsNullOrWhiteSpace(repositoryPath) || !IsRepoValid(repositoryPath))
 			return false;
@@ -255,7 +255,7 @@ internal sealed partial class LibGit2Service // : IVersionControl
 
 	public async Task CreateNewBranchAsync(string repositoryPath, string activeBranch)
 	{
-		SentrySdk.Experimental.Metrics.EmitCounter("Triggered create git branch", 1);
+		SentrySdk.Metrics.EmitCounter("Triggered create git branch", 1);
 
 		var viewModel = new AddBranchDialogViewModel(repositoryPath, activeBranch);
 		var loadBranchesTask = viewModel.LoadBranches();
@@ -285,7 +285,7 @@ internal sealed partial class LibGit2Service // : IVersionControl
 
 	public async Task DeleteBranchAsync(string? repositoryPath, string? activeBranch, string? branchToDelete)
 	{
-		SentrySdk.Experimental.Metrics.EmitCounter("Triggered delete git branch", 1);
+		SentrySdk.Metrics.EmitCounter("Triggered delete git branch", 1);
 
 		if (string.IsNullOrWhiteSpace(repositoryPath) ||
 			string.IsNullOrWhiteSpace(activeBranch) ||


### PR DESCRIPTION
Updated [Sentry](https://github.com/getsentry/sentry-dotnet) from `6.1.0` to `6.8.0`.

**Notable changes**
- > 6.3.0
  > The _Metrics_ APIs are now stable: removed `Experimental` from `SentrySdk`, `SentryOptions` and `IHub` ([#5023](https://github.com/getsentry/sentry-dotnet/pull/5023))
- various bug fixes
- bump transitive Sentry SDKs

**Release notes**
- [6.2.0-alpha.0](https://github.com/getsentry/sentry-dotnet/releases/tag/6.2.0-alpha.0)
- [6.2.0](https://github.com/getsentry/sentry-dotnet/releases/tag/6.2.0)
- [6.3.0](https://github.com/getsentry/sentry-dotnet/releases/tag/6.3.0)
- [6.3.1](https://github.com/getsentry/sentry-dotnet/releases/tag/6.3.1)
- [6.3.2](https://github.com/getsentry/sentry-dotnet/releases/tag/6.3.2)
- [6.4.0](https://github.com/getsentry/sentry-dotnet/releases/tag/6.4.0)
- [6.4.1](https://github.com/getsentry/sentry-dotnet/releases/tag/6.4.1)
- [6.5.0](https://github.com/getsentry/sentry-dotnet/releases/tag/6.5.0)
- [6.6.0](https://github.com/getsentry/sentry-dotnet/releases/tag/6.6.0)
- [6.7.0](https://github.com/getsentry/sentry-dotnet/releases/tag/6.7.0)
- [6.8.0](https://github.com/getsentry/sentry-dotnet/releases/tag/6.8.0)
