### PR TITLE
Feature: Open a new tab by middle clicking the empty space in the tab strip

### DIFF
--- a/src/Files.App.CsWin32/NativeMethods.txt
+++ b/src/Files.App.CsWin32/NativeMethods.txt
@@ -129,6 +129,7 @@ SHCreateShellItemArrayFromIDLists
 ILCreateFromPath
 CLSIDFromString
 FindWindow
+FindWindowEx
 SendMessage
 IsWindowVisible
 COPYDATASTRUCT

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -15,7 +15,10 @@ using System.Runtime.InteropServices;
 using Windows.Foundation.Metadata;
 using Windows.Graphics;
 using Windows.UI.Input;
+using Windows.Win32;
+using Windows.Win32.Foundation;
 using WinUIEx;
+using WinUIEx.Messaging;
 using GridSplitter = Files.App.Controls.GridSplitter;
 using VirtualKey = Windows.System.VirtualKey;
 
@@ -31,9 +34,12 @@ namespace Files.App.Views
 		public SidebarViewModel SidebarAdaptiveViewModel { get; }
 		public MainPageViewModel ViewModel { get; }
 
+		private const int HTCAPTION = 2;
+
 		private bool keyReleased = true;
 
 		private DispatcherQueueTimer _updateDateDisplayTimer;
+		private WindowMessageMonitor? _titleBarMessageMonitor;
 
 		private readonly Dictionary<TabBarItem, double> _sidebarScrollByTab = new();
 		private TabBarItem? _previousSidebarTab;
@@ -119,7 +125,35 @@ namespace Files.App.Views
 		{
 			var height = (int)TabControl.ActualHeight;
 			source.SetRegionRects(NonClientRegionKind.Passthrough, [getScaledRect(this, new RectInt32(0, 0, (int)(TabControl.ActualWidth + TabControl.Margin.Left - TabControl.DragArea.ActualWidth), height))]);
+			AttachTitleBarMessageMonitor();
 			return height;
+		}
+
+		// Caption regions live in a dedicated child window
+		private void AttachTitleBarMessageMonitor()
+		{
+			if (_titleBarMessageMonitor is not null)
+				return;
+
+			var titleBarHwnd = PInvoke.FindWindowEx(new(MainWindow.Instance.WindowHandle), HWND.Null, "InputNonClientPointerSource", null);
+			if (titleBarHwnd.IsNull)
+				return;
+
+			_titleBarMessageMonitor = new WindowMessageMonitor(titleBarHwnd);
+			_titleBarMessageMonitor.WindowMessageReceived += TitleBar_WindowMessageReceived;
+		}
+
+		private void TitleBar_WindowMessageReceived(object? sender, WindowMessageEventArgs e)
+		{
+			if (e.Message.MessageId is not (PInvoke.WM_NCMBUTTONDOWN or PInvoke.WM_NCMBUTTONDBLCLK) ||
+				(int)e.Message.WParam != HTCAPTION || TabControl is null)
+				return;
+
+			// Deferred because this runs inside the window procedure
+			DispatcherQueue.TryEnqueue(async () => await Commands.NewTab.ExecuteAsync());
+
+			e.Result = 0;
+			e.Handled = true;
 		}
 
 		public async void TabItemContent_ContentChanged(object? sender, TabBarItemParameter e)


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #3808

**Steps used to test these changes**

1. Opened Files, middle-clicked the empty strip between the "+" button and the caption buttons — a new tab opens and is selected. Repeated with several tabs open and with the window maximized.
2. Dragged the window by that same empty area, including snapping to the top and side edges.
3. Double-clicked it (maximize/restore), right-clicked it (system menu), used the minimize/maximize/close buttons.
4. Middle-clicked a tab (still closes it), the "+" button, the toolbar, the Omnibar and the file list — no stray tabs.
5. Repeated steps 1–2 with the app language set to an RTL language.

---

The empty tab strip area is registered as a `Caption` region, so middle clicks there never reach the XAML tree. The non-client messages don't reach the main window either: WinUI routes them to a dedicated `InputNonClientPointerSource` **child** window and forwards only `WM_NCLBUTTONDOWN` and `WM_NCRBUTTONUP` up to the top level.

So this PR subclasses that child window via `WinUIEx.WindowMessageMonitor` and handles `WM_NCMBUTTONDOWN` / `WM_NCMBUTTONDBLCLK` with `wParam == HTCAPTION`, invoking the same `Commands.NewTab` the "+" button uses.