### PR TITLE
Fix: Fixed the most frequent crashes in the preview release

### DIFF
--- a/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
+++ b/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
@@ -798,9 +798,9 @@ namespace Files.App.Data.Models
 
 		private static readonly Dictionary<SHOW_WINDOW_CMD, string> showWindowCommandTypes = new()
 		{
-			{ SHOW_WINDOW_CMD.SW_NORMAL, Strings.NormalWindow.GetLocalizedResource() },
-			{ SHOW_WINDOW_CMD.SW_SHOWMINNOACTIVE, Strings.Minimized.GetLocalizedResource() },
-			{ SHOW_WINDOW_CMD.SW_MAXIMIZE, Strings.Maximized.GetLocalizedResource() }
+			[SHOW_WINDOW_CMD.SW_NORMAL] = Strings.NormalWindow.GetLocalizedResource(),
+			[SHOW_WINDOW_CMD.SW_SHOWMINNOACTIVE] = Strings.Minimized.GetLocalizedResource(),
+			[SHOW_WINDOW_CMD.SW_MAXIMIZE] = Strings.Maximized.GetLocalizedResource()
 		};
 
 		/// <summary>

--- a/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
+++ b/src/Files.App/Data/Models/SelectedItemsPropertiesViewModel.cs
@@ -796,17 +796,17 @@ namespace Files.App.Data.Models
 			set => SetProperty(ref runAsAdminEnabled, value);
 		}
 
-		private static readonly IReadOnlyDictionary<SHOW_WINDOW_CMD, string> showWindowCommandTypes = new Dictionary<SHOW_WINDOW_CMD, string>
+		private static readonly Dictionary<SHOW_WINDOW_CMD, string> showWindowCommandTypes = new()
 		{
 			{ SHOW_WINDOW_CMD.SW_NORMAL, Strings.NormalWindow.GetLocalizedResource() },
 			{ SHOW_WINDOW_CMD.SW_SHOWMINNOACTIVE, Strings.Minimized.GetLocalizedResource() },
 			{ SHOW_WINDOW_CMD.SW_MAXIMIZE, Strings.Maximized.GetLocalizedResource() }
-		}.AsReadOnly();
+		};
 
 		/// <summary>
 		/// The available show window command types.
 		/// </summary>
-		public IReadOnlyDictionary<SHOW_WINDOW_CMD, string> ShowWindowCommandTypes { get => showWindowCommandTypes; }
+		public Dictionary<SHOW_WINDOW_CMD, string> ShowWindowCommandTypes { get => showWindowCommandTypes; }
 
 		/// <summary>
 		/// The localized string of the currently selected ShowWindowCommand.

--- a/src/Files.App/Package.appxmanifest
+++ b/src/Files.App/Package.appxmanifest
@@ -16,7 +16,7 @@
     <Identity
         Name="FilesDev"
         Publisher="CN=Files"
-        Version="4.2.14.0" />
+        Version="4.2.15.0" />
 
     <Properties>
         <DisplayName>Files - Dev</DisplayName>

--- a/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
+++ b/src/Files.App/Utils/Storage/Operations/ShellFilesystemOperations.cs
@@ -186,7 +186,7 @@ namespace Files.App.Utils.Storage
 						.Select(item => item.Source)
 						.WhereNotNull();
 
-					await Ioc.Default.GetRequiredService<IDialogService>().ShowDialogAsync(new FileTooLargeDialogViewModel(failingItems));
+					await Ioc.Default.GetRequiredService<IDialogService>().ShowDialogAsync(new FileTooLargeDialogViewModel(failingItems.ToArray()));
 				}
 				// ADS
 				else if (copyResult.Items.All(x => x.HResult == -1))

--- a/src/Files.App/Utils/Storage/StorageBaseItems/BaseBasicStorageItemExtraProperties.cs
+++ b/src/Files.App/Utils/Storage/StorageBaseItems/BaseBasicStorageItemExtraProperties.cs
@@ -16,22 +16,22 @@ namespace Files.App.Utils.Storage
 			_item = item;
 		}
 
-		public override IAsyncOperation<IDictionary<string, object>> RetrievePropertiesAsync(IEnumerable<string> propertiesToRetrieve)
+		public override IAsyncOperation<IDictionary<string, object?>> RetrievePropertiesAsync(IEnumerable<string> propertiesToRetrieve)
 		{
-			return AsyncInfo.Run<IDictionary<string, object>>(async (cancellationToken) =>
+			return AsyncInfo.Run<IDictionary<string, object?>>(async (cancellationToken) =>
 			{
-				var props = new Dictionary<string, object>();
+				var props = new Dictionary<string, object?>();
 
-				propertiesToRetrieve.ForEach(x => props.SetNullablePropertyValue(x, null));
+				propertiesToRetrieve.ForEach(x => props[x] = null);
 
 				// Fill out common properties
 				var ret = _item.AsBaseStorageFile()?.GetBasicPropertiesAsync() ?? _item.AsBaseStorageFolder()?.GetBasicPropertiesAsync();
 
 				var basicProps = ret is not null ? await ret : null;
 
-				props.SetNullablePropertyValue("System.ParsingPath", _item.Path);
-				props.SetNullablePropertyValue("System.DateCreated", basicProps?.DateCreated);
-				props.SetNullablePropertyValue("System.DateModified", basicProps?.DateModified);
+				props["System.ParsingPath"] = _item.Path;
+				props["System.DateCreated"] = basicProps?.DateCreated;
+				props["System.DateModified"] = basicProps?.DateModified;
 
 				return props;
 			});

--- a/src/Files.App/Utils/Storage/StorageBaseItems/BaseStorageItemExtraProperties.cs
+++ b/src/Files.App/Utils/Storage/StorageBaseItems/BaseStorageItemExtraProperties.cs
@@ -10,15 +10,15 @@ namespace Files.App.Utils.Storage
 {
 	public partial class BaseStorageItemExtraProperties : IStorageItemExtraProperties
 	{
-		public virtual IAsyncOperation<IDictionary<string, object>> RetrievePropertiesAsync(IEnumerable<string> propertiesToRetrieve)
+		public virtual IAsyncOperation<IDictionary<string, object?>> RetrievePropertiesAsync(IEnumerable<string> propertiesToRetrieve)
 		{
 			return
 				AsyncInfo.Run((cancellationToken) =>
 				{
-					var props = new Dictionary<string, object>();
-					propertiesToRetrieve.ForEach(x => props.SetNullablePropertyValue(x, null));
+					var props = new Dictionary<string, object?>();
+					propertiesToRetrieve.ForEach(x => props[x] = null);
 
-					return Task.FromResult<IDictionary<string, object>>(props);
+					return Task.FromResult<IDictionary<string, object?>>(props);
 				});
 		}
 
@@ -27,33 +27,10 @@ namespace Files.App.Utils.Storage
 			return Task.CompletedTask.AsAsyncAction();
 		}
 
-		public virtual IAsyncAction SavePropertiesAsync([HasVariant] IEnumerable<KeyValuePair<string, object>> propertiesToSave)
+		public virtual IAsyncAction SavePropertiesAsync([HasVariant] IEnumerable<KeyValuePair<string, object?>> propertiesToSave)
 		{
 			return Task.CompletedTask.AsAsyncAction();
 		}
 
-	}
-
-	public static class StorageItemExtraPropertiesExtensions
-	{
-		public static IAsyncAction SaveNullablePropertiesAsync(
-			this IStorageItemExtraProperties properties,
-			IEnumerable<KeyValuePair<string, object?>> propertiesToSave)
-		{
-			return properties.SavePropertiesAsync(propertiesToSave.Select(
-				static property => new KeyValuePair<string, object>(property.Key, ToWinRtPropertyValue(property.Value))));
-		}
-
-		internal static void SetNullablePropertyValue(
-			this IDictionary<string, object> properties,
-			string name,
-			object? value)
-		{
-			properties[name] = ToWinRtPropertyValue(value);
-		}
-
-		// WinRT property bags use null for unavailable values despite the projected object contract.
-		private static object ToWinRtPropertyValue(object? value)
-			=> value!;
 	}
 }

--- a/src/Files.App/Utils/Storage/StorageItems/SystemStorageFile.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/SystemStorageFile.cs
@@ -221,12 +221,12 @@ namespace Files.App.Utils.Storage
 				this.dateCreated = dateCreated;
 			}
 
-			public override IAsyncOperation<IDictionary<string, object>> RetrievePropertiesAsync(IEnumerable<string> propertiesToRetrieve)
+			public override IAsyncOperation<IDictionary<string, object?>> RetrievePropertiesAsync(IEnumerable<string> propertiesToRetrieve)
 				=> basicProps.RetrievePropertiesAsync(propertiesToRetrieve);
 
 			public override IAsyncAction SavePropertiesAsync()
 				=> basicProps.SavePropertiesAsync();
-			public override IAsyncAction SavePropertiesAsync([HasVariant] IEnumerable<KeyValuePair<string, object>> propertiesToSave)
+			public override IAsyncAction SavePropertiesAsync([HasVariant] IEnumerable<KeyValuePair<string, object?>> propertiesToSave)
 				=> basicProps.SavePropertiesAsync(propertiesToSave);
 		}
 	}

--- a/src/Files.App/Utils/Storage/StorageItems/SystemStorageFolder.cs
+++ b/src/Files.App/Utils/Storage/StorageItems/SystemStorageFolder.cs
@@ -185,12 +185,12 @@ namespace Files.App.Utils.Storage
 				this.dateCreated = dateCreated;
 			}
 
-			public override IAsyncOperation<IDictionary<string, object>> RetrievePropertiesAsync(IEnumerable<string> propertiesToRetrieve)
+			public override IAsyncOperation<IDictionary<string, object?>> RetrievePropertiesAsync(IEnumerable<string> propertiesToRetrieve)
 				=> basicProps.RetrievePropertiesAsync(propertiesToRetrieve);
 
 			public override IAsyncAction SavePropertiesAsync()
 				=> basicProps.SavePropertiesAsync();
-			public override IAsyncAction SavePropertiesAsync([HasVariant] IEnumerable<KeyValuePair<string, object>> propertiesToSave)
+			public override IAsyncAction SavePropertiesAsync([HasVariant] IEnumerable<KeyValuePair<string, object?>> propertiesToSave)
 				=> basicProps.SavePropertiesAsync(propertiesToSave);
 		}
 	}

--- a/src/Files.App/ViewModels/Dialogs/FileTooLargeDialogViewModel.cs
+++ b/src/Files.App/ViewModels/Dialogs/FileTooLargeDialogViewModel.cs
@@ -5,9 +5,9 @@ namespace Files.App.ViewModels.Dialogs
 {
 	public sealed partial class FileTooLargeDialogViewModel : ObservableObject
 	{
-		public IEnumerable<string> Paths { get; private set; }
+		public string[] Paths { get; private set; }
 
-		public FileTooLargeDialogViewModel(IEnumerable<string> paths)
+		public FileTooLargeDialogViewModel(string[] paths)
 		{
 			Paths = paths;
 		}

--- a/src/Files.App/ViewModels/MainPageViewModel.cs
+++ b/src/Files.App/ViewModels/MainPageViewModel.cs
@@ -117,15 +117,33 @@ namespace Files.App.ViewModels
 			context.PageType is not ContentPageTypes.ReleaseNotes &&
 			context.PageType is not ContentPageTypes.Settings;
 
+		private bool canShowPrompts;
+
+		public void OnPageLoaded()
+		{
+			if (canShowPrompts)
+				return;
+
+			canShowPrompts = true;
+			OnPropertyChanged(nameof(ShowReviewPrompt));
+			OnPropertyChanged(nameof(ShowSponsorPrompt));
+		}
+
+		private static bool hasShownReviewPrompt;
+
 		public bool ShowReviewPrompt
 		{
 			get
 			{
+				if (!canShowPrompts || hasShownReviewPrompt)
+					return false;
+
 				var isTargetEnvironment = AppLifecycleHelper.AppEnvironment is AppEnvironment.StoreStable or AppEnvironment.StorePreview;
 				var hasClickedReviewPrompt = UserSettingsService.ApplicationSettingsService.HasClickedReviewPrompt;
 				var launchCountReached = AppLifecycleHelper.TotalLaunchCount == 30;
 
-				return isTargetEnvironment && !hasClickedReviewPrompt && launchCountReached;
+				hasShownReviewPrompt = isTargetEnvironment && !hasClickedReviewPrompt && launchCountReached;
+				return hasShownReviewPrompt;
 			}
 		}
 
@@ -136,7 +154,7 @@ namespace Files.App.ViewModels
 		{
 			get
 			{
-				if (hasShownSponsorPrompt)
+				if (!canShowPrompts || hasShownSponsorPrompt)
 					return false;
 
 				var isTargetEnvironment = AppLifecycleHelper.AppEnvironment is AppEnvironment.Dev or AppEnvironment.SideloadStable or AppEnvironment.SideloadPreview;

--- a/src/Files.App/ViewModels/Properties/Items/CombinedFileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/CombinedFileProperties.cs
@@ -120,7 +120,7 @@ namespace Files.App.ViewModels.Properties
 							{
 								if (file.Properties is not null)
 								{
-									await file.Properties.SaveNullablePropertiesAsync(newDict);
+									await file.Properties.SavePropertiesAsync(newDict);
 								}
 							}
 							catch
@@ -171,7 +171,7 @@ namespace Files.App.ViewModels.Properties
 							{
 								if (file.Properties is not null)
 								{
-									await file.Properties.SaveNullablePropertiesAsync(newDict);
+									await file.Properties.SavePropertiesAsync(newDict);
 								}
 							}
 							catch

--- a/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperties.cs
@@ -232,7 +232,7 @@ namespace Files.App.ViewModels.Properties
 						{
 							if (file.Properties is not null)
 							{
-								await file.Properties.SaveNullablePropertiesAsync(newDict);
+								await file.Properties.SavePropertiesAsync(newDict);
 							}
 						}
 						catch
@@ -274,7 +274,7 @@ namespace Files.App.ViewModels.Properties
 						{
 							if (file.Properties is not null)
 							{
-								await file.Properties.SaveNullablePropertiesAsync(newDict);
+								await file.Properties.SavePropertiesAsync(newDict);
 							}
 						}
 						catch

--- a/src/Files.App/ViewModels/Properties/Items/FileProperty.cs
+++ b/src/Files.App/ViewModels/Properties/Items/FileProperty.cs
@@ -182,7 +182,7 @@ namespace Files.App.ViewModels.Properties
 				{ Property, converter.ConvertBack(Value, null, null, null) }
 			};
 
-			return file.Properties.SaveNullablePropertiesAsync(propsToSave).AsTask();
+			return file.Properties.SavePropertiesAsync(propsToSave).AsTask();
 		}
 
 		/// <summary>

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -924,6 +924,9 @@ namespace Files.App.ViewModels
 
 		public void CancelExtendedPropertiesLoading()
 		{
+			if (isDisposed)
+				return;
+
 			loadPropsCTS.Cancel();
 			loadPropsCTS = new CancellationTokenSource();
 		}
@@ -1505,13 +1508,16 @@ namespace Files.App.ViewModels
 			if (item is null)
 				return;
 
+			if (isDisposed)
+				return;
+
 			itemLoadQueue[item.GetRequiredPath()] = false;
 
-			var cts = loadPropsCTS;
+			var token = loadPropsCTS.Token;
 
 			try
 			{
-				cts.Token.ThrowIfCancellationRequested();
+				token.ThrowIfCancellationRequested();
 				if (itemLoadQueue.TryGetValue(item.GetRequiredPath(), out var canceled) && canceled)
 					return;
 
@@ -1531,18 +1537,18 @@ namespace Files.App.ViewModels
 						loadGroupHeaderInfo = gp is not null && !gp.Model.Initialized && gp.GetExtendedGroupHeaderInfo is not null;
 					}
 
-					cts.Token.ThrowIfCancellationRequested();
-					await LoadThumbnailAsync(item, cts.Token);
+					token.ThrowIfCancellationRequested();
+					await LoadThumbnailAsync(item, token);
 
-					cts.Token.ThrowIfCancellationRequested();
+					token.ThrowIfCancellationRequested();
 					if (item.IsLibrary || item.PrimaryItemAttribute == StorageItemTypes.File || item.IsArchive)
 					{
 						if (!item.IsShortcut && !FtpHelpers.IsFtpPath(item.ItemPath))
 						{
-							matchingStorageFile = await GetFileFromPathAsync(item.GetRequiredPath(), cts.Token);
+							matchingStorageFile = await GetFileFromPathAsync(item.GetRequiredPath(), token);
 							if (matchingStorageFile is not null)
 							{
-								cts.Token.ThrowIfCancellationRequested();
+								token.ThrowIfCancellationRequested();
 
 								var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageFile);
 								var fileFRN = await FileTagsHelper.GetFileFRN(matchingStorageFile);
@@ -1550,7 +1556,7 @@ namespace Files.App.ViewModels
 								var itemType = (item.ItemType == Strings.Folder.GetLocalizedResource()) ? item.ItemType : matchingStorageFile.DisplayType;
 								var extraProperties = await GetExtraProperties(matchingStorageFile);
 
-								cts.Token.ThrowIfCancellationRequested();
+								token.ThrowIfCancellationRequested();
 
 								await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 								{
@@ -1597,12 +1603,12 @@ namespace Files.App.ViewModels
 					{
 						if (!item.IsShortcut && !item.IsHiddenItem && !FtpHelpers.IsFtpPath(item.ItemPath))
 						{
-							BaseStorageFolder? matchingStorageFolder = await GetFolderFromPathAsync(item.GetRequiredPath(), cts.Token);
+							BaseStorageFolder? matchingStorageFolder = await GetFolderFromPathAsync(item.GetRequiredPath(), token);
 							if (matchingStorageFolder is not null)
 							{
 								if (matchingStorageFolder.DisplayName != item.Name && !matchingStorageFolder.DisplayName.StartsWith("$R", StringComparison.Ordinal))
 								{
-									cts.Token.ThrowIfCancellationRequested();
+									token.ThrowIfCancellationRequested();
 									await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 									{
 										item.ItemNameRaw = matchingStorageFolder.DisplayName;
@@ -1615,14 +1621,14 @@ namespace Files.App.ViewModels
 									}
 								}
 
-								cts.Token.ThrowIfCancellationRequested();
+								token.ThrowIfCancellationRequested();
 								var syncStatus = await CheckCloudDriveSyncStatusAsync(matchingStorageFolder);
 								var fileFRN = await FileTagsHelper.GetFileFRN(matchingStorageFolder);
 								var fileTag = await Task.Run(() => FileTagsHelper.ReadFileTag(item.GetRequiredPath()));
 								var itemType = (item.ItemType == Strings.Folder.GetLocalizedResource()) ? item.ItemType : matchingStorageFolder.DisplayType;
 								var extraProperties = await GetExtraProperties(matchingStorageFolder);
 
-								cts.Token.ThrowIfCancellationRequested();
+								token.ThrowIfCancellationRequested();
 
 								await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 								{
@@ -1677,7 +1683,7 @@ namespace Files.App.ViewModels
 				{
 					if (!wasSyncStatusLoaded)
 					{
-						cts.Token.ThrowIfCancellationRequested();
+						token.ThrowIfCancellationRequested();
 						await FilesystemTasks.Wrap(async () =>
 						{
 							var fileTag = await Task.Run(() => FileTagsHelper.ReadFileTag(item.GetRequiredPath()));
@@ -1702,8 +1708,8 @@ namespace Files.App.ViewModels
 							_ = Task.Run(async () =>
 							{
 								await Task.Delay(500);
-								cts.Token.ThrowIfCancellationRequested();
-								await LoadThumbnailAsync(item, cts.Token);
+								token.ThrowIfCancellationRequested();
+								await LoadThumbnailAsync(item, token);
 							});
 						}
 					}
@@ -1712,7 +1718,7 @@ namespace Files.App.ViewModels
 					{
 						var group = gp
 							?? throw new InvalidOperationException("The item group is unavailable while loading its header.");
-						cts.Token.ThrowIfCancellationRequested();
+						token.ThrowIfCancellationRequested();
 						await SafetyExtensions.IgnoreExceptions(() =>
 							dispatcherQueue.EnqueueOrInvokeAsync(() =>
 							{
@@ -1784,7 +1790,10 @@ namespace Files.App.ViewModels
 			if (!getStatus && !getCommit)
 				return;
 
-			var cts = loadPropsCTS;
+			if (isDisposed)
+				return;
+
+			var token = loadPropsCTS.Token;
 			var semaphoreEntered = false;
 			var propertiesLoaded = false;
 			if (getStatus)
@@ -1794,26 +1803,26 @@ namespace Files.App.ViewModels
 
 			try
 			{
-				await gitPropertiesSemaphore.WaitAsync(cts.Token);
+				await gitPropertiesSemaphore.WaitAsync(token);
 				semaphoreEntered = true;
 
 				var gitItemModel = await Task.Run(() =>
 				{
-					cts.Token.ThrowIfCancellationRequested();
+					token.ThrowIfCancellationRequested();
 					if (!GitHelpers.IsRepositoryEx(gitItem.ItemPath, out var repositoryPath))
 						return null;
 
 					using var repository = new Repository(repositoryPath);
 					return GitHelpers.GetGitInformationForItem(repository, gitItem.ItemPath, getStatus, getCommit);
-				}, cts.Token);
+				}, token);
 
 				if (gitItemModel is null)
 					return;
 
-				cts.Token.ThrowIfCancellationRequested();
+				token.ThrowIfCancellationRequested();
 				await dispatcherQueue.EnqueueOrInvokeAsync(() =>
 				{
-					cts.Token.ThrowIfCancellationRequested();
+					token.ThrowIfCancellationRequested();
 
 					if (getStatus)
 					{
@@ -1842,7 +1851,7 @@ namespace Files.App.ViewModels
 
 				propertiesLoaded = true;
 			}
-			catch (OperationCanceledException) when (cts.IsCancellationRequested)
+			catch (OperationCanceledException) when (token.IsCancellationRequested)
 			{
 			}
 			catch (Exception ex)
@@ -1919,6 +1928,9 @@ namespace Files.App.ViewModels
 
 		private async Task RapidAddItemsToCollectionAsync(string? path, string? previousDir, Action? postLoadCallback)
 		{
+			if (isDisposed)
+				return;
+
 			IsSearchResults = false;
 			HasNoWatcher = false;
 			IsLocationUnavailable = false;

--- a/src/Files.App/Views/Layouts/BaseLayoutPage.cs
+++ b/src/Files.App/Views/Layouts/BaseLayoutPage.cs
@@ -1034,7 +1034,7 @@ namespace Files.App.Views.Layouts
 					else
 					{
 						// Only support IStorageItem capable paths
-						var storageItemList = orderedItems.Where(x => !(x.IsHiddenItem && x.IsLinkItem && x.IsRecycleBinItem && x.IsShortcut)).Select(x => VirtualStorageItem.FromListedItem(x));
+						var storageItemList = orderedItems.Where(x => !(x.IsHiddenItem && x.IsLinkItem && x.IsRecycleBinItem && x.IsShortcut)).Select(x => VirtualStorageItem.FromListedItem(x)).ToArray();
 						e.Data.SetStorageItems(storageItemList, false);
 					}
 				}

--- a/src/Files.App/Views/MainPage.xaml.cs
+++ b/src/Files.App/Views/MainPage.xaml.cs
@@ -326,6 +326,8 @@ namespace Files.App.Views
 
 		private void Page_Loaded(object sender, RoutedEventArgs e)
 		{
+			ViewModel.OnPageLoaded();
+
 			MainWindow.Instance.AppWindow.Changed += (_, _) => MainWindow.Instance.RaiseSetTitleBarDragRegion(SetTitleBarDragRegion);
 
 			// Defers loading until after the page has loaded to improve startup perf


### PR DESCRIPTION
- Fixed a startup crash (COMException 0x8000FFFF "XamlRoot must be explicitly set for unparented popup") caused by the review/sponsor TeachingTips opening during the initial x:Bind pass, before the page had a XamlRoot; prompts now open only after MainPage is loaded, once per session
- Fixed an ObjectDisposedException when layout pages called CancelExtendedPropertiesLoading after the ShellViewModel was disposed; added isDisposed guards and switched LoadExtendedItemPropertiesAsync / LoadGitPropertiesAsync to capture the CancellationToken instead of the source
- Fixed an ObjectDisposedException when a refresh started on a disposed ShellViewModel by guarding RapidAddItemsToCollectionAsync
- Fixed a crash (ArgumentException 0x80070057) when opening shortcut properties in the NativeAOT build; ReadOnlyDictionary's value collection can't be bound to ItemsSource, replaced with a plain Dictionary
