### PR TITLE
Code Quality: Fixed crashes in preview

### DIFF
--- a/src/Files.App/App.xaml.cs
+++ b/src/Files.App/App.xaml.cs
@@ -352,6 +352,9 @@ namespace Files.App
 				// Close open content dialogs
 				UIHelpers.CloseAllDialogs();
 
+				// Tear down the shell preview host (prevhost.exe) while the dispatcher still pumps; parking must not keep it attached
+				SafetyExtensions.IgnoreExceptions(() => Ioc.Default.GetRequiredService<InfoPaneViewModel>().UnloadPreview());
+
 				// Close all notification banners except in progress
 				statusCenterViewModel.RemoveAllCompletedItems();
 

--- a/src/Files.App/Services/App/AppUpdateStoreService.cs
+++ b/src/Files.App/Services/App/AppUpdateStoreService.cs
@@ -252,12 +252,20 @@ namespace Files.App.Services
 				catch { }
 			}
 
-			var srcExeFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/FilesOpenDialog/Files.App.Launcher.exe"));
-			var destFolder = await StorageFolder.GetFolderFromPathAsync(destFolderPath);
+			try
+			{
+				var srcExeFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/FilesOpenDialog/Files.App.Launcher.exe"));
+				var destFolder = await StorageFolder.GetFolderFromPathAsync(destFolderPath);
 
-			await srcExeFile.CopyAsync(destFolder, "Files.App.Launcher.exe", NameCollisionOption.ReplaceExisting);
+				await srcExeFile.CopyAsync(destFolder, "Files.App.Launcher.exe", NameCollisionOption.ReplaceExisting);
 
-			App.Logger.LogInformation("Files.App.Launcher updated.");
+				App.Logger.LogInformation("Files.App.Launcher updated.");
+			}
+			catch (Exception ex)
+			{
+				// COMException 0x80070020 when the launcher exe is locked by a running instance or antivirus scan
+				App.Logger.LogError(ex, ex.Message);
+			}
 		}
 
 		private bool HasUpdates()

--- a/src/Files.App/UserControls/NavigationToolbar.xaml.cs
+++ b/src/Files.App/UserControls/NavigationToolbar.xaml.cs
@@ -477,8 +477,8 @@ namespace Files.App.UserControls
 			if (e.Key is VirtualKey.Escape)
 			{
 				Omnibar.IsFocused = false;
-				var paneHolder = ContentPageContext.ShellPage.GetRequiredPaneHolder();
-				paneHolder.FocusActivePane();
+				var paneHolder = ContentPageContext.ShellPage?.PaneHolder;
+				paneHolder?.FocusActivePane();
 			}
 			else if (e.Key is VirtualKey.Tab && Omnibar.IsFocused && !InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down))
 			{

--- a/src/Files.App/Utils/Shell/PreviewHandler.cs
+++ b/src/Files.App/Utils/Shell/PreviewHandler.cs
@@ -380,11 +380,6 @@ namespace Files.App.Utils.Shell
 
 		#region IDisposable pattern
 
-		~PreviewHandler()
-		{
-			Dispose();
-		}
-
 		public void Dispose()
 		{
 			if (disposed)
@@ -392,10 +387,25 @@ namespace Files.App.Utils.Shell
 			disposed = true;
 			init = false;
 
-			previewHandler?.Unload();
-			comSite = null;
+			try
+			{
+				previewHandler?.Unload();
 
-			GC.SuppressFinalize(this);
+				// Break the site connection so the handler releases the PreviewHandlerFrame wrapper deterministically
+				if (previewHandler is IObjectWithSite objectWithSite)
+					objectWithSite.SetSite(null!);
+			}
+			catch (COMException)
+			{
+				// RPC errors (e.g. RPC_S_SERVER_UNAVAILABLE) when the prevhost process already exited
+			}
+
+			if ((object?)previewHandler is ComObject comObject)
+				comObject.FinalRelease();
+
+			previewHandler = null;
+			visuals = null;
+			comSite = null;
 		}
 
 		#endregion

--- a/src/Files.App/ViewModels/ShellViewModel.cs
+++ b/src/Files.App/ViewModels/ShellViewModel.cs
@@ -2444,8 +2444,9 @@ namespace Files.App.ViewModels
 			if (rootFolder is null)
 				return;
 
+			// Null when a concurrent navigation or dispose cleared the context; this enumeration is stale
 			if (currentStorageFolder is null)
-				throw new InvalidOperationException("The storage-folder context is unavailable.");
+				return;
 
 			if (rootFolder is IPasswordProtectedItem ppis)
 				ppis.PasswordRequestedCallback = async (item) =>

--- a/src/Files.App/ViewModels/UserControls/Previews/ShellPreviewViewModel.cs
+++ b/src/Files.App/ViewModels/UserControls/Previews/ShellPreviewViewModel.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Content;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Hosting;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Direct3D;
@@ -31,6 +32,11 @@ namespace Files.App.ViewModels.Previews
 
 		ContentExternalOutputLink? _contentExternalOutputLink;
 		PreviewHandler? _previewHandler;
+		ID3D11Device? _d3d11Device;
+		ID3D11DeviceContext? _d3d11DeviceContext;
+		IDCompositionDevice? _dCompositionDevice;
+		IDCompositionVisual? _childVisual;
+		object? _controlSurface;
 		WNDCLASSEXW _windowClass;
 		WNDPROC _windProc = null!;
 		HWND _hWnd = HWND.Null;
@@ -187,11 +193,6 @@ namespace Files.App.ViewModels.Previews
 			];
 
 			HRESULT hr = default;
-			ID3D11Device? pD3D11Device = null;
-			ID3D11DeviceContext? pD3D11DeviceContext = null;
-			IDXGIDevice? pDXGIDevice = null;
-			object? pControlSurface = null;
-			IDCompositionVisual? pChildVisual = null;
 
 			// Create the D3D11 device
 			foreach (var driverType in driverTypes)
@@ -200,33 +201,33 @@ namespace Files.App.ViewModels.Previews
 					null!, driverType, new(nint.Zero),
 					D3D11_CREATE_DEVICE_FLAG.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
 					ReadOnlySpan<D3D_FEATURE_LEVEL>.Empty, /* SDKVersion */ 7,
-					out pD3D11Device,
-					out pD3D11DeviceContext);
+					out _d3d11Device,
+					out _d3d11DeviceContext);
 
 				if (hr.Succeeded)
 					break;
 			}
 
-			if (pD3D11Device is null)
+			if (_d3d11Device is null)
 				return false;
 
 			// Create the DComp device
-			pDXGIDevice = (IDXGIDevice)pD3D11Device;
-			hr = PInvoke.DCompositionCreateDevice(pDXGIDevice, out IDCompositionDevice pDCompositionDevice);
-			if (hr.Failed)
+			var pDXGIDevice = (IDXGIDevice)_d3d11Device;
+			hr = PInvoke.DCompositionCreateDevice(pDXGIDevice, out _dCompositionDevice);
+			if (hr.Failed || _dCompositionDevice is null)
 				return false;
 
 			// Create the visual
-			hr = pDCompositionDevice.CreateVisual(out pChildVisual);
+			hr = _dCompositionDevice.CreateVisual(out _childVisual);
 			if (hr.Failed)
 				return false;
 
-			hr = pDCompositionDevice.CreateSurfaceFromHwnd(_hWnd, out pControlSurface);
+			hr = _dCompositionDevice.CreateSurfaceFromHwnd(_hWnd, out _controlSurface);
 			if (hr.Failed)
 				return false;
 
-			hr = pChildVisual.SetContent(pControlSurface);
-			if (hr.Failed || pChildVisual is null || pControlSurface is null)
+			hr = _childVisual.SetContent(_controlSurface);
+			if (hr.Failed || _childVisual is null || _controlSurface is null)
 				return false;
 
 			// Get the compositor and set the visual on it
@@ -234,14 +235,14 @@ namespace Files.App.ViewModels.Previews
 			_contentExternalOutputLink = ContentExternalOutputLink.Create(compositor);
 
 			var target = _contentExternalOutputLink.As<Windows.Win32.Extras.IDCompositionTarget>();
-			target.SetRoot(pChildVisual);
+			target.SetRoot(_childVisual);
 
 			_contentExternalOutputLink.PlacementVisual.Size = new(0, 0);
 			_contentExternalOutputLink.PlacementVisual.Scale = new(1 / (float)presenter.XamlRoot.RasterizationScale);
 			ElementCompositionPreview.SetElementChildVisual(presenter, _contentExternalOutputLink.PlacementVisual);
 
 			// Commit the all pending DComp commands
-			pDCompositionDevice.Commit();
+			_dCompositionDevice.Commit();
 
 			var dwAttrib = Convert.ToUInt32(true);
 
@@ -268,6 +269,13 @@ namespace Files.App.ViewModels.Previews
 			_contentExternalOutputLink?.Dispose();
 			_contentExternalOutputLink = null;
 
+			// Release the composition chain leaf-to-root so nothing is left for finalizer-thread teardown
+			ReleaseComObject(ref _childVisual);
+			ReleaseComObject(ref _controlSurface);
+			ReleaseComObject(ref _dCompositionDevice);
+			ReleaseComObject(ref _d3d11DeviceContext);
+			ReleaseComObject(ref _d3d11Device);
+
 			PInvoke.UnregisterClass(_windowClass.lpszClassName, PInvoke.GetModuleHandle(default(PWSTR)));
 
 			if (_pszClassName is not null)
@@ -275,6 +283,14 @@ namespace Files.App.ViewModels.Previews
 				Marshal.FreeHGlobal((nint)_pszClassName);
 				_pszClassName = null;
 			}
+		}
+
+		private static void ReleaseComObject<T>(ref T? comInterface) where T : class
+		{
+			if ((object?)comInterface is ComObject comObject)
+				comObject.FinalRelease();
+
+			comInterface = null;
 		}
 
 		public unsafe void PointerEntered(bool onPreview)


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

To prevent extra work, all changes to the Files codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
- Fixed a crash when pressing Esc in the Omnibar while no shell page is active (FILES-APP-6GC)
- Fixed a crash when navigating away or closing a tab during storage folder enumeration (FILES-APP-6GD)
- Fixed a crash when updating Files.App.Launcher while the file is locked by another process (FILES-APP-6DS)
- Fixed crashes caused by shell preview handler teardown when the app runs in the background (FILES-APP-6GQ):
  - Removed the PreviewHandler finalizer, which made COM calls on the finalizer thread
  - Dispose now breaks the handler's site connection (SetSite(null)) and releases the handler deterministically
  - Fixed a leak of the D3D/DComp objects (device, context, visual, surface) on every preview load
  - The preview host (prevhost.exe) is now detached before the app parks in the background

