### PR TITLE
Fix: Remove the option to Pin to Sidebar for the Libraries root

### DIFF
--- a/src/Files.App/Actions/Sidebar/PinFolderToSidebarAction.cs
+++ b/src/Files.App/Actions/Sidebar/PinFolderToSidebarAction.cs
@@ -65,8 +65,18 @@ namespace Files.App.Actions
 				return
 					item.PrimaryItemAttribute is StorageItemTypes.Folder &&
 					!item.IsArchive &&
-					!pinnedFolders.Contains(item.ItemPath!);
+					!pinnedFolders.Contains(item.ItemPath!) &&
+					!IsLibrariesRoot(item.ItemPath);
 			}
+		}
+
+		/// <summary>
+		/// Check if the path is the libraries root. Windows ignores requests to pin the Libraries root without an error.
+		/// </summary>
+		private static bool IsLibrariesRoot(string? path)
+		{
+			return !string.IsNullOrEmpty(path) &&
+				string.Equals(path, ShellLibraryItem.LibrariesPath, StringComparison.OrdinalIgnoreCase);
 		}
 
 		private void Context_PropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
**Resolved / Related Issues**

- Related to #16857

**Steps used to test these changes**

1. Opened Files and navigated to `%APPDATA%\Microsoft\Windows\Libraries`. "Pin to Sidebar" is no longer an option.
2. Navigated to `%APPDATA%\Microsoft\Windows`, selected the `Libraries` folder and opened the context menu. Also no longer an option.
3. Pinned and unpinned an ordinary folder. Works as before.
4. Confirmed the individual libraries (Documents, Music etc.) can still be pinned.

**Context**

Full investigation is in the comment of issue #16857. Windows silently refuses the `pintohome` verb for the Libraries root when it's invoked programmatically: `IContextMenu::InvokeCommand` returns S_OK and nothing is written to Quick Access. It's not specific to Files, invoking the same verb through `Shell.Application` from PowerShell behaves identically. File Explorer can create the pin but once it exists it can't be removed again from Files, Explorer or `Shell.Application`, so a user who tries this ends up with a sidebar entry they can only get rid of by deleting the Quick Access store.

Since the pin can never succeed, hiding the option seemed better than letting it silently do nothing. This matches how `ContentPageTypes.RecycleBin` is already handled at the top of `GetIsExecutable`.

**One thing I'd like input on**

This covers the case where the folder is addressed by its file system path. When it's reached through the shell namespace (`shell:Libraries`), `ItemPath` is the `\\SHELL\<base64 PIDL>` form instead and isn't caught, so the option still shows there. 
I left it out because catching it means decoding the PIDL inside a synchronous predicate and I didn't want to add that without asking. I can fix that as well if you are okay with it.