### PR TITLE
Fix: Release the handles Files holds on a drive before ejecting it

### DIFF
--- a/src/Files.App.Storage/Legacy/RecycleBinWatcher.cs
+++ b/src/Files.App.Storage/Legacy/RecycleBinWatcher.cs
@@ -78,6 +78,21 @@ namespace Files.App.Storage.Watchers
 				watcher.Dispose();
 		}
 
+		/// <summary>
+		/// Stops watching the Recycle Bin on the given drive so the watcher's handle can't block ejection.
+		/// </summary>
+		public void StopWatcher(string driveRoot)
+		{
+			for (int i = _watchers.Count - 1; i >= 0; i--)
+			{
+				if (_watchers[i].Path.StartsWith(driveRoot, StringComparison.OrdinalIgnoreCase))
+				{
+					_watchers[i].Dispose();
+					_watchers.RemoveAt(i);
+				}
+			}
+		}
+
 		private void Watcher_Changed(object sender, SystemIO.FileSystemEventArgs e)
 		{
 			// Don't listen changes on files starting with '$I'

--- a/src/Files.App.Storage/Legacy/RecycleBinWatcher.cs
+++ b/src/Files.App.Storage/Legacy/RecycleBinWatcher.cs
@@ -39,36 +39,46 @@ namespace Files.App.Storage.Watchers
 		{
 			// NOTE: SHChangeNotifyRegister only works if recycle bin is open in File Explorer.
 
+			foreach (var drive in SystemIO.DriveInfo.GetDrives())
+				StartWatcher(drive.Name);
+		}
+
+		/// <summary>
+		/// Starts watching the Recycle Bin on the given drive if it isn't watched already.
+		/// Re-arms monitoring after a failed eject and when a drive appears after startup.
+		/// </summary>
+		public void StartWatcher(string driveRoot)
+		{
 			// Listen changes only on the Recycle Bin that the current logon user has
 			var sid = WindowsIdentity.GetCurrent().User?.ToString() ?? string.Empty;
 			if (string.IsNullOrEmpty(sid))
 				return;
 
-			foreach (var drive in SystemIO.DriveInfo.GetDrives())
+			// NOTE: Suppressed NullReferenceException caused by EnableRaisingEvents in #15808
+			SafetyExtensions.IgnoreExceptions(() =>
 			{
-				var recyclePath = SystemIO.Path.Combine(drive.Name, "$RECYCLE.BIN", sid);
+				var recyclePath = SystemIO.Path.Combine(driveRoot, "$RECYCLE.BIN", sid);
 
-				if (drive.DriveType is SystemIO.DriveType.Network ||
+				if (new SystemIO.DriveInfo(driveRoot).DriveType is SystemIO.DriveType.Network ||
 					!SystemIO.Directory.Exists(recyclePath))
-					continue;
+					return;
 
-				// NOTE: Suppressed NullReferenceException caused by EnableRaisingEvents in #15808
-				SafetyExtensions.IgnoreExceptions(() =>
+				if (_watchers.Any(x => string.Equals(x.Path, recyclePath, StringComparison.OrdinalIgnoreCase)))
+					return;
+
+				SystemIO.FileSystemWatcher watcher = new()
 				{
-					SystemIO.FileSystemWatcher watcher = new()
-					{
-						Path = recyclePath,
-						Filter = "*.*",
-						NotifyFilter = SystemIO.NotifyFilters.LastWrite | SystemIO.NotifyFilters.FileName | SystemIO.NotifyFilters.DirectoryName
-					};
+					Path = recyclePath,
+					Filter = "*.*",
+					NotifyFilter = SystemIO.NotifyFilters.LastWrite | SystemIO.NotifyFilters.FileName | SystemIO.NotifyFilters.DirectoryName
+				};
 
-					watcher.Created += Watcher_Changed;
-					watcher.Deleted += Watcher_Changed;
-					watcher.EnableRaisingEvents = true;
+				watcher.Created += Watcher_Changed;
+				watcher.Deleted += Watcher_Changed;
+				watcher.EnableRaisingEvents = true;
 
-					_watchers.Add(watcher);
-				});
-			}
+				_watchers.Add(watcher);
+			});
 		}
 
 		/// <inheritdoc/>

--- a/src/Files.App/Data/Models/DrivesViewModel.cs
+++ b/src/Files.App/Data/Models/DrivesViewModel.cs
@@ -93,6 +93,10 @@ namespace Files.App.Data.Models
 				Drives.Add(e);
 			}
 
+			// Watch the Recycle Bin on drives that appear after startup (including reinserted ones)
+			if (!string.IsNullOrEmpty(e.Id))
+				Ioc.Default.GetRequiredService<IStorageTrashBinService>().Watcher.StartWatcher(e.Id.EndsWith('\\') ? e.Id : e.Id + '\\');
+
 			Watcher_EnumerationCompleted(null, EventArgs.Empty);
 		}
 

--- a/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
@@ -15,7 +15,46 @@ namespace Files.App.Utils.Storage
 	{
 		public static async void EjectDeviceAsync(string path)
 		{
+			await ReleaseDriveHandlesAsync(path);
 			await ContextMenu.InvokeVerb("eject", path);
+		}
+
+		/// <summary>
+		/// Releases the handles Files itself holds on the drive (directory change watchers, sidebar
+		/// subtree watchers, the Recycle Bin watcher) so they can't veto the device removal.
+		/// </summary>
+		private static async Task ReleaseDriveHandlesAsync(string path)
+		{
+			var driveRoot = path.EndsWith('\\') ? path : path + '\\';
+
+			// Navigate every pane showing the drive to Home and close its directory watcher
+			var multitaskingContext = Ioc.Default.GetRequiredService<IMultitaskingContext>();
+			foreach (var tab in multitaskingContext.Control?.GetAllTabInstances() ?? [])
+			{
+				if (tab is not ShellPanesPage panesPage)
+					continue;
+
+				foreach (var pane in panesPage.GetPanes())
+				{
+					var panePath = pane.ShellViewModel?.CurrentFolder?.ItemPath;
+					if (panePath is not null && (panePath + '\\').StartsWith(driveRoot, StringComparison.OrdinalIgnoreCase))
+					{
+						pane.ShellViewModel?.CloseWatcher();
+						pane.NavigateHome();
+					}
+				}
+			}
+
+			// Stop sidebar subtree watchers rooted on the drive
+			var drivesViewModel = Ioc.Default.GetRequiredService<DrivesViewModel>();
+			if (drivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(x => string.Equals(x.Path, path, StringComparison.OrdinalIgnoreCase)) is { } driveItem)
+				driveItem.StopWatchingSubfoldersAndDescendants();
+
+			// Drop the Recycle Bin watcher for this drive
+			Ioc.Default.GetRequiredService<IStorageTrashBinService>().Watcher.StopWatcher(driveRoot);
+
+			// Give the released handles a moment to close before the shell issues the removal query
+			await Task.Delay(300);
 		}
 
 		public static async Task<bool> CheckEmptyDrive(string? drivePath)

--- a/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
+++ b/src/Files.App/Utils/Storage/Helpers/DriveHelpers.cs
@@ -15,18 +15,27 @@ namespace Files.App.Utils.Storage
 	{
 		public static async void EjectDeviceAsync(string path)
 		{
-			await ReleaseDriveHandlesAsync(path);
+			var driveRoot = path.EndsWith('\\') ? path : path + '\\';
+
+			ReleaseDriveHandles(driveRoot);
+
+			// Give the released handles a moment to close before the shell issues the removal query
+			await Task.Delay(300);
+
 			await ContextMenu.InvokeVerb("eject", path);
+
+			// If the volume is still mounted the eject was vetoed; re-arm the Recycle Bin watcher
+			await Task.Delay(2000);
+			if (SystemIO.Directory.Exists(driveRoot))
+				Ioc.Default.GetRequiredService<IStorageTrashBinService>().Watcher.StartWatcher(driveRoot);
 		}
 
 		/// <summary>
 		/// Releases the handles Files itself holds on the drive (directory change watchers, sidebar
 		/// subtree watchers, the Recycle Bin watcher) so they can't veto the device removal.
 		/// </summary>
-		private static async Task ReleaseDriveHandlesAsync(string path)
+		private static void ReleaseDriveHandles(string driveRoot)
 		{
-			var driveRoot = path.EndsWith('\\') ? path : path + '\\';
-
 			// Navigate every pane showing the drive to Home and close its directory watcher
 			var multitaskingContext = Ioc.Default.GetRequiredService<IMultitaskingContext>();
 			foreach (var tab in multitaskingContext.Control?.GetAllTabInstances() ?? [])
@@ -47,14 +56,11 @@ namespace Files.App.Utils.Storage
 
 			// Stop sidebar subtree watchers rooted on the drive
 			var drivesViewModel = Ioc.Default.GetRequiredService<DrivesViewModel>();
-			if (drivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(x => string.Equals(x.Path, path, StringComparison.OrdinalIgnoreCase)) is { } driveItem)
+			if (drivesViewModel.Drives.Cast<DriveItem>().FirstOrDefault(x => string.Equals(x.Path?.TrimEnd('\\'), driveRoot.TrimEnd('\\'), StringComparison.OrdinalIgnoreCase)) is { } driveItem)
 				driveItem.StopWatchingSubfoldersAndDescendants();
 
 			// Drop the Recycle Bin watcher for this drive
 			Ioc.Default.GetRequiredService<IStorageTrashBinService>().Watcher.StopWatcher(driveRoot);
-
-			// Give the released handles a moment to close before the shell issues the removal query
-			await Task.Delay(300);
 		}
 
 		public static async Task<bool> CheckEmptyDrive(string? drivePath)


### PR DESCRIPTION
**Resolved / Related Issues**

- Closes #17131

Note: the issue isn't marked `Ready to build`, but it's a confirmed, member-acknowledged bug ("I will keep this open to track Files blocking eject issue"), so I hope a concrete fix is useful. Happy to adjust the approach if the team prefers.

**Description**

Ejecting a removable drive from Files frequently fails with Windows' "device is currently in use" dialog while ejecting the same drive from File Explorer works. The reason is that Files itself holds open handles on the volume and vetoes its own eject:

- every pane showing the drive keeps a `ReadDirectoryChangesW` directory handle open (`ShellViewModel.WatchForDirectoryChanges`),
- every expanded sidebar node on the drive owns a `FileSystemWatcher`,
- `RecycleBinWatcher` arms a watcher on `<drive>\$RECYCLE.BIN\<sid>` for every non-network drive at startup and never releases it per-drive.

`DriveHelpers.EjectDeviceAsync` invoked the shell "eject" verb without releasing any of these, so the PnP query-remove failed. (Explorer avoids this by releasing its handles on `DBT_DEVICEQUERYREMOVE`.)

This PR makes `EjectDeviceAsync` release Files' own holds before invoking the verb:

1. For every pane whose current folder is on the drive: close its directory watcher and navigate it Home.
2. Stop sidebar subtree watchers rooted on the drive (`StopWatchingSubfoldersAndDescendants`).
3. Drop the Recycle Bin watcher for that drive (new per-drive `RecycleBinWatcher.StopWatcher(driveRoot)` overload).
4. Give handles a moment to close, then invoke the existing shell "eject" verb unchanged.

Not covered here (possible follow-ups): open preview-pane streams, in-flight size/search enumerations, and listening for `DBT_DEVICEQUERYREMOVE` so ejects initiated outside Files also succeed — that last one is the structurally complete fix but a much larger change.

**Steps used to test these changes**

1. Built (x64 Release, sideload package) and installed on Windows 11.
2. Inserted a microSD card, opened tabs on it, and browsed folders on the card.
3. Pressed Eject in Files: panes navigated Home and the card ejected successfully on the first attempt. Previously the same flow reliably failed with "device is currently in use" and required closing Files or ejecting from Explorer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
