### PR TITLE
Fix: Fixed issue with filter text box being cleared

### DIFF
--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -215,6 +215,7 @@ namespace Files.App.ViewModels
 		{
 			if (string.IsNullOrWhiteSpace(value))
 				return;
+			
 			if (value != WorkingDirectory)
 			{
 				FilesAndFoldersFilter = null;

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -215,6 +215,10 @@ namespace Files.App.ViewModels
 		{
 			if (string.IsNullOrWhiteSpace(value))
 				return;
+			if (value != WorkingDirectory)
+			{
+				FilesAndFoldersFilter = null;
+			}
 
 			var isLibrary = false;
 			string? name = null;
@@ -2210,7 +2214,6 @@ namespace Files.App.ViewModels
 						{
 							GetDesktopIniFileData();
 							CheckForBackgroundImage();
-							FilesAndFoldersFilter = null;
 						},
 						Microsoft.UI.Dispatching.DispatcherQueuePriority.Low);
 					});

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -217,9 +217,7 @@ namespace Files.App.ViewModels
 				return;
 			
 			if (value != WorkingDirectory)
-			{
 				FilesAndFoldersFilter = null;
-			}
 
 			var isLibrary = false;
 			string? name = null;


### PR DESCRIPTION
…load

This PR fixes an issue where the filter textbox is cleared 1-2 seconds after a folder loads if the user starts typing immediately.

Root cause: The desktopIniUpdateTask runs with Low priority and clears the filter box after the UI thread goes idle. Any text typed by the user before this task executes is overwritten.
Fix: Removed the delayed clearing. Instead, the filter is now cleared synchronously inside SetWorkingDirectoryAsync when the path actually changes (value != WorkingDirectory).
Note: I wasn't able to compile the app locally due to a local toolchain issue, so this fix is based on code analysis. I'm happy to iterate if any feedback or issues arise during testing!

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #18807

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.
1. Performed code analysis on `ShellViewModel.cs` to trace the filter text binding.
2. Verified that the `desktopIniUpdateTask` was asynchronously clearing `FilesAndFoldersFilter` on a low-priority thread, which conflicted with immediate user typing.
3. Verified that `SetWorkingDirectoryAsync` correctly resets the filter synchronously when navigating between folders.