### PR TITLE
Fix: Fixed crash when dropping items onto a folder from another window

### DIFF
--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1178,33 +1178,44 @@ namespace Files.App.Views.Layouts
 
 		protected virtual async void Item_Drop(object sender, DragEventArgs e)
 		{
-			var deferral = e.GetDeferral();
 			e.Handled = true;
+
+			// e.Data is only populated for drags started within this XAML island, drags coming from
+			// another window travel through the shell, so only e.DataView can be read here (#17296)
+			if (e.DataView is null)
+			{
+				e.AcceptedOperation = DataPackageOperation.None;
+				return;
+			}
+
+			DragOperationDeferral? deferral = null;
 
 			try
 			{
-				_ = e.Data.Properties;
-				var exists = e.Data.Properties.TryGetValue("Files_ActionBinder", out var val);
-				_ = val;
-			}
-			catch (NullReferenceException)
-			{
-				// e.Data or e.Data.Properties is null, continue without the property check
-			}
+				deferral = e.GetDeferral();
 
-			// Reset dragged over item
-			dragOverItem = null;
-			var item = GetItemFromElement(sender);
-			if (item is not null)
-			{
-				var parentShellPage = ParentShellPageInstance
-					?? throw new InvalidOperationException("The layout page does not have a parent shell page.");
-				var targetPath = (item as IShortcutItem)?.TargetPath;
-				var destination = !string.IsNullOrEmpty(targetPath) ? targetPath : item.GetRequiredPath();
-				await parentShellPage.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, destination, false, true, item.IsExecutable, item.IsScriptFile);
-			}
+				// Reset dragged over item
+				dragOverItem = null;
 
-			deferral.Complete();
+				var item = GetItemFromElement(sender);
+				if (item is not null)
+				{
+					// This is an async void handler, an escaping exception would take down the window
+					await SafetyExtensions.IgnoreExceptions(async () =>
+					{
+						var parentShellPage = ParentShellPageInstance
+							?? throw new InvalidOperationException("The layout page does not have a parent shell page.");
+						var targetPath = (item as IShortcutItem)?.TargetPath;
+						var destination = !string.IsNullOrEmpty(targetPath) ? targetPath : item.GetRequiredPath();
+						await parentShellPage.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, destination, false, true, item.IsExecutable, item.IsScriptFile);
+					},
+					App.Logger);
+				}
+			}
+			finally
+			{
+				deferral?.Complete();
+			}
 		}
 
 		protected void FileList_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1207,27 +1207,32 @@ namespace Files.App.Views.Layouts
 
 		protected virtual async void Item_Drop(object sender, DragEventArgs e)
 		{
-			var deferral = e.GetDeferral();
 			e.Handled = true;
+
+			if (e.DataView is null)
+			{
+				e.AcceptedOperation = DataPackageOperation.None;
+				return;
+			}
+
+			var deferral = e.GetDeferral();
 
 			try
 			{
-				_ = e.Data.Properties;
-				var exists = e.Data.Properties.TryGetValue("Files_ActionBinder", out var val);
-				_ = val;
+				dragOverItem = null;
+
+				var item = GetItemFromElement(sender);
+				if (item is not null)
+				{
+					await SafetyExtensions.IgnoreExceptions(async () =>
+						await ParentShellPageInstance!.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, (item as IShortcutItem)?.TargetPath ?? item.ItemPath, false, true, item.IsExecutable, item.IsScriptFile),
+						App.Logger);
+				}
 			}
-			catch (NullReferenceException)
+			finally
 			{
-				// e.Data or e.Data.Properties is null, continue without the property check
+				deferral?.Complete();
 			}
-
-			// Reset dragged over item
-			dragOverItem = null;
-			var item = GetItemFromElement(sender);
-			if (item is not null)
-				await ParentShellPageInstance!.FilesystemHelpers.PerformOperationTypeAsync(e.AcceptedOperation, e.DataView, (item as IShortcutItem)?.TargetPath ?? item.ItemPath, false, true, item.IsExecutable, item.IsScriptFile);
-
-			deferral.Complete();
 		}
 
 		protected void FileList_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #17296

**What was wrong**

`BaseLayoutPage.Item_Drop` read `e.Data`, which is only populated for drags started within the same XAML island. A drag coming from another window travels through the shell, so `e.Data` is `null` there and the getter threw a `NullReferenceException`. Since `Item_Drop` is an `async void` handler, the exception went unhandled on the UI thread and took the whole window down.

**Steps used to test these changes**

1. Opened Files and opened a second window (two windows, not two tabs).
2. Dragged a file from the first window onto a **folder icon** in the second window — the file is moved/copied and both windows stay alive. Before this change the second window crashed, losing all its tabs.
3. Verified no regressions on the other item-level drop targets: drop onto a folder within a single window, drop from File Explorer, drop onto an executable and a script (Open with), drop onto a folder shortcut, drop into a zip folder, drop onto a folder in the Grid layout with scroll-locking during drag, and drop onto empty space.
