### PR TITLE
Upload debug symbols to Sentry for better stacktrace

### DIFF
--- a/.github/workflows/cd-sideload-preview.yml
+++ b/.github/workflows/cd-sideload-preview.yml
@@ -75,7 +75,6 @@ jobs:
         -t:Restore `
         -p:Platform=$env:PLATFORM `
         -p:Configuration=$env:CONFIGURATION `
-        -p:PublishReadyToRun=true `
         -v:quiet
 
     - name: Restore NuGet Packages for Launcher Project
@@ -121,6 +120,10 @@ jobs:
 
     - name: Build & package Files
       shell: pwsh
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
       run: |
         $platforms = "$env:APPX_BUNDLE_PLATFORMS" -split '\|'
         foreach ($plat in $platforms) {
@@ -129,6 +132,10 @@ jobs:
             -t:Build `
             -p:Platform=$plat `
             -p:Configuration=$env:CONFIGURATION `
+            -p:SentryUploadSymbols=true `
+            -p:SentryOrg="$env:SENTRY_ORG" `
+            -p:SentryProject="$env:SENTRY_PROJECT" `
+            -p:SentryCLIUploadOptions=--wait `
             -p:AppxPackageDir="$env:APPX_PACKAGE_DIR" `
             -p:AppxBundle=Never `
             -p:GenerateAppxPackageOnBuild=true `

--- a/.github/workflows/cd-sideload-stable.yml
+++ b/.github/workflows/cd-sideload-stable.yml
@@ -75,7 +75,6 @@ jobs:
         -t:Restore `
         -p:Platform=$env:PLATFORM `
         -p:Configuration=$env:CONFIGURATION `
-        -p:PublishReadyToRun=true `
         -v:quiet
 
     - name: Restore NuGet Packages for Launcher Project
@@ -121,6 +120,10 @@ jobs:
 
     - name: Build & package Files
       shell: pwsh
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
       run: |
         $platforms = "$env:APPX_BUNDLE_PLATFORMS" -split '\|'
         foreach ($plat in $platforms) {
@@ -129,6 +132,10 @@ jobs:
             -t:Build `
             -p:Platform=$plat `
             -p:Configuration=$env:CONFIGURATION `
+            -p:SentryUploadSymbols=true `
+            -p:SentryOrg="$env:SENTRY_ORG" `
+            -p:SentryProject="$env:SENTRY_PROJECT" `
+            -p:SentryCLIUploadOptions=--wait `
             -p:AppxPackageDir="$env:APPX_PACKAGE_DIR" `
             -p:AppxBundle=Never `
             -p:GenerateAppxPackageOnBuild=true `

--- a/.github/workflows/cd-store-preview.yml
+++ b/.github/workflows/cd-store-preview.yml
@@ -72,7 +72,6 @@ jobs:
         -t:Restore `
         -p:Platform=$env:PLATFORM `
         -p:Configuration=$env:CONFIGURATION `
-        -p:PublishReadyToRun=true `
         -v:quiet
 
     - name: Restore NuGet Packages for Launcher Project
@@ -118,6 +117,10 @@ jobs:
 
     - name: Build & package Files
       shell: pwsh
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
       run: |
         $platforms = "$env:APPX_BUNDLE_PLATFORMS" -split '\|'
         foreach ($plat in $platforms) {
@@ -126,6 +129,10 @@ jobs:
             -t:Build `
             -p:Platform=$plat `
             -p:Configuration=$env:CONFIGURATION `
+            -p:SentryUploadSymbols=true `
+            -p:SentryOrg="$env:SENTRY_ORG" `
+            -p:SentryProject="$env:SENTRY_PROJECT" `
+            -p:SentryCLIUploadOptions=--wait `
             -p:AppxPackageDir="$env:APPX_PACKAGE_DIR" `
             -p:AppxBundle=Never `
             -p:GenerateAppxPackageOnBuild=true `

--- a/.github/workflows/cd-store-stable.yml
+++ b/.github/workflows/cd-store-stable.yml
@@ -72,7 +72,6 @@ jobs:
         -t:Restore `
         -p:Platform=$env:PLATFORM `
         -p:Configuration=$env:CONFIGURATION `
-        -p:PublishReadyToRun=true `
         -v:quiet
 
     - name: Restore NuGet Packages for Launcher Project
@@ -118,6 +117,10 @@ jobs:
 
     - name: Build & package Files
       shell: pwsh
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+        SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
       run: |
         $platforms = "$env:APPX_BUNDLE_PLATFORMS" -split '\|'
         foreach ($plat in $platforms) {
@@ -126,6 +129,10 @@ jobs:
             -t:Build `
             -p:Platform=$plat `
             -p:Configuration=$env:CONFIGURATION `
+            -p:SentryUploadSymbols=true `
+            -p:SentryOrg="$env:SENTRY_ORG" `
+            -p:SentryProject="$env:SENTRY_PROJECT" `
+            -p:SentryCLIUploadOptions=--wait `
             -p:AppxPackageDir="$env:APPX_PACKAGE_DIR" `
             -p:AppxBundle=Never `
             -p:GenerateAppxPackageOnBuild=true `

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,6 @@ jobs:
           -t:Restore `
           -p:Platform=$env:ARCHITECTURE `
           -p:Configuration=$env:CONFIGURATION `
-          -p:PublishReadyToRun=true `
           -v:quiet
 
     - if: env.CONFIGURATION != env.AUTOMATED_TESTS_CONFIGURATION

--- a/src/Files.App.Server/Files.App.Server.csproj
+++ b/src/Files.App.Server/Files.App.Server.csproj
@@ -20,13 +20,8 @@
         <CsWinRTComponent>true</CsWinRTComponent>
         <CsWinRTWindowsMetadata>$(TargetWindowsVersion)</CsWinRTWindowsMetadata>
         <ApplicationManifest>app.manifest</ApplicationManifest>
-        <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-        <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-        <PublishReadyToRunComposite Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRunComposite>
-        <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-        <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
+        <PublishAot>true</PublishAot>
         <CsWinRTEnableLogging>true</CsWinRTEnableLogging>
-        <IsAotCompatible>true</IsAotCompatible>
         <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
     </PropertyGroup>
 

--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -31,12 +31,7 @@
         <Configurations>Debug;Release</Configurations>
         <CsWinRTIncludes>Files.App.Server;Microsoft.UI.Content.ContentExternalOutputLink;Microsoft.UI.Content.IContentExternalOutputLink</CsWinRTIncludes>
         <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
-        <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-        <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-        <PublishReadyToRunComposite Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRunComposite>
         <ApplicationIcon>Assets\AppTiles\Dev\Logo.ico</ApplicationIcon>
-        <IsTrimmable>true</IsTrimmable>
-        <IsAotCompatible>true</IsAotCompatible>
         <IlcGenerateMstatFile>true</IlcGenerateMstatFile>
         <IlcGenerateDgmlFile>true</IlcGenerateDgmlFile>
     </PropertyGroup>

--- a/src/Files.App/Files.App.csproj
+++ b/src/Files.App/Files.App.csproj
@@ -25,7 +25,6 @@
         <Platforms>x86;x64;arm64</Platforms>
         <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
         <UseWinUI>true</UseWinUI>
-        <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <CETCompat>false</CETCompat>
         <Configurations>Debug;Release</Configurations>


### PR DESCRIPTION
### Resolved / Related Issues

- #4180

### Steps used to test these changes

_None_

---

@yair100 We need to set `SENTRY_AUTH_TOKEN` to Secrets and `SENTRY_ORG` and `SENTRY_PROJECT` to Variables in the Deployments env.

- https://docs.sentry.io/cli/configuration/
- https://github.com/getsentry/sentry-dotnet/blob/007c0b288685ec89272cdd0f8ac176871ca141bb/src/Sentry/buildTransitive/Sentry.targets#L58-L71

