### PR TITLE
Fix: Fixed shell path normalization and window close races

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -281,6 +281,9 @@ namespace Files.App
 		/// </remarks>
 		private async void Window_Closed(object sender, WindowEventArgs args)
 		{
+			// Stop dispatcher timers before the close handler yields and window teardown begins.
+			AppModel.IsMainWindowClosed = true;
+
 			// Save application state and stop any background activity
 			IUserSettingsService userSettingsService = Ioc.Default.GetRequiredService<IUserSettingsService>();
 			StatusCenterViewModel statusCenterViewModel = Ioc.Default.GetRequiredService<StatusCenterViewModel>();
@@ -335,7 +338,6 @@ namespace Files.App
 
 				// Cache the window instead of closing it
 				MainWindow.Instance.AppWindow.Hide();
-				AppModel.IsMainWindowClosed = true;
 
 				// Close all tabs
 				MainPageViewModel.AppInstances.ForEach(tabItem => tabItem.Unload());
@@ -401,7 +403,6 @@ namespace Files.App
 
 			// Destroy cached properties windows
 			FilePropertiesHelpers.DestroyCachedWindows();
-			AppModel.IsMainWindowClosed = true;
 
 			// Wait for ongoing file operations
 			FileOperationsHelpers.WaitForCompletion();

--- a/src/Files.App/Data/EventArguments/NavigationArguments.cs
+++ b/src/Files.App/Data/EventArguments/NavigationArguments.cs
@@ -7,13 +7,21 @@ namespace Files.App.Data.EventArguments
 	{
 		public bool FocusOnNavigation { get; set; } = false;
 
-		public string? NavPathParam { get; set; } = null;
+		public string? NavPathParam
+		{
+			get;
+			set => field = value is null ? null : ShellHelpers.ResolveShellPath(value);
+		}
 
 		public IShellPage? AssociatedTabInstance { get; set; }
 
 		public bool IsSearchResultPage { get; set; } = false;
 
-		public string? SearchPathParam { get; set; } = null;
+		public string? SearchPathParam
+		{
+			get;
+			set => field = value is null ? null : ShellHelpers.ResolveShellPath(value);
+		}
 
 		public string? SearchQuery { get; set; } = null;
 

--- a/src/Files.App/MainWindow.xaml.cs
+++ b/src/Files.App/MainWindow.xaml.cs
@@ -273,7 +273,7 @@ namespace Files.App
 			{
 				if (!string.IsNullOrEmpty(payload))
 				{
-					payload = Constants.UserEnvironmentPaths.ShellPlaces.Get(payload.ToUpperInvariant(), payload) ?? payload;
+					payload = ShellHelpers.ResolveShellPath(payload);
 					var folderResult = await FilesystemTasks.Wrap(() => StorageFolder.GetFolderFromPathAsync(payload).AsTask());
 					if (folderResult.Result is { } folder && !string.IsNullOrEmpty(folder.Path))
 						payload = folder.Path; // Convert short name to long name (#6190)

--- a/src/Files.App/Program.cs
+++ b/src/Files.App/Program.cs
@@ -159,7 +159,7 @@ namespace Files.App
 						switch (command.Type)
 						{
 							case ParsedCommandType.ExplorerShellCommand:
-								if (!Constants.UserEnvironmentPaths.ShellPlaces.ContainsKey(command.Payload.ToUpperInvariant()))
+								if (!ShellHelpers.IsSupportedShellPath(command.Payload))
 								{
 									OpenShellCommandInExplorer(command.Payload, Environment.ProcessId);
 									return;

--- a/src/Files.App/Utils/Shell/ShellHelpers.cs
+++ b/src/Files.App/Utils/Shell/ShellHelpers.cs
@@ -9,6 +9,17 @@ namespace Files.App.Utils.Shell
 	{
 		public static string ResolveShellPath(string shPath)
 		{
+			if (!ShellStorageFolder.IsShellPath(shPath))
+				return shPath;
+
+			var lookupPath = shPath.StartsWith("shell:::", StringComparison.OrdinalIgnoreCase)
+				? shPath.Substring("shell:".Length)
+				: shPath;
+
+			shPath = Constants.UserEnvironmentPaths.ShellPlaces.GetValueOrDefault(
+				lookupPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToUpperInvariant(),
+				shPath);
+
 			if (shPath.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
 				return Constants.UserEnvironmentPaths.RecycleBinPath;
 
@@ -19,6 +30,12 @@ namespace Files.App.Utils.Shell
 				return Constants.UserEnvironmentPaths.NetworkFolderPath;
 
 			return shPath;
+		}
+
+		public static bool IsSupportedShellPath(string shPath)
+		{
+			var resolvedPath = ResolveShellPath(shPath);
+			return Constants.UserEnvironmentPaths.ShellPlaces.Values.Contains(resolvedPath, StringComparer.OrdinalIgnoreCase);
 		}
 
 		public static string GetShellNameFromPath(string shPath)

--- a/src/Files.App/Utils/Shell/ShellHelpers.cs
+++ b/src/Files.App/Utils/Shell/ShellHelpers.cs
@@ -12,12 +12,8 @@ namespace Files.App.Utils.Shell
 			if (!ShellStorageFolder.IsShellPath(shPath))
 				return shPath;
 
-			var lookupPath = shPath.StartsWith("shell:::", StringComparison.OrdinalIgnoreCase)
-				? shPath.Substring("shell:".Length)
-				: shPath;
-
 			shPath = Constants.UserEnvironmentPaths.ShellPlaces.GetValueOrDefault(
-				lookupPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToUpperInvariant(),
+				GetShellPathLookupKey(shPath),
 				shPath);
 
 			if (shPath.StartsWith(Constants.UserEnvironmentPaths.RecycleBinPath, StringComparison.OrdinalIgnoreCase))
@@ -34,8 +30,17 @@ namespace Files.App.Utils.Shell
 
 		public static bool IsSupportedShellPath(string shPath)
 		{
-			var resolvedPath = ResolveShellPath(shPath);
-			return Constants.UserEnvironmentPaths.ShellPlaces.Values.Contains(resolvedPath, StringComparer.OrdinalIgnoreCase);
+			return ShellStorageFolder.IsShellPath(shPath) &&
+				Constants.UserEnvironmentPaths.ShellPlaces.ContainsKey(GetShellPathLookupKey(shPath));
+		}
+
+		private static string GetShellPathLookupKey(string shPath)
+		{
+			var lookupPath = shPath.StartsWith("shell:::", StringComparison.OrdinalIgnoreCase)
+				? shPath.Substring("shell:".Length)
+				: shPath;
+
+			return lookupPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToUpperInvariant();
 		}
 
 		public static string GetShellNameFromPath(string shPath)

--- a/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/FilePropertiesHelpers.cs
@@ -167,15 +167,13 @@ namespace Files.App.Utils.Storage
 				window.AppWindow.Hide();
 				window.Content = null;
 				WindowCache.Add(window);
-
-				if (App.AppModel.DecrementPropertiesWindowCount() == 0)
-				{
-					PropertiesWindowsClosingTCS!.TrySetResult();
-					PropertiesWindowsClosingTCS = null;
-				}
 			}
-			else
-				App.AppModel.DecrementPropertiesWindowCount();
+
+			if (App.AppModel.DecrementPropertiesWindowCount() == 0)
+			{
+				PropertiesWindowsClosingTCS?.TrySetResult();
+				PropertiesWindowsClosingTCS = null;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Normalize shell path so that GUID based path navigation can correctly resolve to shell path Files recognizes. 

Also, fix a silently crash on window close by setting `IsMainWindowClosed` earlier.