### PR TITLE
Code Quality: Replace directory enumeration P/Invokes with CsWin32

### DIFF
--- a/src/Files.App.CsWin32/NativeMethods.txt
+++ b/src/Files.App.CsWin32/NativeMethods.txt
@@ -74,6 +74,7 @@ GetFileTime
 SetFileTime
 GetFileInformationByHandleEx
 FILE_ID_BOTH_DIR_INFO
+IO_REPARSE_TAG_SYMLINK
 FindFirstStreamW
 FindNextStreamW
 WIN32_FIND_STREAM_DATA

--- a/src/Files.App/Extensions/Win32FindDataExtensions.cs
+++ b/src/Files.App/Extensions/Win32FindDataExtensions.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Files Community
 // Licensed under the MIT License.
 
+using Windows.Win32.Foundation;
+using Windows.Win32.Storage.FileSystem;
+
 namespace Files.App.Extensions
 {
 	public static class Win32FindDataExtensions
@@ -16,5 +19,18 @@ namespace Files.App.Extensions
 				(fDataFSize < 0 ? MAX_DWORD + 1 : 0) +
 				(findData.nFileSizeHigh > 0 ? findData.nFileSizeHigh * (MAX_DWORD + 1) : 0);
 		}
+
+		public static long GetSize(this WIN32_FIND_DATAW findData)
+		{
+			long fDataFSize = findData.nFileSizeLow;
+
+			return
+				fDataFSize +
+				(fDataFSize < 0 ? MAX_DWORD + 1 : 0) +
+				(findData.nFileSizeHigh > 0 ? findData.nFileSizeHigh * (MAX_DWORD + 1) : 0);
+		}
+
+		public static DateTime ToDateTime(this SYSTEMTIME value)
+			=> new(value.wYear, value.wMonth, value.wDay, value.wHour, value.wMinute, value.wSecond, value.wMilliseconds, DateTimeKind.Utc);
 	}
 }

--- a/src/Files.App/Services/SizeProvider/CachedSizeProvider.cs
+++ b/src/Files.App/Services/SizeProvider/CachedSizeProvider.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Concurrent;
 using System.IO;
+using Windows.Win32;
+using Windows.Win32.Storage.FileSystem;
 
 namespace Files.App.Services.SizeProvider
 {
@@ -35,21 +37,26 @@ namespace Files.App.Services.SizeProvider
 			async Task<ulong> Calculate(string path, int level = 0)
 			{
 				if (string.IsNullOrEmpty(path))
-				{
 					return 0;
-				}
 
-				IntPtr hFile = Win32PInvoke.FindFirstFileExFromApp($"{path}{Path.DirectorySeparatorChar}*.*", Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
-					out Win32PInvoke.WIN32_FIND_DATA findData, Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH);
+				WIN32_FIND_DATAW findData = default;
+				FindCloseSafeHandle hFile;
+				unsafe
+				{
+					hFile = PInvoke.FindFirstFileEx($"{path}{Path.DirectorySeparatorChar}*.*", FINDEX_INFO_LEVELS.FindExInfoBasic,
+						&findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+				}
+				using FindCloseSafeHandle findHandleScope = hFile;
 
 				ulong size = 0;
 				ulong localSize = 0;
 				string localPath = string.Empty;
 
-				if (hFile.ToInt64() is not -1)
+				if (!hFile.IsInvalid)
 				{
 					do
 					{
+						string fileName = findData.cFileName.ToString();
 						if (((FileAttributes)findData.dwFileAttributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
 							// Skip symbolic links and junctions
 							continue;
@@ -59,9 +66,9 @@ namespace Files.App.Services.SizeProvider
 						{
 							size += (ulong)findData.GetSize();
 						}
-						else if (findData.cFileName is not "." and not "..")
+						else if (fileName is not "." and not "..")
 						{
-							localPath = Path.Combine(path, findData.cFileName);
+							localPath = Path.Combine(path, fileName);
 							localSize = await Calculate(localPath, level + 1);
 							size += localSize;
 						}
@@ -79,11 +86,8 @@ namespace Files.App.Services.SizeProvider
 						}
 
 						if (cancellationToken.IsCancellationRequested)
-						{
 							break;
-						}
-					} while (Win32PInvoke.FindNextFile(hFile, out findData));
-					Win32PInvoke.FindClose(hFile);
+					} while (PInvoke.FindNextFile(hFile, out findData));
 				}
 				return size;
 			}

--- a/src/Files.App/Services/SizeProvider/CachedSizeProvider.cs
+++ b/src/Files.App/Services/SizeProvider/CachedSizeProvider.cs
@@ -39,12 +39,14 @@ namespace Files.App.Services.SizeProvider
 				if (string.IsNullOrEmpty(path))
 					return 0;
 
-				WIN32_FIND_DATAW findData = default;
 				FindCloseSafeHandle hFile;
+				WIN32_FIND_DATAW findData;
 				unsafe
 				{
+					WIN32_FIND_DATAW initialFindData = default;
 					hFile = PInvoke.FindFirstFileEx($"{path}{Path.DirectorySeparatorChar}*.*", FINDEX_INFO_LEVELS.FindExInfoBasic,
-						&findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+						&initialFindData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+					findData = initialFindData;
 				}
 				using FindCloseSafeHandle findHandleScope = hFile;
 
@@ -56,7 +58,6 @@ namespace Files.App.Services.SizeProvider
 				{
 					do
 					{
-						string fileName = findData.cFileName.ToString();
 						if (((FileAttributes)findData.dwFileAttributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
 							// Skip symbolic links and junctions
 							continue;
@@ -66,11 +67,15 @@ namespace Files.App.Services.SizeProvider
 						{
 							size += (ulong)findData.GetSize();
 						}
-						else if (fileName is not "." and not "..")
+						else
 						{
-							localPath = Path.Combine(path, fileName);
-							localSize = await Calculate(localPath, level + 1);
-							size += localSize;
+							string fileName = findData.cFileName.ToString();
+							if (fileName is not "." and not "..")
+							{
+								localPath = Path.Combine(path, fileName);
+								localSize = await Calculate(localPath, level + 1);
+								size += localSize;
+							}
 						}
 
 						if (level <= 3)

--- a/src/Files.App/Utils/Storage/Helpers/FolderHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FolderHelpers.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System.IO;
+using Windows.Win32;
+using Windows.Win32.Storage.FileSystem;
 
 namespace Files.App.Utils.Storage
 {
@@ -9,16 +11,12 @@ namespace Files.App.Utils.Storage
 
 	public static class FolderHelpers
 	{
-		public static bool CheckFolderAccessWithWin32(string path)
+		public static unsafe bool CheckFolderAccessWithWin32(string path)
 		{
-			IntPtr hFileTsk = Win32PInvoke.FindFirstFileExFromApp($"{path}{Path.DirectorySeparatorChar}*.*", Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
-				out Win32PInvoke.WIN32_FIND_DATA _, Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH);
-			if (hFileTsk.ToInt64() != -1)
-			{
-				Win32PInvoke.FindClose(hFileTsk);
-				return true;
-			}
-			return false;
+			WIN32_FIND_DATAW findData = default;
+			using FindCloseSafeHandle hFile = PInvoke.FindFirstFileEx($"{path}{Path.DirectorySeparatorChar}*.*", FINDEX_INFO_LEVELS.FindExInfoBasic,
+				&findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+			return !hFile.IsInvalid;
 		}
 
 		public static async Task<bool> CheckBitlockerStatusAsync(BaseStorageFolder? rootFolder, string path)
@@ -41,106 +39,92 @@ namespace Files.App.Utils.Storage
 		/// </summary>
 		/// <param name="targetPath">The path to the target folder</param>
 		///
-		public static bool CheckForFilesFolders(string targetPath)
+		public static unsafe bool CheckForFilesFolders(string targetPath)
 		{
-			IntPtr hFile = Win32PInvoke.FindFirstFileExFromApp($"{targetPath}{Path.DirectorySeparatorChar}*.*", Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
-				out Win32PInvoke.WIN32_FIND_DATA findData, Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH);
-			if (hFile.ToInt64() == -1)
+			WIN32_FIND_DATAW findData = default;
+			using FindCloseSafeHandle hFile = PInvoke.FindFirstFileEx($"{targetPath}{Path.DirectorySeparatorChar}*.*", FINDEX_INFO_LEVELS.FindExInfoBasic,
+				&findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+			if (hFile.IsInvalid)
 				return false;
 
-			try
+			do
 			{
-				do
-				{
-					if (findData.cFileName is not "." and not "..")
-						return true;
-				}
-				while (Win32PInvoke.FindNextFile(hFile, out findData));
+				string fileName = findData.cFileName.ToString();
+				if (fileName is not "." and not "..")
+					return true;
+			}
+			while (PInvoke.FindNextFile(hFile, out findData));
 
-				return false;
-			}
-			finally
-			{
-				Win32PInvoke.FindClose(hFile);
-			}
+			return false;
 		}
 
-		public static List<SubfolderEntry> EnumerateSubfolders(string path, bool showHidden, bool showProtected, bool showDot, int limit = 1000)
+		public static unsafe List<SubfolderEntry> EnumerateSubfolders(string path, bool showHidden, bool showProtected, bool showDot, int limit = 1000)
 		{
 			var results = new List<SubfolderEntry>();
-			IntPtr hFind = OpenChildSearch(path, out var findData);
-			if (hFind.ToInt64() == -1)
+			WIN32_FIND_DATAW findData = default;
+			using FindCloseSafeHandle hFind = PInvoke.FindFirstFileEx(
+				path + "\\*.*",
+				FINDEX_INFO_LEVELS.FindExInfoBasic,
+				&findData,
+				FINDEX_SEARCH_OPS.FindExSearchNameMatch,
+				FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+			if (hFind.IsInvalid)
 				return results;
 
-			try
+			do
 			{
-				do
-				{
-					if (findData.cFileName is "." or "..")
-						continue;
-					var attrs = (FileAttributes)findData.dwFileAttributes;
-					if ((attrs & FileAttributes.Directory) != FileAttributes.Directory)
-						continue;
+				string fileName = findData.cFileName.ToString();
+				if (fileName is "." or "..")
+					continue;
+				var attrs = (FileAttributes)findData.dwFileAttributes;
+				if ((attrs & FileAttributes.Directory) != FileAttributes.Directory)
+					continue;
 
-					var isHidden = (attrs & FileAttributes.Hidden) == FileAttributes.Hidden;
-					var isSystem = (attrs & FileAttributes.System) == FileAttributes.System;
+				var isHidden = (attrs & FileAttributes.Hidden) == FileAttributes.Hidden;
+				var isSystem = (attrs & FileAttributes.System) == FileAttributes.System;
 
-					if (!showDot && findData.cFileName.StartsWith('.'))
-						continue;
-					if (isHidden && !showHidden)
-						continue;
-					if (isHidden && isSystem && !showProtected)
-						continue;
+				if (!showDot && fileName.StartsWith('.'))
+					continue;
+				if (isHidden && !showHidden)
+					continue;
+				if (isHidden && isSystem && !showProtected)
+					continue;
 
-					var subPath = Path.Combine(path, findData.cFileName);
-					results.Add(new SubfolderEntry(subPath, findData.cFileName, HasSubfolders(subPath), isHidden));
+				var subPath = Path.Combine(path, fileName);
+				results.Add(new SubfolderEntry(subPath, fileName, HasSubfolders(subPath), isHidden));
 
-					if (results.Count == limit)
-						break;
-				}
-				while (Win32PInvoke.FindNextFile(hFind, out findData));
+				if (results.Count == limit)
+					break;
 			}
-			finally
-			{
-				Win32PInvoke.FindClose(hFind);
-			}
+			while (PInvoke.FindNextFile(hFind, out findData));
 
 			var naturalComparer = NaturalStringComparer.GetForProcessor();
 			results.Sort((a, b) => naturalComparer.Compare(a.Name, b.Name));
 			return results;
 		}
 
-		public static bool HasSubfolders(string path)
+		public static unsafe bool HasSubfolders(string path)
 		{
-			IntPtr hFind = OpenChildSearch(path, out var findData);
-			if (hFind.ToInt64() == -1)
-				return false;
-
-			try
-			{
-				do
-				{
-					if (findData.cFileName is "." or "..")
-						continue;
-					if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
-						return true;
-				}
-				while (Win32PInvoke.FindNextFile(hFind, out findData));
-				return false;
-			}
-			finally
-			{
-				Win32PInvoke.FindClose(hFind);
-			}
-		}
-
-		private static IntPtr OpenChildSearch(string path, out Win32PInvoke.WIN32_FIND_DATA findData)
-			=> Win32PInvoke.FindFirstFileExFromApp(
+			WIN32_FIND_DATAW findData = default;
+			using FindCloseSafeHandle hFind = PInvoke.FindFirstFileEx(
 				path + "\\*.*",
-				Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
-				out findData,
-				Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch,
-				IntPtr.Zero,
-				Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH);
+				FINDEX_INFO_LEVELS.FindExInfoBasic,
+				&findData,
+				FINDEX_SEARCH_OPS.FindExSearchNameMatch,
+				FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+			if (hFind.IsInvalid)
+				return false;
+
+			do
+			{
+				string fileName = findData.cFileName.ToString();
+				if (fileName is "." or "..")
+					continue;
+				if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
+					return true;
+			}
+			while (PInvoke.FindNextFile(hFind, out findData));
+			return false;
+		}
 	}
 }

--- a/src/Files.App/Utils/Storage/Helpers/FolderHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FolderHelpers.cs
@@ -73,11 +73,12 @@ namespace Files.App.Utils.Storage
 
 			do
 			{
-				string fileName = findData.cFileName.ToString();
-				if (fileName is "." or "..")
-					continue;
 				var attrs = (FileAttributes)findData.dwFileAttributes;
 				if ((attrs & FileAttributes.Directory) != FileAttributes.Directory)
+					continue;
+
+				string fileName = findData.cFileName.ToString();
+				if (fileName is "." or "..")
 					continue;
 
 				var isHidden = (attrs & FileAttributes.Hidden) == FileAttributes.Hidden;

--- a/src/Files.App/Utils/Storage/Search/FolderSearch.cs
+++ b/src/Files.App/Utils/Storage/Search/FolderSearch.cs
@@ -8,8 +8,10 @@ using System.Text.RegularExpressions;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Search;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Storage.FileSystem;
 using FileAttributes = System.IO.FileAttributes;
-using WIN32_FIND_DATA = Files.App.Helpers.Win32PInvoke.WIN32_FIND_DATA;
 
 namespace Files.App.Utils.Storage
 {
@@ -311,11 +313,15 @@ namespace Files.App.Utils.Storage
 				if (token.IsCancellationRequested)
 					return;
 
-				(Win32PInvoke.SafeFindHandle? hFile, WIN32_FIND_DATA findData) = await Task.Run(() =>
+				(FindCloseSafeHandle? hFile, WIN32_FIND_DATAW findData) = await Task.Run(() =>
 				{
-					int additionalFlags = Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH;
-					var hFileTsk = Win32PInvoke.FindFirstFileExFromAppSafe(match.FilePath, Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
-						out WIN32_FIND_DATA findDataTsk, Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, additionalFlags);
+					WIN32_FIND_DATAW findDataTsk = default;
+					FindCloseSafeHandle hFileTsk;
+					unsafe
+					{
+						hFileTsk = PInvoke.FindFirstFileEx(match.FilePath, FINDEX_INFO_LEVELS.FindExInfoBasic,
+							&findDataTsk, FINDEX_SEARCH_OPS.FindExSearchNameMatch, FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+					}
 					return (hFileTsk, findDataTsk);
 				}).WithTimeoutAsync(TimeSpan.FromSeconds(5));
 				if (token.IsCancellationRequested)
@@ -324,13 +330,14 @@ namespace Files.App.Utils.Storage
 					return;
 				}
 
-				if (hFile is { IsInvalid: false })
+				if (hFile is { IsInvalid: false } tagSearchHandle)
 				{
-					using (hFile)
+					using (tagSearchHandle)
 					{
+						string fileName = findData.cFileName.ToString();
 						var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
 						var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
-						var startWithDot = findData.cFileName.StartsWith('.');
+						var startWithDot = fileName.StartsWith('.');
 
 						bool shouldBeListed = (!isHidden ||
 							(UserSettingsService.FoldersSettingsService.ShowHiddenItems &&
@@ -409,11 +416,15 @@ namespace Files.App.Utils.Storage
 			if (token.IsCancellationRequested)
 				return;
 
-			(Win32PInvoke.SafeFindHandle? hFile, WIN32_FIND_DATA findData) = await Task.Run(() =>
+			(FindCloseSafeHandle? hFile, WIN32_FIND_DATAW findData) = await Task.Run(() =>
 			{
-				int additionalFlags = Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH;
-				var hFileTsk = Win32PInvoke.FindFirstFileExFromAppSafe($"{folder}\\*{QueryWithWildcard}", Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
-					out WIN32_FIND_DATA findDataTsk, Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, additionalFlags);
+				WIN32_FIND_DATAW findDataTsk = default;
+				FindCloseSafeHandle hFileTsk;
+				unsafe
+				{
+					hFileTsk = PInvoke.FindFirstFileEx($"{folder}\\*{QueryWithWildcard}", FINDEX_INFO_LEVELS.FindExInfoBasic,
+						&findDataTsk, FINDEX_SEARCH_OPS.FindExSearchNameMatch, FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+				}
 				return (hFileTsk, findDataTsk);
 			}).WithTimeoutAsync(TimeSpan.FromSeconds(5));
 			if (token.IsCancellationRequested)
@@ -422,7 +433,7 @@ namespace Files.App.Utils.Storage
 				return;
 			}
 
-			var pendingShortcuts = new List<(string Path, WIN32_FIND_DATA FindData)>();
+			var pendingShortcuts = new List<(string Path, WIN32_FIND_DATAW FindData)>();
 
 			if (hFile is { IsInvalid: false } findHandle)
 			{
@@ -431,7 +442,6 @@ namespace Files.App.Utils.Storage
 				{
 					using (findHandle)
 					{
-						var rawHandle = findHandle.DangerousGetHandle();
 						var hasNextFile = false;
 						do
 						{
@@ -440,12 +450,13 @@ namespace Files.App.Utils.Storage
 
 							if (results.Count >= maxItemCount)
 								break;
-							var itemPath = Path.Combine(folder, findData.cFileName);
 
+							string fileName = findData.cFileName.ToString();
+							var itemPath = Path.Combine(folder, fileName);
 							var isSystem = ((FileAttributes)findData.dwFileAttributes & FileAttributes.System) == FileAttributes.System;
 							var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
-							var startWithDot = findData.cFileName.StartsWith('.');
-							var isShortcut = FileExtensionHelpers.IsShortcutOrUrlFile(findData.cFileName);
+							var startWithDot = fileName.StartsWith('.');
+							var isShortcut = FileExtensionHelpers.IsShortcutOrUrlFile(fileName);
 
 							bool shouldBeListed = (hiddenOnly ?
 								(!isHidden && isShortcut) || (isHidden && UserSettingsService.FoldersSettingsService.ShowHiddenItems && (!isSystem || UserSettingsService.FoldersSettingsService.ShowProtectedSystemFiles)) :
@@ -468,8 +479,7 @@ namespace Files.App.Utils.Storage
 
 							if (!token.IsCancellationRequested && (results.Count == 32 || results.Count % 300 == 0 /*|| sampler.CheckNow()*/))
 								SearchTick?.Invoke(this, EventArgs.Empty);
-
-							hasNextFile = Win32PInvoke.FindNextFile(rawHandle, out findData);
+							hasNextFile = PInvoke.FindNextFile(findHandle, out findData);
 						} while (hasNextFile);
 					}
 				});
@@ -484,13 +494,14 @@ namespace Files.App.Utils.Storage
 				if (results.Count >= maxItemCount || token.IsCancellationRequested)
 					break;
 
-				var isUrl = FileExtensionHelpers.IsWebLinkFile(itemFindData.cFileName);
+				string shortcutFileName = itemFindData.cFileName.ToString();
+				var isUrl = FileExtensionHelpers.IsWebLinkFile(shortcutFileName);
 				var shortcutFindData = itemFindData;
 				var isHidden = ((FileAttributes)shortcutFindData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
-				Win32PInvoke.FileTimeToSystemTime(in shortcutFindData.ftLastWriteTime, out Win32PInvoke.SYSTEMTIME modifiedTime);
-				Win32PInvoke.FileTimeToSystemTime(in shortcutFindData.ftCreationTime, out Win32PInvoke.SYSTEMTIME createdTime);
+				PInvoke.FileTimeToSystemTime(shortcutFindData.ftLastWriteTime, out SYSTEMTIME modifiedTime);
+				PInvoke.FileTimeToSystemTime(shortcutFindData.ftCreationTime, out SYSTEMTIME createdTime);
 				var fileSize = Win32FindDataExtensions.GetSize(shortcutFindData);
-				var itemFileExtension = shortcutFindData.cFileName.Contains('.', StringComparison.Ordinal) ? Path.GetExtension(itemPath)! : string.Empty;
+				var itemFileExtension = shortcutFileName.Contains('.', StringComparison.Ordinal) ? Path.GetExtension(itemPath)! : string.Empty;
 
 				var shortcutItem = new ShortcutItem(null)
 				{
@@ -500,7 +511,7 @@ namespace Files.App.Utils.Storage
 					Opacity = isHidden ? Constants.UI.DimItemOpacity : 1,
 					FileImage = null,
 					LoadFileIcon = false,
-					ItemNameRaw = shortcutFindData.cFileName,
+					ItemNameRaw = shortcutFileName,
 					ItemDateModifiedReal = modifiedTime.ToDateTime(),
 					ItemDateCreatedReal = createdTime.ToDateTime(),
 					ItemType = isUrl ? Strings.ShortcutWebLinkFileType.GetLocalizedResource() : Strings.Shortcut.GetLocalizedResource(),
@@ -552,15 +563,18 @@ namespace Files.App.Utils.Storage
 					SearchTick?.Invoke(this, EventArgs.Empty);
 				}
 			}
-
 			if (token.IsCancellationRequested)
 				return;
 
-			(Win32PInvoke.SafeFindHandle? hSubDir, WIN32_FIND_DATA subDirData) = await Task.Run(() =>
+			(FindCloseSafeHandle? hSubDir, WIN32_FIND_DATAW subDirData) = await Task.Run(() =>
 			{
-				int additionalFlags = Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH;
-				var hSubDirTsk = Win32PInvoke.FindFirstFileExFromAppSafe($"{folder}\\*", Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
-					out WIN32_FIND_DATA subDirDataTsk, Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, additionalFlags);
+				WIN32_FIND_DATAW subDirDataTsk = default;
+				FindCloseSafeHandle hSubDirTsk;
+				unsafe
+				{
+					hSubDirTsk = PInvoke.FindFirstFileEx($"{folder}\\*", FINDEX_INFO_LEVELS.FindExInfoBasic,
+						&subDirDataTsk, FINDEX_SEARCH_OPS.FindExSearchNameMatch, FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+				}
 				return (hSubDirTsk, subDirDataTsk);
 			}).WithTimeoutAsync(TimeSpan.FromSeconds(5));
 			if (token.IsCancellationRequested)
@@ -578,18 +592,18 @@ namespace Files.App.Utils.Storage
 				{
 					using (subDirectoryHandle)
 					{
-						var rawHandle = subDirectoryHandle.DangerousGetHandle();
 						var hasNextDir = false;
 						do
 						{
 							if (token.IsCancellationRequested)
 								break;
 
+							string subDirName = subDirData.cFileName.ToString();
 							var isDirectory = ((FileAttributes)subDirData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory;
-							if (isDirectory && subDirData.cFileName != "." && subDirData.cFileName != "..")
-								subDirectories.Add(Path.Combine(folder, subDirData.cFileName));
+							if (isDirectory && subDirName != "." && subDirName != "..")
+								subDirectories.Add(Path.Combine(folder, subDirName));
 
-							hasNextDir = Win32PInvoke.FindNextFile(rawHandle, out subDirData);
+							hasNextDir = PInvoke.FindNextFile(subDirectoryHandle, out subDirData);
 						} while (hasNextDir);
 					}
 				});
@@ -608,20 +622,21 @@ namespace Files.App.Utils.Storage
 			}
 		}
 
-		private ListedItem? GetListedItemAsync(string itemPath, WIN32_FIND_DATA findData)
+		private ListedItem? GetListedItemAsync(string itemPath, WIN32_FIND_DATAW findData)
 		{
+			string fileName = findData.cFileName.ToString();
 			ListedItem? listedItem = null;
 			var isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) == FileAttributes.Hidden;
 			var isFolder = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == FileAttributes.Directory;
-			Win32PInvoke.FileTimeToSystemTime(in findData.ftLastWriteTime, out Win32PInvoke.SYSTEMTIME systemModifiedTimeOutput);
-			Win32PInvoke.FileTimeToSystemTime(in findData.ftCreationTime, out Win32PInvoke.SYSTEMTIME systemCreatedTimeOutput);
+			PInvoke.FileTimeToSystemTime(findData.ftLastWriteTime, out SYSTEMTIME systemModifiedTimeOutput);
+			PInvoke.FileTimeToSystemTime(findData.ftCreationTime, out SYSTEMTIME systemCreatedTimeOutput);
 
 			if (!isFolder)
 			{
 				string? itemFileExtension = null;
 				string? itemType = null;
 				long fileSize = Win32FindDataExtensions.GetSize(findData);
-				if (findData.cFileName.Contains('.', StringComparison.Ordinal))
+				if (fileName.Contains('.', StringComparison.Ordinal))
 				{
 					itemFileExtension = Path.GetExtension(itemPath);
 					itemType = itemFileExtension!.Trim('.') + " " + itemType;
@@ -630,7 +645,7 @@ namespace Files.App.Utils.Storage
 				listedItem = new ListedItem(null)
 				{
 					PrimaryItemAttribute = StorageItemTypes.File,
-					ItemNameRaw = findData.cFileName,
+					ItemNameRaw = fileName,
 					ItemPath = itemPath,
 					ItemDateModifiedReal = systemModifiedTimeOutput.ToDateTime(),
 					ItemDateCreatedReal = systemCreatedTimeOutput.ToDateTime(),
@@ -645,12 +660,12 @@ namespace Files.App.Utils.Storage
 			}
 			else
 			{
-				if (findData.cFileName != "." && findData.cFileName != "..")
+				if (fileName != "." && fileName != "..")
 				{
 					listedItem = new ListedItem(null)
 					{
 						PrimaryItemAttribute = StorageItemTypes.Folder,
-						ItemNameRaw = findData.cFileName,
+						ItemNameRaw = fileName,
 						ItemPath = itemPath,
 						ItemDateModifiedReal = systemModifiedTimeOutput.ToDateTime(),
 						ItemDateCreatedReal = systemCreatedTimeOutput.ToDateTime(),

--- a/src/Files.App/Utils/Storage/StorageItems/VirtualStorageItem.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/VirtualStorageItem.cs
@@ -6,6 +6,9 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Storage.FileSystem;
 
 namespace Files.App.Utils.Storage
 {
@@ -39,48 +42,40 @@ namespace Files.App.Utils.Storage
 			};
 		}
 
-		public static VirtualStorageItem? FromPath(string path)
+		public static unsafe VirtualStorageItem? FromPath(string path)
 		{
-			Win32PInvoke.FINDEX_INFO_LEVELS findInfoLevel = Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic;
-			int additionalFlags = Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH;
-			IntPtr hFile = Win32PInvoke.FindFirstFileExFromApp(path, findInfoLevel, out Win32PInvoke.WIN32_FIND_DATA findData, Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, additionalFlags);
-			if (hFile.ToInt64() != -1)
+			WIN32_FIND_DATAW findData = default;
+			using FindCloseSafeHandle hFile = PInvoke.FindFirstFileEx(path, FINDEX_INFO_LEVELS.FindExInfoBasic, &findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
+			if (!hFile.IsInvalid)
 			{
-				try
-				{
-					// https://learn.microsoft.com/openspecs/windows_protocols/ms-fscc/c8e77b37-3909-4fe6-a4ea-2b9d423b1ee4
-					bool isReparsePoint = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.ReparsePoint) == System.IO.FileAttributes.ReparsePoint;
-					bool isSymlink = isReparsePoint && findData.dwReserved0 == Win32PInvoke.IO_REPARSE_TAG_SYMLINK;
-					bool isHidden = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.Hidden) == System.IO.FileAttributes.Hidden;
-					bool isDirectory = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.Directory) == System.IO.FileAttributes.Directory;
+				// https://learn.microsoft.com/openspecs/windows_protocols/ms-fscc/c8e77b37-3909-4fe6-a4ea-2b9d423b1ee4
+				bool isReparsePoint = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.ReparsePoint) == System.IO.FileAttributes.ReparsePoint;
+				bool isSymlink = isReparsePoint && findData.dwReserved0 == PInvoke.IO_REPARSE_TAG_SYMLINK;
+				bool isHidden = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.Hidden) == System.IO.FileAttributes.Hidden;
+				bool isDirectory = ((System.IO.FileAttributes)findData.dwFileAttributes & System.IO.FileAttributes.Directory) == System.IO.FileAttributes.Directory;
 
-					if (!(isHidden && isSymlink))
+				if (!(isHidden && isSymlink))
+				{
+					DateTime itemCreatedDate;
+
+					try
 					{
-						DateTime itemCreatedDate;
-
-						try
-						{
-							Win32PInvoke.FileTimeToSystemTime(in findData.ftCreationTime, out Win32PInvoke.SYSTEMTIME systemCreatedDateOutput);
-							itemCreatedDate = systemCreatedDateOutput.ToDateTime();
-						}
-						catch (ArgumentException)
-						{
-							// Invalid date means invalid findData, do not add to list
-							return null;
-						}
-
-						return new VirtualStorageItem()
-						{
-							Name = findData.cFileName,
-							Path = path,
-							DateCreated = itemCreatedDate,
-							Attributes = isDirectory ? Windows.Storage.FileAttributes.Directory : Windows.Storage.FileAttributes.Normal
-						};
+						PInvoke.FileTimeToSystemTime(findData.ftCreationTime, out SYSTEMTIME systemCreatedDateOutput);
+						itemCreatedDate = systemCreatedDateOutput.ToDateTime();
 					}
-				}
-				finally
-				{
-					Win32PInvoke.FindClose(hFile);
+					catch (ArgumentException)
+					{
+						// Invalid date means invalid findData, do not add to list
+						return null;
+					}
+
+					return new VirtualStorageItem()
+					{
+						Name = findData.cFileName.ToString(),
+						Path = path,
+						DateCreated = itemCreatedDate,
+						Attributes = isDirectory ? Windows.Storage.FileAttributes.Directory : Windows.Storage.FileAttributes.Normal
+					};
 				}
 			}
 

--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -789,11 +789,11 @@ namespace Files.App.ViewModels.UserControls
 
 			do
 			{
-				string fileName = findData.cFileName.ToString();
-				if (fileName is "." or "..")
+				if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == 0)
 					continue;
 
-				if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == 0)
+				string fileName = findData.cFileName.ToString();
+				if (fileName is "." or "..")
 					continue;
 
 				bool isHidden = ((FileAttributes)findData.dwFileAttributes & FileAttributes.Hidden) != 0;

--- a/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/NavigationToolbarViewModel.cs
@@ -14,6 +14,8 @@ using System.IO;
 using System.Windows.Input;
 using Windows.ApplicationModel.DataTransfer;
 using WinRT;
+using Windows.Win32;
+using Windows.Win32.Storage.FileSystem;
 
 namespace Files.App.ViewModels.UserControls
 {
@@ -767,17 +769,17 @@ namespace Files.App.ViewModels.UserControls
 		/// Enumerates subfolders using Win32 API, including hidden folders based on user settings.
 		/// Returns null if the path cannot be enumerated with Win32.
 		/// </summary>
-		private List<(string Name, string Path, bool IsHidden)>? GetSubfolders(string parentPath)
+		private unsafe List<(string Name, string Path, bool IsHidden)>? GetSubfolders(string parentPath)
 		{
-			IntPtr hFile = Win32PInvoke.FindFirstFileExFromApp(
+			WIN32_FIND_DATAW findData = default;
+			using FindCloseSafeHandle hFile = PInvoke.FindFirstFileEx(
 				$"{parentPath}{Path.DirectorySeparatorChar}*.*",
-				Win32PInvoke.FINDEX_INFO_LEVELS.FindExInfoBasic,
-				out Win32PInvoke.WIN32_FIND_DATA findData,
-				Win32PInvoke.FINDEX_SEARCH_OPS.FindExSearchNameMatch,
-				IntPtr.Zero,
-				Win32PInvoke.FIND_FIRST_EX_LARGE_FETCH);
+				FINDEX_INFO_LEVELS.FindExInfoBasic,
+				&findData,
+				FINDEX_SEARCH_OPS.FindExSearchNameMatch,
+				FIND_FIRST_EX_FLAGS.FIND_FIRST_EX_LARGE_FETCH);
 
-			if (hFile.ToInt64() == -1)
+			if (hFile.IsInvalid)
 				return null;
 
 			var showHidden = UserSettingsService.FoldersSettingsService.ShowHiddenItems;
@@ -787,7 +789,8 @@ namespace Files.App.ViewModels.UserControls
 
 			do
 			{
-				if (findData.cFileName is "." or "..")
+				string fileName = findData.cFileName.ToString();
+				if (fileName is "." or "..")
 					continue;
 
 				if (((FileAttributes)findData.dwFileAttributes & FileAttributes.Directory) == 0)
@@ -799,14 +802,13 @@ namespace Files.App.ViewModels.UserControls
 				if (isHidden && (!showHidden || (isSystem && !showSystem)))
 					continue;
 
-				if (findData.cFileName.StartsWith('.') && !showDot)
+				if (fileName.StartsWith('.') && !showDot)
 					continue;
 
-				folders.Add((findData.cFileName, Path.Combine(parentPath, findData.cFileName), isHidden));
+				folders.Add((fileName, Path.Combine(parentPath, fileName), isHidden));
 			}
-			while (Win32PInvoke.FindNextFile(hFile, out findData));
+			while (PInvoke.FindNextFile(hFile, out findData));
 
-			Win32PInvoke.FindClose(hFile);
 			var naturalComparer = NaturalStringComparer.GetForProcessor();
 			folders.Sort((a, b) => naturalComparer.Compare(a.Name, b.Name));
 


### PR DESCRIPTION
### Resolved / Related Issues

- #4180

### Steps used to test these changes

1. Open regular folders and folders containing many files; verify that files and folders are enumerated correctly and scrolling remains responsive.
2. Toggle hidden files, system files, and dotfiles; refresh and navigate between folders to confirm the filters are applied.
3. Enable folder sizes and verify that folder size calculation completes and updates the displayed values.
4. Run regular and recursive searches, including folders containing shortcuts; cancel a search or navigate away while it is running.
5. Open the breadcrumb chevron flyout in a folder with mixed numeric names; verify that subfolders are naturally sorted and icons load.
6. Test an access-denied folder and, if available, a network share or WSL path; verify that failed enumeration is handled without a crash.
7. Repeatedly refresh folders and close a tab during enumeration or search; verify that the app remains stable.