### PR TITLE
Fix: Suppress Asterisk sound on Alt+Enter by handling WM_MENUCHAR 

### DIFF
--- a/src/Files.App.CsWin32/NativeMethods.txt
+++ b/src/Files.App.CsWin32/NativeMethods.txt
@@ -29,6 +29,7 @@ LRESULT
 WPARAM
 LPARAM
 WM_*
+MENUCHARRESULT
 SetForegroundWindow
 GetForegroundWindow
 GetCurrentThreadId

--- a/src/Files.App.CsWin32/NativeMethods.txt
+++ b/src/Files.App.CsWin32/NativeMethods.txt
@@ -29,7 +29,6 @@ LRESULT
 WPARAM
 LPARAM
 WM_*
-MENUCHARRESULT
 SetForegroundWindow
 GetForegroundWindow
 GetCurrentThreadId

--- a/src/Files.App/Helpers/Win32/Win32PInvoke.Consts.cs
+++ b/src/Files.App/Helpers/Win32/Win32PInvoke.Consts.cs
@@ -27,6 +27,8 @@ namespace Files.App.Helpers
 
 		public const uint FILE_APPEND_DATA = 0x0004;
 
+		public const int MNC_CLOSE = 1;
+
 		public const uint FILE_BEGIN = 0;
 		public const uint FILE_END = 2;
 

--- a/src/Files.App/Helpers/Win32/Win32PInvoke.Consts.cs
+++ b/src/Files.App/Helpers/Win32/Win32PInvoke.Consts.cs
@@ -27,9 +27,6 @@ namespace Files.App.Helpers
 
 		public const uint FILE_APPEND_DATA = 0x0004;
 
-		public const uint WM_MENUCHAR = 0x0120;
-		public const int MNC_CLOSE = 1;
-
 		public const uint FILE_BEGIN = 0;
 		public const uint FILE_END = 2;
 

--- a/src/Files.App/Helpers/Win32/Win32PInvoke.Consts.cs
+++ b/src/Files.App/Helpers/Win32/Win32PInvoke.Consts.cs
@@ -27,6 +27,8 @@ namespace Files.App.Helpers
 
 		public const uint FILE_APPEND_DATA = 0x0004;
 
+		public const uint WM_MENUCHAR = 0x0120;
+		public const int MNC_CLOSE = 1;
 
 		public const uint FILE_BEGIN = 0;
 		public const uint FILE_END = 2;

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -394,6 +394,11 @@ namespace Files.App
 				Win32Helper.ForceWindowPosition(e.Message.LParam);
 				e.Handled = true;
 			}
+			else if (e.Message.MessageId == Win32PInvoke.WM_MENUCHAR)
+			{
+				e.Result = Win32PInvoke.MNC_CLOSE << 16;
+				e.Handled = true;
+			}
 		}
 	}
 }

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -397,7 +397,7 @@ namespace Files.App
 			else if (e.Message.MessageId == Windows.Win32.PInvoke.WM_MENUCHAR &&
 				(e.Message.WParam & 0xFFFF) == '\r')
 			{
-				e.Result = (nint)Windows.Win32.UI.WindowsAndMessaging.MENUCHARRESULT.MNC_CLOSE << 16;
+				e.Result = Win32PInvoke.MNC_CLOSE << 16;
 				e.Handled = true;
 			}
 		}

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -394,9 +394,10 @@ namespace Files.App
 				Win32Helper.ForceWindowPosition(e.Message.LParam);
 				e.Handled = true;
 			}
-			else if (e.Message.MessageId == Win32PInvoke.WM_MENUCHAR)
+			else if (e.Message.MessageId == Windows.Win32.PInvoke.WM_MENUCHAR &&
+				(e.Message.WParam & 0xFFFF) == '\r')
 			{
-				e.Result = Win32PInvoke.MNC_CLOSE << 16;
+				e.Result = (nint)Windows.Win32.UI.WindowsAndMessaging.MENUCHARRESULT.MNC_CLOSE << 16;
 				e.Handled = true;
 			}
 		}


### PR DESCRIPTION
Root cause: Alt+Enter (Properties) triggers WM_MENUCHAR inside DefWindowProc's menu-tracking code since there's no matching mnemonic, which plays the system Asterisk sound. 

Fix: WM_MENUCHAR is sent directly to the window proc rather than posted through the thread's message queue, so it's handled in the existing WindowManager subclass callback alongside WM_WINDOWPOSCHANGING, returning MNC_CLOSE to suppress the beep.




**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #18472

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Tested in FIles, pressed Alt+Enter and Properties dialog opened correctly, no Asterisk sound played
2. Verified the sibling WM_WINDOWPOSCHANGING branch in the handler still fires correctly
3. Verified other Alt + Action items properly worked