### PR TITLE
Code Quality: Trim AI packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,6 +36,10 @@
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.Windows.AI.MachineLearning" Version="2.1.74" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="2.4.4" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.ML" Version="2.1.74" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.Widgets" Version="2.0.5" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.4.0" />
     <PackageVersion Include="TagLibSharp" Version="2.3.0" />
     <PackageVersion Include="UTF.Unknown" Version="2.6.0" />

--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -107,9 +107,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Update="Microsoft.WindowsAppSDK.AI" ExcludeAssets="all" />
-        <PackageReference Update="Microsoft.WindowsAppSDK.ML" ExcludeAssets="all" />
-        <PackageReference Update="Microsoft.WindowsAppSDK.Widgets" ExcludeAssets="all" />
+        <PackageReference Include="Microsoft.WindowsAppSDK.AI" ExcludeAssets="all" />
+        <PackageReference Include="Microsoft.WindowsAppSDK.ML" ExcludeAssets="all" />
+        <PackageReference Include="Microsoft.Windows.AI.MachineLearning" ExcludeAssets="all" />
+        <PackageReference Include="Microsoft.WindowsAppSDK.Widgets" ExcludeAssets="all" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The AI/ML Windows App SDK components were shipping ~39 MB of unused native runtime
(`onnxruntime.dll` + `DirectML.dll`) into the self-contained package. Nothing in the
app references these APIs.

The existing `PackageReference Update="Microsoft.WindowsAppSDK.{AI,ML,Widgets}" ExcludeAssets="all"`
lines were didn't work as expected. `Update` doesn't apply asset exclusion to transitive-only packages, and
the native payload actually lives in the leaf `Microsoft.Windows.AI.MachineLearning` package.

Converted them to direct `PackageReference Include ... ExcludeAssets="all"` (which NuGet honors)
and added the leaf ML package. Restore now records `"include": "None"` for all four, so no
compile/runtime/native/build assets flow into the package.
