### PR TITLE
Fix: Fixed an issue where folder shortcuts wouldn't open when Files was the default file manager

### DIFF
--- a/src/Files.App.Launcher/OpenInFolder.cpp
+++ b/src/Files.App.Launcher/OpenInFolder.cpp
@@ -484,7 +484,7 @@ HRESULT OpenInFolder::NotifyShellOfNavigation(PCIDLIST_ABSOLUTE pidl)
 	wil::unique_variant empty;
 	RETURN_IF_FAILED(m_shellWindows->RegisterPending(GetCurrentThreadId(), &pidlVariant, &empty, SWC_BROWSER, &m_shellWindowCookie));
 	m_isRegistered = true;
-	RETURN_IF_FAILED(m_shellWindows->Register(static_cast<IDispatch*>(this), HandleToLong(m_hwnd), SWC_BROWSER, &m_shellWindowCookie));
+	RETURN_IF_FAILED(m_shellWindows->OnCreated(m_shellWindowCookie, static_cast<IWebBrowserApp*>(this)));
 
 	RETURN_IF_FAILED(m_shellWindows->OnNavigate(m_shellWindowCookie, &pidlVariant));
 


### PR DESCRIPTION
### Resolved / Related Issues

- Closes #18818

### Steps used to test these changes

1. Open Files app
2. Set Files as the default explorer
3. Open a shortcut
4. See if the app opens correctly
