### PR TITLE
Fix: Address several CancellationTokenSource disposal races

### DIFF
--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -2571,6 +2571,10 @@ namespace Files.App.ViewModels
 
 		private void WatchForDirectoryChanges(string path, CloudDriveSyncStatus syncStatus)
 		{
+			// Enumeration is fire-and-forget; don't set up a watcher on a disposed view model.
+			if (isDisposed)
+				return;
+
 			Debug.WriteLine($"WatchForDirectoryChanges: {path}");
 			var hWatchDir = Win32PInvoke.CreateFileFromApp(path, 1, 1 | 2 | 4,
 				IntPtr.Zero, 3, (uint)Win32PInvoke.File_Attributes.BackupSemantics | (uint)Win32PInvoke.File_Attributes.Overlapped, IntPtr.Zero);
@@ -2685,6 +2689,10 @@ namespace Files.App.ViewModels
 
 		private void WatchForGitChanges()
 		{
+			// Enumeration is fire-and-forget; don't set up a watcher on a disposed view model.
+			if (isDisposed)
+				return;
+
 			var hWatchDir = Win32PInvoke.CreateFileFromApp(
 				GitDirectory!,
 				1,
@@ -3297,10 +3305,12 @@ namespace Files.App.ViewModels
 
 			addFilesCTS.Cancel();
 			loadPropsCTS.Cancel();
-			watcherCTS.Cancel();
 			addFilesCTS.Dispose();
 			loadPropsCTS.Dispose();
-			watcherCTS.Dispose();
+
+			// Cancel but don't dispose: fire-and-forget watcher setup may still read watcherCTS.Token,
+			// which throws once disposed. Cancel() still fires the handle-releasing callbacks.
+			watcherCTS.Cancel();
 			SearchIconBitmapImage = null;
 			currentStorageFolder = null;
 		}

--- a/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
+++ b/src/Files.App/Views/Layouts/ColumnLayoutPage.xaml.cs
@@ -345,7 +345,12 @@ namespace Files.App.Views.Layouts
 
 		public override void Dispose()
 		{
+			Bindings.StopTracking();
 			storageArchiveService.CompressionCompleted -= StorageArchiveService_CompressionCompleted;
+			UserSettingsService.LayoutSettingsService.PropertyChanged -= LayoutSettingsService_PropertyChanged;
+			if (ParentShellPageInstance?.ShellViewModel is { } shellViewModel)
+				shellViewModel.ItemLoadStatusChanged -= OnItemLoadStatusChanged;
+
 			base.Dispose();
 			columnsOwner = null;
 		}


### PR DESCRIPTION
Fix several crashes:

```
System.ObjectDisposedException: The CancellationTokenSource has been disposed.
  at System.ThrowHelper.ThrowObjectDisposedException(ExceptionResource)()
  at Files.App.ViewModels.ShellViewModel.CancelExtendedPropertiesLoading()()
  at Files.App.Views.Layouts.ColumnLayoutPage.<ReloadItemIconsAsync>d__42.MoveNext()()

System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread.

  at System.ThrowHelper.ThrowObjectDisposedException(ExceptionResource)()
  at Files.App.ViewModels.ShellViewModel.CancelExtendedPropertiesLoading()()
  at Files.App.Views.Layouts.ColumnLayoutPage.<ReloadItemIconsAsync>d__42.MoveNext()()

System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The CancellationTokenSource has been disposed.)
 ---> System.ObjectDisposedException: The CancellationTokenSource has been disposed.
   at Files.App.ViewModels.ShellViewModel.WatchForDirectoryChanges(String, CloudDriveSyncStatus) + 0x1b9
   at Files.App.ViewModels.ShellViewModel.<RapidAddItemsToCollectionAsync>d__281.MoveNext() + 0x161
--- End of stack trace from previous location ---
   at Files.App.ViewModels.ShellViewModel.<RapidAddItemsToCollectionAsync>d__280.MoveNext() + 0x3b4
   --- End of inner exception stack trace ---
```
