### PR TITLE
Fix: Fixed pinned network computers not showing an icon in the sidebar

### DIFF
--- a/src/Files.App/Data/Models/PinnedFoldersManager.cs
+++ b/src/Files.App/Data/Models/PinnedFoldersManager.cs
@@ -148,6 +148,16 @@ namespace Files.App.Data.Models
 					isFolder,
 					IconOptions.ReturnIconOnly);
 
+				// Shell icon APIs cannot resolve icons for bare network machine roots (e.g. "\\server"); fall back to the sidebar resource icons like DriveItem does.
+				if (result is null)
+				{
+					var isMachineRoot = path.StartsWith(@"\\", StringComparison.Ordinal) &&
+						path.Split('\\', StringSplitOptions.RemoveEmptyEntries).Length == 1;
+					result = UIHelpers.GetSidebarIconResourceInfo(isMachineRoot
+						? Constants.ImageRes.Network
+						: Constants.ImageRes.Folder)?.IconData;
+				}
+
 				locationItem.IconData = result;
 
 				// Assign Icon on the UI thread: it raises PropertyChanged, which builds a XAML IconElement in a realized SidebarItem.


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

- Closes #18683

**Steps used to test these changes**

Reproducing the reporter's steps (share a folder via File Explorer > Properties > Sharing > Advanced Sharing, enter `\127.0.0.1` in Files, pin it to the sidebar) leaves the pinned entry with a blank icon. The reporter's attached debug log contains no icon-related errors or exceptions, confirming the shell icon lookup fails silently (`Win32Helper.GetIcon` returns null) instead of throwing:

1. Pinned a bare network machine path (`\server`) and observed the sidebar entry rendering no icon, while File Explorer shows the computer icon.
2. Traced the load path in `PinnedFoldersManager.LoadIconForLocationItemAsync`: when the shell returns no icon bytes, `LocationItem.Icon` stayed null with no fallback (only the invalid-path branch had a default-icon fallback).
3. Confirmed `DriveItem` already solves this for network drives via the same sidebar resource fallback (`Constants.ImageRes.Network` / `Constants.ImageRes.Folder`), and mirrored that pattern.

The change only adds a fallback when the shell returns no icon bytes, so items whose icons resolve normally are unaffected. The change is verified with a full build of Files.App and its dependencies (x64, Debug): Build succeeded, 0 errors.
