### PR TITLE
Feature: Support scrolling via scroll wheel while selecting items with rectangle

### DIFF
--- a/src/Files.App/UserControls/Selection/RectangleSelection_ListViewBase.cs
+++ b/src/Files.App/UserControls/Selection/RectangleSelection_ListViewBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using CommunityToolkit.WinUI;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -35,6 +36,59 @@ namespace Files.App.UserControls.Selection
 			InitEvents(null, null);
 		}
 
+		private void RectangleSelection_PointerWheelChanged(object sender, PointerRoutedEventArgs e)
+		{
+			if (scrollViewer is null || selectionState is SelectionState.Inactive)
+				return;
+
+			var currentPoint = e.GetCurrentPoint(uiElement);
+
+			// rebuild item bounds on Ctrl+wheel
+			if (e.KeyModifiers.HasFlag(VirtualKeyModifiers.Control))
+			{
+				DispatcherQueue.GetForCurrentThread().TryEnqueue(() =>
+				{
+					if (selectionState is SelectionState.Inactive)
+						return;
+
+					itemsPosition.Clear();
+					scrollViewer.UpdateLayout();
+					FetchItemsPosition();
+
+					if (selectionState is SelectionState.Active)
+						UpdateSelectionFromPointer(sender, currentPoint, scrollViewer.HorizontalOffset, scrollViewer.VerticalOffset);
+				});
+				return;
+			}
+
+			var delta = currentPoint.Properties.MouseWheelDelta;
+			if (delta == 0)
+				return;
+
+			var horizontalOffset = scrollViewer.HorizontalOffset;
+			var verticalOffset = scrollViewer.VerticalOffset;
+			var newHorizontalOffset = horizontalOffset;
+			var newVerticalOffset = verticalOffset;
+			if (scrollViewer.ScrollableHeight > 0)
+				newVerticalOffset = Math.Clamp(verticalOffset - delta, 0, scrollViewer.ScrollableHeight);
+			else if (scrollViewer.ScrollableWidth > 0)
+				newHorizontalOffset = Math.Clamp(horizontalOffset - delta, 0, scrollViewer.ScrollableWidth);
+
+			if (newHorizontalOffset != horizontalOffset || newVerticalOffset != verticalOffset)
+			{
+				scrollViewer.ChangeView(newHorizontalOffset, newVerticalOffset, null, true);
+				scrollViewer.UpdateLayout();
+				FetchItemsPosition();
+			}
+
+			if (selectionState is SelectionState.Starting)
+				ActivateSelection();
+
+			UpdateSelectionFromPointer(sender, currentPoint, newHorizontalOffset, newVerticalOffset);
+
+			e.Handled = true;
+		}
+
 		private void RectangleSelection_PointerMoved(object sender, PointerRoutedEventArgs e)
 		{
 			if (scrollViewer is null)
@@ -43,70 +97,95 @@ namespace Files.App.UserControls.Selection
 			}
 
 			var currentPoint = e.GetCurrentPoint(uiElement);
+			var horizontalOffset = scrollViewer.HorizontalOffset;
 			var verticalOffset = scrollViewer.VerticalOffset;
 			if (selectionState == SelectionState.Starting)
 			{
-				if (!HasMovedMinimalDelta(originDragPoint.X, originDragPoint.Y - verticalOffset, currentPoint.Position.X, currentPoint.Position.Y))
+				if (!HasMovedMinimalDelta(originDragPoint.X - horizontalOffset, originDragPoint.Y - verticalOffset, currentPoint.Position.X, currentPoint.Position.Y))
 				{
 					return;
 				}
 
-				// Clear selected items once if the pointer is pressed and moved
-				selectionStrategy!.StartSelection();
-				OnSelectionStarted();
-				selectionState = SelectionState.Active;
+				ActivateSelection();
 			}
 			if (currentPoint.Properties.IsLeftButtonPressed)
 			{
-				var originDragPointShifted = new Point(originDragPoint.X, originDragPoint.Y - verticalOffset); // Initial drag point relative to the topleft corner
-				base.DrawRectangle(currentPoint, originDragPointShifted, uiElement);
-				// Selected area considering scrolled offset
-				var rect = new System.Drawing.Rectangle((int)Canvas.GetLeft(selectionRectangle), (int)Math.Min(originDragPoint.Y, currentPoint.Position.Y + verticalOffset), (int)selectionRectangle.Width, (int)Math.Abs(originDragPoint.Y - (currentPoint.Position.Y + verticalOffset)));
+				UpdateSelectionFromPointer(sender, currentPoint, horizontalOffset, verticalOffset);
 
-				var selectedItemsBeforeChange = uiElement.SelectedItems.ToArray();
-
-				foreach (var item in itemsPosition.ToList())
-				{
-					try
-					{
-						if (rect.IntersectsWith(item.Value))
-						{
-							selectionStrategy!.HandleIntersectionWithItem(item.Key);
-						}
-						else
-						{
-							selectionStrategy!.HandleNoIntersectionWithItem(item.Key);
-						}
-					}
-					catch (ArgumentException)
-					{
-						// Item is not present in the ItemsSource
-						itemsPosition.Remove(item);
-					}
-				}
+				var newHorizontalOffset = horizontalOffset;
+				var newVerticalOffset = verticalOffset;
 				if (currentPoint.Position.Y > uiElement.ActualHeight - 20)
 				{
-					// Scroll down the list if pointer is at the bottom
-					var scrollIncrement = Math.Min(currentPoint.Position.Y - (uiElement.ActualHeight - 20), 40);
-					scrollViewer.ChangeView(null, verticalOffset + scrollIncrement, null, false);
+					newVerticalOffset += Math.Min(currentPoint.Position.Y - (uiElement.ActualHeight - 20), 40);
 				}
 				else if (currentPoint.Position.Y < 20)
 				{
-					// Scroll up the list if pointer is at the top
-					var scrollIncrement = Math.Min(20 - currentPoint.Position.Y, 40);
-					scrollViewer.ChangeView(null, verticalOffset - scrollIncrement, null, false);
+					newVerticalOffset -= Math.Min(20 - currentPoint.Position.Y, 40);
 				}
 
-				if (selectionChanged is not null)
+				if (currentPoint.Position.X > uiElement.ActualWidth - 20)
 				{
-					var currentSelectedItemsDrag = uiElement.SelectedItems.Cast<object>().ToList();
-					if (prevSelectedItemsDrag is null || !prevSelectedItemsDrag.SequenceEqual(currentSelectedItemsDrag))
+					newHorizontalOffset += Math.Min(currentPoint.Position.X - (uiElement.ActualWidth - 20), 40);
+				}
+				else if (currentPoint.Position.X < 20)
+				{
+					newHorizontalOffset -= Math.Min(20 - currentPoint.Position.X, 40);
+				}
+
+				newHorizontalOffset = Math.Clamp(newHorizontalOffset, 0, scrollViewer.ScrollableWidth);
+				newVerticalOffset = Math.Clamp(newVerticalOffset, 0, scrollViewer.ScrollableHeight);
+				if (newHorizontalOffset != horizontalOffset || newVerticalOffset != verticalOffset)
+					scrollViewer.ChangeView(newHorizontalOffset, newVerticalOffset, null, false);
+			}
+		}
+
+		private void ActivateSelection()
+		{
+			selectionStrategy!.StartSelection();
+			OnSelectionStarted();
+			selectionState = SelectionState.Active;
+		}
+
+		private void UpdateSelectionFromPointer(object sender, PointerPoint currentPoint, double horizontalOffset, double verticalOffset)
+		{
+			var originDragPointShifted = new Point(originDragPoint.X - horizontalOffset, originDragPoint.Y - verticalOffset); // Initial drag point relative to the topleft corner
+			DrawRectangle(currentPoint, originDragPointShifted, uiElement);
+			var currentX = currentPoint.Position.X + horizontalOffset;
+			var currentY = currentPoint.Position.Y + verticalOffset;
+			// Selected area considering scrolled offset
+			var rect = new System.Drawing.Rectangle((int)Math.Min(originDragPoint.X, currentX),(int)Math.Min(originDragPoint.Y, currentY), (int)Math.Abs(originDragPoint.X - currentX), (int)Math.Abs(originDragPoint.Y - currentY));
+
+			var selectedItemsBeforeChange = uiElement.SelectedItems.ToArray();
+
+			foreach (var item in itemsPosition.ToList())
+			{
+				try
+				{
+					if (rect.IntersectsWith(item.Value))
 					{
-						// Trigger SelectionChanged event if the selection has changed
-						var removedItems = selectedItemsBeforeChange.Except(currentSelectedItemsDrag).ToList();
-						selectionChanged(sender, new SelectionChangedEventArgs(removedItems, currentSelectedItemsDrag));
-						prevSelectedItemsDrag = currentSelectedItemsDrag;
+						selectionStrategy!.HandleIntersectionWithItem(item.Key);
 					}
+					else
+					{
+						selectionStrategy!.HandleNoIntersectionWithItem(item.Key);
+					}
+				}
+				catch (ArgumentException)
+				{
+					// Item is not present in the ItemsSource
+					itemsPosition.Remove(item);
+				}
+			}
+
+			if (selectionChanged is not null)
+			{
+				var currentSelectedItemsDrag = uiElement.SelectedItems.Cast<object>().ToList();
+				if (prevSelectedItemsDrag is null || !prevSelectedItemsDrag.SequenceEqual(currentSelectedItemsDrag))
+				{
+					// Trigger SelectionChanged event if the selection has changed
+					var removedItems = selectedItemsBeforeChange.Except(currentSelectedItemsDrag).ToList();
+					selectionChanged(sender, new SelectionChangedEventArgs(removedItems, currentSelectedItemsDrag));
+					prevSelectedItemsDrag = currentSelectedItemsDrag;
 				}
 			}
 		}
@@ -123,12 +202,13 @@ namespace Files.App.UserControls.Selection
 			scrollViewer.ViewChanged -= ScrollViewer_ViewChanged;
 			scrollViewer.ViewChanged += ScrollViewer_ViewChanged;
 
-			originDragPoint = new Point(e.GetCurrentPoint(uiElement).Position.X, e.GetCurrentPoint(uiElement).Position.Y); // Initial drag point relative to the topleft corner
+			var currentPoint = e.GetCurrentPoint(uiElement);
+			originDragPoint = new Point(currentPoint.Position.X, currentPoint.Position.Y); // Initial drag point relative to the topleft corner
 			prevSelectedItems = uiElement.SelectedItems.Cast<object>().ToList(); // Save current selected items
 
-			var verticalOffset = scrollViewer.VerticalOffset;
-			originDragPoint.Y += verticalOffset; // Initial drag point relative to the top of the list (considering scrolled offset)
-			if (!e.GetCurrentPoint(uiElement).Properties.IsLeftButtonPressed || e.Pointer.PointerDeviceType == Microsoft.UI.Input.PointerDeviceType.Touch)
+			originDragPoint.X += scrollViewer.HorizontalOffset;
+			originDragPoint.Y += scrollViewer.VerticalOffset; // Initial drag point relative to the top of the list (considering scrolled offset)
+			if (!currentPoint.Properties.IsLeftButtonPressed || e.Pointer.PointerDeviceType == Microsoft.UI.Input.PointerDeviceType.Touch)
 			{
 				// Trigger only on left click, do not trigger with touch
 				return;
@@ -146,6 +226,8 @@ namespace Files.App.UserControls.Selection
 
 			uiElement.PointerMoved -= RectangleSelection_PointerMoved;
 			uiElement.PointerMoved += RectangleSelection_PointerMoved;
+			uiElement.PointerWheelChanged -= RectangleSelection_PointerWheelChanged;
+			uiElement.PointerWheelChanged += RectangleSelection_PointerWheelChanged;
 			if (selectionChanged is not null)
 			{
 				// Unsunscribe from SelectionChanged event for performance
@@ -158,7 +240,8 @@ namespace Files.App.UserControls.Selection
 		[DynamicWindowsRuntimeCast(typeof(FrameworkElement))]
 		private void FetchItemsPosition()
 		{
-			var verticalOffset = scrollViewer!.VerticalOffset;
+			var horizontalOffset = scrollViewer!.HorizontalOffset;
+			var verticalOffset = scrollViewer.VerticalOffset;
 			foreach (var item in uiElement.Items.ToList().Except(itemsPosition.Keys))
 			{
 				var listViewItem = (FrameworkElement)uiElement.ContainerFromItem(item); // Get ListViewItem
@@ -168,7 +251,7 @@ namespace Files.App.UserControls.Selection
 				}
 
 				var gt = listViewItem.TransformToVisual(uiElement);
-				var itemStartPoint = gt.TransformPoint(new Point(0, verticalOffset)); // Get item position relative to the top of the list (considering scrolled offset)
+				var itemStartPoint = gt.TransformPoint(new Point(horizontalOffset, verticalOffset)); // Get item position relative to the top of the list (considering scrolled offset)
 				var itemRect = new System.Drawing.Rectangle((int)itemStartPoint.X, (int)itemStartPoint.Y, (int)listViewItem.ActualWidth, (int)listViewItem.ActualHeight);
 				itemsPosition[item] = itemRect;
 			}
@@ -195,6 +278,7 @@ namespace Files.App.UserControls.Selection
 			selectionRectangle.Width = 0;
 			selectionRectangle.Height = 0;
 			uiElement.PointerMoved -= RectangleSelection_PointerMoved;
+			uiElement.PointerWheelChanged -= RectangleSelection_PointerWheelChanged;
 
 			scrollViewer.ViewChanged -= ScrollViewer_ViewChanged;
 			uiElement.ReleasePointerCapture(e.Pointer);


### PR DESCRIPTION
…ction

<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Closes #14313

**Steps used to test these changes**

Stability is a top priority for Files and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.

1. Opened Files
2. Open a folder and drag a selection rectangle, then use the mouse wheel without releasing the left button. The list should scroll, and items that enter the rectangle should select.
3. Repeat with hold-still, then wheel (no 5px mouse move first).
4. Switch to list view (horizontal scrolling) and do the same.
5. Ctrl+wheel during an active drag: layout size still changes and hit-testing follows the new item size rather than the stale cache.