### PR TITLE
Feature: Add run-files skill for building and driving the app

### DIFF
--- a/.claude/skills/run-files/.gitignore
+++ b/.claude/skills/run-files/.gitignore
@@ -1,0 +1,2 @@
+# Screenshots produced by driver.ps1 shot/click — local run artifacts.
+_out/

--- a/.claude/skills/run-files/SKILL.md
+++ b/.claude/skills/run-files/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: run-files
+description: Build, deploy, launch, screenshot and click the Files WinUI 3 desktop app on Windows. Use when asked to run Files, start the app, deploy it, take a screenshot of it, drive its UI, or verify a change in the real running app rather than only building it.
+---
+
+# Run the Files app
+
+Files is a **packaged (MSIX) WinUI 3 desktop app** targeting `net10.0-windows10.0.26100.0`.
+It cannot be run by launching `Files.exe` — it needs package identity, the Windows App SDK
+runtime, and a repaired loose layout. Everything is wrapped in one driver:
+
+```
+.claude/skills/run-files/driver.ps1
+```
+
+All paths below are relative to the repo root. All commands were run on Windows 11 with
+PowerShell 7 (`pwsh`). The driver prints `KEY=VALUE` result lines so you can assert on
+output instead of reading prose.
+
+## Prerequisites
+
+Check first — it names exactly what is missing:
+
+```bash
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 prereqs
+```
+
+Expected when healthy:
+
+```
+MSVC=14.51.36231
+VS=C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools
+PREREQS=OK
+```
+
+If it reports `MISSING=...`, install the named item. These are the ones that actually bite:
+
+| Missing | Fix |
+|---|---|
+| `dotnet-sdk-10` | `winget install --id Microsoft.DotNet.SDK.10 --architecture x64 --scope machine` — `global.json` pins `10.0.102`; .NET 8 cannot build this repo. |
+| `vs2026-buildtools` | `winget install --id Microsoft.VisualStudio.BuildTools --override "--quiet --wait --norestart --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools --add Microsoft.VisualStudio.Component.Windows11SDK.26100 --includeRecommended"` |
+| `atl` | See **ATL** below — `--includeRecommended` does **not** include it. |
+| `developer-mode` | Enable Developer Mode in Windows Settings (required to register an unsigned loose package). |
+
+**VS 2022 (17.x) cannot build this repo at all** — two independent blockers: .NET SDK 10
+requires MSBuild 18, and the `.vcxproj` files pin `PlatformToolset = v145` (MSVC 14.5x),
+which ships only with VS 2026. `prereqs` deliberately looks for `[18.0,19.0)` and ignores
+any 17.x install still on the machine.
+
+### ATL
+
+Four C++ projects `#include <atlbase.h>`. ATL is not part of `--includeRecommended`, and
+the VS installer **must be elevated** — with `--quiet` and no elevation it exits `5007`
+having done nothing. `--wait` is a bootstrapper flag and is rejected by `vs_installer.exe`
+(exit `87`). This is the invocation that worked, run from an elevated PowerShell:
+
+```bash
+& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe' modify --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools' --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATLMFC --quiet --norestart
+```
+
+It returns immediately; poll until `VC\Tools\MSVC\<ver>\atlmfc\include\atlbase.h` exists.
+
+## Build
+
+```bash
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 build
+```
+
+```
+RESTORE_EXIT=0
+BUILD_EXIT=0
+```
+
+This runs two passes, both required:
+
+1. `-t:restore -p:RestorePackagesConfig=true` — `Files.App.Launcher.vcxproj` still uses
+   legacy `packages.config` (CppWinRT + WIL), which a plain `-restore` silently skips.
+2. `-restore Files.slnx -p:Configuration=Debug -p:Platform=x64`
+
+**Always build `Files.slnx`, never `Files.App.csproj` alone.** The C++ projects and
+`Files.App.Server` are solution-level `BuildDependency` entries, not `ProjectReference`s —
+a project-scoped build *removes* `Files.App.Server.exe`/`.dll` from the output folder and
+produces an app that will not start.
+
+The build is `-m:1` on purpose; parallel builds race on the shared native output directory.
+
+## Run — agent path
+
+```bash
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 deploy
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 launch
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 shot
+```
+
+Or the whole chain — `prereqs → build → deploy → launch → shot`:
+
+```bash
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 all
+```
+
+`deploy` output on a healthy run:
+
+```
+LAYOUT=D:\Github\Files\src\Files.App\bin\x64\Debug\net10.0-windows10.0.26100.0\win-x64
+WINAPPSDK_NEED=2.4.0.0 HAVE=2.4.0.0
+LOGO_ICO=True
+SERVER_EXE=True
+REGISTER=OK
+AUMID=FilesDev_ykqwq8d6ps0ag!App
+```
+
+`launch` waits for the window title to become `<Page> - Files` (twice in a row); the splash
+title is exactly `Files`. Debug builds are not ReadyToRun, so the very first launch after a
+build can take ~20-40s; warm launches settle in under 10s.
+
+```
+LAUNCH=OK title='Downloads - Files' after=6s
+```
+
+The page name varies — see the session-restore gotcha below.
+
+### Driving the UI
+
+```bash
+# screenshot the window (PNG lands in .claude/skills/run-files/_out/)
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 shot
+
+# click at window-relative coordinates, then auto-screenshot
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 click 177 334
+
+# app's own structured log / process state
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 log 40
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 status
+pwsh -NoProfile -File .claude/skills/run-files/driver.ps1 stop
+```
+
+A successful click — note the title changing, which is your assertion:
+
+```
+FOREGROUND=True
+CLICK=(177,334) screen=(717,574) title='Downloads - Files'
+SHOT=D:\Github\Files\.claude\skills\run-files\_out\click.png
+WINDOW=2880x1541 title='Downloads - Files'
+```
+
+Screenshots use `PrintWindow` with `PW_RENDERFULLCONTENT` (flag `2`). This matters twice:
+plain `CopyFromScreen` captures whatever is on top (you get the wrong window), and WinUI 3
+windows are DWM-composited so flag `0` returns blank.
+
+**Reading coordinates off the PNG:** the capture is the window rect at *real pixel size* —
+here `2880x1541`. If your image viewer scales it down (e.g. shows it at 2000px wide),
+multiply your measured coordinates by the scale factor before passing them to `click`.
+Getting this wrong is silent: the click lands somewhere harmless and the title never changes.
+
+The driver re-reads the window rect immediately before clicking, because restoring/focusing
+the window moves it — in the sample above the same window-relative `(177,334)` mapped to a
+different screen point than on the previous run.
+
+Verify the click worked by reading the `title=` in the output — it tracks the current page
+(`Settings - Files` → `Downloads - Files`). **Look at the PNG.** A dark frame showing only
+`Files Dev` is the splash, i.e. a failed start, not a loaded app.
+
+## Run — human path
+
+Double-click the app from the Start menu after `deploy` (it registers as **Files Dev**).
+There is no `dotnet run` / `msbuild -t:Deploy` path — see Gotchas.
+
+## Test
+
+Per `CLAUDE.md`, this repo has no test suite suitable for agents. A clean
+`BUILD_EXIT=0` is the bar. `tests/` builds as part of the solution.
+
+## Gotchas
+
+- **`msbuild -t:Deploy` does not exist here.** Not on the solution (every non-packaging
+  project errors `MSB4057`) and not on `Files.App.csproj` either — the MSIX packaging
+  targets that define it are not imported. Deployment is `Add-AppxPackage -Register` against
+  the build output, which is what `driver.ps1 deploy` does.
+
+- **`Assets\AppTiles\**` never reaches `bin\`.** The csproj marks only `Assets\Resources\**`
+  and `Assets\FilesOpenDialog\*` as `CopyToOutputDirectory`; `AppTiles` is MSIX *package*
+  content. Registering the raw `bin` folder therefore yields an app that hangs on the splash
+  forever: `new SystemTrayIcon()` (`App.xaml.cs:131`) constructs `System.Drawing.Icon` from
+  `Assets\AppTiles\Dev\Logo.ico`, throws `DirectoryNotFoundException`, and that runs *before*
+  the `MainPage` navigation on line 137. `deploy` copies the folder in as a repair step.
+
+- **Startup exceptions are invisible.** The navigation call is fire-and-forget
+  (`_ = MainWindow.Instance.InitializeApplicationAsync(...)`), so a startup failure produces
+  no log line, no crash, no Event Log entry — just a frozen splash with
+  `Responding=True` and near-zero CPU. `debug.log` stops after `App launched.`
+  To get the real exception, dump the heap:
+
+  ```bash
+  dotnet tool install -g dotnet-dump
+  ~/.dotnet/tools/dotnet-dump.exe collect -p <pid> -o files.dmp --type Full
+  ~/.dotnet/tools/dotnet-dump.exe analyze files.dmp -c "dumpheap -type Exception -stat" -c "exit"
+  ~/.dotnet/tools/dotnet-dump.exe analyze files.dmp -c "printexception -lines <addr>" -c "exit"
+  ```
+
+  The dump is ~650 MB; delete it afterwards.
+
+- **The app's identity is `FilesDev`, and the assembly is `Files`.** `<AssemblyName>Files</AssemblyName>`
+  means the output is `Files.exe`/`Files.dll` — there is no `Files.App.exe`. Looking for the
+  latter will convince you a successful build produced nothing.
+
+- **The WinAppSDK runtime is version-gated.** `AppxManifest.xml` requires
+  `Microsoft.WindowsAppRuntime.2` at a `MinVersion` matching the `Microsoft.WindowsAppSDK`
+  package version. Having 1.6/1.7 and an older 2.x installed is not enough. `deploy` reads
+  the required version out of the manifest and installs the matching MSIX from the
+  already-restored NuGet package (`~/.nuget/packages/microsoft.windowsappsdk.runtime/<ver>/tools/MSIX/win10-x64`)
+  — no download needed.
+
+- **Synthetic clicks silently hit the wrong app.** `SetForegroundWindow` returns `False` from
+  a background process — Windows' foreground lock — so the Files window never activates and
+  `mouse_event` clicks land on whatever *is* foreground. Nothing errors; the title just never
+  changes. `driver.ps1` works around it by attaching to the foreground thread's input queue
+  (`AttachThreadInput`) before calling `SetForegroundWindow`, and prints `FOREGROUND=True`.
+  If it prints `CLICK=ABORT`, it refused to click rather than click blindly into another app.
+
+- **The app restores its previous session.** Startup setting *"Continue where you left off"*
+  is the default, so `launch` may land on whatever page was last open (e.g. `Settings - Files`)
+  rather than `Home - Files`. Don't assert on a specific starting page.
+
+- **`Enter-VsDevShell` prints a harmless `'vswhere.exe' is not recognized` line.** Ignore it;
+  the shell still initialises. `driver.ps1` avoids the dev shell entirely and calls
+  `MSBuild.exe` by absolute path.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `error MSB4236: The SDK 'Microsoft.NET.Sdk' could not be found` | Building with VS 2022's MSBuild 17.x. Use VS 2026 (`driver.ps1` picks it automatically). |
+| `error MSB8020: build tools for v145 cannot be found` | MSVC 14.5x missing — install the VCTools workload from VS 2026. |
+| `fatal error C1083: Cannot open include file: 'atlbase.h'` | ATL not installed. See **ATL** above. |
+| `The missing file is ..\..\packages\Microsoft.Windows.ImplementationLibrary...targets` | `packages.config` not restored — `driver.ps1 build` does this pass first. |
+| `LAUNCH=STUCK title='Files'` | Splash hang. Check `LOGO_ICO=` and `SERVER_EXE=` from `deploy`; re-run `build` (whole solution) then `deploy`. |
+| `REGISTER=FAIL ... 0x80073CF3` (dependency) | WinAppSDK runtime older than the manifest's `MinVersion`. Re-run `deploy`. |
+| `RUNTIME_MSIX_MISSING=...` | NuGet restore hasn't run yet — run `driver.ps1 build` first. |
+| App window shows the *previous* app's content in a screenshot | You used `CopyFromScreen`. Use `driver.ps1 shot` (PrintWindow). |
+| `click` runs, `title=` never changes | Coordinates were read off a scaled view of the PNG — multiply by the scale factor. The PNG is the window's real pixel size (see `WINDOW=`). |
+| `CLICK=ABORT window would not take focus` | Another app is holding the foreground lock. Close/minimise it, or re-run; `shot` still works regardless of focus. |

--- a/.claude/skills/run-files/driver.ps1
+++ b/.claude/skills/run-files/driver.ps1
@@ -1,0 +1,366 @@
+<#
+.SYNOPSIS
+    Build / deploy / launch / drive the Files WinUI 3 app on Windows.
+
+.DESCRIPTION
+    Agent-facing harness. Every subcommand prints a machine-greppable
+    KEY=VALUE result line so callers can assert without parsing prose.
+
+    Usage:  pwsh -NoProfile -File .claude\skills\run-files\driver.ps1 <command> [args]
+
+    Commands:
+      prereqs        Verify toolchain; prints MISSING=... if anything is absent
+      build          Full solution build (x64 Debug). NEVER build the app project alone.
+      deploy         Repair the loose layout + register the MSIX package
+      launch         Start the app, wait until it is past the splash screen
+      status         Process / window / package state
+      log [n]        Tail the app's own debug.log
+      shot [path]    Screenshot the app window (PrintWindow; works when occluded)
+      click <x> <y>  Click at window-relative coordinates, then screenshot
+      stop           Kill the app
+      all            prereqs -> build -> deploy -> launch -> shot
+
+    Screenshots default to .claude\skills\run-files\_out\.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)][string]$Command = 'help',
+    [Parameter(Position = 1)][string]$Arg1,
+    [Parameter(Position = 2)][string]$Arg2,
+    [string]$Configuration = 'Debug',
+    [string]$Platform = 'x64'
+)
+
+$ErrorActionPreference = 'Continue'
+Set-StrictMode -Off
+
+$RepoRoot  = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+$OutDir    = Join-Path $PSScriptRoot '_out'
+$PkgName   = 'FilesDev'          # Identity Name for Debug builds (Preview/Release differ)
+$AppId     = 'App'
+$LogPath   = "$env:LOCALAPPDATA\Packages\FilesDev_ykqwq8d6ps0ag\LocalState\debug.log"
+
+if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir -Force | Out-Null }
+
+# ---------------------------------------------------------------- helpers
+
+function Get-VsPath {
+    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (-not (Test-Path $vswhere)) { return $null }
+    # -version 18 matters: VS 2022 (17.x) cannot build this repo at all.
+    & $vswhere -products '*' -version '[18.0,19.0)' -property installationPath -latest 2>$null | Select-Object -First 1
+}
+
+function Get-LayoutDir {
+    # The registered layout is the plain build output folder, not a packaging dir.
+    $base = Join-Path $RepoRoot "src\Files.App\bin\$Platform\$Configuration"
+    if (-not (Test-Path $base)) { return $null }
+    $m = Get-ChildItem $base -Recurse -Filter 'AppxManifest.xml' -File -EA SilentlyContinue |
+         Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($m) { return $m.Directory.FullName }
+    return $null
+}
+
+# Sets $script:LastExit. MSBuild's own output is echoed, but kept out of the
+# return value so the KEY=VALUE result lines stay clean.
+function Invoke-MSBuild {
+    param([string[]]$MsBuildArgs)
+    $script:LastExit = 1
+    $vs = Get-VsPath
+    if (-not $vs) { Write-Output 'MISSING=VS2026BuildTools'; return }
+    $msbuild = Join-Path $vs 'MSBuild\Current\Bin\amd64\MSBuild.exe'
+    if (-not (Test-Path $msbuild)) { Write-Output 'MISSING=MSBuild18'; return }
+    Push-Location $RepoRoot
+    try {
+        # -m:1 on purpose: parallel builds race on the shared native output dir.
+        $out = & $msbuild @MsBuildArgs -m:1 2>&1
+        $script:LastExit = $LASTEXITCODE
+        $out | ForEach-Object { Write-Output $_ }
+    } finally { Pop-Location }
+}
+
+function Get-AppWindow {
+    Get-Process -Name 'Files' -EA SilentlyContinue |
+        Where-Object { $_.MainWindowHandle -ne 0 } | Select-Object -First 1
+}
+
+Add-Type -AssemblyName System.Drawing -EA SilentlyContinue
+if (-not ('FilesWin' -as [type])) {
+    Add-Type @'
+using System; using System.Runtime.InteropServices;
+public class FilesWin {
+  [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr h, IntPtr hdc, uint f);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RC r);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int c);
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int x, int y);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint f, uint x, uint y, uint d, IntPtr e);
+  [DllImport("user32.dll")] public static extern bool SetProcessDpiAwarenessContext(IntPtr v);
+  [DllImport("user32.dll")] public static extern bool SetProcessDPIAware();
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern bool BringWindowToTop(IntPtr h);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr h, IntPtr pid);
+  [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint a, uint b, bool attach);
+  [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
+  public struct RC { public int L, T, Rt, B; }
+
+  // A background process cannot call SetForegroundWindow directly -- Windows'
+  // foreground lock makes it return false and do nothing. Attaching our input
+  // queue to the current foreground thread lifts that restriction.
+  public static bool ForceForeground(IntPtr h) {
+    IntPtr fg = GetForegroundWindow();
+    if (fg == h) return true;
+    uint us = GetCurrentThreadId();
+    uint them = GetWindowThreadProcessId(fg, IntPtr.Zero);
+    bool attached = (us != them) && AttachThreadInput(us, them, true);
+    ShowWindow(h, 9);
+    BringWindowToTop(h);
+    bool ok = SetForegroundWindow(h);
+    if (attached) AttachThreadInput(us, them, false);
+    return ok || GetForegroundWindow() == h;
+  }
+}
+'@
+}
+
+# MUST run before any window/cursor call. Without it this process is DPI-virtualised:
+# PrintWindow yields a physical-pixel bitmap while SetCursorPos is interpreted in
+# scaled coordinates, so clicks land in the wrong place on a HiDPI display.
+# -4 = DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+if (-not [FilesWin]::SetProcessDpiAwarenessContext([IntPtr](-4))) {
+    [FilesWin]::SetProcessDPIAware() | Out-Null
+}
+
+function Save-WindowShot {
+    param([string]$Path)
+    $p = Get-AppWindow
+    if (-not $p) { Write-Output 'SHOT=NOWINDOW'; return }
+    $h = $p.MainWindowHandle
+    $r = New-Object FilesWin+RC
+    [FilesWin]::GetWindowRect($h, [ref]$r) | Out-Null
+    $w = $r.Rt - $r.L; $ht = $r.B - $r.T
+    if ($w -le 0 -or $ht -le 0) { Write-Output 'SHOT=BADRECT'; return }
+    $bmp = New-Object System.Drawing.Bitmap($w, $ht)
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    $hdc = $g.GetHdc()
+    # flag 2 = PW_RENDERFULLCONTENT: required for WinUI 3 / DWM-composited windows,
+    # and captures correctly even when another window is on top.
+    [FilesWin]::PrintWindow($h, $hdc, 2) | Out-Null
+    $g.ReleaseHdc($hdc); $g.Dispose()
+    $bmp.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png); $bmp.Dispose()
+    Write-Output "SHOT=$Path"
+    Write-Output "WINDOW=${w}x${ht} title='$($p.MainWindowTitle)'"
+}
+
+# ---------------------------------------------------------------- commands
+
+function Cmd-Prereqs {
+    $missing = @()
+
+    $sdks = (& dotnet --list-sdks 2>$null) -join "`n"
+    if ($sdks -notmatch '(?m)^10\.') { $missing += 'dotnet-sdk-10' }
+
+    $vs = Get-VsPath
+    if (-not $vs) { $missing += 'vs2026-buildtools' }
+    else {
+        $msvc = Get-ChildItem (Join-Path $vs 'VC\Tools\MSVC') -Directory -EA SilentlyContinue |
+                Sort-Object Name -Descending | Select-Object -First 1
+        if (-not $msvc) { $missing += 'msvc-v145' }
+        else {
+            Write-Output "MSVC=$($msvc.Name)"
+            # PlatformToolset v145 in the .vcxproj files maps to MSVC 14.5x.
+            if (-not (Test-Path (Join-Path $msvc.FullName 'atlmfc\include\atlbase.h'))) {
+                $missing += 'atl'    # NOT included by --includeRecommended
+            }
+        }
+        Write-Output "VS=$vs"
+    }
+
+    $devmode = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' `
+                -Name AllowDevelopmentWithoutDevLicense -EA SilentlyContinue).AllowDevelopmentWithoutDevLicense
+    if ($devmode -ne 1) { $missing += 'developer-mode' }
+
+    if ($missing.Count) { Write-Output "MISSING=$($missing -join ',')" }
+    else { Write-Output 'PREREQS=OK' }
+    $script:Ok = ($missing.Count -eq 0)
+}
+
+function Cmd-Build {
+    # packages.config restore is a SEPARATE pass: plain `-restore` only handles
+    # PackageReference, and Files.App.Launcher.vcxproj still uses packages.config.
+    Invoke-MSBuild @('-t:restore', '-p:RestorePackagesConfig=true', 'Files.slnx',
+                     "-p:Configuration=$Configuration", "-p:Platform=$Platform",
+                     '-v:quiet', '-clp:ErrorsOnly')
+    Write-Output "RESTORE_EXIT=$($script:LastExit)"
+
+    # Always the whole solution: the C++ projects and Files.App.Server are
+    # solution-level BuildDependency entries, not ProjectReferences.
+    Invoke-MSBuild @('-restore', 'Files.slnx',
+                     "-p:Configuration=$Configuration", "-p:Platform=$Platform",
+                     '-v:quiet', '-clp:ErrorsOnly')
+    Write-Output "BUILD_EXIT=$($script:LastExit)"
+    $script:Ok = ($script:LastExit -eq 0)
+}
+
+function Cmd-Deploy {
+    $script:Ok = $false
+    $layout = Get-LayoutDir
+    if (-not $layout) { Write-Output 'DEPLOY=NOLAYOUT (run build first)'; return }
+    Write-Output "LAYOUT=$layout"
+
+    # --- WinAppSDK framework package ---------------------------------------
+    # The manifest hard-requires a MinVersion; the runtime MSIX ships inside the
+    # already-restored NuGet package, so no download is needed.
+    $manifest = Join-Path $layout 'AppxManifest.xml'
+    $dep = ([xml](Get-Content $manifest)).Package.Dependencies.PackageDependency |
+           Where-Object { $_.Name -like 'Microsoft.WindowsAppRuntime*' } | Select-Object -First 1
+    if ($dep) {
+        $need = [version]$dep.MinVersion
+        $have = Get-AppxPackage -Name $dep.Name -EA SilentlyContinue |
+                ForEach-Object { [version]$_.Version } | Sort-Object -Descending | Select-Object -First 1
+        Write-Output "WINAPPSDK_NEED=$need HAVE=$have"
+        if (-not $have -or $have -lt $need) {
+            $ver = "$($need.Major).$($need.Minor).$($need.Build)"
+            $msixDir = "$env:USERPROFILE\.nuget\packages\microsoft.windowsappsdk.runtime\$ver\tools\MSIX\win10-x64"
+            if (Test-Path $msixDir) {
+                foreach ($n in 'Microsoft.WindowsAppRuntime.2', 'Microsoft.WindowsAppRuntime.Main.2',
+                               'Microsoft.WindowsAppRuntime.Singleton.2', 'Microsoft.WindowsAppRuntime.DDLM.2') {
+                    $f = Join-Path $msixDir "$n.msix"
+                    if (Test-Path $f) {
+                        try { Add-AppxPackage -Path $f -EA Stop; Write-Output "RUNTIME_OK=$n" }
+                        catch { Write-Output "RUNTIME_FAIL=$n" }
+                    }
+                }
+            } else { Write-Output "RUNTIME_MSIX_MISSING=$msixDir" }
+        }
+    }
+
+    # --- layout repair ------------------------------------------------------
+    # Assets\AppTiles\** is MSIX *package* content and is NOT marked
+    # CopyToOutputDirectory, so it never lands in bin\. Registering bin\ without
+    # it makes `new SystemTrayIcon()` throw DirectoryNotFoundException on Logo.ico
+    # during startup -- swallowed by a fire-and-forget, leaving a frozen splash.
+    $tile = Join-Path $layout 'Assets\AppTiles\Dev\Logo.ico'
+    if (-not (Test-Path $tile)) {
+        Copy-Item (Join-Path $RepoRoot 'src\Files.App\Assets\AppTiles') `
+                  (Join-Path $layout 'Assets\') -Recurse -Force
+        Write-Output 'REPAIR=AppTiles copied'
+    }
+    Write-Output "LOGO_ICO=$(Test-Path $tile)"
+    Write-Output "SERVER_EXE=$(Test-Path (Join-Path $layout 'Files.App.Server.exe'))"
+
+    try { Add-AppxPackage -Register $manifest -EA Stop; Write-Output 'REGISTER=OK' }
+    catch { Write-Output "REGISTER=FAIL $($_.Exception.Message)"; return }
+
+    $pkg = Get-AppxPackage -Name $PkgName
+    Write-Output "AUMID=$($pkg.PackageFamilyName)!$AppId"
+    $script:Ok = $true
+}
+
+function Cmd-Launch {
+    $script:Ok = $false
+    $pkg = Get-AppxPackage -Name $PkgName -EA SilentlyContinue
+    if (-not $pkg) { Write-Output 'LAUNCH=NOTREGISTERED (run deploy first)'; return }
+    Get-Process -Name 'Files' -EA SilentlyContinue | Stop-Process -Force
+    Remove-Item $LogPath -Force -EA SilentlyContinue
+    Start-Sleep -Seconds 2
+
+    Start-Process "shell:AppsFolder\$($pkg.PackageFamilyName)!$AppId"
+
+    # Splash title is exactly 'Files'; a loaded page reads '<Page> - Files'.
+    # Debug builds are not ReadyToRun, so first paint takes a while.
+    # Require two consecutive matches: the tab title can be restored (Startup
+    # setting "Continue where you left off") before the content actually renders.
+    $hits = 0
+    for ($i = 0; $i -lt 40; $i++) {
+        Start-Sleep -Seconds 3
+        $p = Get-AppWindow
+        if ($p -and $p.MainWindowTitle -match ' - Files$') { $hits++ } else { $hits = 0 }
+        if ($hits -ge 2) {
+            Write-Output "LAUNCH=OK title='$($p.MainWindowTitle)' after=$(($i+1)*3)s"
+            $script:Ok = $true
+            return
+        }
+    }
+    $p = Get-AppWindow
+    Write-Output "LAUNCH=STUCK title='$($p.MainWindowTitle)' (see: driver.ps1 log)"
+}
+
+function Cmd-Status {
+    $p = Get-Process -Name 'Files' -EA SilentlyContinue
+    if ($p) {
+        foreach ($x in $p) {
+            Write-Output ("PROC=Files pid={0} cpu={1}s responding={2} title='{3}'" -f `
+                $x.Id, [math]::Round($x.CPU, 1), $x.Responding, $x.MainWindowTitle)
+        }
+    } else { Write-Output 'PROC=none' }
+    $srv = Get-Process -Name 'Files.App.Server' -EA SilentlyContinue
+    Write-Output "SERVER_PROC=$(if ($srv) { $srv.Id } else { 'none' })"
+    $pkg = Get-AppxPackage -Name $PkgName -EA SilentlyContinue
+    Write-Output "PACKAGE=$(if ($pkg) { $pkg.PackageFullName } else { 'not registered' })"
+    Write-Output "LOG=$LogPath exists=$(Test-Path $LogPath)"
+}
+
+function Cmd-Log {
+    $n = if ($Arg1) { [int]$Arg1 } else { 30 }
+    if (Test-Path $LogPath) { Get-Content $LogPath -Tail $n } else { Write-Output 'LOG=missing' }
+}
+
+function Cmd-Shot {
+    $path = if ($Arg1) { $Arg1 } else { Join-Path $OutDir 'app.png' }
+    $p = Get-AppWindow
+    if ($p) { [FilesWin]::ShowWindow($p.MainWindowHandle, 9) | Out-Null; Start-Sleep -Seconds 1 }
+    Save-WindowShot -Path $path
+}
+
+function Cmd-Click {
+    if (-not $Arg1 -or -not $Arg2) { Write-Output 'CLICK=USAGE click <x> <y>'; return }
+    $p = Get-AppWindow
+    if (-not $p) { Write-Output 'CLICK=NOWINDOW'; return }
+    $h = $p.MainWindowHandle
+    $fg = [FilesWin]::ForceForeground($h)
+    Write-Output "FOREGROUND=$fg"
+    if (-not $fg) { Write-Output 'CLICK=ABORT window would not take focus; clicks would hit another app'; return }
+    Start-Sleep -Seconds 2
+    # Re-read the rect immediately before clicking: the window can move between
+    # a screenshot and the click, which silently shifts every coordinate.
+    $r = New-Object FilesWin+RC
+    [FilesWin]::GetWindowRect($h, [ref]$r) | Out-Null
+    $x = $r.L + [int]$Arg1; $y = $r.T + [int]$Arg2
+    [FilesWin]::SetCursorPos($x, $y) | Out-Null; Start-Sleep -Milliseconds 400
+    [FilesWin]::mouse_event(0x0002, 0, 0, 0, [IntPtr]::Zero)
+    [FilesWin]::mouse_event(0x0004, 0, 0, 0, [IntPtr]::Zero)
+    Start-Sleep -Seconds 6
+    $p.Refresh()
+    Write-Output "CLICK=($Arg1,$Arg2) screen=($x,$y) title='$($p.MainWindowTitle)'"
+    Save-WindowShot -Path (Join-Path $OutDir 'click.png')
+}
+
+function Cmd-Stop {
+    Get-Process -Name 'Files', 'Files.App.Server' -EA SilentlyContinue | Stop-Process -Force
+    Write-Output 'STOP=OK'
+}
+
+$script:Ok = $true
+
+switch ($Command.ToLower()) {
+    'prereqs' { Cmd-Prereqs }
+    'build'   { Cmd-Build }
+    'deploy'  { Cmd-Deploy }
+    'launch'  { Cmd-Launch }
+    'status'  { Cmd-Status }
+    'log'     { Cmd-Log }
+    'shot'    { Cmd-Shot }
+    'click'   { Cmd-Click }
+    'stop'    { Cmd-Stop }
+    'all'     {
+        Cmd-Prereqs; if (-not $script:Ok) { Write-Output 'ABORT=prereqs'; break }
+        Cmd-Build;   if (-not $script:Ok) { Write-Output 'ABORT=build';   break }
+        Cmd-Deploy;  if (-not $script:Ok) { Write-Output 'ABORT=deploy';  break }
+        Cmd-Launch;  if (-not $script:Ok) { Write-Output 'ABORT=launch';  break }
+        Cmd-Shot
+    }
+    default {
+        Write-Output 'commands: prereqs build deploy launch status log shot click stop all'
+    }
+}


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes # _(none — see note below)_

I don't have an approved `Ready to build` issue for this. It's developer tooling rather than a change to app behaviour, so there's nothing user-facing to file. Happy to open an issue first and re-submit, or to close this if the project would rather not carry agent tooling in-tree — please just say which.

**What this adds**

`.claude/skills/run-files/` — a skill that lets an AI coding agent (or a new contributor) build, deploy, launch and interact with Files from a clean machine. Nothing in the app or build is modified; the change is three new files under `.claude/`.

- `driver.ps1` — `prereqs | build | deploy | launch | status | log | shot | click | stop | all`. Each subcommand prints `KEY=VALUE` result lines so they can be asserted on.
- `SKILL.md` — documents the driver, the required toolchain, and the failure modes.
- `.gitignore` — keeps generated screenshots out of the repo.

It encodes a handful of things that aren't discoverable from the build files:

- **Build the whole solution.** The C++ projects and `Files.App.Server` are solution-level `BuildDependency` entries, not `ProjectReference`s, so a project-scoped build of `Files.App.csproj` removes `Files.App.Server.exe` from the output.
- **`packages.config` needs its own restore pass.** `Files.App.Launcher.vcxproj` still uses it, and a plain `-restore` silently skips it.
- **The loose layout needs repair before registering.** `Assets\AppTiles\**` is MSIX package content and isn't marked `CopyToOutputDirectory`, so registering the build output produces an app that hangs on the splash screen forever: `new SystemTrayIcon()` (`App.xaml.cs:131`) throws `DirectoryNotFoundException` loading `Logo.ico` *before* `MainPage` is navigated to on line 137, and the fire-and-forget call swallows it — no log line, no crash, no Event Log entry.
- **Toolchain floor.** .NET SDK 10, and VS 2026 Build Tools for both MSBuild 18 and the `v145` toolset the `.vcxproj` files pin. VS 2022 17.x can build neither. ATL is required by four C++ projects and is not included by `--includeRecommended`.

**Steps used to test these changes**

Run on Windows 11, x64 Debug, starting from a machine with neither the .NET 10 SDK nor VS 2026 installed.

1. Installed .NET SDK 10.0.400 and VS 2026 Build Tools (VCTools + ManagedDesktopBuildTools + Windows 11 SDK 26100), then the ATL component.
2. Ran `driver.ps1 prereqs` → `PREREQS=OK`, `MSVC=14.51.36231`.
3. Ran `driver.ps1 build` → `RESTORE_EXIT=0`, `BUILD_EXIT=0` for the full `Files.slnx`.
4. Ran `driver.ps1 deploy` → `LOGO_ICO=True`, `SERVER_EXE=True`, `REGISTER=OK`.
5. Ran `driver.ps1 launch` → `LAUNCH=OK title='Downloads - Files' after=6s`. Confirmed the startup log enumerated drives C–N and detected iCloud Drive, iCloud Photos and OneDrive.
6. Ran `driver.ps1 shot` and inspected the PNG — Home rendered with Quick access, Drives with correct free-space figures, and a populated sidebar.
7. Ran `driver.ps1 click 177 334` → `FOREGROUND=True`, title changed to `Downloads - Files`; the screenshot showed the Downloads folder with 27 items and breadcrumb `Local Disk (C:) › Users › jeffr › Downloads`.
8. Re-ran the documented command sequence from a clean shell after converting the files to CRLF, to confirm `SKILL.md` matches actual output.

No test suite was run: per `CLAUDE.md` this repo has no test suite suitable for agents, and a clean build is the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
