### PR TITLE
Feature: Add optional TeraCopy integration for copy and move operations

### DIFF
--- a/src/Files.App/Data/Contracts/IGeneralSettingsService.cs
+++ b/src/Files.App/Data/Contracts/IGeneralSettingsService.cs
@@ -281,6 +281,11 @@ namespace Files.App.Data.Contracts
 		bool ShowSendToMenu { get; set; }
 
 		/// <summary>
+		/// Gets or sets a value indicating whether or not to use TeraCopy for copy and move operations when it is installed.
+		/// </summary>
+		bool UseTeraCopy { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating whether or not to leave app running in the background.
 		/// </summary>
 		bool LeaveAppRunning { get; set; }

--- a/src/Files.App/Services/Settings/GeneralSettingsService.cs
+++ b/src/Files.App/Services/Settings/GeneralSettingsService.cs
@@ -293,6 +293,12 @@ namespace Files.App.Services.Settings
 			set => Set(value);
 		}
 
+		public bool UseTeraCopy
+		{
+			get => Get(false);
+			set => Set(value);
+		}
+
 		public bool ShowOpenInNewTab
 		{
 			get => Get(true);

--- a/src/Files.App/Strings/en-US/Resources.resw
+++ b/src/Files.App/Strings/en-US/Resources.resw
@@ -4728,4 +4728,10 @@
   <data name="ConfirmRemoveTagsDialogContent" xml:space="preserve">
     <value>Are you sure you want to remove tags from the selected items?</value>
   </data>
+  <data name="UseTeraCopy" xml:space="preserve">
+    <value>Copy and move files with TeraCopy</value>
+  </data>
+  <data name="UseTeraCopyDescription" xml:space="preserve">
+    <value>Hand copy and move operations off to TeraCopy, which shows its own progress window and handles conflicts. Requires TeraCopy to be installed.</value>
+  </data>
 </root>

--- a/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
+++ b/src/Files.App/Utils/Storage/Operations/FilesystemHelpers.cs
@@ -306,6 +306,11 @@ namespace Files.App.Utils.Storage
 			source = await source.ToListAsync();
 			destination = await destination.ToListAsync();
 
+			if (registerHistory &&
+				UserSettingsService.GeneralSettingsService.UseTeraCopy &&
+				TeraCopyHelper.CanRun((IList<IStorageItemWithPath>)source, (IList<string>)destination))
+				return await TeraCopyHelper.RunAsync(FilesystemOperationType.Copy, (IList<IStorageItemWithPath>)source, (IList<string>)destination);
+
 			var returnStatus = ReturnResult.InProgress;
 
 			var banner = StatusCenterHelper.AddCard_Copy(
@@ -448,6 +453,11 @@ namespace Files.App.Utils.Storage
 		{
 			source = await source.ToListAsync();
 			destination = await destination.ToListAsync();
+
+			if (registerHistory &&
+				UserSettingsService.GeneralSettingsService.UseTeraCopy &&
+				TeraCopyHelper.CanRun((IList<IStorageItemWithPath>)source, (IList<string>)destination))
+				return await TeraCopyHelper.RunAsync(FilesystemOperationType.Move, (IList<IStorageItemWithPath>)source, (IList<string>)destination);
 
 			var returnStatus = ReturnResult.InProgress;
 

--- a/src/Files.App/Utils/Storage/Operations/TeraCopyHelper.cs
+++ b/src/Files.App/Utils/Storage/Operations/TeraCopyHelper.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Files Community
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Text;
+
+namespace Files.App.Utils.Storage
+{
+	/// <summary>
+	/// Hands copy and move operations off to TeraCopy when the integration is enabled.
+	/// </summary>
+	public static class TeraCopyHelper
+	{
+		public static string? DetectTeraCopyPath()
+		{
+			string[] candidates =
+			[
+				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "TeraCopy", "TeraCopy.exe"),
+				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "TeraCopy", "TeraCopy.exe"),
+				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Programs", "TeraCopy", "TeraCopy.exe"),
+				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "TeraCopy", "TeraCopy.exe"),
+			];
+
+			return candidates.FirstOrDefault(File.Exists);
+		}
+
+		public static bool CanRun(IList<IStorageItemWithPath> source, IList<string> destination)
+		{
+			if (source.Count == 0 || source.Count != destination.Count)
+				return false;
+
+			if (DetectTeraCopyPath() is null)
+				return false;
+
+			var trashBinService = Ioc.Default.GetRequiredService<IStorageTrashBinService>();
+
+			if (source.Any(item => !IsSupportedPath(item.Path) || trashBinService.IsUnderTrashBin(item.Path)))
+				return false;
+
+			// TeraCopy takes a single destination folder; require every item to land in the
+			// same folder under its original name, otherwise the built-in engine handles it
+			var destinationFolder = Path.GetDirectoryName(destination[0]);
+			if (string.IsNullOrEmpty(destinationFolder) || !IsSupportedPath(destinationFolder) || trashBinService.IsUnderTrashBin(destinationFolder))
+				return false;
+
+			for (int i = 0; i < source.Count; i++)
+			{
+				if (!string.Equals(Path.GetDirectoryName(destination[i]), destinationFolder, StringComparison.OrdinalIgnoreCase) ||
+					!string.Equals(Path.GetFileName(destination[i]), source[i].Name, StringComparison.OrdinalIgnoreCase))
+					return false;
+			}
+
+			return true;
+		}
+
+		public static async Task<ReturnResult> RunAsync(FilesystemOperationType operationType, IList<IStorageItemWithPath> source, IList<string> destination)
+		{
+			var teraCopyPath = DetectTeraCopyPath();
+			if (teraCopyPath is null)
+				return ReturnResult.Failed;
+
+			var destinationFolder = Path.GetDirectoryName(destination[0])!;
+
+			// TeraCopy reads the source list from a UTF-8 file, one path per line
+			var fileList = Path.Combine(Path.GetTempPath(), $"Files-TeraCopy-{Guid.NewGuid():N}.txt");
+			await File.WriteAllLinesAsync(fileList, source.Select(item => item.Path), new UTF8Encoding(true));
+
+			var operation = operationType == FilesystemOperationType.Move ? "Move" : "Copy";
+			var arguments = $"{operation} *{QuoteArgument(fileList)} {QuoteArgument(destinationFolder)}";
+
+			var launched = await LaunchHelper.LaunchAppAsync(teraCopyPath, arguments, destinationFolder);
+
+			return launched ? ReturnResult.Success : ReturnResult.Failed;
+		}
+
+		private static bool IsSupportedPath(string? path)
+		{
+			return !string.IsNullOrWhiteSpace(path) &&
+				!path.StartsWith(@"\\?\", StringComparison.Ordinal) &&
+				!FtpHelpers.IsFtpPath(path) &&
+				!ZipStorageFolder.IsZipPath(path, false);
+		}
+
+		private static string QuoteArgument(string path)
+		{
+			// A trailing backslash (e.g. drive roots) would escape the closing quote
+			return "\"" + (path.EndsWith('\\') ? path + "\\" : path) + "\"";
+		}
+	}
+}

--- a/src/Files.App/ViewModels/Settings/AdvancedViewModel.cs
+++ b/src/Files.App/ViewModels/Settings/AdvancedViewModel.cs
@@ -364,6 +364,22 @@ namespace Files.App.ViewModels.Settings
 			}
 		}
 
+		public bool IsTeraCopyAvailable
+			=> TeraCopyHelper.DetectTeraCopyPath() is not null;
+
+		public bool UseTeraCopy
+		{
+			get => UserSettingsService.GeneralSettingsService.UseTeraCopy;
+			set
+			{
+				if (value == UserSettingsService.GeneralSettingsService.UseTeraCopy)
+					return;
+
+				UserSettingsService.GeneralSettingsService.UseTeraCopy = value;
+				OnPropertyChanged();
+			}
+		}
+
 		public bool EnableThumbnailCache
 		{
 			get => UserSettingsService.GeneralSettingsService.EnableThumbnailCache;

--- a/src/Files.App/Views/Settings/AdvancedPage.xaml
+++ b/src/Files.App/Views/Settings/AdvancedPage.xaml
@@ -194,6 +194,17 @@
 				</wctcontrols:SettingsCard.HeaderIcon>
 				<ToggleSwitch AutomationProperties.Name="{helpers:ResourceString Name=ShowFlattenOptions}" IsOn="{x:Bind ViewModel.ShowFlattenOptions, Mode=TwoWay}" />
 			</wctcontrols:SettingsCard>
+
+			<!--  TeraCopy integration  -->
+			<wctcontrols:SettingsCard
+				Description="{helpers:ResourceString Name=UseTeraCopyDescription}"
+				Header="{helpers:ResourceString Name=UseTeraCopy}"
+				IsEnabled="{x:Bind ViewModel.IsTeraCopyAvailable}">
+				<wctcontrols:SettingsCard.HeaderIcon>
+					<FontIcon Glyph="&#xE8C8;" />
+				</wctcontrols:SettingsCard.HeaderIcon>
+				<ToggleSwitch AutomationProperties.Name="{helpers:ResourceString Name=UseTeraCopy}" IsOn="{x:Bind ViewModel.UseTeraCopy, Mode=TwoWay}" />
+			</wctcontrols:SettingsCard>
 		</StackPanel>
 	</Grid>
 </Page>


### PR DESCRIPTION
**Resolved / Related Issues**

- Related to #7518 (also requested in #18394, #17553)

Note: #7518 isn't marked `Ready to build` yet, but @gave92 suggested there that invoking TeraCopy the way other file managers do would be acceptable, so this PR implements that as a concrete starting point. Happy to adjust scope or approach to whatever the team prefers.

**Description**

Adds an opt-in setting (Settings → Advanced → Experimental: "Copy and move files with TeraCopy", off by default, disabled when TeraCopy isn't installed) that hands copy and move operations off to TeraCopy.

Implementation notes:

- The handoff happens at the top of `FilesystemHelpers.CopyItemsAsync` / `MoveItemsAsync`, so paste, drag-drop, and sidebar/breadcrumb drops are all covered by one guard.
- TeraCopy is invoked through its vendor-documented file-manager CLI (the same integration TeraCopy ships for Total Commander / Directory Opus): `TeraCopy.exe Copy|Move *"<list file>" "<destination>"`, with sources written to a UTF-8 list file.
- `TeraCopyHelper.CanRun` falls back to the built-in engine for anything TeraCopy shouldn't handle: FTP, archive paths, `\\?\` paths, Recycle Bin sources, operations that rename items or fan out to multiple destination folders, and internal calls with `registerHistory: false` (so undo/redo always replays through the built-in engine).
- TeraCopy shows its own progress window and conflict dialogs, so no StatusCenter card is created for handed-off operations.

Known limitations (called out for review): handed-off operations don't register undo history and don't update the file tags database. If the team would rather gate those differently I'm happy to iterate.

**Steps used to test these changes**

1. Built (x64 Release, sideload package) and installed on Windows 11 with TeraCopy 4.0.3 present.
2. Enabled the new toggle in Settings → Advanced.
3. Copy-paste and drag-drop of files and folders: the TeraCopy window appears, performs the operation, and the results are correct on disk.
4. With the toggle off, operations use the built-in engine exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
