### PR TITLE
Fix: Fixed issue with copying text from rename text box

### DIFF
--- a/src/Files.App/Helpers/MenuFlyout/FastContextFlyout.cs
+++ b/src/Files.App/Helpers/MenuFlyout/FastContextFlyout.cs
@@ -48,6 +48,7 @@ namespace Files.App.Helpers.ContextFlyouts
 		{
 			Flyout.Opening += (sender, e) => App.LastOpenedFlyout = Flyout;
 			Flyout.Opened += Flyout_Opened;
+			Flyout.Closed += Flyout_Closed;
 		}
 
 		/// <summary>
@@ -552,6 +553,17 @@ namespace Files.App.Helpers.ContextFlyouts
 			{
 				Debug.WriteLine(ex);
 			}
+		}
+
+		private void Flyout_Closed(object? sender, object e)
+		{
+			if (primaryRow?.Tag is not Panel row)
+				return;
+
+			// Fixes #18820: Primary command accelerators remain active after the flyout closes,
+			// overriding shortcuts in focused text controls such as the rename TextBox.
+			foreach (var button in row.Children.OfType<Button>())
+				button.KeyboardAccelerators.Clear();
 		}
 
 		private bool PredictOpensUpward()

--- a/src/Files.App/Helpers/MenuFlyout/FastContextFlyout.cs
+++ b/src/Files.App/Helpers/MenuFlyout/FastContextFlyout.cs
@@ -560,8 +560,6 @@ namespace Files.App.Helpers.ContextFlyouts
 			if (primaryRow?.Tag is not Panel row)
 				return;
 
-			// Fixes #18820: Primary command accelerators remain active after the flyout closes,
-			// overriding shortcuts in focused text controls such as the rename TextBox.
 			foreach (var button in row.Children.OfType<Button>())
 				button.KeyboardAccelerators.Clear();
 		}


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #18820

**Description**

Opening the item context menu leaves its primary command keyboard accelerators active after the flyout closes. This allows the CopyItem command to override Ctrl+C while the rename TextBox has focus.

This change clears the primary command button accelerators when FastContextFlyout closes.

**Steps used to test these changes**

1. Opened Files and selected a folder.
2. Opened and closed the item context menu.
3. Started renaming the selected folder from the command bar.
4. Selected part of the name and pressed Ctrl+C.
5. Pasted into another text box and verified that the selected text was copied instead of the folder.
6. Exited rename mode, selected a folder, and verified that Ctrl+C still copies the selected folder.