### PR TITLE
Code Quality: Enable Direct P/Invoke

### DIFF
--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -41,6 +41,25 @@
     <PropertyGroup>
         <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
     </PropertyGroup>
+
+    <ItemGroup>
+        <DirectPInvoke Include="ADVAPI32" />
+        <DirectPInvoke Include="api-ms-win-core-com-l1-1-0" />
+        <DirectPInvoke Include="api-ms-win-core-com-l1-1-1" />
+        <DirectPInvoke Include="api-ms-win-core-winrt-l1-1-0" />
+        <DirectPInvoke Include="api-ms-win-core-winrt-robuffer-l1-1-0" />
+        <DirectPInvoke Include="api-ms-win-core-winrt-string-l1-1-0" />
+        <DirectPInvoke Include="CRYPT32" />
+        <DirectPInvoke Include="GDI32" />
+        <DirectPInvoke Include="KERNEL32.dll" />
+        <DirectPInvoke Include="Microsoft.WindowsAppRuntime.Bootstrap" />
+        <DirectPInvoke Include="OLE32" />
+        <DirectPInvoke Include="OLEAUT32" />
+        <DirectPInvoke Include="USER32" />
+        <_WindowsAppRuntimeBootstrapLibrary Include="@(WindowsAppSdkComponentPackages->'%(FullPath)lib\native\$(Platform)\Microsoft.WindowsAppRuntime.Bootstrap.lib')" />
+        <NativeLibrary Include="runtimeobject.lib" />
+        <NativeLibrary Include="@(_WindowsAppRuntimeBootstrapLibrary->Exists())" />
+    </ItemGroup>
   
     <ItemGroup>
         <Manifest Include="app.manifest" />


### PR DESCRIPTION
Enable Direct P/Invoke for NativeAOT to import them during linking, so that we don't pay runtime lazy initialization and resolution for some common modules.