### PR TITLE
Fix: Fixed crash on window close

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -27,6 +27,7 @@ namespace Files.App
 		public static TaskCompletionSource? SplashScreenLoadingTCS { get; private set; }
 		public static string? OutputPath { get; set; }
 
+		private bool _isMainWindowClosing;
 		private static FlyoutBase? _LastOpenedFlyout;
 		public static FlyoutBase? LastOpenedFlyout
 		{
@@ -255,10 +256,13 @@ namespace Files.App
 		{
 			Logger.LogInformation($"Window_Activated: State={args.WindowActivationState}");
 
+			if (args.WindowActivationState is not WindowActivationState.Deactivated)
+				_isMainWindowClosing = false;
+
 			ActiveSessionTracker.OnActivationChanged(args.WindowActivationState != WindowActivationState.Deactivated);
 
 			// MainWindow derives from WinUIEx.WindowEx, so it doesn't get the backdrop wiring in Files.App.Data.Items.WindowEx
-			if (MainWindow.Instance.SystemBackdrop is AppSystemBackdrop appSystemBackdrop)
+			if (!_isMainWindowClosing && MainWindow.Instance.SystemBackdrop is AppSystemBackdrop appSystemBackdrop)
 				appSystemBackdrop.SetInputActive(args.WindowActivationState is not WindowActivationState.Deactivated);
 
 			if (args.WindowActivationState != WindowActivationState.Deactivated)
@@ -280,6 +284,8 @@ namespace Files.App
 		/// </remarks>
 		private async void Window_Closed(object sender, WindowEventArgs args)
 		{
+			_isMainWindowClosing = true;
+
 			// Save application state and stop any background activity
 			IUserSettingsService userSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
 			StatusCenterViewModel statusCenterViewModel = Ioc.Default.GetRequiredService<StatusCenterViewModel>();

--- a/src/Files.App/Data/Items/WindowEx.cs
+++ b/src/Files.App/Data/Items/WindowEx.cs
@@ -23,6 +23,7 @@ namespace Files.App.Data.Items
 	public unsafe partial class WindowEx : Window, IDisposable
 	{
 		private bool _isInitialized;
+		private bool _isClosing;
 		private readonly WNDPROC _oldWndProc;
 		private readonly WNDPROC _newWndProc;
 
@@ -286,12 +287,16 @@ namespace Files.App.Data.Items
 
 		private void WindowEx_Closed(object sender, WindowEventArgs args)
 		{
+			_isClosing = true;
 			StoreWindowPlacementData();
 		}
 
 		private void WindowEx_Activated(object sender, WindowActivatedEventArgs args)
 		{
-			if (SystemBackdrop is AppSystemBackdrop appSystemBackdrop)
+			if (args.WindowActivationState is not WindowActivationState.Deactivated)
+				_isClosing = false;
+
+			if (!_isClosing && SystemBackdrop is AppSystemBackdrop appSystemBackdrop)
 				appSystemBackdrop.SetInputActive(args.WindowActivationState is not WindowActivationState.Deactivated);
 		}
 


### PR DESCRIPTION
WinUI raises a final `Deactivated` event during window destruction, but the handler was querying `SystemBackdrop` after its native window had begun teardown so that it could lead to null pointer access.